### PR TITLE
feat: add mobile app reviews plugins (iOS + Android)

### DIFF
--- a/docs/mobile-app-reviews.md
+++ b/docs/mobile-app-reviews.md
@@ -1,0 +1,355 @@
+# Mobile App Reviews Plugins
+
+Collect customer reviews from the Apple App Store and Google Play Store using two dedicated plugins.
+
+## Overview
+
+The mobile app reviews feature consists of two separate plugins:
+
+| Plugin | Folder | Source | Identifier |
+|--------|--------|--------|------------|
+| iOS App Reviews | `plugins/app_reviews_ios/` | Apple App Store | `app_reviews_ios` |
+| Android App Reviews | `plugins/app_reviews_android/` | Google Play Store | `app_reviews_android` |
+
+Each plugin is independent — its own Lambda, schedule, secrets, watermarks, and circuit breaker. If one platform has issues, the other continues running.
+
+## Plugin Structure
+
+Each plugin handler subclasses `BaseIngestor` from `_shared/base_ingestor.py`. The import pattern follows the existing webscraper convention:
+
+```python
+from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
+```
+
+```
+plugins/
+├── app_reviews_ios/
+│   ├── manifest.json
+│   └── ingestor/
+│       ├── handler.py          # IOSAppReviewsIngestor (subclasses BaseIngestor)
+│       ├── itunes_client.py    # Apple App Store RSS feed client
+│       ├── countries.py        # iOS storefront country codes
+│       └── models.py           # App config validation (IOSAppConfig dataclass)
+│
+└── app_reviews_android/
+    ├── manifest.json
+    └── ingestor/
+        ├── handler.py          # AndroidAppReviewsIngestor (subclasses BaseIngestor)
+        ├── play_client.py      # Google Play Store scraper client
+        ├── countries.py        # Play Store country codes
+        └── models.py           # App config validation (AndroidAppConfig dataclass)
+```
+
+Both plugins follow the same conventions as the existing `webscraper` plugin:
+- `manifest.json` at the plugin root drives CDK infrastructure and frontend UI
+- All Python code lives under `ingestor/` for correct Lambda bundling
+- Each handler subclasses `_shared/base_ingestor.py`
+- Lambda bundling copies plugin code + `_shared/` + `lambda/shared/` (see `ingestion-stack.ts`)
+
+## Settings Page UI
+
+Both plugins appear as cards in **Settings → Data Sources & Integrations**, rendered dynamically from their manifests. Each card configures a single app.
+
+### iOS Plugin Settings
+
+The iOS plugin card shows these config fields:
+
+| Field | Key | Type | Default | Description |
+|-------|-----|------|---------|-------------|
+| App Name | `app_name` | text | — | Logical app name (required) |
+| App Store ID | `app_id` | text | — | Apple App Store numeric ID (required) |
+| Review Sort Order | `sort_by` | select | `most_recent` | `most_recent` or `most_critical` |
+| Max Countries Per Run | `max_countries_per_run` | text | `40` | Limit country iteration |
+| Max Reviews Per Run | `max_reviews_per_run` | text | `500` | Max reviews to collect per run |
+| Run Frequency | `frequency_minutes` | select | `1440` (Daily) | Schedule override |
+
+### Android Plugin Settings
+
+The Android plugin card shows these config fields:
+
+| Field | Key | Type | Default | Description |
+|-------|-----|------|---------|-------------|
+| App Name | `app_name` | text | — | Logical app name (required) |
+| Package Name | `package_name` | text | — | Android package name (required) |
+| Review Sort Order | `sort_by` | select | `newest` | `newest` or `rating` |
+| Max Countries Per Run | `max_countries_per_run` | text | `20` | Limit country iteration |
+| Max Reviews Per Run | `max_reviews_per_run` | text | `500` | Max reviews to collect per run |
+| Run Frequency | `frequency_minutes` | select | `1440` (Daily) | Schedule override |
+
+### Run Frequency Options
+
+Both plugins offer the same frequency options via a select dropdown:
+
+| Value | Label |
+|-------|-------|
+| `15` | Every 15 minutes |
+| `30` | Every 30 minutes |
+| `60` | Every hour |
+| `180` | Every 3 hours |
+| `360` | Every 6 hours |
+| `720` | Every 12 hours |
+| `1440` | Daily |
+
+### Sort Order
+
+**iOS options:**
+- `most_recent` — Fetch newest reviews first (default, recommended)
+- `most_critical` — Fetch lowest-rated reviews first
+
+**Android options:**
+- `newest` — Fetch newest reviews first (default, recommended)
+- `rating` — Fetch by rating (maps to `Sort.MOST_RELEVANT`)
+
+### Countries Per Run
+
+The `max_countries_per_run` field caps how many storefront countries the plugin iterates through per Lambda invocation. This controls the tradeoff between global coverage and Lambda execution time.
+
+- iOS default: 40 countries (~50 reviews each = ~2000 candidates before dedup)
+- Android default: 20 countries (Play Store reviews are more globally pooled)
+
+### Credentials Storage
+
+Credentials are stored in AWS Secrets Manager with keys namespaced by source plugin ID (e.g., `app_reviews_ios_app_name`, `app_reviews_android_package_name`). This prevents plugins from overwriting each other's values. The `BaseIngestor._load_secrets()` method automatically strips the prefix when loading.
+
+## How Global Collection Works
+
+### Strategy
+
+For the configured app, the plugin:
+
+1. Loads the list of supported storefront country codes from `countries.py`
+2. Shuffles the country list (so we don't always stall on the same countries if time runs out)
+3. Limits to `max_countries_per_run` countries
+4. Iterates through countries, fetching the most recent reviews from each
+5. Merges all reviews across countries into a single dict keyed by composite ID
+6. Deduplicates by stable review ID (same review in multiple storefronts gets one entry)
+7. Sorts by date descending
+8. Keeps only the top N reviews based on `max_reviews_per_run`
+9. Filters out reviews older than the watermark
+10. Yields each review to the base ingestor pipeline
+
+### iOS Collection
+
+The iOS plugin uses `app-store-web-scraper` which wraps Apple's undocumented iTunes RSS endpoint:
+
+```
+https://itunes.apple.com/{country}/rss/customerreviews/page={page}/id={app_id}/sortby=mostrecent/json
+```
+
+- Returns up to 50 reviews per page, max 10 pages = 500 reviews per country
+- Built-in session with connection pooling, rate-limit delays (500ms + 200ms jitter), and retry backoff (3 retries, factor 2, max 10s)
+- No authentication required
+- Sorted by most recent by default
+- Returns structured `AppReview` objects with `id`, `date`, `rating`, `title`, `review`, `developer_response`
+- Best effort: if a country 404s or times out, it's skipped with a warning log
+
+```python
+from app_store_web_scraper import AppStoreEntry, AppStoreSession
+
+session = AppStoreSession(
+    delay=0.5,
+    delay_jitter=0.2,
+    retries=3,
+    retries_backoff_factor=2,
+    retries_backoff_max=10,
+)
+
+app = AppStoreEntry(app_id=585629514, country="ch", session=session)
+
+for review in app.reviews(limit=50):
+    print(review.id, review.date, review.rating, review.title, review.review)
+```
+
+### Android Collection
+
+The Android plugin uses `google-play-scraper`:
+
+```python
+from google_play_scraper import Sort, reviews
+
+result, continuation_token = reviews(
+    "de.zalando.mobile",
+    lang="en",
+    country="ch",
+    sort=Sort.NEWEST,
+    count=100,
+)
+```
+
+- Fetches 100 reviews per country per request
+- Supports `Sort.NEWEST` and `Sort.MOST_RELEVANT`
+- Country and language parameters filter by storefront
+- No authentication required
+- Returns `reviewId`, `content`, `score`, `at`, `userName`, `replyContent`, `repliedAt`, `appVersion`, `thumbsUpCount`
+
+### Deduplication
+
+Each review gets a stable composite ID:
+
+- iOS: `ios_{app_id}_{review_id}` (Apple provides a unique review ID in the RSS feed)
+- Android: `android_{package_name}_{review_id}` (Google provides a unique review ID)
+
+The same review appearing in multiple country storefronts gets the same ID and is deduplicated during the merge step.
+
+## Watermark Strategy
+
+Each plugin uses the existing `BaseIngestor` watermark mechanism with keys scoped per app:
+
+| Watermark Key | Value | Purpose |
+|---------------|-------|---------|
+| `{app_name}_last_published_at` | ISO 8601 timestamp | Newest review timestamp from last successful run |
+| `{app_name}_last_run` | ISO 8601 timestamp | When the last collection ran |
+
+### Incremental Logic
+
+1. On each run, check `{app_name}_last_run` against `frequency_minutes` — skip if not due yet
+2. Load the watermark `{app_name}_last_published_at`
+3. Collect and deduplicate reviews across countries
+4. Skip reviews with date ≤ watermark
+5. Yield remaining reviews to the pipeline
+6. Update watermark to the newest review date from this run
+7. Update `{app_name}_last_run` to current time
+
+### Tradeoffs
+
+- The iTunes RSS endpoint (iOS) returns max 10 pages × 50 reviews = 500 reviews per country. For most apps this covers recent reviews well. Very high-volume apps in a single country may miss some reviews between runs.
+- The Play Store scraper (Android) fetches 100 reviews per country. Deeper fetching is possible but capped by `max_reviews_per_run` and Lambda timeout.
+- Watermarks are best-effort. If a review's date is backdated by the store, it may be missed.
+
+## Output Format
+
+Each yielded review follows the VoC pipeline's expected schema.
+
+### iOS Output
+
+```python
+{
+    "id": "ios_585629514_12345678",
+    "channel": "app_review_ios",
+    "text": "Great app!\n\nLove the new features",  # title + "\n\n" + body
+    "title": "Great app!",
+    "rating": 5,
+    "created_at": "2026-03-06T14:30:00+00:00",
+    "url": "https://apps.apple.com/app/id585629514",
+    "author": "HappyUser123",
+    "brand_handles_matched": ["VoC Analytics"],
+    "source_platform_override": "zalando_ios",  # {app_name}_ios
+    "app_name": "zalando",
+    "app_identifier": "585629514",
+    "country": "us",
+    "developer_response": "Thanks for the feedback!",
+}
+```
+
+### Android Output
+
+```python
+{
+    "id": "android_de.zalando.mobile_abc123",
+    "channel": "app_review_android",
+    "text": "Love the new features",
+    "title": "",
+    "rating": 5,
+    "created_at": "2026-03-06T14:30:00+00:00",
+    "url": "https://play.google.com/store/apps/details?id=de.zalando.mobile",
+    "author": "HappyUser123",
+    "brand_handles_matched": ["VoC Analytics"],
+    "source_platform_override": "zalando_android",  # {app_name}_android
+    "app_name": "zalando",
+    "app_identifier": "de.zalando.mobile",
+    "country": "us",
+    "app_version": "24.3.1",
+    "developer_response": "Thanks!",
+    "developer_response_date": "2026-03-07T10:00:00+00:00",
+    "thumbs_up_count": 3,
+}
+```
+
+The `source_platform_override` field causes `BaseIngestor.normalize_item()` to use the app-specific name for S3 partitioning instead of the generic plugin ID.
+
+## Supported Countries
+
+### iOS Storefronts (40 countries)
+
+US, GB, DE, FR, JP, AU, CA, IT, ES, NL, BR, MX, IN, KR, SE, NO, DK, FI, CH, AT, BE, PT, PL, CZ, RU, TR, SA, AE, ZA, SG, HK, TW, TH, MY, PH, ID, VN, CO, CL, AR
+
+### Play Store Countries (20 countries)
+
+US, GB, DE, FR, JP, AU, CA, IT, ES, NL, BR, MX, IN, KR, SE, RU, TR, SA, ZA, SG
+
+### Overriding Countries
+
+Set `max_countries_per_run` in the Settings UI to limit iteration. Countries are shuffled each run for fair coverage over time.
+
+## Error Handling
+
+- One country failing does not stop other countries (warning logged, empty list returned)
+- All errors are logged with structured context (app name, country, error type)
+- The platform circuit breaker (`_shared/circuit_breaker.py`) auto-disables the plugin after repeated failures
+- Audit events are emitted at each lifecycle stage via `_shared/audit.py` (`plugin.invoked`, `plugin.completed`, `plugin.failed`, `message.ingested`)
+- Metrics are emitted per app: `iOS_{app_name}_Reviews`, `Android_{app_name}_Reviews`, and `*_Errors` on failure
+
+## Dependencies
+
+### iOS: `app-store-web-scraper`
+
+- Actively maintained (last release Jun 2024)
+- Built-in session management with connection pooling via `urllib3.PoolManager`
+- Configurable rate-limit delays with jitter to avoid Apple throttling
+- Retry logic with exponential backoff
+- Returns structured `AppReview` objects
+- Uses Apple's undocumented iTunes RSS endpoint
+
+### Android: `google-play-scraper`
+
+- Standard Python library for Play Store data
+- Zero external dependencies
+- Supports `Sort.NEWEST` and `Sort.MOST_RELEVANT`
+- Country and language parameters for storefront filtering
+
+### Lambda Layer Requirements
+
+Both packages are in the ingestion Lambda layer (`lambda/layers/ingestion-deps/requirements.txt`):
+
+```
+app-store-web-scraper>=0.3.0
+google-play-scraper>=1.2.7
+```
+
+Neither package requires native C extensions, so they work on ARM64 (Graviton) without Docker-based builds.
+
+## Setup & Deployment
+
+1. Both plugins are enabled in `pluginStatus` in `voc-datalake/cdk.context.json`:
+
+```json
+{
+  "pluginStatus": {
+    "webscraper": true,
+    "app_reviews_ios": true,
+    "app_reviews_android": true
+  }
+}
+```
+
+2. Deploy:
+
+```bash
+npm run generate:config
+cdk deploy --all
+```
+
+3. In the Settings page, expand each plugin card and enter the app details (App Name, Package Name / App Store ID)
+
+4. Enable the schedule via the toggle in the Settings UI
+
+## Assumptions & Limitations
+
+- **Single app per plugin**: Currently each plugin supports one app configuration. Multi-app support (multiple package names / app IDs per plugin) is planned.
+- **Implementation prerequisite**: The `KNOWN_SOURCES` set in `_shared/schemas.py` and the `_get_known_prefixes()` list in `_shared/base_ingestor.py` must include `app_reviews_ios` and `app_reviews_android` for proper secret filtering and message validation.
+- **Unofficial APIs**: Both plugins use unofficial/public endpoints. These can change without notice. The circuit breaker will auto-disable the plugin if endpoints break.
+- **Rate limiting**: Apple and Google may rate-limit aggressive scraping. `app-store-web-scraper` has built-in delays with jitter. For Google, the country shuffle and configurable `max_countries_per_run` help manage request volume.
+- **iOS review depth**: Max 500 reviews per country (10 pages × 50). High-volume apps may miss reviews between runs if the schedule is too infrequent.
+- **No authentication**: Neither source requires API keys. The plugins use public endpoints only.
+- **Review language**: Reviews are returned in their original language. The VoC processing pipeline handles translation via Amazon Translate.
+- **Developer responses**: Available in both sources but may not always be present. Included when available.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -6,17 +6,11 @@ This document describes the plugin-based architecture for VoC data source connec
 
 ## Why a Plugin Architecture?
 
-### Current Problems
+### Current Problems (Pre-Plugin)
 
-1. **Tight coupling**: Data sources are hardcoded across multiple files:
-   - `sourceConfig.ts` (frontend UI configuration)
-   - `ingestion-stack.ts` (CDK infrastructure)
-   - `analytics-stack.ts` (webhook routes)
-   - `cdk.context.json` (enabled sources list)
-
-2. **Difficult to contribute**: Adding a new connector requires changes in 4+ files across frontend and backend.
-
-3. **No single source of truth**: UI fields, infrastructure config, and secrets are defined separately.
+1. **Tight coupling**: Data sources were hardcoded across multiple files (frontend UI, CDK stacks, context config).
+2. **Difficult to contribute**: Adding a new connector required changes in 4+ files across frontend and backend.
+3. **No single source of truth**: UI fields, infrastructure config, and secrets were defined separately.
 
 ### Benefits of Plugin Architecture
 
@@ -45,17 +39,19 @@ This document describes the plugin-based architecture for VoC data source connec
 ┌─────────────────────────────────────────────────────────────────────┐
 │                      CDK Plugin Loader                              │
 │  - Scans plugins/ folder                                            │
-│  - Validates manifests with Zod                                     │
+│  - Validates manifests with Zod (security-hardened schemas)         │
+│  - Verifies code integrity via SHA-256 hashes                       │
 │  - Creates Lambda functions                                         │
 │  - Creates EventBridge schedules                                    │
 │  - Creates API Gateway webhook routes                               │
-│  - Aggregates secrets template                                      │
+│  - Aggregates secrets template (prefixed per plugin)                │
 └─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │                      Frontend Build                                  │
 │  - Extracts UI-relevant fields from manifests                       │
+│  - Reads pluginStatus from cdk.context.json for enabled flag        │
 │  - Generates manifests.json bundle                                  │
 │  - Settings page renders dynamically from manifests                 │
 └─────────────────────────────────────────────────────────────────────┘
@@ -69,9 +65,13 @@ This document describes the plugin-based architecture for VoC data source connec
 voc-datalake/
 ├── plugins/
 │   ├── _shared/                      # Shared code for all plugins
+│   │   ├── __init__.py               # Exports BaseIngestor, BaseWebhook, etc.
 │   │   ├── base_ingestor.py          # Base class for polling ingestors
 │   │   ├── base_webhook.py           # Base class for webhook handlers
-│   │   └── __init__.py
+│   │   ├── circuit_breaker.py        # Auto-disable after repeated failures
+│   │   ├── audit.py                  # Structured audit logging + EventBridge
+│   │   ├── schemas.py                # Pydantic message validation schemas
+│   │   └── test/                     # Tests for shared modules
 │   │
 │   ├── _template/                    # Starter template for new plugins
 │   │   ├── manifest.json
@@ -87,11 +87,19 @@ voc-datalake/
 ├── lib/
 │   ├── plugin-loader.ts              # Discovers and validates plugins
 │   └── stacks/
-│       ├── ingestion-stack.ts        # Uses plugin loader
-│       └── analytics-stack.ts        # Uses plugin loader for webhooks
+│       ├── ingestion-stack.ts        # Creates ingestor Lambdas from plugins
+│       └── api-stack.ts              # Creates webhook routes from plugins
+│
+├── scripts/
+│   ├── generate-manifests.ts         # Generates frontend manifests.json
+│   ├── generate-integrity.ts         # Generates SHA-256 code hashes
+│   ├── validate-plugins.ts           # Validates plugin configurations
+│   └── test-plugin-loader.ts         # Tests plugin loading
 │
 └── frontend/src/
     ├── plugins/
+    │   ├── index.ts                  # Plugin loader (getEnabledPlugins, etc.)
+    │   ├── types.ts                  # Zod schemas + TypeScript types
     │   └── manifests.json            # Generated at build time
     └── pages/Settings/
         ├── Settings.tsx              # Reads from manifests.json
@@ -109,6 +117,8 @@ The `manifest.json` is the single source of truth for each plugin. It defines:
 - **Configuration**: What fields the user needs to fill in
 - **Secrets**: What credentials to store in Secrets Manager
 - **Setup instructions**: How to configure the external service
+- **Version**: Semver version string
+- **Integrity**: SHA-256 hashes for code verification
 
 ### Manifest Schema
 
@@ -116,43 +126,45 @@ The `manifest.json` is the single source of truth for each plugin. It defines:
 {
   "id": "webscraper",
   "name": "Web Scraper",
-  "icon": "🌐",
-  "description": "Extract reviews from web pages using CSS selectors or JSON-LD",
+  "icon": "🕷️",
+  "description": "Configurable scraper for extracting feedback from websites",
   "category": "import",
-  
+  "version": "1.0.0",
+
   "infrastructure": {
     "ingestor": {
       "enabled": true,
-      "schedule": "rate(30 minutes)",
+      "schedule": "rate(15 minutes)",
       "timeout": 300,
       "memory": 512
     }
   },
-  
+
   "config": [
     {
       "key": "configs",
-      "label": "Scraper Configurations",
+      "label": "Scraper Configurations (JSON)",
       "type": "textarea",
+      "placeholder": "[{\"id\": \"example\", ...}]",
       "required": false,
-      "secret": true
+      "secret": false
     }
   ],
-  
+
   "setup": {
     "title": "Web Scraper Setup",
-    "color": "blue",
+    "color": "gray",
     "steps": [
-      "Navigate to the Scrapers page in the dashboard",
-      "Create a new scraper configuration",
-      "Enter the URL to scrape and configure CSS selectors",
-      "Test the scraper to verify extraction works",
-      "Enable the scraper to run on schedule"
+      "Configure scrapers via the Scrapers page in the dashboard",
+      "Each scraper can use CSS selectors or JSON-LD extraction",
+      "Supports pagination and custom frequencies",
+      "Test scrapers before enabling them",
+      "Scrapers run automatically based on their configured frequency"
     ]
   },
-  
+
   "secrets": {
-    "webscraper_configs": "[]"
+    "configs": "[]"
   }
 }
 ```
@@ -161,16 +173,19 @@ The `manifest.json` is the single source of truth for each plugin. It defines:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | Yes | Unique identifier, used in folder name and AWS resource names |
-| `name` | string | Yes | Display name in UI |
-| `icon` | string | Yes | Emoji or path to SVG icon |
+| `id` | string | Yes | Unique identifier (lowercase, underscores, max 32 chars) |
+| `name` | string | Yes | Display name in UI (max 256 chars, no control chars) |
+| `icon` | string | Yes | Emoji or path to SVG icon (max 64 chars) |
 | `description` | string | No | Short description shown in UI |
 | `category` | enum | No | One of: `reviews`, `social`, `import`, `search`, `scraper` |
 | `infrastructure` | object | Yes | AWS resources to deploy |
-| `config` | array | Yes | Configuration fields for UI |
-| `webhooks` | array | No | Webhook endpoints to display in UI |
-| `setup` | object | No | Setup instructions for UI |
+| `config` | array | Yes | Configuration fields for UI (max 20 fields) |
+| `webhooks` | array | No | Webhook endpoints to display in UI (max 5) |
+| `setup` | object | No | Setup instructions for UI (max 15 steps) |
 | `secrets` | object | No | Secret keys to add to Secrets Manager template |
+| `version` | string | No | Semver version (e.g., `1.0.0`) |
+| `minPlatformVersion` | string | No | Minimum platform version required |
+| `integrity` | object | No | SHA-256 hashes for code verification |
 
 ### Infrastructure Options
 
@@ -179,28 +194,35 @@ The `manifest.json` is the single source of truth for each plugin. It defines:
 ```json
 "ingestor": {
   "enabled": true,
-  "schedule": "rate(5 minutes)",  // EventBridge schedule expression
-  "timeout": 120,                  // Lambda timeout in seconds
-  "memory": 256                    // Lambda memory in MB
+  "schedule": "rate(15 minutes)",
+  "timeout": 120,
+  "memory": 256
 }
 ```
 
+- Schedule uses EventBridge rate or cron expressions
+- Schedule is created but **disabled by default** — user enables via Settings UI
 - If `schedule` is omitted, no EventBridge rule is created (useful for S3-triggered lambdas)
-- Schedule is created but **disabled by default** - user enables via Settings UI
+- Timeout max: 300 seconds (enforced by plugin loader)
+- Memory max: 1024 MB (enforced by plugin loader)
 
 #### Webhook (API Gateway Route)
 
 ```json
 "webhook": {
   "enabled": true,
-  "path": "/webhooks/{plugin}",  // API Gateway path (plugin ID substituted)
-  "methods": ["POST"]            // HTTP methods to allow
+  "path": "/webhooks/my_source",
+  "methods": ["POST"],
+  "signatureHeader": "X-Signature",
+  "signatureMethod": "hmac_sha256"
 }
 ```
 
-- Creates a Lambda function and API Gateway integration
+- Creates a Lambda function and API Gateway integration in `api-stack.ts`
 - No authentication (webhooks must be accessible by external services)
 - Webhook URL is displayed in Settings UI for user to copy
+- Methods restricted to: `GET`, `POST`, `PUT`, `DELETE` (max 4)
+- Path must start with `/` and contain only safe characters (no traversal)
 
 #### S3 Trigger
 
@@ -212,7 +234,8 @@ The `manifest.json` is the single source of truth for each plugin. It defines:
 ```
 
 - Triggers Lambda when files with matching suffixes are uploaded to S3 import bucket
-- No schedule needed - event-driven
+- No schedule needed — event-driven
+- Max 5 suffixes allowed
 
 ### Config Field Types
 
@@ -227,498 +250,282 @@ The `manifest.json` is the single source of truth for each plugin. It defines:
 
 ```json
 {
-  "key": "api_key",           // Key used in secrets/config storage
-  "label": "API Key",         // Display label in UI
-  "type": "password",         // Input type
-  "required": true,           // Show as required in UI
-  "placeholder": "Enter...",  // Placeholder text
-  "secret": true              // Store in Secrets Manager (vs. config)
+  "key": "api_key",
+  "label": "API Key",
+  "type": "password",
+  "required": true,
+  "placeholder": "Enter your API key",
+  "secret": true
 }
 ```
+
+- `key`: Safe identifier (lowercase alphanumeric + underscores, max 64 chars)
+- `label`: Display label in UI (max 256 chars, no control characters or XSS patterns)
+- `secret`: If `true`, stored in Secrets Manager; otherwise stored in config
 
 ---
 
-## Example Manifests
+## Shared Plugin Modules (`_shared/`)
 
-### Web Scraper Plugin
+The `_shared/` directory contains base classes and utilities used by all plugins.
 
-The webscraper plugin extracts reviews from web pages using CSS selectors or JSON-LD structured data.
+### `__init__.py`
 
-```json
-{
-  "id": "webscraper",
-  "name": "Web Scraper",
-  "icon": "🌐",
-  "description": "Extract reviews from web pages using CSS selectors or JSON-LD",
-  "category": "import",
-  
-  "infrastructure": {
-    "ingestor": {
-      "enabled": true,
-      "schedule": "rate(30 minutes)",
-      "timeout": 300,
-      "memory": 512
-    }
-  },
-  
-  "config": [
-    {
-      "key": "configs",
-      "label": "Scraper Configurations",
-      "type": "textarea",
-      "required": false,
-      "secret": true
-    }
-  ],
-  
-  "setup": {
-    "title": "Web Scraper Setup",
-    "color": "blue",
-    "steps": [
-      "Navigate to the Scrapers page in the dashboard",
-      "Create a new scraper configuration",
-      "Enter the URL to scrape and configure CSS selectors",
-      "Test the scraper to verify extraction works",
-      "Enable the scraper to run on schedule"
-    ]
-  },
-  
-  "secrets": {
-    "webscraper_configs": "[]"
-  }
-}
+Exports the public API:
+
+```python
+from .base_ingestor import BaseIngestor
+from .base_webhook import BaseWebhook
+from .audit import emit_audit_event, AuditAction
+from .circuit_breaker import CircuitBreaker
 ```
 
-### Custom Plugin Template
+### `base_ingestor.py`
 
-Use the `_template` folder as a starting point for creating new plugins:
+Base class for all polling ingestors. Provides:
 
-```json
-{
-  "id": "my_custom_source",
-  "name": "My Custom Source",
-  "icon": "🔌",
-  "description": "Custom data source connector",
-  "category": "import",
-  
-  "infrastructure": {
-    "ingestor": {
-      "enabled": true,
-      "schedule": "rate(15 minutes)",
-      "timeout": 120,
-      "memory": 256
-    }
-  },
-  
-  "config": [
-    {
-      "key": "api_key",
-      "label": "API Key",
-      "type": "password",
-      "required": true,
-      "secret": true
-    }
-  ],
-  
-  "setup": {
-    "title": "Custom Source Setup",
-    "color": "blue",
-    "steps": [
-      "Obtain API credentials from your data source",
-      "Enter the API key above",
-      "Enable the integration"
-    ]
-  },
-  
-  "secrets": {
-    "my_custom_source_api_key": ""
-  }
-}
-```
+- **Secrets loading** with per-plugin prefix isolation
+- **Watermark management** via DynamoDB (get/set per source+key)
+- **S3 raw data storage** with partitioned keys (`raw/{source}/{year}/{month}/{day}/{id}.json`)
+- **Deterministic S3 IDs** to prevent duplicates (source ID or SHA-256 content hash)
+- **SQS batch sending** (batches of 10, with 100-item flush threshold)
+- **Circuit breaker integration** (checks before run, records success/failure)
+- **Audit event emission** at each lifecycle stage
+- **Item normalization** with `source_platform_override` support
+
+Key methods:
+
+| Method | Description |
+|--------|-------------|
+| `fetch_new_items()` | Abstract — subclasses implement data fetching |
+| `get_watermark(key)` | Read watermark from DynamoDB |
+| `set_watermark(key, value)` | Write watermark to DynamoDB |
+| `normalize_item(item)` | Normalize to common schema + store raw to S3 |
+| `store_raw_to_s3(item)` | Store raw data with partitioned S3 key |
+| `send_to_queue(items)` | Send batch to SQS processing queue |
+| `run()` | Main execution: circuit breaker check → fetch → normalize → queue |
+
+### `base_webhook.py`
+
+Base class for webhook handlers. Provides:
+
+- **Secrets loading** with prefix isolation (same as base_ingestor)
+- **Body parsing** (JSON, base64-encoded)
+- **Item normalization** (similar to base_ingestor but with `is_webhook: True`)
+- **SQS batch sending**
+- **Client IP extraction** from API Gateway event
+- **Audit event emission**
+- **Error handling** with structured responses (400 for bad JSON, 500 for errors)
+
+### `circuit_breaker.py`
+
+Auto-disables plugins after repeated failures:
+
+- Tracks failures in DynamoDB with TTL (24h auto-cleanup)
+- Configurable threshold (default: 5 failures) and window (default: 15 minutes)
+- When tripped: disables the EventBridge schedule rule via `events.disable_rule()`
+- Records trip state in DynamoDB (`CIRCUIT#{plugin_id}#TRIPPED`)
+- Emits `plugin.disabled` audit event
+- Resets on successful run (`record_success()` clears trip state)
+
+### `audit.py`
+
+Structured audit logging for all plugin operations:
+
+- Always logs to CloudWatch via Powertools logger
+- Optionally sends to EventBridge (if `AUDIT_EVENT_BUS` is configured)
+- Typed actions: `plugin.invoked`, `plugin.completed`, `plugin.failed`, `plugin.disabled`, `webhook.received`, `webhook.rejected`, `message.ingested`, etc.
+
+### `schemas.py`
+
+Pydantic validation schemas for messages entering the processing pipeline:
+
+- **`IngestMessage`**: Validates required fields (`id`, `source_platform`, `text`, `created_at`), optional fields (`rating`, `url`, `author`, `title`, `language`, etc.)
+- **`MessageMetadata`**: Flat metadata with primitive values only (no nested objects for security)
+- **Sanitization**: Strips control characters, normalizes whitespace, validates URLs
+- **Constraints**: Max text 50KB, max ID 256 chars, max URL 2048 chars, rating 1-5, `created_at` not more than 1 day in the future
+- **`validate_message()`** and **`safe_validate_message()`** functions for use by the processor
 
 ---
 
 ## CDK Implementation
 
-### Plugin Loader
+### Plugin Loader (`lib/plugin-loader.ts`)
 
-The plugin loader scans the `plugins/` directory, validates manifests, and provides them to CDK stacks.
+The plugin loader scans the `plugins/` directory, validates manifests with security-hardened Zod schemas, and provides them to CDK stacks.
+
+#### Security Features
+
+The Zod schemas enforce:
+
+- **`PluginIdSchema`**: Lowercase alphanumeric + underscores, max 32 chars, must start with letter
+- **`SafeStringSchema`**: No control characters, no `<script>`, `javascript:`, or `data:` patterns
+- **`SafePathSchema`**: Must start with `/`, no `..` traversal, no `//`
+- **`ScheduleSchema`**: Only valid EventBridge rate/cron expressions
+- **`ConfigKeySchema`**: Safe identifier pattern
+- **`IntegritySchema`**: SHA-256 hash format validation
+
+#### Manifest Limits
+
+Enforced at load time:
+
+- Timeout: max 300 seconds
+- Memory: max 1024 MB
+- Schedule: cannot be more frequent than 1 minute
+- Config fields: max 20
+- Setup steps: max 15
+- Webhook info: max 5
+- S3 trigger suffixes: max 5
+
+#### Code Integrity Verification
+
+Optional SHA-256 verification of plugin code:
 
 ```typescript
-// lib/plugin-loader.ts
-import * as fs from 'fs';
-import * as path from 'path';
-import { z } from 'zod';
+loadPlugins(pluginsDir, { verifyIntegrity: true });
+```
 
-// ============================================
-// Zod Schema for Manifest Validation
-// ============================================
+Computes SHA-256 hash of all `.py` files in `ingestor/` and `webhook/` directories and compares against `integrity` field in manifest.
 
-const ConfigFieldSchema = z.object({
-  key: z.string(),
-  label: z.string(),
-  type: z.enum(['text', 'password', 'textarea', 'select']),
-  required: z.boolean().optional().default(false),
-  placeholder: z.string().optional(),
-  secret: z.boolean().optional().default(false),
-  options: z.array(z.object({
-    value: z.string(),
-    label: z.string(),
-  })).optional(),
-});
+Generate hashes with:
 
-const WebhookInfoSchema = z.object({
-  name: z.string(),
-  events: z.array(z.string()),
-  docUrl: z.string().url().optional(),
-});
+```bash
+npx ts-node scripts/generate-integrity.ts
+```
 
-const SetupSchema = z.object({
-  title: z.string(),
-  color: z.enum(['blue', 'orange', 'green', 'gray']).optional().default('blue'),
-  steps: z.array(z.string()),
-});
+#### Secret Aggregation
 
-const IngestorInfraSchema = z.object({
-  enabled: z.boolean(),
-  schedule: z.string().optional(),
-  timeout: z.number().min(1).max(900).default(120),
-  memory: z.number().min(128).max(10240).default(256),
-});
+Secrets are prefixed with the plugin ID for isolation:
 
-const WebhookInfraSchema = z.object({
-  enabled: z.boolean(),
-  path: z.string(),
-  methods: z.array(z.string()).default(['POST']),
-});
-
-const S3TriggerSchema = z.object({
-  enabled: z.boolean(),
-  suffixes: z.array(z.string()),
-});
-
-const InfrastructureSchema = z.object({
-  ingestor: IngestorInfraSchema.optional(),
-  webhook: WebhookInfraSchema.optional(),
-  s3Trigger: S3TriggerSchema.optional(),
-});
-
-const ManifestSchema = z.object({
-  id: z.string().regex(/^[a-z0-9_]+$/, 'ID must be lowercase alphanumeric with underscores'),
-  name: z.string(),
-  icon: z.string(),
-  description: z.string().optional(),
-  category: z.enum(['reviews', 'social', 'import', 'search', 'scraper']).optional(),
-  infrastructure: InfrastructureSchema,
-  config: z.array(ConfigFieldSchema).default([]),
-  webhooks: z.array(WebhookInfoSchema).optional(),
-  setup: SetupSchema.optional(),
-  secrets: z.record(z.string()).optional(),
-});
-
-export type PluginManifest = z.infer<typeof ManifestSchema>;
-export type ConfigField = z.infer<typeof ConfigFieldSchema>;
-
-// ============================================
-// Plugin Discovery
-// ============================================
-
-export function loadPlugins(pluginsDir: string): PluginManifest[] {
-  const plugins: PluginManifest[] = [];
-  const errors: string[] = [];
-  
-  if (!fs.existsSync(pluginsDir)) {
-    console.warn(`Plugins directory not found: ${pluginsDir}`);
-    return plugins;
-  }
-  
-  const entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
-  
-  for (const entry of entries) {
-    // Skip non-directories and special folders
-    if (!entry.isDirectory()) continue;
-    if (entry.name.startsWith('_')) continue;
-    
-    const manifestPath = path.join(pluginsDir, entry.name, 'manifest.json');
-    
-    if (!fs.existsSync(manifestPath)) {
-      console.warn(`No manifest.json found in plugins/${entry.name}, skipping`);
-      continue;
-    }
-    
-    try {
-      const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-      const parsed = ManifestSchema.parse(raw);
-      
-      // Validate folder name matches manifest ID
-      if (parsed.id !== entry.name) {
-        errors.push(`Plugin folder '${entry.name}' does not match manifest id '${parsed.id}'`);
-        continue;
-      }
-      
-      plugins.push(parsed);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        errors.push(`Invalid manifest in plugins/${entry.name}: ${err.message}`);
-      } else {
-        errors.push(`Failed to load plugins/${entry.name}: ${err}`);
-      }
-    }
-  }
-  
-  if (errors.length > 0) {
-    console.error('Plugin loading errors:');
-    errors.forEach(e => console.error(`  - ${e}`));
-    throw new Error(`Failed to load ${errors.length} plugin(s)`);
-  }
-  
-  console.log(`Loaded ${plugins.length} plugins: ${plugins.map(p => p.id).join(', ')}`);
-  return plugins;
-}
-
-// ============================================
-// Helper Functions
-// ============================================
-
-export function getEnabledPlugins(
-  plugins: PluginManifest[], 
-  enabledSources: string[]
-): PluginManifest[] {
-  return plugins.filter(p => enabledSources.includes(p.id));
-}
-
+```typescript
 export function aggregateSecrets(plugins: PluginManifest[]): Record<string, string> {
   const secrets: Record<string, string> = {};
   for (const plugin of plugins) {
     if (plugin.secrets) {
-      Object.assign(secrets, plugin.secrets);
+      for (const [key, value] of Object.entries(plugin.secrets)) {
+        secrets[`${plugin.id}_${key}`] = value;  // e.g., "webscraper_configs"
+      }
     }
   }
   return secrets;
 }
-
-export function getPluginsWithIngestor(plugins: PluginManifest[]): PluginManifest[] {
-  return plugins.filter(p => p.infrastructure.ingestor?.enabled);
-}
-
-export function getPluginsWithWebhook(plugins: PluginManifest[]): PluginManifest[] {
-  return plugins.filter(p => p.infrastructure.webhook?.enabled);
-}
-
-export function getPluginsWithS3Trigger(plugins: PluginManifest[]): PluginManifest[] {
-  return plugins.filter(p => p.infrastructure.s3Trigger?.enabled);
-}
 ```
 
----
+At runtime, `BaseIngestor._load_secrets()` strips the prefix so plugins access secrets by their clean key name (e.g., `self.secrets.get("configs")`).
 
-### Ingestion Stack Changes
+### Ingestion Stack (`lib/stacks/ingestion-stack.ts`)
 
-The ingestion stack uses the plugin loader to dynamically create resources.
+The ingestion stack uses the plugin loader to dynamically create resources for each enabled plugin.
 
 ```typescript
-// lib/stacks/ingestion-stack.ts (key changes)
-import * as path from 'path';
-import { 
-  loadPlugins, 
-  getEnabledPlugins, 
-  aggregateSecrets,
-  PluginManifest 
-} from '../plugin-loader';
+// Load plugins from manifests
+const pluginsDir = path.join(__dirname, '../../plugins');
+const allPlugins = loadPlugins(pluginsDir);
+const enabledPlugins = getEnabledPlugins(allPlugins, config.enabledSources);
 
-export class VocIngestionStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props: VocIngestionStackProps) {
-    super(scope, id, props);
-    
-    // ============================================
-    // Load Plugins
-    // ============================================
-    const pluginsDir = path.join(__dirname, '../../plugins');
-    const allPlugins = loadPlugins(pluginsDir);
-    const enabledPlugins = getEnabledPlugins(allPlugins, props.config.enabledSources);
-    
-    // ============================================
-    // Secrets Manager - Aggregate from all plugins
-    // ============================================
-    const secretsTemplate = aggregateSecrets(allPlugins);
-    
-    const apiSecrets = new secretsmanager.Secret(this, 'VocApiSecrets', {
-      secretName: uniqueName('voc-datalake/api-credentials'),
-      description: 'API credentials for VoC data sources',
-      generateSecretString: {
-        secretStringTemplate: JSON.stringify(secretsTemplate),
-        generateStringKey: 'placeholder',
-      },
-    });
-    
-    // ============================================
-    // Create Lambda for each enabled plugin
-    // ============================================
-    for (const plugin of enabledPlugins) {
-      this.createPluginResources(plugin, {
-        role: ingestionRole,
-        commonEnv,
-        dependenciesLayer,
-        s3ImportBucket: this.s3ImportBucket,
-      });
-    }
-  }
-  
-  private createPluginResources(
-    plugin: PluginManifest,
-    context: {
-      role: iam.Role;
-      commonEnv: Record<string, string>;
-      dependenciesLayer: lambda.LayerVersion;
-      s3ImportBucket: s3.Bucket;
-    }
-  ) {
-    const { role, commonEnv, dependenciesLayer, s3ImportBucket } = context;
-    const infra = plugin.infrastructure;
-    
-    // ============================================
-    // Ingestor Lambda
-    // ============================================
-    if (infra.ingestor?.enabled) {
-      // Bundle plugin code with shared modules
-      const ingestorCode = lambda.Code.fromAsset('plugins', {
-        exclude: ['**/__pycache__', '*.pyc'],
-        bundling: {
-          image: lambda.Runtime.PYTHON_3_12.bundlingImage,
-          command: [
-            'bash', '-c', [
-              'mkdir -p /asset-output',
-              `cp -r /asset-input/${plugin.id}/ingestor/* /asset-output/`,
-              'cp -r /asset-input/_shared/* /asset-output/',
-            ].join(' && '),
-          ],
-          platform: 'linux/arm64',
-        },
-      });
-      
-      const fn = new lambda.Function(this, `Ingestor${this.capitalize(plugin.id)}`, {
-        functionName: `voc-ingestor-${plugin.id}`,
-        runtime: lambda.Runtime.PYTHON_3_12,
-        architecture: lambda.Architecture.ARM_64,
-        handler: 'handler.lambda_handler',
-        code: ingestorCode,
-        role: role,
-        timeout: cdk.Duration.seconds(infra.ingestor.timeout),
-        memorySize: infra.ingestor.memory,
-        environment: {
-          ...commonEnv,
-          SOURCE_PLATFORM: plugin.id,
-        },
-        layers: [dependenciesLayer],
-      });
-      
-      this.ingestionLambdas.set(plugin.id, fn);
-      
-      // EventBridge schedule (if defined)
-      if (infra.ingestor.schedule) {
-        new events.Rule(this, `Schedule${this.capitalize(plugin.id)}`, {
-          ruleName: `voc-ingest-${plugin.id}-schedule`,
-          schedule: events.Schedule.expression(infra.ingestor.schedule),
-          targets: [new targets.LambdaFunction(fn, { retryAttempts: 2 })],
-          enabled: false,  // Disabled by default - enable via Settings UI
-        });
-      }
-      
-      // S3 trigger (if defined)
-      if (infra.s3Trigger?.enabled) {
-        s3ImportBucket.grantReadWrite(fn);
-        for (const suffix of infra.s3Trigger.suffixes) {
-          s3ImportBucket.addEventNotification(
-            s3.EventType.OBJECT_CREATED,
-            new s3n.LambdaDestination(fn),
-            { suffix }
-          );
-        }
-      }
-    }
-  }
-  
-  private capitalize(str: string): string {
-    return str.charAt(0).toUpperCase() + str.slice(1).replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-  }
+// Secrets Manager - aggregated from all plugins (prefixed)
+const apiSecrets = this.createApiSecrets(allPlugins);
+
+// Create Lambda for each enabled plugin with ingestor
+const ingestorPlugins = getPluginsWithIngestor(enabledPlugins);
+for (const plugin of ingestorPlugins) {
+  this.createIngestorLambda(plugin, ingestionRole, commonEnv, dependenciesLayer, aggregatesTable);
 }
 ```
 
-### Analytics Stack Changes (Webhooks)
+#### Lambda Bundling
+
+Each plugin Lambda bundles three code sources:
 
 ```typescript
-// lib/stacks/analytics-stack.ts (key changes)
-import { loadPlugins, getEnabledPlugins, getPluginsWithWebhook } from '../plugin-loader';
+private bundlePluginCode(pluginId: string): lambda.Code {
+  return lambda.Code.fromAsset('.', {
+    bundling: {
+      image: lambda.Runtime.PYTHON_3_14.bundlingImage,
+      command: ['bash', '-c', [
+        'mkdir -p /asset-output',
+        // 1. Plugin ingestor code
+        `cp -r /asset-input/plugins/${pluginId}/ingestor/* /asset-output/`,
+        // 2. Plugin shared modules (_shared/)
+        'cp -r /asset-input/plugins/_shared /asset-output/',
+        // 3. Lambda shared modules (logging, aws, http)
+        'cp -r /asset-input/lambda/shared /asset-output/',
+      ].join(' && ')],
+      platform: 'linux/arm64',
+    },
+  });
+}
+```
 
-export class VocAnalyticsStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props: VocAnalyticsStackProps) {
-    super(scope, id, props);
-    
-    // Load plugins
-    const pluginsDir = path.join(__dirname, '../../plugins');
-    const allPlugins = loadPlugins(pluginsDir);
-    const enabledPlugins = getEnabledPlugins(allPlugins, props.config.enabledSources);
-    const webhookPlugins = getPluginsWithWebhook(enabledPlugins);
-    
-    // Create webhook routes
-    const webhooksResource = this.api.root.addResource('webhooks');
-    
-    for (const plugin of webhookPlugins) {
-      this.createWebhookRoute(plugin, webhooksResource, webhookRole);
-    }
-  }
-  
-  private createWebhookRoute(
-    plugin: PluginManifest,
-    webhooksResource: apigateway.Resource,
-    role: iam.Role
-  ) {
-    const webhookConfig = plugin.infrastructure.webhook!;
-    
-    // Bundle webhook handler
-    const webhookCode = lambda.Code.fromAsset(`plugins/${plugin.id}/webhook`, {
-      bundling: {
-        image: lambda.Runtime.PYTHON_3_12.bundlingImage,
-        command: [
-          'bash', '-c', [
-            'mkdir -p /asset-output',
-            'cp -r /asset-input/* /asset-output/',
-            'cp -r /asset-input/../../_shared/* /asset-output/',
-          ].join(' && '),
-        ],
-      },
-    });
-    
-    const webhookFn = new lambda.Function(this, `Webhook${this.capitalize(plugin.id)}`, {
-      functionName: `voc-webhook-${plugin.id}`,
-      runtime: lambda.Runtime.PYTHON_3_12,
-      architecture: lambda.Architecture.ARM_64,
-      handler: 'handler.lambda_handler',
-      code: webhookCode,
-      role: role,
-      timeout: cdk.Duration.seconds(30),
-      environment: {
-        PROCESSING_QUEUE_URL: this.processingQueueUrl,
-        FEEDBACK_TABLE: this.feedbackTable.tableName,
-        BRAND_NAME: this.brandName,
-      },
-    });
-    
-    // Create API Gateway resource and method
-    const pluginResource = webhooksResource.addResource(plugin.id);
-    const integration = new apigateway.LambdaIntegration(webhookFn);
-    
-    for (const method of webhookConfig.methods) {
-      pluginResource.addMethod(method, integration);  // No auth - external webhook
-    }
-    
-    // Output webhook URL
-    new cdk.CfnOutput(this, `${this.capitalize(plugin.id)}WebhookUrl`, {
-      value: `${this.api.url}webhooks/${plugin.id}`,
-    });
+This means each Lambda deployment package contains:
+- The plugin's own `handler.py` (and any other files in `ingestor/`)
+- The `_shared/` directory (base classes, circuit breaker, audit, schemas)
+- The `lambda/shared/` directory (logging, AWS client helpers, HTTP utilities)
+
+#### Lambda Configuration
+
+```typescript
+const fn = new lambda.Function(this, `Ingestor${capitalize(plugin.id)}`, {
+  functionName: uniqueName(`voc-ingestor-${plugin.id}`),
+  runtime: lambda.Runtime.PYTHON_3_14,
+  architecture: lambda.Architecture.ARM_64,
+  handler: 'handler.lambda_handler',
+  code: ingestorCode,
+  role: ingestionRole,  // Shared role for all plugins
+  timeout: cdk.Duration.seconds(infra.timeout),
+  memorySize: infra.memory,
+  environment: {
+    ...commonEnv,
+    SOURCE_PLATFORM: plugin.id,
+    PLUGIN_ID: plugin.id,
+  },
+  layers: [dependenciesLayer],
+  logGroup: new logs.LogGroup(this, `IngestorLogs${capitalize(plugin.id)}`, {
+    logGroupName: uniqueName(`/aws/lambda/voc-ingestor-${plugin.id}`),
+    retention: logs.RetentionDays.TWO_WEEKS,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  }),
+});
+```
+
+Key details:
+- Runtime: Python 3.14 on ARM64 (Graviton)
+- Each plugin gets its own CloudWatch Log Group with 2-week retention
+- EventBridge schedule is disabled by default
+- All plugins share a single IAM role with minimal permissions
+
+### API Stack — Webhooks (`lib/stacks/api-stack.ts`)
+
+Webhook routes are created in the API stack (not a separate analytics stack):
+
+```typescript
+const pluginsDir = path.join(__dirname, '../../plugins');
+const allPlugins = loadPlugins(pluginsDir);
+const enabledPlugins = getEnabledPlugins(allPlugins, props.enabledSources);
+const webhookPlugins = getPluginsWithWebhook(enabledPlugins);
+
+// Create webhook Lambdas
+for (const plugin of webhookPlugins) {
+  const webhookFn = this.createWebhookLambda(plugin, webhookRole, ...);
+  webhookLambdas.set(plugin.id, webhookFn);
+}
+
+// Create API Gateway routes under /webhooks/{pluginId}
+const webhooksResource = this.api.root.addResource('webhooks');
+for (const plugin of webhookPlugins) {
+  const pluginResource = webhooksResource.addResource(plugin.id);
+  for (const method of plugin.infrastructure.webhook.methods) {
+    pluginResource.addMethod(method, webhookIntegration);  // No auth
   }
 }
 ```
+
+Webhook Lambdas:
+- Runtime: Python 3.14 on ARM64
+- Timeout: 30 seconds (fixed)
+- Memory: 256 MB (fixed)
+- Bundling: copies `plugins/{id}/webhook/*` + `plugins/_shared/`
+- No authentication (external webhooks must be publicly accessible)
 
 ---
 
@@ -726,20 +533,18 @@ export class VocAnalyticsStack extends cdk.Stack {
 
 ### Build-Time Manifest Generation
 
-At build time, extract UI-relevant fields from manifests and bundle for frontend.
+The `scripts/generate-manifests.ts` script:
+
+1. Loads all plugin manifests via `loadPlugins()`
+2. Reads `pluginStatus` from `cdk.context.json` to determine enabled/disabled state
+3. Extracts only UI-relevant fields
+4. Writes `frontend/src/plugins/manifests.json`
 
 ```typescript
 // scripts/generate-manifests.ts
-import * as fs from 'fs';
-import * as path from 'path';
-import { loadPlugins } from '../lib/plugin-loader';
-
-const pluginsDir = path.join(__dirname, '../plugins');
-const outputPath = path.join(__dirname, '../frontend/src/plugins/manifests.json');
-
+const pluginStatus = loadPluginStatus();  // from cdk.context.json
 const plugins = loadPlugins(pluginsDir);
 
-// Extract only UI-relevant fields
 const frontendManifests = plugins.map(plugin => ({
   id: plugin.id,
   name: plugin.name,
@@ -752,60 +557,24 @@ const frontendManifests = plugins.map(plugin => ({
   hasIngestor: !!plugin.infrastructure.ingestor?.enabled,
   hasWebhook: !!plugin.infrastructure.webhook?.enabled,
   hasS3Trigger: !!plugin.infrastructure.s3Trigger?.enabled,
+  version: plugin.version,
+  enabled: pluginStatus[plugin.id] ?? false,  // from cdk.context.json
 }));
-
-// Ensure directory exists
-fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-
-// Write manifests
-fs.writeFileSync(outputPath, JSON.stringify(frontendManifests, null, 2));
-
-console.log(`Generated ${frontendManifests.length} plugin manifests to ${outputPath}`);
 ```
 
-Add to `package.json`:
+Run via:
 
-```json
-{
-  "scripts": {
-    "generate:manifests": "ts-node scripts/generate-manifests.ts",
-    "prebuild": "npm run generate:manifests",
-    "build": "vite build"
-  }
-}
+```bash
+npm run generate:manifests
+# or as part of the full config generation:
+npm run generate:config
 ```
 
-### Frontend Manifest Types
+### Frontend Manifest Types (`frontend/src/plugins/types.ts`)
+
+The frontend uses Zod for runtime validation of manifests:
 
 ```typescript
-// frontend/src/plugins/types.ts
-import { z } from 'zod';
-
-export const ConfigFieldSchema = z.object({
-  key: z.string(),
-  label: z.string(),
-  type: z.enum(['text', 'password', 'textarea', 'select']),
-  required: z.boolean().optional(),
-  placeholder: z.string().optional(),
-  secret: z.boolean().optional(),
-  options: z.array(z.object({
-    value: z.string(),
-    label: z.string(),
-  })).optional(),
-});
-
-export const WebhookInfoSchema = z.object({
-  name: z.string(),
-  events: z.array(z.string()),
-  docUrl: z.string().optional(),
-});
-
-export const SetupSchema = z.object({
-  title: z.string(),
-  color: z.enum(['blue', 'orange', 'green', 'gray']).optional(),
-  steps: z.array(z.string()),
-});
-
 export const PluginManifestSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -818,206 +587,51 @@ export const PluginManifestSchema = z.object({
   hasIngestor: z.boolean(),
   hasWebhook: z.boolean(),
   hasS3Trigger: z.boolean(),
+  version: z.string().optional(),
+  enabled: z.boolean(),
 });
-
-export type PluginManifest = z.infer<typeof PluginManifestSchema>;
-export type ConfigField = z.infer<typeof ConfigFieldSchema>;
-export type WebhookInfo = z.infer<typeof WebhookInfoSchema>;
-export type SetupInfo = z.infer<typeof SetupSchema>;
-
-// Runtime validation
-export function validateManifests(data: unknown): PluginManifest[] {
-  const schema = z.array(PluginManifestSchema);
-  return schema.parse(data);
-}
 ```
 
-### Loading Manifests
+Includes type guards (`isPluginManifest`, `isPluginManifestArray`) and safe validation (`safeValidateManifests`).
+
+### Loading Manifests (`frontend/src/plugins/index.ts`)
 
 ```typescript
-// frontend/src/plugins/index.ts
+import { safeValidateManifests, type PluginManifest } from './types';
 import rawManifests from './manifests.json';
-import { validateManifests, PluginManifest } from './types';
 
-// Validate at runtime
-let manifests: PluginManifest[];
-try {
-  manifests = validateManifests(rawManifests);
-} catch (err) {
-  console.error('Invalid plugin manifests:', err);
-  manifests = [];
-}
+const validatedManifests = safeValidateManifests(rawManifests);
+const manifests: PluginManifest[] = validatedManifests ?? [];
 
-export function getPluginManifests(): PluginManifest[] {
-  return manifests;
-}
-
-export function getPluginById(id: string): PluginManifest | undefined {
-  return manifests.find(m => m.id === id);
-}
-
-export function getPluginsByCategory(category: string): PluginManifest[] {
-  return manifests.filter(m => m.category === category);
-}
+export function getPluginManifests(): PluginManifest[] { return manifests; }
+export function getEnabledPlugins(): PluginManifest[] { return manifests.filter(m => m.enabled); }
+export function getPluginById(id: string): PluginManifest | undefined { ... }
+export function getPluginsByCategory(category: string): PluginManifest[] { ... }
+export function getPluginsWithIngestor(): PluginManifest[] { ... }
+export function getPluginsWithWebhook(): PluginManifest[] { ... }
+export function getPluginsWithS3Trigger(): PluginManifest[] { ... }
 ```
 
-### Updated Settings Page
+### Settings Page
+
+The Settings page renders plugin cards dynamically from manifests:
 
 ```tsx
-// frontend/src/pages/Settings/Settings.tsx
 import { getPluginManifests } from '../../plugins';
-import SourceCard from './SourceCard';
 
-function DataSourcesSection({ apiEndpoint }: { apiEndpoint: string }) {
+function DataSourcesSection({ apiEndpoint }) {
   const manifests = getPluginManifests();
-  
   return (
-    <div className="card">
-      <h2 className="text-lg font-semibold mb-2">Data Sources & Integrations</h2>
-      <p className="text-sm text-gray-500 mb-4">
-        Configure API credentials, webhooks, and enable/disable data source schedules.
-      </p>
-      
-      {!apiEndpoint && (
-        <div className="flex items-start gap-2 text-sm text-amber-600 bg-amber-50 p-3 rounded-lg mb-4">
-          <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
-          <span>Configure the API endpoint above to manage data sources.</span>
-        </div>
-      )}
-      
-      <div className="space-y-3 sm:space-y-4">
-        {manifests.map(manifest => (
-          <SourceCard 
-            key={manifest.id} 
-            manifest={manifest} 
-            apiEndpoint={apiEndpoint} 
-          />
-        ))}
-      </div>
+    <div className="space-y-3">
+      {manifests.map(manifest => (
+        <SourceCard key={manifest.id} manifest={manifest} apiEndpoint={apiEndpoint} />
+      ))}
     </div>
   );
 }
 ```
 
-### Updated SourceCard Component
-
-```tsx
-// frontend/src/pages/Settings/SourceCard.tsx
-import type { PluginManifest, ConfigField } from '../../plugins/types';
-
-interface SourceCardProps {
-  readonly manifest: PluginManifest;
-  readonly apiEndpoint: string;
-}
-
-export default function SourceCard({ manifest, apiEndpoint }: SourceCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [credentials, setCredentials] = useState<Record<string, string>>({});
-  // ... other state
-  
-  return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden">
-      <SourceCardHeader
-        manifest={manifest}
-        isExpanded={isExpanded}
-        onToggleExpand={() => setIsExpanded(!isExpanded)}
-        // ... other props
-      />
-      
-      {isExpanded && (
-        <div className="p-3 sm:p-4 border-t border-gray-200 space-y-4">
-          {/* Webhooks section - only if manifest has webhooks */}
-          {manifest.webhooks && manifest.webhooks.length > 0 && (
-            <WebhooksSection
-              webhooks={manifest.webhooks}
-              sourceKey={manifest.id}
-              webhookBaseUrl={`${apiEndpoint}webhooks/`}
-            />
-          )}
-          
-          {/* Config fields - dynamically rendered from manifest */}
-          {manifest.config.length > 0 && (
-            <CredentialsSection
-              fields={manifest.config}
-              credentials={credentials}
-              onCredentialsChange={setCredentials}
-              // ... other props
-            />
-          )}
-          
-          {/* Setup instructions - only if manifest has setup */}
-          {manifest.setup && (
-            <SetupInstructionsSection setup={manifest.setup} />
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// Dynamic field rendering based on config type
-function ConfigFieldInput({ 
-  field, 
-  value, 
-  showSecrets, 
-  onChange 
-}: {
-  field: ConfigField;
-  value: string;
-  showSecrets: boolean;
-  onChange: (value: string) => void;
-}) {
-  const placeholder = field.placeholder ?? `Enter ${field.label.toLowerCase()}`;
-  
-  switch (field.type) {
-    case 'textarea':
-      return (
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="input text-sm min-h-[80px]"
-        />
-      );
-    
-    case 'select':
-      return (
-        <select
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="input text-sm"
-        >
-          <option value="">Select...</option>
-          {field.options?.map(opt => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
-      );
-    
-    case 'password':
-      return (
-        <input
-          type={showSecrets ? 'text' : 'password'}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="input text-sm"
-        />
-      );
-    
-    default:
-      return (
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="input text-sm"
-        />
-      );
-  }
-}
-```
+Each `SourceCard` dynamically renders config fields based on the manifest's `config` array, supporting `text`, `password`, `textarea`, and `select` field types.
 
 ---
 
@@ -1025,7 +639,7 @@ function ConfigFieldInput({
 
 ### How It Works
 
-1. **Deploy time**: `enabledSources` in `cdk.context.json` controls which plugins get AWS resources
+1. **Deploy time**: `pluginStatus` in `cdk.context.json` controls which plugins get AWS resources
 2. **Runtime**: Settings UI toggles EventBridge rules on/off via API
 3. **No redeploy needed** to enable/disable a deployed plugin
 
@@ -1034,13 +648,19 @@ function ConfigFieldInput({
 ```json
 // cdk.context.json
 {
-  "brandName": "MyBrand",
-  "brandHandles": ["@mybrand", "mybrand"],
-  "primaryLanguage": "en",
-  "enabledSources": [
-    "webscraper"
-  ]
+  "pluginStatus": {
+    "webscraper": true
+  }
 }
+```
+
+The CDK entry point (`bin/voc-datalake.ts`) derives `enabledSources` from `pluginStatus`:
+
+```typescript
+const pluginStatus = app.node.tryGetContext('pluginStatus') || {};
+const enabledSources = Object.entries(pluginStatus)
+  .filter(([, enabled]) => enabled === true)
+  .map(([pluginId]) => pluginId);
 ```
 
 ### API Endpoints for Enable/Disable
@@ -1051,76 +671,29 @@ POST /sources/{sourceId}/disable  → Disables EventBridge schedule
 GET  /sources/status              → Returns status of all sources
 ```
 
-### Backend Implementation
-
-```python
-# lambda/api/sources_handler.py
-import boto3
-
-events = boto3.client('events')
-
-def enable_source(source_id: str) -> dict:
-    """Enable the EventBridge schedule for a source."""
-    rule_name = f'voc-ingest-{source_id}-schedule'
-    
-    try:
-        events.enable_rule(Name=rule_name)
-        return {'enabled': True, 'source': source_id}
-    except events.exceptions.ResourceNotFoundException:
-        return {'error': f'Source {source_id} not found', 'enabled': False}
-
-def disable_source(source_id: str) -> dict:
-    """Disable the EventBridge schedule for a source."""
-    rule_name = f'voc-ingest-{source_id}-schedule'
-    
-    try:
-        events.disable_rule(Name=rule_name)
-        return {'enabled': False, 'source': source_id}
-    except events.exceptions.ResourceNotFoundException:
-        return {'error': f'Source {source_id} not found', 'enabled': False}
-
-def get_sources_status() -> dict:
-    """Get enabled/disabled status of all sources."""
-    # List all voc-ingest-* rules
-    response = events.list_rules(NamePrefix='voc-ingest-')
-    
-    sources = {}
-    for rule in response.get('Rules', []):
-        # Extract source ID from rule name: voc-ingest-{source}-schedule
-        parts = rule['Name'].split('-')
-        if len(parts) >= 3:
-            source_id = parts[2]
-            sources[source_id] = {
-                'enabled': rule['State'] == 'ENABLED',
-                'schedule': rule.get('ScheduleExpression', ''),
-            }
-    
-    return {'sources': sources}
-```
-
 ---
 
 ## Creating a New Plugin
 
 ### Step-by-Step Guide
 
-1. **Create the folder structure**
+1. **Copy the template**
 
 ```bash
-mkdir -p plugins/my_source/ingestor
+cp -r plugins/_template plugins/my_source
 ```
 
-2. **Create the manifest**
+2. **Update the manifest** (`plugins/my_source/manifest.json`)
 
 ```json
-// plugins/my_source/manifest.json
 {
   "id": "my_source",
   "name": "My Source",
   "icon": "🔌",
   "description": "Fetches data from My Source API",
   "category": "reviews",
-  
+  "version": "1.0.0",
+
   "infrastructure": {
     "ingestor": {
       "enabled": true,
@@ -1129,7 +702,7 @@ mkdir -p plugins/my_source/ingestor
       "memory": 256
     }
   },
-  
+
   "config": [
     {
       "key": "api_key",
@@ -1139,7 +712,7 @@ mkdir -p plugins/my_source/ingestor
       "secret": true
     }
   ],
-  
+
   "setup": {
     "title": "My Source Setup",
     "color": "blue",
@@ -1149,57 +722,50 @@ mkdir -p plugins/my_source/ingestor
       "Paste the key above"
     ]
   },
-  
+
   "secrets": {
-    "my_source_api_key": ""
+    "api_key": ""
   }
 }
 ```
 
-3. **Create the handler**
+3. **Implement the handler** (`plugins/my_source/ingestor/handler.py`)
 
 ```python
-# plugins/my_source/ingestor/handler.py
-"""
-My Source Ingestor - Fetches data from My Source API.
-"""
+"""My Source Ingestor - Fetches data from My Source API."""
 from typing import Generator
-from base_ingestor import BaseIngestor, logger, tracer, metrics
+
+from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
 
 
 class MySourceIngestor(BaseIngestor):
     """Ingestor for My Source API."""
-    
+
     def __init__(self):
         super().__init__()
-        self.api_key = self.secrets.get('my_source_api_key', '')
-    
+        # Secrets are prefix-stripped: "my_source_api_key" → "api_key"
+        self.api_key = self.secrets.get("api_key", "")
+
     def fetch_new_items(self) -> Generator[dict, None, None]:
         """Fetch new items from My Source."""
         if not self.api_key:
             logger.warning("No My Source API key configured")
             return
-        
-        # Get watermark for incremental fetching
-        last_id = self.get_watermark('last_id')
-        
-        # TODO: Implement your API fetching logic here
-        # Example:
-        # response = requests.get(
-        #     'https://api.mysource.com/reviews',
-        #     headers={'Authorization': f'Bearer {self.api_key}'},
-        #     params={'since_id': last_id}
-        # )
-        # 
-        # for item in response.json()['reviews']:
-        #     yield {
-        #         'id': item['id'],
-        #         'text': item['content'],
-        #         'rating': item['score'],
-        #         'created_at': item['created_at'],
-        #         'url': item['url'],
-        #     }
-        
+
+        last_id = self.get_watermark("last_id")
+        logger.info(f"Fetching items since last_id: {last_id}")
+
+        # Implement your API fetching logic here
+        # yield {
+        #     "id": "unique_id",
+        #     "text": "Feedback content",
+        #     "rating": 4.5,
+        #     "created_at": "2026-01-08T10:30:00Z",
+        #     "url": "https://source.com/review/123",
+        #     "channel": "review",
+        #     "author": "John D.",
+        #     "title": "Great product!",
+        # }
         pass
 
 
@@ -1212,500 +778,80 @@ def lambda_handler(event, context):
     return ingestor.run()
 ```
 
-4. **Add to enabled sources**
+4. **Enable the plugin** in `cdk.context.json`
 
 ```json
-// cdk.context.json
 {
-  "enabledSources": [
-    "webscraper",
-    "my_source"  // Add your new source
-  ]
+  "pluginStatus": {
+    "webscraper": true,
+    "my_source": true
+  }
 }
 ```
 
-5. **Deploy**
+5. **Generate manifests and deploy**
 
 ```bash
+npm run generate:config
 cdk deploy VocIngestionStack
+```
+
+6. **Validate** (optional)
+
+```bash
+npm run validate:plugins
 ```
 
 ---
 
 ## Message Schema (Output Contract)
 
-All plugins must output messages in this format to the SQS processing queue.
+All plugins must output messages in this format to the SQS processing queue. Messages are validated by the Pydantic schemas in `_shared/schemas.py`.
 
 ### Required Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Unique identifier from the source (used for deduplication) |
-| `source_platform` | string | Plugin ID (e.g., `webscraper`) |
-| `text` | string | The feedback content |
-| `created_at` | string | ISO 8601 timestamp |
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `id` | string | 1-256 chars | Unique identifier from the source |
+| `source_platform` | string | `^[a-z][a-z0-9_]*$` | Plugin ID |
+| `text` | string | 1-50,000 chars | The feedback content |
+| `created_at` | datetime | Not >1 day in future | ISO 8601 timestamp |
 
 ### Optional Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `rating` | number | Rating 1-5 (if applicable) |
-| `url` | string | Source URL |
-| `channel` | string | Sub-channel (e.g., `review`, `comment`, `mention`) |
-| `author` | string | Author name/handle |
-| `title` | string | Review title (if applicable) |
-| `language` | string | ISO language code |
-| `brand_handles_matched` | string[] | Which brand handles were matched |
-| `metadata` | object | Plugin-specific additional data |
-
-### Example Message
-
-```json
-{
-  "id": "review_abc123",
-  "source_platform": "webscraper",
-  "channel": "review",
-  "text": "Great product! Fast shipping and excellent quality.",
-  "rating": 5,
-  "created_at": "2026-01-08T10:30:00Z",
-  "url": "https://example.com/reviews/abc123",
-  "author": "John D.",
-  "title": "Excellent experience",
-  "language": "en",
-  "brand_handles_matched": ["MyBrand"],
-  "metadata": {
-    "is_verified": true,
-    "location_id": "loc_123"
-  }
-}
-```
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `rating` | float | 1.0-5.0 | Rating (if applicable) |
+| `url` | string | Max 2048 chars, http(s) | Source URL |
+| `channel` | string | Max 64 chars | Sub-channel (review, comment, mention) |
+| `author` | string | Max 256 chars | Author name/handle |
+| `title` | string | Max 500 chars | Review title |
+| `language` | string | `^[a-z]{2}(-[A-Z]{2})?$` | ISO language code |
+| `brand_handles_matched` | string[] | Max 10 items | Which brand handles were matched |
+| `metadata` | object | Flat primitives only | Plugin-specific additional data |
+| `source_platform_override` | string | — | Override source for S3 partitioning |
 
 ### Validation
 
-The processor Lambda validates incoming messages:
+The `_shared/schemas.py` module provides Pydantic-based validation:
 
 ```python
-def validate_message(msg: dict) -> tuple[bool, list[str]]:
-    """Validate a message against the schema."""
-    errors = []
-    
-    # Required fields
-    if not msg.get('id'):
-        errors.append('Missing required field: id')
-    if not msg.get('source_platform'):
-        errors.append('Missing required field: source_platform')
-    if not msg.get('text'):
-        errors.append('Missing required field: text')
-    if not msg.get('created_at'):
-        errors.append('Missing required field: created_at')
-    
-    # Validate created_at format
-    if msg.get('created_at'):
-        try:
-            datetime.fromisoformat(msg['created_at'].replace('Z', '+00:00'))
-        except ValueError:
-            errors.append('Invalid created_at format (must be ISO 8601)')
-    
-    # Validate rating range
-    if msg.get('rating') is not None:
-        if not isinstance(msg['rating'], (int, float)) or not 1 <= msg['rating'] <= 5:
-            errors.append('Rating must be a number between 1 and 5')
-    
-    return len(errors) == 0, errors
+from _shared.schemas import validate_message, safe_validate_message, MessageValidationError
+
+# Raises MessageValidationError on failure
+validated = validate_message(raw_dict)
+
+# Returns (message, errors) tuple
+message, errors = safe_validate_message(raw_dict)
 ```
 
----
-
-## Migration Plan
-
-### Phase 1: Create Plugin Structure
-
-1. Create `plugins/` folder
-2. Create `plugins/_shared/` with base classes
-3. Create `plugins/_template/` with starter template
-
-### Phase 2: Migrate Existing Connectors
-
-For each existing connector:
-
-1. Create `plugins/{source}/manifest.json`
-2. Move `lambda/ingestors/{source}/*` → `plugins/{source}/ingestor/`
-3. Move `lambda/webhooks/{source}/*` → `plugins/{source}/webhook/` (if exists)
-4. Update imports in handler files
-
-### Phase 3: Update CDK
-
-1. Create `lib/plugin-loader.ts`
-2. Update `ingestion-stack.ts` to use plugin loader
-3. Update `analytics-stack.ts` for dynamic webhook routes
-4. Remove hardcoded source configs
-
-### Phase 4: Update Frontend
-
-1. Create `scripts/generate-manifests.ts`
-2. Add prebuild script to `package.json`
-3. Create `frontend/src/plugins/` with types and loader
-4. Update Settings page to use manifests
-5. Remove `sourceConfig.ts`
-
-### Phase 5: Cleanup
-
-1. Remove `lambda/ingestors/` (now in plugins)
-2. Remove `lambda/webhooks/` (now in plugins)
-3. Update documentation
-4. Test all connectors
-
----
-
-## File Changes Summary
-
-### Files to Create
-
-| File | Purpose |
-|------|---------|
-| `plugins/_shared/base_ingestor.py` | Base class for ingestors |
-| `plugins/_shared/base_webhook.py` | Base class for webhooks |
-| `plugins/_template/manifest.json` | Template manifest |
-| `plugins/_template/ingestor/handler.py` | Template handler |
-| `plugins/{source}/manifest.json` | Manifest for each source |
-| `lib/plugin-loader.ts` | CDK plugin discovery |
-| `scripts/generate-manifests.ts` | Frontend manifest generator |
-| `frontend/src/plugins/types.ts` | TypeScript types |
-| `frontend/src/plugins/index.ts` | Plugin loader |
-
-### Files to Modify
-
-| File | Changes |
-|------|---------|
-| `lib/stacks/ingestion-stack.ts` | Use plugin loader instead of hardcoded configs |
-| `lib/stacks/analytics-stack.ts` | Dynamic webhook routes from plugins |
-| `frontend/src/pages/Settings/Settings.tsx` | Import from plugins instead of sourceConfig |
-| `frontend/src/pages/Settings/SourceCard.tsx` | Accept manifest prop instead of sourceInfo |
-| `package.json` | Add generate:manifests script |
-
-### Files to Delete
-
-| File | Reason |
-|------|--------|
-| `frontend/src/pages/Settings/sourceConfig.ts` | Replaced by manifests.json |
-| `lambda/ingestors/*` | Moved to plugins/ |
-| `lambda/webhooks/*` | Moved to plugins/ |
-
----
-
-## Testing
-
-### Manifest Validation
-
-```bash
-# Validate all manifests at build time
-npm run generate:manifests
-```
-
-### Plugin Handler Testing
-
-```bash
-# Test individual plugin
-cd plugins/webscraper/ingestor
-python -m pytest test_handler.py
-```
-
-### Integration Testing
-
-```bash
-# Deploy to dev environment
-cdk deploy --context enabledSources='["webscraper"]'
-
-# Test via Settings UI
-# 1. Enable the source
-# 2. Check CloudWatch logs for Lambda execution
-# 3. Verify data appears in feedback table
-```
-
----
-
-## FAQ
-
-### Q: Do I need to redeploy to add a new plugin?
-
-**A:** Yes, adding a new plugin requires `cdk deploy` to create the Lambda and EventBridge resources. However, enabling/disabling an existing plugin does not require redeployment.
-
-### Q: Can I have a plugin without a Lambda?
-
-**A:** Not currently. Every plugin needs at least an ingestor Lambda. For webhook-only sources, the ingestor can be a no-op that just validates credentials.
-
-### Q: How do I test a plugin locally?
-
-**A:** You can run the handler directly:
-
-```python
-# In plugins/my_source/ingestor/
-python -c "from handler import MySourceIngestor; i = MySourceIngestor(); print(list(i.fetch_new_items()))"
-```
-
-### Q: Where are credentials stored?
-
-**A:** All credentials are stored in AWS Secrets Manager under `voc-datalake/api-credentials-{hash}`, where `{hash}` is a deployment-specific suffix derived from your AWS account ID and region. The secrets template is aggregated from all plugin manifests at deploy time. You can find the exact secret name in the CloudFormation outputs of the VocIngestionStack.
-
-### Q: Can plugins have custom UI components?
-
-**A:** No, the UI is data-driven from the manifest. All plugins use the same SourceCard component with dynamic field rendering. This keeps the architecture simple and consistent.
-
-
----
-
-## SQS Message Validation Layer
-
-### Why Validation Matters
-
-Since plugins can be contributed by the community, we cannot blindly trust the data they send. A validation layer acts as a gatekeeper between plugins and the core processing pipeline.
-
-```
-┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────┐
-│   Plugin    │ ──▶ │  SQS Queue      │ ──▶ │  Validator      │ ──▶ │  Processor  │
-│  (any src)  │     │  (raw messages) │     │  (gatekeeper)   │     │  (trusted)  │
-└─────────────┘     └─────────────────┘     └─────────────────┘     └─────────────┘
-                                                    │
-                                                    ▼ (invalid)
-                                            ┌─────────────────┐
-                                            │  DLQ + Metrics  │
-                                            └─────────────────┘
-```
-
-### Validation Strategy
-
-1. **Schema validation**: Required fields, types, formats
-2. **Sanitization**: Strip dangerous content, limit sizes
-3. **Rate limiting**: Prevent a single plugin from flooding the queue
-4. **Source verification**: Validate source_platform matches known plugins
-
-### Implementation
-
-```python
-# lambda/processor/validator.py
-"""
-Message Validator - Validates all incoming messages before processing.
-This is the security boundary between untrusted plugin output and trusted processing.
-"""
-import re
-from datetime import datetime
-from typing import Any
-from zod_python import z  # Or use pydantic/jsonschema
-
-# ============================================
-# Schema Definition
-# ============================================
-
-# Maximum sizes to prevent abuse
-MAX_TEXT_LENGTH = 50_000  # 50KB max for feedback text
-MAX_ID_LENGTH = 256
-MAX_URL_LENGTH = 2048
-MAX_METADATA_SIZE = 10_000  # 10KB max for metadata JSON
-
-# Known plugin IDs (loaded from manifests at deploy time)
-KNOWN_SOURCES = {
-    'webscraper', 'manual_import', 's3_import'
-}
-
-class ValidationError(Exception):
-    """Raised when message validation fails."""
-    def __init__(self, errors: list[str]):
-        self.errors = errors
-        super().__init__(f"Validation failed: {', '.join(errors)}")
-
-
-def validate_message(msg: dict) -> dict:
-    """
-    Validate and sanitize an incoming message.
-    
-    Returns the sanitized message if valid.
-    Raises ValidationError if invalid.
-    """
-    errors: list[str] = []
-    
-    # ============================================
-    # Required Fields
-    # ============================================
-    
-    # id - required, string, max length
-    msg_id = msg.get('id')
-    if not msg_id:
-        errors.append('Missing required field: id')
-    elif not isinstance(msg_id, str):
-        errors.append('Field id must be a string')
-    elif len(msg_id) > MAX_ID_LENGTH:
-        errors.append(f'Field id exceeds max length ({MAX_ID_LENGTH})')
-    
-    # source_platform - required, must be known
-    source = msg.get('source_platform')
-    if not source:
-        errors.append('Missing required field: source_platform')
-    elif not isinstance(source, str):
-        errors.append('Field source_platform must be a string')
-    elif source not in KNOWN_SOURCES:
-        errors.append(f'Unknown source_platform: {source}')
-    
-    # text - required, string, max length
-    text = msg.get('text')
-    if not text:
-        errors.append('Missing required field: text')
-    elif not isinstance(text, str):
-        errors.append('Field text must be a string')
-    elif len(text) > MAX_TEXT_LENGTH:
-        errors.append(f'Field text exceeds max length ({MAX_TEXT_LENGTH})')
-    
-    # created_at - required, valid ISO 8601
-    created_at = msg.get('created_at')
-    if not created_at:
-        errors.append('Missing required field: created_at')
-    elif not isinstance(created_at, str):
-        errors.append('Field created_at must be a string')
-    else:
-        try:
-            # Normalize and validate ISO format
-            parsed = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
-            # Reject dates too far in the future (likely errors)
-            if parsed.year > datetime.now().year + 1:
-                errors.append('Field created_at is too far in the future')
-        except ValueError:
-            errors.append('Field created_at must be valid ISO 8601 format')
-    
-    # ============================================
-    # Optional Fields
-    # ============================================
-    
-    # rating - optional, number 1-5
-    rating = msg.get('rating')
-    if rating is not None:
-        if not isinstance(rating, (int, float)):
-            errors.append('Field rating must be a number')
-        elif not 1 <= rating <= 5:
-            errors.append('Field rating must be between 1 and 5')
-    
-    # url - optional, valid URL format, max length
-    url = msg.get('url')
-    if url is not None:
-        if not isinstance(url, str):
-            errors.append('Field url must be a string')
-        elif len(url) > MAX_URL_LENGTH:
-            errors.append(f'Field url exceeds max length ({MAX_URL_LENGTH})')
-        elif url and not url.startswith(('http://', 'https://')):
-            errors.append('Field url must be a valid HTTP(S) URL')
-    
-    # channel - optional, string
-    channel = msg.get('channel')
-    if channel is not None and not isinstance(channel, str):
-        errors.append('Field channel must be a string')
-    
-    # metadata - optional, object, max size
-    metadata = msg.get('metadata')
-    if metadata is not None:
-        if not isinstance(metadata, dict):
-            errors.append('Field metadata must be an object')
-        else:
-            import json
-            metadata_size = len(json.dumps(metadata))
-            if metadata_size > MAX_METADATA_SIZE:
-                errors.append(f'Field metadata exceeds max size ({MAX_METADATA_SIZE} bytes)')
-    
-    # ============================================
-    # Fail if any errors
-    # ============================================
-    
-    if errors:
-        raise ValidationError(errors)
-    
-    # ============================================
-    # Sanitize and return
-    # ============================================
-    
-    return sanitize_message(msg)
-
-
-def sanitize_message(msg: dict) -> dict:
-    """
-    Sanitize a validated message.
-    - Strip control characters from text
-    - Normalize whitespace
-    - Remove any unexpected fields
-    """
-    # Allowed fields only (whitelist approach)
-    allowed_fields = {
-        'id', 'source_platform', 'source_channel', 'text', 'rating',
-        'created_at', 'url', 'channel', 'author', 'title', 'language',
-        'brand_handles_matched', 'metadata', 'is_update', 'ingested_at',
-        's3_raw_uri', 'raw_data'
-    }
-    
-    sanitized = {k: v for k, v in msg.items() if k in allowed_fields}
-    
-    # Sanitize text - remove control characters except newlines/tabs
-    if 'text' in sanitized:
-        text = sanitized['text']
-        # Remove control chars except \n, \r, \t
-        text = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', text)
-        # Normalize excessive whitespace
-        text = re.sub(r'\n{3,}', '\n\n', text)
-        sanitized['text'] = text.strip()
-    
-    # Sanitize title similarly
-    if 'title' in sanitized and sanitized['title']:
-        title = sanitized['title']
-        title = re.sub(r'[\x00-\x1f\x7f]', '', title)
-        sanitized['title'] = title.strip()
-    
-    return sanitized
-```
-
-### Integration with Processor
-
-```python
-# lambda/processor/handler.py
-from validator import validate_message, ValidationError
-from shared.logging import logger, metrics
-
-def process_message(record: dict) -> dict:
-    """Process a single SQS message."""
-    body = json.loads(record['body'])
-    
-    # ============================================
-    # Validation Gate
-    # ============================================
-    try:
-        validated = validate_message(body)
-    except ValidationError as e:
-        logger.warning(f"Message validation failed: {e.errors}", extra={
-            'source': body.get('source_platform', 'unknown'),
-            'message_id': body.get('id', 'unknown'),
-            'errors': e.errors,
-        })
-        metrics.add_metric(name="ValidationFailures", unit="Count", value=1)
-        # Don't raise - message goes to DLQ after max retries
-        # Or explicitly send to DLQ for invalid messages
-        return {'status': 'invalid', 'errors': e.errors}
-    
-    # ============================================
-    # Process validated message
-    # ============================================
-    # ... rest of processing logic with trusted data
-```
-
-### Metrics and Alerting
-
-Track validation failures to detect misbehaving plugins:
-
-```python
-# CloudWatch metrics emitted by validator
-metrics.add_metric(name="ValidationFailures", unit="Count", value=1, dimensions={
-    'source_platform': source,
-    'error_type': 'missing_field'  # or 'invalid_format', 'unknown_source', etc.
-})
-```
-
-Create CloudWatch alarms:
-- Alert if validation failure rate > 5% for any source
-- Alert if unknown source_platform appears (potential security issue)
-- Alert if message size limits are hit frequently
+Validation includes:
+- Required field presence and type checking
+- String sanitization (control character removal)
+- URL format validation
+- Future date rejection
+- Metadata: flat primitives only (no nested objects)
+- Extra fields rejected (`extra = "forbid"`)
 
 ---
 
@@ -1713,39 +859,11 @@ Create CloudWatch alarms:
 
 ### The Problem
 
-If plugins can define arbitrary infrastructure, they could:
-- Accidentally break core platform resources
-- Create security vulnerabilities
-- Cause unexpected costs
-- Conflict with other plugins
+If plugins can define arbitrary infrastructure, they could accidentally break core platform resources, create security vulnerabilities, cause unexpected costs, or conflict with other plugins.
 
 ### Solution: Constrained Plugin Infrastructure
 
 Plugins don't define raw CDK/CloudFormation. Instead, they declare **what they need** in the manifest, and the platform creates resources using **controlled templates**.
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                     Plugin Manifest                                  │
-│  "I need: polling Lambda, webhook endpoint, these secrets"          │
-└─────────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                     Platform CDK (Controlled)                        │
-│  - Creates Lambda with fixed role, VPC, limits                      │
-│  - Creates API Gateway route under /webhooks/{id}                   │
-│  - Adds secrets to shared Secrets Manager                           │
-│  - All resources tagged and named consistently                      │
-└─────────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                     Isolated Plugin Resources                        │
-│  - Lambda: voc-ingestor-{plugin-id}                                 │
-│  - Schedule: voc-ingest-{plugin-id}-schedule                        │
-│  - Logs: /aws/lambda/voc-ingestor-{plugin-id}                       │
-└─────────────────────────────────────────────────────────────────────┘
-```
 
 ### What Plugins CAN Declare
 
@@ -1754,7 +872,7 @@ Plugins don't define raw CDK/CloudFormation. Instead, they declare **what they n
 | Polling Lambda | `infrastructure.ingestor` | Lambda with shared role, fixed limits |
 | Webhook Lambda | `infrastructure.webhook` | Lambda + API Gateway route |
 | S3 Trigger | `infrastructure.s3Trigger` | S3 event notification |
-| Secrets | `secrets` | Entries in shared Secrets Manager |
+| Secrets | `secrets` | Entries in shared Secrets Manager (prefixed) |
 | Schedule | `infrastructure.ingestor.schedule` | EventBridge rule (disabled by default) |
 
 ### What Plugins CANNOT Do
@@ -1766,154 +884,36 @@ Plugins don't define raw CDK/CloudFormation. Instead, they declare **what they n
 - Access resources outside the plugin sandbox
 - Define arbitrary CloudFormation
 
-### Resource Boundaries
-
-#### Shared Resources (Read/Write via Platform)
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                     Shared Resources                                 │
-│                                                                      │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                 │
-│  │ SQS Queue   │  │ Secrets Mgr │  │ Raw S3      │                 │
-│  │ (write)     │  │ (read)      │  │ (write)     │                 │
-│  └─────────────┘  └─────────────┘  └─────────────┘                 │
-│         ▲               ▲               ▲                           │
-│         │               │               │                           │
-│  ┌──────┴───────────────┴───────────────┴──────┐                   │
-│  │           Shared IAM Role                    │                   │
-│  │  - sqs:SendMessage (processing queue only)   │                   │
-│  │  - secretsmanager:GetSecretValue             │                   │
-│  │  - s3:PutObject (raw bucket only)            │                   │
-│  │  - dynamodb:* (watermarks table only)        │                   │
-│  └──────────────────────────────────────────────┘                   │
-│                          ▲                                          │
-│         ┌────────────────┼────────────────┐                        │
-│         │                │                │                        │
-│  ┌──────┴─────┐  ┌───────┴──────┐  ┌─────┴──────┐                 │
-│  │ Plugin A   │  │ Plugin B     │  │ Plugin C   │                 │
-│  │ Lambda     │  │ Lambda       │  │ Lambda     │                 │
-│  └────────────┘  └──────────────┘  └────────────┘                 │
-│                                                                      │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-#### Per-Plugin Resources (Isolated)
-
-Each plugin gets its own:
-- Lambda function (isolated execution)
-- CloudWatch Log Group (isolated logs)
-- EventBridge Rule (isolated schedule)
-- Webhook route (isolated endpoint)
-
-### IAM Role Design
+### Shared IAM Role
 
 All plugin Lambdas share a single, tightly-scoped IAM role:
 
-```typescript
-// lib/stacks/ingestion-stack.ts
-const pluginRole = new iam.Role(this, 'PluginLambdaRole', {
-  assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-  managedPolicies: [
-    iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
-  ],
-});
-
-// Minimal permissions - only what plugins need
-pluginRole.addToPolicy(new iam.PolicyStatement({
-  sid: 'SendToProcessingQueue',
-  effect: iam.Effect.ALLOW,
-  actions: ['sqs:SendMessage', 'sqs:SendMessageBatch'],
-  resources: [processingQueue.queueArn],
-}));
-
-pluginRole.addToPolicy(new iam.PolicyStatement({
-  sid: 'ReadSecrets',
-  effect: iam.Effect.ALLOW,
-  actions: ['secretsmanager:GetSecretValue'],
-  resources: [apiSecrets.secretArn],
-}));
-
-pluginRole.addToPolicy(new iam.PolicyStatement({
-  sid: 'WriteRawData',
-  effect: iam.Effect.ALLOW,
-  actions: ['s3:PutObject'],
-  resources: [`${rawDataBucket.bucketArn}/raw/*`],
-}));
-
-pluginRole.addToPolicy(new iam.PolicyStatement({
-  sid: 'ManageWatermarks',
-  effect: iam.Effect.ALLOW,
-  actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:UpdateItem'],
-  resources: [watermarksTable.tableArn],
-}));
-
-// KMS for encryption
-kmsKey.grantEncryptDecrypt(pluginRole);
+```
+┌──────────────────────────────────────────────────┐
+│           Shared IAM Role                         │
+│  - sqs:SendMessage (processing queue only)        │
+│  - secretsmanager:GetSecretValue                  │
+│  - s3:PutObject, s3:GetObject (raw bucket)        │
+│  - dynamodb:GetItem/PutItem (watermarks table)    │
+│  - dynamodb:ReadWrite (aggregates table)          │
+│  - kms:Encrypt/Decrypt                            │
+└──────────────────────────────────────────────────┘
+                       ▲
+      ┌────────────────┼────────────────┐
+      │                │                │
+┌─────┴─────┐  ┌──────┴─────┐  ┌──────┴─────┐
+│ Plugin A  │  │ Plugin B   │  │ Plugin C   │
+│ Lambda    │  │ Lambda     │  │ Lambda     │
+└───────────┘  └────────────┘  └────────────┘
 ```
 
-### Lambda Constraints
+### Per-Plugin Resources (Isolated)
 
-All plugin Lambdas are created with fixed constraints:
-
-```typescript
-function createPluginLambda(plugin: PluginManifest, role: iam.Role): lambda.Function {
-  const infra = plugin.infrastructure.ingestor!;
-  
-  return new lambda.Function(this, `Ingestor${plugin.id}`, {
-    functionName: `voc-ingestor-${plugin.id}`,
-    runtime: lambda.Runtime.PYTHON_3_12,
-    architecture: lambda.Architecture.ARM_64,
-    handler: 'handler.lambda_handler',
-    role: role,  // Shared role - no custom permissions
-    
-    // Constrained limits
-    timeout: cdk.Duration.seconds(Math.min(infra.timeout, 300)),  // Max 5 min
-    memorySize: Math.min(infra.memory, 1024),  // Max 1GB
-    
-    // No VPC access (plugins don't need it)
-    vpc: undefined,
-    
-    // Reserved concurrency to prevent runaway costs
-    reservedConcurrentExecutions: 10,
-    
-    // Environment - only safe variables
-    environment: {
-      SOURCE_PLATFORM: plugin.id,
-      PROCESSING_QUEUE_URL: processingQueue.queueUrl,
-      WATERMARKS_TABLE: watermarksTable.tableName,
-      RAW_DATA_BUCKET: rawDataBucket.bucketName,
-      SECRETS_ARN: apiSecrets.secretArn,
-      BRAND_NAME: config.brandName,
-      // No sensitive values directly in env
-    },
-  });
-}
-```
-
-### Webhook Isolation
-
-Webhook endpoints are isolated under `/webhooks/{plugin-id}`:
-
-```typescript
-// All webhooks under /webhooks prefix
-const webhooksResource = api.root.addResource('webhooks');
-
-for (const plugin of webhookPlugins) {
-  // Each plugin gets its own sub-resource
-  const pluginResource = webhooksResource.addResource(plugin.id);
-  
-  // Only POST allowed (or as specified in manifest)
-  for (const method of plugin.infrastructure.webhook!.methods) {
-    pluginResource.addMethod(method, integration, {
-      // No authorization (external webhooks)
-      authorizationType: apigateway.AuthorizationType.NONE,
-      // But we can add request validation
-      requestValidator: requestValidator,
-    });
-  }
-}
-```
+Each plugin gets its own:
+- Lambda function (`voc-ingestor-{plugin-id}`)
+- CloudWatch Log Group (`/aws/lambda/voc-ingestor-{plugin-id}`)
+- EventBridge Rule (`voc-ingest-{plugin-id}-schedule`)
+- Webhook route (`/webhooks/{plugin-id}`) if applicable
 
 ### Secrets Isolation
 
@@ -1925,1691 +925,99 @@ class BaseIngestor:
     def _load_secrets(self) -> dict:
         """Load only this plugin's secrets."""
         all_secrets = get_secret(SECRETS_ARN)
-        
+
         # Filter to only keys prefixed with this plugin's ID
         prefix = f"{self.source_platform}_"
-        return {
-            k.replace(prefix, ''): v 
-            for k, v in all_secrets.items() 
-            if k.startswith(prefix)
-        }
+        filtered = {}
+        for key, value in all_secrets.items():
+            if key.startswith(prefix):
+                clean_key = key[len(prefix):]
+                filtered[clean_key] = value
+            elif not any(key.startswith(f"{p}_") for p in self._get_known_prefixes()):
+                filtered[key] = value  # Legacy/shared keys
+
+        return filtered if filtered else all_secrets
 ```
 
 This means:
-- `webscraper` plugin sees: `configs`
-- Each plugin can only access its own secrets
-
-### Cost Controls
-
-#### Per-Plugin Limits
-
-| Resource | Limit | Enforced By |
-|----------|-------|-------------|
-| Lambda timeout | 5 minutes max | CDK validation |
-| Lambda memory | 1GB max | CDK validation |
-| Lambda concurrency | 10 concurrent | Reserved concurrency |
-| Schedule frequency | 1 minute min | CDK validation |
-| Message size | 256KB | SQS limit |
-
-#### Manifest Validation
-
-```typescript
-// lib/plugin-loader.ts
-function validateManifestLimits(manifest: PluginManifest): void {
-  const infra = manifest.infrastructure;
-  
-  if (infra.ingestor) {
-    if (infra.ingestor.timeout > 300) {
-      throw new Error(`Plugin ${manifest.id}: timeout cannot exceed 300 seconds`);
-    }
-    if (infra.ingestor.memory > 1024) {
-      throw new Error(`Plugin ${manifest.id}: memory cannot exceed 1024 MB`);
-    }
-    if (infra.ingestor.schedule) {
-      // Validate schedule isn't too frequent
-      const schedule = infra.ingestor.schedule;
-      if (schedule.includes('rate(') && schedule.includes('second')) {
-        throw new Error(`Plugin ${manifest.id}: schedule cannot be more frequent than 1 minute`);
-      }
-    }
-  }
-}
-```
-
-### Monitoring and Alerts
-
-Track plugin behavior to detect issues:
-
-```typescript
-// Per-plugin CloudWatch alarms
-for (const plugin of enabledPlugins) {
-  // Error rate alarm
-  new cloudwatch.Alarm(this, `${plugin.id}ErrorAlarm`, {
-    metric: fn.metricErrors(),
-    threshold: 10,
-    evaluationPeriods: 3,
-    alarmDescription: `Plugin ${plugin.id} error rate too high`,
-  });
-  
-  // Duration alarm (approaching timeout)
-  new cloudwatch.Alarm(this, `${plugin.id}DurationAlarm`, {
-    metric: fn.metricDuration(),
-    threshold: infra.ingestor!.timeout * 1000 * 0.8,  // 80% of timeout
-    evaluationPeriods: 3,
-    alarmDescription: `Plugin ${plugin.id} approaching timeout`,
-  });
-  
-  // Invocation spike alarm
-  new cloudwatch.Alarm(this, `${plugin.id}InvocationAlarm`, {
-    metric: fn.metricInvocations(),
-    threshold: 1000,  // Per 5 minutes
-    evaluationPeriods: 1,
-    alarmDescription: `Plugin ${plugin.id} invocation spike`,
-  });
-}
-```
-
-### Plugin Review Process (for Open Source)
-
-Before merging a community plugin:
-
-1. **Manifest review**: Check for reasonable limits, valid schema
-2. **Code review**: No malicious code, follows patterns
-3. **Test execution**: Run in isolated test environment
-4. **Security scan**: Check for hardcoded secrets, unsafe operations
-
-```yaml
-# .github/workflows/plugin-review.yml
-name: Plugin Review
-on:
-  pull_request:
-    paths:
-      - 'plugins/**'
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Validate manifests
-        run: npm run validate:manifests
-      
-      - name: Lint plugin code
-        run: |
-          for dir in plugins/*/; do
-            if [ -f "$dir/ingestor/handler.py" ]; then
-              pylint "$dir/ingestor/handler.py"
-            fi
-          done
-      
-      - name: Security scan
-        run: |
-          # Check for hardcoded secrets
-          grep -r "api_key\s*=" plugins/ && exit 1 || true
-          # Check for unsafe imports
-          grep -r "import os\|import subprocess" plugins/ && echo "Review required" || true
-      
-      - name: Test plugin
-        run: |
-          for dir in plugins/*/; do
-            if [ -f "$dir/ingestor/test_handler.py" ]; then
-              pytest "$dir/ingestor/test_handler.py"
-            fi
-          done
-```
+- `webscraper` plugin sees: `configs` (from `webscraper_configs`)
+- `my_source` plugin sees: `api_key` (from `my_source_api_key`)
+- Plugins cannot read each other's secrets
 
 ---
 
-## Summary: Security Model
+## Testing
 
-| Layer | Protection |
-|-------|------------|
-| **Manifest** | Schema validation, limit enforcement |
-| **IAM** | Shared role with minimal permissions |
-| **Lambda** | Fixed runtime, memory, timeout limits |
-| **SQS** | Message validation before processing |
-| **Secrets** | Prefix-based isolation |
-| **API Gateway** | Isolated webhook routes |
-| **Monitoring** | Per-plugin alarms and metrics |
-| **Review** | PR checks for community plugins |
-
-This ensures plugins can only:
-- Read their own secrets
-- Write to the processing queue
-- Store raw data in S3
-- Manage their own watermarks
-
-They cannot:
-- Access other plugins' data
-- Modify core infrastructure
-- Create new AWS resources
-- Exceed cost/performance limits
-
-
----
-
-## Cost Allocation and Observability
-
-### Cost Tagging Strategy
-
-Every resource created for a plugin gets tagged for cost allocation and tracking.
-
-#### Tag Schema
-
-| Tag | Value | Purpose |
-|-----|-------|---------|
-| `Project` | `VoC-DataLake` | Top-level project identification |
-| `Feature` | `Plugin` | Distinguishes plugin costs from core platform |
-| `Plugin` | `{plugin-id}` | Identifies specific plugin (e.g., `webscraper`) |
-| `PluginCategory` | `{category}` | Groups plugins (e.g., `reviews`, `social`) |
-| `Environment` | `dev`/`staging`/`prod` | Environment separation |
-| `ManagedBy` | `CDK` | Infrastructure management |
-
-#### Implementation
-
-```typescript
-// lib/stacks/ingestion-stack.ts
-import { Tags } from 'aws-cdk-lib';
-
-function tagPluginResources(
-  construct: Construct, 
-  plugin: PluginManifest,
-  environment: string
-): void {
-  Tags.of(construct).add('Project', 'VoC-DataLake');
-  Tags.of(construct).add('Feature', 'Plugin');
-  Tags.of(construct).add('Plugin', plugin.id);
-  Tags.of(construct).add('PluginCategory', plugin.category || 'uncategorized');
-  Tags.of(construct).add('Environment', environment);
-  Tags.of(construct).add('ManagedBy', 'CDK');
-}
-
-// Apply to all plugin resources
-for (const plugin of enabledPlugins) {
-  const fn = createPluginLambda(plugin, role);
-  tagPluginResources(fn, plugin, environment);
-  
-  if (plugin.infrastructure.ingestor?.schedule) {
-    const rule = createScheduleRule(plugin, fn);
-    tagPluginResources(rule, plugin, environment);
-  }
-  
-  // Log group
-  const logGroup = new logs.LogGroup(this, `Logs${plugin.id}`, {
-    logGroupName: `/aws/lambda/voc-ingestor-${plugin.id}`,
-    retention: logs.RetentionDays.TWO_WEEKS,
-  });
-  tagPluginResources(logGroup, plugin, environment);
-}
-```
-
-#### AWS Cost Explorer Setup
-
-1. **Activate tags** in AWS Billing Console:
-   - Go to Billing → Cost Allocation Tags
-   - Activate: `Plugin`, `PluginCategory`, `Feature`
-
-2. **Create Cost Reports**:
-   - Group by `Plugin` tag to see per-plugin costs
-   - Filter by `Feature=Plugin` to see total plugin costs vs core platform
-
-3. **Set Budgets**:
-   - Per-plugin budget alerts
-   - Total plugins budget cap
-
-```typescript
-// Optional: Create budget alerts per plugin
-import * as budgets from 'aws-cdk-lib/aws-budgets';
-
-for (const plugin of enabledPlugins) {
-  new budgets.CfnBudget(this, `Budget${plugin.id}`, {
-    budget: {
-      budgetName: `voc-plugin-${plugin.id}-monthly`,
-      budgetType: 'COST',
-      timeUnit: 'MONTHLY',
-      budgetLimit: {
-        amount: 50,  // $50/month per plugin default
-        unit: 'USD',
-      },
-      costFilters: {
-        TagKeyValue: [`user:Plugin$${plugin.id}`],
-      },
-    },
-    notificationsWithSubscribers: [{
-      notification: {
-        notificationType: 'ACTUAL',
-        comparisonOperator: 'GREATER_THAN',
-        threshold: 80,  // Alert at 80%
-      },
-      subscribers: [{
-        subscriptionType: 'EMAIL',
-        address: 'alerts@example.com',
-      }],
-    }],
-  });
-}
-```
-
----
-
-## Monitoring and Alerting
-
-### CloudWatch Dashboard
-
-Create a dedicated dashboard for plugin observability:
-
-```typescript
-// lib/stacks/ingestion-stack.ts
-import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
-
-const dashboard = new cloudwatch.Dashboard(this, 'PluginDashboard', {
-  dashboardName: 'VoC-Plugins-Overview',
-});
-
-// Add widgets for each plugin
-for (const plugin of enabledPlugins) {
-  const fn = this.ingestionLambdas.get(plugin.id)!;
-  
-  // Plugin section header
-  dashboard.addWidgets(
-    new cloudwatch.TextWidget({
-      markdown: `# ${plugin.icon} ${plugin.name}`,
-      width: 24,
-      height: 1,
-    })
-  );
-  
-  // Metrics row
-  dashboard.addWidgets(
-    // Invocations
-    new cloudwatch.GraphWidget({
-      title: `${plugin.id} - Invocations`,
-      left: [fn.metricInvocations()],
-      width: 6,
-    }),
-    // Errors
-    new cloudwatch.GraphWidget({
-      title: `${plugin.id} - Errors`,
-      left: [fn.metricErrors()],
-      width: 6,
-    }),
-    // Duration
-    new cloudwatch.GraphWidget({
-      title: `${plugin.id} - Duration`,
-      left: [fn.metricDuration()],
-      width: 6,
-    }),
-    // Throttles
-    new cloudwatch.GraphWidget({
-      title: `${plugin.id} - Throttles`,
-      left: [fn.metricThrottles()],
-      width: 6,
-    })
-  );
-}
-
-// Summary widgets
-dashboard.addWidgets(
-  new cloudwatch.TextWidget({
-    markdown: '# 📊 Summary',
-    width: 24,
-    height: 1,
-  }),
-  // Total messages processed
-  new cloudwatch.SingleValueWidget({
-    title: 'Total Messages Ingested (24h)',
-    metrics: [new cloudwatch.Metric({
-      namespace: 'VoC/Ingestion',
-      metricName: 'ItemsIngested',
-      statistic: 'Sum',
-      period: cdk.Duration.hours(24),
-    })],
-    width: 8,
-  }),
-  // Validation failures
-  new cloudwatch.SingleValueWidget({
-    title: 'Validation Failures (24h)',
-    metrics: [new cloudwatch.Metric({
-      namespace: 'VoC/Processing',
-      metricName: 'ValidationFailures',
-      statistic: 'Sum',
-      period: cdk.Duration.hours(24),
-    })],
-    width: 8,
-  }),
-  // Active plugins
-  new cloudwatch.SingleValueWidget({
-    title: 'Active Plugins',
-    metrics: [new cloudwatch.Metric({
-      namespace: 'VoC/Plugins',
-      metricName: 'ActivePlugins',
-      statistic: 'Maximum',
-      period: cdk.Duration.hours(1),
-    })],
-    width: 8,
-  })
-);
-```
-
-### Per-Plugin Alarms
-
-```typescript
-// lib/plugin-alarms.ts
-import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
-import * as sns from 'aws-cdk-lib/aws-sns';
-
-export function createPluginAlarms(
-  scope: Construct,
-  plugin: PluginManifest,
-  fn: lambda.Function,
-  alertTopic: sns.Topic
-): void {
-  const alarmNamePrefix = `VoC-Plugin-${plugin.id}`;
-  
-  // ============================================
-  // Error Rate Alarm
-  // ============================================
-  const errorAlarm = new cloudwatch.Alarm(scope, `${plugin.id}ErrorAlarm`, {
-    alarmName: `${alarmNamePrefix}-HighErrorRate`,
-    alarmDescription: `Plugin ${plugin.name} error rate exceeds threshold`,
-    metric: fn.metricErrors({
-      period: cdk.Duration.minutes(5),
-      statistic: 'Sum',
-    }),
-    threshold: 5,
-    evaluationPeriods: 2,
-    comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-  });
-  errorAlarm.addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
-  
-  // ============================================
-  // Duration Alarm (approaching timeout)
-  // ============================================
-  const timeoutMs = (plugin.infrastructure.ingestor?.timeout || 120) * 1000;
-  const durationAlarm = new cloudwatch.Alarm(scope, `${plugin.id}DurationAlarm`, {
-    alarmName: `${alarmNamePrefix}-HighDuration`,
-    alarmDescription: `Plugin ${plugin.name} execution time approaching timeout`,
-    metric: fn.metricDuration({
-      period: cdk.Duration.minutes(5),
-      statistic: 'p95',
-    }),
-    threshold: timeoutMs * 0.8,  // 80% of timeout
-    evaluationPeriods: 3,
-    comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-  });
-  durationAlarm.addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
-  
-  // ============================================
-  // Throttle Alarm
-  // ============================================
-  const throttleAlarm = new cloudwatch.Alarm(scope, `${plugin.id}ThrottleAlarm`, {
-    alarmName: `${alarmNamePrefix}-Throttled`,
-    alarmDescription: `Plugin ${plugin.name} is being throttled`,
-    metric: fn.metricThrottles({
-      period: cdk.Duration.minutes(5),
-      statistic: 'Sum',
-    }),
-    threshold: 1,
-    evaluationPeriods: 1,
-    comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-  });
-  throttleAlarm.addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
-  
-  // ============================================
-  // No Invocations Alarm (plugin stopped working)
-  // ============================================
-  if (plugin.infrastructure.ingestor?.schedule) {
-    const noInvocationsAlarm = new cloudwatch.Alarm(scope, `${plugin.id}NoInvocationsAlarm`, {
-      alarmName: `${alarmNamePrefix}-NoInvocations`,
-      alarmDescription: `Plugin ${plugin.name} has not run in expected timeframe`,
-      metric: fn.metricInvocations({
-        period: cdk.Duration.hours(1),
-        statistic: 'Sum',
-      }),
-      threshold: 0,
-      evaluationPeriods: 2,
-      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
-    });
-    noInvocationsAlarm.addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
-  }
-  
-  // ============================================
-  // Validation Failures Alarm (plugin sending bad data)
-  // ============================================
-  const validationAlarm = new cloudwatch.Alarm(scope, `${plugin.id}ValidationAlarm`, {
-    alarmName: `${alarmNamePrefix}-ValidationFailures`,
-    alarmDescription: `Plugin ${plugin.name} sending invalid messages`,
-    metric: new cloudwatch.Metric({
-      namespace: 'VoC/Processing',
-      metricName: 'ValidationFailures',
-      dimensionsMap: { source_platform: plugin.id },
-      period: cdk.Duration.minutes(15),
-      statistic: 'Sum',
-    }),
-    threshold: 10,
-    evaluationPeriods: 1,
-    comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-  });
-  validationAlarm.addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
-}
-```
-
-### Custom Metrics from Plugins
-
-Plugins emit standardized metrics via the shared `metrics` utility:
-
-```python
-# plugins/_shared/base_ingestor.py
-from shared.logging import metrics
-
-class BaseIngestor:
-    def run(self) -> dict:
-        """Main execution with metrics."""
-        try:
-            items = list(self.fetch_new_items())
-            
-            # Emit plugin-specific metrics
-            metrics.add_metric(
-                name="ItemsIngested",
-                unit="Count",
-                value=len(items),
-                dimensions={'source_platform': self.source_platform}
-            )
-            
-            if items:
-                self.send_to_queue(items)
-            
-            return {"status": "success", "items_processed": len(items)}
-            
-        except Exception as e:
-            metrics.add_metric(
-                name="IngestionErrors",
-                unit="Count",
-                value=1,
-                dimensions={'source_platform': self.source_platform}
-            )
-            raise
-```
-
-### Metric Namespace Structure
-
-```
-VoC/
-├── Ingestion/
-│   ├── ItemsIngested          (dimensions: source_platform)
-│   ├── IngestionErrors        (dimensions: source_platform)
-│   └── IngestionDuration      (dimensions: source_platform)
-│
-├── Processing/
-│   ├── MessagesProcessed      (dimensions: source_platform)
-│   ├── ValidationFailures     (dimensions: source_platform, error_type)
-│   └── ProcessingDuration     (dimensions: source_platform)
-│
-├── Webhooks/
-│   ├── WebhookReceived        (dimensions: source_platform)
-│   ├── WebhookErrors          (dimensions: source_platform)
-│   └── WebhookLatency         (dimensions: source_platform)
-│
-└── Plugins/
-    ├── ActivePlugins          (count of enabled plugins)
-    └── PluginHealth           (dimensions: source_platform, status)
-```
-
-### Log Insights Queries
-
-Pre-built queries for troubleshooting:
-
-```
-# Errors by plugin (last 24h)
-fields @timestamp, @message, source_platform
-| filter @message like /ERROR/
-| stats count() by source_platform
-| sort count desc
-
-# Slow executions by plugin
-fields @timestamp, @duration, source_platform
-| filter @duration > 10000
-| stats avg(@duration), max(@duration), count() by source_platform
-
-# Validation failures breakdown
-fields @timestamp, @message, source_platform, errors
-| filter @message like /Validation failed/
-| stats count() by source_platform, errors
-
-# Items ingested per plugin per hour
-fields @timestamp, source_platform, items_processed
-| filter @message like /items_processed/
-| stats sum(items_processed) by bin(1h), source_platform
-```
-
-### Alert Routing
-
-Route alerts based on severity and plugin:
-
-```typescript
-// lib/stacks/ingestion-stack.ts
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
-
-// Critical alerts (errors, throttles)
-const criticalTopic = new sns.Topic(this, 'PluginCriticalAlerts', {
-  topicName: 'voc-plugin-critical-alerts',
-  displayName: 'VoC Plugin Critical Alerts',
-});
-criticalTopic.addSubscription(
-  new subscriptions.EmailSubscription('oncall@example.com')
-);
-
-// Warning alerts (high duration, no invocations)
-const warningTopic = new sns.Topic(this, 'PluginWarningAlerts', {
-  topicName: 'voc-plugin-warning-alerts',
-  displayName: 'VoC Plugin Warning Alerts',
-});
-warningTopic.addSubscription(
-  new subscriptions.EmailSubscription('team@example.com')
-);
-
-// Per-plugin Slack channels (optional)
-for (const plugin of enabledPlugins) {
-  const pluginTopic = new sns.Topic(this, `PluginAlerts${plugin.id}`, {
-    topicName: `voc-plugin-${plugin.id}-alerts`,
-  });
-  // Could route to plugin-specific Slack channel
-}
-```
-
-### Health Check Endpoint
-
-API endpoint to check plugin health:
-
-```python
-# lambda/api/plugin_health_handler.py
-def get_plugin_health() -> dict:
-    """Get health status of all plugins."""
-    events = boto3.client('events')
-    cloudwatch = boto3.client('cloudwatch')
-    
-    plugins = {}
-    
-    # Get all plugin schedules
-    rules = events.list_rules(NamePrefix='voc-ingest-')
-    
-    for rule in rules.get('Rules', []):
-        plugin_id = rule['Name'].replace('voc-ingest-', '').replace('-schedule', '')
-        
-        # Get recent metrics
-        errors = cloudwatch.get_metric_statistics(
-            Namespace='AWS/Lambda',
-            MetricName='Errors',
-            Dimensions=[{'Name': 'FunctionName', 'Value': f'voc-ingestor-{plugin_id}'}],
-            StartTime=datetime.utcnow() - timedelta(hours=1),
-            EndTime=datetime.utcnow(),
-            Period=3600,
-            Statistics=['Sum']
-        )
-        
-        invocations = cloudwatch.get_metric_statistics(
-            Namespace='AWS/Lambda',
-            MetricName='Invocations',
-            Dimensions=[{'Name': 'FunctionName', 'Value': f'voc-ingestor-{plugin_id}'}],
-            StartTime=datetime.utcnow() - timedelta(hours=1),
-            EndTime=datetime.utcnow(),
-            Period=3600,
-            Statistics=['Sum']
-        )
-        
-        error_count = errors['Datapoints'][0]['Sum'] if errors['Datapoints'] else 0
-        invocation_count = invocations['Datapoints'][0]['Sum'] if invocations['Datapoints'] else 0
-        
-        # Determine health status
-        if rule['State'] != 'ENABLED':
-            status = 'disabled'
-        elif error_count > 0 and invocation_count > 0 and error_count / invocation_count > 0.1:
-            status = 'unhealthy'
-        elif invocation_count == 0:
-            status = 'inactive'
-        else:
-            status = 'healthy'
-        
-        plugins[plugin_id] = {
-            'status': status,
-            'enabled': rule['State'] == 'ENABLED',
-            'schedule': rule.get('ScheduleExpression', ''),
-            'last_hour': {
-                'invocations': int(invocation_count),
-                'errors': int(error_count),
-            }
-        }
-    
-    return {
-        'plugins': plugins,
-        'summary': {
-            'total': len(plugins),
-            'healthy': sum(1 for p in plugins.values() if p['status'] == 'healthy'),
-            'unhealthy': sum(1 for p in plugins.values() if p['status'] == 'unhealthy'),
-            'disabled': sum(1 for p in plugins.values() if p['status'] == 'disabled'),
-        }
-    }
-```
-
-### Frontend Health Display
-
-Show plugin health in Settings UI:
-
-```tsx
-// frontend/src/pages/Settings/PluginHealthBadge.tsx
-type HealthStatus = 'healthy' | 'unhealthy' | 'inactive' | 'disabled';
-
-const statusConfig: Record<HealthStatus, { color: string; icon: ReactNode; label: string }> = {
-  healthy: { color: 'green', icon: <CheckCircle2 size={14} />, label: 'Healthy' },
-  unhealthy: { color: 'red', icon: <AlertCircle size={14} />, label: 'Unhealthy' },
-  inactive: { color: 'yellow', icon: <Clock size={14} />, label: 'Inactive' },
-  disabled: { color: 'gray', icon: <Pause size={14} />, label: 'Disabled' },
-};
-
-function PluginHealthBadge({ status }: { status: HealthStatus }) {
-  const config = statusConfig[status];
-  return (
-    <span className={`flex items-center gap-1 text-xs text-${config.color}-600`}>
-      {config.icon}
-      {config.label}
-    </span>
-  );
-}
-```
-
----
-
-## Summary: Observability Stack
-
-| Component | Purpose |
-|-----------|---------|
-| **Cost Tags** | Track spend per plugin via AWS Cost Explorer |
-| **Budgets** | Alert when plugin costs exceed threshold |
-| **Dashboard** | Visual overview of all plugin metrics |
-| **Alarms** | Automated alerts for errors, throttles, timeouts |
-| **Custom Metrics** | Plugin-specific metrics (items ingested, etc.) |
-| **Log Insights** | Pre-built queries for troubleshooting |
-| **Health API** | Programmatic health check endpoint |
-| **Health UI** | Visual health status in Settings page |
-
-This gives you full visibility into:
-- How much each plugin costs
-- Whether plugins are working correctly
-- When plugins need attention
-- Historical trends and patterns
-
-
----
-
-## Security Hardening
-
-### Issue Tracker
-
-| Priority | Issue | Status |
-|----------|-------|--------|
-| 🔴 Critical | Secrets not isolated at IAM level | Addressed below |
-| 🔴 Critical | No webhook authentication | Addressed below |
-| 🔴 Critical | Manifest injection risks | Addressed below |
-| 🟠 High | No code integrity verification | Addressed below |
-| 🟠 High | Metadata allows arbitrary objects | Addressed below |
-| 🟠 High | No audit logging | Addressed below |
-| 🟡 Medium | No versioning | Addressed below |
-| 🟡 Medium | No circuit breaker | Addressed below |
-| 🟡 Medium | No resource tagging | Already addressed in Cost Allocation section |
-| 🟢 Low | Manual Python validation | Addressed below |
-
----
-
-### 🔴 Critical: Per-Plugin Secrets Isolation
-
-**Problem**: All plugins share one Secrets Manager secret. A compromised plugin could read other plugins' credentials.
-
-**Solution**: One secret per plugin with IAM conditions.
-
-```typescript
-// lib/stacks/ingestion-stack.ts
-for (const plugin of enabledPlugins) {
-  // Create dedicated secret for each plugin
-  const pluginSecret = new secretsmanager.Secret(this, `Secret${plugin.id}`, {
-    secretName: `voc-datalake/plugins/${plugin.id}`,
-    description: `Credentials for ${plugin.name} plugin`,
-    generateSecretString: {
-      secretStringTemplate: JSON.stringify(plugin.secrets || {}),
-      generateStringKey: 'placeholder',
-    },
-  });
-  
-  // Tag for cost allocation
-  Tags.of(pluginSecret).add('Plugin', plugin.id);
-  
-  // Create plugin-specific role with access only to its secret
-  const pluginRole = new iam.Role(this, `Role${plugin.id}`, {
-    assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-    roleName: `voc-plugin-${plugin.id}-role`,
-    managedPolicies: [
-      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
-    ],
-  });
-  
-  // Grant access ONLY to this plugin's secret
-  pluginSecret.grantRead(pluginRole);
-  
-  // Shared resources with scoped access
-  pluginRole.addToPolicy(new iam.PolicyStatement({
-    sid: 'SendToProcessingQueue',
-    actions: ['sqs:SendMessage', 'sqs:SendMessageBatch'],
-    resources: [processingQueue.queueArn],
-  }));
-  
-  pluginRole.addToPolicy(new iam.PolicyStatement({
-    sid: 'WriteRawData',
-    actions: ['s3:PutObject'],
-    resources: [`${rawDataBucket.bucketArn}/raw/${plugin.id}/*`],  // Scoped to plugin prefix
-  }));
-  
-  pluginRole.addToPolicy(new iam.PolicyStatement({
-    sid: 'ManageWatermarks',
-    actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:UpdateItem'],
-    resources: [watermarksTable.tableArn],
-    conditions: {
-      'ForAllValues:StringLike': {
-        'dynamodb:LeadingKeys': [`${plugin.id}#*`],  // Scoped to plugin prefix
-      },
-    },
-  }));
-  
-  // Create Lambda with plugin-specific role
-  const fn = new lambda.Function(this, `Ingestor${plugin.id}`, {
-    role: pluginRole,  // Dedicated role, not shared
-    environment: {
-      SECRETS_ARN: pluginSecret.secretArn,  // Only this plugin's secret
-      // ...
-    },
-    // ...
-  });
-}
-```
-
----
-
-### 🔴 Critical: Webhook Signature Verification
-
-**Problem**: Webhook endpoints are publicly accessible. Without signature verification, anyone can send fake events.
-
-**Solution**: Always verify webhook signatures in your handler before processing events. Each provider has its own signing method: consult your provider's documentation for the specific implementation details.
-
----
-
-### 🔴 Critical: Manifest Input Sanitization
-
-**Problem**: Manifest values could contain injection attacks (path traversal, command injection).
-
-**Solution**: Strict validation with allowlists and sanitization.
-
-```typescript
-// lib/plugin-loader.ts
-import { z } from 'zod';
-
-// Strict ID pattern - only lowercase alphanumeric and underscores
-const PluginIdSchema = z.string()
-  .min(1)
-  .max(32)
-  .regex(/^[a-z][a-z0-9_]*$/, 'ID must start with letter, contain only lowercase alphanumeric and underscores');
-
-// Safe path pattern - no traversal
-const SafePathSchema = z.string()
-  .max(128)
-  .regex(/^\/[a-z0-9\-_\/]*$/, 'Path must start with / and contain only safe characters')
-  .refine(path => !path.includes('..'), 'Path traversal not allowed')
-  .refine(path => !path.includes('//'), 'Double slashes not allowed');
-
-// Safe string - no control characters or dangerous patterns
-const SafeStringSchema = z.string()
-  .max(256)
-  .refine(s => !/[\x00-\x1f\x7f]/.test(s), 'Control characters not allowed')
-  .refine(s => !/<script|javascript:|data:/i.test(s), 'Potentially dangerous content');
-
-// Icon - only emoji or safe SVG path
-const IconSchema = z.string()
-  .max(64)
-  .refine(s => {
-    // Allow emoji (most are in these ranges)
-    const isEmoji = /^[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]+$/u.test(s);
-    // Or safe relative path to SVG
-    const isSafePath = /^[a-z0-9\-_]+\.svg$/.test(s);
-    return isEmoji || isSafePath;
-  }, 'Icon must be emoji or safe SVG filename');
-
-// Schedule expression - only safe EventBridge patterns
-const ScheduleSchema = z.string()
-  .regex(/^rate\(\d+\s+(minute|minutes|hour|hours|day|days)\)$|^cron\([0-9,\-\*\/\s]+\)$/, 
-    'Invalid schedule expression');
-
-// Config key - safe identifier
-const ConfigKeySchema = z.string()
-  .min(1)
-  .max(64)
-  .regex(/^[a-z][a-z0-9_]*$/, 'Config key must be safe identifier');
-
-// Full manifest schema with strict validation
-const StrictManifestSchema = z.object({
-  id: PluginIdSchema,
-  name: SafeStringSchema,
-  icon: IconSchema,
-  description: SafeStringSchema.optional(),
-  category: z.enum(['reviews', 'social', 'import', 'search', 'scraper']).optional(),
-  
-  infrastructure: z.object({
-    ingestor: z.object({
-      enabled: z.boolean(),
-      schedule: ScheduleSchema.optional(),
-      timeout: z.number().int().min(1).max(300),
-      memory: z.number().int().min(128).max(1024),
-    }).optional(),
-    webhook: z.object({
-      enabled: z.boolean(),
-      path: SafePathSchema,
-      methods: z.array(z.enum(['GET', 'POST', 'PUT', 'DELETE'])).max(4),
-      signatureHeader: z.string().max(64).regex(/^[A-Za-z0-9\-]+$/).optional(),
-      signatureMethod: z.string().max(32).regex(/^[a-z_]+$/).optional(),
-    }).optional(),
-    s3Trigger: z.object({
-      enabled: z.boolean(),
-      suffixes: z.array(z.string().regex(/^\.[a-z0-9]+$/).max(10)).max(5),
-    }).optional(),
-  }),
-  
-  config: z.array(z.object({
-    key: ConfigKeySchema,
-    label: SafeStringSchema,
-    type: z.enum(['text', 'password', 'textarea', 'select']),
-    required: z.boolean().optional(),
-    placeholder: SafeStringSchema.optional(),
-    secret: z.boolean().optional(),
-  })).max(20),
-  
-  webhooks: z.array(z.object({
-    name: SafeStringSchema,
-    events: z.array(SafeStringSchema).max(10),
-    docUrl: z.string().url().max(256).optional(),
-  })).max(5).optional(),
-  
-  setup: z.object({
-    title: SafeStringSchema,
-    color: z.enum(['blue', 'orange', 'green', 'gray']).optional(),
-    steps: z.array(SafeStringSchema).max(10),
-  }).optional(),
-  
-  secrets: z.record(ConfigKeySchema, z.string().max(0)).max(10).optional(),  // Values must be empty in manifest
-  
-  version: z.string().regex(/^\d+\.\d+\.\d+$/, 'Version must be semver').optional(),
-});
-
-export function loadAndValidateManifest(manifestPath: string): PluginManifest {
-  const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-  
-  // Strict validation
-  const result = StrictManifestSchema.safeParse(raw);
-  
-  if (!result.success) {
-    const errors = result.error.errors.map(e => `${e.path.join('.')}: ${e.message}`);
-    throw new Error(`Invalid manifest: ${errors.join(', ')}`);
-  }
-  
-  return result.data;
-}
-```
-
----
-
-### 🟠 High: Code Integrity Verification
-
-**Problem**: No way to verify plugin code hasn't been tampered with.
-
-**Solution**: SHA256 hash of plugin code stored in manifest and verified at deploy time.
-
-```json
-// manifest.json with integrity hash
-{
-  "id": "webscraper",
-  "version": "1.2.0",
-  "integrity": {
-    "ingestor": "sha256-a1b2c3d4e5f6...",
-    "webhook": "sha256-f6e5d4c3b2a1..."
-  }
-}
-```
-
-```typescript
-// lib/plugin-loader.ts
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
-
-function computeDirectoryHash(dirPath: string): string {
-  /**
-   * Compute SHA256 hash of all Python files in a directory.
-   * Files are sorted for deterministic hashing.
-   */
-  const files: string[] = [];
-  
-  function collectFiles(dir: string) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory() && !entry.name.startsWith('__')) {
-        collectFiles(fullPath);
-      } else if (entry.isFile() && entry.name.endsWith('.py')) {
-        files.push(fullPath);
-      }
-    }
-  }
-  
-  collectFiles(dirPath);
-  files.sort();
-  
-  const hash = crypto.createHash('sha256');
-  for (const file of files) {
-    const content = fs.readFileSync(file);
-    hash.update(content);
-  }
-  
-  return 'sha256-' + hash.digest('hex');
-}
-
-function verifyPluginIntegrity(plugin: PluginManifest, pluginsDir: string): void {
-  const pluginDir = path.join(pluginsDir, plugin.id);
-  
-  // Verify ingestor code
-  if (plugin.infrastructure.ingestor?.enabled) {
-    const ingestorDir = path.join(pluginDir, 'ingestor');
-    const actualHash = computeDirectoryHash(ingestorDir);
-    const expectedHash = plugin.integrity?.ingestor;
-    
-    if (!expectedHash) {
-      throw new Error(`Plugin ${plugin.id}: missing integrity hash for ingestor`);
-    }
-    
-    if (actualHash !== expectedHash) {
-      throw new Error(
-        `Plugin ${plugin.id}: ingestor code integrity check failed.\n` +
-        `Expected: ${expectedHash}\n` +
-        `Actual: ${actualHash}`
-      );
-    }
-  }
-  
-  // Verify webhook code
-  if (plugin.infrastructure.webhook?.enabled) {
-    const webhookDir = path.join(pluginDir, 'webhook');
-    const actualHash = computeDirectoryHash(webhookDir);
-    const expectedHash = plugin.integrity?.webhook;
-    
-    if (!expectedHash) {
-      throw new Error(`Plugin ${plugin.id}: missing integrity hash for webhook`);
-    }
-    
-    if (actualHash !== expectedHash) {
-      throw new Error(
-        `Plugin ${plugin.id}: webhook code integrity check failed.\n` +
-        `Expected: ${expectedHash}\n` +
-        `Actual: ${actualHash}`
-      );
-    }
-  }
-  
-  console.log(`✓ Plugin ${plugin.id} integrity verified`);
-}
-
-// Script to generate integrity hashes
-// Run: npx ts-node scripts/generate-integrity.ts
-export function generateIntegrityHashes(pluginId: string, pluginsDir: string): void {
-  const pluginDir = path.join(pluginsDir, pluginId);
-  const manifestPath = path.join(pluginDir, 'manifest.json');
-  
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-  
-  manifest.integrity = {};
-  
-  const ingestorDir = path.join(pluginDir, 'ingestor');
-  if (fs.existsSync(ingestorDir)) {
-    manifest.integrity.ingestor = computeDirectoryHash(ingestorDir);
-  }
-  
-  const webhookDir = path.join(pluginDir, 'webhook');
-  if (fs.existsSync(webhookDir)) {
-    manifest.integrity.webhook = computeDirectoryHash(webhookDir);
-  }
-  
-  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-  console.log(`Updated integrity hashes for ${pluginId}`);
-}
-```
-
-**CI/CD integration:**
-
-```yaml
-# .github/workflows/plugin-integrity.yml
-name: Verify Plugin Integrity
-on:
-  pull_request:
-    paths:
-      - 'plugins/**'
-
-jobs:
-  verify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Verify integrity hashes
-        run: |
-          npm run verify:integrity
-          
-      - name: Check for uncommitted hash changes
-        run: |
-          git diff --exit-code plugins/*/manifest.json || \
-            (echo "ERROR: Integrity hashes out of date. Run 'npm run generate:integrity'" && exit 1)
-```
-
----
-
-### 🟠 High: Restrict Metadata to Primitives
-
-**Problem**: `metadata` field allows arbitrary nested objects, potential for abuse.
-
-**Solution**: Restrict to flat object with primitive values only.
-
-```typescript
-// Strict metadata schema - primitives only, no nesting
-const MetadataValueSchema = z.union([
-  z.string().max(1000),
-  z.number(),
-  z.boolean(),
-  z.null(),
-]);
-
-const MetadataSchema = z.record(
-  z.string().max(64).regex(/^[a-z_][a-z0-9_]*$/),  // Safe keys only
-  MetadataValueSchema
-).refine(
-  obj => Object.keys(obj).length <= 20,
-  'Metadata cannot have more than 20 keys'
-);
-
-// In message validation
-const MessageSchema = z.object({
-  // ... other fields
-  metadata: MetadataSchema.optional(),
-});
-```
-
-```python
-# lambda/processor/validator.py
-def validate_metadata(metadata: dict) -> tuple[bool, list[str]]:
-    """Validate metadata is flat with primitive values only."""
-    errors = []
-    
-    if not isinstance(metadata, dict):
-        return False, ['metadata must be an object']
-    
-    if len(metadata) > 20:
-        errors.append('metadata cannot have more than 20 keys')
-    
-    for key, value in metadata.items():
-        # Validate key
-        if not isinstance(key, str):
-            errors.append(f'metadata key must be string, got {type(key)}')
-            continue
-        if len(key) > 64:
-            errors.append(f'metadata key "{key[:20]}..." exceeds max length')
-        if not re.match(r'^[a-z_][a-z0-9_]*$', key):
-            errors.append(f'metadata key "{key}" contains invalid characters')
-        
-        # Validate value - primitives only
-        if value is None:
-            continue
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, (int, float)):
-            continue
-        if isinstance(value, str):
-            if len(value) > 1000:
-                errors.append(f'metadata value for "{key}" exceeds max length')
-            continue
-        
-        # Reject nested objects, arrays, etc.
-        errors.append(f'metadata value for "{key}" must be primitive (string, number, boolean, null)')
-    
-    return len(errors) == 0, errors
-```
-
----
-
-### 🟠 High: Audit Logging
-
-**Problem**: No structured audit trail for plugin operations.
-
-**Solution**: Emit structured audit events to CloudWatch Logs and optionally to S3/EventBridge.
-
-```python
-# plugins/_shared/audit.py
-"""
-Structured audit logging for plugin operations.
-"""
-import json
-import os
-from datetime import datetime, timezone
-from typing import Literal
-from dataclasses import dataclass, asdict
-
-from shared.logging import logger
-from shared.aws import get_eventbridge_client
-
-AUDIT_EVENT_BUS = os.environ.get('AUDIT_EVENT_BUS', '')
-
-AuditAction = Literal[
-    'plugin.invoked',
-    'plugin.completed',
-    'plugin.failed',
-    'plugin.enabled',
-    'plugin.disabled',
-    'webhook.received',
-    'webhook.verified',
-    'webhook.rejected',
-    'message.ingested',
-    'message.validated',
-    'message.rejected',
-    'secret.accessed',
-    'config.updated',
-]
-
-@dataclass
-class AuditEvent:
-    """Structured audit event."""
-    timestamp: str
-    action: AuditAction
-    plugin_id: str
-    success: bool
-    details: dict
-    request_id: str = ''
-    user_id: str = ''
-    ip_address: str = ''
-    
-    def to_dict(self) -> dict:
-        return asdict(self)
-
-
-def emit_audit_event(
-    action: AuditAction,
-    plugin_id: str,
-    success: bool,
-    details: dict = None,
-    request_id: str = '',
-    user_id: str = '',
-    ip_address: str = '',
-) -> None:
-    """
-    Emit a structured audit event.
-    
-    Events are:
-    1. Logged to CloudWatch (always)
-    2. Sent to EventBridge (if configured)
-    """
-    event = AuditEvent(
-        timestamp=datetime.now(timezone.utc).isoformat(),
-        action=action,
-        plugin_id=plugin_id,
-        success=success,
-        details=details or {},
-        request_id=request_id,
-        user_id=user_id,
-        ip_address=ip_address,
-    )
-    
-    # Always log to CloudWatch
-    logger.info('AUDIT', extra={'audit_event': event.to_dict()})
-    
-    # Optionally send to EventBridge for downstream processing
-    if AUDIT_EVENT_BUS:
-        try:
-            events = get_eventbridge_client()
-            events.put_events(Entries=[{
-                'Source': 'voc.plugins',
-                'DetailType': f'Plugin Audit: {action}',
-                'Detail': json.dumps(event.to_dict()),
-                'EventBusName': AUDIT_EVENT_BUS,
-            }])
-        except Exception as e:
-            logger.warning(f'Failed to send audit event to EventBridge: {e}')
-
-
-# Usage in base_ingestor.py
-class BaseIngestor:
-    def run(self) -> dict:
-        emit_audit_event('plugin.invoked', self.source_platform, True)
-        
-        try:
-            items = list(self.fetch_new_items())
-            
-            for item in items:
-                emit_audit_event('message.ingested', self.source_platform, True, {
-                    'message_id': item.get('id'),
-                })
-            
-            self.send_to_queue(items)
-            
-            emit_audit_event('plugin.completed', self.source_platform, True, {
-                'items_processed': len(items),
-            })
-            
-            return {"status": "success", "items_processed": len(items)}
-            
-        except Exception as e:
-            emit_audit_event('plugin.failed', self.source_platform, False, {
-                'error': str(e),
-                'error_type': type(e).__name__,
-            })
-            raise
-```
-
-**Log Insights query for audit events:**
-
-```
-# All audit events for a plugin
-fields @timestamp, audit_event.action, audit_event.success, audit_event.details
-| filter audit_event.plugin_id = 'webscraper'
-| sort @timestamp desc
-| limit 100
-
-# Failed operations across all plugins
-fields @timestamp, audit_event.plugin_id, audit_event.action, audit_event.details.error
-| filter audit_event.success = false
-| sort @timestamp desc
-
-# Webhook rejections (potential attacks)
-fields @timestamp, audit_event.plugin_id, audit_event.details.ip_address, audit_event.details.reason
-| filter audit_event.action = 'webhook.rejected'
-| stats count() by audit_event.details.ip_address
-| sort count desc
-```
-
----
-
-### 🟡 Medium: Plugin Versioning
-
-**Problem**: No way to track plugin versions or manage upgrades.
-
-**Solution**: Require semver in manifest, track in DynamoDB.
-
-```json
-// manifest.json
-{
-  "id": "webscraper",
-  "version": "1.2.0",
-  "minPlatformVersion": "2.0.0",
-  // ...
-}
-```
-
-```typescript
-// lib/plugin-loader.ts
-import * as semver from 'semver';
-
-const PLATFORM_VERSION = '2.1.0';  // Current platform version
-
-function validatePluginVersion(plugin: PluginManifest): void {
-  // Version is required
-  if (!plugin.version) {
-    throw new Error(`Plugin ${plugin.id}: version is required`);
-  }
-  
-  // Must be valid semver
-  if (!semver.valid(plugin.version)) {
-    throw new Error(`Plugin ${plugin.id}: invalid version "${plugin.version}"`);
-  }
-  
-  // Check platform compatibility
-  if (plugin.minPlatformVersion) {
-    if (!semver.gte(PLATFORM_VERSION, plugin.minPlatformVersion)) {
-      throw new Error(
-        `Plugin ${plugin.id} requires platform version ${plugin.minPlatformVersion}, ` +
-        `but current version is ${PLATFORM_VERSION}`
-      );
-    }
-  }
-}
-```
-
-**Version tracking in DynamoDB:**
-
-```python
-# Track deployed plugin versions
-def record_plugin_deployment(plugin_id: str, version: str) -> None:
-    """Record plugin deployment for version tracking."""
-    table = dynamodb.Table(os.environ['PLUGINS_TABLE'])
-    
-    table.put_item(Item={
-        'pk': f'PLUGIN#{plugin_id}',
-        'sk': f'VERSION#{version}',
-        'deployed_at': datetime.now(timezone.utc).isoformat(),
-        'deployed_by': os.environ.get('DEPLOYED_BY', 'cdk'),
-    })
-    
-    # Update current version pointer
-    table.update_item(
-        Key={'pk': f'PLUGIN#{plugin_id}', 'sk': 'CURRENT'},
-        UpdateExpression='SET version = :v, updated_at = :t',
-        ExpressionAttributeValues={
-            ':v': version,
-            ':t': datetime.now(timezone.utc).isoformat(),
-        }
-    )
-```
-
----
-
-### 🟡 Medium: Circuit Breaker
-
-**Problem**: A failing plugin keeps running and wasting resources.
-
-**Solution**: Auto-disable plugins after repeated failures.
-
-```python
-# plugins/_shared/circuit_breaker.py
-"""
-Circuit breaker pattern for plugins.
-Auto-disables plugins after repeated failures.
-"""
-import os
-from datetime import datetime, timezone, timedelta
-from shared.aws import get_dynamodb_resource, get_eventbridge_client
-
-FAILURE_THRESHOLD = int(os.environ.get('CIRCUIT_BREAKER_THRESHOLD', '5'))
-WINDOW_MINUTES = int(os.environ.get('CIRCUIT_BREAKER_WINDOW', '15'))
-
-dynamodb = get_dynamodb_resource()
-events = get_eventbridge_client()
-
-
-class CircuitBreaker:
-    def __init__(self, plugin_id: str):
-        self.plugin_id = plugin_id
-        self.table = dynamodb.Table(os.environ['WATERMARKS_TABLE'])
-    
-    def record_failure(self, error: str) -> None:
-        """Record a failure. May trigger circuit breaker."""
-        now = datetime.now(timezone.utc)
-        window_start = now - timedelta(minutes=WINDOW_MINUTES)
-        
-        # Get recent failures
-        response = self.table.query(
-            KeyConditionExpression='pk = :pk AND sk BETWEEN :start AND :end',
-            ExpressionAttributeValues={
-                ':pk': f'FAILURES#{self.plugin_id}',
-                ':start': window_start.isoformat(),
-                ':end': now.isoformat(),
-            }
-        )
-        
-        recent_failures = len(response.get('Items', []))
-        
-        # Record this failure
-        self.table.put_item(Item={
-            'pk': f'FAILURES#{self.plugin_id}',
-            'sk': now.isoformat(),
-            'error': error[:500],  # Truncate
-            'ttl': int((now + timedelta(hours=24)).timestamp()),  # Auto-cleanup
-        })
-        
-        # Check if threshold exceeded
-        if recent_failures + 1 >= FAILURE_THRESHOLD:
-            self._trip_breaker(recent_failures + 1, error)
-    
-    def _trip_breaker(self, failure_count: int, last_error: str) -> None:
-        """Disable the plugin schedule."""
-        rule_name = f'voc-ingest-{self.plugin_id}-schedule'
-        
-        try:
-            events.disable_rule(Name=rule_name)
-            
-            # Record the trip
-            self.table.put_item(Item={
-                'pk': f'CIRCUIT#{self.plugin_id}',
-                'sk': 'TRIPPED',
-                'tripped_at': datetime.now(timezone.utc).isoformat(),
-                'failure_count': failure_count,
-                'last_error': last_error[:500],
-            })
-            
-            # Emit audit event
-            from audit import emit_audit_event
-            emit_audit_event('plugin.disabled', self.plugin_id, True, {
-                'reason': 'circuit_breaker',
-                'failure_count': failure_count,
-                'last_error': last_error,
-            })
-            
-            print(f"CIRCUIT BREAKER: Disabled {self.plugin_id} after {failure_count} failures")
-            
-        except Exception as e:
-            print(f"Failed to trip circuit breaker: {e}")
-    
-    def record_success(self) -> None:
-        """Record a success. Resets failure count."""
-        # Clear the circuit breaker state on success
-        self.table.delete_item(
-            Key={'pk': f'CIRCUIT#{self.plugin_id}', 'sk': 'TRIPPED'}
-        )
-    
-    def is_open(self) -> bool:
-        """Check if circuit breaker is open (plugin disabled)."""
-        response = self.table.get_item(
-            Key={'pk': f'CIRCUIT#{self.plugin_id}', 'sk': 'TRIPPED'}
-        )
-        return 'Item' in response
-
-
-# Integration with base_ingestor.py
-class BaseIngestor:
-    def __init__(self):
-        # ...
-        self.circuit_breaker = CircuitBreaker(self.source_platform)
-    
-    def run(self) -> dict:
-        # Check circuit breaker before running
-        if self.circuit_breaker.is_open():
-            logger.warning(f"Circuit breaker open for {self.source_platform}, skipping")
-            return {"status": "skipped", "reason": "circuit_breaker_open"}
-        
-        try:
-            items = list(self.fetch_new_items())
-            self.send_to_queue(items)
-            
-            # Record success
-            self.circuit_breaker.record_success()
-            
-            return {"status": "success", "items_processed": len(items)}
-            
-        except Exception as e:
-            # Record failure
-            self.circuit_breaker.record_failure(str(e))
-            raise
-```
-
-**Manual reset via API:**
-
-```python
-# lambda/api/plugin_handler.py
-def reset_circuit_breaker(plugin_id: str) -> dict:
-    """Manually reset circuit breaker and re-enable plugin."""
-    # Clear circuit breaker state
-    table = dynamodb.Table(os.environ['WATERMARKS_TABLE'])
-    table.delete_item(
-        Key={'pk': f'CIRCUIT#{plugin_id}', 'sk': 'TRIPPED'}
-    )
-    
-    # Re-enable the schedule
-    events.enable_rule(Name=f'voc-ingest-{plugin_id}-schedule')
-    
-    emit_audit_event('plugin.enabled', plugin_id, True, {
-        'reason': 'manual_reset',
-    })
-    
-    return {'status': 'reset', 'plugin': plugin_id}
-```
-
----
-
-### 🟢 Low: Pydantic Validation
-
-**Problem**: Manual Python validation is error-prone.
-
-**Solution**: Use Pydantic for runtime validation with automatic error messages.
-
-```python
-# plugins/_shared/schemas.py
-"""
-Pydantic schemas for message validation.
-"""
-from datetime import datetime
-from typing import Optional
-from pydantic import BaseModel, Field, field_validator, model_validator
-import re
-
-
-class MessageMetadata(BaseModel):
-    """Flat metadata with primitive values only."""
-    model_config = {'extra': 'forbid'}  # No extra fields allowed
-    
-    # Define known metadata fields explicitly
-    is_verified: Optional[bool] = None
-    location_id: Optional[str] = Field(None, max_length=64)
-    reference_id: Optional[str] = Field(None, max_length=64)
-    reply_count: Optional[int] = Field(None, ge=0)
-    like_count: Optional[int] = Field(None, ge=0)
-    
-    @field_validator('location_id', 'reference_id')
-    @classmethod
-    def validate_safe_string(cls, v: Optional[str]) -> Optional[str]:
-        if v is None:
-            return v
-        if re.search(r'[\x00-\x1f\x7f]', v):
-            raise ValueError('Control characters not allowed')
-        return v
-
-
-class IngestMessage(BaseModel):
-    """Schema for messages sent to processing queue."""
-    model_config = {'extra': 'forbid'}
-    
-    # Required fields
-    id: str = Field(..., min_length=1, max_length=256)
-    source_platform: str = Field(..., pattern=r'^[a-z][a-z0-9_]*$')
-    text: str = Field(..., min_length=1, max_length=50_000)
-    created_at: datetime
-    
-    # Optional fields
-    rating: Optional[float] = Field(None, ge=1, le=5)
-    url: Optional[str] = Field(None, max_length=2048)
-    channel: Optional[str] = Field(None, max_length=64)
-    author: Optional[str] = Field(None, max_length=256)
-    title: Optional[str] = Field(None, max_length=500)
-    language: Optional[str] = Field(None, pattern=r'^[a-z]{2}(-[A-Z]{2})?$')
-    brand_handles_matched: Optional[list[str]] = Field(None, max_length=10)
-    metadata: Optional[MessageMetadata] = None
-    
-    # Internal fields (set by platform)
-    ingested_at: Optional[datetime] = None
-    s3_raw_uri: Optional[str] = None
-    
-    @field_validator('id', 'source_platform', 'channel', 'author', 'title')
-    @classmethod
-    def sanitize_string(cls, v: Optional[str]) -> Optional[str]:
-        if v is None:
-            return v
-        # Remove control characters
-        v = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', v)
-        return v.strip()
-    
-    @field_validator('text')
-    @classmethod
-    def sanitize_text(cls, v: str) -> str:
-        # Remove control characters except newlines/tabs
-        v = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', v)
-        # Normalize excessive newlines
-        v = re.sub(r'\n{3,}', '\n\n', v)
-        return v.strip()
-    
-    @field_validator('url')
-    @classmethod
-    def validate_url(cls, v: Optional[str]) -> Optional[str]:
-        if v is None:
-            return v
-        if not v.startswith(('http://', 'https://')):
-            raise ValueError('URL must start with http:// or https://')
-        return v
-    
-    @model_validator(mode='after')
-    def validate_created_at_not_future(self) -> 'IngestMessage':
-        if self.created_at > datetime.now(self.created_at.tzinfo) + timedelta(days=1):
-            raise ValueError('created_at cannot be more than 1 day in the future')
-        return self
-
-
-# Usage in processor
-from pydantic import ValidationError
-
-def validate_message(raw: dict) -> IngestMessage:
-    """Validate and parse a raw message."""
-    try:
-        return IngestMessage.model_validate(raw)
-    except ValidationError as e:
-        # Convert to our error format
-        errors = [f"{err['loc']}: {err['msg']}" for err in e.errors()]
-        raise MessageValidationError(errors)
-```
-
-**Benefits of Pydantic:**
-- Automatic type coercion (string dates → datetime)
-- Clear error messages with field paths
-- JSON Schema generation for documentation
-- Serialization/deserialization built-in
-- IDE autocomplete support
-
----
-
-## Security Checklist
-
-Before deploying a plugin, verify:
-
-- [ ] Manifest passes strict schema validation
-- [ ] Code integrity hash matches
-- [ ] No hardcoded secrets in code
-- [ ] Webhook signature verification implemented (if webhook)
-- [ ] All config keys use safe identifiers
-- [ ] Version follows semver
-- [ ] Tests pass
-- [ ] Code review completed (for community plugins)
+### Manifest Validation
 
 ```bash
-# Run all security checks
-npm run security:check -- --plugin=webscraper
+# Validate all manifests at build time
+npm run validate:plugins
 
-# Output:
-# ✓ Manifest schema valid
-# ✓ Code integrity verified
-# ✓ No hardcoded secrets found
-# ✓ Webhook signature verification present
-# ✓ Config keys valid
-# ✓ Version valid (1.2.0)
-# ✓ Tests pass (12/12)
-# 
-# Plugin webscraper passed all security checks
+# Generate frontend manifests (also validates)
+npm run generate:manifests
 ```
+
+### Plugin Handler Testing
+
+Tests for shared modules live in `plugins/_shared/test/`:
+
+```bash
+cd voc-datalake
+python -m pytest plugins/_shared/test/ -v
+```
+
+### Plugin Loader Tests
+
+```bash
+npx ts-node scripts/test-plugin-loader.ts
+```
+
+### Integration Testing
+
+```bash
+# Deploy to dev environment
+cdk deploy --all
+
+# Test via Settings UI:
+# 1. Enable the source
+# 2. Check CloudWatch logs for Lambda execution
+# 3. Verify data appears in feedback table
+```
+
+---
+
+## FAQ
+
+### Q: Do I need to redeploy to add a new plugin?
+
+**A:** Yes, adding a new plugin requires `cdk deploy` to create the Lambda and EventBridge resources. However, enabling/disabling an existing deployed plugin does not require redeployment — use the Settings UI toggle.
+
+### Q: Can I have a plugin without a Lambda?
+
+**A:** Not currently. Every plugin needs at least an ingestor or webhook Lambda.
+
+### Q: How do I test a plugin locally?
+
+**A:** You can run the handler directly (requires environment variables to be set):
+
+```python
+cd plugins/my_source/ingestor
+python -c "from handler import MySourceIngestor; i = MySourceIngestor(); print(list(i.fetch_new_items()))"
+```
+
+### Q: Where are credentials stored?
+
+**A:** All credentials are stored in AWS Secrets Manager under `voc-datalake/api-credentials-{hash}`. The secrets template is aggregated from all plugin manifests at deploy time, with each key prefixed by the plugin ID. You can find the exact secret name in the CloudFormation outputs of the VocIngestionStack.
+
+### Q: Can plugins have custom UI components?
+
+**A:** No, the UI is data-driven from the manifest. All plugins use the same SourceCard component with dynamic field rendering. This keeps the architecture simple and consistent.
+
+### Q: What Python runtime do plugins use?
+
+**A:** Python 3.14 on ARM64 (Graviton). All plugins share the same `ingestion-deps` Lambda layer which includes `requests`, `aws-lambda-powertools`, `beautifulsoup4`, `lxml`, and `tenacity`.
+
+### Q: What happens when a plugin fails repeatedly?
+
+**A:** The circuit breaker in `_shared/circuit_breaker.py` tracks failures in DynamoDB. After 5 failures within 15 minutes (configurable), it automatically disables the plugin's EventBridge schedule and emits an audit event. The plugin must be manually re-enabled via the Settings UI.

--- a/voc-datalake/cdk.context.json
+++ b/voc-datalake/cdk.context.json
@@ -5,7 +5,9 @@
   "environment": "production",
   "brandName": "VoC Analytics",
   "pluginStatus": {
-    "webscraper": true
+    "webscraper": true,
+    "app_reviews_ios": true,
+    "app_reviews_android": true
   },
   "menuStatus": {
     "dashboard": true,

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -592,6 +592,44 @@ describe('API Client', () => {
     })
   })
 
+  describe('getIntegrationCredentials', () => {
+    it('fetches credentials with keys as comma-separated query param', async () => {
+      const mockCredentials = { app_name: 'my-app', package_name: 'com.example.app' }
+      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockCredentials),
+      })
+
+      const result = await api.getIntegrationCredentials('app_reviews_android', ['app_name', 'package_name'])
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.example.com/integrations/app_reviews_android/credentials?keys=app_name,package_name',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'Authorization': 'mock-id-token',
+          }),
+        })
+      )
+      expect(result).toEqual(mockCredentials)
+    })
+
+    it('handles single key', async () => {
+      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ app_id: '585629514' }),
+      })
+
+      const result = await api.getIntegrationCredentials('app_reviews_ios', ['app_id'])
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.example.com/integrations/app_reviews_ios/credentials?keys=app_id',
+        expect.any(Object)
+      )
+      expect(result).toEqual({ app_id: '585629514' })
+    })
+  })
+
   describe('testIntegration', () => {
     it('sends POST request to test integration', async () => {
       ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -228,11 +228,16 @@ export const api = {
   },
 
   // Data Source Schedules
-  getSourcesStatus: () => fetchApi<{ sources: Record<string, { enabled: boolean; schedule?: string; rule_name?: string; exists?: boolean; error?: string }> }>('/sources/status'),
+  getSourcesStatus: (sources?: string[]) => {
+    const params = sources?.length ? `?sources=${sources.join(',')}` : ''
+    return fetchApi<{ sources: Record<string, { enabled: boolean; schedule?: string; rule_name?: string; exists?: boolean; error?: string }> }>(`/sources/status${params}`)
+  },
   
   enableSource: (source: string) => fetchApi<{ success: boolean; source: string; enabled: boolean; message?: string }>(`/sources/${source}/enable`, { method: 'PUT' }),
   
   disableSource: (source: string) => fetchApi<{ success: boolean; source: string; enabled: boolean; message?: string }>(`/sources/${source}/disable`, { method: 'PUT' }),
+
+  runSource: (source: string) => fetchApi<{ success: boolean; message: string; source: string }>(`/sources/${source}/run`, { method: 'POST' }),
 
   // Brand Settings (persisted to DynamoDB)
   getBrandSettings: () => fetchApi<{
@@ -298,6 +303,9 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify(credentials)
     }),
+
+  getIntegrationCredentials: (source: string, keys: string[]) =>
+    fetchApi<Record<string, string>>(`/integrations/${source}/credentials?keys=${keys.join(',')}`),
   
   testIntegration: (source: string) => 
     fetchApi<{ success: boolean; message?: string; error?: string; details?: Record<string, unknown> }>(`/integrations/${source}/test`, {

--- a/voc-datalake/frontend/src/components/Layout/Layout.tsx
+++ b/voc-datalake/frontend/src/components/Layout/Layout.tsx
@@ -300,12 +300,11 @@ export default function Layout() {
   const { mobileMenuOpen, openMenu, closeMenu } = useMobileMenu(location.pathname)
 
   // Filter nav items based on user role and menu config
-  const devBypassAdmin = import.meta.env.DEV && !authService.isConfigured()
   const visibleNavItems = NAV_ITEMS.filter(item => {
     // Check if menu item is enabled in config
     if (!isMenuItemEnabled(item.menuKey)) return false
-    // Check admin-only restriction (bypass in dev when Cognito is not configured)
-    if (item.adminOnly && !isAdmin && !devBypassAdmin) return false
+    // Check admin-only restriction
+    if (item.adminOnly && !isAdmin) return false
     return true
   })
 

--- a/voc-datalake/frontend/src/components/Layout/Layout.tsx
+++ b/voc-datalake/frontend/src/components/Layout/Layout.tsx
@@ -300,11 +300,12 @@ export default function Layout() {
   const { mobileMenuOpen, openMenu, closeMenu } = useMobileMenu(location.pathname)
 
   // Filter nav items based on user role and menu config
+  const devBypassAdmin = import.meta.env.DEV && !authService.isConfigured()
   const visibleNavItems = NAV_ITEMS.filter(item => {
     // Check if menu item is enabled in config
     if (!isMenuItemEnabled(item.menuKey)) return false
-    // Check admin-only restriction
-    if (item.adminOnly && !isAdmin) return false
+    // Check admin-only restriction (bypass in dev when Cognito is not configured)
+    if (item.adminOnly && !isAdmin && !devBypassAdmin) return false
     return true
   })
 

--- a/voc-datalake/frontend/src/pages/Scrapers/constants.ts
+++ b/voc-datalake/frontend/src/pages/Scrapers/constants.ts
@@ -21,7 +21,7 @@ export const DEFAULT_SCRAPER: Omit<ScraperConfig, 'id'> = {
   enabled: true,
   base_url: '',
   urls: [],
-  frequency_minutes: 60,
+  frequency_minutes: 1440,
   extraction_method: 'css',
   container_selector: '.review',
   text_selector: '.review-text',

--- a/voc-datalake/frontend/src/pages/Settings/SourceCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/SourceCard.test.tsx
@@ -16,6 +16,7 @@ const mockUpdateIntegrationCredentials = vi.fn()
 const mockTestIntegration = vi.fn()
 const mockEnableSource = vi.fn()
 const mockDisableSource = vi.fn()
+const mockGetIntegrationCredentials = vi.fn()
 
 vi.mock('../../api/client', () => ({
   api: {
@@ -26,6 +27,8 @@ vi.mock('../../api/client', () => ({
     testIntegration: (source: string) => mockTestIntegration(source),
     enableSource: (source: string) => mockEnableSource(source),
     disableSource: (source: string) => mockDisableSource(source),
+    getIntegrationCredentials: (source: string, keys: string[]) =>
+      mockGetIntegrationCredentials(source, keys),
   },
 }))
 
@@ -70,6 +73,7 @@ describe('SourceCard', () => {
     vi.clearAllMocks()
     mockGetIntegrationStatus.mockResolvedValue({ test_source: { configured: false } })
     mockGetSourcesStatus.mockResolvedValue({ sources: { test_source: { enabled: false } } })
+    mockGetIntegrationCredentials.mockResolvedValue({})
   })
 
   describe('Header', () => {
@@ -251,7 +255,7 @@ describe('SourceCard', () => {
       await user.click(screen.getByRole('button', { name: /save/i }))
 
       await waitFor(() => {
-        expect(mockUpdateIntegrationCredentials).toHaveBeenCalledWith('test_source', { api_key: 'secret-key' })
+        expect(mockUpdateIntegrationCredentials).toHaveBeenCalledWith('test_source', { api_key: 'secret-key', business_id: 'Enter ID' })
       })
     })
 
@@ -270,7 +274,7 @@ describe('SourceCard', () => {
 
       // Verify mutation was called - the success message is shown via internal state
       await waitFor(() => {
-        expect(mockUpdateIntegrationCredentials).toHaveBeenCalledWith('test_source', { api_key: 'secret-key' })
+        expect(mockUpdateIntegrationCredentials).toHaveBeenCalledWith('test_source', { api_key: 'secret-key', business_id: 'Enter ID' })
       })
     })
   })
@@ -459,6 +463,68 @@ describe('SourceCard', () => {
 
       const instructionsSection = screen.getByText('Setup Instructions').closest('div')
       expect(instructionsSection).toHaveClass('bg-orange-50')
+    })
+  })
+
+  describe('Credential Fetching', () => {
+    it('fetches saved credentials when card is expanded', async () => {
+      const user = userEvent.setup()
+      mockGetIntegrationCredentials.mockResolvedValue({ api_key: 'saved-key', business_id: 'saved-id' })
+
+      render(
+        <SourceCard manifest={mockManifest} apiEndpoint="https://api.example.com" />,
+        { wrapper: createWrapper() }
+      )
+
+      await user.click(screen.getByRole('button', { name: /test source/i }))
+
+      await waitFor(() => {
+        expect(mockGetIntegrationCredentials).toHaveBeenCalledWith('test_source', ['api_key', 'business_id'])
+      })
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter api key')).toHaveValue('saved-key')
+        expect(screen.getByPlaceholderText('Enter ID')).toHaveValue('saved-id')
+      })
+    })
+
+    it('does not overwrite local user edits with fetched credentials', async () => {
+      const user = userEvent.setup()
+      // Delay the credential fetch so user can type first
+      mockGetIntegrationCredentials.mockImplementation(() =>
+        new Promise(resolve => setTimeout(() => resolve({ api_key: 'saved-key', business_id: 'saved-id' }), 100))
+      )
+
+      render(
+        <SourceCard manifest={mockManifest} apiEndpoint="https://api.example.com" />,
+        { wrapper: createWrapper() }
+      )
+
+      await user.click(screen.getByRole('button', { name: /test source/i }))
+      await user.type(screen.getByPlaceholderText('Enter api key'), 'user-typed-key')
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter api key')).toHaveValue('user-typed-key')
+        // business_id was not edited, so it should be populated from fetch
+        expect(screen.getByPlaceholderText('Enter ID')).toHaveValue('saved-id')
+      })
+    })
+
+    it('does not fetch credentials when config is empty', async () => {
+      const user = userEvent.setup()
+      const noConfigManifest: PluginManifest = {
+        ...mockManifest,
+        config: [],
+      }
+
+      render(
+        <SourceCard manifest={noConfigManifest} apiEndpoint="https://api.example.com" />,
+        { wrapper: createWrapper() }
+      )
+
+      await user.click(screen.getByRole('button', { name: /test source/i }))
+
+      expect(mockGetIntegrationCredentials).not.toHaveBeenCalled()
     })
   })
 

--- a/voc-datalake/frontend/src/pages/Settings/SourceCard.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/SourceCard.tsx
@@ -6,9 +6,9 @@
  */
 
 import type React from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Save, Check, AlertCircle, Loader2, Copy, ExternalLink, Eye, EyeOff, CheckCircle2, Webhook, Key, TestTube } from 'lucide-react'
+import { Save, Check, AlertCircle, Loader2, Copy, ExternalLink, Eye, EyeOff, CheckCircle2, Webhook, Key, TestTube, Play } from 'lucide-react'
 import { api } from '../../api/client'
 import S3ImportExplorer from '../../components/S3ImportExplorer'
 import clsx from 'clsx'
@@ -54,6 +54,7 @@ export default function SourceCard({ manifest, apiEndpoint }: SourceCardProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [showSecrets, setShowSecrets] = useState(false)
   const [credentials, setCredentials] = useState<Record<string, string>>({})
+  const hasFetchedCredentials = useRef(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null)
   const [serverStatus, setServerStatus] = useState<{ enabled: boolean; loading?: boolean }>({ enabled: false })
@@ -66,9 +67,31 @@ export default function SourceCard({ manifest, apiEndpoint }: SourceCardProps) {
 
   const sourceStatus = integrationStatus?.[manifest.id]
 
+  // Task 4.1: Fetch saved credentials when the card is expanded
+  const { data: fetchedCredentials } = useQuery({
+    queryKey: ['integration-credentials', manifest.id],
+    queryFn: () => api.getIntegrationCredentials(manifest.id, manifest.config.map(f => f.key)),
+    enabled: isExpanded && manifest.config.length > 0,
+  })
+
+  // Task 4.2: Merge fetched credentials into local state without overwriting user edits
+  useEffect(() => {
+    if (!fetchedCredentials || hasFetchedCredentials.current) return
+    hasFetchedCredentials.current = true
+    setCredentials(prev => {
+      const merged = { ...prev }
+      for (const [key, value] of Object.entries(fetchedCredentials)) {
+        if (!merged[key]) {
+          merged[key] = value
+        }
+      }
+      return merged
+    })
+  }, [fetchedCredentials])
+
   useEffect(() => {
     if (apiEndpoint) {
-      api.getSourcesStatus().then(response => {
+      api.getSourcesStatus([manifest.id]).then(response => {
         const status = response.sources?.[manifest.id]
         if (status) setServerStatus({ enabled: status.enabled })
       }).catch(() => {})
@@ -80,12 +103,18 @@ export default function SourceCard({ manifest, apiEndpoint }: SourceCardProps) {
     onSuccess: () => {
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 3000)
+      hasFetchedCredentials.current = false
       queryClient.invalidateQueries({ queryKey: ['integration-status'] })
+      queryClient.invalidateQueries({ queryKey: ['integration-credentials', manifest.id] })
     },
   })
 
   const testMutation = useMutation({
     mutationFn: () => api.testIntegration(manifest.id),
+  })
+
+  const runMutation = useMutation({
+    mutationFn: () => api.runSource(manifest.id),
   })
 
   const toggleEnabled = async (enabled: boolean) => {
@@ -138,6 +167,8 @@ export default function SourceCard({ manifest, apiEndpoint }: SourceCardProps) {
               sourceStatus={sourceStatus}
               saveSuccess={saveSuccess}
               testMutation={testMutation}
+              runMutation={runMutation}
+              hasIngestor={manifest.hasIngestor}
               updateCredentialsMutation={updateCredentialsMutation}
               onCredentialsChange={setCredentials}
               onToggleSecrets={() => setShowSecrets(!showSecrets)}
@@ -183,7 +214,7 @@ function SourceCardHeader({ manifest, sourceStatus, serverStatus, apiEndpoint, i
       className="w-full flex flex-col sm:flex-row sm:items-center justify-between p-3 sm:p-4 hover:bg-gray-50 gap-2 sm:gap-3"
     >
       <div className="flex items-center gap-2 sm:gap-3">
-        <span className="text-xl sm:text-2xl">{manifest.icon}</span>
+        <span className="w-12 h-12 sm:w-13 sm:h-13 rounded-lg bg-gray-100 text-gray-600 flex items-center justify-center text-[10px] font-semibold flex-shrink-0 overflow-hidden truncate px-1">{manifest.icon.slice(0, 8)}</span>
         <div className="text-left min-w-0">
           <span className="font-medium text-sm sm:text-base">{manifest.name}</span>
           {manifest.description && <p className="text-xs text-gray-500 line-clamp-1">{manifest.description}</p>}
@@ -267,13 +298,15 @@ interface CredentialsSectionProps {
   readonly sourceStatus: { configured?: boolean } | undefined
   readonly saveSuccess: boolean
   readonly testMutation: { isPending: boolean; data?: { success: boolean; message?: string; error?: string }; mutate: () => void }
+  readonly runMutation: { isPending: boolean; data?: { success: boolean; message?: string }; mutate: () => void }
+  readonly hasIngestor: boolean
   readonly updateCredentialsMutation: { isPending: boolean; mutate: (creds: Record<string, string>) => void }
   readonly onCredentialsChange: (creds: Record<string, string>) => void
   readonly onToggleSecrets: () => void
 }
 
 function CredentialsSection({
-  fields, credentials, showSecrets, sourceStatus, saveSuccess, testMutation, updateCredentialsMutation,
+  fields, credentials, showSecrets, sourceStatus, saveSuccess, testMutation, runMutation, hasIngestor, updateCredentialsMutation,
   onCredentialsChange, onToggleSecrets
 }: CredentialsSectionProps) {
   const saveIcon = getSaveButtonIcon(updateCredentialsMutation.isPending, saveSuccess)
@@ -304,7 +337,23 @@ function CredentialsSection({
             {showSecrets ? 'Hide' : 'Show'}
           </button>
           <button
-            onClick={() => updateCredentialsMutation.mutate(credentials)}
+            onClick={() => {
+              // Build complete credentials: include all config fields so untouched fields
+              // with defaults/placeholders don't get lost
+              const completeCreds: Record<string, string> = {}
+              for (const field of fields) {
+                const current = credentials[field.key]
+                if (current !== undefined && current !== '') {
+                  completeCreds[field.key] = current
+                } else if (field.options && field.options.length > 0) {
+                  // Select fields: use first option as default if not set
+                  completeCreds[field.key] = field.options[0].value
+                } else if (field.placeholder) {
+                  completeCreds[field.key] = field.placeholder
+                }
+              }
+              updateCredentialsMutation.mutate(completeCreds)
+            }}
             disabled={updateCredentialsMutation.isPending || Object.keys(credentials).length === 0}
             className={clsx('btn flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2', saveButtonClass)}
           >
@@ -320,10 +369,23 @@ function CredentialsSection({
             {testMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <TestTube size={14} />}
             Test
           </button>
+          {hasIngestor && (
+            <button
+              onClick={() => runMutation.mutate()}
+              disabled={runMutation.isPending}
+              className="btn btn-secondary flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2"
+            >
+              {runMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
+              Run Now
+            </button>
+          )}
         </div>
 
         {testMutation.data && (
           <TestResultMessage success={testMutation.data.success} message={testMutation.data.message || testMutation.data.error || 'Unknown result'} />
+        )}
+        {runMutation.data && (
+          <TestResultMessage success={runMutation.data.success} message={runMutation.data.message || 'Run triggered'} />
         )}
       </div>
     </div>

--- a/voc-datalake/frontend/src/plugins/manifests.json
+++ b/voc-datalake/frontend/src/plugins/manifests.json
@@ -1,8 +1,228 @@
 [
   {
+    "id": "app_reviews_android",
+    "name": "Android App Reviews",
+    "icon": "Android",
+    "description": "Collect customer reviews from the Google Play Store",
+    "category": "reviews",
+    "config": [
+      {
+        "key": "app_name",
+        "label": "App Name",
+        "type": "text",
+        "required": true,
+        "placeholder": "my-app",
+        "secret": false
+      },
+      {
+        "key": "package_name",
+        "label": "Package Name",
+        "type": "text",
+        "required": true,
+        "placeholder": "com.example.app",
+        "secret": false
+      },
+      {
+        "key": "sort_by",
+        "label": "Review Sort Order",
+        "type": "select",
+        "required": false,
+        "secret": false,
+        "options": [
+          {
+            "value": "newest",
+            "label": "Newest (recommended)"
+          },
+          {
+            "value": "rating",
+            "label": "By Rating"
+          }
+        ]
+      },
+      {
+        "key": "max_countries_per_run",
+        "label": "Max Countries Per Run",
+        "type": "text",
+        "required": false,
+        "placeholder": "20",
+        "secret": false
+      },
+      {
+        "key": "max_reviews_per_run",
+        "label": "Max Reviews Per Run",
+        "type": "text",
+        "required": false,
+        "placeholder": "500",
+        "secret": false
+      },
+      {
+        "key": "frequency_minutes",
+        "label": "Run Frequency",
+        "type": "select",
+        "required": false,
+        "secret": false,
+        "options": [
+          {
+            "value": "15",
+            "label": "Every 15 minutes"
+          },
+          {
+            "value": "30",
+            "label": "Every 30 minutes"
+          },
+          {
+            "value": "60",
+            "label": "Every hour"
+          },
+          {
+            "value": "180",
+            "label": "Every 3 hours"
+          },
+          {
+            "value": "360",
+            "label": "Every 6 hours"
+          },
+          {
+            "value": "720",
+            "label": "Every 12 hours"
+          },
+          {
+            "value": "1440",
+            "label": "Daily"
+          }
+        ]
+      }
+    ],
+    "setup": {
+      "title": "Android App Reviews Setup",
+      "color": "green",
+      "steps": [
+        "Find your app's package name from the Play Store URL (e.g. com.example.app)",
+        "Enter the App Name and Package Name above",
+        "Choose a run frequency and optionally adjust country limits",
+        "Enable the schedule to start collecting reviews"
+      ]
+    },
+    "hasIngestor": true,
+    "hasWebhook": false,
+    "hasS3Trigger": false,
+    "version": "1.0.0",
+    "enabled": true
+  },
+  {
+    "id": "app_reviews_ios",
+    "name": "iOS App Reviews",
+    "icon": "iOS",
+    "description": "Collect customer reviews from the Apple App Store",
+    "category": "reviews",
+    "config": [
+      {
+        "key": "app_name",
+        "label": "App Name",
+        "type": "text",
+        "required": true,
+        "placeholder": "my-app",
+        "secret": false
+      },
+      {
+        "key": "app_id",
+        "label": "App Store ID",
+        "type": "text",
+        "required": true,
+        "placeholder": "585629514",
+        "secret": false
+      },
+      {
+        "key": "sort_by",
+        "label": "Review Sort Order",
+        "type": "select",
+        "required": false,
+        "secret": false,
+        "options": [
+          {
+            "value": "most_recent",
+            "label": "Most Recent (recommended)"
+          },
+          {
+            "value": "most_critical",
+            "label": "Most Critical"
+          }
+        ]
+      },
+      {
+        "key": "max_countries_per_run",
+        "label": "Max Countries Per Run",
+        "type": "text",
+        "required": false,
+        "placeholder": "40",
+        "secret": false
+      },
+      {
+        "key": "max_reviews_per_run",
+        "label": "Max Reviews Per Run",
+        "type": "text",
+        "required": false,
+        "placeholder": "500",
+        "secret": false
+      },
+      {
+        "key": "frequency_minutes",
+        "label": "Run Frequency",
+        "type": "select",
+        "required": false,
+        "secret": false,
+        "options": [
+          {
+            "value": "15",
+            "label": "Every 15 minutes"
+          },
+          {
+            "value": "30",
+            "label": "Every 30 minutes"
+          },
+          {
+            "value": "60",
+            "label": "Every hour"
+          },
+          {
+            "value": "180",
+            "label": "Every 3 hours"
+          },
+          {
+            "value": "360",
+            "label": "Every 6 hours"
+          },
+          {
+            "value": "720",
+            "label": "Every 12 hours"
+          },
+          {
+            "value": "1440",
+            "label": "Daily"
+          }
+        ]
+      }
+    ],
+    "setup": {
+      "title": "iOS App Reviews Setup",
+      "color": "blue",
+      "steps": [
+        "Find your app's numeric ID from the App Store URL (e.g. 585629514)",
+        "Enter the App Name and App Store ID above",
+        "Choose a run frequency and optionally adjust country limits",
+        "Enable the schedule to start collecting reviews"
+      ]
+    },
+    "hasIngestor": true,
+    "hasWebhook": false,
+    "hasS3Trigger": false,
+    "version": "1.0.0",
+    "enabled": true
+  },
+  {
     "id": "webscraper",
     "name": "Web Scraper",
-    "icon": "🕷️",
+    "icon": "Web",
     "description": "Configurable scraper for extracting feedback from websites",
     "category": "import",
     "config": [

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -65,7 +65,19 @@ def get_integration_status():
 @app.get("/integrations/<source>/credentials")
 @tracer.capture_method
 def get_credentials(source: str):
-    """Get saved credentials for an integration, filtered by requested keys."""
+    """Get saved configuration values for an integration so the Settings UI
+    can pre-populate form fields (e.g. app_name, sort_by, frequency).
+
+    This is NOT returning sensitive API keys — the app review plugins use
+    public endpoints with no authentication. The values stored in Secrets
+    Manager for these plugins are non-secret configuration like app names,
+    package names, and tuning parameters. Secrets Manager is reused as the
+    storage backend because the existing plugin infrastructure already
+    reads config from there via BaseIngestor._load_secrets().
+
+    The caller must specify which keys to retrieve via the `keys` query
+    parameter (comma-separated). Only matching keys are returned.
+    """
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')
 

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_secrets_client
 from shared.api import create_api_resolver, api_handler
-from shared.exceptions import ConfigurationError, ServiceError
+from shared.exceptions import ConfigurationError, ServiceError, ValidationError
 
 import boto3
 
@@ -22,9 +22,16 @@ secretsmanager = get_secrets_client()
 events_client = boto3.client("events")
 
 SECRETS_ARN = os.environ.get("SECRETS_ARN", "")
-DEPLOYMENT_HASH = os.environ.get("DEPLOYMENT_HASH", "")
+AWS_ACCOUNT_ID = os.environ.get("DEPLOY_ACCOUNT_ID", os.environ.get("AWS_ACCOUNT_ID", ""))
+AWS_REGION = os.environ.get("DEPLOY_REGION", os.environ.get("AWS_REGION", ""))
 
 app = create_api_resolver()
+
+
+def _build_rule_name(source: str) -> str:
+    """Build EventBridge rule name matching CDK's uniqueName() pattern."""
+    suffix = f"-{AWS_ACCOUNT_ID}-{AWS_REGION}" if AWS_ACCOUNT_ID and AWS_REGION else ""
+    return f"voc-ingest-{source}-schedule{suffix}"
 
 
 @app.get("/integrations/status")
@@ -55,6 +62,42 @@ def get_integration_status():
         raise ServiceError('Failed to retrieve integration status')
 
 
+@app.get("/integrations/<source>/credentials")
+@tracer.capture_method
+def get_credentials(source: str):
+    """Get saved credentials for an integration, filtered by requested keys."""
+    if not SECRETS_ARN:
+        raise ConfigurationError('Secrets not configured')
+
+    params = app.current_event.query_string_parameters or {}
+    keys_param = params.get('keys', '')
+    if not keys_param:
+        raise ValidationError('Missing required query parameter: keys')
+
+    requested_keys = [k.strip() for k in keys_param.split(',') if k.strip()]
+
+    try:
+        response = secretsmanager.get_secret_value(SecretId=SECRETS_ARN)
+        secrets = json.loads(response.get('SecretString', '{}'))
+
+        prefix = f"{source}_"
+        result = {}
+        for key in requested_keys:
+            prefixed_key = f"{prefix}{key}"
+            if prefixed_key in secrets and secrets[prefixed_key]:
+                result[key] = secrets[prefixed_key]
+            elif key in secrets and secrets[key]:
+                # Fallback to unprefixed for backward compatibility
+                result[key] = secrets[key]
+
+        return result
+    except ConfigurationError:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to get credentials for {source}: {e}")
+        raise ServiceError('Failed to retrieve credentials')
+
+
 @app.put("/integrations/<source>/credentials")
 @tracer.capture_method
 def update_credentials(source: str):
@@ -68,9 +111,10 @@ def update_credentials(source: str):
         response = secretsmanager.get_secret_value(SecretId=SECRETS_ARN)
         secrets = json.loads(response.get('SecretString', '{}'))
         
+        prefix = f"{source}_"
         for key, value in body.items():
             if value:
-                secrets[key] = value
+                secrets[f"{prefix}{key}"] = value
         
         secretsmanager.put_secret_value(SecretId=SECRETS_ARN, SecretString=json.dumps(secrets))
         return {'success': True, 'message': f'Credentials updated for {source}'}
@@ -88,18 +132,50 @@ def test_integration(source: str):
     return {'success': True, 'message': f'Integration {source} test not implemented'}
 
 
+@app.post("/sources/<source>/run")
+@tracer.capture_method
+def run_source(source: str):
+    """Manually trigger a data source ingestor Lambda."""
+    # Function name follows uniqueName() pattern: voc-ingestor-{id}-{account}-{region}
+    suffix = f"-{AWS_ACCOUNT_ID}-{AWS_REGION}" if AWS_ACCOUNT_ID and AWS_REGION else ""
+    function_name = f"voc-ingestor-{source}{suffix}"
+
+    lambda_client = boto3.client("lambda")
+    try:
+        response = lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType="Event",
+            Payload=json.dumps({"manual_trigger": True}).encode(),
+        )
+        status_code = response.get("StatusCode", 0)
+        if status_code == 202:
+            return {"success": True, "message": f"Triggered {source} ingestor", "source": source}
+        raise ServiceError(f"Lambda invoke returned status {status_code}")
+    except lambda_client.exceptions.ResourceNotFoundException:
+        raise ServiceError(f"Ingestor Lambda not found for source: {source}")
+    except ServiceError:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to trigger source {source}: {e}")
+        raise ServiceError(f"Failed to trigger {source} ingestor")
+
+
 @app.get("/sources/status")
 @tracer.capture_method
 def get_sources_status():
     """Get status of all data source schedules."""
-    sources = ['webscraper', 'manual_import', 's3_import']
+    params = app.current_event.query_string_parameters or {}
+    sources_param = params.get('sources', '')
     
-    # Build rule name suffix based on deployment hash
-    rule_suffix = f"-{DEPLOYMENT_HASH}" if DEPLOYMENT_HASH else ""
+    # Use requested sources or fall back to defaults
+    if sources_param:
+        sources = [s.strip() for s in sources_param.split(',') if s.strip()]
+    else:
+        sources = ['webscraper', 'manual_import', 's3_import']
     
     status = {}
     for source in sources:
-        rule_name = f"voc-ingest-{source}-schedule{rule_suffix}"
+        rule_name = _build_rule_name(source)
         try:
             response = events_client.describe_rule(Name=rule_name)
             status[source] = {
@@ -121,8 +197,7 @@ def get_sources_status():
 @tracer.capture_method
 def enable_source(source: str):
     """Enable a data source schedule."""
-    rule_suffix = f"-{DEPLOYMENT_HASH}" if DEPLOYMENT_HASH else ""
-    rule_name = f"voc-ingest-{source}-schedule{rule_suffix}"
+    rule_name = _build_rule_name(source)
     try:
         events_client.enable_rule(Name=rule_name)
         return {'success': True, 'source': source, 'enabled': True}
@@ -135,8 +210,7 @@ def enable_source(source: str):
 @tracer.capture_method
 def disable_source(source: str):
     """Disable a data source schedule."""
-    rule_suffix = f"-{DEPLOYMENT_HASH}" if DEPLOYMENT_HASH else ""
-    rule_name = f"voc-ingest-{source}-schedule{rule_suffix}"
+    rule_name = _build_rule_name(source)
     try:
         events_client.disable_rule(Name=rule_name)
         return {'success': True, 'source': source, 'enabled': False}

--- a/voc-datalake/lambda/api/test/test_integrations_handler.py
+++ b/voc-datalake/lambda/api/test/test_integrations_handler.py
@@ -79,6 +79,134 @@ class TestGetIntegrationStatus:
         assert 'error' in body
 
 
+class TestGetCredentials:
+    """Tests for GET /integrations/<source>/credentials endpoint."""
+
+    @patch('integrations_handler.secretsmanager')
+    def test_returns_matching_credentials(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        """Returns only key-value pairs matching the requested keys."""
+        # Arrange
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({
+                'app_reviews_android_app_name': 'my-app',
+                'app_reviews_android_package_name': 'com.example.app',
+                'unrelated_key': 'should-not-appear',
+            })
+        }
+
+        from integrations_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/app_reviews_android/credentials',
+            path_params={'source': 'app_reviews_android'},
+            query_params={'keys': 'app_name,package_name'},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 200
+        assert body == {'app_name': 'my-app', 'package_name': 'com.example.app'}
+
+    @patch('integrations_handler.secretsmanager')
+    def test_returns_empty_object_when_no_saved_credentials(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        """Returns empty object when source has no saved credentials."""
+        # Arrange
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({})
+        }
+
+        from integrations_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/app_reviews_ios/credentials',
+            path_params={'source': 'app_reviews_ios'},
+            query_params={'keys': 'app_id,app_name'},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 200
+        assert body == {}
+
+    @patch('integrations_handler.secretsmanager')
+    def test_returns_400_when_keys_param_missing(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        """Returns 400 when keys query parameter is missing."""
+        # Arrange
+        from integrations_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/webscraper/credentials',
+            path_params={'source': 'webscraper'},
+            query_params={},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 400
+        assert 'error' in body
+
+    @patch('integrations_handler.secretsmanager')
+    def test_returns_error_when_secrets_manager_fails(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        """Returns 500 when Secrets Manager call fails."""
+        # Arrange
+        mock_secrets.get_secret_value.side_effect = Exception('Access denied')
+
+        from integrations_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/webscraper/credentials',
+            path_params={'source': 'webscraper'},
+            query_params={'keys': 'webscraper_api_key'},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 500
+        assert 'error' in body
+
+    @patch('integrations_handler.SECRETS_ARN', '')
+    def test_raises_configuration_error_when_secrets_arn_missing(
+        self, api_gateway_event, lambda_context
+    ):
+        """Raises ConfigurationError when SECRETS_ARN is not set."""
+        # Arrange
+        from integrations_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/webscraper/credentials',
+            path_params={'source': 'webscraper'},
+            query_params={'keys': 'webscraper_api_key'},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 500
+        assert 'error' in body
+
+
 class TestUpdateCredentials:
     """Tests for PUT /integrations/<source>/credentials endpoint."""
 
@@ -140,7 +268,7 @@ class TestUpdateCredentials:
         call_args = mock_secrets.put_secret_value.call_args
         saved_secrets = json.loads(call_args[1]['SecretString'])
         assert saved_secrets['webscraper_api_key'] == 'existing_key'
-        assert saved_secrets['webscraper_configs'] == '[]'
+        assert saved_secrets['webscraper_webscraper_configs'] == '[]'
 
     @patch('integrations_handler.secretsmanager')
     def test_returns_error_when_update_fails(

--- a/voc-datalake/lambda/layers/ingestion-deps/requirements.txt
+++ b/voc-datalake/lambda/layers/ingestion-deps/requirements.txt
@@ -1,5 +1,7 @@
-requests>=2.31.0
-aws-lambda-powertools[tracer]>=2.30.0
-beautifulsoup4>=4.12.0
-lxml>=5.0.0
-tenacity>=8.2.0
+requests>=2.32.5
+aws-lambda-powertools[tracer]>=3.25.0
+beautifulsoup4>=4.14.3
+lxml>=6.0.2
+tenacity>=9.1.4
+app-store-web-scraper>=0.2.0
+google-play-scraper>=1.2.7

--- a/voc-datalake/lambda/layers/processing-deps/requirements.txt
+++ b/voc-datalake/lambda/layers/processing-deps/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools[tracer]>=2.30.0
-pydantic>=2.12.0
-requests>=2.31.0
-tenacity>=8.2.0
+aws-lambda-powertools[tracer]>=3.25.0
+pydantic>=2.12.5
+requests>=2.32.5
+tenacity>=9.1.4

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -165,7 +165,11 @@ export class VocApiStack extends cdk.Stack {
     }));
     integrationsRole.addToPolicy(new iam.PolicyStatement({
       actions: ['events:EnableRule', 'events:DisableRule', 'events:DescribeRule'],
-      resources: [`arn:aws:events:${this.region}:${this.account}:rule/voc-ingest-*-schedule`],
+      resources: [`arn:aws:events:${this.region}:${this.account}:rule/voc-ingest-*-schedule*`],
+    }));
+    integrationsRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['lambda:InvokeFunction'],
+      resources: [`arn:aws:lambda:${this.region}:${this.account}:function:voc-ingestor-*`],
     }));
     NagSuppressions.addResourceSuppressions(integrationsRole, pluginSystemSuppressions, true);
 
@@ -178,7 +182,7 @@ export class VocApiStack extends cdk.Stack {
       role: integrationsRole,
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
-      environment: { SECRETS_ARN: secretsArn, ALLOWED_ORIGIN: allowedOrigin, POWERTOOLS_SERVICE_NAME: 'voc-integrations-api', LOG_LEVEL: 'INFO' },
+      environment: { SECRETS_ARN: secretsArn, ALLOWED_ORIGIN: allowedOrigin, POWERTOOLS_SERVICE_NAME: 'voc-integrations-api', LOG_LEVEL: 'INFO', DEPLOY_ACCOUNT_ID: cdk.Aws.ACCOUNT_ID, DEPLOY_REGION: cdk.Aws.REGION },
       layers: [apiLayer],
       logGroup: this.createLogGroup('IntegrationsApiLogs', uniqueName('voc-integrations-api')),
     });
@@ -646,7 +650,9 @@ export class VocApiStack extends cdk.Stack {
     const integrationsResource = this.api.root.addResource('integrations');
     integrationsResource.addResource('status').addMethod('GET', integrationsIntegration, authMethodOptions);
     const intSourceResource = integrationsResource.addResource('{source}');
-    intSourceResource.addResource('credentials').addMethod('PUT', integrationsIntegration, authMethodOptions);
+    const intCredentialsResource = intSourceResource.addResource('credentials');
+    intCredentialsResource.addMethod('PUT', integrationsIntegration, authMethodOptions);
+    intCredentialsResource.addMethod('GET', integrationsIntegration, authMethodOptions);
     intSourceResource.addResource('test').addMethod('POST', integrationsIntegration, authMethodOptions);
 
     // /sources/*
@@ -655,6 +661,7 @@ export class VocApiStack extends cdk.Stack {
     const srcSourceResource = sourcesResource.addResource('{source}');
     srcSourceResource.addResource('enable').addMethod('PUT', integrationsIntegration, authMethodOptions);
     srcSourceResource.addResource('disable').addMethod('PUT', integrationsIntegration, authMethodOptions);
+    srcSourceResource.addResource('run').addMethod('POST', integrationsIntegration, authMethodOptions);
 
     // /scrapers/*
     const scrapersResource = this.api.root.addResource('scrapers');

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -282,6 +282,8 @@ export class VocIngestionStack extends cdk.Stack {
       PRIMARY_LANGUAGE: config.primaryLanguage,
       POWERTOOLS_SERVICE_NAME: 'voc-ingestion',
       LOG_LEVEL: 'INFO',
+      DEPLOY_ACCOUNT_ID: cdk.Aws.ACCOUNT_ID,
+      DEPLOY_REGION: cdk.Aws.REGION,
     };
   }
 

--- a/voc-datalake/lib/utils/nag-suppressions.ts
+++ b/voc-datalake/lib/utils/nag-suppressions.ts
@@ -152,6 +152,7 @@ export const pluginSystemSuppressions: NagPackSuppression[] = [
     reason: 'Plugin system requires wildcards for dynamic Lambda function names and EventBridge rules created at runtime',
     appliesTo: [
       { regex: '/Resource::arn:aws:lambda:.*:.*:function:voc-ingestor-webscraper-\*/' },
+      { regex: '/Resource::arn:aws:lambda:.*:.*:function:voc-ingestor-\*/' },
       { regex: '/Resource::arn:aws:lambda:.*:.*:function:voc-manual-import-processor-\*/' },
       { regex: '/Resource::arn:aws:lambda:.*:.*:function:voc-projects-api-\*/' },
       { regex: '/Resource::arn:aws:events:.*:.*:rule.voc-ingest-.*-schedule/' },

--- a/voc-datalake/plugins/_shared/app_reviews_utils.py
+++ b/voc-datalake/plugins/_shared/app_reviews_utils.py
@@ -1,0 +1,151 @@
+"""
+Shared utilities for app review ingestor plugins (iOS and Android).
+
+Extracts common logic for frequency throttling, watermark management,
+and integer parsing to avoid duplication across platform-specific handlers.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+
+from _shared.base_ingestor import logger, metrics
+
+
+def parse_int(value: str, default: int) -> int:
+    """Safely parse a positive integer from string, returning default on failure."""
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except (ValueError, TypeError):
+        return default
+
+
+def is_due_for_run(
+    get_watermark_fn,
+    app_name: str,
+    frequency_minutes: int,
+) -> bool:
+    """
+    Check if enough time has passed since the last run.
+
+    Returns True if the app is due for a new collection run.
+    """
+    last_run = get_watermark_fn(f"{app_name}_last_run")
+    if not last_run:
+        return True
+
+    try:
+        last_run_dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
+        next_run = last_run_dt + timedelta(minutes=frequency_minutes)
+        return datetime.now(timezone.utc) >= next_run
+    except (ValueError, TypeError):
+        return True
+
+
+def load_watermark_dt(get_watermark_fn, watermark_key: str) -> datetime | None:
+    """Load and parse a watermark timestamp, returning None on failure."""
+    last_published = get_watermark_fn(watermark_key)
+    if not last_published:
+        return None
+    try:
+        return datetime.fromisoformat(last_published.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def yield_new_reviews(
+    reviews: list[dict],
+    watermark_dt: datetime | None,
+    date_field: str,
+    format_fn,
+    app_config,
+) -> Generator[tuple[dict, datetime | None], None, None]:
+    """
+    Yield formatted reviews newer than the watermark.
+
+    Yields (formatted_review, review_datetime) tuples.
+    The caller is responsible for tracking the newest date and updating watermarks.
+    """
+    for review in reviews:
+        review_date = review.get(date_field)
+        if review_date and hasattr(review_date, "isoformat"):
+            review_dt = review_date
+        else:
+            review_dt = None
+
+        # Skip reviews older than watermark
+        if watermark_dt and review_dt and review_dt <= watermark_dt:
+            continue
+
+        formatted = format_fn(review, app_config)
+        yield formatted, review_dt
+
+
+def process_app_reviews(
+    *,
+    app_config,
+    app_name: str,
+    platform_label: str,
+    date_field: str,
+    get_watermark_fn,
+    set_watermark_fn,
+    frequency_minutes: int,
+    collect_fn,
+    format_fn,
+) -> Generator[dict, None, None]:
+    """
+    Shared review processing pipeline for a single app.
+
+    Handles frequency throttling, watermark loading, review collection,
+    filtering, yielding, watermark updates, and metrics emission.
+    """
+    # Check frequency-based throttling
+    if not is_due_for_run(get_watermark_fn, app_name, frequency_minutes):
+        logger.info(
+            f"Skipping {platform_label} {app_name} - not due yet "
+            f"(frequency: {frequency_minutes}m)"
+        )
+        return
+
+    logger.info(f"Collecting {platform_label} reviews for {app_name}")
+
+    # Load watermark
+    watermark_key = f"{app_name}_last_published_at"
+    watermark_dt = load_watermark_dt(get_watermark_fn, watermark_key)
+
+    try:
+        reviews = collect_fn(app_config)
+    except Exception as e:
+        logger.error(f"Failed to collect reviews for {app_name}: {e}")
+        metrics.add_metric(
+            name=f"{platform_label}_{app_name}_Errors", unit="Count", value=1
+        )
+        return
+
+    newest_date = watermark_dt
+    yielded = 0
+
+    for formatted, review_dt in yield_new_reviews(
+        reviews, watermark_dt, date_field, format_fn, app_config
+    ):
+        yield formatted
+        yielded += 1
+
+        if review_dt and (newest_date is None or review_dt > newest_date):
+            newest_date = review_dt
+
+    # Update watermarks
+    if newest_date and newest_date != watermark_dt:
+        set_watermark_fn(watermark_key, newest_date.isoformat())
+
+    set_watermark_fn(
+        f"{app_name}_last_run", datetime.now(timezone.utc).isoformat()
+    )
+
+    metrics.add_metric(
+        name=f"{platform_label}_{app_name}_Reviews", unit="Count", value=yielded
+    )
+    logger.info(
+        f"{platform_label} {app_name}: yielded {yielded} new reviews "
+        f"(from {len(reviews)} candidates)"
+    )

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -84,7 +84,8 @@ class BaseIngestor(ABC):
         """Get list of known plugin prefixes for secret filtering."""
         # This could be loaded from environment or manifest
         return [
-            "webscraper", "s3_import", "manual_import"
+            "webscraper", "s3_import", "manual_import",
+            "app_reviews_ios", "app_reviews_android",
         ]
 
     def get_watermark(self, key: str, default: str = None) -> str:

--- a/voc-datalake/plugins/_shared/circuit_breaker.py
+++ b/voc-datalake/plugins/_shared/circuit_breaker.py
@@ -78,7 +78,11 @@ class CircuitBreaker:
 
     def _trip_breaker(self, failure_count: int, last_error: str) -> None:
         """Disable the plugin schedule."""
-        rule_name = f"voc-ingest-{self.plugin_id}-schedule"
+        # Match CDK's uniqueName() pattern: {base}-{account}-{region}
+        account_id = os.environ.get("DEPLOY_ACCOUNT_ID", os.environ.get("AWS_ACCOUNT_ID", ""))
+        region = os.environ.get("DEPLOY_REGION", os.environ.get("AWS_REGION", ""))
+        suffix = f"-{account_id}-{region}" if account_id and region else ""
+        rule_name = f"voc-ingest-{self.plugin_id}-schedule{suffix}"
 
         try:
             if HAS_EVENTBRIDGE:

--- a/voc-datalake/plugins/_shared/schemas.py
+++ b/voc-datalake/plugins/_shared/schemas.py
@@ -23,7 +23,8 @@ MAX_METADATA_VALUE_LENGTH = 1000
 
 # Known plugin IDs (for validation)
 KNOWN_SOURCES = {
-    "webscraper", "s3_import", "manual_import"
+    "webscraper", "s3_import", "manual_import",
+    "app_reviews_ios", "app_reviews_android",
 }
 
 

--- a/voc-datalake/plugins/app_reviews_android/ingestor/countries.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/countries.py
@@ -1,0 +1,11 @@
+"""
+Google Play Store country codes.
+
+Play Store reviews are more globally pooled than iOS, so fewer
+countries are needed for good coverage.
+"""
+
+ANDROID_COUNTRIES = [
+    "us", "gb", "de", "fr", "jp", "au", "ca", "it", "es", "nl",
+    "br", "mx", "in", "kr", "se", "ru", "tr", "sa", "za", "sg",
+]

--- a/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Generator
 
 from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
+from _shared.app_reviews_utils import parse_int, process_app_reviews
 from countries import ANDROID_COUNTRIES
 from play_client import fetch_reviews_for_country
 from models import AndroidAppConfig
@@ -22,26 +23,18 @@ class AndroidAppReviewsIngestor(BaseIngestor):
         super().__init__()
         self.app_configs = self._load_app_configs()
         self.sort_by = self.secrets.get("sort_by", "newest")
-        self.max_countries = self._parse_int(
+        self.max_countries = parse_int(
             self.secrets.get("max_countries_per_run", "20"), 20
         )
-        self.frequency_minutes = self._parse_int(
+        self.frequency_minutes = parse_int(
             self.secrets.get("frequency_minutes", "60"), 60
         )
-
-    def _parse_int(self, value: str, default: int) -> int:
-        """Safely parse an integer from string."""
-        try:
-            parsed = int(value)
-            return parsed if parsed > 0 else default
-        except (ValueError, TypeError):
-            return default
 
     def _load_app_configs(self) -> list[AndroidAppConfig]:
         """Load app configuration from individual secret fields."""
         app_name = self.secrets.get("app_name", "").strip()
         package_name = self.secrets.get("package_name", "").strip()
-        max_reviews = self._parse_int(
+        max_reviews = parse_int(
             self.secrets.get("max_reviews_per_run", "500"), 500
         )
 
@@ -147,81 +140,16 @@ class AndroidAppReviewsIngestor(BaseIngestor):
             return
 
         for app in self.app_configs:
-            # Check frequency-based throttling
-            last_run = self.get_watermark(f"{app.name}_last_run")
-            if last_run:
-                try:
-                    from datetime import timedelta
-                    last_run_dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
-                    next_run = last_run_dt + timedelta(minutes=self.frequency_minutes)
-                    if datetime.now(timezone.utc) < next_run:
-                        logger.info(f"Skipping Android {app.name} - not due yet (frequency: {self.frequency_minutes}m)")
-                        continue
-                except (ValueError, TypeError):
-                    pass
-
-            logger.info(
-                f"Collecting Android reviews for {app.name} "
-                f"(package={app.package_name})"
-            )
-
-            # Load watermark
-            watermark_key = f"{app.name}_last_published_at"
-            last_published = self.get_watermark(watermark_key)
-            watermark_dt = None
-            if last_published:
-                try:
-                    watermark_dt = datetime.fromisoformat(
-                        last_published.replace("Z", "+00:00")
-                    )
-                except (ValueError, TypeError):
-                    watermark_dt = None
-
-            try:
-                reviews = self._collect_reviews_for_app(app)
-            except Exception as e:
-                logger.error(f"Failed to collect reviews for {app.name}: {e}")
-                metrics.add_metric(
-                    name=f"Android_{app.name}_Errors", unit="Count", value=1
-                )
-                continue
-
-            newest_date = watermark_dt
-            yielded = 0
-
-            for review in reviews:
-                review_date = review.get("at")
-                if review_date and hasattr(review_date, "isoformat"):
-                    review_dt = review_date
-                else:
-                    review_dt = None
-
-                # Skip reviews older than watermark
-                if watermark_dt and review_dt and review_dt <= watermark_dt:
-                    continue
-
-                formatted = self._format_review(review, app)
-                yield formatted
-                yielded += 1
-
-                # Track newest date for watermark update
-                if review_dt and (newest_date is None or review_dt > newest_date):
-                    newest_date = review_dt
-
-            # Update watermark
-            if newest_date and newest_date != watermark_dt:
-                self.set_watermark(watermark_key, newest_date.isoformat())
-
-            self.set_watermark(
-                f"{app.name}_last_run", datetime.now(timezone.utc).isoformat()
-            )
-
-            metrics.add_metric(
-                name=f"Android_{app.name}_Reviews", unit="Count", value=yielded
-            )
-            logger.info(
-                f"Android {app.name}: yielded {yielded} new reviews "
-                f"(from {len(reviews)} candidates)"
+            yield from process_app_reviews(
+                app_config=app,
+                app_name=app.name,
+                platform_label="Android",
+                date_field="at",
+                get_watermark_fn=self.get_watermark,
+                set_watermark_fn=self.set_watermark,
+                frequency_minutes=self.frequency_minutes,
+                collect_fn=self._collect_reviews_for_app,
+                format_fn=self._format_review,
             )
 
 

--- a/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
@@ -1,0 +1,234 @@
+"""
+Android App Reviews Ingestor - Collects reviews from the Google Play Store.
+
+Uses google-play-scraper to fetch reviews across multiple countries,
+deduplicates by review ID, and yields to the base ingestor pipeline.
+"""
+
+import random
+from datetime import datetime, timezone
+from typing import Generator
+
+from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
+from countries import ANDROID_COUNTRIES
+from play_client import fetch_reviews_for_country
+from models import AndroidAppConfig
+
+
+class AndroidAppReviewsIngestor(BaseIngestor):
+    """Ingestor for Google Play Store reviews."""
+
+    def __init__(self):
+        super().__init__()
+        self.app_configs = self._load_app_configs()
+        self.sort_by = self.secrets.get("sort_by", "newest")
+        self.max_countries = self._parse_int(
+            self.secrets.get("max_countries_per_run", "20"), 20
+        )
+        self.frequency_minutes = self._parse_int(
+            self.secrets.get("frequency_minutes", "60"), 60
+        )
+
+    def _parse_int(self, value: str, default: int) -> int:
+        """Safely parse an integer from string."""
+        try:
+            parsed = int(value)
+            return parsed if parsed > 0 else default
+        except (ValueError, TypeError):
+            return default
+
+    def _load_app_configs(self) -> list[AndroidAppConfig]:
+        """Load app configuration from individual secret fields."""
+        app_name = self.secrets.get("app_name", "").strip()
+        package_name = self.secrets.get("package_name", "").strip()
+        max_reviews = self._parse_int(
+            self.secrets.get("max_reviews_per_run", "500"), 500
+        )
+
+        if not app_name or not package_name:
+            return []
+
+        try:
+            config = AndroidAppConfig(
+                name=app_name,
+                package_name=package_name,
+                enabled=True,
+                max_reviews_per_run=max_reviews,
+            )
+            return [config]
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Invalid Android app config: {e}")
+            return []
+
+    def _collect_reviews_for_app(self, app: AndroidAppConfig) -> list[dict]:
+        """
+        Collect reviews across countries for a single app.
+
+        Shuffles countries for fair coverage, deduplicates by review ID,
+        and caps at max_reviews_per_run.
+        """
+        countries = list(ANDROID_COUNTRIES)
+        random.shuffle(countries)
+        if self.max_countries and self.max_countries < len(countries):
+            countries = countries[: self.max_countries]
+
+        all_reviews: dict[str, dict] = {}
+
+        for country in countries:
+            reviews = fetch_reviews_for_country(
+                package_name=app.package_name,
+                country=country,
+                count=100,
+                sort_by=self.sort_by,
+            )
+            for review in reviews:
+                review_id = review.get("reviewId", "")
+                if not review_id:
+                    continue
+                composite_id = f"android_{app.package_name}_{review_id}"
+                if composite_id not in all_reviews:
+                    all_reviews[composite_id] = {
+                        **review,
+                        "composite_id": composite_id,
+                        "country": country,
+                    }
+
+        # Sort by date descending and cap
+        sorted_reviews = sorted(
+            all_reviews.values(),
+            key=lambda r: r.get("at") or datetime.min.replace(tzinfo=timezone.utc),
+            reverse=True,
+        )
+        return sorted_reviews[: app.max_reviews_per_run]
+
+    def _format_review(self, review: dict, app: AndroidAppConfig) -> dict:
+        """Format a raw review into the VoC pipeline schema."""
+        date = review.get("at")
+        if date and hasattr(date, "isoformat"):
+            created_at = date.isoformat()
+        elif isinstance(date, str):
+            created_at = date
+        else:
+            created_at = datetime.now(timezone.utc).isoformat()
+
+        text = review.get("content", "")
+        dev_response = review.get("replyContent")
+        dev_response_date = review.get("repliedAt")
+
+        return {
+            "id": review["composite_id"],
+            "channel": "app_review_android",
+            "text": text,
+            "title": "",
+            "rating": review.get("score"),
+            "created_at": created_at,
+            "url": f"https://play.google.com/store/apps/details?id={app.package_name}",
+            "author": review.get("userName", "Anonymous"),
+            "brand_handles_matched": [self.brand_name] if self.brand_name else [],
+            "source_platform_override": f"{app.name}_android",
+            "app_name": app.name,
+            "app_identifier": app.package_name,
+            "country": review.get("country", ""),
+            "app_version": review.get("reviewCreatedVersion"),
+            "developer_response": dev_response if dev_response else None,
+            "developer_response_date": (
+                dev_response_date.isoformat()
+                if dev_response_date and hasattr(dev_response_date, "isoformat")
+                else None
+            ),
+            "thumbs_up_count": review.get("thumbsUpCount", 0),
+        }
+
+    @tracer.capture_method
+    def fetch_new_items(self) -> Generator[dict, None, None]:
+        """Fetch new reviews from all configured Android apps."""
+        if not self.app_configs:
+            logger.warning("No Android app configurations found")
+            return
+
+        for app in self.app_configs:
+            # Check frequency-based throttling
+            last_run = self.get_watermark(f"{app.name}_last_run")
+            if last_run:
+                try:
+                    from datetime import timedelta
+                    last_run_dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
+                    next_run = last_run_dt + timedelta(minutes=self.frequency_minutes)
+                    if datetime.now(timezone.utc) < next_run:
+                        logger.info(f"Skipping Android {app.name} - not due yet (frequency: {self.frequency_minutes}m)")
+                        continue
+                except (ValueError, TypeError):
+                    pass
+
+            logger.info(
+                f"Collecting Android reviews for {app.name} "
+                f"(package={app.package_name})"
+            )
+
+            # Load watermark
+            watermark_key = f"{app.name}_last_published_at"
+            last_published = self.get_watermark(watermark_key)
+            watermark_dt = None
+            if last_published:
+                try:
+                    watermark_dt = datetime.fromisoformat(
+                        last_published.replace("Z", "+00:00")
+                    )
+                except (ValueError, TypeError):
+                    watermark_dt = None
+
+            try:
+                reviews = self._collect_reviews_for_app(app)
+            except Exception as e:
+                logger.error(f"Failed to collect reviews for {app.name}: {e}")
+                metrics.add_metric(
+                    name=f"Android_{app.name}_Errors", unit="Count", value=1
+                )
+                continue
+
+            newest_date = watermark_dt
+            yielded = 0
+
+            for review in reviews:
+                review_date = review.get("at")
+                if review_date and hasattr(review_date, "isoformat"):
+                    review_dt = review_date
+                else:
+                    review_dt = None
+
+                # Skip reviews older than watermark
+                if watermark_dt and review_dt and review_dt <= watermark_dt:
+                    continue
+
+                formatted = self._format_review(review, app)
+                yield formatted
+                yielded += 1
+
+                # Track newest date for watermark update
+                if review_dt and (newest_date is None or review_dt > newest_date):
+                    newest_date = review_dt
+
+            # Update watermark
+            if newest_date and newest_date != watermark_dt:
+                self.set_watermark(watermark_key, newest_date.isoformat())
+
+            self.set_watermark(
+                f"{app.name}_last_run", datetime.now(timezone.utc).isoformat()
+            )
+
+            metrics.add_metric(
+                name=f"Android_{app.name}_Reviews", unit="Count", value=yielded
+            )
+            logger.info(
+                f"Android {app.name}: yielded {yielded} new reviews "
+                f"(from {len(reviews)} candidates)"
+            )
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event, context):
+    """Lambda entry point."""
+    ingestor = AndroidAppReviewsIngestor()
+    return ingestor.run()

--- a/voc-datalake/plugins/app_reviews_android/ingestor/models.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/models.py
@@ -1,0 +1,32 @@
+"""
+App configuration validation for Android App Reviews plugin.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AndroidAppConfig:
+    """Configuration for a single Android app to collect reviews from."""
+    name: str
+    package_name: str
+    enabled: bool = True
+    max_reviews_per_run: int = 500
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AndroidAppConfig":
+        """Create from dictionary, with validation."""
+        name = data.get("name", "").strip()
+        if not name:
+            raise ValueError("App config missing required field: name")
+
+        package_name = data.get("package_name", "").strip()
+        if not package_name:
+            raise ValueError(f"App '{name}' missing required field: package_name")
+
+        return cls(
+            name=name,
+            package_name=package_name,
+            enabled=data.get("enabled", True),
+            max_reviews_per_run=int(data.get("max_reviews_per_run", 500)),
+        )

--- a/voc-datalake/plugins/app_reviews_android/ingestor/play_client.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/play_client.py
@@ -1,0 +1,44 @@
+"""
+Google Play Store review client using google-play-scraper.
+
+Wraps the library with pagination, error handling, and structured output.
+"""
+
+from google_play_scraper import Sort, reviews
+from _shared.base_ingestor import logger
+
+
+SORT_MAP = {
+    "newest": Sort.NEWEST,
+    "rating": Sort.MOST_RELEVANT,
+}
+
+
+def fetch_reviews_for_country(
+    package_name: str,
+    country: str,
+    count: int = 100,
+    sort_by: str = "newest",
+) -> list[dict]:
+    """
+    Fetch reviews for a single app in a single country.
+
+    Returns list of dicts with keys: reviewId, at, userName, score, content,
+    reviewCreatedVersion, replyContent, repliedAt, thumbsUpCount.
+    """
+    sort_order = SORT_MAP.get(sort_by, Sort.NEWEST)
+
+    try:
+        result, _ = reviews(
+            package_name,
+            lang="en",
+            country=country,
+            sort=sort_order,
+            count=count,
+        )
+        return result or []
+    except Exception as e:
+        logger.warning(
+            f"Failed to fetch Android reviews for {package_name} in {country}: {e}"
+        )
+        return []

--- a/voc-datalake/plugins/app_reviews_android/manifest.json
+++ b/voc-datalake/plugins/app_reviews_android/manifest.json
@@ -1,0 +1,99 @@
+{
+  "id": "app_reviews_android",
+  "name": "Android App Reviews",
+  "icon": "Android",
+  "description": "Collect customer reviews from the Google Play Store",
+  "category": "reviews",
+  "version": "1.0.0",
+
+  "infrastructure": {
+    "ingestor": {
+      "enabled": true,
+      "schedule": "rate(30 minutes)",
+      "timeout": 300,
+      "memory": 512
+    }
+  },
+
+  "config": [
+    {
+      "key": "app_name",
+      "label": "App Name",
+      "type": "text",
+      "placeholder": "my-app",
+      "required": true,
+      "secret": false
+    },
+    {
+      "key": "package_name",
+      "label": "Package Name",
+      "type": "text",
+      "placeholder": "com.example.app",
+      "required": true,
+      "secret": false
+    },
+    {
+      "key": "sort_by",
+      "label": "Review Sort Order",
+      "type": "select",
+      "required": false,
+      "secret": false,
+      "options": [
+        { "value": "newest", "label": "Newest (recommended)" },
+        { "value": "rating", "label": "By Rating" }
+      ]
+    },
+    {
+      "key": "max_countries_per_run",
+      "label": "Max Countries Per Run",
+      "type": "text",
+      "placeholder": "20",
+      "required": false,
+      "secret": false
+    },
+    {
+      "key": "max_reviews_per_run",
+      "label": "Max Reviews Per Run",
+      "type": "text",
+      "placeholder": "500",
+      "required": false,
+      "secret": false
+    },
+    {
+      "key": "frequency_minutes",
+      "label": "Run Frequency",
+      "type": "select",
+      "required": false,
+      "secret": false,
+      "options": [
+        { "value": "15", "label": "Every 15 minutes" },
+        { "value": "30", "label": "Every 30 minutes" },
+        { "value": "60", "label": "Every hour" },
+        { "value": "180", "label": "Every 3 hours" },
+        { "value": "360", "label": "Every 6 hours" },
+        { "value": "720", "label": "Every 12 hours" },
+        { "value": "1440", "label": "Daily" }
+      ]
+    }
+  ],
+
+  "setup": {
+    "title": "Android App Reviews Setup",
+    "color": "green",
+    "steps": [
+      "Find your app's package name from the Play Store URL (e.g. com.example.app)",
+      "Enter the App Name and Package Name above",
+      "Choose a run frequency and optionally adjust country limits",
+      "Enable the schedule to start collecting reviews"
+    ]
+  },
+
+  "secrets": {
+    "app_name": "",
+    "package_name": "",
+    "sort_by": "newest",
+    "max_countries_per_run": "20",
+    "max_reviews_per_run": "500",
+    "frequency_minutes": "1440"
+  }
+}

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/countries.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/countries.py
@@ -1,0 +1,13 @@
+"""
+iOS App Store storefront country codes.
+
+Curated list of high-traffic storefronts. Reviews are fetched per-country
+and deduplicated by review ID.
+"""
+
+IOS_COUNTRIES = [
+    "us", "gb", "de", "fr", "jp", "au", "ca", "it", "es", "nl",
+    "br", "mx", "in", "kr", "se", "no", "dk", "fi", "ch", "at",
+    "be", "pt", "pl", "cz", "ru", "tr", "sa", "ae", "za", "sg",
+    "hk", "tw", "th", "my", "ph", "id", "vn", "co", "cl", "ar",
+]

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/handler.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Generator
 
 from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
+from _shared.app_reviews_utils import parse_int, process_app_reviews
 from countries import IOS_COUNTRIES
 from itunes_client import create_session, fetch_reviews_for_country
 from models import IOSAppConfig
@@ -22,27 +23,19 @@ class IOSAppReviewsIngestor(BaseIngestor):
         super().__init__()
         self.app_configs = self._load_app_configs()
         self.sort_by = self.secrets.get("sort_by", "most_recent")
-        self.max_countries = self._parse_int(
+        self.max_countries = parse_int(
             self.secrets.get("max_countries_per_run", "40"), 40
         )
-        self.frequency_minutes = self._parse_int(
+        self.frequency_minutes = parse_int(
             self.secrets.get("frequency_minutes", "60"), 60
         )
         self.session = create_session()
-
-    def _parse_int(self, value: str, default: int) -> int:
-        """Safely parse an integer from string."""
-        try:
-            parsed = int(value)
-            return parsed if parsed > 0 else default
-        except (ValueError, TypeError):
-            return default
 
     def _load_app_configs(self) -> list[IOSAppConfig]:
         """Load app configuration from individual secret fields."""
         app_name = self.secrets.get("app_name", "").strip()
         app_id = self.secrets.get("app_id", "").strip()
-        max_reviews = self._parse_int(
+        max_reviews = parse_int(
             self.secrets.get("max_reviews_per_run", "500"), 500
         )
 
@@ -142,78 +135,16 @@ class IOSAppReviewsIngestor(BaseIngestor):
             return
 
         for app in self.app_configs:
-            # Check frequency-based throttling
-            last_run = self.get_watermark(f"{app.name}_last_run")
-            if last_run:
-                try:
-                    from datetime import timedelta
-                    last_run_dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
-                    next_run = last_run_dt + timedelta(minutes=self.frequency_minutes)
-                    if datetime.now(timezone.utc) < next_run:
-                        logger.info(f"Skipping iOS {app.name} - not due yet (frequency: {self.frequency_minutes}m)")
-                        continue
-                except (ValueError, TypeError):
-                    pass
-
-            logger.info(f"Collecting iOS reviews for {app.name} (app_id={app.app_id})")
-
-            # Load watermark
-            watermark_key = f"{app.name}_last_published_at"
-            last_published = self.get_watermark(watermark_key)
-            watermark_dt = None
-            if last_published:
-                try:
-                    watermark_dt = datetime.fromisoformat(
-                        last_published.replace("Z", "+00:00")
-                    )
-                except (ValueError, TypeError):
-                    watermark_dt = None
-
-            try:
-                reviews = self._collect_reviews_for_app(app)
-            except Exception as e:
-                logger.error(f"Failed to collect reviews for {app.name}: {e}")
-                metrics.add_metric(
-                    name=f"iOS_{app.name}_Errors", unit="Count", value=1
-                )
-                continue
-
-            newest_date = watermark_dt
-            yielded = 0
-
-            for review in reviews:
-                review_date = review.get("date")
-                if review_date and hasattr(review_date, "isoformat"):
-                    review_dt = review_date
-                else:
-                    review_dt = None
-
-                # Skip reviews older than watermark
-                if watermark_dt and review_dt and review_dt <= watermark_dt:
-                    continue
-
-                formatted = self._format_review(review, app)
-                yield formatted
-                yielded += 1
-
-                # Track newest date for watermark update
-                if review_dt and (newest_date is None or review_dt > newest_date):
-                    newest_date = review_dt
-
-            # Update watermark
-            if newest_date and newest_date != watermark_dt:
-                self.set_watermark(watermark_key, newest_date.isoformat())
-
-            self.set_watermark(
-                f"{app.name}_last_run", datetime.now(timezone.utc).isoformat()
-            )
-
-            metrics.add_metric(
-                name=f"iOS_{app.name}_Reviews", unit="Count", value=yielded
-            )
-            logger.info(
-                f"iOS {app.name}: yielded {yielded} new reviews "
-                f"(from {len(reviews)} candidates)"
+            yield from process_app_reviews(
+                app_config=app,
+                app_name=app.name,
+                platform_label="iOS",
+                date_field="date",
+                get_watermark_fn=self.get_watermark,
+                set_watermark_fn=self.set_watermark,
+                frequency_minutes=self.frequency_minutes,
+                collect_fn=self._collect_reviews_for_app,
+                format_fn=self._format_review,
             )
 
 

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/handler.py
@@ -1,0 +1,226 @@
+"""
+iOS App Reviews Ingestor - Collects reviews from the Apple App Store.
+
+Uses app-store-web-scraper to fetch reviews across multiple countries,
+deduplicates by review ID, and yields to the base ingestor pipeline.
+"""
+
+import random
+from datetime import datetime, timezone
+from typing import Generator
+
+from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
+from countries import IOS_COUNTRIES
+from itunes_client import create_session, fetch_reviews_for_country
+from models import IOSAppConfig
+
+
+class IOSAppReviewsIngestor(BaseIngestor):
+    """Ingestor for Apple App Store reviews."""
+
+    def __init__(self):
+        super().__init__()
+        self.app_configs = self._load_app_configs()
+        self.sort_by = self.secrets.get("sort_by", "most_recent")
+        self.max_countries = self._parse_int(
+            self.secrets.get("max_countries_per_run", "40"), 40
+        )
+        self.frequency_minutes = self._parse_int(
+            self.secrets.get("frequency_minutes", "60"), 60
+        )
+        self.session = create_session()
+
+    def _parse_int(self, value: str, default: int) -> int:
+        """Safely parse an integer from string."""
+        try:
+            parsed = int(value)
+            return parsed if parsed > 0 else default
+        except (ValueError, TypeError):
+            return default
+
+    def _load_app_configs(self) -> list[IOSAppConfig]:
+        """Load app configuration from individual secret fields."""
+        app_name = self.secrets.get("app_name", "").strip()
+        app_id = self.secrets.get("app_id", "").strip()
+        max_reviews = self._parse_int(
+            self.secrets.get("max_reviews_per_run", "500"), 500
+        )
+
+        if not app_name or not app_id:
+            return []
+
+        try:
+            config = IOSAppConfig(
+                name=app_name,
+                app_id=app_id,
+                enabled=True,
+                max_reviews_per_run=max_reviews,
+            )
+            return [config]
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Invalid iOS app config: {e}")
+            return []
+
+    def _collect_reviews_for_app(self, app: IOSAppConfig) -> list[dict]:
+        """
+        Collect reviews across countries for a single app.
+
+        Shuffles countries for fair coverage, deduplicates by review ID,
+        and caps at max_reviews_per_run.
+        """
+        countries = list(IOS_COUNTRIES)
+        random.shuffle(countries)
+        if self.max_countries and self.max_countries < len(countries):
+            countries = countries[: self.max_countries]
+
+        all_reviews: dict[str, dict] = {}
+
+        for country in countries:
+            reviews = fetch_reviews_for_country(
+                app_id=app.app_id,
+                country=country,
+                session=self.session,
+                limit=50,
+                sort_by=self.sort_by,
+            )
+            for review in reviews:
+                review_id = review["id"]
+                composite_id = f"ios_{app.app_id}_{review_id}"
+                if composite_id not in all_reviews:
+                    all_reviews[composite_id] = {
+                        **review,
+                        "composite_id": composite_id,
+                        "country": country,
+                    }
+
+        # Sort by date descending and cap
+        sorted_reviews = sorted(
+            all_reviews.values(),
+            key=lambda r: r.get("date") or datetime.min.replace(tzinfo=timezone.utc),
+            reverse=True,
+        )
+        return sorted_reviews[: app.max_reviews_per_run]
+
+    def _format_review(self, review: dict, app: IOSAppConfig) -> dict:
+        """Format a raw review into the VoC pipeline schema."""
+        date = review.get("date")
+        if date and hasattr(date, "isoformat"):
+            created_at = date.isoformat()
+        elif isinstance(date, str):
+            created_at = date
+        else:
+            created_at = datetime.now(timezone.utc).isoformat()
+
+        title = review.get("title", "")
+        body = review.get("review", "")
+        text = f"{title}\n\n{body}" if title else body
+
+        dev_response = review.get("developer_response")
+
+        return {
+            "id": review["composite_id"],
+            "channel": "app_review_ios",
+            "text": text,
+            "title": title,
+            "rating": review.get("rating"),
+            "created_at": created_at,
+            "url": f"https://apps.apple.com/app/id{app.app_id}",
+            "author": review.get("user_name", "Anonymous"),
+            "brand_handles_matched": [self.brand_name] if self.brand_name else [],
+            "source_platform_override": f"{app.name}_ios",
+            "app_name": app.name,
+            "app_identifier": app.app_id,
+            "country": review.get("country", ""),
+            "developer_response": dev_response if dev_response else None,
+        }
+
+    @tracer.capture_method
+    def fetch_new_items(self) -> Generator[dict, None, None]:
+        """Fetch new reviews from all configured iOS apps."""
+        if not self.app_configs:
+            logger.warning("No iOS app configurations found")
+            return
+
+        for app in self.app_configs:
+            # Check frequency-based throttling
+            last_run = self.get_watermark(f"{app.name}_last_run")
+            if last_run:
+                try:
+                    from datetime import timedelta
+                    last_run_dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
+                    next_run = last_run_dt + timedelta(minutes=self.frequency_minutes)
+                    if datetime.now(timezone.utc) < next_run:
+                        logger.info(f"Skipping iOS {app.name} - not due yet (frequency: {self.frequency_minutes}m)")
+                        continue
+                except (ValueError, TypeError):
+                    pass
+
+            logger.info(f"Collecting iOS reviews for {app.name} (app_id={app.app_id})")
+
+            # Load watermark
+            watermark_key = f"{app.name}_last_published_at"
+            last_published = self.get_watermark(watermark_key)
+            watermark_dt = None
+            if last_published:
+                try:
+                    watermark_dt = datetime.fromisoformat(
+                        last_published.replace("Z", "+00:00")
+                    )
+                except (ValueError, TypeError):
+                    watermark_dt = None
+
+            try:
+                reviews = self._collect_reviews_for_app(app)
+            except Exception as e:
+                logger.error(f"Failed to collect reviews for {app.name}: {e}")
+                metrics.add_metric(
+                    name=f"iOS_{app.name}_Errors", unit="Count", value=1
+                )
+                continue
+
+            newest_date = watermark_dt
+            yielded = 0
+
+            for review in reviews:
+                review_date = review.get("date")
+                if review_date and hasattr(review_date, "isoformat"):
+                    review_dt = review_date
+                else:
+                    review_dt = None
+
+                # Skip reviews older than watermark
+                if watermark_dt and review_dt and review_dt <= watermark_dt:
+                    continue
+
+                formatted = self._format_review(review, app)
+                yield formatted
+                yielded += 1
+
+                # Track newest date for watermark update
+                if review_dt and (newest_date is None or review_dt > newest_date):
+                    newest_date = review_dt
+
+            # Update watermark
+            if newest_date and newest_date != watermark_dt:
+                self.set_watermark(watermark_key, newest_date.isoformat())
+
+            self.set_watermark(
+                f"{app.name}_last_run", datetime.now(timezone.utc).isoformat()
+            )
+
+            metrics.add_metric(
+                name=f"iOS_{app.name}_Reviews", unit="Count", value=yielded
+            )
+            logger.info(
+                f"iOS {app.name}: yielded {yielded} new reviews "
+                f"(from {len(reviews)} candidates)"
+            )
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event, context):
+    """Lambda entry point."""
+    ingestor = IOSAppReviewsIngestor()
+    return ingestor.run()

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/itunes_client.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/itunes_client.py
@@ -1,0 +1,59 @@
+"""
+Apple App Store review client using app-store-web-scraper.
+
+Wraps the library with connection pooling, rate limiting, and error handling.
+"""
+
+from app_store_web_scraper import AppStoreEntry, AppStoreSession
+from _shared.base_ingestor import logger
+
+
+def create_session(delay: float = 0.5, jitter: float = 0.2, retries: int = 3) -> AppStoreSession:
+    """Create a shared session with connection pooling and rate limiting."""
+    return AppStoreSession(
+        delay=delay,
+        delay_jitter=jitter,
+        retries=retries,
+        retries_backoff_factor=2,
+        retries_backoff_max=10,
+    )
+
+
+def fetch_reviews_for_country(
+    app_id: str,
+    country: str,
+    session: AppStoreSession,
+    limit: int = 50,
+    sort_by: str = "most_recent",
+) -> list[dict]:
+    """
+    Fetch reviews for a single app in a single country.
+
+    Returns list of dicts with keys: id, date, user_name, rating, title, review,
+    developer_response.
+    """
+    try:
+        sort_map = {
+            "most_recent": "mostrecent",
+            "most_critical": "mosthelpful",
+        }
+        app = AppStoreEntry(
+            app_id=int(app_id),
+            country=country,
+            session=session,
+        )
+        reviews = []
+        for review in app.reviews(limit=limit):
+            reviews.append({
+                "id": str(review.id),
+                "date": review.date,
+                "user_name": review.user_name,
+                "rating": review.rating,
+                "title": review.title,
+                "review": review.review,
+                "developer_response": getattr(review, "developer_response", None),
+            })
+        return reviews
+    except Exception as e:
+        logger.warning(f"Failed to fetch iOS reviews for app {app_id} in {country}: {e}")
+        return []

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/models.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/models.py
@@ -1,0 +1,32 @@
+"""
+App configuration validation for iOS App Reviews plugin.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class IOSAppConfig:
+    """Configuration for a single iOS app to collect reviews from."""
+    name: str
+    app_id: str
+    enabled: bool = True
+    max_reviews_per_run: int = 500
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "IOSAppConfig":
+        """Create from dictionary, with validation."""
+        name = data.get("name", "").strip()
+        if not name:
+            raise ValueError("App config missing required field: name")
+
+        app_id = str(data.get("app_id", "")).strip()
+        if not app_id:
+            raise ValueError(f"App '{name}' missing required field: app_id")
+
+        return cls(
+            name=name,
+            app_id=app_id,
+            enabled=data.get("enabled", True),
+            max_reviews_per_run=int(data.get("max_reviews_per_run", 500)),
+        )

--- a/voc-datalake/plugins/app_reviews_ios/manifest.json
+++ b/voc-datalake/plugins/app_reviews_ios/manifest.json
@@ -1,0 +1,99 @@
+{
+  "id": "app_reviews_ios",
+  "name": "iOS App Reviews",
+  "icon": "iOS",
+  "description": "Collect customer reviews from the Apple App Store",
+  "category": "reviews",
+  "version": "1.0.0",
+
+  "infrastructure": {
+    "ingestor": {
+      "enabled": true,
+      "schedule": "rate(30 minutes)",
+      "timeout": 300,
+      "memory": 512
+    }
+  },
+
+  "config": [
+    {
+      "key": "app_name",
+      "label": "App Name",
+      "type": "text",
+      "placeholder": "my-app",
+      "required": true,
+      "secret": false
+    },
+    {
+      "key": "app_id",
+      "label": "App Store ID",
+      "type": "text",
+      "placeholder": "585629514",
+      "required": true,
+      "secret": false
+    },
+    {
+      "key": "sort_by",
+      "label": "Review Sort Order",
+      "type": "select",
+      "required": false,
+      "secret": false,
+      "options": [
+        { "value": "most_recent", "label": "Most Recent (recommended)" },
+        { "value": "most_critical", "label": "Most Critical" }
+      ]
+    },
+    {
+      "key": "max_countries_per_run",
+      "label": "Max Countries Per Run",
+      "type": "text",
+      "placeholder": "40",
+      "required": false,
+      "secret": false
+    },
+    {
+      "key": "max_reviews_per_run",
+      "label": "Max Reviews Per Run",
+      "type": "text",
+      "placeholder": "500",
+      "required": false,
+      "secret": false
+    },
+    {
+      "key": "frequency_minutes",
+      "label": "Run Frequency",
+      "type": "select",
+      "required": false,
+      "secret": false,
+      "options": [
+        { "value": "15", "label": "Every 15 minutes" },
+        { "value": "30", "label": "Every 30 minutes" },
+        { "value": "60", "label": "Every hour" },
+        { "value": "180", "label": "Every 3 hours" },
+        { "value": "360", "label": "Every 6 hours" },
+        { "value": "720", "label": "Every 12 hours" },
+        { "value": "1440", "label": "Daily" }
+      ]
+    }
+  ],
+
+  "setup": {
+    "title": "iOS App Reviews Setup",
+    "color": "blue",
+    "steps": [
+      "Find your app's numeric ID from the App Store URL (e.g. 585629514)",
+      "Enter the App Name and App Store ID above",
+      "Choose a run frequency and optionally adjust country limits",
+      "Enable the schedule to start collecting reviews"
+    ]
+  },
+
+  "secrets": {
+    "app_name": "",
+    "app_id": "",
+    "sort_by": "most_recent",
+    "max_countries_per_run": "40",
+    "max_reviews_per_run": "500",
+    "frequency_minutes": "1440"
+  }
+}

--- a/voc-datalake/plugins/webscraper/manifest.json
+++ b/voc-datalake/plugins/webscraper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "webscraper",
   "name": "Web Scraper",
-  "icon": "🕷️",
+  "icon": "Web",
   "description": "Configurable scraper for extracting feedback from websites",
   "category": "import",
   "version": "1.0.0",

--- a/voc-datalake/scripts/build-layers.sh
+++ b/voc-datalake/scripts/build-layers.sh
@@ -27,9 +27,9 @@ mkdir -p "$PROCESSING_DEPS_DIR/python"
 docker run --rm --platform "$PLATFORM" \
   -v "$PROCESSING_DEPS_DIR:/var/task" \
   "$DOCKER_IMAGE" \
-  pip install -r /var/task/requirements.txt -t /var/task/python --upgrade --quiet
+  bash -c 'pip install --upgrade pip boto3 botocore --quiet --root-user-action=ignore && pip install -r /var/task/requirements.txt -t /var/task/python --upgrade --quiet --root-user-action=ignore'
 
-echo "✓ processing-deps layer built successfully"
+echo "processing-deps layer built successfully"
 echo "  Size: $(du -sh "$PROCESSING_DEPS_DIR/python" | cut -f1)"
 
 # Build ingestion-deps layer if it exists
@@ -37,16 +37,16 @@ INGESTION_DEPS_DIR="$LAYERS_DIR/ingestion-deps"
 if [ -f "$INGESTION_DEPS_DIR/requirements.txt" ]; then
   echo ""
   echo "=== Building ingestion-deps layer ==="
-  
+
   rm -rf "$INGESTION_DEPS_DIR/python"
   mkdir -p "$INGESTION_DEPS_DIR/python"
-  
+
   docker run --rm --platform "$PLATFORM" \
     -v "$INGESTION_DEPS_DIR:/var/task" \
     "$DOCKER_IMAGE" \
-    pip install -r /var/task/requirements.txt -t /var/task/python --upgrade --quiet
-  
-  echo "✓ ingestion-deps layer built successfully"
+    bash -c 'pip install --upgrade pip boto3 botocore --quiet --root-user-action=ignore && pip install -r /var/task/requirements.txt -t /var/task/python --upgrade --quiet --root-user-action=ignore'
+
+  echo "ingestion-deps layer built successfully"
   echo "  Size: $(du -sh "$INGESTION_DEPS_DIR/python" | cut -f1)"
 fi
 


### PR DESCRIPTION
## Mobile App Reviews Plugins

Adds two new data source plugins for collecting customer reviews from the Apple App Store and Google Play Store.

### New Plugins

- **app_reviews_ios** — Collects iOS App Store reviews using `app-store-web-scraper`, iterating across 40 country storefronts with deduplication, watermarking, and configurable frequency
- **app_reviews_android** — Collects Google Play Store reviews using `google-play-scraper`, iterating across 20 country storefronts with the same pipeline

Each plugin has its own Lambda, EventBridge schedule, secrets, watermarks, and circuit breaker. They appear as configurable cards on the Settings page.

### Supporting Changes

- Added GET `/integrations/{source}/credentials` endpoint so saved credentials load back into the UI
- Namespaced credential keys per source in Secrets Manager to prevent plugins from overwriting each other
- Save now includes default values for untouched fields (select defaults, placeholders)
- Added `DEPLOY_ACCOUNT_ID`/`DEPLOY_REGION` env vars for correct ingestor Lambda invocation via Run Now
- Updated `docs/mobile-app-reviews.md` to match actual implementation

### Testing

- Backend: 17/17 integration handler tests pass
- Frontend: 28/28 SourceCard tests, 92/92 API client tests pass
