### PR TITLE
fix: use source_platform instead of brand_name for source filtering

### DIFF
--- a/voc-datalake/frontend/src/pages/Categories/useCategoriesData.test.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/useCategoriesData.test.tsx
@@ -282,9 +282,9 @@ describe('useFeedbackData', () => {
     expect(result.current.filteredFeedback[0].feedback_id).toBe('2')
   })
 
-  it('filters by source', async () => {
+  it('filters by source_platform (not brand_name)', async () => {
     const { result } = renderHook(
-      () => useFeedbackData(7, 'BrandA', ['delivery'], 'all', [], 0, 'https://api.example.com', true),
+      () => useFeedbackData(7, 'webscraper', ['delivery'], 'all', [], 0, 'https://api.example.com', true),
       { wrapper: createWrapper() }
     )
 
@@ -292,9 +292,27 @@ describe('useFeedbackData', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    // Only items with brand_name 'BrandA' should pass (the hook filters by brand_name)
+    // Should filter by source_platform, not brand_name
     expect(result.current.filteredFeedback).toHaveLength(1)
-    expect(result.current.filteredFeedback[0].brand_name).toBe('BrandA')
+    expect(result.current.filteredFeedback[0].source_platform).toBe('webscraper')
+  })
+
+  it('does not filter by brand_name when source is selected', async () => {
+    // This test ensures we're filtering by source_platform, not brand_name
+    // If we filtered by brand_name, selecting 'webscraper' would return 0 results
+    // because no item has brand_name === 'webscraper'
+    const { result } = renderHook(
+      () => useFeedbackData(7, 'webscraper', [], 'all', [], 0, 'https://api.example.com', true),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // Should find the item with source_platform 'webscraper'
+    expect(result.current.filteredFeedback.length).toBeGreaterThan(0)
+    expect(result.current.filteredFeedback.every(item => item.source_platform === 'webscraper')).toBe(true)
   })
 
   it('passes sentiment filter to API', async () => {

--- a/voc-datalake/frontend/src/pages/Categories/useCategoriesData.ts
+++ b/voc-datalake/frontend/src/pages/Categories/useCategoriesData.ts
@@ -133,7 +133,7 @@ export function useFeedbackData(
     return feedbackData.items.filter(item => {
       if (minRating > 0 && (!item.rating || item.rating < minRating)) return false
       if (selectedCategories.length > 1 && !selectedCategories.includes(item.category)) return false
-      if (selectedSource && item.brand_name !== selectedSource) return false
+      if (selectedSource && item.source_platform !== selectedSource) return false
       if (selectedKeywords.length > 0) {
         const text = (item.original_text + ' ' + (item.problem_summary || '')).toLowerCase()
         const hasKeyword = selectedKeywords.some(kw => text.includes(kw.toLowerCase()))

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.test.tsx
@@ -149,6 +149,24 @@ describe('ProblemAnalysis', () => {
       expect(expandButton).toBeTruthy()
     })
   })
+describe('source filtering', () => {
+    it('renders source filter dropdown with available sources', async () => {
+      render(<ProblemAnalysis />, { wrapper: createWrapper() })
+
+      // Wait for loading to complete
+      await waitFor(() => {
+        expect(document.querySelector('.animate-spin')).not.toBeInTheDocument()
+      })
+
+      // The source filter dropdown should be present with "All Sources" option
+      const sourceSelects = document.querySelectorAll('select')
+      expect(sourceSelects.length).toBeGreaterThan(0)
+      
+      // First select should have "All Sources" option
+      const firstSelect = sourceSelects[0]
+      expect(firstSelect.querySelector('option[value=""]')).toBeTruthy()
+    })
+  })
 })
 
 // Note: Testing "not configured" state requires module re-mocking which is complex

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -246,7 +246,7 @@ export default function ProblemAnalysis() {
       .filter(item => !showUrgentOnly || item.urgency === 'high')
       .filter(item => !selectedCategory || item.category === selectedCategory)
       .filter(item => !selectedSubcategory || item.subcategory === selectedSubcategory)
-      .filter(item => !selectedSource || item.brand_name === selectedSource)
+      .filter(item => !selectedSource || item.source_platform === selectedSource)
 
     for (const item of filteredItems) {
       const category = item.category || 'uncategorized'


### PR DESCRIPTION
Fixes #17

The source filter in ProblemAnalysis and Categories pages was incorrectly comparing against item.brand_name instead of item.source_platform, causing the filter to return zero results.

Changes:
- ProblemAnalysis.tsx: Changed filter to use source_platform
- useCategoriesData.ts: Changed filter to use source_platform
- Updated tests to verify correct field is used for filtering

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
