### PR TITLE
Set the removal policy of resources to destroy when stack is deleted

### DIFF
--- a/voc-datalake/lib/stacks/bedrock-access-stack.ts
+++ b/voc-datalake/lib/stacks/bedrock-access-stack.ts
@@ -173,6 +173,10 @@ export class BedrockAccessStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(2),
       code: lambda.Code.fromInline(this.getModelAgreementLambdaCode()),
       description: 'Creates Bedrock model agreements by fetching offer tokens and accepting EULA',
+      logGroup: new logs.LogGroup(this, 'ModelAgreementLambdaLogs', {
+        retention: logs.RetentionDays.ONE_WEEK,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      }),
     });
 
     // Grant Bedrock permissions to the Lambda

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -6,6 +6,7 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
@@ -63,7 +64,7 @@ export class VocCoreStack extends cdk.Stack {
       alias: uniqueName('voc-datalake-key'),
       description: 'KMS key for VoC Data Lake encryption',
       enableKeyRotation: true,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     // ============================================
@@ -75,7 +76,8 @@ export class VocCoreStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
       versioned: false,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
       lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
     });
 
@@ -86,7 +88,8 @@ export class VocCoreStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
       versioned: false,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
       serverAccessLogsBucket: this.accessLogsBucket,
       serverAccessLogsPrefix: 'raw-data-bucket/',
       cors: [{
@@ -176,7 +179,7 @@ export class VocCoreStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: this.kmsKey,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       timeToLiveAttribute: 'ttl',
       stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
     });
@@ -218,7 +221,7 @@ export class VocCoreStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: this.kmsKey,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       timeToLiveAttribute: 'ttl',
     });
 
@@ -237,7 +240,7 @@ export class VocCoreStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: this.kmsKey,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     // Projects Table
@@ -249,7 +252,7 @@ export class VocCoreStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: this.kmsKey,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     this.projectsTable.addGlobalSecondaryIndex({
@@ -268,7 +271,7 @@ export class VocCoreStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: this.kmsKey,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       timeToLiveAttribute: 'ttl',
     });
 
@@ -288,7 +291,7 @@ export class VocCoreStack extends cdk.Stack {
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: this.kmsKey,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       timeToLiveAttribute: 'ttl',
     });
 
@@ -325,6 +328,10 @@ export class VocCoreStack extends cdk.Stack {
       code: lambda.Code.fromInline(this.getCustomMessageLambdaCode(signInUrl)),
       timeout: cdk.Duration.seconds(10),
       description: 'Customizes Cognito email messages for different scenarios',
+      logGroup: new logs.LogGroup(this, 'CustomMessageLambdaLogs', {
+        retention: logs.RetentionDays.TWO_WEEKS,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      }),
     });
 
     // Cognito User Pool
@@ -345,7 +352,7 @@ export class VocCoreStack extends cdk.Stack {
         requireSymbols: false,
       },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       userVerification: {
         emailSubject: 'VoC Analytics - Verify your email',
         emailBody: 'Welcome to VoC Analytics!\n\nYour verification code is: {####}\n\nThis code expires in 24 hours.\n\nIf you did not request this, please ignore this email.',

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -141,7 +141,8 @@ export class VocIngestionStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
       versioned: false,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
       serverAccessLogsBucket: accessLogsBucket,
       serverAccessLogsPrefix: 's3-import-bucket/',
       cors: [
@@ -183,6 +184,7 @@ export class VocIngestionStack extends cdk.Stack {
         }),
         generateStringKey: 'placeholder',
       },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
   }
 
@@ -192,6 +194,7 @@ export class VocIngestionStack extends cdk.Stack {
       encryption: sqs.QueueEncryption.KMS,
       encryptionMasterKey: kmsKey,
       retentionPeriod: cdk.Duration.days(14),
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
   }
 
@@ -202,6 +205,7 @@ export class VocIngestionStack extends cdk.Stack {
       encryptionMasterKey: kmsKey,
       visibilityTimeout: cdk.Duration.minutes(6),
       deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
   }
 


### PR DESCRIPTION
### Summary

This PR sets the removal policy of resources to be destroyed when the stack is deleted to ensure there are no resources left behind which could incur costs

*Issue #, if available:*
Closes: #32 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
