### PR TITLE
feat: move async job handlers to separate Lambdas

### DIFF
--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -5,18 +5,14 @@ Separate Lambda to handle projects endpoints and avoid policy size limits.
 
 import json
 import os
-import base64
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import Any
 
 from shared.logging import logger, tracer
-from shared.aws import (
-    get_dynamodb_resource, get_bedrock_client, invoke_self_async, BEDROCK_MODEL_ID
-)
+from shared.aws import invoke_lambda_async
 from shared.api import create_api_resolver, validate_days, validate_int, api_handler, DecimalEncoder
-from shared.converse import converse
 from shared.tables import get_jobs_table, get_aggregates_table
-from shared.jobs import create_job, update_job_status, job_handler, JobContext
+from shared.jobs import create_job
 from shared.exceptions import NotFoundError, ServiceError
 
 from boto3.dynamodb.conditions import Key
@@ -28,16 +24,18 @@ from projects import (
     create_document, update_document, delete_document,
     create_persona, update_persona, delete_persona,
     add_persona_note, update_persona_note, delete_persona_note,
-    regenerate_persona_avatar, generate_persona_avatar, get_avatar_cdn_url,
+    regenerate_persona_avatar,
 )
 
 # API resolver with standard CORS
 app = create_api_resolver()
 
-# Environment
-PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
-FEEDBACK_TABLE = os.environ.get('FEEDBACK_TABLE', '')
-RAW_DATA_BUCKET = os.environ.get('RAW_DATA_BUCKET', '')
+# Environment - Job Lambda function names
+PERSONA_GENERATOR_FUNCTION = os.environ.get('PERSONA_GENERATOR_FUNCTION', '')
+DOCUMENT_GENERATOR_FUNCTION = os.environ.get('DOCUMENT_GENERATOR_FUNCTION', '')
+DOCUMENT_MERGER_FUNCTION = os.environ.get('DOCUMENT_MERGER_FUNCTION', '')
+PERSONA_IMPORTER_FUNCTION = os.environ.get('PERSONA_IMPORTER_FUNCTION', '')
+
 
 def validate_persona_count(value, default=3):
     """Validate persona count parameter."""
@@ -105,7 +103,11 @@ def api_import_persona(project_id: str):
         'media_type': body.get('media_type', '')
     }
     job_id, _ = create_job(project_id, 'import_persona', 'import_config', config)
-    invoke_self_async({'job_type': 'import_persona', 'project_id': project_id, 'job_id': job_id, 'import_config': config})
+    invoke_lambda_async(PERSONA_IMPORTER_FUNCTION, {
+        'project_id': project_id,
+        'job_id': job_id,
+        'import_config': config
+    })
     return {'success': True, 'job_id': job_id, 'status': 'running', 'message': 'Persona import started.'}
 
 
@@ -159,7 +161,11 @@ def api_generate_personas(project_id: str):
         'custom_instructions': body.get('custom_instructions', ''),
     }
     job_id, _ = create_job(project_id, 'generate_personas', 'filters', filters, ttl_minutes=30*24*60)
-    invoke_self_async({'job_type': 'generate_personas', 'project_id': project_id, 'job_id': job_id, 'filters': filters})
+    invoke_lambda_async(PERSONA_GENERATOR_FUNCTION, {
+        'project_id': project_id,
+        'job_id': job_id,
+        'filters': filters
+    })
     return {'success': True, 'job_id': job_id, 'status': 'running', 'message': 'Persona generation started.'}
 
 
@@ -211,7 +217,11 @@ def api_generate_document(project_id: str):
     body = app.current_event.json_body or {}
     doc_type = body.get('doc_type', 'prd')
     job_id, _ = create_job(project_id, f'generate_{doc_type}', 'doc_config', body, status='pending')
-    invoke_self_async({'job_type': f'generate_{doc_type}', 'project_id': project_id, 'job_id': job_id, 'doc_config': body})
+    invoke_lambda_async(DOCUMENT_GENERATOR_FUNCTION, {
+        'project_id': project_id,
+        'job_id': job_id,
+        'doc_config': body
+    })
     return {'success': True, 'job_id': job_id, 'status': 'pending', 'message': f'{doc_type.upper()} generation started.'}
 
 
@@ -227,7 +237,11 @@ def api_merge_documents(project_id: str):
     """Merge multiple documents."""
     body = app.current_event.json_body or {}
     job_id, _ = create_job(project_id, 'merge_documents', 'merge_config', body, status='pending')
-    invoke_self_async({'job_type': 'merge_documents', 'project_id': project_id, 'job_id': job_id, 'merge_config': body})
+    invoke_lambda_async(DOCUMENT_MERGER_FUNCTION, {
+        'project_id': project_id,
+        'job_id': job_id,
+        'merge_config': body
+    })
     return {'success': True, 'job_id': job_id, 'status': 'pending', 'message': 'Document merge started.'}
 
 
@@ -341,347 +355,6 @@ def api_patch_prioritization_scores():
 
 
 # ============================================
-# Async Job Handlers
-# ============================================
-
-@job_handler(error_message='Persona generation failed')
-def handle_generate_personas_job(ctx: JobContext, project_id: str, job_id: str, filters: dict) -> dict:
-    """Handle async persona generation job."""
-    def progress_callback(progress: int, step: str):
-        ctx.update_progress(progress, step)
-    
-    result = generate_personas(project_id, filters, progress_callback=progress_callback)
-    return result
-
-
-@job_handler(error_message='Document generation failed')
-def handle_generate_document_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) -> dict:
-    """Handle async document generation job (PRD/PRFAQ)."""
-    dynamodb = get_dynamodb_resource()
-    projects_table = dynamodb.Table(PROJECTS_TABLE)
-    feedback_table = dynamodb.Table(FEEDBACK_TABLE)
-    
-    ctx.update_progress(10, 'gathering_context')
-    
-    doc_type = doc_config.get('doc_type', 'prd')
-    title = doc_config.get('title', 'Untitled')
-    feature_idea = doc_config.get('feature_idea', '')
-    data_sources = doc_config.get('data_sources', {})
-    customer_questions = doc_config.get('customer_questions', [])
-    
-    context_parts = []
-    
-    # Gather feedback
-    if data_sources.get('feedback'):
-        ctx.update_progress(20, 'fetching_feedback')
-        feedback_sources = doc_config.get('feedback_sources', [])
-        feedback_categories = doc_config.get('feedback_categories', [])
-        days = doc_config.get('days', 30)
-        
-        feedback_items = []
-        current_date = datetime.now(timezone.utc)
-        for i in range(min(days, 14)):
-            date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-            resp = feedback_table.query(
-                IndexName='gsi1-by-date',
-                KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=100, ScanIndexForward=False
-            )
-            feedback_items.extend(resp.get('Items', []))
-            if len(feedback_items) >= 100:
-                break
-        
-        if feedback_sources:
-            feedback_items = [f for f in feedback_items if f.get('source_platform') in feedback_sources]
-        if feedback_categories:
-            feedback_items = [f for f in feedback_items if f.get('category') in feedback_categories]
-        
-        if feedback_items:
-            feedback_text = "## Customer Feedback\n\n"
-            for i, item in enumerate(feedback_items[:30], 1):
-                feedback_text += f"**Review {i}** ({item.get('source_platform', 'unknown')}, {item.get('sentiment_label', 'unknown')}): {item.get('original_text', '')[:300]}\n\n"
-            context_parts.append(feedback_text)
-    
-    # Gather personas
-    if data_sources.get('personas'):
-        ctx.update_progress(30, 'fetching_personas')
-        selected_ids = doc_config.get('selected_persona_ids', [])
-        resp = projects_table.query(KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'))
-        personas = [i for i in resp.get('Items', []) if i.get('sk', '').startswith('PERSONA#')]
-        if selected_ids:
-            personas = [p for p in personas if p.get('persona_id') in selected_ids]
-        if personas:
-            persona_text = "## User Personas\n\n"
-            for p in personas:
-                persona_text += f"**{p.get('name')}**: {p.get('tagline', '')}\n- Goals: {', '.join(p.get('goals', [])[:3])}\n- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n\n"
-            context_parts.append(persona_text)
-    
-    # Gather documents
-    if data_sources.get('documents') or data_sources.get('research'):
-        ctx.update_progress(40, 'fetching_documents')
-        selected_ids = doc_config.get('selected_document_ids', [])
-        resp = projects_table.query(KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'))
-        docs = [i for i in resp.get('Items', []) if i.get('sk', '').startswith(('RESEARCH#', 'PRD#', 'PRFAQ#', 'DOC#'))]
-        if selected_ids:
-            docs = [d for d in docs if d.get('document_id') in selected_ids]
-        if docs:
-            doc_text = "## Reference Documents\n\n"
-            for d in docs[:3]:
-                doc_text += f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:3000]}\n\n"
-            context_parts.append(doc_text)
-    
-    ctx.update_progress(50, 'generating_document')
-    context = '\n\n'.join(context_parts) if context_parts else 'No additional context provided.'
-    
-    # Build prompts based on doc type
-    if doc_type == 'prd':
-        system_prompt = """You are a senior product manager creating a Product Requirements Document (PRD).
-Create a comprehensive PRD that includes: Problem Statement, Goals & Success Metrics, User Stories, Requirements (functional & non-functional), Out of Scope, Timeline, and Risks."""
-        user_prompt = f"Create a PRD for: {title}\n\nFeature Description: {feature_idea}\n\n{context}\n\nGenerate a complete PRD in markdown format."
-    else:
-        q_labels = ["Who is the customer?", "What is the customer problem or opportunity?", "What is the most important customer benefit?", "How do you know what customers need or want?", "What does the customer experience look like?"]
-        questions_context = "\n\n".join([f"**{q_labels[i]}**\n{q.strip()}" for i, q in enumerate(customer_questions[:5]) if q and q.strip()])
-        system_prompt = """You are creating an Amazon-style Working Backwards PR-FAQ document. Write in "Oprah-speak" NOT "Geek-speak". Keep it simple. This is NOT a spec - it's a customer-focused announcement."""
-        user_prompt = f"Create an Amazon Working Backwards PR-FAQ for: {title}\n\nFeature Description: {feature_idea}\n\n## Working Backwards Input:\n{questions_context or 'Use the customer feedback context below.'}\n\n{context}\n\nGenerate a COMPLETE PR-FAQ with PRESS RELEASE, CUSTOMER FAQ (10 questions), and INTERNAL FAQ (10 questions)."
-    
-    ctx.update_progress(60, 'calling_ai')
-    max_tokens = 8000 if doc_type == 'prfaq' else 5000
-    content = converse(prompt=user_prompt, system_prompt=system_prompt, max_tokens=max_tokens)
-    
-    ctx.update_progress(90, 'saving_document')
-    now = datetime.now(timezone.utc).isoformat()
-    doc_id = f"{doc_type}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
-    
-    projects_table.put_item(Item={
-        'pk': f'PROJECT#{project_id}', 'sk': f'{doc_type.upper()}#{doc_id}',
-        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS', 'gsi1sk': now,
-        'document_id': doc_id, 'document_type': doc_type, 'title': title,
-        'content': content, 'job_id': job_id, 'created_at': now,
-    })
-    projects_table.update_item(
-        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
-        UpdateExpression='SET document_count = document_count + :one, updated_at = :now',
-        ExpressionAttributeValues={':one': 1, ':now': now}
-    )
-    
-    return {'document_id': doc_id, 'title': title}
-
-
-@job_handler(error_message='Document merge failed')
-def handle_merge_documents_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict) -> dict:
-    """Handle async document merge job."""
-    dynamodb = get_dynamodb_resource()
-    projects_table = dynamodb.Table(PROJECTS_TABLE)
-    feedback_table = dynamodb.Table(FEEDBACK_TABLE)
-    
-    ctx.update_progress(10, 'gathering_documents')
-    
-    output_type = merge_config.get('output_type', 'custom')
-    title = merge_config.get('title', 'Merged Document')
-    instructions = merge_config.get('instructions', '')
-    selected_doc_ids = merge_config.get('selected_document_ids', [])
-    selected_persona_ids = merge_config.get('selected_persona_ids', [])
-    use_feedback = merge_config.get('use_feedback', False)
-    
-    resp = projects_table.query(KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'))
-    all_items = resp.get('Items', [])
-    
-    docs = [i for i in all_items if i.get('sk', '').startswith(('RESEARCH#', 'PRD#', 'PRFAQ#', 'DOC#'))]
-    selected_docs = [d for d in docs if d.get('document_id') in selected_doc_ids]
-    
-    if len(selected_docs) < 2:
-        raise ValueError("At least 2 documents are required for merging")
-    
-    ctx.update_progress(20, 'preparing_context')
-    
-    doc_context = "## SOURCE DOCUMENTS TO MERGE\n\n"
-    for i, doc in enumerate(selected_docs, 1):
-        doc_context += f"### Document {i}: {doc.get('title', 'Untitled')} ({doc.get('document_type', 'unknown').upper()})\n\n{doc.get('content', '')[:8000]}\n\n---\n\n"
-    
-    context_parts = [doc_context]
-    
-    if selected_persona_ids:
-        ctx.update_progress(30, 'fetching_personas')
-        personas = [i for i in all_items if i.get('sk', '').startswith('PERSONA#')]
-        selected_personas = [p for p in personas if p.get('persona_id') in selected_persona_ids]
-        if selected_personas:
-            persona_text = "## USER PERSONAS FOR CONTEXT\n\n"
-            for p in selected_personas:
-                persona_text += f"**{p.get('name')}**: {p.get('tagline', '')}\n- Goals: {', '.join(p.get('goals', [])[:3])}\n- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n\n"
-            context_parts.append(persona_text)
-    
-    if use_feedback:
-        ctx.update_progress(40, 'fetching_feedback')
-        feedback_sources = merge_config.get('feedback_sources', [])
-        feedback_categories = merge_config.get('feedback_categories', [])
-        days = merge_config.get('days', 30)
-        
-        feedback_items = []
-        current_date = datetime.now(timezone.utc)
-        for i in range(min(days, 14)):
-            date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-            resp = feedback_table.query(
-                IndexName='gsi1-by-date',
-                KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=100, ScanIndexForward=False
-            )
-            feedback_items.extend(resp.get('Items', []))
-            if len(feedback_items) >= 100:
-                break
-        
-        if feedback_sources:
-            feedback_items = [f for f in feedback_items if f.get('source_platform') in feedback_sources]
-        if feedback_categories:
-            feedback_items = [f for f in feedback_items if f.get('category') in feedback_categories]
-        
-        if feedback_items:
-            feedback_text = "## ADDITIONAL CUSTOMER FEEDBACK\n\n"
-            for i, item in enumerate(feedback_items[:20], 1):
-                feedback_text += f"**Review {i}** ({item.get('source_platform', 'unknown')}, {item.get('sentiment_label', 'unknown')}): {item.get('original_text', '')[:250]}\n\n"
-            context_parts.append(feedback_text)
-    
-    ctx.update_progress(50, 'generating_merged_document')
-    context = '\n\n'.join(context_parts)
-    
-    if output_type == 'prd':
-        system_prompt = "You are a senior product manager creating a revised PRD. Merge and revise the provided source documents according to the user's instructions."
-    elif output_type == 'prfaq':
-        system_prompt = "You are creating a revised Amazon-style PR-FAQ. Merge and revise the provided source documents. Include PRESS RELEASE, CUSTOMER FAQ (10 questions), and INTERNAL FAQ (10 questions)."
-    else:
-        system_prompt = "You are a skilled document editor. Merge and revise the provided source documents according to the user's instructions."
-    
-    user_prompt = f"## MERGE INSTRUCTIONS\n{instructions}\n\n## OUTPUT DOCUMENT TITLE\n{title}\n\n{context}\n\nCreate a new {output_type.upper() if output_type != 'custom' else 'document'} incorporating all relevant feedback."
-    
-    ctx.update_progress(60, 'calling_ai')
-    max_tokens = 8000 if output_type == 'prfaq' else 6000
-    content = converse(prompt=user_prompt, system_prompt=system_prompt, max_tokens=max_tokens)
-    
-    ctx.update_progress(90, 'saving_document')
-    now = datetime.now(timezone.utc).isoformat()
-    doc_type_prefix = output_type if output_type in ['prd', 'prfaq'] else 'doc'
-    doc_id = f"{doc_type_prefix}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
-    
-    projects_table.put_item(Item={
-        'pk': f'PROJECT#{project_id}', 'sk': f'{doc_type_prefix.upper()}#{doc_id}',
-        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS', 'gsi1sk': now,
-        'document_id': doc_id, 'document_type': output_type if output_type in ['prd', 'prfaq'] else 'custom',
-        'title': title, 'content': content, 'job_id': job_id,
-        'source_documents': selected_doc_ids, 'merge_instructions': instructions, 'created_at': now,
-    })
-    projects_table.update_item(
-        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
-        UpdateExpression='SET document_count = document_count + :one, updated_at = :now',
-        ExpressionAttributeValues={':one': 1, ':now': now}
-    )
-    
-    return {'document_id': doc_id, 'title': title}
-
-
-@job_handler(error_message='Persona import failed')
-def handle_import_persona_job(ctx: JobContext, project_id: str, job_id: str, import_config: dict) -> dict:
-    """Handle async persona import job."""
-    dynamodb = get_dynamodb_resource()
-    projects_table = dynamodb.Table(PROJECTS_TABLE)
-    
-    ctx.update_progress(10, 'extracting_persona')
-    
-    input_type = import_config.get('input_type', 'text')
-    content = import_config.get('content', '')
-    media_type = import_config.get('media_type', '')
-    
-    logger.info(f"[IMPORT_PERSONA_JOB] Starting import from {input_type} for project {project_id}")
-    
-    system_prompt = """You are a UX researcher expert at extracting persona information from documents and images.
-Extract persona data from the provided input and output a structured JSON object.
-CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
-
-    json_schema = '{"name": "Full Name", "tagline": "One sentence", "confidence": "high", "identity": {...}, "goals_motivations": {...}, "pain_points": {...}, "behaviors": {...}, "context_environment": {...}, "quotes": [...], "scenario": {...}}'
-    
-    # Build converse content
-    converse_content = []
-    if input_type == 'image':
-        converse_content.append({
-            'image': {
-                'format': (media_type or 'image/png').split('/')[-1],
-                'source': {'bytes': base64.b64decode(content)}
-            }
-        })
-        converse_content.append({'text': f"Extract the persona information from this image.\n\nOutput a JSON object with this structure:\n{json_schema}\n\nOutput ONLY the JSON object."})
-    else:
-        text_content = content if input_type == 'text' else f"[PDF content - extract persona from this document]"
-        converse_content.append({'text': f"Extract the persona information from this text:\n\n---\n{text_content}\n---\n\nOutput a JSON object with this structure:\n{json_schema}\n\nOutput ONLY the JSON object."})
-    
-    ctx.update_progress(30, 'calling_ai')
-    
-    bedrock = get_bedrock_client()
-    response = bedrock.converse(
-        modelId=BEDROCK_MODEL_ID,
-        system=[{'text': system_prompt}],
-        messages=[{'role': 'user', 'content': converse_content}],
-        inferenceConfig={'maxTokens': 4096}
-    )
-    
-    response_text = response.get('output', {}).get('message', {}).get('content', [{}])[0].get('text', '')
-    
-    # Parse JSON
-    json_text = response_text
-    if '```json' in json_text:
-        json_text = json_text.split('```json')[1].split('```')[0]
-    elif '```' in json_text:
-        json_text = json_text.split('```')[1].split('```')[0]
-    
-    persona_data = json.loads(json_text.strip())
-    logger.info(f"[IMPORT_PERSONA_JOB] Extracted persona: {persona_data.get('name', 'Unknown')}")
-    
-    ctx.update_progress(60, 'generating_avatar')
-    
-    now = datetime.now(timezone.utc).isoformat()
-    persona_id = f"persona_{datetime.now().strftime('%Y%m%d%H%M%S')}"
-    
-    item = {
-        'pk': f'PROJECT#{project_id}', 'sk': f'PERSONA#{persona_id}',
-        'gsi1pk': f'PROJECT#{project_id}#PERSONAS', 'gsi1sk': now,
-        'persona_id': persona_id,
-        'name': persona_data.get('name', 'Imported Persona'),
-        'tagline': persona_data.get('tagline', ''),
-        'confidence': persona_data.get('confidence', 'medium'),
-        'identity': persona_data.get('identity', {}),
-        'goals_motivations': persona_data.get('goals_motivations', {}),
-        'pain_points': persona_data.get('pain_points', {}),
-        'behaviors': persona_data.get('behaviors', {}),
-        'context_environment': persona_data.get('context_environment', {}),
-        'quotes': persona_data.get('quotes', []),
-        'scenario': persona_data.get('scenario', {}),
-        'research_notes': [],
-        'imported_from': input_type,
-        'created_at': now, 'updated_at': now,
-    }
-    
-    # Generate avatar
-    avatar_data = {'persona_id': persona_id, **item}
-    avatar_result = generate_persona_avatar(avatar_data, RAW_DATA_BUCKET)
-    if avatar_result.get('avatar_url'):
-        item['avatar_url'] = avatar_result['avatar_url']
-        item['avatar_prompt'] = avatar_result.get('avatar_prompt', '')
-    
-    ctx.update_progress(90, 'saving_persona')
-    
-    projects_table.put_item(Item=item)
-    projects_table.update_item(
-        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
-        UpdateExpression='SET persona_count = persona_count + :one, updated_at = :now',
-        ExpressionAttributeValues={':one': 1, ':now': now}
-    )
-    
-    persona_name = item.get('name', 'Imported Persona')
-    if item.get('avatar_url') and item['avatar_url'].startswith('s3://'):
-        item['avatar_url'] = get_avatar_cdn_url(item['avatar_url'])
-    
-    logger.info(f"[IMPORT_PERSONA_JOB] Successfully imported persona: {persona_name}")
-    return {'persona_id': persona_id, 'title': f'Imported: {persona_name}'}
-
-
-# ============================================
 # Lambda Handler
 # ============================================
 
@@ -690,17 +363,6 @@ def lambda_handler(event: dict, context: Any) -> dict:
     """Main Lambda handler for projects API."""
     try:
         logger.info(f"Received event: {json.dumps(event)}")
-        
-        # Route async job invocations
-        job_type = event.get('job_type')
-        if job_type == 'generate_personas':
-            return handle_generate_personas_job(event)
-        if job_type in ['generate_prd', 'generate_prfaq']:
-            return handle_generate_document_job(event)
-        if job_type == 'merge_documents':
-            return handle_merge_documents_job(event)
-        if job_type == 'import_persona':
-            return handle_import_persona_job(event)
         
         # Normal API Gateway request
         result = app.resolve(event, context)

--- a/voc-datalake/lambda/jobs/__init__.py
+++ b/voc-datalake/lambda/jobs/__init__.py
@@ -1,0 +1,5 @@
+"""
+Job Lambda handlers for async background processing.
+
+Each job type has its own Lambda for isolation and independent scaling.
+"""

--- a/voc-datalake/lambda/jobs/conftest.py
+++ b/voc-datalake/lambda/jobs/conftest.py
@@ -1,0 +1,63 @@
+"""Shared test fixtures for job Lambda handlers."""
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Add lambda directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Set required environment variables before importing handlers
+os.environ.setdefault('PROJECTS_TABLE', 'test-projects-table')
+os.environ.setdefault('FEEDBACK_TABLE', 'test-feedback-table')
+os.environ.setdefault('JOBS_TABLE', 'test-jobs-table')
+os.environ.setdefault('AGGREGATES_TABLE', 'test-aggregates-table')
+os.environ.setdefault('RAW_DATA_BUCKET', 'test-raw-data-bucket')
+os.environ.setdefault('AVATARS_CDN_URL', 'https://cdn.example.com/avatars')
+
+
+@pytest.fixture
+def mock_dynamodb():
+    """Mock DynamoDB resource and tables."""
+    with patch('shared.aws.get_dynamodb_resource') as mock:
+        mock_resource = MagicMock()
+        mock_table = MagicMock()
+        mock_resource.Table.return_value = mock_table
+        mock.return_value = mock_resource
+        yield {'resource': mock_resource, 'table': mock_table}
+
+
+@pytest.fixture
+def mock_jobs_table():
+    """Mock jobs table for status updates."""
+    with patch('shared.tables.get_jobs_table') as mock:
+        mock_table = MagicMock()
+        mock.return_value = mock_table
+        yield mock_table
+
+
+@pytest.fixture
+def mock_bedrock():
+    """Mock Bedrock client."""
+    with patch('shared.aws.get_bedrock_client') as mock:
+        mock_client = MagicMock()
+        mock.return_value = mock_client
+        yield mock_client
+
+
+@pytest.fixture
+def mock_converse():
+    """Mock converse function."""
+    with patch('shared.converse.converse') as mock:
+        mock.return_value = "Generated content from LLM"
+        yield mock
+
+
+@pytest.fixture
+def sample_job_event():
+    """Sample job event with common fields."""
+    return {
+        'project_id': 'proj_20250101120000',
+        'job_id': 'job_abc123def456',
+    }

--- a/voc-datalake/lambda/jobs/document_generator/__init__.py
+++ b/voc-datalake/lambda/jobs/document_generator/__init__.py
@@ -1,0 +1,1 @@
+"""Document generator job Lambda (PRD/PRFAQ)."""

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -1,0 +1,168 @@
+"""
+Document Generator Job Lambda Handler
+
+Generates PRD or PR-FAQ documents using LLM with project context.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+
+# Add parent directory to path for shared module imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from boto3.dynamodb.conditions import Key
+
+from shared.logging import logger
+from shared.jobs import job_handler, JobContext
+from shared.aws import get_dynamodb_resource
+from shared.converse import converse
+
+# Environment
+PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
+FEEDBACK_TABLE = os.environ.get('FEEDBACK_TABLE', '')
+
+
+@job_handler(error_message='Document generation failed')
+def handle_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) -> dict:
+    """Handle async document generation job (PRD/PRFAQ).
+    
+    Args:
+        ctx: Job context for progress updates
+        project_id: Project ID
+        job_id: Job ID
+        doc_config: Document configuration (doc_type, title, feature_idea, data_sources, etc.)
+        
+    Returns:
+        Result dict with document_id and title
+    """
+    dynamodb = get_dynamodb_resource()
+    projects_table = dynamodb.Table(PROJECTS_TABLE)
+    feedback_table = dynamodb.Table(FEEDBACK_TABLE)
+    
+    ctx.update_progress(10, 'gathering_context')
+    
+    doc_type = doc_config.get('doc_type', 'prd')
+    title = doc_config.get('title', 'Untitled')
+    feature_idea = doc_config.get('feature_idea', '')
+    data_sources = doc_config.get('data_sources', {})
+    customer_questions = doc_config.get('customer_questions', [])
+    
+    context_parts = []
+    
+    # Gather feedback
+    if data_sources.get('feedback'):
+        ctx.update_progress(20, 'fetching_feedback')
+        feedback_sources = doc_config.get('feedback_sources', [])
+        feedback_categories = doc_config.get('feedback_categories', [])
+        days = doc_config.get('days', 30)
+        
+        feedback_items = []
+        current_date = datetime.now(timezone.utc)
+        for i in range(min(days, 14)):
+            date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
+            resp = feedback_table.query(
+                IndexName='gsi1-by-date',
+                KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
+                Limit=100, ScanIndexForward=False
+            )
+            feedback_items.extend(resp.get('Items', []))
+            if len(feedback_items) >= 100:
+                break
+        
+        if feedback_sources:
+            feedback_items = [f for f in feedback_items if f.get('source_platform') in feedback_sources]
+        if feedback_categories:
+            feedback_items = [f for f in feedback_items if f.get('category') in feedback_categories]
+        
+        if feedback_items:
+            feedback_text = "## Customer Feedback\n\n"
+            for i, item in enumerate(feedback_items[:30], 1):
+                feedback_text += f"**Review {i}** ({item.get('source_platform', 'unknown')}, {item.get('sentiment_label', 'unknown')}): {item.get('original_text', '')[:300]}\n\n"
+            context_parts.append(feedback_text)
+    
+    # Gather personas
+    if data_sources.get('personas'):
+        ctx.update_progress(30, 'fetching_personas')
+        selected_ids = doc_config.get('selected_persona_ids', [])
+        resp = projects_table.query(KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'))
+        personas = [i for i in resp.get('Items', []) if i.get('sk', '').startswith('PERSONA#')]
+        if selected_ids:
+            personas = [p for p in personas if p.get('persona_id') in selected_ids]
+        if personas:
+            persona_text = "## User Personas\n\n"
+            for p in personas:
+                persona_text += f"**{p.get('name')}**: {p.get('tagline', '')}\n- Goals: {', '.join(p.get('goals', [])[:3])}\n- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n\n"
+            context_parts.append(persona_text)
+    
+    # Gather documents
+    if data_sources.get('documents') or data_sources.get('research'):
+        ctx.update_progress(40, 'fetching_documents')
+        selected_ids = doc_config.get('selected_document_ids', [])
+        resp = projects_table.query(KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'))
+        docs = [i for i in resp.get('Items', []) if i.get('sk', '').startswith(('RESEARCH#', 'PRD#', 'PRFAQ#', 'DOC#'))]
+        if selected_ids:
+            docs = [d for d in docs if d.get('document_id') in selected_ids]
+        if docs:
+            doc_text = "## Reference Documents\n\n"
+            for d in docs[:3]:
+                doc_text += f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:3000]}\n\n"
+            context_parts.append(doc_text)
+    
+    ctx.update_progress(50, 'generating_document')
+    context = '\n\n'.join(context_parts) if context_parts else 'No additional context provided.'
+    
+    # Build prompts based on doc type
+    if doc_type == 'prd':
+        system_prompt = """You are a senior product manager creating a Product Requirements Document (PRD).
+Create a comprehensive PRD that includes: Problem Statement, Goals & Success Metrics, User Stories, Requirements (functional & non-functional), Out of Scope, Timeline, and Risks."""
+        user_prompt = f"Create a PRD for: {title}\n\nFeature Description: {feature_idea}\n\n{context}\n\nGenerate a complete PRD in markdown format."
+    else:
+        q_labels = [
+            "Who is the customer?",
+            "What is the customer problem or opportunity?",
+            "What is the most important customer benefit?",
+            "How do you know what customers need or want?",
+            "What does the customer experience look like?"
+        ]
+        questions_context = "\n\n".join([
+            f"**{q_labels[i]}**\n{q.strip()}"
+            for i, q in enumerate(customer_questions[:5])
+            if q and q.strip()
+        ])
+        system_prompt = """You are creating an Amazon-style Working Backwards PR-FAQ document. Write in "Oprah-speak" NOT "Geek-speak". Keep it simple. This is NOT a spec - it's a customer-focused announcement."""
+        user_prompt = f"Create an Amazon Working Backwards PR-FAQ for: {title}\n\nFeature Description: {feature_idea}\n\n## Working Backwards Input:\n{questions_context or 'Use the customer feedback context below.'}\n\n{context}\n\nGenerate a COMPLETE PR-FAQ with PRESS RELEASE, CUSTOMER FAQ (10 questions), and INTERNAL FAQ (10 questions)."
+    
+    ctx.update_progress(60, 'calling_ai')
+    max_tokens = 8000 if doc_type == 'prfaq' else 5000
+    content = converse(prompt=user_prompt, system_prompt=system_prompt, max_tokens=max_tokens)
+    
+    ctx.update_progress(90, 'saving_document')
+    now = datetime.now(timezone.utc).isoformat()
+    doc_id = f"{doc_type}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    
+    projects_table.put_item(Item={
+        'pk': f'PROJECT#{project_id}',
+        'sk': f'{doc_type.upper()}#{doc_id}',
+        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS',
+        'gsi1sk': now,
+        'document_id': doc_id,
+        'document_type': doc_type,
+        'title': title,
+        'content': content,
+        'job_id': job_id,
+        'created_at': now,
+    })
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
+        UpdateExpression='SET document_count = document_count + :one, updated_at = :now',
+        ExpressionAttributeValues={':one': 1, ':now': now}
+    )
+    
+    return {'document_id': doc_id, 'title': title}
+
+
+def lambda_handler(event: dict, context) -> dict:
+    """Lambda entry point."""
+    logger.info(f"Document generator invoked with event keys: {list(event.keys())}")
+    return handle_job(event)

--- a/voc-datalake/lambda/jobs/document_generator/test/__init__.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for document generator job Lambda."""

--- a/voc-datalake/lambda/jobs/document_generator/test/conftest.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/conftest.py
@@ -1,0 +1,50 @@
+"""Test fixtures for document generator job."""
+
+import pytest
+
+# Import shared fixtures
+from jobs.conftest import *  # noqa: F401, F403
+
+
+@pytest.fixture
+def prd_generation_event(sample_job_event):
+    """Sample PRD generation job event."""
+    return {
+        **sample_job_event,
+        'doc_config': {
+            'doc_type': 'prd',
+            'title': 'Test PRD',
+            'feature_idea': 'Improve user onboarding flow',
+            'data_sources': {
+                'feedback': True,
+                'personas': True,
+                'documents': False,
+            },
+            'days': 30,
+        }
+    }
+
+
+@pytest.fixture
+def prfaq_generation_event(sample_job_event):
+    """Sample PR-FAQ generation job event."""
+    return {
+        **sample_job_event,
+        'doc_config': {
+            'doc_type': 'prfaq',
+            'title': 'Test PR-FAQ',
+            'feature_idea': 'New mobile app feature',
+            'data_sources': {
+                'feedback': True,
+                'personas': True,
+            },
+            'customer_questions': [
+                'Small business owners',
+                'They struggle with inventory management',
+                'Save 10 hours per week',
+                'Customer interviews and feedback',
+                'Simple mobile-first experience',
+            ],
+            'days': 30,
+        }
+    }

--- a/voc-datalake/lambda/jobs/document_generator/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_handler.py
@@ -1,0 +1,191 @@
+"""Tests for document generator job handler."""
+
+import pytest
+from unittest.mock import MagicMock, call
+
+# Constants for max_tokens validation
+PRD_MIN_TOKENS = 5000
+PRFAQ_MIN_TOKENS = 8000
+
+
+class TestDocumentGeneratorHandler:
+    """Tests for the document generator job Lambda handler."""
+
+    @pytest.fixture(autouse=True)
+    def setup_empty_query_response(self, mock_dynamodb):
+        """Set default empty query response for all tests."""
+        mock_dynamodb['table'].query.return_value = {'Items': []}
+
+    def test_successful_prd_generation(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test successful PRD generation job."""
+        from jobs.document_generator.handler import lambda_handler
+
+        result = lambda_handler(prd_generation_event, None)
+
+        assert result['success'] is True
+        assert 'document_id' in result
+        assert result['document_id'].startswith('prd_')
+        mock_converse.assert_called_once()
+
+    def test_successful_prfaq_generation(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prfaq_generation_event
+    ):
+        """Test successful PR-FAQ generation job."""
+        from jobs.document_generator.handler import lambda_handler
+
+        result = lambda_handler(prfaq_generation_event, None)
+
+        assert result['success'] is True
+        assert 'document_id' in result
+        assert result['document_id'].startswith('prfaq_')
+        call_kwargs = mock_converse.call_args.kwargs
+        assert call_kwargs.get('max_tokens', 0) >= PRFAQ_MIN_TOKENS
+
+    def test_prd_uses_correct_system_prompt(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that PRD generation uses appropriate system prompt."""
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prd_generation_event, None)
+
+        call_kwargs = mock_converse.call_args.kwargs
+        system_prompt = call_kwargs.get('system_prompt', '')
+        assert 'PRD' in system_prompt or 'Product Requirements' in system_prompt
+
+    def test_prfaq_uses_correct_system_prompt(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prfaq_generation_event
+    ):
+        """Test that PR-FAQ generation uses appropriate system prompt."""
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prfaq_generation_event, None)
+
+        call_kwargs = mock_converse.call_args.kwargs
+        system_prompt = call_kwargs.get('system_prompt', '')
+        assert 'PR-FAQ' in system_prompt or 'Working Backwards' in system_prompt
+
+    def test_document_saved_to_dynamodb(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that generated document is saved to DynamoDB."""
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prd_generation_event, None)
+
+        mock_dynamodb['table'].put_item.assert_called()
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert 'document_id' in item
+        assert item.get('document_type') == 'prd'
+        assert item.get('title') == 'Test PRD'
+        assert 'content' in item
+        assert 'created_at' in item
+
+    def test_project_document_count_updated(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that project document_count is incremented after generation."""
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prd_generation_event, None)
+
+        # Find the update_item call for META
+        update_calls = mock_dynamodb['table'].update_item.call_args_list
+        meta_update = next(
+            (c for c in update_calls if 'META' in str(c.kwargs.get('Key', {}))),
+            None
+        )
+        assert meta_update is not None, "Project META should be updated"
+        assert 'document_count' in meta_update.kwargs.get('UpdateExpression', '')
+
+    def test_job_status_updated_on_failure(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that job status is updated to failed on error."""
+        from jobs.document_generator.handler import lambda_handler
+        from shared.exceptions import ServiceError
+
+        mock_converse.side_effect = Exception("Bedrock error")
+
+        with pytest.raises(ServiceError, match="Document generation failed"):
+            lambda_handler(prd_generation_event, None)
+
+        mock_jobs_table.update_item.assert_called()
+        update_call = mock_jobs_table.update_item.call_args
+        expr_values = update_call.kwargs.get('ExpressionAttributeValues', {})
+        assert expr_values.get(':status') == 'failed'
+
+    def test_progress_updates_during_generation(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that progress is updated at key stages."""
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prd_generation_event, None)
+
+        # Verify multiple progress updates occurred
+        update_calls = mock_jobs_table.update_item.call_args_list
+        assert len(update_calls) >= 2, "Should have multiple progress updates"
+
+    def test_gathers_feedback_when_enabled(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that feedback is gathered when data_sources.feedback is True."""
+        mock_feedback_table = MagicMock()
+        mock_feedback_table.query.return_value = {
+            'Items': [
+                {
+                    'original_text': 'Great app!',
+                    'source_platform': 'app_store',
+                    'sentiment_label': 'positive'
+                },
+            ]
+        }
+
+        def table_factory(name):
+            if 'feedback' in name.lower():
+                return mock_feedback_table
+            return mock_dynamodb['table']
+
+        mock_dynamodb['resource'].Table.side_effect = table_factory
+
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prd_generation_event, None)
+
+        # Verify feedback table was specifically queried
+        assert mock_feedback_table.query.called, "Feedback table should be queried"
+
+    def test_skips_feedback_when_disabled(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that feedback is not gathered when data_sources.feedback is False."""
+        prd_generation_event['doc_config']['data_sources']['feedback'] = False
+        mock_feedback_table = MagicMock()
+
+        def table_factory(name):
+            if 'feedback' in name.lower():
+                return mock_feedback_table
+            return mock_dynamodb['table']
+
+        mock_dynamodb['resource'].Table.side_effect = table_factory
+
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(prd_generation_event, None)
+
+        # Feedback table should not be queried
+        assert not mock_feedback_table.query.called, "Feedback table should not be queried"
+
+    def test_returns_title_in_result(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, prd_generation_event
+    ):
+        """Test that result includes the document title."""
+        from jobs.document_generator.handler import lambda_handler
+
+        result = lambda_handler(prd_generation_event, None)
+
+        assert result.get('title') == 'Test PRD'

--- a/voc-datalake/lambda/jobs/document_merger/__init__.py
+++ b/voc-datalake/lambda/jobs/document_merger/__init__.py
@@ -1,0 +1,1 @@
+"""Document merger job Lambda."""

--- a/voc-datalake/lambda/jobs/document_merger/handler.py
+++ b/voc-datalake/lambda/jobs/document_merger/handler.py
@@ -1,0 +1,156 @@
+"""
+Document Merger Job Lambda Handler
+
+Merges multiple documents into a single document using LLM.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+
+# Add parent directory to path for shared module imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from boto3.dynamodb.conditions import Key
+
+from shared.logging import logger
+from shared.jobs import job_handler, JobContext
+from shared.aws import get_dynamodb_resource
+from shared.converse import converse
+
+# Environment
+PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
+FEEDBACK_TABLE = os.environ.get('FEEDBACK_TABLE', '')
+
+
+@job_handler(error_message='Document merge failed')
+def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict) -> dict:
+    """Handle async document merge job.
+    
+    Args:
+        ctx: Job context for progress updates
+        project_id: Project ID
+        job_id: Job ID
+        merge_config: Merge configuration (output_type, title, instructions, selected_document_ids, etc.)
+        
+    Returns:
+        Result dict with document_id and title
+    """
+    dynamodb = get_dynamodb_resource()
+    projects_table = dynamodb.Table(PROJECTS_TABLE)
+    feedback_table = dynamodb.Table(FEEDBACK_TABLE)
+    
+    ctx.update_progress(10, 'gathering_documents')
+    
+    output_type = merge_config.get('output_type', 'custom')
+    title = merge_config.get('title', 'Merged Document')
+    instructions = merge_config.get('instructions', '')
+    selected_doc_ids = merge_config.get('selected_document_ids', [])
+    selected_persona_ids = merge_config.get('selected_persona_ids', [])
+    use_feedback = merge_config.get('use_feedback', False)
+    
+    resp = projects_table.query(KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'))
+    all_items = resp.get('Items', [])
+    
+    docs = [i for i in all_items if i.get('sk', '').startswith(('RESEARCH#', 'PRD#', 'PRFAQ#', 'DOC#'))]
+    selected_docs = [d for d in docs if d.get('document_id') in selected_doc_ids]
+    
+    if len(selected_docs) < 2:
+        raise ValueError("At least 2 documents are required for merging")
+    
+    ctx.update_progress(20, 'preparing_context')
+    
+    doc_context = "## SOURCE DOCUMENTS TO MERGE\n\n"
+    for i, doc in enumerate(selected_docs, 1):
+        doc_context += f"### Document {i}: {doc.get('title', 'Untitled')} ({doc.get('document_type', 'unknown').upper()})\n\n{doc.get('content', '')[:8000]}\n\n---\n\n"
+    
+    context_parts = [doc_context]
+    
+    if selected_persona_ids:
+        ctx.update_progress(30, 'fetching_personas')
+        personas = [i for i in all_items if i.get('sk', '').startswith('PERSONA#')]
+        selected_personas = [p for p in personas if p.get('persona_id') in selected_persona_ids]
+        if selected_personas:
+            persona_text = "## USER PERSONAS FOR CONTEXT\n\n"
+            for p in selected_personas:
+                persona_text += f"**{p.get('name')}**: {p.get('tagline', '')}\n- Goals: {', '.join(p.get('goals', [])[:3])}\n- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n\n"
+            context_parts.append(persona_text)
+    
+    if use_feedback:
+        ctx.update_progress(40, 'fetching_feedback')
+        feedback_sources = merge_config.get('feedback_sources', [])
+        feedback_categories = merge_config.get('feedback_categories', [])
+        days = merge_config.get('days', 30)
+        
+        feedback_items = []
+        current_date = datetime.now(timezone.utc)
+        for i in range(min(days, 14)):
+            date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
+            resp = feedback_table.query(
+                IndexName='gsi1-by-date',
+                KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
+                Limit=100, ScanIndexForward=False
+            )
+            feedback_items.extend(resp.get('Items', []))
+            if len(feedback_items) >= 100:
+                break
+        
+        if feedback_sources:
+            feedback_items = [f for f in feedback_items if f.get('source_platform') in feedback_sources]
+        if feedback_categories:
+            feedback_items = [f for f in feedback_items if f.get('category') in feedback_categories]
+        
+        if feedback_items:
+            feedback_text = "## ADDITIONAL CUSTOMER FEEDBACK\n\n"
+            for i, item in enumerate(feedback_items[:20], 1):
+                feedback_text += f"**Review {i}** ({item.get('source_platform', 'unknown')}, {item.get('sentiment_label', 'unknown')}): {item.get('original_text', '')[:250]}\n\n"
+            context_parts.append(feedback_text)
+    
+    ctx.update_progress(50, 'generating_merged_document')
+    context = '\n\n'.join(context_parts)
+    
+    if output_type == 'prd':
+        system_prompt = "You are a senior product manager creating a revised PRD. Merge and revise the provided source documents according to the user's instructions."
+    elif output_type == 'prfaq':
+        system_prompt = "You are creating a revised Amazon-style PR-FAQ. Merge and revise the provided source documents. Include PRESS RELEASE, CUSTOMER FAQ (10 questions), and INTERNAL FAQ (10 questions)."
+    else:
+        system_prompt = "You are a skilled document editor. Merge and revise the provided source documents according to the user's instructions."
+    
+    user_prompt = f"## MERGE INSTRUCTIONS\n{instructions}\n\n## OUTPUT DOCUMENT TITLE\n{title}\n\n{context}\n\nCreate a new {output_type.upper() if output_type != 'custom' else 'document'} incorporating all relevant feedback."
+    
+    ctx.update_progress(60, 'calling_ai')
+    max_tokens = 8000 if output_type == 'prfaq' else 6000
+    content = converse(prompt=user_prompt, system_prompt=system_prompt, max_tokens=max_tokens)
+    
+    ctx.update_progress(90, 'saving_document')
+    now = datetime.now(timezone.utc).isoformat()
+    doc_type_prefix = output_type if output_type in ['prd', 'prfaq'] else 'doc'
+    doc_id = f"{doc_type_prefix}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    
+    projects_table.put_item(Item={
+        'pk': f'PROJECT#{project_id}',
+        'sk': f'{doc_type_prefix.upper()}#{doc_id}',
+        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS',
+        'gsi1sk': now,
+        'document_id': doc_id,
+        'document_type': output_type if output_type in ['prd', 'prfaq'] else 'custom',
+        'title': title,
+        'content': content,
+        'job_id': job_id,
+        'source_documents': selected_doc_ids,
+        'merge_instructions': instructions,
+        'created_at': now,
+    })
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
+        UpdateExpression='SET document_count = document_count + :one, updated_at = :now',
+        ExpressionAttributeValues={':one': 1, ':now': now}
+    )
+    
+    return {'document_id': doc_id, 'title': title}
+
+
+def lambda_handler(event: dict, context) -> dict:
+    """Lambda entry point."""
+    logger.info(f"Document merger invoked with event keys: {list(event.keys())}")
+    return handle_job(event)

--- a/voc-datalake/lambda/jobs/document_merger/test/__init__.py
+++ b/voc-datalake/lambda/jobs/document_merger/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for document merger job Lambda."""

--- a/voc-datalake/lambda/jobs/document_merger/test/conftest.py
+++ b/voc-datalake/lambda/jobs/document_merger/test/conftest.py
@@ -1,0 +1,43 @@
+"""Test fixtures for document merger job."""
+
+import pytest
+
+# Import shared fixtures
+from jobs.conftest import *  # noqa: F401, F403
+
+
+@pytest.fixture
+def merge_documents_event(sample_job_event):
+    """Sample document merge job event."""
+    return {
+        **sample_job_event,
+        'merge_config': {
+            'output_type': 'prd',
+            'title': 'Merged PRD',
+            'instructions': 'Combine the key insights from both documents',
+            'selected_document_ids': ['doc_1', 'doc_2'],
+            'selected_persona_ids': [],
+            'use_feedback': False,
+        }
+    }
+
+
+@pytest.fixture
+def mock_project_documents():
+    """Mock project documents for merging."""
+    return [
+        {
+            'sk': 'PRD#doc_1',
+            'document_id': 'doc_1',
+            'document_type': 'prd',
+            'title': 'First PRD',
+            'content': 'Content of first PRD...',
+        },
+        {
+            'sk': 'RESEARCH#doc_2',
+            'document_id': 'doc_2',
+            'document_type': 'research',
+            'title': 'Research Report',
+            'content': 'Research findings...',
+        },
+    ]

--- a/voc-datalake/lambda/jobs/document_merger/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/document_merger/test/test_handler.py
@@ -1,0 +1,110 @@
+"""Tests for document merger job handler."""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestDocumentMergerHandler:
+    """Tests for the document merger job Lambda handler."""
+
+    def test_successful_document_merge(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, 
+        merge_documents_event, mock_project_documents
+    ):
+        """Test successful document merge job."""
+        mock_dynamodb['table'].query.return_value = {'Items': mock_project_documents}
+        
+        from jobs.document_merger.handler import lambda_handler
+        
+        result = lambda_handler(merge_documents_event, None)
+        
+        assert result['success'] is True
+        assert 'document_id' in result
+        mock_converse.assert_called_once()
+
+    def test_fails_with_less_than_two_documents(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, merge_documents_event
+    ):
+        """Test that merge fails when less than 2 documents are selected."""
+        from jobs.document_merger.handler import lambda_handler
+        from shared.exceptions import ServiceError
+        
+        # Only one document available
+        mock_dynamodb['table'].query.return_value = {
+            'Items': [{'sk': 'PRD#doc_1', 'document_id': 'doc_1', 'content': 'test'}]
+        }
+        
+        with pytest.raises((ServiceError, ValueError)):
+            lambda_handler(merge_documents_event, None)
+
+    def test_merged_document_saved_to_dynamodb(
+        self, mock_dynamodb, mock_jobs_table, mock_converse,
+        merge_documents_event, mock_project_documents
+    ):
+        """Test that merged document is saved to DynamoDB."""
+        mock_dynamodb['table'].query.return_value = {'Items': mock_project_documents}
+        
+        from jobs.document_merger.handler import lambda_handler
+        
+        lambda_handler(merge_documents_event, None)
+        
+        mock_dynamodb['table'].put_item.assert_called()
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert 'source_documents' in item
+        assert item.get('merge_instructions') == merge_documents_event['merge_config']['instructions']
+
+    def test_uses_correct_output_type_prefix(
+        self, mock_dynamodb, mock_jobs_table, mock_converse,
+        merge_documents_event, mock_project_documents
+    ):
+        """Test that document uses correct SK prefix based on output_type."""
+        mock_dynamodb['table'].query.return_value = {'Items': mock_project_documents}
+        
+        from jobs.document_merger.handler import lambda_handler
+        
+        # Test PRD output type
+        merge_documents_event['merge_config']['output_type'] = 'prd'
+        lambda_handler(merge_documents_event, None)
+        
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert item.get('sk', '').startswith('PRD#')
+
+    def test_custom_output_type_uses_doc_prefix(
+        self, mock_dynamodb, mock_jobs_table, mock_converse,
+        merge_documents_event, mock_project_documents
+    ):
+        """Test that custom output type uses DOC# prefix."""
+        mock_dynamodb['table'].query.return_value = {'Items': mock_project_documents}
+        
+        from jobs.document_merger.handler import lambda_handler
+        
+        merge_documents_event['merge_config']['output_type'] = 'custom'
+        lambda_handler(merge_documents_event, None)
+        
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert item.get('sk', '').startswith('DOC#')
+
+    def test_includes_personas_when_selected(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, merge_documents_event
+    ):
+        """Test that personas are included in context when selected."""
+        mock_items = [
+            {'sk': 'PRD#doc_1', 'document_id': 'doc_1', 'content': 'PRD content'},
+            {'sk': 'PRD#doc_2', 'document_id': 'doc_2', 'content': 'PRD content 2'},
+            {'sk': 'PERSONA#persona_1', 'persona_id': 'persona_1', 'name': 'Test User', 'tagline': 'A test persona'},
+        ]
+        mock_dynamodb['table'].query.return_value = {'Items': mock_items}
+        
+        merge_documents_event['merge_config']['selected_persona_ids'] = ['persona_1']
+        
+        from jobs.document_merger.handler import lambda_handler
+        
+        lambda_handler(merge_documents_event, None)
+        
+        # Verify persona context was included in prompt
+        call_kwargs = mock_converse.call_args.kwargs
+        prompt = call_kwargs.get('prompt', '')
+        assert 'Test User' in prompt or 'PERSONA' in prompt

--- a/voc-datalake/lambda/jobs/persona_generator/__init__.py
+++ b/voc-datalake/lambda/jobs/persona_generator/__init__.py
@@ -1,0 +1,1 @@
+"""Persona generator job Lambda."""

--- a/voc-datalake/lambda/jobs/persona_generator/handler.py
+++ b/voc-datalake/lambda/jobs/persona_generator/handler.py
@@ -1,0 +1,44 @@
+"""
+Persona Generator Job Lambda Handler
+
+Generates UX research personas from customer feedback using multi-step LLM chain.
+"""
+
+import os
+import sys
+
+# Add parent directory to path for shared module imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from shared.logging import logger
+from shared.jobs import job_handler, JobContext
+from shared.exceptions import ConfigurationError
+
+# Import from api/projects.py - the business logic stays there
+from api.projects import generate_personas
+
+
+@job_handler(error_message='Persona generation failed')
+def handle_job(ctx: JobContext, project_id: str, job_id: str, filters: dict) -> dict:
+    """Handle async persona generation job.
+    
+    Args:
+        ctx: Job context for progress updates
+        project_id: Project ID
+        job_id: Job ID
+        filters: Generation filters (sources, categories, sentiments, days, persona_count, custom_instructions)
+        
+    Returns:
+        Result dict with generated personas
+    """
+    def progress_callback(progress: int, step: str):
+        ctx.update_progress(progress, step)
+    
+    result = generate_personas(project_id, filters, progress_callback=progress_callback)
+    return result
+
+
+def lambda_handler(event: dict, context) -> dict:
+    """Lambda entry point."""
+    logger.info(f"Persona generator invoked with event keys: {list(event.keys())}")
+    return handle_job(event)

--- a/voc-datalake/lambda/jobs/persona_generator/test/__init__.py
+++ b/voc-datalake/lambda/jobs/persona_generator/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for persona generator job Lambda."""

--- a/voc-datalake/lambda/jobs/persona_generator/test/conftest.py
+++ b/voc-datalake/lambda/jobs/persona_generator/test/conftest.py
@@ -1,0 +1,38 @@
+"""Test fixtures for persona generator job."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Import shared fixtures
+from jobs.conftest import *  # noqa: F401, F403
+
+
+@pytest.fixture
+def mock_generate_personas():
+    """Mock the generate_personas function from api.projects."""
+    with patch('api.projects.generate_personas') as mock:
+        mock.return_value = {
+            'success': True,
+            'personas': [
+                {'persona_id': 'persona_1', 'name': 'Test Persona 1'},
+                {'persona_id': 'persona_2', 'name': 'Test Persona 2'},
+            ],
+            'metadata': {'feedback_count': 50}
+        }
+        yield mock
+
+
+@pytest.fixture
+def persona_generation_event(sample_job_event):
+    """Sample persona generation job event."""
+    return {
+        **sample_job_event,
+        'filters': {
+            'sources': ['app_store', 'play_store'],
+            'categories': ['usability'],
+            'sentiments': ['negative', 'neutral'],
+            'days': 30,
+            'persona_count': 3,
+            'custom_instructions': '',
+        }
+    }

--- a/voc-datalake/lambda/jobs/persona_generator/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/persona_generator/test/test_handler.py
@@ -1,0 +1,86 @@
+"""Tests for persona generator job handler."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestPersonaGeneratorHandler:
+    """Tests for the persona generator job Lambda handler."""
+
+    def test_successful_persona_generation(
+        self, mock_jobs_table, mock_generate_personas, persona_generation_event
+    ):
+        """Test successful persona generation job."""
+        from jobs.persona_generator.handler import lambda_handler
+        
+        result = lambda_handler(persona_generation_event, None)
+        
+        assert result['success'] is True
+        mock_generate_personas.assert_called_once()
+        # Verify progress callback was passed
+        call_args = mock_generate_personas.call_args
+        assert 'progress_callback' in call_args.kwargs
+
+    def test_job_status_updated_on_completion(
+        self, mock_jobs_table, mock_generate_personas, persona_generation_event
+    ):
+        """Test that job status is updated to completed."""
+        from jobs.persona_generator.handler import lambda_handler
+        
+        lambda_handler(persona_generation_event, None)
+        
+        # Verify job was marked as completed
+        mock_jobs_table.update_item.assert_called()
+        last_call = mock_jobs_table.update_item.call_args
+        assert ':status' in str(last_call) or 'completed' in str(last_call)
+
+    def test_job_status_updated_on_failure(
+        self, mock_jobs_table, mock_generate_personas, persona_generation_event
+    ):
+        """Test that job status is updated to failed on error."""
+        from jobs.persona_generator.handler import lambda_handler
+        from shared.exceptions import ServiceError
+        
+        mock_generate_personas.side_effect = Exception("LLM error")
+        
+        with pytest.raises(ServiceError):
+            lambda_handler(persona_generation_event, None)
+        
+        # Verify job was marked as failed
+        mock_jobs_table.update_item.assert_called()
+
+    def test_progress_callback_updates_job(
+        self, mock_jobs_table, mock_generate_personas, persona_generation_event
+    ):
+        """Test that progress callback updates job status."""
+        from jobs.persona_generator.handler import lambda_handler
+        
+        # Capture the progress callback
+        captured_callback = None
+        def capture_callback(*args, **kwargs):
+            nonlocal captured_callback
+            captured_callback = kwargs.get('progress_callback')
+            return {'success': True, 'personas': []}
+        
+        mock_generate_personas.side_effect = capture_callback
+        
+        lambda_handler(persona_generation_event, None)
+        
+        # Verify callback was provided
+        assert captured_callback is not None
+        
+        # Call the callback and verify it updates job status
+        captured_callback(50, 'generating_personas')
+        assert mock_jobs_table.update_item.called
+
+    def test_handler_extracts_filters_from_event(
+        self, mock_jobs_table, mock_generate_personas, persona_generation_event
+    ):
+        """Test that handler correctly extracts filters from event."""
+        from jobs.persona_generator.handler import lambda_handler
+        
+        lambda_handler(persona_generation_event, None)
+        
+        call_args = mock_generate_personas.call_args
+        assert call_args[0][0] == persona_generation_event['project_id']
+        assert call_args[0][1] == persona_generation_event['filters']

--- a/voc-datalake/lambda/jobs/persona_importer/__init__.py
+++ b/voc-datalake/lambda/jobs/persona_importer/__init__.py
@@ -1,0 +1,1 @@
+"""Persona importer job Lambda."""

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -1,0 +1,150 @@
+"""
+Persona Importer Job Lambda Handler
+
+Imports personas from PDF, image, or text using LLM extraction.
+"""
+
+import os
+import sys
+import json
+import base64
+from datetime import datetime, timezone
+
+# Add parent directory to path for shared module imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from shared.logging import logger
+from shared.jobs import job_handler, JobContext
+from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from api.projects import generate_persona_avatar, get_avatar_cdn_url
+
+# Environment
+PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
+RAW_DATA_BUCKET = os.environ.get('RAW_DATA_BUCKET', '')
+
+
+@job_handler(error_message='Persona import failed')
+def handle_job(ctx: JobContext, project_id: str, job_id: str, import_config: dict) -> dict:
+    """Handle async persona import job.
+    
+    Args:
+        ctx: Job context for progress updates
+        project_id: Project ID
+        job_id: Job ID
+        import_config: Import configuration (input_type, content, media_type)
+        
+    Returns:
+        Result dict with persona_id and title
+    """
+    dynamodb = get_dynamodb_resource()
+    projects_table = dynamodb.Table(PROJECTS_TABLE)
+    
+    ctx.update_progress(10, 'extracting_persona')
+    
+    input_type = import_config.get('input_type', 'text')
+    content = import_config.get('content', '')
+    media_type = import_config.get('media_type', '')
+    
+    logger.info(f"[IMPORT_PERSONA_JOB] Starting import from {input_type} for project {project_id}")
+    
+    system_prompt = """You are a UX researcher expert at extracting persona information from documents and images.
+Extract persona data from the provided input and output a structured JSON object.
+CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
+
+    json_schema = '{"name": "Full Name", "tagline": "One sentence", "confidence": "high", "identity": {...}, "goals_motivations": {...}, "pain_points": {...}, "behaviors": {...}, "context_environment": {...}, "quotes": [...], "scenario": {...}}'
+    
+    # Build converse content
+    converse_content = []
+    if input_type == 'image':
+        converse_content.append({
+            'image': {
+                'format': (media_type or 'image/png').split('/')[-1],
+                'source': {'bytes': base64.b64decode(content)}
+            }
+        })
+        converse_content.append({
+            'text': f"Extract the persona information from this image.\n\nOutput a JSON object with this structure:\n{json_schema}\n\nOutput ONLY the JSON object."
+        })
+    else:
+        text_content = content if input_type == 'text' else "[PDF content - extract persona from this document]"
+        converse_content.append({
+            'text': f"Extract the persona information from this text:\n\n---\n{text_content}\n---\n\nOutput a JSON object with this structure:\n{json_schema}\n\nOutput ONLY the JSON object."
+        })
+    
+    ctx.update_progress(30, 'calling_ai')
+    
+    bedrock = get_bedrock_client()
+    response = bedrock.converse(
+        modelId=BEDROCK_MODEL_ID,
+        system=[{'text': system_prompt}],
+        messages=[{'role': 'user', 'content': converse_content}],
+        inferenceConfig={'maxTokens': 4096}
+    )
+    
+    response_text = response.get('output', {}).get('message', {}).get('content', [{}])[0].get('text', '')
+    
+    # Parse JSON
+    json_text = response_text
+    if '```json' in json_text:
+        json_text = json_text.split('```json')[1].split('```')[0]
+    elif '```' in json_text:
+        json_text = json_text.split('```')[1].split('```')[0]
+    
+    persona_data = json.loads(json_text.strip())
+    logger.info(f"[IMPORT_PERSONA_JOB] Extracted persona: {persona_data.get('name', 'Unknown')}")
+    
+    ctx.update_progress(60, 'generating_avatar')
+    
+    now = datetime.now(timezone.utc).isoformat()
+    persona_id = f"persona_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    
+    item = {
+        'pk': f'PROJECT#{project_id}',
+        'sk': f'PERSONA#{persona_id}',
+        'gsi1pk': f'PROJECT#{project_id}#PERSONAS',
+        'gsi1sk': now,
+        'persona_id': persona_id,
+        'name': persona_data.get('name', 'Imported Persona'),
+        'tagline': persona_data.get('tagline', ''),
+        'confidence': persona_data.get('confidence', 'medium'),
+        'identity': persona_data.get('identity', {}),
+        'goals_motivations': persona_data.get('goals_motivations', {}),
+        'pain_points': persona_data.get('pain_points', {}),
+        'behaviors': persona_data.get('behaviors', {}),
+        'context_environment': persona_data.get('context_environment', {}),
+        'quotes': persona_data.get('quotes', []),
+        'scenario': persona_data.get('scenario', {}),
+        'research_notes': [],
+        'imported_from': input_type,
+        'created_at': now,
+        'updated_at': now,
+    }
+    
+    # Generate avatar
+    avatar_data = {'persona_id': persona_id, **item}
+    avatar_result = generate_persona_avatar(avatar_data, RAW_DATA_BUCKET)
+    if avatar_result.get('avatar_url'):
+        item['avatar_url'] = avatar_result['avatar_url']
+        item['avatar_prompt'] = avatar_result.get('avatar_prompt', '')
+    
+    ctx.update_progress(90, 'saving_persona')
+    
+    projects_table.put_item(Item=item)
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
+        UpdateExpression='SET persona_count = persona_count + :one, updated_at = :now',
+        ExpressionAttributeValues={':one': 1, ':now': now}
+    )
+    
+    persona_name = item.get('name', 'Imported Persona')
+    if item.get('avatar_url') and item['avatar_url'].startswith('s3://'):
+        item['avatar_url'] = get_avatar_cdn_url(item['avatar_url'])
+    
+    logger.info(f"[IMPORT_PERSONA_JOB] Successfully imported persona: {persona_name}")
+    return {'persona_id': persona_id, 'title': f'Imported: {persona_name}'}
+
+
+def lambda_handler(event: dict, context) -> dict:
+    """Lambda entry point."""
+    logger.info(f"Persona importer invoked with event keys: {list(event.keys())}")
+    return handle_job(event)

--- a/voc-datalake/lambda/jobs/persona_importer/test/__init__.py
+++ b/voc-datalake/lambda/jobs/persona_importer/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for persona importer job Lambda."""

--- a/voc-datalake/lambda/jobs/persona_importer/test/conftest.py
+++ b/voc-datalake/lambda/jobs/persona_importer/test/conftest.py
@@ -1,0 +1,84 @@
+"""Test fixtures for persona importer job."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Import shared fixtures
+from jobs.conftest import *  # noqa: F401, F403
+
+
+@pytest.fixture
+def text_import_event(sample_job_event):
+    """Sample text-based persona import job event."""
+    return {
+        **sample_job_event,
+        'import_config': {
+            'input_type': 'text',
+            'content': '''
+            Name: Sarah Chen
+            Role: Product Manager at a mid-size tech company
+            
+            Goals:
+            - Ship features faster
+            - Better understand customer needs
+            - Reduce time spent on documentation
+            
+            Frustrations:
+            - Too many meetings
+            - Scattered feedback across tools
+            - Hard to prioritize features
+            ''',
+            'media_type': '',
+        }
+    }
+
+
+@pytest.fixture
+def image_import_event(sample_job_event):
+    """Sample image-based persona import job event."""
+    # Base64 encoded 1x1 PNG (minimal valid image)
+    minimal_png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+    return {
+        **sample_job_event,
+        'import_config': {
+            'input_type': 'image',
+            'content': minimal_png,
+            'media_type': 'image/png',
+        }
+    }
+
+
+@pytest.fixture
+def mock_bedrock_persona_response():
+    """Mock Bedrock response with extracted persona data."""
+    return {
+        'output': {
+            'message': {
+                'content': [{
+                    'text': '''{
+                        "name": "Sarah Chen",
+                        "tagline": "Efficiency-focused PM seeking better tools",
+                        "confidence": "high",
+                        "identity": {"role": "Product Manager", "company_size": "mid-size"},
+                        "goals_motivations": {"primary": ["Ship faster", "Understand customers"]},
+                        "pain_points": {"primary": ["Too many meetings", "Scattered feedback"]},
+                        "behaviors": {},
+                        "context_environment": {},
+                        "quotes": ["I spend too much time in meetings"],
+                        "scenario": {}
+                    }'''
+                }]
+            }
+        }
+    }
+
+
+@pytest.fixture
+def mock_avatar_generation():
+    """Mock avatar generation function."""
+    with patch('api.projects.generate_persona_avatar') as mock:
+        mock.return_value = {
+            'avatar_url': 's3://test-bucket/avatars/test.png',
+            'avatar_prompt': 'Professional headshot of Sarah Chen'
+        }
+        yield mock

--- a/voc-datalake/lambda/jobs/persona_importer/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/test/test_handler.py
@@ -1,0 +1,152 @@
+"""Tests for persona importer job handler."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestPersonaImporterHandler:
+    """Tests for the persona importer job Lambda handler."""
+
+    def test_successful_text_import(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response
+    ):
+        """Test successful persona import from text."""
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        
+        from jobs.persona_importer.handler import lambda_handler
+        
+        result = lambda_handler(text_import_event, None)
+        
+        assert result['success'] is True
+        assert 'persona_id' in result
+        mock_bedrock.converse.assert_called_once()
+
+    def test_successful_image_import(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, image_import_event, mock_bedrock_persona_response
+    ):
+        """Test successful persona import from image."""
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        
+        from jobs.persona_importer.handler import lambda_handler
+        
+        result = lambda_handler(image_import_event, None)
+        
+        assert result['success'] is True
+        assert 'persona_id' in result
+        
+        # Verify image was included in converse call
+        call_args = mock_bedrock.converse.call_args
+        messages = call_args.kwargs.get('messages', [])
+        assert any('image' in str(m) for m in messages)
+
+    def test_persona_saved_to_dynamodb(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response
+    ):
+        """Test that imported persona is saved to DynamoDB."""
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        
+        from jobs.persona_importer.handler import lambda_handler
+        
+        lambda_handler(text_import_event, None)
+        
+        mock_dynamodb['table'].put_item.assert_called()
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert item.get('name') == 'Sarah Chen'
+        assert item.get('imported_from') == 'text'
+
+    def test_avatar_generated_for_imported_persona(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response
+    ):
+        """Test that avatar is generated for imported persona."""
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        
+        from jobs.persona_importer.handler import lambda_handler
+        
+        lambda_handler(text_import_event, None)
+        
+        mock_avatar_generation.assert_called_once()
+        
+        # Verify avatar URL is saved
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert 'avatar_url' in item
+
+    def test_handles_json_in_markdown_code_block(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event
+    ):
+        """Test that handler extracts JSON from markdown code blocks."""
+        mock_bedrock.converse.return_value = {
+            'output': {
+                'message': {
+                    'content': [{
+                        'text': '''Here's the extracted persona:
+                        
+```json
+{
+    "name": "Test User",
+    "tagline": "A test persona",
+    "confidence": "medium",
+    "identity": {},
+    "goals_motivations": {},
+    "pain_points": {},
+    "behaviors": {},
+    "context_environment": {},
+    "quotes": [],
+    "scenario": {}
+}
+```'''
+                    }]
+                }
+            }
+        }
+        
+        from jobs.persona_importer.handler import lambda_handler
+        
+        result = lambda_handler(text_import_event, None)
+        
+        assert result['success'] is True
+        put_call = mock_dynamodb['table'].put_item.call_args
+        item = put_call.kwargs.get('Item', {})
+        assert item.get('name') == 'Test User'
+
+    def test_job_fails_on_invalid_json(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event
+    ):
+        """Test that job fails when LLM returns invalid JSON."""
+        from jobs.persona_importer.handler import lambda_handler
+        from shared.exceptions import ServiceError
+        
+        mock_bedrock.converse.return_value = {
+            'output': {
+                'message': {
+                    'content': [{'text': 'This is not valid JSON'}]
+                }
+            }
+        }
+        
+        with pytest.raises(ServiceError):
+            lambda_handler(text_import_event, None)
+        
+        mock_jobs_table.update_item.assert_called()
+
+    def test_persona_count_incremented(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response
+    ):
+        """Test that project persona count is incremented."""
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        
+        from jobs.persona_importer.handler import lambda_handler
+        
+        lambda_handler(text_import_event, None)
+        
+        # Verify update_item was called to increment persona_count
+        update_calls = [c for c in mock_dynamodb['table'].update_item.call_args_list]
+        assert any('persona_count' in str(c) for c in update_calls)

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -390,7 +390,6 @@ export class VocApiStack extends cdk.Stack {
         'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0',
       ],
     }));
-    projectsRole.addToPolicy(new iam.PolicyStatement({ actions: ['lambda:InvokeFunction'], resources: [`arn:aws:lambda:${this.region}:${this.account}:function:voc-projects-api-*`] }));
     rawDataBucket.grantReadWrite(projectsRole, 'avatars/*');
 
     const projectsLambda = new lambda.Function(this, 'ProjectsApi', {
@@ -400,8 +399,8 @@ export class VocApiStack extends cdk.Stack {
       handler: 'projects_handler.lambda_handler',
       code: createApiLambdaCode('projects_handler.py'),
       role: projectsRole,
-      timeout: cdk.Duration.minutes(15),
-      memorySize: 1024,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 512,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
@@ -417,6 +416,186 @@ export class VocApiStack extends cdk.Stack {
       layers: [apiLayer],
       logGroup: this.createLogGroup('ProjectsApiLogs', uniqueName('voc-projects-api')),
     });
+
+    // ============================================
+    // JOB LAMBDAS (Async Background Processing)
+    // ============================================
+
+    /**
+     * Creates an optimized Lambda code bundle for job handlers.
+     * Includes the job handler, shared modules, and api/projects.py for business logic.
+     */
+    const createJobLambdaCode = (jobFolder: string): lambda.Code => {
+      return lambda.Code.fromAsset('lambda', {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_14.bundlingImage,
+          command: [
+            'bash', '-c',
+            `mkdir -p /asset-output/api && ` +
+            `cp /asset-input/jobs/${jobFolder}/handler.py /asset-output/ && ` +
+            `cp -r /asset-input/shared /asset-output/ && ` +
+            `cp /asset-input/api/projects.py /asset-output/api/`
+          ],
+          platform: 'linux/arm64',
+        },
+      });
+    };
+
+    // Persona Generator Job Lambda
+    const personaGeneratorRole = this.createLambdaRole('PersonaGeneratorRole');
+    feedbackTable.grantReadData(personaGeneratorRole);
+    projectsTable.grantReadWriteData(personaGeneratorRole);
+    jobsTable.grantReadWriteData(personaGeneratorRole);
+    aggregatesTable.grantReadData(personaGeneratorRole);
+    kmsKey.grantEncryptDecrypt(personaGeneratorRole);
+    personaGeneratorRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+      resources: [
+        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0',
+      ],
+    }));
+    rawDataBucket.grantReadWrite(personaGeneratorRole, 'avatars/*');
+
+    const personaGeneratorLambda = new lambda.Function(this, 'PersonaGeneratorJob', {
+      functionName: uniqueName('voc-job-persona-generator'),
+      runtime: lambda.Runtime.PYTHON_3_14,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'handler.lambda_handler',
+      code: createJobLambdaCode('persona_generator'),
+      role: personaGeneratorRole,
+      timeout: cdk.Duration.minutes(15),
+      memorySize: 1024,
+      environment: {
+        PROJECTS_TABLE: projectsTable.tableName,
+        FEEDBACK_TABLE: feedbackTable.tableName,
+        AGGREGATES_TABLE: aggregatesTable.tableName,
+        JOBS_TABLE: jobsTable.tableName,
+        RAW_DATA_BUCKET: rawDataBucket.bucketName,
+        AVATARS_CDN_URL: avatarsCdnUrl,
+        POWERTOOLS_SERVICE_NAME: 'voc-job-persona-generator',
+        LOG_LEVEL: 'INFO',
+      },
+      layers: [apiLayer],
+      logGroup: this.createLogGroup('PersonaGeneratorJobLogs', uniqueName('voc-job-persona-generator')),
+    });
+
+    // Document Generator Job Lambda (PRD/PRFAQ)
+    const documentGeneratorRole = this.createLambdaRole('DocumentGeneratorRole');
+    feedbackTable.grantReadData(documentGeneratorRole);
+    projectsTable.grantReadWriteData(documentGeneratorRole);
+    jobsTable.grantReadWriteData(documentGeneratorRole);
+    kmsKey.grantEncryptDecrypt(documentGeneratorRole);
+    documentGeneratorRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel'],
+      resources: [
+        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
+      ],
+    }));
+
+    const documentGeneratorLambda = new lambda.Function(this, 'DocumentGeneratorJob', {
+      functionName: uniqueName('voc-job-document-generator'),
+      runtime: lambda.Runtime.PYTHON_3_14,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'handler.lambda_handler',
+      code: createJobLambdaCode('document_generator'),
+      role: documentGeneratorRole,
+      timeout: cdk.Duration.minutes(10),
+      memorySize: 1024,
+      environment: {
+        PROJECTS_TABLE: projectsTable.tableName,
+        FEEDBACK_TABLE: feedbackTable.tableName,
+        JOBS_TABLE: jobsTable.tableName,
+        POWERTOOLS_SERVICE_NAME: 'voc-job-document-generator',
+        LOG_LEVEL: 'INFO',
+      },
+      layers: [apiLayer],
+      logGroup: this.createLogGroup('DocumentGeneratorJobLogs', uniqueName('voc-job-document-generator')),
+    });
+
+    // Document Merger Job Lambda
+    const documentMergerRole = this.createLambdaRole('DocumentMergerRole');
+    feedbackTable.grantReadData(documentMergerRole);
+    projectsTable.grantReadWriteData(documentMergerRole);
+    jobsTable.grantReadWriteData(documentMergerRole);
+    kmsKey.grantEncryptDecrypt(documentMergerRole);
+    documentMergerRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel'],
+      resources: [
+        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
+      ],
+    }));
+
+    const documentMergerLambda = new lambda.Function(this, 'DocumentMergerJob', {
+      functionName: uniqueName('voc-job-document-merger'),
+      runtime: lambda.Runtime.PYTHON_3_14,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'handler.lambda_handler',
+      code: createJobLambdaCode('document_merger'),
+      role: documentMergerRole,
+      timeout: cdk.Duration.minutes(10),
+      memorySize: 1024,
+      environment: {
+        PROJECTS_TABLE: projectsTable.tableName,
+        FEEDBACK_TABLE: feedbackTable.tableName,
+        JOBS_TABLE: jobsTable.tableName,
+        POWERTOOLS_SERVICE_NAME: 'voc-job-document-merger',
+        LOG_LEVEL: 'INFO',
+      },
+      layers: [apiLayer],
+      logGroup: this.createLogGroup('DocumentMergerJobLogs', uniqueName('voc-job-document-merger')),
+    });
+
+    // Persona Importer Job Lambda
+    const personaImporterRole = this.createLambdaRole('PersonaImporterRole');
+    projectsTable.grantReadWriteData(personaImporterRole);
+    jobsTable.grantReadWriteData(personaImporterRole);
+    kmsKey.grantEncryptDecrypt(personaImporterRole);
+    personaImporterRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel'],
+      resources: [
+        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0',
+      ],
+    }));
+    rawDataBucket.grantReadWrite(personaImporterRole, 'avatars/*');
+
+    const personaImporterLambda = new lambda.Function(this, 'PersonaImporterJob', {
+      functionName: uniqueName('voc-job-persona-importer'),
+      runtime: lambda.Runtime.PYTHON_3_14,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'handler.lambda_handler',
+      code: createJobLambdaCode('persona_importer'),
+      role: personaImporterRole,
+      timeout: cdk.Duration.minutes(5),
+      memorySize: 512,
+      environment: {
+        PROJECTS_TABLE: projectsTable.tableName,
+        JOBS_TABLE: jobsTable.tableName,
+        RAW_DATA_BUCKET: rawDataBucket.bucketName,
+        AVATARS_CDN_URL: avatarsCdnUrl,
+        POWERTOOLS_SERVICE_NAME: 'voc-job-persona-importer',
+        LOG_LEVEL: 'INFO',
+      },
+      layers: [apiLayer],
+      logGroup: this.createLogGroup('PersonaImporterJobLogs', uniqueName('voc-job-persona-importer')),
+    });
+
+    // Add job Lambda function names to Projects API environment
+    projectsLambda.addEnvironment('PERSONA_GENERATOR_FUNCTION', personaGeneratorLambda.functionName);
+    projectsLambda.addEnvironment('DOCUMENT_GENERATOR_FUNCTION', documentGeneratorLambda.functionName);
+    projectsLambda.addEnvironment('DOCUMENT_MERGER_FUNCTION', documentMergerLambda.functionName);
+    projectsLambda.addEnvironment('PERSONA_IMPORTER_FUNCTION', personaImporterLambda.functionName);
+
+    // Grant Projects API permission to invoke job Lambdas
+    personaGeneratorLambda.grantInvoke(projectsRole);
+    documentGeneratorLambda.grantInvoke(projectsRole);
+    documentMergerLambda.grantInvoke(projectsRole);
+    personaImporterLambda.grantInvoke(projectsRole);
 
     // Chat Stream (Function URL)
     const chatStreamRole = this.createLambdaRole('ChatStreamLambdaRole');


### PR DESCRIPTION
## Summary
Closes #21

Moves async job handlers from `projects_handler.py` to 4 dedicated Lambda functions for better isolation, independent scaling, and easier maintenance.

## Changes

### New Job Lambdas
- `voc-job-persona-generator` - Generates personas from feedback (15min timeout, 1024MB)
- `voc-job-document-generator` - Creates PRD/PRFAQ documents (10min timeout, 1024MB)
- `voc-job-document-merger` - Merges multiple documents (10min timeout, 1024MB)
- `voc-job-persona-importer` - Imports personas from text/image (5min timeout, 512MB)

### Projects API Lambda
- Reduced timeout from 15min to 30s (no longer runs long jobs)
- Reduced memory from 1024MB to 512MB
- Now invokes job Lambdas via `invoke_lambda_async()`

### Infrastructure
- Added 4 new Lambda definitions in `api-stack.ts`
- Each job Lambda has only the permissions it needs (least privilege)
- Projects API granted invoke permission on all 4 job Lambdas

## Testing
- Added unit tests for all 4 job handlers
- Existing `@job_handler` decorator tests pass
- CDK TypeScript compiles successfully

## Dependencies
This PR builds on PR #50 which added the `@job_handler` decorator.
