### PR TITLE
fix: add frontend CloudFront domain to avatars CDN CORS policy

### DIFF
--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -57,7 +57,8 @@ export class VocCoreStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VocCoreStackProps) {
     super(scope, id, props);
 
-    const corsAllowedOrigins = ['http://localhost:5173', 'http://localhost:3000'];
+    // Base CORS origins for localhost development
+    const corsAllowedOriginsBase = ['http://localhost:5173', 'http://localhost:3000'];
 
     // ============================================
     // KMS KEY
@@ -96,7 +97,7 @@ export class VocCoreStack extends cdk.Stack {
       serverAccessLogsPrefix: 'raw-data-bucket/',
       cors: [{
         allowedMethods: [s3.HttpMethods.GET],
-        allowedOrigins: corsAllowedOrigins,
+        allowedOrigins: corsAllowedOriginsBase,
         allowedHeaders: ['*'],
         maxAge: 3600,
       }],
@@ -118,7 +119,36 @@ export class VocCoreStack extends cdk.Stack {
     // CLOUDFRONT DISTRIBUTIONS
     // ============================================
     
-    // Avatars CDN
+    // Frontend hosting distribution (created first so we can use its domain for CORS)
+    this.frontendDistribution = new cloudfront.Distribution(this, 'FrontendDistribution', {
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(this.websiteBucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+        compress: true,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+      },
+      defaultRootObject: 'index.html',
+      errorResponses: [
+        { httpStatus: 404, responseHttpStatus: 200, responsePagePath: '/index.html', ttl: cdk.Duration.minutes(5) },
+        { httpStatus: 403, responseHttpStatus: 200, responsePagePath: '/index.html', ttl: cdk.Duration.minutes(5) },
+      ],
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      enableLogging: true,
+      logBucket: this.accessLogsBucket,
+      logFilePrefix: 'cloudfront-frontend/',
+    });
+    NagSuppressions.addResourceSuppressions(this.frontendDistribution, cloudfrontDefaultCertSuppressions);
+    this.frontendDomainName = this.frontendDistribution.distributionDomainName;
+
+    // CORS origins including the production frontend domain
+    const corsAllowedOrigins = [
+      ...corsAllowedOriginsBase,
+      `https://${this.frontendDomainName}`,
+    ];
+    
+    // Avatars CDN (created after frontend so we can include its domain in CORS)
     const avatarsCorsPolicy = new cloudfront.ResponseHeadersPolicy(this, 'AvatarsCorsPolicy', {
       responseHeadersPolicyName: uniqueName('voc-avatars-cors-policy'),
       corsBehavior: {
@@ -152,29 +182,6 @@ export class VocCoreStack extends cdk.Stack {
     cdk.Annotations.of(this).acknowledgeWarning('@aws-cdk/aws-cloudfront-origins:wildcardKeyPolicyForOac');
     NagSuppressions.addResourceSuppressions(avatarsDistribution, cloudfrontDefaultCertSuppressions);
     this.avatarsCdnUrl = `https://${avatarsDistribution.distributionDomainName}`;
-
-    // Frontend hosting distribution
-    this.frontendDistribution = new cloudfront.Distribution(this, 'FrontendDistribution', {
-      defaultBehavior: {
-        origin: origins.S3BucketOrigin.withOriginAccessControl(this.websiteBucket),
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
-        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
-        compress: true,
-        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
-      },
-      defaultRootObject: 'index.html',
-      errorResponses: [
-        { httpStatus: 404, responseHttpStatus: 200, responsePagePath: '/index.html', ttl: cdk.Duration.minutes(5) },
-        { httpStatus: 403, responseHttpStatus: 200, responsePagePath: '/index.html', ttl: cdk.Duration.minutes(5) },
-      ],
-      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
-      enableLogging: true,
-      logBucket: this.accessLogsBucket,
-      logFilePrefix: 'cloudfront-frontend/',
-    });
-    NagSuppressions.addResourceSuppressions(this.frontendDistribution, cloudfrontDefaultCertSuppressions);
-    this.frontendDomainName = this.frontendDistribution.distributionDomainName;
 
 
     // ============================================

--- a/voc-datalake/package-lock.json
+++ b/voc-datalake/package-lock.json
@@ -973,7 +973,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1543,8 +1542,7 @@
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.4.tgz",
       "integrity": "sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1732,7 +1730,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1939,7 +1936,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1968,7 +1964,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
Fixes #16

The avatars CDN CORS policy only included localhost origins, causing avatar images to fail loading during PDF export from the production frontend.

Changes:
- Reordered CloudFront distribution creation so frontend is created first
- Added frontend CloudFront domain to avatars CDN CORS allowed origins
- This allows the frontend to fetch avatar images for PDF generation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
