### PR TITLE
fix: send conversation history to Bedrock in all chat endpoints

### DIFF
--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -220,11 +220,11 @@ export const api = {
   }),
 
   // Chat with streaming (uses Lambda Function URL to bypass API Gateway timeout)
-  chatStream: async (message: string, context?: string, days?: number): Promise<{ response: string; sources?: FeedbackItem[]; metadata?: { total_feedback: number; days_analyzed: number; urgent_count: number } }> => {
+  chatStream: async (message: string, context?: string, days?: number, history?: { role: 'user' | 'assistant'; content: string }[]): Promise<{ response: string; sources?: FeedbackItem[]; metadata?: { total_feedback: number; days_analyzed: number; urgent_count: number } }> => {
     const streamEndpoint = await getStreamUrl()
     if (!streamEndpoint) return api.chat(message, context)
     const { streamApi } = await import('./streamApi')
-    return streamApi.chatStream(streamEndpoint, message, context, days)
+    return streamApi.chatStream(streamEndpoint, message, context, days, history)
   },
 
   // Data Source Schedules
@@ -402,11 +402,11 @@ export const api = {
     import('./projectsApi').then(m => m.projectsApi.importPersona(projectId, data)),
   projectChat: (projectId: string, message: string, selectedPersonas?: string[], selectedDocuments?: string[]) =>
     import('./projectsApi').then(m => m.projectsApi.projectChat(projectId, message, selectedPersonas, selectedDocuments)),
-  projectChatStream: async (projectId: string, message: string, selectedPersonas?: string[], selectedDocuments?: string[]) => {
+  projectChatStream: async (projectId: string, message: string, selectedPersonas?: string[], selectedDocuments?: string[], history?: { role: 'user' | 'assistant'; content: string }[]) => {
     const streamEndpoint = await getStreamUrl()
     if (!streamEndpoint) return api.projectChat(projectId, message, selectedPersonas, selectedDocuments)
     const { streamApi } = await import('./streamApi')
-    return streamApi.projectChatStream(streamEndpoint, projectId, message, selectedPersonas, selectedDocuments)
+    return streamApi.projectChatStream(streamEndpoint, projectId, message, selectedPersonas, selectedDocuments, history)
   },
   runResearch: (projectId: string, data: { question: string; title?: string; sources?: string[]; categories?: string[]; sentiments?: string[]; days?: number; selected_persona_ids?: string[]; selected_document_ids?: string[] }) =>
     import('./projectsApi').then(m => m.projectsApi.runResearch(projectId, data)),

--- a/voc-datalake/frontend/src/api/streamApi.ts
+++ b/voc-datalake/frontend/src/api/streamApi.ts
@@ -102,20 +102,26 @@ export interface ProjectChatStreamResponse {
   context?: { feedback_count: number; persona_count: number; document_count: number }
 }
 
+export interface HistoryMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
 export const streamApi = {
-  chatStream: (streamEndpoint: string, message: string, context?: string, days?: number) =>
-    fetchStream<ChatStreamResponse>(streamEndpoint, '/chat/stream', { message, context, days: days || 7 }),
-  
+  chatStream: (streamEndpoint: string, message: string, context?: string, days?: number, history?: HistoryMessage[]) =>
+    fetchStream<ChatStreamResponse>(streamEndpoint, '/chat/stream', { message, context, days: days || 7, history: history ?? [] }),
+
   projectChatStream: (
     streamEndpoint: string,
     projectId: string,
     message: string,
     selectedPersonas?: string[],
-    selectedDocuments?: string[]
+    selectedDocuments?: string[],
+    history?: HistoryMessage[]
   ) =>
     fetchStream<ProjectChatStreamResponse>(
       streamEndpoint,
       `/projects/${projectId}/chat/stream`,
-      { message, selected_personas: selectedPersonas, selected_documents: selectedDocuments }
+      { message, selected_personas: selectedPersonas, selected_documents: selectedDocuments, history: history ?? [] }
     ),
 }

--- a/voc-datalake/frontend/src/pages/Chat/Chat.tsx
+++ b/voc-datalake/frontend/src/pages/Chat/Chat.tsx
@@ -158,15 +158,15 @@ export default function Chat() {
   }
 
   const chatMutation = useMutation({
-    mutationFn: async ({ message, conversationId }: { message: string; conversationId: string }) => {
+    mutationFn: async ({ message, conversationId, history }: { message: string; conversationId: string; history: { role: 'user' | 'assistant'; content: string }[] }) => {
       const contextParts = [`Time range: last ${days} days`]
       if (filters.source) contextParts.push(`Source: ${filters.source}`)
       if (filters.category) contextParts.push(`Category: ${filters.category}`)
       if (filters.sentiment) contextParts.push(`Sentiment: ${filters.sentiment}`)
-      
+
       const context = contextParts.join('. ')
       // Use streaming endpoint for better performance (bypasses API Gateway 29s timeout)
-      const response = await api.chatStream(message, context, days)
+      const response = await api.chatStream(message, context, days, history)
       return { response, conversationId }
     },
     onSuccess: ({ response, conversationId }) => {
@@ -190,9 +190,10 @@ export default function Chat() {
     if (!input.trim() || chatMutation.isPending) return
 
     const conversationId = activeConversationId ?? createConversation()
+    const history = (activeConversation?.messages ?? []).map(m => ({ role: m.role, content: m.content }))
 
     addMessage(conversationId, { role: 'user', content: input, filters })
-    chatMutation.mutate({ message: input, conversationId })
+    chatMutation.mutate({ message: input, conversationId, history })
     setInput('')
   }
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.tsx
@@ -70,9 +70,10 @@ export default function ProjectDetail() {
 
   // Handlers
   const handleSendChat = useCallback((message: string, personaIds: string[], documentIds: string[]) => {
+    const history = chatMessages.map(m => ({ role: m.role, content: m.content }))
     setChatMessages(p => [...p, { role: 'user', content: message }])
-    chatMut.mutate({ message, personas: personaIds, documents: documentIds })
-  }, [chatMut])
+    chatMut.mutate({ message, personas: personaIds, documents: documentIds, history })
+  }, [chatMut, chatMessages])
 
   const handleImportPersona = useCallback(() => {
     importPersonaMut.mutate(

--- a/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
@@ -291,11 +291,11 @@ interface UseChatMutationProps {
 export function useChatMutation({ id, onSuccess }: UseChatMutationProps) {
   const projectId = id ?? ''
 
-  return useMutation({ 
-    mutationFn: (params: { message: string; personas: string[]; documents: string[] }) => 
-      api.projectChatStream(projectId, params.message, params.personas, params.documents), 
-    onSuccess: (r) => { 
-      if (r.success) onSuccess(r.response) 
-    } 
+  return useMutation({
+    mutationFn: (params: { message: string; personas: string[]; documents: string[]; history?: { role: 'user' | 'assistant'; content: string }[] }) =>
+      api.projectChatStream(projectId, params.message, params.personas, params.documents, params.history),
+    onSuccess: (r) => {
+      if (r.success) onSuccess(r.response)
+    }
   })
 }

--- a/voc-datalake/lambda/api/chat_handler.py
+++ b/voc-datalake/lambda/api/chat_handler.py
@@ -44,6 +44,7 @@ def chat():
     """AI chat endpoint for querying feedback data using Bedrock."""
     body = app.current_event.json_body
     message = body.get('message', '')
+    history = body.get('history', [])
     
     params = app.current_event.query_string_parameters or {}
     days = validate_days(params.get('days'), default=7)
@@ -145,6 +146,7 @@ Top Categories: {', '.join([f"{cat}: {count}" for cat, count in sorted(category_
             prompt=f"{data_context}\n\nQuestion: {message}",
             system_prompt=system_prompt,
             max_tokens=1500,
+            history=history,
         )
         
         return {

--- a/voc-datalake/lambda/api/chat_stream_handler.py
+++ b/voc-datalake/lambda/api/chat_stream_handler.py
@@ -72,17 +72,7 @@ def project_chat_handler(event, context):
             return error_response(metadata.get('error', 'Project not found'), 404)
         
         # Build message list with conversation history (Anthropic Messages API format)
-        anthropic_messages = []
-        for turn in history:
-            role = turn.get('role', '')
-            content = turn.get('content', '')
-            if role in ('user', 'assistant') and isinstance(content, str) and content.strip():
-                anthropic_messages.append({'role': role, 'content': content})
-        if len(anthropic_messages) > 40:
-            anthropic_messages = anthropic_messages[-40:]
-        while anthropic_messages and anthropic_messages[0]['role'] != 'user':
-            anthropic_messages.pop(0)
-        anthropic_messages.append({'role': 'user', 'content': user_message})
+        anthropic_messages = _build_messages_with_history(history, user_message, format='anthropic')
 
         # Call Bedrock with streaming
         response = bedrock.invoke_model_with_response_stream(
@@ -91,7 +81,7 @@ def project_chat_handler(event, context):
             accept='application/json',
             body=json.dumps({
                 'anthropic_version': 'bedrock-2023-05-31',
-                'max_tokens': 3000,
+                'max_tokens': 4096,
                 'system': system_prompt,
                 'messages': anthropic_messages
             })
@@ -439,7 +429,7 @@ def voc_chat_handler(event, context):
                 system=[{'text': system_prompt}],
                 messages=messages,
                 toolConfig=tool_config,
-                inferenceConfig={'maxTokens': 2000}
+                inferenceConfig={'maxTokens': 4096}
             )
             
             output = response.get('output', {})

--- a/voc-datalake/lambda/api/chat_stream_handler.py
+++ b/voc-datalake/lambda/api/chat_stream_handler.py
@@ -15,7 +15,7 @@ from shared.api import (
     validate_days, get_configured_categories, sum_daily_metric,
     api_handler, json_response, error_response
 )
-from shared.converse import get_search_feedback_tool
+from shared.converse import get_search_feedback_tool, _build_messages_with_history
 from shared.project_chat import build_chat_context
 
 # AWS Clients
@@ -58,6 +58,7 @@ def project_chat_handler(event, context):
             return error_response('Project ID required', 400)
         
         message = body.get('message', '')
+        history = body.get('history', [])
         system_prompt, user_message, metadata = build_chat_context(
             projects_table,
             feedback_table,
@@ -70,6 +71,19 @@ def project_chat_handler(event, context):
         if system_prompt is None:
             return error_response(metadata.get('error', 'Project not found'), 404)
         
+        # Build message list with conversation history (Anthropic Messages API format)
+        anthropic_messages = []
+        for turn in history:
+            role = turn.get('role', '')
+            content = turn.get('content', '')
+            if role in ('user', 'assistant') and isinstance(content, str) and content.strip():
+                anthropic_messages.append({'role': role, 'content': content})
+        if len(anthropic_messages) > 40:
+            anthropic_messages = anthropic_messages[-40:]
+        while anthropic_messages and anthropic_messages[0]['role'] != 'user':
+            anthropic_messages.pop(0)
+        anthropic_messages.append({'role': 'user', 'content': user_message})
+
         # Call Bedrock with streaming
         response = bedrock.invoke_model_with_response_stream(
             modelId=BEDROCK_MODEL_ID,
@@ -79,7 +93,7 @@ def project_chat_handler(event, context):
                 'anthropic_version': 'bedrock-2023-05-31',
                 'max_tokens': 3000,
                 'system': system_prompt,
-                'messages': [{'role': 'user', 'content': user_message}]
+                'messages': anthropic_messages
             })
         )
         
@@ -404,11 +418,12 @@ def voc_chat_handler(event, context):
         message = body.get('message', '')
         if not message:
             return error_response('Message is required', 400)
-        
+
+        history = body.get('history', [])
         system_prompt, user_message, metadata = get_voc_chat_context(body)
         filters = metadata.get('filters', {})
-        
-        messages = [{'role': 'user', 'content': [{'text': user_message}]}]
+
+        messages = _build_messages_with_history(history, user_message)
         sources = []
         tool_config = {'tools': [get_search_feedback_tool()]}
         

--- a/voc-datalake/lambda/api/test/test_chat_stream_handler.py
+++ b/voc-datalake/lambda/api/test/test_chat_stream_handler.py
@@ -232,16 +232,73 @@ class TestProjectChatHandler:
     def test_returns_error_when_project_id_missing(self):
         """Returns 400 when project_id not in path."""
         from chat_stream_handler import project_chat_handler
-        
+
         event = {
             'body': json.dumps({'message': 'Hello'}),
             'rawPath': '/invalid/path'
         }
         context = MagicMock()
-        
+
         response = project_chat_handler(event, context)
-        
+
         assert response['statusCode'] == 400
+
+    @patch('chat_stream_handler.bedrock')
+    @patch('chat_stream_handler.build_chat_context')
+    def test_forwards_history_in_anthropic_format(self, mock_context, mock_bedrock):
+        """Threads history to Bedrock as Anthropic Messages (string content)."""
+        mock_context.return_value = ('SYS', 'current question', {})
+        mock_bedrock.invoke_model_with_response_stream.return_value = {'body': []}
+
+        from chat_stream_handler import project_chat_handler
+
+        event = {
+            'body': json.dumps({
+                'message': 'current question',
+                'history': [
+                    {'role': 'user', 'content': 'first'},
+                    {'role': 'assistant', 'content': 'reply 1'},
+                ],
+            }),
+            'rawPath': '/projects/proj-123/chat/stream',
+        }
+        context = MagicMock()
+
+        project_chat_handler(event, context)
+
+        body = json.loads(
+            mock_bedrock.invoke_model_with_response_stream.call_args.kwargs['body']
+        )
+        assert body['messages'] == [
+            {'role': 'user', 'content': 'first'},
+            {'role': 'assistant', 'content': 'reply 1'},
+            {'role': 'user', 'content': 'current question'},
+        ]
+        assert body['max_tokens'] == 4096
+
+    @patch('chat_stream_handler.bedrock')
+    @patch('chat_stream_handler.build_chat_context')
+    def test_handles_missing_history(self, mock_context, mock_bedrock):
+        """Works with no history field; sends only the current message."""
+        mock_context.return_value = ('SYS', 'just a question', {})
+        mock_bedrock.invoke_model_with_response_stream.return_value = {'body': []}
+
+        from chat_stream_handler import project_chat_handler
+
+        event = {
+            'body': json.dumps({'message': 'just a question'}),
+            'rawPath': '/projects/proj-123/chat/stream',
+        }
+        context = MagicMock()
+
+        project_chat_handler(event, context)
+
+        body = json.loads(
+            mock_bedrock.invoke_model_with_response_stream.call_args.kwargs['body']
+        )
+        assert body['messages'] == [
+            {'role': 'user', 'content': 'just a question'},
+        ]
 
 
 class TestVocChatHandler:
@@ -294,3 +351,38 @@ class TestVocChatHandler:
         body = json.loads(response['body'])
         assert body['response'] == 'Hello! How can I help you?'
         assert body['metadata']['tool_used'] is False
+
+    @patch('chat_stream_handler.bedrock')
+    @patch('chat_stream_handler.get_aggregated_metrics')
+    def test_forwards_history_to_bedrock(self, mock_metrics, mock_bedrock):
+        """History turns are threaded into the Bedrock Converse request."""
+        mock_metrics.return_value = {
+            'total': 0,
+            'sentiment': {'positive': 0, 'negative': 0, 'neutral': 0, 'mixed': 0},
+            'categories': {},
+            'urgent': 0,
+        }
+        mock_bedrock.converse.return_value = {
+            'stopReason': 'end_turn',
+            'output': {'message': {'content': [{'text': 'response'}]}},
+        }
+
+        from chat_stream_handler import voc_chat_handler
+
+        event = {
+            'body': json.dumps({
+                'message': 'follow-up',
+                'history': [
+                    {'role': 'user', 'content': 'first'},
+                    {'role': 'assistant', 'content': 'reply 1'},
+                ],
+            })
+        }
+        voc_chat_handler(event, MagicMock())
+
+        sent_messages = mock_bedrock.converse.call_args.kwargs['messages']
+        assert sent_messages[0] == {'role': 'user', 'content': [{'text': 'first'}]}
+        assert sent_messages[1] == {'role': 'assistant', 'content': [{'text': 'reply 1'}]}
+        assert sent_messages[-1]['role'] == 'user'
+        # Last message wraps the user_message built from the current question
+        assert 'follow-up' in sent_messages[-1]['content'][0]['text']

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -30,23 +30,34 @@ class BedrockThrottlingError(Exception):
     pass
 
 
-def _build_messages_with_history(history: list[dict], current_message: str) -> list[dict]:
-    """Build Bedrock Converse API messages array from prior turns + current user message."""
+def _build_messages_with_history(
+    history: list[dict],
+    current_message: str,
+    format: str = 'converse',
+) -> list[dict]:
+    """Build messages array from prior turns + current user message.
+
+    format='converse' returns Bedrock Converse API shape (content as text blocks).
+    format='anthropic' returns Anthropic Messages API shape (content as plain string).
+    """
+    def wrap(text: str):
+        return [{'text': text}] if format == 'converse' else text
+
     messages = []
     for turn in history:
         role = turn.get('role', '')
         content = turn.get('content', '')
         if role in ('user', 'assistant') and isinstance(content, str) and content.strip():
-            messages.append({'role': role, 'content': [{'text': content}]})
+            messages.append({'role': role, 'content': wrap(content)})
 
-    if len(messages) > MAX_HISTORY_TURNS * 2:
-        messages = messages[-(MAX_HISTORY_TURNS * 2):]
+    if len(messages) > MAX_HISTORY_TURNS:
+        messages = messages[-MAX_HISTORY_TURNS:]
 
     # Bedrock requires the first message to be from 'user'
     while messages and messages[0]['role'] != 'user':
         messages.pop(0)
 
-    messages.append({'role': 'user', 'content': [{'text': current_message}]})
+    messages.append({'role': 'user', 'content': wrap(current_message)})
     return messages
 
 
@@ -334,7 +345,7 @@ def converse_with_tools(
     system_prompt: str,
     tools: list[dict],
     tool_executor: Callable[[str, dict], str],
-    max_tokens: int = 2000,
+    max_tokens: int = 4096,
     max_iterations: int = 4,
     model_id: str | None = None,
     history: list[dict] | None = None,

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -13,6 +13,7 @@ from shared.aws import get_bedrock_client, BEDROCK_MODEL_ID
 
 # Retry configuration
 DEFAULT_MAX_RETRIES = 5
+MAX_HISTORY_TURNS = 20
 DEFAULT_BASE_DELAY = 1.0  # seconds
 DEFAULT_MAX_DELAY = 30.0  # seconds
 
@@ -29,6 +30,26 @@ class BedrockThrottlingError(Exception):
     pass
 
 
+def _build_messages_with_history(history: list[dict], current_message: str) -> list[dict]:
+    """Build Bedrock Converse API messages array from prior turns + current user message."""
+    messages = []
+    for turn in history:
+        role = turn.get('role', '')
+        content = turn.get('content', '')
+        if role in ('user', 'assistant') and isinstance(content, str) and content.strip():
+            messages.append({'role': role, 'content': [{'text': content}]})
+
+    if len(messages) > MAX_HISTORY_TURNS * 2:
+        messages = messages[-(MAX_HISTORY_TURNS * 2):]
+
+    # Bedrock requires the first message to be from 'user'
+    while messages and messages[0]['role'] != 'user':
+        messages.pop(0)
+
+    messages.append({'role': 'user', 'content': [{'text': current_message}]})
+    return messages
+
+
 def converse(
     prompt: str,
     system_prompt: str = "",
@@ -39,6 +60,7 @@ def converse(
     max_retries: int = DEFAULT_MAX_RETRIES,
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
+    history: list[dict] | None = None,
 ) -> str:
     """
     Simple text completion using Bedrock Converse API with retry support.
@@ -73,9 +95,9 @@ def converse(
         logger.error(f"[BEDROCK] Failed to get Bedrock client: {e}")
         raise
     
-    messages = [{'role': 'user', 'content': [{'text': prompt}]}]
+    messages = _build_messages_with_history(history or [], prompt)
     system = [{'text': system_prompt}] if system_prompt else None
-    
+
     kwargs = {
         'modelId': used_model,
         'messages': messages,
@@ -315,6 +337,7 @@ def converse_with_tools(
     max_tokens: int = 2000,
     max_iterations: int = 4,
     model_id: str | None = None,
+    history: list[dict] | None = None,
 ) -> tuple[str, list]:
     """
     Converse with tool use support (agentic loop).
@@ -334,7 +357,7 @@ def converse_with_tools(
     """
     client = get_bedrock_client()
     
-    messages = [{'role': 'user', 'content': [{'text': prompt}]}]
+    messages = _build_messages_with_history(history or [], prompt)
     tool_config = {'tools': tools}
     collected_metadata = []
     

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -736,6 +736,232 @@ class TestProcessToolUses:
         ]
         
         results, metadata = _process_tool_uses(content, lambda n, i: ('result', None))
-        
+
         assert len(results) == 1
         assert metadata == []
+
+
+class TestBuildMessagesWithHistory:
+    """Tests for _build_messages_with_history helper function."""
+
+    def test_empty_history_returns_only_current_message(self):
+        """Returns single user message when history is empty."""
+        from shared.converse import _build_messages_with_history
+
+        result = _build_messages_with_history([], 'Hello')
+
+        assert result == [{'role': 'user', 'content': [{'text': 'Hello'}]}]
+
+    def test_includes_valid_history_turns(self):
+        """Preserves valid user/assistant turns and appends current message."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': 'Hello!'},
+        ]
+        result = _build_messages_with_history(history, 'How are you?')
+
+        assert result == [
+            {'role': 'user', 'content': [{'text': 'Hi'}]},
+            {'role': 'assistant', 'content': [{'text': 'Hello!'}]},
+            {'role': 'user', 'content': [{'text': 'How are you?'}]},
+        ]
+
+    def test_skips_invalid_roles(self):
+        """Skips turns with roles other than user/assistant."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'system', 'content': 'system note'},
+            {'role': 'tool', 'content': 'tool output'},
+            {'role': 'assistant', 'content': 'Hello!'},
+        ]
+        result = _build_messages_with_history(history, 'Q')
+
+        roles = [m['role'] for m in result]
+        assert roles == ['user', 'assistant', 'user']
+
+    def test_skips_non_string_content(self):
+        """Skips turns whose content is not a string."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': None},
+            {'role': 'user', 'content': 123},
+            {'role': 'assistant', 'content': ['a', 'b']},
+        ]
+        result = _build_messages_with_history(history, 'Q')
+
+        assert len(result) == 2  # one valid history + current
+        assert result[0]['content'] == [{'text': 'Hi'}]
+
+    def test_skips_empty_or_whitespace_content(self):
+        """Skips turns with empty or whitespace-only content."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'user', 'content': ''},
+            {'role': 'assistant', 'content': '   '},
+            {'role': 'user', 'content': 'real message'},
+        ]
+        result = _build_messages_with_history(history, 'Q')
+
+        assert len(result) == 2
+        assert result[0]['content'] == [{'text': 'real message'}]
+
+    def test_caps_history_at_max_history_turns(self):
+        """Trims history to MAX_HISTORY_TURNS messages, keeping the most recent."""
+        from shared.converse import _build_messages_with_history, MAX_HISTORY_TURNS
+
+        history = []
+        for i in range(MAX_HISTORY_TURNS + 10):
+            role = 'user' if i % 2 == 0 else 'assistant'
+            history.append({'role': role, 'content': f'msg{i}'})
+
+        result = _build_messages_with_history(history, 'current')
+
+        # MAX_HISTORY_TURNS history messages + 1 current
+        assert len(result) == MAX_HISTORY_TURNS + 1
+        # Most recent history messages should be preserved
+        assert result[-2]['content'] == [{'text': f'msg{MAX_HISTORY_TURNS + 9}'}]
+
+    def test_first_message_must_be_user(self):
+        """Drops leading assistant messages so first is from user."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'assistant', 'content': 'Sure thing'},
+            {'role': 'user', 'content': 'Then what?'},
+            {'role': 'assistant', 'content': 'Then this.'},
+        ]
+        result = _build_messages_with_history(history, 'Got it')
+
+        assert result[0]['role'] == 'user'
+        assert result[0]['content'] == [{'text': 'Then what?'}]
+
+    def test_appends_current_message_last(self):
+        """Current message is always the last entry and from user."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': 'Hi back'},
+        ]
+        result = _build_messages_with_history(history, 'final question')
+
+        assert result[-1] == {'role': 'user', 'content': [{'text': 'final question'}]}
+
+    def test_anthropic_format_uses_string_content(self):
+        """format='anthropic' returns content as plain strings."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': 'Hello!'},
+        ]
+        result = _build_messages_with_history(history, 'How are you?', format='anthropic')
+
+        assert result == [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': 'Hello!'},
+            {'role': 'user', 'content': 'How are you?'},
+        ]
+
+    def test_converse_format_is_default(self):
+        """Default format wraps content in [{'text': ...}] blocks."""
+        from shared.converse import _build_messages_with_history
+
+        result = _build_messages_with_history([], 'Hello')
+
+        assert result == [{'role': 'user', 'content': [{'text': 'Hello'}]}]
+
+    def test_anthropic_format_drops_leading_assistant(self):
+        """First-must-be-user rule still applies in anthropic format."""
+        from shared.converse import _build_messages_with_history
+
+        history = [
+            {'role': 'assistant', 'content': 'Greetings'},
+            {'role': 'user', 'content': 'Hi'},
+        ]
+        result = _build_messages_with_history(history, 'Q', format='anthropic')
+
+        assert result[0] == {'role': 'user', 'content': 'Hi'}
+
+
+class TestConverseHistory:
+    """Tests for converse() honoring conversation history."""
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_passes_history_to_bedrock(self, mock_get_client):
+        """History turns are forwarded to Bedrock messages."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'reply'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        history = [
+            {'role': 'user', 'content': 'first'},
+            {'role': 'assistant', 'content': 'reply 1'},
+        ]
+        converse('second', history=history)
+
+        sent_messages = mock_client.converse.call_args.kwargs['messages']
+        assert sent_messages == [
+            {'role': 'user', 'content': [{'text': 'first'}]},
+            {'role': 'assistant', 'content': [{'text': 'reply 1'}]},
+            {'role': 'user', 'content': [{'text': 'second'}]},
+        ]
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_works_without_history(self, mock_get_client):
+        """No history defaults to single current message."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'reply'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        converse('hello')
+
+        sent_messages = mock_client.converse.call_args.kwargs['messages']
+        assert sent_messages == [{'role': 'user', 'content': [{'text': 'hello'}]}]
+
+
+class TestConverseWithToolsHistory:
+    """Tests for converse_with_tools() honoring conversation history."""
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_seeds_messages_with_history(self, mock_get_client):
+        """History turns seed the messages list passed to Bedrock."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'answer'}]}},
+            'stopReason': 'end_turn',
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse_with_tools
+        history = [
+            {'role': 'user', 'content': 'previous'},
+            {'role': 'assistant', 'content': 'prior reply'},
+        ]
+        converse_with_tools(
+            prompt='now',
+            system_prompt='sys',
+            tools=[],
+            tool_executor=lambda n, i: ('r', None),
+            history=history,
+        )
+
+        sent_messages = mock_client.converse.call_args.kwargs['messages']
+        assert sent_messages == [
+            {'role': 'user', 'content': [{'text': 'previous'}]},
+            {'role': 'assistant', 'content': [{'text': 'prior reply'}]},
+            {'role': 'user', 'content': [{'text': 'now'}]},
+        ]


### PR DESCRIPTION
Prior turns were stored client-side but never forwarded to Bedrock, so follow-up questions like "tell me more about that" had no context.

This PR addresses this issue https://github.com/aws-samples/sample-voice-of-customer-datalake/issues/100 and #92 

## Techical details

Backend: added _build_messages_with_history() helper in converse.py; all three chat handlers (non-streaming VoC, streaming project, streaming VoC/tool-use) now extract 'history' from the request body and prepend the last 20 turns before the current message.

Frontend: history is collected before adding the new user message and threaded through streamApi → client.ts → Chat.tsx and ProjectDetail/useProjectData.ts → handleSendChat.