### PR TITLE
fix: sync config store with runtime config on app load

### DIFF
--- a/voc-datalake/frontend/src/App.tsx
+++ b/voc-datalake/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import AdminRoute from './components/AdminRoute'
 import PageLoader from './components/PageLoader'
 import Login from './pages/Login'
 import { loadRuntimeConfig, isConfigLoaded } from './runtimeConfig'
+import { useConfigStore } from './store/configStore'
 
 // Lazy load pages for better code splitting
 const Dashboard = lazy(() => import('./pages/Dashboard'))
@@ -68,17 +69,23 @@ const router = createBrowserRouter([
 export default function App() {
   const [configReady, setConfigReady] = useState(isConfigLoaded())
   const [error, setError] = useState<string | null>(null)
+  const syncWithRuntimeConfig = useConfigStore((state) => state.syncWithRuntimeConfig)
 
   useEffect(() => {
     if (!configReady) {
       loadRuntimeConfig()
-        .then(() => setConfigReady(true))
+        .then(() => {
+          // Sync the config store with runtime config to ensure
+          // first-time users get the correct API endpoint
+          syncWithRuntimeConfig()
+          setConfigReady(true)
+        })
         .catch((err) => {
           console.error('Failed to load config:', err)
           setError('Failed to load application configuration')
         })
     }
-  }, [configReady])
+  }, [configReady, syncWithRuntimeConfig])
 
   if (error) {
     return (

--- a/voc-datalake/frontend/src/store/configStore.test.ts
+++ b/voc-datalake/frontend/src/store/configStore.test.ts
@@ -1,8 +1,18 @@
 /**
  * @fileoverview Tests for configStore Zustand store.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useConfigStore } from './configStore'
+import * as runtimeConfig from '../runtimeConfig'
+
+// Mock the runtimeConfig module
+vi.mock('../runtimeConfig', () => ({
+  isConfigLoaded: vi.fn(() => false),
+  getRuntimeConfig: vi.fn(() => ({
+    apiEndpoint: 'https://runtime-api.example.com',
+    cognito: { userPoolId: 'pool-123', clientId: 'client-123', region: 'us-east-1' }
+  }))
+}))
 
 describe('configStore', () => {
   beforeEach(() => {
@@ -105,6 +115,52 @@ describe('configStore', () => {
 
       const { customDateRange } = useConfigStore.getState()
       expect(customDateRange).toBeNull()
+    })
+  })
+
+  describe('syncWithRuntimeConfig', () => {
+    it('updates apiEndpoint from runtime config when config is loaded', () => {
+      // Mock isConfigLoaded to return true
+      vi.mocked(runtimeConfig.isConfigLoaded).mockReturnValue(true)
+      vi.mocked(runtimeConfig.getRuntimeConfig).mockReturnValue({
+        apiEndpoint: 'https://runtime-api.example.com',
+        cognito: { userPoolId: 'pool-123', clientId: 'client-123', region: 'us-east-1' }
+      })
+
+      const { syncWithRuntimeConfig } = useConfigStore.getState()
+      syncWithRuntimeConfig()
+
+      const { config } = useConfigStore.getState()
+      expect(config.apiEndpoint).toBe('https://runtime-api.example.com')
+    })
+
+    it('does not update apiEndpoint when runtime config is not loaded', () => {
+      vi.mocked(runtimeConfig.isConfigLoaded).mockReturnValue(false)
+
+      const { syncWithRuntimeConfig, setConfig } = useConfigStore.getState()
+      setConfig({ apiEndpoint: 'https://local-api.example.com' })
+      syncWithRuntimeConfig()
+
+      const { config } = useConfigStore.getState()
+      expect(config.apiEndpoint).toBe('https://local-api.example.com')
+    })
+
+    it('does not update when runtime endpoint matches store endpoint', () => {
+      vi.mocked(runtimeConfig.isConfigLoaded).mockReturnValue(true)
+      vi.mocked(runtimeConfig.getRuntimeConfig).mockReturnValue({
+        apiEndpoint: 'https://same-api.example.com',
+        cognito: { userPoolId: 'pool-123', clientId: 'client-123', region: 'us-east-1' }
+      })
+
+      const { syncWithRuntimeConfig, setConfig } = useConfigStore.getState()
+      setConfig({ apiEndpoint: 'https://same-api.example.com' })
+      
+      const setStateSpy = vi.spyOn(useConfigStore, 'setState')
+      syncWithRuntimeConfig()
+
+      // setState should not be called since endpoints match
+      expect(setStateSpy).not.toHaveBeenCalled()
+      setStateSpy.mockRestore()
     })
   })
 })

--- a/voc-datalake/frontend/src/store/configStore.ts
+++ b/voc-datalake/frontend/src/store/configStore.ts
@@ -26,6 +26,7 @@ interface ConfigStore {
   setConfig: (config: Partial<Config>) => void
   setTimeRange: (range: '24h' | '48h' | '7d' | '30d' | 'custom') => void
   setCustomDateRange: (range: { start: string; end: string } | null) => void
+  syncWithRuntimeConfig: () => void
 }
 
 const defaultSourceConfig: SourceConfig = {
@@ -50,7 +51,7 @@ function getApiEndpoint(): string {
 
 export const useConfigStore = create<ConfigStore>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       config: {
         apiEndpoint: getApiEndpoint(),
         brandName: '',
@@ -68,6 +69,24 @@ export const useConfigStore = create<ConfigStore>()(
       })),
       setTimeRange: (range) => set({ timeRange: range }),
       setCustomDateRange: (range) => set({ customDateRange: range }),
+      /**
+       * Syncs the store's apiEndpoint with the runtime config.
+       * This ensures first-time users get the correct API endpoint
+       * from the deployed config.json rather than relying on localStorage.
+       */
+      syncWithRuntimeConfig: () => {
+        if (isConfigLoaded()) {
+          const runtimeConfig = getRuntimeConfig()
+          const currentConfig = get().config
+          // Only update if runtime config has a valid endpoint and store doesn't
+          // or if they differ (runtime config takes precedence)
+          if (runtimeConfig.apiEndpoint && runtimeConfig.apiEndpoint !== currentConfig.apiEndpoint) {
+            set((state) => ({
+              config: { ...state.config, apiEndpoint: runtimeConfig.apiEndpoint }
+            }))
+          }
+        }
+      }
     }),
     { name: 'voc-config' }
   )


### PR DESCRIPTION
Fixes #35

The Dashboard was showing 'Go to Settings' for first-time users even when brand settings were already configured. This happened because:

1. The configStore persists to localStorage
2. First-time users have empty localStorage
3. The Dashboard checked config.apiEndpoint from the store, not runtime config

Solution:
- Added syncWithRuntimeConfig() to configStore that updates the store's apiEndpoint from runtime config when it differs
- Call syncWithRuntimeConfig() in App.tsx after loadRuntimeConfig() completes
- This ensures first-time users get the correct API endpoint from config.json

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
