### PR TITLE
fix: optimize Lambda bundles to include only required handler code

### DIFF
--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -727,6 +727,6 @@ curl -X POST "$STREAM_URL/chat/stream" \
 | Issue | Cause | Solution |
 |-------|-------|----------|
 | `No module named 'pydantic_core._pydantic_core'` | Layer built for wrong architecture | Rebuild with `./scripts/build-layers.sh` (uses ARM64) |
-| `No module named 'shared'` | Lambda code bundling issue | Check `apiCodeWithShared` bundling in analytics-stack.ts |
+| `No module named 'shared'` | Lambda code bundling issue | Check `createApiLambdaCode` bundling in api-stack.ts |
 | 502 errors | Lambda import/runtime error | Check CloudWatch logs for specific error |
 | CORS errors on 4XX/5XX | Missing gateway responses | Ensure `addGatewayResponse` for DEFAULT_4XX/5XX |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -62,8 +62,29 @@ npm run check        # lint + typecheck + test
 |---------|-------------|
 | `npm run lint` | Runs ESLint to catch code quality issues |
 | `npm run typecheck` | Runs TypeScript compiler to verify types |
-| `npm run test` | Runs Vitest test suite |
+| `npm run test` | Runs Vitest test suite (frontend + CDK) |
 | `npm run test:coverage` | Runs tests with coverage report |
+
+### Python Lambda Tests
+
+Lambda handlers have their own test suite using pytest:
+
+```bash
+cd voc-datalake
+
+# Run all Lambda tests
+pytest
+
+# Run with coverage report
+pytest --cov=lambda --cov-report=html:coverage_html
+
+# Run specific handler tests
+pytest lambda/processor/test/
+pytest lambda/aggregator/test/
+pytest lambda/api/test/
+```
+
+Test coverage reports are generated in `voc-datalake/coverage_html/`.
 
 ## Anthropic Model Access (First-Time Setup)
 

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,58 @@
+## Summary
+
+Optimizes Lambda deployment bundles so each API Lambda only includes the code it needs, rather than bundling all handlers together.
+
+## Problem
+
+Previously, all API Lambda functions shared a single code bundle containing every handler file:
+
+```
+lambda-deployment.zip
+├── metrics_handler.py
+├── chat_handler.py
+├── integrations_handler.py
+├── scrapers_handler.py
+├── settings_handler.py
+├── projects_handler.py
+├── ... (all other API handlers)
+└── shared/
+```
+
+This meant each Lambda had large amounts of unused code, increasing deployment size and cold start times.
+
+## Solution
+
+Introduced a `createApiLambdaCode()` helper function that creates optimized bundles per Lambda:
+
+```typescript
+const createApiLambdaCode = (handlerFileName: string): lambda.Code => {
+  return lambda.Code.fromAsset('lambda', {
+    bundling: {
+      image: lambda.Runtime.PYTHON_3_14.bundlingImage,
+      command: [
+        'bash', '-c',
+        `mkdir -p /asset-output && ` +
+        `cp /asset-input/api/${handlerFileName} /asset-output/ && ` +
+        `cp -r /asset-input/shared /asset-output/`
+      ],
+      platform: 'linux/arm64',
+    },
+  });
+};
+```
+
+Now each Lambda receives only:
+- Its specific handler file (e.g., `metrics_handler.py`)
+- The `shared/` directory with common modules
+
+## Changes
+
+- Replaced shared `apiCodeWithShared` variable with `createApiLambdaCode()` helper
+- Updated all 14 API Lambda functions to use optimized individual bundles
+
+## Testing
+
+- TypeScript compilation passes
+- All existing tests pass
+
+Closes #1

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -85,14 +85,27 @@ export class VocApiStack extends cdk.Stack {
       description: 'Dependencies for API lambdas (ARM64/Graviton)',
     });
 
-    // Bundled Lambda code
-    const apiCodeWithShared = lambda.Code.fromAsset('lambda', {
-      bundling: {
-        image: lambda.Runtime.PYTHON_3_14.bundlingImage,
-        command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/api/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],
-        platform: 'linux/arm64',
-      },
-    });
+    /**
+     * Creates an optimized Lambda code bundle containing only the specified handler
+     * and the shared modules. This reduces deployment size and improves cold start times.
+     * 
+     * @param handlerFileName - The handler file name (e.g., 'metrics_handler.py')
+     * @returns Lambda Code asset with only the required files
+     */
+    const createApiLambdaCode = (handlerFileName: string): lambda.Code => {
+      return lambda.Code.fromAsset('lambda', {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_14.bundlingImage,
+          command: [
+            'bash', '-c',
+            `mkdir -p /asset-output && ` +
+            `cp /asset-input/api/${handlerFileName} /asset-output/ && ` +
+            `cp -r /asset-input/shared /asset-output/`
+          ],
+          platform: 'linux/arm64',
+        },
+      });
+    };
 
     // ============================================
     // LAMBDA FUNCTIONS
@@ -109,7 +122,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'metrics_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('metrics_handler.py'),
       role: metricsRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 512,
@@ -140,7 +153,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'integrations_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('integrations_handler.py'),
       role: integrationsRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -179,7 +192,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'scrapers_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('scrapers_handler.py'),
       role: scrapersRole,
       timeout: cdk.Duration.seconds(60),
       memorySize: 512,
@@ -202,7 +215,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'manual_import_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('manual_import_handler.py'),
       role: manualImportRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -233,7 +246,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'manual_import_processor.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('manual_import_processor.py'),
       role: manualImportProcessorRole,
       timeout: cdk.Duration.minutes(5),
       memorySize: 1024,
@@ -256,7 +269,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'settings_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('settings_handler.py'),
       role: settingsRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -275,7 +288,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'logs_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('logs_handler.py'),
       role: logsRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -296,7 +309,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'users_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('users_handler.py'),
       role: usersRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -317,7 +330,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'feedback_form_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('feedback_form_handler.py'),
       role: feedbackFormRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -342,7 +355,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'chat_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('chat_handler.py'),
       role: chatRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 512,
@@ -376,7 +389,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'projects_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('projects_handler.py'),
       role: projectsRole,
       timeout: cdk.Duration.minutes(15),
       memorySize: 1024,
@@ -412,7 +425,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'chat_stream_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('chat_stream_handler.py'),
       role: chatStreamRole,
       timeout: cdk.Duration.minutes(5),
       memorySize: 1024,
@@ -445,7 +458,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 's3_import_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('s3_import_handler.py'),
       role: s3ImportRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
@@ -466,7 +479,7 @@ export class VocApiStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'data_explorer_handler.lambda_handler',
-      code: apiCodeWithShared,
+      code: createApiLambdaCode('data_explorer_handler.py'),
       role: dataExplorerRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,


### PR DESCRIPTION
## Summary

Optimizes Lambda deployment bundles so each API Lambda only includes the code it needs, rather than bundling all handlers together.

## Problem

Previously, all API Lambda functions shared a single code bundle containing every handler file:

```
lambda-deployment.zip
├── metrics_handler.py
├── chat_handler.py
├── integrations_handler.py
├── scrapers_handler.py
├── settings_handler.py
├── projects_handler.py
├── ... (all other API handlers)
└── shared/
```

This meant each Lambda had large amounts of unused code, increasing deployment size and cold start times.

## Solution

Introduced a `createApiLambdaCode()` helper function that creates optimized bundles per Lambda:

```typescript
const createApiLambdaCode = (handlerFileName: string): lambda.Code => {
  return lambda.Code.fromAsset('lambda', {
    bundling: {
      image: lambda.Runtime.PYTHON_3_14.bundlingImage,
      command: [
        'bash', '-c',
        `mkdir -p /asset-output && ` +
        `cp /asset-input/api/${handlerFileName} /asset-output/ && ` +
        `cp -r /asset-input/shared /asset-output/`
      ],
      platform: 'linux/arm64',
    },
  });
};
```

Now each Lambda receives only:
- Its specific handler file (e.g., `metrics_handler.py`)
- The `shared/` directory with common modules

## Changes

- Replaced shared `apiCodeWithShared` variable with `createApiLambdaCode()` helper
- Updated all 14 API Lambda functions to use optimized individual bundles

## Testing

- TypeScript compilation passes
- All existing tests pass

Closes #1
