### PR TITLE
fix: duplicate check PK mismatch causing ~$69/day in wasted Comprehend/Translate charges

### DIFF
--- a/voc-datalake/lambda/processor/handler.py
+++ b/voc-datalake/lambda/processor/handler.py
@@ -467,16 +467,20 @@ def process_feedback(raw_record: dict, idempotency_key: str = None) -> dict:
     source_platform = raw_record.get('source_platform', 'unknown')
     source_id = raw_record.get('id', '')
     
+    # Resolve source_display early — used as PK for both duplicate check and write
+    brand_name = raw_record.get('brand_name', '')
+    source_display = brand_name if brand_name else source_platform
+    
     # Generate deterministic ID based on source to prevent duplicates
     original_text = raw_record.get('text', '')
     created_at_raw = raw_record.get('created_at', '')
     url = raw_record.get('url', '')
     feedback_id = generate_deterministic_id(source_platform, source_id, original_text, created_at_raw, url)
     
-    # Check for duplicate before expensive LLM processing
-    # This is a secondary check - idempotency decorator is the primary protection
-    if check_duplicate(source_platform, feedback_id):
-        logger.info(f"Skipping duplicate feedback: {source_platform}/{source_id}")
+    # Check for duplicate before expensive Comprehend/Translate/Bedrock processing
+    # Uses source_display (brand_name) to match the PK used when writing items
+    if check_duplicate(source_display, feedback_id):
+        logger.info(f"Skipping duplicate feedback: {source_display}/{source_id}")
         metrics.add_metric(name="DuplicatesSkipped", unit="Count", value=1)
         return None
     
@@ -495,10 +499,6 @@ def process_feedback(raw_record: dict, idempotency_key: str = None) -> dict:
     
     urgency = insights.get('urgency', 'low')
     sentiment_score = insights.get('sentiment_score', sentiment['score'])
-    
-    # Use brand_name for source display (e.g., "Acme Corp - webscraper"), fallback to source_platform
-    brand_name = raw_record.get('brand_name', '')
-    source_display = brand_name if brand_name else source_platform
     
     # Build DynamoDB item with GSI keys
     item = {


### PR DESCRIPTION
## Problem

The processor's `check_duplicate()` was looking up items using `SOURCE#{source_platform}` (e.g. `SOURCE#webscraper`), but items are written to DynamoDB with `SOURCE#{brand_name}` (e.g. `SOURCE#Acme Corp`). This PK mismatch meant the duplicate check **never found existing items**, so every scraped review was re-processed through Comprehend, Translate, and Bedrock on every hourly scraper run.

With ~200 reviews scraped hourly across 24 runs/day, that's ~4,800 unnecessary processing cycles per day, costing **~$69/day** ($29 Comprehend + $40 Translate).

## Changes

### Fix 1: Processor PK mismatch (critical)
- **`lambda/processor/handler.py`**: Moved `brand_name`/`source_display` resolution before `check_duplicate()` so the lookup key matches the write key

### Fix 2: Ingestor-level dedup (defense in depth)
- **`plugins/_shared/base_ingestor.py`**: Added `filter_duplicates()` method that checks DynamoDB before sending items to SQS, preventing unnecessary queue/S3 churn
- **`lib/stacks/ingestion-stack.ts`**: Added `FEEDBACK_TABLE` env var and `grantReadData` to the ingestion role

## Testing
- All 47 processor tests pass
- All 88 plugin/ingestor tests pass
- CDK TypeScript compiles clean

## Cost Impact
Expected daily cost reduction: **~$69/day → ~$0** for re-scraped content (only genuinely new reviews will incur processing costs).