### PR TITLE
fix: replace MD5 with SHA-256 for content hashing

### DIFF
--- a/docs/processing-pipeline.md
+++ b/docs/processing-pipeline.md
@@ -80,7 +80,7 @@ The processor prevents duplicate entries using deterministic IDs.
 feedback_id = hash(f"{source_platform}:{source_id}")
 
 # Fallback for scraped content
-text_hash = md5(text[:500])
+text_hash = sha256(text[:500])
 feedback_id = hash(f"{source_platform}:{created_at}:{text_hash}:{url}")
 ```
 

--- a/voc-datalake/lambda/processor/handler.py
+++ b/voc-datalake/lambda/processor/handler.py
@@ -428,7 +428,7 @@ def generate_deterministic_id(source_platform: str, source_id: str, text: str = 
     else:
         # Fallback: generate ID from content signature
         # Use text hash (first 500 chars to handle minor variations)
-        text_hash = hashlib.md5(text[:500].encode()).hexdigest()[:16] if text else ''
+        text_hash = hashlib.sha256(text[:500].encode()).hexdigest()[:16] if text else ''
         # Include created_at (review date) to differentiate reviews with similar text
         # Include URL for additional uniqueness
         content = f"{source_platform}:{created_at}:{text_hash}:{url}"

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -135,7 +135,7 @@ class BaseIngestor(ABC):
         created_at = item.get("created_at", "")
         url = item.get("url", "")
         
-        text_hash = hashlib.md5(text[:500].encode()).hexdigest()[:16] if text else ""
+        text_hash = hashlib.sha256(text[:500].encode()).hexdigest()[:16] if text else ""
         content = f"{created_at}:{text_hash}:{url}"
         return hashlib.sha256(content.encode()).hexdigest()[:32]
 

--- a/voc-datalake/plugins/_shared/test/test_base_ingestor.py
+++ b/voc-datalake/plugins/_shared/test/test_base_ingestor.py
@@ -425,7 +425,7 @@ class TestBaseIngestorGenerateDeterministicId:
         result = ingestor._generate_deterministic_id(item)
         
         # Should generate deterministic SHA-256 hash (32 hex chars)
-        assert result == '6f8bcf85bf9acfa69ffa24b8754a38c1'
+        assert result == '4f06ec9dc8d32cd7b2585b137a910cd5'
 
     @patch('_shared.base_ingestor.get_dynamodb_resource')
     @patch('_shared.base_ingestor.get_s3_client')


### PR DESCRIPTION
## Summary
Replaces weak MD5 cryptographic hash with SHA-256 for content hashing.

## Changes
- `voc-datalake/plugins/_shared/base_ingestor.py` - MD5 → SHA-256
- `voc-datalake/lambda/processor/handler.py` - MD5 → SHA-256
- `docs/processing-pipeline.md` - Updated documentation
- `voc-datalake/plugins/_shared/test/test_base_ingestor.py` - Updated expected hash

## Security
Resolves CodeQL alert: `py/weak-sensitive-data-hashing`

MD5 is considered cryptographically weak. SHA-256 provides stronger collision resistance.