### PR TITLE
Use random inital password for admin and force change on first login

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,18 @@ After deployment, an initial admin user is created automatically:
 | Field | Value |
 |-------|-------|
 | Username | `admin` |
-| Password | `VocAnalytics@@2026` |
+| Password | Check CloudFormation stack outputs for `AdminUserPassword` |
 
-> ⚠️ **Security Warning**: Change this password immediately after your first login!
+The password is randomly generated during deployment and stored as a CloudFormation output. Retrieve it with:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name VocCoreStack \
+  --query 'Stacks[0].Outputs[?OutputKey==`AdminUserPassword`].OutputValue' \
+  --output text
+```
+
+> 🔒 **Note**: You will be prompted to change this password on your first login.
 
 ## ⚙️ Configuration
 

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -9,6 +9,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import { randomInt } from 'crypto';
 import { Construct } from 'constructs';
 import { uniqueName } from '../utils/naming';
 import { NagSuppressions } from 'cdk-nag';
@@ -461,10 +462,15 @@ The VoC Analytics Team`,
     // ============================================
     // INITIAL ADMIN USER (for greenfield deployments)
     // ============================================
-    // Create initial admin user using custom resource
     const initialAdminUsername = 'admin';
     const initialAdminEmail = 'admin@local.host';
-    const initialAdminPassword = 'VocAnalytics@@2026';
+    
+    // Generate random password (16 chars: uppercase, lowercase, numbers, special chars)
+    const randomPassword = Array.from({ length: 16 }, () => {
+      const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%^&*';
+      return chars[randomInt(0, chars.length)];
+    }).join('');
+    const initialAdminPassword = randomPassword;
 
     // Create the admin user
     const createAdminUser = new cr.AwsCustomResource(this, 'CreateAdminUser', {
@@ -479,7 +485,7 @@ The VoC Analytics Team`,
             { Name: 'email_verified', Value: 'true' },
             { Name: 'name', Value: 'Admin' },
           ],
-          MessageAction: 'SUPPRESS', // Don't send email for initial admin
+          MessageAction: 'SUPPRESS',
         },
         physicalResourceId: cr.PhysicalResourceId.of(uniqueName('admin-user')),
       },
@@ -491,7 +497,7 @@ The VoC Analytics Team`,
       ]),
     });
 
-    // Set permanent password for admin user
+    // Set temporary password for admin user (must change on first login)
     const setAdminPassword = new cr.AwsCustomResource(this, 'SetAdminPassword', {
       onCreate: {
         service: 'CognitoIdentityServiceProvider',
@@ -500,7 +506,6 @@ The VoC Analytics Team`,
           UserPoolId: this.userPool.userPoolId,
           Username: initialAdminUsername,
           Password: initialAdminPassword,
-          Permanent: true,
         },
         physicalResourceId: cr.PhysicalResourceId.of(uniqueName('admin-password')),
       },
@@ -644,6 +649,10 @@ The VoC Analytics Team`,
     new cdk.CfnOutput(this, 'UserPoolDomain', { value: `${domainPrefix}.auth.${this.region}.amazoncognito.com`, description: 'Cognito User Pool Domain' });
     new cdk.CfnOutput(this, 'CognitoRegion', { value: this.region, description: 'AWS Region for Cognito' });
     new cdk.CfnOutput(this, 'IdentityPoolId', { value: this.identityPool.ref, description: 'Cognito Identity Pool ID for AWS IAM auth' });
+    new cdk.CfnOutput(this, 'InitialAdminPassword', { 
+      value: initialAdminPassword, 
+      description: 'Initial admin user password (username: admin)'
+    });
   }
 
   private getCustomMessageLambdaCode(signInUrl: string): string {


### PR DESCRIPTION
*Issue #, if available:* closes #59

*Description of changes:*
Changes the initial `admin` password to be a random string. The admin user can retrieve the password from the Core CFN stack outputs. User must also change this password on initial login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
