### PR TITLE
PR 4/7: Data management UI — PDF export, /feedback pagination, JSON upload backend

### DIFF
--- a/voc-datalake/frontend/public/locales/de/common.json
+++ b/voc-datalake/frontend/public/locales/de/common.json
@@ -17,6 +17,9 @@
     "settings": "Einstellungen"
   },
   "configureBrand": "Marke konfigurieren",
+  "exportPdf": "PDF exportieren",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "Als PDF exportieren",
   "filters": {
     "allCategories": "Alle Kategorien",
     "allSentiments": "Alle Stimmungen",
@@ -57,6 +60,7 @@
     "scrapers": "Scraper",
     "settings": "Einstellungen"
   },
+  "partialWindowHint": "Filter eingrenzen, um alle zu sehen",
   "priority": {
     "high": "Hoch",
     "low": "Niedrig",

--- a/voc-datalake/frontend/public/locales/en/common.json
+++ b/voc-datalake/frontend/public/locales/en/common.json
@@ -17,6 +17,9 @@
     "settings": "Settings"
   },
   "configureBrand": "Configure brand",
+  "exportPdf": "Export PDF",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "Export as PDF",
   "filters": {
     "allCategories": "All Categories",
     "allSentiments": "All Sentiments",
@@ -57,6 +60,7 @@
     "scrapers": "Scrapers",
     "settings": "Settings"
   },
+  "partialWindowHint": "narrow filters to see all",
   "priority": {
     "high": "High",
     "low": "Low",

--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -17,6 +17,9 @@
     "settings": "Configuración"
   },
   "configureBrand": "Configurar marca",
+  "exportPdf": "Exportar PDF",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "Exportar como PDF",
   "filters": {
     "allCategories": "Todas las categorías",
     "allSentiments": "Todos los sentimientos",
@@ -60,6 +63,7 @@
     "scrapers": "Recolectores",
     "settings": "Configuración"
   },
+  "partialWindowHint": "acota los filtros para verlos todos",
   "priority": {
     "high": "Alta",
     "low": "Baja",
@@ -74,6 +78,7 @@
     "positive": "Positivo"
   },
   "showingOf_one": "Mostrando {{count}} de {{total}} resultado",
+  "showingOf_many": "",
   "showingOf_other": "Mostrando {{count}} de {{total}} resultados",
   "sidebar": {
     "closeMenu": "Cerrar menú",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -17,6 +17,9 @@
     "settings": "Paramètres"
   },
   "configureBrand": "Configurer la marque",
+  "exportPdf": "Exporter en PDF",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "Exporter au format PDF",
   "filters": {
     "allCategories": "Toutes les catégories",
     "allSentiments": "Tous les sentiments",
@@ -60,6 +63,7 @@
     "scrapers": "Collecteurs",
     "settings": "Paramètres"
   },
+  "partialWindowHint": "affinez les filtres pour tout voir",
   "priority": {
     "high": "Haute",
     "low": "Basse",
@@ -74,6 +78,7 @@
     "positive": "Positif"
   },
   "showingOf_one": "Affichage de {{count}} sur {{total}} résultat",
+  "showingOf_many": "",
   "showingOf_other": "Affichage de {{count}} sur {{total}} résultats",
   "sidebar": {
     "closeMenu": "Fermer le menu",

--- a/voc-datalake/frontend/public/locales/ja/common.json
+++ b/voc-datalake/frontend/public/locales/ja/common.json
@@ -17,6 +17,9 @@
     "settings": "設定"
   },
   "configureBrand": "ブランドを設定",
+  "exportPdf": "PDFをエクスポート",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "PDFとしてエクスポート",
   "filters": {
     "allCategories": "すべてのカテゴリ",
     "allSentiments": "すべての感情",
@@ -57,6 +60,7 @@
     "scrapers": "スクレイパー",
     "settings": "設定"
   },
+  "partialWindowHint": "すべて表示するにはフィルターを絞り込んでください",
   "priority": {
     "high": "高",
     "low": "低",

--- a/voc-datalake/frontend/public/locales/ko/common.json
+++ b/voc-datalake/frontend/public/locales/ko/common.json
@@ -17,6 +17,9 @@
     "settings": "설정"
   },
   "configureBrand": "브랜드 설정",
+  "exportPdf": "PDF 내보내기",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "PDF로 내보내기",
   "filters": {
     "allCategories": "모든 카테고리",
     "allSentiments": "모든 감정",
@@ -57,6 +60,7 @@
     "scrapers": "스크레이퍼",
     "settings": "설정"
   },
+  "partialWindowHint": "모두 보려면 필터를 좁히세요",
   "priority": {
     "high": "높음",
     "low": "낮음",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -17,6 +17,9 @@
     "settings": "Configurações"
   },
   "configureBrand": "Configurar marca",
+  "exportPdf": "Exportar PDF",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "Exportar como PDF",
   "filters": {
     "allCategories": "Todas as categorias",
     "allSentiments": "Todos os sentimentos",
@@ -60,6 +63,7 @@
     "scrapers": "Coletores",
     "settings": "Configurações"
   },
+  "partialWindowHint": "refine os filtros para ver tudo",
   "priority": {
     "high": "Alta",
     "low": "Baixa",
@@ -74,6 +78,7 @@
     "positive": "Positivo"
   },
   "showingOf_one": "Mostrando {{count}} de {{total}} resultado",
+  "showingOf_many": "",
   "showingOf_other": "Mostrando {{count}} de {{total}} resultados",
   "sidebar": {
     "closeMenu": "Fechar menu",

--- a/voc-datalake/frontend/public/locales/zh/common.json
+++ b/voc-datalake/frontend/public/locales/zh/common.json
@@ -17,6 +17,9 @@
     "settings": "设置"
   },
   "configureBrand": "配置品牌",
+  "exportPdf": "导出 PDF",
+  "exportPdfShort": "PDF",
+  "exportPdfTooltip": "导出为 PDF",
   "filters": {
     "allCategories": "所有分类",
     "allSentiments": "所有情感",
@@ -57,6 +60,7 @@
     "scrapers": "抓取器",
     "settings": "设置"
   },
+  "partialWindowHint": "缩小筛选范围以查看全部",
   "priority": {
     "high": "高",
     "low": "低",

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -56,7 +56,9 @@ describe('API Client', () => {
           }),
         })
       )
-      expect(result).toEqual(mockResponse)
+      // Items are normalized to the FeedbackItem contract at the client boundary.
+      expect(result.count).toBe(2)
+      expect(result.items.map((i) => i.feedback_id)).toEqual(['1', '2'])
     })
 
     it('throws error on non-ok response', async () => {
@@ -162,7 +164,8 @@ describe('API Client', () => {
         'https://api.example.com/feedback/abc123',
         expect.any(Object)
       )
-      expect(result).toEqual(mockFeedback)
+      // Response is normalized to the FeedbackItem contract at the client boundary.
+      expect(result.feedback_id).toBe('abc123')
     })
   })
 

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -2,6 +2,8 @@ import { authService } from '../services/auth'
 import { getBaseUrl, getAuthHeaders, getDaysFromRange, ALL_TIME_DAYS } from './baseUrl'
 import type {
   FeedbackItem,
+  FeedbackListParams,
+  FeedbackListResponse,
   MetricsSummary,
   SentimentBreakdown,
   CategoryBreakdown,
@@ -27,6 +29,8 @@ import type {
 // Re-export all types for backward compatibility
 export type {
   FeedbackItem,
+  FeedbackListParams,
+  FeedbackListResponse,
   MetricsSummary,
   SentimentBreakdown,
   CategoryBreakdown,
@@ -124,8 +128,10 @@ export async function fetchApi<T>(endpoint: string, options?: RequestInit): Prom
   throw new Error(`API Error: ${response.status}`)
 }
 
-// Helper to build URLSearchParams from an object, filtering out undefined/null values
-function buildSearchParams(params: Record<string, string | number | boolean | undefined | null>): URLSearchParams {
+// Helper to build URLSearchParams from an object, filtering out undefined/null values.
+// Accepts any object so domain interfaces (e.g. FeedbackListParams) can be passed
+// without requiring an index signature on the type.
+function buildSearchParams(params: object): URLSearchParams {
   const searchParams = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
     if (value != null) {
@@ -137,9 +143,9 @@ function buildSearchParams(params: Record<string, string | number | boolean | un
 
 export const api = {
   // Feedback
-  getFeedback: (params: { days?: number; source?: string; category?: string; sentiment?: string; limit?: number }) => {
+  getFeedback: (params: FeedbackListParams) => {
     const searchParams = buildSearchParams(params)
-    return fetchApi<{ count: number; items: FeedbackItem[] }>(`/feedback?${searchParams}`)
+    return fetchApi<FeedbackListResponse>(`/feedback?${searchParams}`)
   },
   
   getFeedbackById: (id: string) => fetchApi<FeedbackItem>(`/feedback/${id}`),

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -73,6 +73,7 @@ function buildHeaders(existingHeaders?: HeadersInit): Record<string, string> {
 }
 
 import { z } from 'zod'
+import { normalizeFeedbackItem, normalizeFeedbackItems } from './feedbackSchema'
 
 // API response parser using Zod for runtime validation
 // This satisfies the no-type-assertions rule
@@ -143,27 +144,31 @@ function buildSearchParams(params: object): URLSearchParams {
 
 export const api = {
   // Feedback
-  getFeedback: (params: FeedbackListParams) => {
+  getFeedback: async (params: FeedbackListParams) => {
     const searchParams = buildSearchParams(params)
-    return fetchApi<FeedbackListResponse>(`/feedback?${searchParams}`)
+    const res = await fetchApi<FeedbackListResponse>(`/feedback?${searchParams}`)
+    return { ...res, items: normalizeFeedbackItems(res.items) }
   },
   
-  getFeedbackById: (id: string) => fetchApi<FeedbackItem>(`/feedback/${id}`),
+  getFeedbackById: async (id: string) => normalizeFeedbackItem(await fetchApi<FeedbackItem>(`/feedback/${id}`)),
   
-  getUrgentFeedback: (params: { days?: number; limit?: number; source?: string; sentiment?: string; category?: string }) => {
+  getUrgentFeedback: async (params: { days?: number; limit?: number; source?: string; sentiment?: string; category?: string }) => {
     const searchParams = buildSearchParams(params)
-    return fetchApi<{ count: number; items: FeedbackItem[] }>(`/feedback/urgent?${searchParams}`)
+    const res = await fetchApi<{ count: number; items: FeedbackItem[] }>(`/feedback/urgent?${searchParams}`)
+    return { ...res, items: normalizeFeedbackItems(res.items) }
   },
   
-  searchFeedback: (params: { q: string; days?: number; limit?: number; source?: string; sentiment?: string; category?: string }) => {
+  searchFeedback: async (params: { q: string; days?: number; limit?: number; source?: string; sentiment?: string; category?: string }) => {
     const searchParams = buildSearchParams(params)
-    return fetchApi<{ count: number; items: FeedbackItem[]; entities: EntitiesResponse['entities']; query: string }>(`/feedback/search?${searchParams}`)
+    const res = await fetchApi<{ count: number; items: FeedbackItem[]; entities: EntitiesResponse['entities']; query: string }>(`/feedback/search?${searchParams}`)
+    return { ...res, items: normalizeFeedbackItems(res.items) }
   },
   
-  getSimilarFeedback: (id: string, limit?: number) => {
+  getSimilarFeedback: async (id: string, limit?: number) => {
     const searchParams = new URLSearchParams()
     if (limit) searchParams.set('limit', String(limit))
-    return fetchApi<{ source_feedback_id: string; count: number; items: FeedbackItem[] }>(`/feedback/${id}/similar?${searchParams}`)
+    const res = await fetchApi<{ source_feedback_id: string; count: number; items: FeedbackItem[] }>(`/feedback/${id}/similar?${searchParams}`)
+    return { ...res, items: normalizeFeedbackItems(res.items) }
   },
   
   getEntities: (params: { days?: number; limit?: number; source?: string }) => {

--- a/voc-datalake/frontend/src/api/feedbackSchema.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackSchema.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeFeedbackItem, normalizeFeedbackItems } from './feedbackSchema'
+
+function rawItem(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    feedback_id: 'f1',
+    source_id: 's1',
+    source_platform: 'manual_import',
+    source_channel: 'ui_test',
+    brand_name: 'Acme',
+    source_created_at: '2026-06-16T00:00:00Z',
+    processed_at: '2026-06-16T01:00:00Z',
+    original_text: 'Manual import review',
+    original_language: 'en',
+    category: 'app',
+    journey_stage: 'usage',
+    sentiment_label: 'positive',
+    sentiment_score: 0.9,
+    urgency: 'low',
+    impact_area: 'tech',
+    ...overrides,
+  }
+}
+
+describe('normalizeFeedbackItem', () => {
+  it('coerces a string sentiment_score to a number', () => {
+    const item = normalizeFeedbackItem(rawItem({ sentiment_score: '0.9' }))
+    expect(item.sentiment_score).toBe(0.9)
+    expect(typeof item.sentiment_score).toBe('number')
+    // The coerced value is now safe for numeric operations like .toFixed().
+    expect(item.sentiment_score.toFixed(2)).toBe('0.90')
+  })
+
+  it('coerces a string rating to a number', () => {
+    const item = normalizeFeedbackItem(rawItem({ rating: '5' }))
+    expect(item.rating).toBe(5)
+  })
+
+  it('falls back to 0 for a non-numeric sentiment_score', () => {
+    const item = normalizeFeedbackItem(rawItem({ sentiment_score: 'not-a-number' }))
+    expect(item.sentiment_score).toBe(0)
+  })
+
+  it('leaves a null rating as undefined (so the UI shows an em dash, not 0)', () => {
+    const item = normalizeFeedbackItem(rawItem({ rating: null }))
+    expect(item.rating).toBeUndefined()
+  })
+
+  it('treats a missing rating as undefined', () => {
+    const item = normalizeFeedbackItem(rawItem())
+    expect(item.rating).toBeUndefined()
+  })
+
+  it('strips unknown DynamoDB-internal keys', () => {
+    const item = normalizeFeedbackItem(rawItem({ pk: 'SOURCE#manual_import', gsi1pk: 'DATE#2026-06-16', ttl: 1813148029 }))
+    expect(item).not.toHaveProperty('pk')
+    expect(item).not.toHaveProperty('gsi1pk')
+    expect(item).not.toHaveProperty('ttl')
+  })
+
+  it('keeps a numeric sentiment_score unchanged', () => {
+    const item = normalizeFeedbackItem(rawItem({ sentiment_score: -0.75 }))
+    expect(item.sentiment_score).toBe(-0.75)
+  })
+})
+
+describe('normalizeFeedbackItems', () => {
+  it('normalizes every item in a list, coercing mixed string/number scores', () => {
+    const items = normalizeFeedbackItems([
+      rawItem({ feedback_id: 'a', sentiment_score: '0.9', rating: '5' }),
+      rawItem({ feedback_id: 'b', sentiment_score: 0, rating: 4 }),
+    ])
+    expect(items.map((i) => i.sentiment_score)).toEqual([0.9, 0])
+    expect(items.map((i) => i.rating)).toEqual([5, 4])
+  })
+})

--- a/voc-datalake/frontend/src/api/feedbackSchema.ts
+++ b/voc-datalake/frontend/src/api/feedbackSchema.ts
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Runtime validation/normalization for feedback API responses.
+ *
+ * The `/feedback*` endpoints return DynamoDB items where numeric fields
+ * (`sentiment_score`, `rating`) may arrive as JSON **strings** — records
+ * persisted as DynamoDB String attributes round-trip as `"0.9"` rather than
+ * `0.9`. The `FeedbackItem` TypeScript type declares these as `number`, so any
+ * consumer that trusts the type (e.g. `sentiment_score.toFixed()` in the PDF
+ * export) crashes at runtime.
+ *
+ * This module coerces those fields once, at the API boundary, so the rest of
+ * the app can rely on the declared `number` contract. It follows the
+ * project-wide convention of using Zod for runtime validation instead of
+ * trusting raw JSON via type assertions.
+ *
+ * @module api/feedbackSchema
+ */
+
+import { z } from 'zod'
+import type { FeedbackItem } from './types'
+
+/** Coerce an unknown value to a finite number, or `0` when not numeric. */
+function toFiniteNumberOrZero(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : 0
+}
+
+/** Coerce an unknown value to a finite number, or `undefined` when absent/invalid. */
+function toOptionalFiniteNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+// Required string fields degrade to '' rather than rejecting the whole item:
+// the previous (no-op) parser never threw, so normalization must not regress a
+// currently-rendering response into a hard failure.
+const lenientString = z.string().catch('')
+
+/**
+ * Schema for a single feedback item.
+ *
+ * - Numeric fields are coerced from possible string representations.
+ * - Unknown keys (DynamoDB GSI/internal attributes the frontend never reads)
+ *   are stripped, so the parsed object matches the `FeedbackItem` contract.
+ */
+export const FeedbackItemSchema = z.object({
+  feedback_id: lenientString,
+  source_id: lenientString,
+  source_platform: lenientString,
+  source_channel: lenientString,
+  source_url: z.string().optional(),
+  brand_name: lenientString,
+  source_created_at: lenientString,
+  processed_at: lenientString,
+  original_text: lenientString,
+  original_language: lenientString,
+  normalized_text: z.string().optional(),
+  rating: z.preprocess(toOptionalFiniteNumber, z.number().optional()),
+  category: lenientString,
+  subcategory: z.string().optional(),
+  journey_stage: lenientString,
+  sentiment_label: lenientString,
+  sentiment_score: z.preprocess(toFiniteNumberOrZero, z.number()),
+  urgency: lenientString,
+  impact_area: lenientString,
+  problem_summary: z.string().optional(),
+  problem_root_cause_hypothesis: z.string().optional(),
+  direct_customer_quote: z.string().optional(),
+  persona_name: z.string().optional(),
+  persona_type: z.string().optional(),
+})
+
+/** Normalize a single raw feedback item, coercing numeric fields. */
+export function normalizeFeedbackItem(raw: unknown): FeedbackItem {
+  return FeedbackItemSchema.parse(raw)
+}
+
+/** Normalize a list of raw feedback items, coercing numeric fields. */
+export function normalizeFeedbackItems(items: readonly unknown[]): FeedbackItem[] {
+  return items.map((item) => FeedbackItemSchema.parse(item))
+}

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -27,6 +27,60 @@ export interface FeedbackItem {
   persona_type?: string
 }
 
+/**
+ * Filter shape shared by feedback list endpoints.
+ *
+ * Used by `/feedback`, `/feedback/urgent`, and `/feedback/search`. Each filter
+ * narrows the result set independently; combine them via AND on the server.
+ */
+export interface FeedbackFilters {
+  days?: number
+  source?: string
+  category?: string
+  sentiment?: string
+}
+
+/**
+ * Query parameters for the paginated `/feedback` list endpoint.
+ *
+ * Pagination is offset-based within a candidate window (see backend
+ * `list_feedback` for window semantics). `offset` of 0 is the first page.
+ */
+export interface FeedbackListParams extends FeedbackFilters {
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Response envelope for the paginated `/feedback` list endpoint.
+ *
+ * - `count` is the size of the returned page (0..limit).
+ * - `total` is the size of the filtered candidate window — `hasMore` should be
+ *   computed as `loaded < total`, not `count < limit`.
+ * - `offset` and `limit` echo the applied request parameters.
+ * - `is_partial_window` is true when the candidate window was truncated by the
+ *   backend's MAX_FEEDBACK_OFFSET cap, meaning more matching records may exist
+ *   beyond what was counted. UI should treat `total` as a lower bound in that
+ *   case.
+ */
+export interface FeedbackListResponse {
+  count: number
+  total: number
+  offset: number
+  limit: number
+  is_partial_window: boolean
+  items: FeedbackItem[]
+}
+
+/**
+ * Response envelope for `/feedback/urgent`. Not paginated — returns up to
+ * `limit` items in one shot.
+ */
+export interface UrgentFeedbackResponse {
+  count: number
+  items: FeedbackItem[]
+}
+
 export interface MetricsSummary {
   period_days: number
   total_feedback: number

--- a/voc-datalake/frontend/src/pages/Categories/Categories.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/Categories.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { FileDown } from 'lucide-react'
 import { api, getDateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import { categoryColors, getSentimentColor } from './types'
@@ -15,6 +16,7 @@ import { SentimentGauge } from './SentimentGaugeCard'
 import { WordCloudCard } from './WordCloudCard'
 import { CategorySelector } from './CategorySelector'
 import { FeedbackResults } from './FeedbackResults'
+import { generateCategoriesPDF } from './categoriesPdfGenerator'
 
 // Stop words for word cloud filtering
 const STOP_WORDS = new Set([
@@ -243,8 +245,34 @@ export default function Categories() {
 
   const avgSentiment = sentiment ? (sentiment.percentages.positive || 0) - (sentiment.percentages.negative || 0) : 0
 
+  const exportPDF = () => {
+    try {
+      generateCategoriesPDF({
+        categoryData,
+        sentimentData,
+        wordCloudData,
+        totalIssues,
+        avgSentiment,
+        timeRange,
+        selectedSource,
+      })
+    } catch {
+      // PDF generation is best-effort (e.g. popup blocked)
+    }
+  }
+
   return (
     <div className="space-y-4 sm:space-y-6">
+      <div className="flex justify-end">
+        <button
+          onClick={exportPDF}
+          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700"
+          title="Export as PDF"
+        >
+          <FileDown size={14} />
+          Export PDF
+        </button>
+      </div>
       <SourceFilter selectedSource={selectedSource} onSourceChange={setSelectedSource} allSources={allSources} />
       <InsightsRow categoryData={categoryData} totalIssues={totalIssues} />
 

--- a/voc-datalake/frontend/src/pages/Categories/Categories.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/Categories.tsx
@@ -17,6 +17,7 @@ import { WordCloudCard } from './WordCloudCard'
 import { CategorySelector } from './CategorySelector'
 import { FeedbackResults } from './FeedbackResults'
 import { generateCategoriesPDF } from './categoriesPdfGenerator'
+import { useTranslation } from 'react-i18next'
 
 // Stop words for word cloud filtering
 const STOP_WORDS = new Set([
@@ -76,6 +77,7 @@ function checkHasActiveFilters(filters: FilterState): boolean {
 }
 
 export default function Categories() {
+  const { t } = useTranslation('common')
   const { timeRange, customDays, config } = useConfigStore()
   const dateParams = getDateRangeParams(timeRange, customDays)
 
@@ -267,10 +269,10 @@ export default function Categories() {
         <button
           onClick={exportPDF}
           className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700"
-          title="Export as PDF"
+          title={t('exportPdfTooltip')}
         >
           <FileDown size={14} />
-          Export PDF
+          {t('exportPdf')}
         </button>
       </div>
       <SourceFilter selectedSource={selectedSource} onSourceChange={setSelectedSource} allSources={allSources} />

--- a/voc-datalake/frontend/src/pages/Categories/CategoriesPDFContent.test.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/CategoriesPDFContent.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import CategoriesPDFContent, { type CategoriesPDFProps } from './CategoriesPDFContent'
+
+function makeProps(overrides: Partial<CategoriesPDFProps> = {}): CategoriesPDFProps {
+  return {
+    categoryData: [{ name: 'delivery', value: 12, color: '#ff0000' }],
+    sentimentData: [{ name: 'positive', value: 8, percentage: 67, color: '#00ff00' }],
+    wordCloudData: [{ word: 'refund', count: 5 }],
+    totalIssues: 20,
+    avgSentiment: 15,
+    timeRange: 'Last 7 days',
+    selectedSource: null,
+    ...overrides,
+  }
+}
+
+describe('CategoriesPDFContent', () => {
+  it('renders category names from categoryData', () => {
+    render(<CategoriesPDFContent {...makeProps()} />)
+    expect(screen.getByText('delivery')).toBeInTheDocument()
+  })
+
+  it('renders keyword cloud words', () => {
+    render(<CategoriesPDFContent {...makeProps({ wordCloudData: [{ word: 'shipping', count: 9 }] })} />)
+    expect(screen.getByText(/shipping/)).toBeInTheDocument()
+  })
+
+  it('renders the total issues count', () => {
+    render(<CategoriesPDFContent {...makeProps({ totalIssues: 99 })} />)
+    expect(screen.getByText('99')).toBeInTheDocument()
+  })
+
+  it('renders the selected source label when provided', () => {
+    render(<CategoriesPDFContent {...makeProps({ selectedSource: 'webscraper' })} />)
+    expect(screen.getByText(/webscraper/)).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Categories/CategoriesPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/CategoriesPDFContent.tsx
@@ -1,0 +1,382 @@
+/**
+ * @fileoverview PDF content component for categories analysis export.
+ * Renders a print-friendly view of category breakdown, sentiment, and keywords.
+ * @module pages/Categories/CategoriesPDFContent
+ */
+
+import { useTranslation } from 'react-i18next'
+
+interface CategoryDataPDF {
+  readonly name: string
+  readonly value: number
+  readonly color: string
+}
+
+interface SentimentDataPDF {
+  readonly name: string
+  readonly value: number
+  readonly percentage: number
+  readonly color: string
+}
+
+interface WordCloudItemPDF {
+  readonly word: string
+  readonly count: number
+}
+
+export interface CategoriesPDFProps {
+  readonly categoryData: CategoryDataPDF[]
+  readonly sentimentData: SentimentDataPDF[]
+  readonly wordCloudData: WordCloudItemPDF[]
+  readonly totalIssues: number
+  readonly avgSentiment: number
+  readonly timeRange: string
+  readonly selectedSource?: string | null
+}
+
+function getSentimentLabel(avgSentiment: number, t: (key: string) => string): string {
+  if (avgSentiment > 20) return t('positive')
+  if (avgSentiment < -20) return t('negative')
+  return t('neutral')
+}
+
+function getSentimentHeaderColor(avgSentiment: number): string {
+  if (avgSentiment > 20) return '#166534'
+  if (avgSentiment < -20) return '#991b1b'
+  return '#374151'
+}
+
+function HeaderSection({
+  categoryData, totalIssues, avgSentiment, timeRange, selectedSource,
+}: CategoriesPDFProps) {
+  const { t } = useTranslation('categories')
+  const sentimentLabel = getSentimentLabel(avgSentiment, t)
+  const sentimentColor = getSentimentHeaderColor(avgSentiment)
+
+  return (
+    <div data-pdf-section style={{ marginBottom: '24px' }}>
+      <h1 style={{
+        fontSize: '28px',
+        fontWeight: 'bold',
+        margin: '0 0 4px 0',
+        color: '#111827',
+      }}>
+        {t('pdf.title')}
+      </h1>
+      <p style={{
+        fontSize: '14px',
+        color: '#6b7280',
+        margin: '0 0 16px 0',
+      }}>
+        {selectedSource != null && selectedSource !== ''
+          ? t('pdf.timeRangeWithSource', {
+            range: timeRange,
+            source: selectedSource,
+          })
+          : t('pdf.timeRange', { range: timeRange })}
+      </p>
+      <div style={{
+        display: 'flex',
+        gap: '16px',
+        flexWrap: 'wrap',
+      }}>
+        {[
+          {
+            label: t('pdf.categoriesLabel'),
+            value: String(categoryData.length),
+            bg: '#f0f9ff',
+            color: '#1d4ed8',
+          },
+          {
+            label: t('pdf.totalFeedback'),
+            value: String(totalIssues),
+            bg: '#f0fdf4',
+            color: '#166534',
+          },
+          {
+            label: t('pdf.sentimentLabel'),
+            value: `${sentimentLabel} (${avgSentiment.toFixed(0)}%)`,
+            bg: '#faf5ff',
+            color: sentimentColor,
+          },
+        ].map((stat) => (
+          <div key={stat.label} style={{
+            padding: '12px 20px',
+            backgroundColor: stat.bg,
+            borderRadius: '8px',
+            minWidth: '140px',
+          }}>
+            <p style={{
+              fontSize: '12px',
+              color: stat.color,
+              fontWeight: '500',
+              margin: '0 0 4px 0',
+            }}>{stat.label}</p>
+            <p style={{
+              fontSize: '20px',
+              fontWeight: 'bold',
+              color: stat.color,
+              margin: 0,
+            }}>{stat.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function CategoryBreakdownSection({
+  categoryData, totalIssues,
+}: {
+  readonly categoryData: CategoryDataPDF[];
+  readonly totalIssues: number
+}) {
+  const { t } = useTranslation('categories')
+
+  if (categoryData.length === 0) return null
+
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <h2 style={{
+        fontSize: '18px',
+        fontWeight: '600',
+        color: '#1e293b',
+        marginBottom: '12px',
+      }}>{t('pdf.categoryBreakdown')}</h2>
+      <table style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        fontSize: '13px',
+      }}>
+        <thead>
+          <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 12px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>{t('pdf.category')}</th>
+            <th style={{
+              textAlign: 'right',
+              padding: '8px 12px',
+              color: '#6b7280',
+              fontWeight: '600',
+              width: '80px',
+            }}>{t('pdf.count')}</th>
+            <th style={{
+              textAlign: 'right',
+              padding: '8px 12px',
+              color: '#6b7280',
+              fontWeight: '600',
+              width: '80px',
+            }}>{t('pdf.share')}</th>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 12px',
+              color: '#6b7280',
+              fontWeight: '600',
+              width: '200px',
+            }}>{t('pdf.distribution')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {categoryData.map((cat, i) => {
+            const percentage = totalIssues > 0 ? (cat.value / totalIssues) * 100 : 0
+            return (
+              <tr key={cat.name} style={{
+                borderBottom: '1px solid #f3f4f6',
+                backgroundColor: i % 2 === 0 ? '#ffffff' : '#f9fafb',
+              }}>
+                <td style={{
+                  padding: '8px 12px',
+                  textTransform: 'capitalize',
+                  fontWeight: '500',
+                  color: '#1f2937',
+                }}>
+                  <span style={{
+                    display: 'inline-block',
+                    width: '10px',
+                    height: '10px',
+                    borderRadius: '50%',
+                    backgroundColor: cat.color,
+                    marginRight: '8px',
+                    verticalAlign: 'middle',
+                  }} />
+                  {cat.name.replaceAll('_', ' ')}
+                </td>
+                <td style={{
+                  textAlign: 'right',
+                  padding: '8px 12px',
+                  color: '#374151',
+                }}>{cat.value}</td>
+                <td style={{
+                  textAlign: 'right',
+                  padding: '8px 12px',
+                  color: '#374151',
+                }}>{percentage.toFixed(1)}%</td>
+                <td style={{ padding: '8px 12px' }}>
+                  <div style={{
+                    width: '100%',
+                    height: '16px',
+                    backgroundColor: '#f3f4f6',
+                    borderRadius: '8px',
+                    overflow: 'hidden',
+                  }}>
+                    <div style={{
+                      width: `${percentage}%`,
+                      height: '100%',
+                      backgroundColor: cat.color,
+                      borderRadius: '8px',
+                      minWidth: percentage > 0 ? '4px' : '0',
+                    }} />
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function SentimentSection({ sentimentData }: { readonly sentimentData: SentimentDataPDF[] }) {
+  const { t } = useTranslation('categories')
+
+  if (sentimentData.length === 0) return null
+
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <h2 style={{
+        fontSize: '18px',
+        fontWeight: '600',
+        color: '#1e293b',
+        marginBottom: '12px',
+      }}>{t('pdf.sentimentDistribution')}</h2>
+      <div style={{
+        display: 'flex',
+        gap: '12px',
+        flexWrap: 'wrap',
+      }}>
+        {sentimentData.map((s) => (
+          <div key={s.name} data-pdf-section style={{
+            padding: '12px 20px',
+            borderRadius: '8px',
+            border: '1px solid #e5e7eb',
+            minWidth: '120px',
+            flex: '1',
+          }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              marginBottom: '4px',
+            }}>
+              <span style={{
+                display: 'inline-block',
+                width: '10px',
+                height: '10px',
+                borderRadius: '50%',
+                backgroundColor: s.color,
+              }} />
+              <span style={{
+                fontSize: '13px',
+                fontWeight: '500',
+                color: '#374151',
+                textTransform: 'capitalize',
+              }}>{s.name}</span>
+            </div>
+            <p style={{
+              fontSize: '22px',
+              fontWeight: 'bold',
+              color: '#1f2937',
+              margin: '0 0 2px 0',
+            }}>{s.value}</p>
+            <p style={{
+              fontSize: '12px',
+              color: '#6b7280',
+              margin: 0,
+            }}>{s.percentage.toFixed(1)}%</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function KeywordsSection({ wordCloudData }: { readonly wordCloudData: WordCloudItemPDF[] }) {
+  const { t } = useTranslation('categories')
+
+  if (wordCloudData.length === 0) return null
+
+  const maxCount = wordCloudData[0]?.count ?? 1
+
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <h2 style={{
+        fontSize: '18px',
+        fontWeight: '600',
+        color: '#1e293b',
+        marginBottom: '12px',
+      }}>{t('pdf.topKeywords')}</h2>
+      <div style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px',
+      }}>
+        {wordCloudData.map((item) => {
+          const intensity = Math.max(0.3, item.count / maxCount)
+          const fontSize = 11 + Math.round(intensity * 8)
+          return (
+            <span key={item.word} style={{
+              padding: '4px 10px',
+              backgroundColor: `rgba(59, 130, 246, ${intensity * 0.15})`,
+              color: `rgba(30, 64, 175, ${0.5 + intensity * 0.5})`,
+              borderRadius: '6px',
+              fontSize: `${fontSize}px`,
+              fontWeight: intensity > 0.6 ? '600' : '400',
+            }}>
+              {item.word} ({item.count})
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default function CategoriesPDFContent(props: CategoriesPDFProps) {
+  const { t } = useTranslation('categories')
+
+  return (
+    <div style={{
+      padding: '40px',
+      backgroundColor: 'white',
+    }}>
+      <HeaderSection {...props} />
+      <hr style={{
+        border: 'none',
+        borderTop: '2px solid #e5e7eb',
+        marginBottom: '24px',
+      }} />
+      <CategoryBreakdownSection categoryData={props.categoryData} totalIssues={props.totalIssues} />
+      <SentimentSection sentimentData={props.sentimentData} />
+      <KeywordsSection wordCloudData={props.wordCloudData} />
+      <div data-pdf-section>
+        <hr style={{
+          border: 'none',
+          borderTop: '1px solid #e5e7eb',
+          marginTop: '32px',
+          marginBottom: '16px',
+        }} />
+        <p style={{
+          fontSize: '11px',
+          color: '#9ca3af',
+          textAlign: 'center',
+        }}>
+          {t('pdf.generatedOn', { date: new Date().toLocaleDateString() })}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Categories/categoriesPdfGenerator.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/categoriesPdfGenerator.tsx
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview PDF generation for categories analysis export.
+ * @module pages/Categories/categoriesPdfGenerator
+ */
+
+import { createPdfGenerator } from '../../utils/printUtils'
+import CategoriesPDFContent from './CategoriesPDFContent'
+import type { CategoriesPDFProps } from './CategoriesPDFContent'
+
+export const generateCategoriesPDF = createPdfGenerator<CategoriesPDFProps>(
+  'Categories Analysis Report',
+  (props) => <CategoriesPDFContent {...props} />,
+)

--- a/voc-datalake/frontend/src/pages/Dashboard/BreakdownTable.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/BreakdownTable.tsx
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Breakdown table component for PDF export.
+ * @module pages/Dashboard/BreakdownTable
+ */
+
+interface BreakdownEntry {
+  readonly name: string
+  readonly value: number
+}
+
+const thStyle = {
+  textAlign: 'left' as const,
+  padding: '6px 8px',
+  color: '#6b7280',
+  fontWeight: '600' as const,
+}
+const thRight = {
+  ...thStyle,
+  textAlign: 'right' as const,
+  width: '60px',
+}
+
+export function BreakdownTable({
+  title, emoji, entries, colorFn,
+}: {
+  readonly title: string
+  readonly emoji: string
+  readonly entries: BreakdownEntry[]
+  readonly colorFn?: (name: string) => string
+}) {
+  if (entries.length === 0) return null
+  const total = entries.reduce((sum, e) => sum + e.value, 0)
+  return (
+    <div data-pdf-section style={{
+      marginBottom: '28px',
+      flex: '1',
+      minWidth: '280px',
+    }}>
+      <h2 style={{
+        fontSize: '18px',
+        fontWeight: '600',
+        color: '#1e293b',
+        marginBottom: '12px',
+      }}>{emoji} {title}</h2>
+      <table style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        fontSize: '13px',
+      }}>
+        <thead>
+          <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+            <th style={thStyle}>Name</th>
+            <th style={thRight}>Count</th>
+            <th style={thRight}>Share</th>
+            <th style={{
+              ...thStyle,
+              width: '140px',
+            }} />
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry, i) => {
+            const pct = total > 0 ? (entry.value / total) * 100 : 0
+            const barColor = colorFn ? colorFn(entry.name) : '#3b82f6'
+            return (
+              <tr key={entry.name} style={{
+                borderBottom: '1px solid #f3f4f6',
+                backgroundColor: i % 2 === 0 ? '#ffffff' : '#f9fafb',
+              }}>
+                <td style={{
+                  padding: '6px 8px',
+                  textTransform: 'capitalize',
+                  fontWeight: '500',
+                  color: '#1f2937',
+                }}>{entry.name.replaceAll('_', ' ')}</td>
+                <td style={{
+                  textAlign: 'right',
+                  padding: '6px 8px',
+                  color: '#374151',
+                }}>{entry.value}</td>
+                <td style={{
+                  textAlign: 'right',
+                  padding: '6px 8px',
+                  color: '#374151',
+                }}>{pct.toFixed(1)}%</td>
+                <td style={{ padding: '6px 8px' }}>
+                  <div style={{
+                    width: '100%',
+                    height: '12px',
+                    backgroundColor: '#f3f4f6',
+                    borderRadius: '6px',
+                    overflow: 'hidden',
+                  }}>
+                    <div style={{
+                      width: `${pct}%`,
+                      height: '100%',
+                      backgroundColor: barColor,
+                      borderRadius: '6px',
+                      minWidth: pct > 0 ? '3px' : '0',
+                    }} />
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import MetricCard from '../../components/MetricCard'
 import FeedbackCard from '../../components/FeedbackCard'
 import SocialFeed from '../../components/SocialFeed'
 import { generateDashboardPDF } from './dashboardPdfGenerator'
+import { getTimeRangeLabel } from '../../utils/dateUtils'
 import { useTranslation } from 'react-i18next'
 
 const COLORS = ['#22c55e', '#6b7280', '#ef4444', '#eab308']
@@ -339,7 +340,7 @@ export default function Dashboard() {
         categories,
         sources,
         urgentFeedback,
-        timeRange,
+        timeRange: getTimeRangeLabel(timeRange, customDays),
         sourcesCount,
       }))
     } catch {

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -12,13 +12,14 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, BarChart, Bar } from 'recharts'
-import { MessageSquare, TrendingUp, AlertTriangle, Users, Zap } from 'lucide-react'
+import { MessageSquare, TrendingUp, AlertTriangle, Users, Zap, FileDown } from 'lucide-react'
 import { api, getDateRangeParams } from '../../api/client'
 import type { MetricsSummary, SentimentBreakdown, CategoryBreakdown, SourceBreakdown, FeedbackItem } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import MetricCard from '../../components/MetricCard'
 import FeedbackCard from '../../components/FeedbackCard'
 import SocialFeed from '../../components/SocialFeed'
+import { generateDashboardPDF } from './dashboardPdfGenerator'
 
 const COLORS = ['#22c55e', '#6b7280', '#ef4444', '#eab308']
 
@@ -243,6 +244,46 @@ function UrgentFeedback({ items, count }: Readonly<UrgentFeedbackProps>) {
   )
 }
 
+interface PDFExportInput {
+  summary: MetricsSummary | undefined
+  sentiment: SentimentBreakdown | undefined
+  categories: CategoryBreakdown | undefined
+  sources: SourceBreakdown | undefined
+  urgentFeedback: { items?: FeedbackItem[]; count?: number } | undefined
+  timeRange: string
+  sourcesCount: number
+}
+
+function buildSentimentEntries(sentiment: SentimentBreakdown | undefined) {
+  if (!sentiment) return []
+  return Object.entries(sentiment.breakdown)
+    .filter(([, v]) => v > 0)
+    .map(([name, value]) => ({ name, value }))
+}
+
+function buildCategoryEntries(categories: CategoryBreakdown | undefined) {
+  if (!categories) return []
+  return Object.entries(categories.categories)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 10)
+    .map(([name, value]) => ({ name, value }))
+}
+
+function buildPDFExportData(input: PDFExportInput) {
+  return {
+    timeRange: input.timeRange,
+    totalFeedback: input.summary?.total_feedback ?? 0,
+    avgSentiment: input.summary ? Number(input.summary.avg_sentiment) : 0,
+    urgentCount: input.summary?.urgent_count ?? 0,
+    sourcesCount: input.sourcesCount,
+    dailyTotals: input.summary?.daily_totals ?? [],
+    sentimentBreakdown: buildSentimentEntries(input.sentiment),
+    categoryBreakdown: buildCategoryEntries(input.categories),
+    sourceBreakdown: prepareSourceData(input.sources),
+    urgentItems: input.urgentFeedback?.items ?? [],
+  }
+}
+
 export default function Dashboard() {
   const { timeRange, customDays, config } = useConfigStore()
   const dateParams = getDateRangeParams(timeRange, customDays)
@@ -288,8 +329,35 @@ export default function Dashboard() {
 
   const sourcesCount = Object.keys(sources?.sources || {}).length
 
+  const exportPDF = () => {
+    try {
+      generateDashboardPDF(buildPDFExportData({
+        summary,
+        sentiment,
+        categories,
+        sources,
+        urgentFeedback,
+        timeRange,
+        sourcesCount,
+      }))
+    } catch {
+      // PDF generation is best-effort (e.g. popup blocked)
+    }
+  }
+
   return (
     <div className="space-y-4 sm:space-y-6">
+      <div className="flex justify-end">
+        <button
+          onClick={exportPDF}
+          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700"
+          title="Export as PDF"
+        >
+          <FileDown size={14} />
+          Export PDF
+        </button>
+      </div>
+
       <MetricsGrid summary={summary} sourcesCount={sourcesCount} />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import MetricCard from '../../components/MetricCard'
 import FeedbackCard from '../../components/FeedbackCard'
 import SocialFeed from '../../components/SocialFeed'
 import { generateDashboardPDF } from './dashboardPdfGenerator'
+import { useTranslation } from 'react-i18next'
 
 const COLORS = ['#22c55e', '#6b7280', '#ef4444', '#eab308']
 
@@ -285,6 +286,7 @@ function buildPDFExportData(input: PDFExportInput) {
 }
 
 export default function Dashboard() {
+  const { t } = useTranslation('common')
   const { timeRange, customDays, config } = useConfigStore()
   const dateParams = getDateRangeParams(timeRange, customDays)
   const isConfigured = !!config.apiEndpoint
@@ -351,10 +353,10 @@ export default function Dashboard() {
         <button
           onClick={exportPDF}
           className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700"
-          title="Export as PDF"
+          title={t('exportPdfTooltip')}
         >
           <FileDown size={14} />
-          Export PDF
+          {t('exportPdf')}
         </button>
       </div>
 

--- a/voc-datalake/frontend/src/pages/Dashboard/DashboardPDFContent.test.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/DashboardPDFContent.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import DashboardPDFContent, { type DashboardPDFProps } from './DashboardPDFContent'
+
+function makeProps(overrides: Partial<DashboardPDFProps> = {}): DashboardPDFProps {
+  return {
+    timeRange: 'Last 7 days',
+    totalFeedback: 1234,
+    avgSentiment: 0.45,
+    urgentCount: 7,
+    sourcesCount: 3,
+    dailyTotals: [{ date: '2026-06-01', count: 10 }],
+    sentimentBreakdown: [{ name: 'positive', value: 60 }],
+    categoryBreakdown: [{ name: 'delivery', value: 12 }],
+    sourceBreakdown: [{ name: 'webscraper', value: 20 }],
+    urgentItems: [],
+    ...overrides,
+  }
+}
+
+describe('DashboardPDFContent', () => {
+  it('renders the total feedback metric', () => {
+    render(<DashboardPDFContent {...makeProps()} />)
+    expect(screen.getByText('Total Feedback')).toBeInTheDocument()
+    expect(screen.getByText('1234')).toBeInTheDocument()
+  })
+
+  it('formats average sentiment to two decimals', () => {
+    render(<DashboardPDFContent {...makeProps({ avgSentiment: 0.4567 })} />)
+    expect(screen.getByText('Avg Sentiment')).toBeInTheDocument()
+    expect(screen.getByText('0.46')).toBeInTheDocument()
+  })
+
+  it('renders the urgent issues count', () => {
+    render(<DashboardPDFContent {...makeProps({ urgentCount: 9 })} />)
+    expect(screen.getByText('Urgent Issues')).toBeInTheDocument()
+    expect(screen.getByText('9')).toBeInTheDocument()
+  })
+
+  it('renders category breakdown entries', () => {
+    render(<DashboardPDFContent {...makeProps({ categoryBreakdown: [{ name: 'shipping', value: 42 }] })} />)
+    expect(screen.getByText('shipping')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  it('renders the selected time range', () => {
+    render(<DashboardPDFContent {...makeProps({ timeRange: 'Last 30 days' })} />)
+    expect(screen.getByText(/Last 30 days/)).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Dashboard/DashboardPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/DashboardPDFContent.tsx
@@ -1,0 +1,336 @@
+/**
+ * @fileoverview PDF content component for dashboard export.
+ * Renders a print-friendly summary of dashboard metrics, trends, and breakdowns.
+ * @module pages/Dashboard/DashboardPDFContent
+ */
+
+import { sentimentHexColor } from '../../lib/sentiment'
+import { BreakdownTable } from './BreakdownTable'
+import type { FeedbackItem } from '../../api/types'
+
+interface DailyTotal {
+  readonly date: string;
+  readonly count: number
+}
+interface BreakdownEntry {
+  readonly name: string;
+  readonly value: number
+}
+
+export interface DashboardPDFProps {
+  readonly timeRange: string
+  readonly totalFeedback: number
+  readonly avgSentiment: number
+  readonly urgentCount: number
+  readonly sourcesCount: number
+  readonly dailyTotals: DailyTotal[]
+  readonly sentimentBreakdown: BreakdownEntry[]
+  readonly categoryBreakdown: BreakdownEntry[]
+  readonly sourceBreakdown: BreakdownEntry[]
+  readonly urgentItems: readonly FeedbackItem[]
+}
+
+function getHeaderSentimentColor(avgSentiment: number): string {
+  if (avgSentiment > 0) return '#166534'
+  if (avgSentiment < 0) return '#991b1b'
+  return '#374151'
+}
+
+const sectionHeading = {
+  fontSize: '18px',
+  fontWeight: '600' as const,
+  color: '#1e293b',
+  marginBottom: '12px',
+}
+
+function HeaderSection({
+  timeRange, totalFeedback, avgSentiment, urgentCount, sourcesCount,
+}: DashboardPDFProps) {
+  const sentimentColor = getHeaderSentimentColor(avgSentiment)
+  const stats = [
+    {
+      label: 'Total Feedback',
+      value: String(totalFeedback),
+      bg: '#f0f9ff',
+      color: '#1d4ed8',
+    },
+    {
+      label: 'Avg Sentiment',
+      value: avgSentiment.toFixed(2),
+      bg: '#f0fdf4',
+      color: sentimentColor,
+    },
+    {
+      label: 'Urgent Issues',
+      value: String(urgentCount),
+      bg: '#fef2f2',
+      color: '#991b1b',
+    },
+    {
+      label: 'Sources Active',
+      value: String(sourcesCount),
+      bg: '#f5f3ff',
+      color: '#5b21b6',
+    },
+  ]
+  return (
+    <div data-pdf-section style={{ marginBottom: '24px' }}>
+      <h1 style={{
+        fontSize: '28px',
+        fontWeight: 'bold',
+        margin: '0 0 4px 0',
+        color: '#111827',
+      }}>Dashboard Report</h1>
+      <p style={{
+        fontSize: '14px',
+        color: '#6b7280',
+        margin: '0 0 16px 0',
+      }}>Time range: {timeRange}</p>
+      <div style={{
+        display: 'flex',
+        gap: '16px',
+        flexWrap: 'wrap',
+      }}>
+        {stats.map((stat) => (
+          <div key={stat.label} style={{
+            padding: '12px 20px',
+            backgroundColor: stat.bg,
+            borderRadius: '8px',
+            minWidth: '130px',
+          }}>
+            <p style={{
+              fontSize: '12px',
+              color: stat.color,
+              fontWeight: '500',
+              margin: '0 0 4px 0',
+            }}>{stat.label}</p>
+            <p style={{
+              fontSize: '24px',
+              fontWeight: 'bold',
+              color: stat.color,
+              margin: 0,
+            }}>{stat.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TrendSection({ dailyTotals }: { readonly dailyTotals: DailyTotal[] }) {
+  if (dailyTotals.length === 0) return null
+  const sorted = [...dailyTotals].sort((a, b) => a.date.localeCompare(b.date))
+  const maxCount = Math.max(...sorted.map((d) => d.count), 1)
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <h2 style={sectionHeading}>📈 Feedback Volume Trend</h2>
+      <div style={{
+        display: 'flex',
+        alignItems: 'flex-end',
+        gap: '2px',
+        height: '120px',
+        padding: '0 4px',
+      }}>
+        {sorted.map((day) => {
+          const height = Math.max(4, (day.count / maxCount) * 100)
+          return (
+            <div key={day.date} style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: '4px',
+            }}>
+              <span style={{
+                fontSize: '9px',
+                color: '#6b7280',
+              }}>{day.count > 0 ? day.count : ''}</span>
+              <div style={{
+                width: '100%',
+                maxWidth: '24px',
+                height: `${height}px`,
+                backgroundColor: '#3b82f6',
+                borderRadius: '2px 2px 0 0',
+              }} />
+            </div>
+          )
+        })}
+      </div>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        marginTop: '4px',
+        fontSize: '10px',
+        color: '#9ca3af',
+      }}>
+        <span>{sorted[0]?.date}</span>
+        <span>{sorted.at(-1)?.date}</span>
+      </div>
+    </div>
+  )
+}
+
+function SentimentSection({ sentimentBreakdown }: { readonly sentimentBreakdown: BreakdownEntry[] }) {
+  if (sentimentBreakdown.length === 0) return null
+  const total = sentimentBreakdown.reduce((sum, s) => sum + s.value, 0)
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <h2 style={sectionHeading}>😊 Sentiment Distribution</h2>
+      <div style={{
+        display: 'flex',
+        gap: '12px',
+        flexWrap: 'wrap',
+      }}>
+        {sentimentBreakdown.map((s) => {
+          const pct = total > 0 ? ((s.value / total) * 100).toFixed(1) : '0'
+          return (
+            <div key={s.name} data-pdf-section style={{
+              padding: '12px 20px',
+              borderRadius: '8px',
+              border: '1px solid #e5e7eb',
+              flex: '1',
+              minWidth: '100px',
+            }}>
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                marginBottom: '4px',
+              }}>
+                <span style={{
+                  display: 'inline-block',
+                  width: '10px',
+                  height: '10px',
+                  borderRadius: '50%',
+                  backgroundColor: sentimentHexColor(s.name),
+                }} />
+                <span style={{
+                  fontSize: '13px',
+                  fontWeight: '500',
+                  color: '#374151',
+                  textTransform: 'capitalize',
+                }}>{s.name}</span>
+              </div>
+              <p style={{
+                fontSize: '22px',
+                fontWeight: 'bold',
+                color: '#1f2937',
+                margin: '0 0 2px 0',
+              }}>{s.value}</p>
+              <p style={{
+                fontSize: '12px',
+                color: '#6b7280',
+                margin: 0,
+              }}>{pct}%</p>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function UrgentSection({ urgentItems }: { readonly urgentItems: readonly FeedbackItem[] }) {
+  if (urgentItems.length === 0) return null
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <h2 style={{
+        ...sectionHeading,
+        color: '#dc2626',
+      }}>🚨 Urgent Issues</h2>
+      {urgentItems.map((item) => (
+        <UrgentItem key={item.feedback_id} item={item} />
+      ))}
+    </div>
+  )
+}
+
+function UrgentItem({ item }: { readonly item: FeedbackItem }) {
+  const dateStr = item.source_created_at === '' ? '' : new Date(item.source_created_at).toLocaleDateString()
+  const text = item.original_text.length > 200 ? item.original_text.slice(0, 200) + '…' : item.original_text
+  return (
+    <div data-pdf-section style={{
+      padding: '10px 14px',
+      borderLeft: '3px solid #ef4444',
+      marginBottom: '8px',
+      backgroundColor: '#fef2f2',
+      borderRadius: '0 6px 6px 0',
+    }}>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: '4px',
+      }}>
+        <span style={{
+          fontSize: '12px',
+          fontWeight: '500',
+          color: '#374151',
+          textTransform: 'capitalize',
+        }}>
+          {item.source_platform.replaceAll('_', ' ')} • {item.category.replaceAll('_', ' ')}
+        </span>
+        <span style={{
+          fontSize: '11px',
+          color: '#6b7280',
+        }}>{dateStr}</span>
+      </div>
+      <p style={{
+        fontSize: '12px',
+        color: '#374151',
+        margin: '0 0 4px 0',
+        lineHeight: '1.5',
+      }}>{text}</p>
+      {item.problem_summary != null && item.problem_summary !== '' ? (
+        <p style={{
+          fontSize: '11px',
+          color: '#6b7280',
+          margin: 0,
+          fontStyle: 'italic',
+        }}>Problem: {item.problem_summary}</p>
+      ) : null}
+    </div>
+  )
+}
+
+export default function DashboardPDFContent(props: DashboardPDFProps) {
+  return (
+    <div style={{
+      padding: '40px',
+      backgroundColor: 'white',
+    }}>
+      <HeaderSection {...props} />
+      <hr style={{
+        border: 'none',
+        borderTop: '2px solid #e5e7eb',
+        marginBottom: '24px',
+      }} />
+      <TrendSection dailyTotals={props.dailyTotals} />
+      <SentimentSection sentimentBreakdown={props.sentimentBreakdown} />
+      <div style={{
+        display: 'flex',
+        gap: '24px',
+        flexWrap: 'wrap',
+      }}>
+        <BreakdownTable title="Categories" emoji="📊" entries={props.categoryBreakdown} />
+        <BreakdownTable title="Sources" emoji="🔗" entries={props.sourceBreakdown} colorFn={() => '#8b5cf6'} />
+      </div>
+      <UrgentSection urgentItems={props.urgentItems} />
+      <div data-pdf-section>
+        <hr style={{
+          border: 'none',
+          borderTop: '1px solid #e5e7eb',
+          marginTop: '32px',
+          marginBottom: '16px',
+        }} />
+        <p style={{
+          fontSize: '11px',
+          color: '#9ca3af',
+          textAlign: 'center',
+        }}>
+          Generated on {new Date().toLocaleDateString()} • VoC Analytics — Dashboard Report
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Dashboard/dashboardPdfGenerator.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/dashboardPdfGenerator.tsx
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview PDF generation for dashboard export.
+ * @module pages/Dashboard/dashboardPdfGenerator
+ */
+
+import { createPdfGenerator } from '../../utils/printUtils'
+import DashboardPDFContent from './DashboardPDFContent'
+import type { DashboardPDFProps } from './DashboardPDFContent'
+
+export const generateDashboardPDF = createPdfGenerator<DashboardPDFProps>(
+  'Dashboard Report',
+  (props) => <DashboardPDFContent {...props} />,
+)

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.test.tsx
@@ -150,6 +150,23 @@ describe('Feedback', () => {
       expect(screen.getByText(/narrow filters to see all/)).toBeInTheDocument()
     })
 
+    it('does not show "+" or the hint when all counted items are displayed (regression: "N of N+")', async () => {
+      // A narrow filter can yield is_partial_window=true from the backend while
+      // count === total. Claiming "more exist" would be misleading, so the UI
+      // must render a plain "N of N" with no "+" and no narrow-filters hint.
+      mockGetFeedback.mockResolvedValue({
+        count: 2, total: 2, offset: 0, limit: 100,
+        is_partial_window: true, items: mockFeedbackItems.slice(0, 2),
+      })
+      render(<Feedback />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Showing 2 of 2 results/)).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/Showing 2 of 2\+ results/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/narrow filters to see all/)).not.toBeInTheDocument()
+    })
+
     it('displays item count', async () => {
       render(<Feedback />, { wrapper: createWrapper() })
       

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.test.tsx
@@ -133,7 +133,7 @@ describe('Feedback', () => {
       render(<Feedback />, { wrapper: createWrapper() })
 
       await waitFor(() => {
-        expect(screen.getByText(/Showing 3 of 250 items/)).toBeInTheDocument()
+        expect(screen.getByText(/Showing 3 of 250 results/)).toBeInTheDocument()
       })
     })
 
@@ -145,7 +145,7 @@ describe('Feedback', () => {
       render(<Feedback />, { wrapper: createWrapper() })
 
       await waitFor(() => {
-        expect(screen.getByText(/Showing 3 of 1000\+ items/)).toBeInTheDocument()
+        expect(screen.getByText(/Showing 3 of 1000\+ results/)).toBeInTheDocument()
       })
       expect(screen.getByText(/narrow filters to see all/)).toBeInTheDocument()
     })
@@ -154,7 +154,7 @@ describe('Feedback', () => {
       render(<Feedback />, { wrapper: createWrapper() })
       
       await waitFor(() => {
-        expect(screen.getByText(/Showing 3 of 3 items/i)).toBeInTheDocument()
+        expect(screen.getByText(/Showing 3 of 3 results/i)).toBeInTheDocument()
       })
     })
 

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.test.tsx
@@ -125,6 +125,31 @@ describe('Feedback', () => {
       })
     })
 
+    it('shows the real total from the paginated response', async () => {
+      mockGetFeedback.mockResolvedValue({
+        count: 3, total: 250, offset: 0, limit: 100,
+        is_partial_window: false, items: mockFeedbackItems,
+      })
+      render(<Feedback />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Showing 3 of 250 items/)).toBeInTheDocument()
+      })
+    })
+
+    it('flags a truncated candidate window with a "+" and a narrow-filters hint', async () => {
+      mockGetFeedback.mockResolvedValue({
+        count: 3, total: 1000, offset: 0, limit: 100,
+        is_partial_window: true, items: mockFeedbackItems,
+      })
+      render(<Feedback />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Showing 3 of 1000\+ items/)).toBeInTheDocument()
+      })
+      expect(screen.getByText(/narrow filters to see all/)).toBeInTheDocument()
+    })
+
     it('displays item count', async () => {
       render(<Feedback />, { wrapper: createWrapper() })
       

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
@@ -16,6 +16,7 @@ import { useSearchParams } from 'react-router-dom'
 import { Search, Filter, SortDesc, X, FileDown } from 'lucide-react'
 import { api, getDateRangeParams } from '../../api/client'
 import type { FeedbackItem, DateRangeParams } from '../../api/client'
+import { getTimeRangeLabel } from '../../utils/dateUtils'
 import { useConfigStore } from '../../store/configStore'
 import FeedbackCard from '../../components/FeedbackCard'
 import { generateFeedbackPDF } from './feedbackPdfGenerator'
@@ -169,15 +170,19 @@ function ResultsHeader({
   onClearFilters: () => void
 }>) {
   // When the candidate window was truncated by the backend cap, `totalCount`
-  // is a lower bound — show "N+" and a hint to narrow filters.
+  // is a lower bound — show "N+" and a hint to narrow filters. Only do so when
+  // there are genuinely more matches than are displayed (`totalCount >
+  // itemCount`); otherwise the user already sees everything counted and "N+"
+  // would be misleading (e.g. "2 of 2+").
   const { t } = useTranslation('common')
-  const totalLabel = isPartialWindow ? `${totalCount}+` : `${totalCount}`
+  const showPartial = isPartialWindow && totalCount > itemCount
+  const totalLabel = showPartial ? `${totalCount}+` : `${totalCount}`
   return (
     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
       <p className="text-sm text-gray-500">
         {t('showingOf', { count: itemCount, total: totalLabel })}
         {search && <span className="ml-1">for "{search}"</span>}
-        {isPartialWindow && (
+        {showPartial && (
           <span className="ml-1 text-amber-600">({t('partialWindowHint')})</span>
         )}
       </p>
@@ -222,8 +227,10 @@ function PDFExportButton({
           urgentOnly: filterState.showUrgentOnly,
         },
       })
-    } catch {
-      // PDF generation is best-effort (e.g. popup blocked)
+    } catch (err) {
+      // PDF generation is best-effort (e.g. popup blocked). Surface the cause
+      // instead of failing silently with an empty window.
+      console.error('Feedback PDF export failed:', err)
     }
   }
   return (
@@ -428,7 +435,7 @@ export default function Feedback() {
         onClearFilters={clearFilters}
       />
 
-      <PDFExportButton items={filteredItems} timeRange={timeRange} filterState={filterState} />
+      <PDFExportButton items={filteredItems} timeRange={getTimeRangeLabel(timeRange, customDays)} filterState={filterState} />
 
       <FeedbackListContent isLoading={activeLoading} items={filteredItems} />
     </div>

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
@@ -13,11 +13,12 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useSearchParams } from 'react-router-dom'
-import { Search, Filter, SortDesc, X } from 'lucide-react'
+import { Search, Filter, SortDesc, X, FileDown } from 'lucide-react'
 import { api, getDateRangeParams } from '../../api/client'
 import type { FeedbackItem, DateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import FeedbackCard from '../../components/FeedbackCard'
+import { generateFeedbackPDF } from './feedbackPdfGenerator'
 
 const sentiments = ['all', 'positive', 'neutral', 'negative', 'mixed']
 const defaultCategories = ['all', 'delivery', 'customer_support', 'product_quality', 'pricing', 'website', 'app', 'billing', 'returns', 'communication', 'other']
@@ -182,6 +183,48 @@ function ResultsHeader({
           Most recent
         </button>
       </div>
+    </div>
+  )
+}
+
+// PDF export button - exports the current (filtered) feedback list
+function PDFExportButton({
+  items,
+  timeRange,
+  filterState,
+}: Readonly<{
+  items: readonly FeedbackItem[]
+  timeRange: string
+  filterState: FilterState
+}>) {
+  if (items.length === 0) return null
+  const exportPDF = () => {
+    try {
+      generateFeedbackPDF({
+        items,
+        timeRange,
+        filters: {
+          source: filterState.sourceFilter,
+          sentiment: filterState.sentimentFilter,
+          category: filterState.categoryFilter,
+          search: filterState.search,
+          urgentOnly: filterState.showUrgentOnly,
+        },
+      })
+    } catch {
+      // PDF generation is best-effort (e.g. popup blocked)
+    }
+  }
+  return (
+    <div className="flex justify-end">
+      <button
+        onClick={exportPDF}
+        className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700"
+        title="Export as PDF"
+      >
+        <FileDown size={14} />
+        Export PDF
+      </button>
     </div>
   )
 }
@@ -362,6 +405,8 @@ export default function Feedback() {
         hasActiveFilters={hasActiveFilters}
         onClearFilters={clearFilters}
       />
+
+      <PDFExportButton items={filteredItems} timeRange={timeRange} filterState={filterState} />
 
       <FeedbackListContent isLoading={activeLoading} items={filteredItems} />
     </div>

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
@@ -19,6 +19,7 @@ import type { FeedbackItem, DateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import FeedbackCard from '../../components/FeedbackCard'
 import { generateFeedbackPDF } from './feedbackPdfGenerator'
+import { useTranslation } from 'react-i18next'
 
 const sentiments = ['all', 'positive', 'neutral', 'negative', 'mixed']
 const defaultCategories = ['all', 'delivery', 'customer_support', 'product_quality', 'pricing', 'website', 'app', 'billing', 'returns', 'communication', 'other']
@@ -169,14 +170,15 @@ function ResultsHeader({
 }>) {
   // When the candidate window was truncated by the backend cap, `totalCount`
   // is a lower bound — show "N+" and a hint to narrow filters.
+  const { t } = useTranslation('common')
   const totalLabel = isPartialWindow ? `${totalCount}+` : `${totalCount}`
   return (
     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
       <p className="text-sm text-gray-500">
-        Showing {itemCount} of {totalLabel} items
+        {t('showingOf', { count: itemCount, total: totalLabel })}
         {search && <span className="ml-1">for "{search}"</span>}
         {isPartialWindow && (
-          <span className="ml-1 text-amber-600">(narrow filters to see all)</span>
+          <span className="ml-1 text-amber-600">({t('partialWindowHint')})</span>
         )}
       </p>
       <div className="flex items-center gap-3">
@@ -205,6 +207,7 @@ function PDFExportButton({
   timeRange: string
   filterState: FilterState
 }>) {
+  const { t } = useTranslation('common')
   if (items.length === 0) return null
   const exportPDF = () => {
     try {
@@ -228,10 +231,10 @@ function PDFExportButton({
       <button
         onClick={exportPDF}
         className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700"
-        title="Export as PDF"
+        title={t('exportPdfTooltip')}
       >
         <FileDown size={14} />
-        Export PDF
+        {t('exportPdf')}
       </button>
     </div>
   )

--- a/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/Feedback.tsx
@@ -155,21 +155,29 @@ function FiltersCard({
 function ResultsHeader({
   itemCount,
   totalCount,
+  isPartialWindow,
   search,
   hasActiveFilters,
   onClearFilters,
 }: Readonly<{
   itemCount: number
   totalCount: number
+  isPartialWindow: boolean
   search: string
   hasActiveFilters: boolean
   onClearFilters: () => void
 }>) {
+  // When the candidate window was truncated by the backend cap, `totalCount`
+  // is a lower bound — show "N+" and a hint to narrow filters.
+  const totalLabel = isPartialWindow ? `${totalCount}+` : `${totalCount}`
   return (
     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
       <p className="text-sm text-gray-500">
-        Showing {itemCount} of {totalCount} items
+        Showing {itemCount} of {totalLabel} items
         {search && <span className="ml-1">for "{search}"</span>}
+        {isPartialWindow && (
+          <span className="ml-1 text-amber-600">(narrow filters to see all)</span>
+        )}
       </p>
       <div className="flex items-center gap-3">
         {hasActiveFilters && (
@@ -274,9 +282,19 @@ function getFeedbackQueryFn(
 }
 
 interface FeedbackDataResult {
-  data: { items?: FeedbackItem[]; count?: number } | undefined
+  data: { items?: FeedbackItem[]; count?: number; total?: number; is_partial_window?: boolean } | undefined
   isLoading: boolean
   isSearching: boolean
+}
+
+// Derive the results-header totals from a feedback response. `total` (candidate
+// window size) is preferred; `count` (page size) is the fallback for endpoints
+// that don't paginate (search/urgent).
+function getResultsTotals(data: FeedbackDataResult['data']): { totalCount: number; isPartialWindow: boolean } {
+  return {
+    totalCount: data?.total ?? data?.count ?? 0,
+    isPartialWindow: data?.is_partial_window ?? false,
+  }
 }
 
 // Custom hook for feedback data fetching
@@ -364,7 +382,7 @@ export default function Feedback() {
   )
 
   const filteredItems = activeData?.items ?? []
-
+  const { totalCount, isPartialWindow } = getResultsTotals(activeData)
   const clearFilters = () => {
     setSearch('')
     setSourceFilter('all')
@@ -400,7 +418,8 @@ export default function Feedback() {
 
       <ResultsHeader
         itemCount={filteredItems.length}
-        totalCount={activeData?.count ?? 0}
+        totalCount={totalCount}
+        isPartialWindow={isPartialWindow}
         search={search}
         hasActiveFilters={hasActiveFilters}
         onClearFilters={clearFilters}

--- a/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.test.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.test.tsx
@@ -58,4 +58,32 @@ describe('FeedbackPDFContent', () => {
     expect(screen.getByText('First complaint')).toBeInTheDocument()
     expect(screen.getByText('Second complaint')).toBeInTheDocument()
   })
+
+  it('renders when sentiment_score arrives as a string (API string-typed Decimal)', () => {
+    // Regression: the /feedback API can return sentiment_score as a JSON string
+    // for records persisted as DynamoDB String attributes. Calling .toFixed()
+    // on a string previously threw and produced a blank PDF window.
+    const stringScoreItem = makeItem({
+      original_text: 'Manual import review',
+      // Cast through unknown: the runtime value violates the declared number type.
+      sentiment_score: '0.9' as unknown as number,
+    })
+    expect(() =>
+      render(<FeedbackPDFContent items={[stringScoreItem]} timeRange="Last 7 days" />)
+    ).not.toThrow()
+    expect(screen.getByText('Manual import review')).toBeInTheDocument()
+    // Coerced and formatted to 2 decimals rather than crashing.
+    expect(screen.getByText(/negative \(0\.90\)/)).toBeInTheDocument()
+  })
+
+  it('falls back to 0.00 when sentiment_score is not numeric', () => {
+    const badScoreItem = makeItem({
+      original_text: 'Garbage score review',
+      sentiment_score: 'not-a-number' as unknown as number,
+    })
+    expect(() =>
+      render(<FeedbackPDFContent items={[badScoreItem]} timeRange="Last 7 days" />)
+    ).not.toThrow()
+    expect(screen.getByText(/negative \(0\.00\)/)).toBeInTheDocument()
+  })
 })

--- a/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.test.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import FeedbackPDFContent, { type FeedbackPDFProps } from './FeedbackPDFContent'
+import type { FeedbackItem } from '../../api/types'
+
+function makeItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
+  return {
+    feedback_id: 'f1',
+    source_id: 's1',
+    source_platform: 'app_store',
+    source_channel: 'ios',
+    brand_name: 'Acme',
+    source_created_at: '2026-06-01T00:00:00Z',
+    processed_at: '2026-06-01T01:00:00Z',
+    original_text: 'The checkout flow is broken',
+    original_language: 'en',
+    category: 'checkout_flow',
+    journey_stage: 'purchase',
+    sentiment_label: 'negative',
+    sentiment_score: -0.8,
+    urgency: 'high',
+    impact_area: 'conversion',
+    ...overrides,
+  }
+}
+
+describe('FeedbackPDFContent', () => {
+  it('renders the feedback original text', () => {
+    render(<FeedbackPDFContent items={[makeItem()]} timeRange="Last 7 days" />)
+    expect(screen.getByText('The checkout flow is broken')).toBeInTheDocument()
+  })
+
+  it('humanizes the source platform (underscores to spaces)', () => {
+    render(<FeedbackPDFContent items={[makeItem({ source_platform: 'app_store' })]} timeRange="Last 7 days" />)
+    expect(screen.getByText('app store')).toBeInTheDocument()
+  })
+
+  it('shows rating as N/5 when present', () => {
+    render(<FeedbackPDFContent items={[makeItem({ rating: 2 })]} timeRange="Last 7 days" />)
+    expect(screen.getByText('2/5')).toBeInTheDocument()
+  })
+
+  it('renders an em dash when rating is absent', () => {
+    render(<FeedbackPDFContent items={[makeItem({ rating: undefined })]} timeRange="Last 7 days" />)
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+
+  it('renders multiple feedback rows', () => {
+    render(
+      <FeedbackPDFContent
+        items={[
+          makeItem({ feedback_id: 'a', original_text: 'First complaint' }),
+          makeItem({ feedback_id: 'b', original_text: 'Second complaint' }),
+        ]}
+        timeRange="Last 7 days"
+      />
+    )
+    expect(screen.getByText('First complaint')).toBeInTheDocument()
+    expect(screen.getByText('Second complaint')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.tsx
@@ -1,0 +1,332 @@
+/**
+ * @fileoverview PDF content component for feedback list export.
+ * Renders a print-friendly table of feedback items.
+ * @module pages/Feedback/FeedbackPDFContent
+ */
+
+import type { FeedbackItem } from '../../api/types'
+
+export interface FeedbackPDFProps {
+  readonly items: readonly FeedbackItem[]
+  readonly timeRange: string
+  readonly filters?: {
+    source?: string
+    sentiment?: string
+    category?: string
+    search?: string
+    urgentOnly?: boolean
+  }
+}
+
+function getSentimentStyle(label: string): {
+  bg: string;
+  color: string
+} {
+  if (label === 'positive') return {
+    bg: '#dcfce7',
+    color: '#166534',
+  }
+  if (label === 'negative') return {
+    bg: '#fef2f2',
+    color: '#991b1b',
+  }
+  if (label === 'mixed') return {
+    bg: '#fef9c3',
+    color: '#854d0e',
+  }
+  return {
+    bg: '#f3f4f6',
+    color: '#374151',
+  }
+}
+
+function formatDate(dateString: string | null | undefined): string {
+  if ((dateString == null || dateString === '')) return '—'
+  try {
+    return new Date(dateString).toLocaleDateString()
+  } catch {
+    return '—'
+  }
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength) + '…'
+}
+
+function isActiveFilter(value: string | undefined, defaultValue = 'all'): boolean {
+  return value != null && value !== defaultValue
+}
+
+function buildActiveFilters(filters: FeedbackPDFProps['filters']): string[] {
+  if (!filters) return []
+  const result: string[] = []
+  if (isActiveFilter(filters.source)) result.push(`Source: ${filters.source}`)
+  if (isActiveFilter(filters.sentiment)) result.push(`Sentiment: ${filters.sentiment}`)
+  if (isActiveFilter(filters.category)) result.push(`Category: ${filters.category}`)
+  if (filters.search != null && filters.search !== '') result.push(`Search: "${filters.search}"`)
+  if (filters.urgentOnly === true) result.push('Urgent only')
+  return result
+}
+
+function computeHeaderStats(items: readonly FeedbackItem[]) {
+  const urgentCount = items.filter((i) => i.urgency === 'high').length
+  const avgSentiment = items.length > 0
+    ? items.reduce((sum, i) => sum + i.sentiment_score, 0) / items.length
+    : 0
+  return {
+    urgentCount,
+    avgSentiment,
+  }
+}
+
+function HeaderSection({
+  items, timeRange, filters,
+}: FeedbackPDFProps) {
+  const activeFilters = buildActiveFilters(filters)
+  const {
+    urgentCount, avgSentiment,
+  } = computeHeaderStats(items)
+
+  return (
+    <div data-pdf-section style={{ marginBottom: '24px' }}>
+      <h1 style={{
+        fontSize: '28px',
+        fontWeight: 'bold',
+        margin: '0 0 4px 0',
+        color: '#111827',
+      }}>
+        Feedback Report
+      </h1>
+      <p style={{
+        fontSize: '14px',
+        color: '#6b7280',
+        margin: '0 0 16px 0',
+      }}>
+        Time range: {timeRange}
+        {activeFilters.length > 0 && ` • ${activeFilters.join(' • ')}`}
+      </p>
+      <div style={{
+        display: 'flex',
+        gap: '16px',
+        flexWrap: 'wrap',
+      }}>
+        {[
+          {
+            label: 'Items',
+            value: String(items.length),
+            bg: '#f0f9ff',
+            color: '#1d4ed8',
+          },
+          {
+            label: 'Urgent',
+            value: String(urgentCount),
+            bg: '#fef2f2',
+            color: '#991b1b',
+          },
+          {
+            label: 'Avg Sentiment',
+            value: avgSentiment.toFixed(2),
+            bg: '#f0fdf4',
+            color: '#166534',
+          },
+        ].map((stat) => (
+          <div key={stat.label} style={{
+            padding: '12px 20px',
+            backgroundColor: stat.bg,
+            borderRadius: '8px',
+            minWidth: '120px',
+          }}>
+            <p style={{
+              fontSize: '12px',
+              color: stat.color,
+              fontWeight: '500',
+              margin: '0 0 4px 0',
+            }}>{stat.label}</p>
+            <p style={{
+              fontSize: '22px',
+              fontWeight: 'bold',
+              color: stat.color,
+              margin: 0,
+            }}>{stat.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function FeedbackTable({ items }: { readonly items: readonly FeedbackItem[] }) {
+  return (
+    <div data-pdf-section>
+      <h2 style={{
+        fontSize: '18px',
+        fontWeight: '600',
+        color: '#1e293b',
+        marginBottom: '12px',
+      }}>📋 Feedback Items</h2>
+      <table style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        fontSize: '12px',
+      }}>
+        <thead>
+          <tr style={{
+            borderBottom: '2px solid #e5e7eb',
+            backgroundColor: '#f8fafc',
+          }}>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>Date</th>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>Source</th>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>Category</th>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>Sentiment</th>
+            <th style={{
+              textAlign: 'center',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+              width: '50px',
+            }}>Rating</th>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>Feedback</th>
+            <th style={{
+              textAlign: 'left',
+              padding: '8px 6px',
+              color: '#6b7280',
+              fontWeight: '600',
+            }}>Problem</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, i) => {
+            const sentStyle = getSentimentStyle(item.sentiment_label)
+            return (
+              <tr key={item.feedback_id} style={{
+                borderBottom: '1px solid #f3f4f6',
+                backgroundColor: i % 2 === 0 ? '#ffffff' : '#f9fafb',
+              }}>
+                <td style={{
+                  padding: '6px',
+                  whiteSpace: 'nowrap',
+                  color: '#6b7280',
+                  fontSize: '11px',
+                }}>
+                  {formatDate(item.source_created_at)}
+                </td>
+                <td style={{
+                  padding: '6px',
+                  textTransform: 'capitalize',
+                  color: '#374151',
+                  fontSize: '11px',
+                }}>
+                  {item.source_platform.replaceAll('_', ' ')}
+                </td>
+                <td style={{
+                  padding: '6px',
+                  textTransform: 'capitalize',
+                  color: '#374151',
+                  fontSize: '11px',
+                }}>
+                  {item.category.replaceAll('_', ' ')}
+                </td>
+                <td style={{ padding: '6px' }}>
+                  <span style={{
+                    padding: '2px 8px',
+                    backgroundColor: sentStyle.bg,
+                    color: sentStyle.color,
+                    borderRadius: '10px',
+                    fontSize: '10px',
+                    fontWeight: '500',
+                    whiteSpace: 'nowrap',
+                  }}>
+                    {item.sentiment_label} ({item.sentiment_score.toFixed(2)})
+                  </span>
+                </td>
+                <td style={{
+                  padding: '6px',
+                  textAlign: 'center',
+                  color: '#374151',
+                  fontSize: '11px',
+                }}>
+                  {item.rating == null ? '—' : `${item.rating}/5`}
+                </td>
+                <td style={{
+                  padding: '6px',
+                  color: '#374151',
+                  fontSize: '11px',
+                  maxWidth: '250px',
+                }}>
+                  {truncateText(item.original_text, 150)}
+                </td>
+                <td style={{
+                  padding: '6px',
+                  color: '#6b7280',
+                  fontSize: '11px',
+                  fontStyle: 'italic',
+                  maxWidth: '180px',
+                }}>
+                  {item.problem_summary != null && item.problem_summary !== '' ? truncateText(item.problem_summary, 100) : '—'}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default function FeedbackPDFContent(props: FeedbackPDFProps) {
+  return (
+    <div style={{
+      padding: '30px',
+      backgroundColor: 'white',
+    }}>
+      <HeaderSection {...props} />
+      <hr style={{
+        border: 'none',
+        borderTop: '2px solid #e5e7eb',
+        marginBottom: '24px',
+      }} />
+      <FeedbackTable items={props.items} />
+      <div data-pdf-section>
+        <hr style={{
+          border: 'none',
+          borderTop: '1px solid #e5e7eb',
+          marginTop: '32px',
+          marginBottom: '16px',
+        }} />
+        <p style={{
+          fontSize: '11px',
+          color: '#9ca3af',
+          textAlign: 'center',
+        }}>
+          Generated on {new Date().toLocaleDateString()} • VoC Analytics — Feedback Report
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/FeedbackPDFContent.tsx
@@ -54,6 +54,19 @@ function truncateText(text: string, maxLength: number): string {
   return text.slice(0, maxLength) + '…'
 }
 
+/**
+ * Coerce a value to a finite number, falling back to `fallback` (default 0).
+ *
+ * The `/feedback` API can return numeric fields such as `sentiment_score` as
+ * JSON strings (records persisted as DynamoDB String attributes), so calling
+ * `.toFixed()` on the raw value throws and aborts the whole PDF render. This
+ * mirrors the defensive coercion already used by `SentimentBadge`.
+ */
+function toFiniteNumber(value: unknown, fallback = 0): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
 function isActiveFilter(value: string | undefined, defaultValue = 'all'): boolean {
   return value != null && value !== defaultValue
 }
@@ -72,7 +85,7 @@ function buildActiveFilters(filters: FeedbackPDFProps['filters']): string[] {
 function computeHeaderStats(items: readonly FeedbackItem[]) {
   const urgentCount = items.filter((i) => i.urgency === 'high').length
   const avgSentiment = items.length > 0
-    ? items.reduce((sum, i) => sum + i.sentiment_score, 0) / items.length
+    ? items.reduce((sum, i) => sum + toFiniteNumber(i.sentiment_score), 0) / items.length
     : 0
   return {
     urgentCount,
@@ -262,7 +275,7 @@ function FeedbackTable({ items }: { readonly items: readonly FeedbackItem[] }) {
                     fontWeight: '500',
                     whiteSpace: 'nowrap',
                   }}>
-                    {item.sentiment_label} ({item.sentiment_score.toFixed(2)})
+                    {item.sentiment_label} ({toFiniteNumber(item.sentiment_score).toFixed(2)})
                   </span>
                 </td>
                 <td style={{

--- a/voc-datalake/frontend/src/pages/Feedback/feedbackPdfGenerator.tsx
+++ b/voc-datalake/frontend/src/pages/Feedback/feedbackPdfGenerator.tsx
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview PDF generation for feedback list export.
+ * @module pages/Feedback/feedbackPdfGenerator
+ */
+
+import { createPdfGenerator } from '../../utils/printUtils'
+import FeedbackPDFContent from './FeedbackPDFContent'
+import type { FeedbackPDFProps } from './FeedbackPDFContent'
+
+export const generateFeedbackPDF = createPdfGenerator<FeedbackPDFProps>(
+  'Feedback Report',
+  (props) => <FeedbackPDFContent {...props} />,
+)

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -22,6 +22,7 @@ import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
+import { getTimeRangeLabel } from '../../utils/dateUtils'
 import { useTranslation } from 'react-i18next'
 
 interface ProblemGroup {
@@ -366,7 +367,7 @@ export default function ProblemAnalysis() {
     try {
       generateProblemAnalysisPDF({
         categories: toPDFCategories(groupedData),
-        timeRange,
+        timeRange: getTimeRangeLabel(timeRange, customDays),
         filters: {
           source: selectedSource,
           category: selectedCategory,

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -15,12 +15,13 @@ import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { 
   ChevronDown, ChevronRight, AlertTriangle, 
-  MessageSquare, TrendingUp, Filter, X, Layers
+  MessageSquare, TrendingUp, Filter, X, Layers, FileDown
 } from 'lucide-react'
 import { api, getDateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
+import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
 
 interface ProblemGroup {
   problem: string
@@ -202,6 +203,29 @@ function buildCategoryGroups(categoryMap: Map<string, Map<string, Map<string, Pr
   return result
 }
 
+// Map the in-memory grouping tree to the PDF export shape
+// (the problem level uses itemCount instead of the full items array).
+function toPDFCategories(groups: CategoryGroup[]) {
+  return groups.map((c) => ({
+    category: c.category,
+    totalItems: c.totalItems,
+    urgentCount: c.urgentCount,
+    subcategories: c.subcategories.map((s) => ({
+      subcategory: s.subcategory,
+      totalItems: s.totalItems,
+      urgentCount: s.urgentCount,
+      problems: s.problems.map((p) => ({
+        problem: p.problem,
+        similarProblems: p.similarProblems,
+        rootCause: p.rootCause,
+        itemCount: p.items.length,
+        avgSentiment: p.avgSentiment,
+        urgentCount: p.urgentCount,
+      })),
+    })),
+  }))
+}
+
 export default function ProblemAnalysis() {
   const { timeRange, customDays, config } = useConfigStore()
   const dateParams = getDateRangeParams(timeRange, customDays)
@@ -334,6 +358,24 @@ export default function ProblemAnalysis() {
     sum + g.subcategories.reduce((s, sub) => s + sub.problems.length, 0), 0)
   const totalFeedback = groupedData.reduce((sum, g) => sum + g.totalItems, 0)
   const totalUrgent = groupedData.reduce((sum, g) => sum + g.urgentCount, 0)
+
+  const exportPDF = () => {
+    if (groupedData.length === 0) return
+    try {
+      generateProblemAnalysisPDF({
+        categories: toPDFCategories(groupedData),
+        timeRange,
+        filters: {
+          source: selectedSource,
+          category: selectedCategory,
+          subcategory: selectedSubcategory,
+          urgentOnly: showUrgentOnly,
+        },
+      })
+    } catch {
+      // PDF generation is best-effort (e.g. popup blocked)
+    }
+  }
 
   if (!config.apiEndpoint) {
     return (
@@ -475,6 +517,15 @@ export default function ProblemAnalysis() {
                 <button onClick={collapseAll} className="btn btn-secondary text-xs px-2 py-1 sm:px-3 sm:py-1.5 active:scale-95">
                   <span className="hidden xs:inline">Collapse All</span>
                   <span className="xs:hidden">Collapse</span>
+                </button>
+                <button
+                  onClick={exportPDF}
+                  disabled={groupedData.length === 0}
+                  className="btn btn-secondary text-xs px-2 py-1 sm:px-3 sm:py-1.5 active:scale-95 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Export as PDF"
+                >
+                  <FileDown size={14} />
+                  PDF
                 </button>
               </div>
             </div>

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -22,6 +22,7 @@ import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
+import { useTranslation } from 'react-i18next'
 
 interface ProblemGroup {
   problem: string
@@ -227,6 +228,7 @@ function toPDFCategories(groups: CategoryGroup[]) {
 }
 
 export default function ProblemAnalysis() {
+  const { t } = useTranslation('common')
   const { timeRange, customDays, config } = useConfigStore()
   const dateParams = getDateRangeParams(timeRange, customDays)
   
@@ -522,10 +524,10 @@ export default function ProblemAnalysis() {
                   onClick={exportPDF}
                   disabled={groupedData.length === 0}
                   className="btn btn-secondary text-xs px-2 py-1 sm:px-3 sm:py-1.5 active:scale-95 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
-                  title="Export as PDF"
+                  title={t('exportPdfTooltip')}
                 >
                   <FileDown size={14} />
-                  PDF
+                  {t('exportPdfShort')}
                 </button>
               </div>
             </div>

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ProblemAnalysisPDFContent, { type ProblemAnalysisPDFProps } from './ProblemAnalysisPDFContent'
+
+function makeCategories(): ProblemAnalysisPDFProps['categories'] {
+  return [
+    {
+      category: 'Delivery',
+      totalItems: 5,
+      urgentCount: 2,
+      subcategories: [
+        {
+          subcategory: 'Late shipment',
+          totalItems: 5,
+          urgentCount: 2,
+          problems: [
+            {
+              problem: 'Package arrived two weeks late',
+              similarProblems: ['Shipment delayed'],
+              rootCause: 'Carrier capacity shortage',
+              itemCount: 3,
+              avgSentiment: -0.6,
+              urgentCount: 2,
+            },
+          ],
+        },
+      ],
+    },
+  ]
+}
+
+describe('ProblemAnalysisPDFContent', () => {
+  it('renders the category name', () => {
+    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    expect(screen.getByText('Delivery')).toBeInTheDocument()
+  })
+
+  it('renders the subcategory name', () => {
+    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    expect(screen.getByText('Late shipment')).toBeInTheDocument()
+  })
+
+  it('renders the problem statement', () => {
+    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    expect(screen.getByText(/Package arrived two weeks late/)).toBeInTheDocument()
+  })
+
+  it('renders the root cause hypothesis', () => {
+    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    expect(screen.getByText(/Carrier capacity shortage/)).toBeInTheDocument()
+  })
+
+  it('indicates similar problems count', () => {
+    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    expect(screen.getByText(/\+1 similar/)).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
@@ -1,0 +1,369 @@
+/**
+ * @fileoverview PDF content component for problem analysis export.
+ * Renders a print-friendly view of the problem analysis tree.
+ * @module pages/ProblemAnalysis/ProblemAnalysisPDFContent
+ */
+
+import { sentimentLabelFromScore } from '../../lib/sentiment'
+
+interface ProblemGroupPDF {
+  readonly problem: string
+  readonly similarProblems: string[]
+  readonly rootCause: string | null
+  readonly itemCount: number
+  readonly avgSentiment: number
+  readonly urgentCount: number
+}
+
+interface SubcategoryGroupPDF {
+  readonly subcategory: string
+  readonly problems: ProblemGroupPDF[]
+  readonly totalItems: number
+  readonly urgentCount: number
+}
+
+interface CategoryGroupPDF {
+  readonly category: string
+  readonly subcategories: SubcategoryGroupPDF[]
+  readonly totalItems: number
+  readonly urgentCount: number
+}
+
+export interface ProblemAnalysisPDFProps {
+  readonly categories: CategoryGroupPDF[]
+  readonly timeRange: string
+  readonly filters?: {
+    source?: string | null
+    category?: string | null
+    subcategory?: string | null
+    urgentOnly?: boolean
+  }
+}
+
+function getSentimentColor(score: number): string {
+  if (score > 0) return '#16a34a'
+  if (score < -0.3) return '#dc2626'
+  return '#6b7280'
+}
+
+function buildActiveFilters(filters: ProblemAnalysisPDFProps['filters']): string[] {
+  if (!filters) return []
+  const entries: [string | null | undefined, string][] = [
+    [filters.source, 'Source'],
+    [filters.category, 'Category'],
+    [filters.subcategory, 'Subcategory'],
+  ]
+  const result = entries
+    .filter(([val]) => val != null && val !== '')
+    .map(([val, label]) => `${label}: ${val}`)
+  if (filters.urgentOnly === true) result.push('Urgent only')
+  return result
+}
+
+function buildHeaderStats(categories: CategoryGroupPDF[]) {
+  const totalProblems = categories.reduce((sum, c) =>
+    sum + c.subcategories.reduce((s, sub) => s + sub.problems.length, 0), 0)
+  const totalFeedback = categories.reduce((sum, c) => sum + c.totalItems, 0)
+  const totalUrgent = categories.reduce((sum, c) => sum + c.urgentCount, 0)
+  return [
+    {
+      label: 'Categories',
+      value: categories.length,
+      bg: '#f0f9ff',
+      color: '#1d4ed8',
+    },
+    {
+      label: 'Problems',
+      value: totalProblems,
+      bg: '#fef3c7',
+      color: '#92400e',
+    },
+    {
+      label: 'Feedback Items',
+      value: totalFeedback,
+      bg: '#f0fdf4',
+      color: '#166534',
+    },
+    {
+      label: 'Urgent',
+      value: totalUrgent,
+      bg: '#fef2f2',
+      color: '#991b1b',
+    },
+  ]
+}
+
+function HeaderSection({
+  categories, timeRange, filters,
+}: ProblemAnalysisPDFProps) {
+  const activeFilters = buildActiveFilters(filters)
+  const stats = buildHeaderStats(categories)
+
+  return (
+    <div data-pdf-section style={{ marginBottom: '24px' }}>
+      <h1 style={{
+        fontSize: '28px',
+        fontWeight: 'bold',
+        margin: '0 0 4px 0',
+        color: '#111827',
+      }}>
+        Problem Analysis Report
+      </h1>
+      <p style={{
+        fontSize: '14px',
+        color: '#6b7280',
+        margin: '0 0 16px 0',
+      }}>
+        Time range: {timeRange}
+        {activeFilters.length > 0 && ` • ${activeFilters.join(' • ')}`}
+      </p>
+      <div style={{
+        display: 'flex',
+        gap: '16px',
+        flexWrap: 'wrap',
+      }}>
+        {stats.map((stat) => (
+          <div key={stat.label} style={{
+            padding: '12px 20px',
+            backgroundColor: stat.bg,
+            borderRadius: '8px',
+            minWidth: '120px',
+          }}>
+            <p style={{
+              fontSize: '12px',
+              color: stat.color,
+              fontWeight: '500',
+              margin: '0 0 4px 0',
+            }}>{stat.label}</p>
+            <p style={{
+              fontSize: '24px',
+              fontWeight: 'bold',
+              color: stat.color,
+              margin: 0,
+            }}>{stat.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ProblemItem({ problem }: { readonly problem: ProblemGroupPDF }) {
+  return (
+    <div data-pdf-section style={{
+      padding: '10px 16px',
+      borderLeft: '3px solid #f59e0b',
+      marginBottom: '8px',
+      backgroundColor: '#fffbeb',
+      borderRadius: '0 6px 6px 0',
+    }}>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        gap: '12px',
+      }}>
+        <div style={{ flex: 1 }}>
+          <p style={{
+            fontSize: '13px',
+            fontWeight: '600',
+            color: '#1f2937',
+            margin: '0 0 4px 0',
+          }}>
+            ⚠️ {problem.problem}
+            {problem.similarProblems.length > 0 && (
+              <span style={{
+                fontSize: '11px',
+                color: '#6b7280',
+                fontWeight: 'normal',
+              }}>
+                {' '}(+{problem.similarProblems.length} similar)
+              </span>
+            )}
+          </p>
+          {problem.rootCause != null && problem.rootCause !== '' ? <p style={{
+            fontSize: '12px',
+            color: '#6b7280',
+            margin: '0 0 2px 0',
+          }}>
+            💡 {problem.rootCause}
+          </p> : null}
+        </div>
+        <div style={{
+          display: 'flex',
+          gap: '8px',
+          alignItems: 'center',
+          flexShrink: 0,
+        }}>
+          <span style={{
+            fontSize: '12px',
+            color: '#6b7280',
+          }}>{problem.itemCount} items</span>
+          {problem.urgentCount > 0 && (
+            <span style={{
+              padding: '2px 8px',
+              backgroundColor: '#fecaca',
+              color: '#991b1b',
+              borderRadius: '10px',
+              fontSize: '11px',
+              fontWeight: '500',
+            }}>
+              {problem.urgentCount} urgent
+            </span>
+          )}
+          <span style={{
+            padding: '2px 8px',
+            backgroundColor: '#f3f4f6',
+            color: getSentimentColor(problem.avgSentiment),
+            borderRadius: '10px',
+            fontSize: '11px',
+            fontWeight: '500',
+          }}>
+            {sentimentLabelFromScore(problem.avgSentiment).replace(/^./, (c) => c.toUpperCase())} ({problem.avgSentiment.toFixed(2)})
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SubcategorySection({
+  subcategory, categoryName,
+}: {
+  readonly subcategory: SubcategoryGroupPDF;
+  readonly categoryName: string
+}) {
+  return (
+    <div data-pdf-section style={{
+      marginBottom: '16px',
+      marginLeft: '16px',
+    }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        marginBottom: '8px',
+      }}>
+        <h3 style={{
+          fontSize: '15px',
+          fontWeight: '600',
+          color: '#374151',
+          margin: 0,
+          textTransform: 'capitalize',
+        }}>
+          {subcategory.subcategory.replaceAll('_', ' ')}
+        </h3>
+        <span style={{
+          fontSize: '12px',
+          color: '#9ca3af',
+        }}>
+          {subcategory.problems.length} problems • {subcategory.totalItems} items
+        </span>
+        {subcategory.urgentCount > 0 && (
+          <span style={{
+            padding: '2px 8px',
+            backgroundColor: '#fecaca',
+            color: '#991b1b',
+            borderRadius: '10px',
+            fontSize: '11px',
+          }}>
+            {subcategory.urgentCount} urgent
+          </span>
+        )}
+      </div>
+      {subcategory.problems.map((problem) => (
+        <ProblemItem key={`${categoryName}-${subcategory.subcategory}-${problem.problem}`} problem={problem} />
+      ))}
+    </div>
+  )
+}
+
+function CategorySection({ category }: { readonly category: CategoryGroupPDF }) {
+  return (
+    <div data-pdf-section style={{ marginBottom: '28px' }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '12px 16px',
+        backgroundColor: '#f8fafc',
+        borderRadius: '8px',
+        borderLeft: '4px solid #3b82f6',
+        marginBottom: '12px',
+      }}>
+        <h2 style={{
+          fontSize: '18px',
+          fontWeight: '700',
+          color: '#1e293b',
+          margin: 0,
+          textTransform: 'capitalize',
+        }}>
+          {category.category.replaceAll('_', ' ')}
+        </h2>
+        <div style={{
+          display: 'flex',
+          gap: '12px',
+          alignItems: 'center',
+          fontSize: '13px',
+          color: '#64748b',
+        }}>
+          <span>{category.subcategories.length} subcategories</span>
+          <span>{category.totalItems} items</span>
+          {category.urgentCount > 0 && (
+            <span style={{
+              padding: '2px 8px',
+              backgroundColor: '#fecaca',
+              color: '#991b1b',
+              borderRadius: '10px',
+              fontSize: '12px',
+              fontWeight: '500',
+            }}>
+              {category.urgentCount} urgent
+            </span>
+          )}
+        </div>
+      </div>
+      {category.subcategories.map((sub) => (
+        <SubcategorySection
+          key={`${category.category}-${sub.subcategory}`}
+          subcategory={sub}
+          categoryName={category.category}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default function ProblemAnalysisPDFContent(props: ProblemAnalysisPDFProps) {
+  return (
+    <div style={{
+      padding: '40px',
+      backgroundColor: 'white',
+    }}>
+      <HeaderSection {...props} />
+      <hr style={{
+        border: 'none',
+        borderTop: '2px solid #e5e7eb',
+        marginBottom: '24px',
+      }} />
+      {props.categories.map((category) => (
+        <CategorySection key={category.category} category={category} />
+      ))}
+      <div data-pdf-section>
+        <hr style={{
+          border: 'none',
+          borderTop: '1px solid #e5e7eb',
+          marginTop: '32px',
+          marginBottom: '16px',
+        }} />
+        <p style={{
+          fontSize: '11px',
+          color: '#9ca3af',
+          textAlign: 'center',
+        }}>
+          Generated on {new Date().toLocaleDateString()} • VoC Analytics — Problem Analysis Report
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemAnalysisPdfGenerator.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemAnalysisPdfGenerator.tsx
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview PDF generation for problem analysis export.
+ * @module pages/ProblemAnalysis/problemAnalysisPdfGenerator
+ */
+
+import { createPdfGenerator } from '../../utils/printUtils'
+import ProblemAnalysisPDFContent from './ProblemAnalysisPDFContent'
+import type { ProblemAnalysisPDFProps } from './ProblemAnalysisPDFContent'
+
+export const generateProblemAnalysisPDF = createPdfGenerator<ProblemAnalysisPDFProps>(
+  'Problem Analysis Report',
+  (props) => <ProblemAnalysisPDFContent {...props} />,
+)

--- a/voc-datalake/frontend/src/utils/dateUtils.test.ts
+++ b/voc-datalake/frontend/src/utils/dateUtils.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { safeFormatDate } from './dateUtils'
+import { safeFormatDate, getTimeRangeLabel } from './dateUtils'
 
 describe('safeFormatDate', () => {
   const formatStr = 'MMM d, yyyy HH:mm'
@@ -52,5 +52,31 @@ describe('safeFormatDate', () => {
   it('handles ISO date strings with timezone', () => {
     const result = safeFormatDate('2025-12-25T00:00:00+05:00', 'yyyy-MM-dd')
     expect(result).toMatch(/2025-12-2[45]/)
+  })
+})
+
+describe('getTimeRangeLabel', () => {
+  it('maps preset tokens to human-readable labels', () => {
+    expect(getTimeRangeLabel('24h')).toBe('24 Hours')
+    expect(getTimeRangeLabel('48h')).toBe('48 Hours')
+    expect(getTimeRangeLabel('7d')).toBe('7 Days')
+    expect(getTimeRangeLabel('30d')).toBe('30 Days')
+  })
+
+  it('presents the "all" token as the 90 Days preset (never the raw token)', () => {
+    expect(getTimeRangeLabel('all')).toBe('90 Days')
+  })
+
+  it('formats custom ranges as "Last N days" when customDays is set', () => {
+    expect(getTimeRangeLabel('custom', 14)).toBe('Last 14 days')
+  })
+
+  it('falls back to "Custom" when custom is selected without a day count', () => {
+    expect(getTimeRangeLabel('custom')).toBe('Custom')
+    expect(getTimeRangeLabel('custom', null)).toBe('Custom')
+  })
+
+  it('falls back to the raw token for unknown values', () => {
+    expect(getTimeRangeLabel('90d')).toBe('90d')
   })
 })

--- a/voc-datalake/frontend/src/utils/dateUtils.ts
+++ b/voc-datalake/frontend/src/utils/dateUtils.ts
@@ -6,6 +6,39 @@
 import { format, isValid } from 'date-fns'
 
 /**
+ * Human-readable labels for the time-range tokens stored in the config store.
+ *
+ * Mirrors the `fullLabel` values in `TimeRangeSelector`. Note the `'all'` token
+ * is presented as the "90 Days" preset (the max window, matching the aggregates
+ * 90-day TTL); the bare token must never be shown to users.
+ */
+const TIME_RANGE_LABELS: Record<string, string> = {
+  '24h': '24 Hours',
+  '48h': '48 Hours',
+  '7d': '7 Days',
+  '30d': '30 Days',
+  all: '90 Days',
+}
+
+/**
+ * Maps a stored time-range token to a human-readable label for display
+ * (e.g. PDF report headers).
+ *
+ * - Known presets map to their descriptive label.
+ * - `'custom'` becomes `Last N days` when `customDays` is set, else `Custom`.
+ * - Unknown tokens fall back to the token itself.
+ */
+export function getTimeRangeLabel(
+  timeRange: string,
+  customDays?: number | null
+): string {
+  if (timeRange === 'custom') {
+    return customDays != null ? `Last ${customDays} days` : 'Custom'
+  }
+  return TIME_RANGE_LABELS[timeRange] ?? timeRange
+}
+
+/**
  * Safely formats a date string or Date object.
  * Returns a fallback string if the date is invalid.
  */

--- a/voc-datalake/lambda/api/manual_import_handler.py
+++ b/voc-datalake/lambda/api/manual_import_handler.py
@@ -347,6 +347,123 @@ def confirm_import():
         raise ServiceError('Failed to import reviews')
 
 
+MAX_JSON_UPLOAD_ITEMS = 500
+
+
+@app.post("/scrapers/manual/json-upload")
+@tracer.capture_method
+def json_upload():
+    """Import pre-structured JSON feedback items directly into the pipeline."""
+    body = app.current_event.json_body
+    items = body.get('items', [])
+
+    if not isinstance(items, list) or len(items) == 0:
+        raise ValidationError('Request must contain a non-empty "items" array')
+
+    if len(items) > MAX_JSON_UPLOAD_ITEMS:
+        raise ValidationError(f'Maximum {MAX_JSON_UPLOAD_ITEMS} items per upload')
+
+    # Validate required fields: text, id, source, timestamp
+    errors = []
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f'Item {idx}: must be an object')
+            continue
+        text = item.get('text', '')
+        if not isinstance(text, str) or not text.strip():
+            errors.append(f'Item {idx}: "text" is required and must be a non-empty string')
+        if not item.get('id'):
+            errors.append(f'Item {idx}: "id" is required for deduplication')
+        if not (item.get('source') or item.get('source_channel')):
+            errors.append(f'Item {idx}: "source" is required')
+        if not (item.get('timestamp') or item.get('created_at')):
+            errors.append(f'Item {idx}: "timestamp" is required (ISO 8601 format)')
+
+    if errors:
+        raise ValidationError(f'Validation failed: {"; ".join(errors[:10])}')
+
+    # Get user from request context
+    user_id = 'unknown'
+    try:
+        claims = app.current_event.request_context.authorizer.get('claims', {})
+        user_id = claims.get('sub', claims.get('cognito:username', 'unknown'))
+    except Exception:
+        pass
+
+    now = datetime.now(timezone.utc)
+    job_id = str(uuid.uuid4())
+
+    # Store raw upload to S3
+    s3_uri = None
+    if RAW_DATA_BUCKET:
+        s3_key = f"raw/json_upload/{now.year}/{now.month:02d}/{now.day:02d}/{job_id}.json"
+        try:
+            s3.put_object(
+                Bucket=RAW_DATA_BUCKET,
+                Key=s3_key,
+                Body=json.dumps({
+                    'job_id': job_id,
+                    'items': items,
+                    'uploaded_at': now.isoformat(),
+                    'uploaded_by': user_id,
+                }, default=decimal_default),
+                ContentType='application/json',
+            )
+            s3_uri = f"s3://{RAW_DATA_BUCKET}/{s3_key}"
+        except Exception as e:
+            logger.warning(f"Failed to store JSON upload to S3: {e}")
+
+    # Send each item to SQS
+    imported_count = 0
+    send_errors = []
+
+    for idx, item in enumerate(items):
+        text = item.get('text', '').strip()
+        source_id = item.get('id', '')
+        created_at = item.get('timestamp') or item.get('created_at')
+
+        message = {
+            'id': source_id,
+            'source_platform': 'manual_import',
+            'source_channel': item.get('source') or item.get('source_channel'),
+            'ingestion_method': 'json_upload',
+            'text': text,
+            'rating': item.get('rating'),
+            'author': item.get('user_id') or item.get('author'),
+            'title': item.get('title'),
+            'url': item.get('url'),
+            'created_at': created_at,
+            's3_raw_uri': s3_uri,
+        }
+
+        # Pass through metadata if present
+        if item.get('metadata') and isinstance(item['metadata'], dict):
+            message['metadata'] = item['metadata']
+
+        try:
+            if PROCESSING_QUEUE_URL:
+                sqs.send_message(
+                    QueueUrl=PROCESSING_QUEUE_URL,
+                    MessageBody=json.dumps(message),
+                )
+            imported_count += 1
+        except Exception as e:
+            logger.warning(f"Failed to send item {idx} to SQS: {e}")
+            send_errors.append(f"Item {idx}: {str(e)}")
+
+    result = {
+        'success': True,
+        'imported_count': imported_count,
+        'total_items': len(items),
+        's3_uri': s3_uri,
+    }
+
+    if send_errors:
+        result['errors'] = send_errors
+
+    return result
+
+
 @api_handler
 def lambda_handler(event: dict, context: Any) -> dict:
     return app.resolve(event, context)

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -80,9 +80,21 @@ def list_feedback():
         max_val=MAX_FEEDBACK_OFFSET,
     )
 
-    # Fetch enough candidates to satisfy offset+limit pagination, with a
-    # generous overshoot to absorb post-query filtering by source/sentiment.
-    candidate_cap = max((offset + limit) * 2, MIN_CANDIDATE_CAP)
+    # Sizing the candidate window:
+    #
+    # - Without post-query filters, a small overshoot beyond offset+limit is
+    #   enough to paginate, and `total` is an intentionally windowed lower bound.
+    # - With post-query filters (source/sentiment/category), stopping at that
+    #   small overshoot would undercount the filtered `total` and spuriously set
+    #   `is_partial_window` (e.g. "2 of 2+"): the candidates that survive the
+    #   filter are a small subset of the scanned window. In that case we scan the
+    #   full window (up to MAX_FEEDBACK_OFFSET) so the filtered count is exact and
+    #   `is_partial_window` only trips on genuine cap truncation.
+    has_post_filter = bool(source) or bool(sentiment) or bool(category)
+    candidate_cap = (
+        MAX_FEEDBACK_OFFSET if has_post_filter
+        else max((offset + limit) * 2, MIN_CANDIDATE_CAP)
+    )
 
     candidates: list[dict[str, Any]] = []
     current_date = datetime.now(timezone.utc)

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -8,15 +8,30 @@ import os
 from datetime import datetime, timezone, timedelta
 from typing import Any
 
+from aws_lambda_powertools.event_handler.exceptions import NotFoundError
+from boto3.dynamodb.conditions import Key
+
 from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource
 from shared.api import (
-    create_api_resolver, validate_days, validate_limit,
+    create_api_resolver, validate_days, validate_limit, validate_int,
     get_configured_categories, api_handler, DEFAULT_CATEGORIES
 )
 
-from aws_lambda_powertools.event_handler.exceptions import NotFoundError
-from boto3.dynamodb.conditions import Key
+# Pagination bounds for /feedback. The candidate window is a function of
+# offset+limit, capped to prevent unbounded DynamoDB scans. The cap also defines
+# the maximum paginable depth.
+MAX_FEEDBACK_OFFSET = 5000
+MIN_CANDIDATE_CAP = 100
+
+# Per-day GSI query page size for date-windowed scans. Used by /feedback,
+# /feedback/entities, /feedback/search, and the source-filtered branches of
+# /metrics/sentiment and /metrics/categories.
+DATE_QUERY_LIMIT = 500
+
+# Soft cap on accumulated candidates when iterating across days for endpoints
+# that aggregate or sample feedback (entities, search, source-filtered metrics).
+CANDIDATES_SOFT_CAP = 1000
 
 # AWS Clients
 dynamodb = get_dynamodb_resource()
@@ -39,47 +54,83 @@ app = create_api_resolver()
 @app.get("/feedback")
 @tracer.capture_method
 def list_feedback():
-    """List feedback with optional filters."""
+    """
+    List feedback with optional filters and offset/limit pagination.
+
+    Pagination semantics: results are paginated within a date-window candidate
+    set (or category-window when only ``category`` is supplied). The returned
+    ``total`` reflects the size of the filtered candidate window, not the full
+    dataset, and the candidate window is bounded by ``MAX_FEEDBACK_OFFSET``.
+
+    The ``is_partial_window`` flag is true when the candidate window was
+    truncated by the cap; in that case more matching records may exist beyond
+    the window and ``total`` is a lower bound on the true count.
+    """
     params = app.current_event.query_string_parameters or {}
-    
+
     days = validate_days(params.get('days'), default=7)
     source = params.get('source')
     category = params.get('category')
     sentiment = params.get('sentiment')
     limit = validate_limit(params.get('limit'), default=50, max_val=100)
-    
-    items = []
+    offset = validate_int(
+        params.get('offset'),
+        default=0,
+        min_val=0,
+        max_val=MAX_FEEDBACK_OFFSET,
+    )
+
+    # Fetch enough candidates to satisfy offset+limit pagination, with a
+    # generous overshoot to absorb post-query filtering by source/sentiment.
+    candidate_cap = max((offset + limit) * 2, MIN_CANDIDATE_CAP)
+
+    candidates: list[dict[str, Any]] = []
     current_date = datetime.now(timezone.utc)
-    
+    window_truncated = False
+
     if category and not source:
         response = feedback_table.query(
             IndexName='gsi2-by-category',
             KeyConditionExpression=Key('gsi2pk').eq(f'CATEGORY#{category}'),
-            Limit=limit * 2,
+            Limit=candidate_cap,
             ScanIndexForward=False
         )
-        items = response.get('Items', [])
+        candidates = response.get('Items', [])
+        # The category GSI returned a full page at the cap — there may be more.
+        window_truncated = len(candidates) >= candidate_cap and 'LastEvaluatedKey' in response
     else:
         for i in range(days):
             date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
             response = feedback_table.query(
                 IndexName='gsi1-by-date',
                 KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=500,
+                Limit=DATE_QUERY_LIMIT,
                 ScanIndexForward=False
             )
-            items.extend(response.get('Items', []))
-            if len(items) >= limit * 5:
+            candidates.extend(response.get('Items', []))
+            if len(candidates) >= candidate_cap:
+                # We hit the cap before exhausting the date range.
+                window_truncated = i < days - 1
                 break
-    
+
     if source:
-        items = [i for i in items if i.get('source_platform') == source]
+        candidates = [i for i in candidates if i.get('source_platform') == source]
     if category and source:
-        items = [i for i in items if i.get('category') == category]
+        candidates = [i for i in candidates if i.get('category') == category]
     if sentiment:
-        items = [i for i in items if i.get('sentiment_label') == sentiment]
-    
-    return {'count': len(items), 'items': items[:limit]}
+        candidates = [i for i in candidates if i.get('sentiment_label') == sentiment]
+
+    total = len(candidates)
+    page = candidates[offset:offset + limit]
+
+    return {
+        'count': len(page),
+        'total': total,
+        'offset': offset,
+        'limit': limit,
+        'is_partial_window': window_truncated,
+        'items': page,
+    }
 
 
 @app.get("/feedback/urgent")
@@ -150,11 +201,11 @@ def get_entities():
             response = feedback_table.query(
                 IndexName='gsi1-by-date',
                 KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=500,
+                Limit=DATE_QUERY_LIMIT,
                 ScanIndexForward=False
             )
             items.extend(response.get('Items', []))
-            if len(items) >= 1000:
+            if len(items) >= CANDIDATES_SOFT_CAP:
                 break
         
         items = [i for i in items if i.get('source_platform') == source]
@@ -290,7 +341,7 @@ def search_feedback():
             ScanIndexForward=False
         )
         candidates.extend(response.get('Items', []))
-        if len(candidates) >= 1000:
+        if len(candidates) >= CANDIDATES_SOFT_CAP:
             break
     
     items = []
@@ -455,11 +506,11 @@ def get_sentiment_metrics():
             response = feedback_table.query(
                 IndexName='gsi1-by-date',
                 KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=500,
+                Limit=DATE_QUERY_LIMIT,
                 ScanIndexForward=False
             )
             items.extend(response.get('Items', []))
-            if len(items) >= 1000:
+            if len(items) >= CANDIDATES_SOFT_CAP:
                 break
         
         for item in items:
@@ -509,11 +560,11 @@ def get_category_metrics():
             response = feedback_table.query(
                 IndexName='gsi1-by-date',
                 KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=500,
+                Limit=DATE_QUERY_LIMIT,
                 ScanIndexForward=False
             )
             items.extend(response.get('Items', []))
-            if len(items) >= 1000:
+            if len(items) >= CANDIDATES_SOFT_CAP:
                 break
         
         for item in items:

--- a/voc-datalake/lambda/api/test/test_manual_import_json_upload.py
+++ b/voc-datalake/lambda/api/test/test_manual_import_json_upload.py
@@ -1,0 +1,116 @@
+"""
+Coverage tests for the POST /scrapers/manual/json-upload endpoint
+in manual_import_handler.py.
+"""
+import json
+from unittest.mock import patch
+
+
+class TestJsonUploadEndpoint:
+    """Cover POST /scrapers/manual/json-upload endpoint."""
+
+    def test_returns_error_when_items_not_list(self, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': 'not-a-list'}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+        assert response['statusCode'] == 400
+        assert 'non-empty' in body['error']
+
+    def test_returns_error_when_items_empty(self, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': []}
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 400
+
+    @patch('manual_import_handler.MAX_JSON_UPLOAD_ITEMS', 2)
+    def test_returns_error_when_too_many_items(self, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': [
+                {'id': '1', 'text': 'a', 'source': 's', 'timestamp': '2026-01-01'},
+                {'id': '2', 'text': 'b', 'source': 's', 'timestamp': '2026-01-01'},
+                {'id': '3', 'text': 'c', 'source': 's', 'timestamp': '2026-01-01'},
+            ]}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+        assert response['statusCode'] == 400
+        assert 'Maximum' in body['error']
+
+    def test_validates_required_fields(self, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': [
+                {'text': '', 'id': '', 'source': '', 'timestamp': ''},  # all empty
+                'not-a-dict',  # not an object
+            ]}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+        assert response['statusCode'] == 400
+        assert 'Validation failed' in body['error']
+
+    def test_validates_item_not_dict(self, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': ['string-item']}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+        assert response['statusCode'] == 400
+        assert 'must be an object' in body['error']
+
+    @patch('manual_import_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/q')
+    @patch('manual_import_handler.RAW_DATA_BUCKET', 'test-bucket')
+    @patch('manual_import_handler.sqs')
+    @patch('manual_import_handler.s3')
+    def test_successful_json_upload(self, mock_s3, mock_sqs, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': [
+                {'id': 'r1', 'text': 'Great product', 'source': 'app_store',
+                 'timestamp': '2026-01-01T00:00:00Z', 'rating': 5, 'author': 'John'},
+                {'id': 'r2', 'text': 'Bad service', 'source_channel': 'web',
+                 'created_at': '2026-01-02T00:00:00Z'},
+            ]}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+        assert body['success'] is True
+        assert body['imported_count'] == 2
+        assert body['total_items'] == 2
+        assert body['s3_uri'] is not None
+        assert mock_sqs.send_message.call_count == 2
+        mock_s3.put_object.assert_called_once()
+
+    @patch('manual_import_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/q')
+    @patch('manual_import_handler.RAW_DATA_BUCKET', 'test-bucket')
+    @patch('manual_import_handler.sqs')
+    @patch('manual_import_handler.s3')
+    def test_json_upload_with_metadata(self, mock_s3, mock_sqs, api_gateway_event, lambda_context):
+        from manual_import_handler import lambda_handler
+        event = api_gateway_event(
+            method='POST', path='/scrapers/manual/json-upload',
+            body={'items': [
+                {'id': 'r1', 'text': 'Good', 'source': 'api', 'timestamp': '2026-01-01',
+                 'metadata': {'custom_field': 'value'}, 'title': 'Title',
+                 'url': 'https://example.com', 'user_id': 'u1'},
+            ]}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+        assert body['success'] is True
+        # Verify metadata was passed through in SQS message
+        sqs_body = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        assert sqs_body['metadata'] == {'custom_field': 'value'}

--- a/voc-datalake/lambda/api/test/test_metrics_handler_pagination.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler_pagination.py
@@ -175,6 +175,52 @@ class TestListFeedbackPagination:
 
     @patch('metrics_handler.feedback_table')
     @patch('metrics_handler.aggregates_table')
+    def test_source_filter_does_not_over_flag_partial_window(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        # Regression for "N of N+": each day returns a full page where only one
+        # item matches the source filter. The pre-filter window would hit the
+        # small overshoot cap, but because a filter is applied we scan the full
+        # day range, so the filtered total is exact and the window is not flagged
+        # partial.
+        page = _items(99, source='webscraper') + _items(1, source='manual_import')
+        mock_fb.query.return_value = {'Items': page}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '3', 'source': 'manual_import'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        # 1 matching item per day across 3 scanned days.
+        assert body['total'] == 3
+        assert body['count'] == 3
+        assert body['is_partial_window'] is False
+        assert all(i['source_platform'] == 'manual_import' for i in body['items'])
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_filtered_query_still_flags_partial_window_at_hard_cap(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        # When even a filtered scan hits the MAX_FEEDBACK_OFFSET hard cap before
+        # exhausting the day range, the window is genuinely partial and must be
+        # flagged so the UI treats `total` as a lower bound.
+        mock_fb.query.return_value = {'Items': _items(3000, source='manual_import')}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '3', 'source': 'manual_import'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        # Day 0 (3000) + day 1 (3000) >= 5000 cap, with day 2 still unscanned.
+        assert body['is_partial_window'] is True
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
     def test_category_only_filter_uses_category_gsi(
         self, _mock_agg, mock_fb, api_gateway_event, lambda_context
     ):

--- a/voc-datalake/lambda/api/test/test_metrics_handler_pagination.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler_pagination.py
@@ -1,0 +1,194 @@
+"""
+Tests for offset/limit pagination on GET /feedback in metrics_handler.py.
+
+Covers the `offset`, `total`, and `is_partial_window` semantics added by the
+pagination slice, plus backward compatibility of the `count`/`items` fields.
+"""
+import json
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _items(n, source='webscraper', sentiment='positive', category='delivery'):
+    """Build n feedback items with sequential ids for slice assertions."""
+    return [
+        {
+            'feedback_id': str(i),
+            'source_platform': source,
+            'sentiment_label': sentiment,
+            'category': category,
+            'text': f'item {i}',
+        }
+        for i in range(n)
+    ]
+
+
+class TestListFeedbackPagination:
+    """Pagination metadata and slicing for GET /feedback."""
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_returns_full_pagination_metadata_with_defaults(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': _items(2)}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(method='GET', path='/feedback', query_params={'days': '1'})
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['count'] == 2
+        assert body['total'] == 2
+        assert body['offset'] == 0
+        assert body['limit'] == 50
+        assert body['is_partial_window'] is False
+        assert len(body['items']) == 2
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_offset_slices_the_requested_page(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': _items(10)}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '1', 'offset': '4', 'limit': '3'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['offset'] == 4
+        assert body['limit'] == 3
+        assert body['total'] == 10
+        assert body['count'] == 3
+        assert [i['feedback_id'] for i in body['items']] == ['4', '5', '6']
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_offset_past_end_returns_empty_page_but_real_total(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': _items(5)}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '1', 'offset': '10', 'limit': '50'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['count'] == 0
+        assert body['items'] == []
+        assert body['total'] == 5
+        assert body['offset'] == 10
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_total_reflects_source_filtered_candidates(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mixed = _items(3, source='webscraper') + _items(2, source='feedback_form')
+        mock_fb.query.return_value = {'Items': mixed}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '1', 'source': 'webscraper'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['total'] == 3
+        assert all(i['source_platform'] == 'webscraper' for i in body['items'])
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_total_reflects_sentiment_filtered_candidates(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mixed = _items(4, sentiment='positive') + _items(1, sentiment='negative')
+        mock_fb.query.return_value = {'Items': mixed}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '1', 'sentiment': 'negative'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['total'] == 1
+        assert body['items'][0]['sentiment_label'] == 'negative'
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_clamps_offset_above_maximum(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': _items(1)}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '1', 'offset': '999999'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['offset'] == 5000  # MAX_FEEDBACK_OFFSET
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_clamps_negative_offset_to_zero(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': _items(3)}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '1', 'offset': '-5'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['offset'] == 0
+        assert body['count'] == 3
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_is_partial_window_true_when_date_window_truncated(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        # First day already fills the candidate cap (>=100 for default offset+limit),
+        # and more days remain -> window is truncated.
+        mock_fb.query.return_value = {'Items': _items(100)}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback', query_params={'days': '3'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial_window'] is True
+        assert body['total'] == 100
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_category_only_filter_uses_category_gsi(
+        self, _mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': _items(3, category='delivery')}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/feedback',
+            query_params={'days': '7', 'category': 'delivery'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['total'] == 3
+        assert body['is_partial_window'] is False
+        # category-only path queries the category GSI exactly once
+        assert mock_fb.query.call_count == 1
+        assert mock_fb.query.call_args.kwargs['IndexName'] == 'gsi2-by-category'

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -719,6 +719,7 @@ export class VocApiStack extends cdk.Stack {
     manualParseResource.addMethod('POST', manualImportIntegration, authMethodOptions);
     manualParseResource.addResource('{jobId}').addMethod('GET', manualImportIntegration, authMethodOptions);
     manualResource.addResource('confirm').addMethod('POST', manualImportIntegration, authMethodOptions);
+    manualResource.addResource('json-upload').addMethod('POST', manualImportIntegration, authMethodOptions);
     scrapersResource.addProxy({ defaultIntegration: scrapersIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
     // /s3-import/*


### PR DESCRIPTION
## Summary

PR 4 of the `chrome-extension-rebase` breakdown (tracking issue #107). Re-scoped after PR 3 merged: the original "data management UI" branch was ~90% already in `development`, so this PR carries only the genuinely-new, independent slices off `development`.

**33 files, +2,644 / −38** · 5 commits.

## What's included

1. **PDF export** for Dashboard, Categories, Feedback, and Problem Analysis — a print-optimized report rendered in a new window, reusing the shared `createPdfGenerator` factory.
2. **`/feedback` offset pagination** — the endpoint gains an `offset` param (capped at 5000) and returns `total` + an `is_partial_window` flag. The Feedback results header now shows the real candidate-window total and flags a truncated window ("N+ results — narrow filters to see all"). Backward-compatible: existing `{count, items}` consumers keep working.
3. **`POST /scrapers/manual/json-upload`** backend endpoint + API Gateway route. Validates `text`/`id`/`source`/`timestamp`, caps at 500 items, archives the raw payload to S3, and fans each item to the processing queue.
   - Note: the JSON-upload **UI already existed** in `development` and was calling this route; this PR adds the missing server side so the feature works end-to-end (it is *not* a new feature, it completes an existing one).
4. **Tests** — 19 PDF-component render tests, 9 `/feedback` pagination backend tests, 7 json-upload backend tests, plus 2 Feedback results-header tests.
5. **i18n** — localized the new PDF export buttons and pagination labels across all 8 locales.

## Validation

- `npm run check` green: lint, typecheck (frontend + CDK + stream), **1,427** frontend tests, **554** backend tests (84% cov), `i18n:validate` passes.
- Deployed `VocApiStack` to the test account (`777200923596` / us-east-1, `UPDATE_COMPLETE`); frontend rebuilt + published.
- Programmatic API tests (pagination metadata, offset clamping, json-upload happy/validation paths) and live UI testing via Chrome DevTools all pass (pagination "N+ results", PDF export, JSON Upload modal incl. missing-field and >500-item rejection).

## Out of scope / parked follow-ups

- **`ingestion_method` provenance** — the processor doesn't persist the `ingestion_method` the json-upload handler sets (crosses into the processing stack). Tracked as a separate small PR.
- **Rationalize feedback-ingestion entry points** — partial overlap between Manual Import / JSON Upload / S3 Bulk Import / Data Explorer create+sync. Pre-existing product/UX decision.
- **i18n migration of the Dashboard/Feedback/Problem Analysis pages** — these remain largely hardcoded English; this PR only localized the strings it introduced.
