### PR TITLE
use PyJWT for shared cognito auth moduleuse pyjwt for auth

### DIFF
--- a/voc-datalake/lambda/layers/processing-deps/requirements.txt
+++ b/voc-datalake/lambda/layers/processing-deps/requirements.txt
@@ -2,3 +2,4 @@ aws-lambda-powertools[tracer]>=2.30.0
 pydantic>=2.12.0
 requests>=2.31.0
 tenacity>=8.2.0
+PyJWT[crypto]>=2.8.0

--- a/voc-datalake/lambda/shared/auth.py
+++ b/voc-datalake/lambda/shared/auth.py
@@ -2,21 +2,11 @@
 Shared authentication utilities for VoC Lambda functions.
 Provides Cognito JWT validation for Function URL handlers.
 
-Security Architecture:
-=====================
-This module implements custom Cognito JWT validation for Lambda Function URLs
-with authType: NONE. This approach was chosen over IAM auth (SigV4) because:
-
-1. The frontend uses Cognito User Pool authentication (not Identity Pool)
-2. SigV4 signing would require adding a Cognito Identity Pool and AWS SDK
-3. JWT validation provides equivalent security when implemented correctly
-
 Security Controls:
-- Cryptographic signature verification using Cognito JWKS (RS256)
+- Cryptographic signature verification using PyJWT with RS256 algorithm allowlist
 - Token issuer validation against configured User Pool
-- Token expiration validation with clock skew tolerance
+- Token expiration validation
 - Token type validation (id/access tokens only)
-- Audience validation for ID tokens
 
 The JWT validation follows AWS Cognito best practices:
 https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html
@@ -24,11 +14,10 @@ https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-po
 
 import json
 import os
-import base64
-import hashlib
-import urllib.request
-from datetime import datetime, timezone
 from functools import wraps
+
+import jwt
+from jwt import PyJWKClient, PyJWKClientError
 
 from shared.logging import logger
 
@@ -36,179 +25,28 @@ from shared.logging import logger
 USER_POOL_ID = os.environ.get('USER_POOL_ID', '')
 AWS_REGION = os.environ.get('AWS_REGION', 'us-east-1')
 
-# Cache for Cognito JWKS (JSON Web Key Set) with TTL
-_cached_jwks: dict | None = None
-_jwks_cache_time: datetime | None = None
-JWKS_CACHE_TTL_SECONDS = 3600  # 1 hour cache for JWKS
+# Security: Only allow RS256 algorithm (prevents algorithm confusion attacks)
+ALLOWED_ALGORITHMS = ["RS256"]
+JWKS_CACHE_TTL_SECONDS = 3600
 
-# Clock skew tolerance for token expiration (5 minutes)
-CLOCK_SKEW_SECONDS = 300
+# Cached JWKS client (reused across Lambda invocations)
+_jwks_client: PyJWKClient | None = None
 
 
-def get_cognito_jwks() -> dict | None:
-    """
-    Fetch Cognito JWKS for token signature verification (cached with TTL).
-    
-    The JWKS contains the public keys used to verify JWT signatures.
-    Keys are cached for 1 hour to reduce latency while allowing key rotation.
-    """
-    global _cached_jwks, _jwks_cache_time
-    
-    now = datetime.now(timezone.utc)
-    if _cached_jwks is not None and _jwks_cache_time is not None:
-        cache_age = (now - _jwks_cache_time).total_seconds()
-        if cache_age < JWKS_CACHE_TTL_SECONDS:
-            return _cached_jwks
-    
+def _get_signing_key(token: str):
+    """Get the signing key for a token from JWKS."""
+    global _jwks_client
     if not USER_POOL_ID:
-        logger.warning("USER_POOL_ID not configured - authentication disabled")
         return None
-    
-    try:
+    if _jwks_client is None:
         jwks_url = f"https://cognito-idp.{AWS_REGION}.amazonaws.com/{USER_POOL_ID}/.well-known/jwks.json"
-        with urllib.request.urlopen(jwks_url, timeout=5) as response:
-            _cached_jwks = json.loads(response.read().decode())
-            _jwks_cache_time = now
-            logger.info("Refreshed Cognito JWKS cache")
-            return _cached_jwks
-    except Exception as e:
-        logger.error(f"Failed to fetch Cognito JWKS: {e}")
-        if _cached_jwks is not None:
-            logger.warning("Using stale JWKS cache due to fetch failure")
-            return _cached_jwks
-        return None
-
-
-def base64url_decode(data: str) -> bytes:
-    """Decode base64url-encoded data with proper padding."""
-    padding = 4 - len(data) % 4
-    if padding != 4:
-        data += '=' * padding
-    return base64.urlsafe_b64decode(data)
-
-
-def decode_jwt_parts(token: str) -> tuple[dict | None, dict | None, bytes | None]:
-    """
-    Decode JWT into header, payload, and signature.
-    Returns (header, payload, signature) or (None, None, None) on error.
-    """
-    try:
-        parts = token.split('.')
-        if len(parts) != 3:
-            return None, None, None
-        
-        header = json.loads(base64url_decode(parts[0]))
-        payload = json.loads(base64url_decode(parts[1]))
-        signature = base64url_decode(parts[2])
-        
-        return header, payload, signature
-    except Exception as e:
-        logger.warning(f"Failed to decode JWT parts: {e}")
-        return None, None, None
-
-
-def get_public_key_from_jwks(jwks: dict, kid: str) -> dict | None:
-    """Find the public key in JWKS matching the key ID (kid)."""
-    for key in jwks.get('keys', []):
-        if key.get('kid') == kid:
-            return key
-    return None
-
-
-def verify_rs256_signature(token: str, jwks: dict) -> bool:
-    """
-    Verify RS256 JWT signature using Cognito JWKS.
-    
-    This implements cryptographic signature verification per RFC 7515.
-    Uses the RSA public key from JWKS to verify the token wasn't tampered with.
-    """
-    try:
-        header, payload, signature = decode_jwt_parts(token)
-        if not header or not payload or signature is None:
-            return False
-        
-        if header.get('alg') != 'RS256':
-            logger.warning(f"Unexpected JWT algorithm: {header.get('alg')}")
-            return False
-        
-        kid = header.get('kid')
-        if not kid:
-            logger.warning("JWT missing key ID (kid)")
-            return False
-        
-        public_key = get_public_key_from_jwks(jwks, kid)
-        if not public_key:
-            logger.warning(f"No matching key found in JWKS for kid: {kid}")
-            return False
-        
-        if public_key.get('kty') != 'RSA':
-            logger.warning(f"Unexpected key type: {public_key.get('kty')}")
-            return False
-        
-        if public_key.get('use') != 'sig':
-            logger.warning(f"Key not for signature verification: {public_key.get('use')}")
-            return False
-        
-        n = public_key.get('n')
-        e = public_key.get('e')
-        
-        if not n or not e:
-            logger.warning("JWK missing RSA components (n, e)")
-            return False
-        
-        parts = token.split('.')
-        signing_input = f"{parts[0]}.{parts[1]}".encode('utf-8')
-        
-        n_bytes = base64url_decode(n)
-        e_bytes = base64url_decode(e)
-        
-        n_int = int.from_bytes(n_bytes, 'big')
-        e_int = int.from_bytes(e_bytes, 'big')
-        
-        sig_int = int.from_bytes(signature, 'big')
-        decrypted = pow(sig_int, e_int, n_int)
-        
-        key_size = (n_int.bit_length() + 7) // 8
-        decrypted_bytes = decrypted.to_bytes(key_size, 'big')
-        
-        # PKCS#1 v1.5 signature verification
-        sha256_digest_info = bytes([
-            0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
-            0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
-        ])
-        
-        message_hash = hashlib.sha256(signing_input).digest()
-        
-        t_len = len(sha256_digest_info) + len(message_hash)
-        ps_len = key_size - t_len - 3
-        
-        if ps_len < 8:
-            logger.warning("Key too small for PKCS#1 v1.5 padding")
-            return False
-        
-        expected = bytes([0x00, 0x01]) + bytes([0xFF] * ps_len) + bytes([0x00]) + sha256_digest_info + message_hash
-        
-        if decrypted_bytes == expected:
-            return True
-        
-        logger.warning("JWT signature verification failed")
-        return False
-        
-    except Exception as e:
-        logger.warning(f"JWT signature verification error: {e}")
-        return False
+        _jwks_client = PyJWKClient(jwks_url, cache_keys=True, lifespan=JWKS_CACHE_TTL_SECONDS)
+    return _jwks_client.get_signing_key_from_jwt(token)
 
 
 def validate_cognito_token(token: str) -> tuple[bool, str, dict | None]:
     """
-    Validate a Cognito JWT token with full cryptographic verification.
-    
-    Validation steps (per AWS Cognito documentation):
-    1. Verify the JWT signature using the public key from JWKS
-    2. Verify the token is not expired (with clock skew tolerance)
-    3. Verify the issuer matches the Cognito User Pool
-    4. Verify the token_use claim (id or access)
-    5. For ID tokens, verify the audience (aud) matches the app client ID
+    Validate a Cognito JWT token using PyJWT.
     
     Returns (is_valid, error_message, claims).
     """
@@ -216,40 +54,41 @@ def validate_cognito_token(token: str) -> tuple[bool, str, dict | None]:
         logger.warning("Cognito validation skipped - USER_POOL_ID not configured")
         return True, "", None
     
-    header, claims, signature = decode_jwt_parts(token)
-    if not header or not claims or signature is None:
-        return False, "Invalid token format", None
-    
-    jwks = get_cognito_jwks()
-    if jwks:
-        if not verify_rs256_signature(token, jwks):
-            return False, "Invalid token signature", None
-    else:
-        logger.warning("JWKS unavailable - skipping signature verification")
-    
-    expected_issuer = f"https://cognito-idp.{AWS_REGION}.amazonaws.com/{USER_POOL_ID}"
-    if claims.get('iss') != expected_issuer:
+    try:
+        signing_key = _get_signing_key(token)
+        if signing_key is None:
+            return True, "", None
+        
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=ALLOWED_ALGORITHMS,
+            issuer=f"https://cognito-idp.{AWS_REGION}.amazonaws.com/{USER_POOL_ID}",
+            options={"require": ["exp", "iss", "token_use"]}
+        )
+        
+        # Cognito-specific: validate token_use claim
+        if claims.get('token_use') not in ('id', 'access'):
+            return False, "Invalid token type", None
+        
+        return True, "", claims
+        
+    except jwt.ExpiredSignatureError:
+        return False, "Token expired", None
+    except jwt.ImmatureSignatureError:
+        return False, "Token not yet valid", None
+    except jwt.InvalidIssuerError:
         return False, "Invalid token issuer", None
-    
-    exp = claims.get('exp')
-    if exp:
-        current_time = datetime.now(timezone.utc).timestamp()
-        if current_time > (exp + CLOCK_SKEW_SECONDS):
-            return False, "Token expired", None
-    else:
-        return False, "Token missing expiration", None
-    
-    token_use = claims.get('token_use')
-    if token_use not in ('id', 'access'):
-        return False, "Invalid token type", None
-    
-    nbf = claims.get('nbf')
-    if nbf:
-        current_time = datetime.now(timezone.utc).timestamp()
-        if current_time < (nbf - CLOCK_SKEW_SECONDS):
-            return False, "Token not yet valid", None
-    
-    return True, "", claims
+    except jwt.InvalidSignatureError:
+        return False, "Invalid token signature", None
+    except jwt.DecodeError:
+        return False, "Invalid token format", None
+    except PyJWKClientError as e:
+        logger.warning(f"JWKS client error: {e}")
+        return False, "Invalid token signature", None
+    except jwt.InvalidTokenError as e:
+        logger.warning(f"Token validation error: {e}")
+        return False, str(e), None
 
 
 def validate_auth(event: dict) -> tuple[bool, str]:

--- a/voc-datalake/lambda/shared/test/test_auth.py
+++ b/voc-datalake/lambda/shared/test/test_auth.py
@@ -1,0 +1,312 @@
+"""
+Tests for shared/auth.py - Cognito JWT validation for VoC Lambda functions.
+
+Uses real RS256 signatures - no mocking of crypto functions.
+"""
+
+import json
+import time
+import pytest
+from unittest.mock import patch, MagicMock
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
+
+
+# Generate a test RSA key pair (2048-bit, same as Cognito)
+_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_public_key = _private_key.public_key()
+
+
+def make_signed_token(claims: dict, kid: str = "test-key-id") -> str:
+    """Create a real RS256-signed JWT."""
+    return jwt.encode(claims, _private_key, algorithm="RS256", headers={"kid": kid})
+
+
+def valid_claims(token_use: str = "access") -> dict:
+    return {
+        "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_test",
+        "token_use": token_use,
+        "exp": int(time.time()) + 3600,
+        "sub": "user-123",
+        "email": "test@example.com",
+    }
+
+
+@pytest.fixture(autouse=True)
+def setup_env():
+    """Set up module state for each test."""
+    import shared.auth as auth_module
+    auth_module._jwks_client = None
+    auth_module.USER_POOL_ID = "us-east-1_test"
+    auth_module.AWS_REGION = "us-east-1"
+
+
+@pytest.fixture
+def mock_jwks():
+    """Mock PyJWKClient to return our test public key."""
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = _public_key
+    
+    with patch("shared.auth._get_signing_key", return_value=mock_signing_key):
+        yield
+
+
+class TestValidateAuth:
+    """Tests for validate_auth with real RS256 signatures."""
+
+    def test_valid_token_accepted(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims())
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is True
+        assert error == ""
+
+    def test_tampered_payload_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims())
+        # Tamper with the payload (change middle part)
+        parts = token.split('.')
+        tampered = f"{parts[0]}.eyJmb28iOiJiYXIifQ.{parts[2]}"
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {tampered}"}})
+        
+        assert is_valid is False
+        assert "signature" in error.lower()
+
+    def test_wrong_key_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        # Sign with a different key
+        other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        token = jwt.encode(valid_claims(), other_key, algorithm="RS256", headers={"kid": "test-key-id"})
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is False
+        assert "signature" in error.lower()
+
+    def test_missing_authorization_header(self):
+        from shared.auth import validate_auth
+        
+        is_valid, error = validate_auth({"headers": {}})
+        
+        assert is_valid is False
+        assert "Authorization" in error
+
+    def test_none_headers_handled(self):
+        from shared.auth import validate_auth
+        
+        is_valid, error = validate_auth({"headers": None})
+        
+        assert is_valid is False
+
+    def test_bearer_prefix_stripped(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims())
+        
+        is_valid, _ = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is True
+
+    def test_raw_token_accepted(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims())
+        
+        is_valid, _ = validate_auth({"headers": {"Authorization": token}})
+        
+        assert is_valid is True
+
+    def test_case_insensitive_authorization_header(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims())
+        
+        is_valid, _ = validate_auth({"headers": {"authorization": f"Bearer {token}"}})
+        
+        assert is_valid is True
+
+    def test_case_insensitive_bearer_prefix(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims())
+        
+        is_valid, _ = validate_auth({"headers": {"Authorization": f"bearer {token}"}})
+        
+        assert is_valid is True
+
+    def test_expired_token_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        claims = valid_claims()
+        claims["exp"] = int(time.time()) - 600
+        token = make_signed_token(claims)
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is False
+        assert "expired" in error.lower()
+
+    def test_wrong_issuer_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        claims = valid_claims()
+        claims["iss"] = "https://evil.com"
+        token = make_signed_token(claims)
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is False
+        assert "issuer" in error.lower()
+
+    def test_invalid_token_use_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        claims = valid_claims()
+        claims["token_use"] = "refresh"
+        token = make_signed_token(claims)
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is False
+
+    def test_id_token_accepted(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims("id"))
+        
+        is_valid, _ = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is True
+
+    def test_access_token_accepted(self, mock_jwks):
+        from shared.auth import validate_auth
+        token = make_signed_token(valid_claims("access"))
+        
+        is_valid, _ = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is True
+
+    def test_malformed_token_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": "Bearer not.valid"}})
+        
+        assert is_valid is False
+
+    def test_skips_validation_when_disabled(self):
+        import shared.auth as auth_module
+        auth_module.USER_POOL_ID = ""
+        
+        is_valid, _ = auth_module.validate_auth({"headers": {"Authorization": "any-token"}})
+        
+        assert is_valid is True
+
+    def test_nbf_future_token_rejected(self, mock_jwks):
+        from shared.auth import validate_auth
+        claims = valid_claims()
+        claims["nbf"] = int(time.time()) + 600
+        token = make_signed_token(claims)
+        
+        is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+        
+        assert is_valid is False
+        assert "not yet valid" in error.lower()
+
+    def test_unknown_kid_rejected(self):
+        from shared.auth import validate_auth
+        from jwt import PyJWKClientError
+        
+        # Mock _get_signing_key to raise PyJWKClientError for unknown kid
+        with patch("shared.auth._get_signing_key", side_effect=PyJWKClientError("Key not found")):
+            token = make_signed_token(valid_claims(), kid="unknown-key")
+            
+            is_valid, error = validate_auth({"headers": {"Authorization": f"Bearer {token}"}})
+            
+            assert is_valid is False
+            assert "signature" in error.lower()
+
+
+class TestUnauthorizedResponse:
+    """Tests for unauthorized_response helper."""
+
+    def test_returns_401_status(self):
+        from shared.auth import unauthorized_response
+        
+        result = unauthorized_response()
+        
+        assert result["statusCode"] == 401
+
+    def test_includes_www_authenticate_header(self):
+        from shared.auth import unauthorized_response
+        
+        result = unauthorized_response()
+        
+        assert "WWW-Authenticate" in result["headers"]
+        assert "Bearer" in result["headers"]["WWW-Authenticate"]
+
+    def test_includes_custom_error_message(self):
+        from shared.auth import unauthorized_response
+        
+        result = unauthorized_response("Custom error")
+        body = json.loads(result["body"])
+        
+        assert body["error"] == "Custom error"
+
+    def test_default_error_message(self):
+        from shared.auth import unauthorized_response
+        
+        result = unauthorized_response()
+        body = json.loads(result["body"])
+        
+        assert body["error"] == "Unauthorized"
+
+    def test_content_type_is_json(self):
+        from shared.auth import unauthorized_response
+        
+        result = unauthorized_response()
+        
+        assert result["headers"]["Content-Type"] == "application/json"
+
+
+class TestRequireAuthDecorator:
+    """Tests for require_auth decorator."""
+
+    def test_returns_401_when_unauthorized(self):
+        from shared.auth import require_auth
+        
+        @require_auth
+        def handler(event, context):
+            return {"statusCode": 200}
+        
+        result = handler({"headers": {}}, None)
+        
+        assert result["statusCode"] == 401
+
+    def test_passes_through_when_authorized(self, mock_jwks):
+        from shared.auth import require_auth
+        token = make_signed_token(valid_claims())
+        
+        @require_auth
+        def handler(event, context):
+            return {"statusCode": 200, "body": "success"}
+        
+        result = handler({"headers": {"Authorization": f"Bearer {token}"}}, None)
+        
+        assert result["statusCode"] == 200
+        assert result["body"] == "success"
+
+    def test_preserves_function_name(self):
+        from shared.auth import require_auth
+        
+        @require_auth
+        def my_handler(event, context):
+            return {"statusCode": 200}
+        
+        assert my_handler.__name__ == "my_handler"
+
+    def test_returns_error_message_in_401_response(self):
+        from shared.auth import require_auth
+        
+        @require_auth
+        def handler(event, context):
+            return {"statusCode": 200}
+        
+        result = handler({"headers": {}}, None)
+        body = json.loads(result["body"])
+        
+        assert "error" in body


### PR DESCRIPTION
*Description of changes:*
- Updates the Cognito authorisation code used by the lambda function URL to use `PyJWT`
- Adds unit tests for `auth` module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
