### PR TITLE
Fixed logging permissions for access logging bucket and API GW logging

### DIFF
--- a/voc-datalake/bin/voc-datalake.ts
+++ b/voc-datalake/bin/voc-datalake.ts
@@ -8,7 +8,7 @@ import { VocIngestionStack } from '../lib/stacks/ingestion-stack';
 import { VocProcessingStack } from '../lib/stacks/processing-stack-consolidated';
 import { VocApiStack } from '../lib/stacks/api-stack';
 import { BedrockAccessStack, AnthropicUseCaseSchema } from '../lib/stacks/bedrock-access-stack';
-import { lambdaBasicExecutionRoleSuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, comprehendSuppressions, translateSuppressions } from '../lib/utils/nag-suppressions';
+import { lambdaBasicExecutionRoleSuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, comprehendSuppressions, translateSuppressions, apiGatewayPushToCloudwatchLogsRoleSuppressions } from '../lib/utils/nag-suppressions';
 
 const app = new cdk.App();
 
@@ -159,6 +159,6 @@ NagSuppressions.addStackSuppressions(coreStack, [...lambdaBasicExecutionRoleSupp
 // Apply stack-level suppressions
 NagSuppressions.addStackSuppressions(ingestionStack, [...lambdaBasicExecutionRoleSuppressions, ...dynamoDbGsiSuppressions, ...kmsEncryptionSuppressions, ...s3BucketSuppressions], true);
 NagSuppressions.addStackSuppressions(processingStack, [...lambdaBasicExecutionRoleSuppressions, ...dynamoDbGsiSuppressions, ...kmsEncryptionSuppressions, ...bedrockModelSuppressions, ...pluginSystemSuppressions, ...comprehendSuppressions, ...translateSuppressions], true);
-NagSuppressions.addStackSuppressions(apiStack, [...lambdaBasicExecutionRoleSuppressions, ...dynamoDbGsiSuppressions, ...kmsEncryptionSuppressions, ...s3BucketSuppressions, ...bedrockModelSuppressions, ...pluginSystemSuppressions, ...cdkAssetsSuppressions, ...comprehendSuppressions, ...translateSuppressions], true);
+NagSuppressions.addStackSuppressions(apiStack, [...lambdaBasicExecutionRoleSuppressions, ...apiGatewayPushToCloudwatchLogsRoleSuppressions, ...dynamoDbGsiSuppressions, ...kmsEncryptionSuppressions, ...s3BucketSuppressions, ...bedrockModelSuppressions, ...pluginSystemSuppressions, ...cdkAssetsSuppressions, ...comprehendSuppressions, ...translateSuppressions], true);
 
 app.synth();

--- a/voc-datalake/cdk.json
+++ b/voc-datalake/cdk.json
@@ -26,7 +26,7 @@
     "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
     "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
     "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
-    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": false,
     "@aws-cdk/core:enablePartitionLiterals": true,
     "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
     "@aws-cdk/aws-iam:standardizedServicePrincipals": true,

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -81,6 +81,7 @@ export class VocCoreStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
       lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
     });
 
     this.rawDataBucket = new s3.Bucket(this, 'RawDataBucket', {
@@ -556,10 +557,6 @@ The VoC Analytics Team`,
     new cdk.CfnOutput(this, 'UserPoolClientId', { value: this.userPoolClient.userPoolClientId, description: 'Cognito User Pool Client ID for frontend' });
     new cdk.CfnOutput(this, 'UserPoolDomain', { value: `${domainPrefix}.auth.${this.region}.amazoncognito.com`, description: 'Cognito User Pool Domain' });
     new cdk.CfnOutput(this, 'CognitoRegion', { value: this.region, description: 'AWS Region for Cognito' });
-    
-    // Initial admin credentials (for reference)
-    new cdk.CfnOutput(this, 'InitialAdminUsername', { value: initialAdminUsername, description: 'Initial admin username' });
-    new cdk.CfnOutput(this, 'InitialAdminPassword', { value: initialAdminPassword, description: 'Initial admin password (change after first login)' });
   }
 
   private getCustomMessageLambdaCode(signInUrl: string): string {

--- a/voc-datalake/lib/utils/nag-suppressions.ts
+++ b/voc-datalake/lib/utils/nag-suppressions.ts
@@ -38,6 +38,15 @@ export const lambdaBasicExecutionRoleSuppressions: NagPackSuppression[] = [
   },
 ];
 
+// AmazonAPIGatewayPushToCloudWatchLogs - AWS managed policy for API Gateway to publish logs to CloudWatch 
+export const apiGatewayPushToCloudwatchLogsRoleSuppressions: NagPackSuppression[] = [
+  {
+    id: 'AwsSolutions-IAM4',
+    reason: 'AmazonAPIGatewayPushToCloudWatchLogs is AWS-recommended managed policy for API Gateway to push to CloudWatch logging with minimal permissions',
+    appliesTo: ['Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'],
+  },
+];
+
 // CloudFront distributions using default certificate
 export const cloudfrontDefaultCertSuppressions: NagPackSuppression[] = [
   {

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -26,9 +26,9 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all && node scripts/convert-template.mjs VocCoreStack VocIngestionStack  VocProcessingStack VocApiStack BedrockAccessStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
-    "prebuild:frontend": "npm run generate:config",
-    "convert:templates": "node scripts/convert-template.mjs VocCoreStack VocIngestionStack  VocProcessingStack VocApiStack BedrockAccessStack"
+    "prebuild:frontend": "npm run generate:config"
   },
   "keywords": [
     "aws",


### PR DESCRIPTION
### Summary

This PR fixes the logging permissions for access logging bucket and sets up the account level role for API GW logging to Cloudwatch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
