### PR TITLE
PR 5/7: User admin & Cognito hardening

### DIFF
--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -78,7 +78,7 @@
     "positive": "Positivo"
   },
   "showingOf_one": "Mostrando {{count}} de {{total}} resultado",
-  "showingOf_many": "",
+  "showingOf_many": "Mostrando {{count}} de {{total}} resultados",
   "showingOf_other": "Mostrando {{count}} de {{total}} resultados",
   "sidebar": {
     "closeMenu": "Cerrar menú",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -78,7 +78,7 @@
     "positive": "Positif"
   },
   "showingOf_one": "Affichage de {{count}} sur {{total}} résultat",
-  "showingOf_many": "",
+  "showingOf_many": "Affichage de {{count}} sur {{total}} résultats",
   "showingOf_other": "Affichage de {{count}} sur {{total}} résultats",
   "sidebar": {
     "closeMenu": "Fermer le menu",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -78,7 +78,7 @@
     "positive": "Positivo"
   },
   "showingOf_one": "Mostrando {{count}} de {{total}} resultado",
-  "showingOf_many": "",
+  "showingOf_many": "Mostrando {{count}} de {{total}} resultados",
   "showingOf_other": "Mostrando {{count}} de {{total}} resultados",
   "sidebar": {
     "closeMenu": "Fechar menu",

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -595,7 +595,14 @@ export const api = {
   // User Administration (admin only)
   getUsers: () => fetchApi<{ success: boolean; users: CognitoUser[]; message?: string }>('/users'),
   
-  createUser: (data: { username: string; email: string; name?: string; group: 'admins' | 'users' }) =>
+  createUser: (data: {
+    username: string
+    email: string
+    name?: string
+    given_name?: string
+    family_name?: string
+    group: 'admins' | 'users'
+  }) =>
     fetchApi<{ success: boolean; message?: string; error?: string; user?: CognitoUser }>('/users', {
       method: 'POST',
       body: JSON.stringify(data)
@@ -605,6 +612,19 @@ export const api = {
     fetchApi<{ success: boolean; message: string }>(`/users/${encodeURIComponent(username)}/group`, {
       method: 'PUT',
       body: JSON.stringify({ group })
+    }),
+
+  // Update user attributes (first/last name). Used by EditUserModal.
+  updateUser: (username: string, data: { given_name: string; family_name: string }) =>
+    fetchApi<{
+      success: boolean
+      message: string
+      given_name: string
+      family_name: string
+      name: string
+    }>(`/users/${encodeURIComponent(username)}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
     }),
   
   resetUserPassword: (username: string) =>

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -427,6 +427,8 @@ export interface CognitoUser {
   username: string
   email: string
   name: string
+  given_name?: string
+  family_name?: string
   status: string
   enabled: boolean
   groups: string[]

--- a/voc-datalake/frontend/src/components/UserAdmin/CreateUserModal.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/CreateUserModal.tsx
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview Modal for creating new Cognito users.
+ * @module components/UserAdmin/CreateUserModal
+ */
+
+import { useMutation } from '@tanstack/react-query'
+import {
+  UserPlus, Shield, Eye, Loader2, AlertCircle, Mail,
+} from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import NameFields from './NameFields'
+
+type UserGroup = 'admins' | 'users'
+
+interface CreateUserModalProps {
+  readonly isOpen: boolean
+  readonly onClose: () => void
+  readonly onSuccess: () => void
+}
+
+export default function CreateUserModal({
+  isOpen, onClose, onSuccess,
+}: CreateUserModalProps) {
+  const { t } = useTranslation('components')
+  const [email, setEmail] = useState('')
+  const [givenName, setGivenName] = useState('')
+  const [familyName, setFamilyName] = useState('')
+  const [group, setGroup] = useState<UserGroup>('users')
+  const [error, setError] = useState('')
+
+  useEscapeKey(isOpen, onClose)
+
+  const createMutation = useMutation({
+    mutationFn: () => api.createUser({
+      username: email,
+      email,
+      given_name: givenName,
+      family_name: familyName,
+      group,
+    }),
+    onSuccess: (data) => {
+      if (data.success) {
+        setEmail('')
+        setGivenName('')
+        setFamilyName('')
+        setGroup('users')
+        setError('')
+        onSuccess()
+        onClose()
+      } else {
+        setError(data.error != null && data.error !== '' ? data.error : 'Failed to create user')
+      }
+    },
+    onError: (err: Error) => setError(err.message),
+  })
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-4 sm:p-6">
+        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+          <UserPlus size={20} className="text-blue-600" />
+          {t('userAdmin.addNewUser')}
+        </h3>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {t('userAdmin.emailLabel')}
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="user@example.com"
+              className="input"
+              autoFocus
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              {t('userAdmin.emailHelp')}
+            </p>
+          </div>
+
+          <NameFields
+            givenName={givenName}
+            familyName={familyName}
+            onGivenNameChange={setGivenName}
+            onFamilyNameChange={setFamilyName}
+          />
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {t('userAdmin.roleLabel')}
+            </label>
+            <div className="flex gap-4">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="group"
+                  value="users"
+                  checked={group === 'users'}
+                  onChange={() => setGroup('users')}
+                  className="text-blue-600"
+                />
+                <Eye size={16} className="text-gray-500" />
+                <span>{t('userAdmin.userRole')}</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="group"
+                  value="admins"
+                  checked={group === 'admins'}
+                  onChange={() => setGroup('admins')}
+                  className="text-blue-600"
+                />
+                <Shield size={16} className="text-purple-500" />
+                <span>{t('userAdmin.adminRole')}</span>
+              </label>
+            </div>
+          </div>
+
+          {error === '' ? null : <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 p-3 rounded-lg">
+            <AlertCircle size={16} className="flex-shrink-0" />
+            <span>{error}</span>
+          </div>}
+        </div>
+
+        <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 mt-6">
+          <button onClick={onClose} className="btn btn-secondary w-full sm:w-auto">
+            {t('userAdmin.cancel')}
+          </button>
+          <button
+            onClick={() => createMutation.mutate()}
+            disabled={email === '' || createMutation.isPending}
+            className="btn btn-primary flex items-center justify-center gap-2 w-full sm:w-auto"
+          >
+            {createMutation.isPending ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Mail size={16} />
+            )}
+            {t('userAdmin.sendInvite')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/components/UserAdmin/EditUserModal.component.test.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/EditUserModal.component.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Component tests for EditUserModal — open/close, form validation,
+ * submit mutation, and error display.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockUpdateUser = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  api: {
+    updateUser: (username: string, data: unknown) => mockUpdateUser(username, data),
+  },
+}))
+
+import EditUserModal from './EditUserModal'
+import type { CognitoUser } from '../../api/types'
+
+const testUser: CognitoUser = {
+  username: 'user-123',
+  email: 'test@example.com',
+  name: 'Test User',
+  given_name: 'Test',
+  family_name: 'User',
+  status: 'CONFIRMED',
+  enabled: true,
+  groups: ['users'],
+  created_at: null,
+  last_modified: null,
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const defaultProps = {
+  isOpen: true,
+  user: testUser,
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+}
+
+describe('EditUserModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateUser.mockResolvedValue({ success: true, message: 'User updated' })
+  })
+
+  it('renders nothing when isOpen is false', () => {
+    render(
+      <EditUserModal {...defaultProps} isOpen={false} />,
+      { wrapper: createWrapper() },
+    )
+
+    expect(screen.queryByText('test@example.com')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when user is null', () => {
+    render(
+      <EditUserModal {...defaultProps} user={null} />,
+      { wrapper: createWrapper() },
+    )
+
+    expect(screen.queryByText('test@example.com')).not.toBeInTheDocument()
+  })
+
+  it('displays user email and pre-filled name fields when open', () => {
+    render(
+      <EditUserModal {...defaultProps} />,
+      { wrapper: createWrapper() },
+    )
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Test')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('User')).toBeInTheDocument()
+  })
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <EditUserModal {...defaultProps} onClose={onClose} />,
+      { wrapper: createWrapper() },
+    )
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('disables Save button when no changes are made', () => {
+    render(
+      <EditUserModal {...defaultProps} />,
+      { wrapper: createWrapper() },
+    )
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('enables Save button when name is changed', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <EditUserModal {...defaultProps} />,
+      { wrapper: createWrapper() },
+    )
+
+    await user.clear(screen.getByDisplayValue('Test'))
+    await user.type(screen.getByDisplayValue(''), 'Updated')
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('disables Save button when both name fields are cleared', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <EditUserModal {...defaultProps} />,
+      { wrapper: createWrapper() },
+    )
+
+    await user.clear(screen.getByDisplayValue('Test'))
+    await user.clear(screen.getByDisplayValue('User'))
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+  })
+
+  it('calls updateUser API with correct args on submit', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onSuccess = vi.fn()
+
+    render(
+      <EditUserModal {...defaultProps} onClose={onClose} onSuccess={onSuccess} />,
+      { wrapper: createWrapper() },
+    )
+
+    await user.clear(screen.getByDisplayValue('Test'))
+    await user.type(screen.getByDisplayValue(''), 'NewFirst')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith('user-123', {
+        given_name: 'NewFirst',
+        family_name: 'User',
+      })
+    })
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledOnce()
+      expect(onClose).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('displays error when API returns success false', async () => {
+    mockUpdateUser.mockResolvedValue({ success: false, message: 'Name too long' })
+    const user = userEvent.setup()
+
+    render(
+      <EditUserModal {...defaultProps} />,
+      { wrapper: createWrapper() },
+    )
+
+    await user.clear(screen.getByDisplayValue('Test'))
+    await user.type(screen.getByDisplayValue(''), 'X')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Name too long')).toBeInTheDocument()
+    })
+  })
+
+  it('displays error when API call throws', async () => {
+    mockUpdateUser.mockRejectedValue(new Error('Network error'))
+    const user = userEvent.setup()
+
+    render(
+      <EditUserModal {...defaultProps} />,
+      { wrapper: createWrapper() },
+    )
+
+    await user.clear(screen.getByDisplayValue('Test'))
+    await user.type(screen.getByDisplayValue(''), 'X')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+})

--- a/voc-datalake/frontend/src/components/UserAdmin/EditUserModal.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/EditUserModal.tsx
@@ -1,0 +1,170 @@
+/**
+ * @fileoverview Modal for editing Cognito user attributes (first/last name).
+ * @module components/UserAdmin/EditUserModal
+ */
+
+import { useMutation } from '@tanstack/react-query'
+import {
+  Pencil, Loader2, AlertCircle,
+} from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import NameFields from './NameFields'
+import type { CognitoUser } from '../../api/types'
+
+interface EditUserModalProps {
+  readonly isOpen: boolean
+  readonly user: CognitoUser | null
+  readonly onClose: () => void
+  readonly onSuccess: () => void
+}
+
+function useEditUserMutation(opts: {
+  user: CognitoUser
+  givenName: string
+  familyName: string
+  onSuccess: () => void
+  onClose: () => void
+  setError: (msg: string) => void
+}) {
+  return useMutation({
+    mutationFn: () => api.updateUser(opts.user.username, {
+      given_name: opts.givenName,
+      family_name: opts.familyName,
+    }),
+    onSuccess: (data) => {
+      if (data.success) {
+        opts.setError('')
+        opts.onSuccess()
+        opts.onClose()
+      } else {
+        const msg = typeof data.message === 'string' && data.message !== '' ? data.message : 'Failed to update user'
+        opts.setError(msg)
+      }
+    },
+    onError: (err: Error) => opts.setError(err.message),
+  })
+}
+
+function EditUserForm({
+  user, givenName, familyName, error,
+  onGivenNameChange, onFamilyNameChange, onSubmit, isPending,
+}: {
+  readonly user: CognitoUser
+  readonly givenName: string
+  readonly familyName: string
+  readonly error: string
+  readonly onGivenNameChange: (v: string) => void
+  readonly onFamilyNameChange: (v: string) => void
+  readonly onSubmit: () => void
+  readonly isPending: boolean
+}) {
+  const { t } = useTranslation('components')
+  const hasChanges = givenName !== (user.given_name ?? '') || familyName !== (user.family_name ?? '')
+  const hasName = givenName.trim() !== '' || familyName.trim() !== ''
+
+  return (
+    <div className="space-y-4">
+      <NameFields
+        givenName={givenName}
+        familyName={familyName}
+        onGivenNameChange={onGivenNameChange}
+        onFamilyNameChange={onFamilyNameChange}
+        autoFocusFirst
+      />
+
+      {error === '' ? null : (
+        <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 p-3 rounded-lg">
+          <AlertCircle size={16} className="flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 mt-6">
+        <button
+          onClick={onSubmit}
+          disabled={!hasChanges || !hasName || isPending}
+          className="btn btn-primary flex items-center justify-center gap-2 w-full sm:w-auto"
+        >
+          {isPending ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <Pencil size={16} />
+          )}
+          {t('userAdmin.saveChanges')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function EditUserModalContent({
+  user, onClose, onSuccess,
+}: {
+  readonly user: CognitoUser;
+  readonly onClose: () => void;
+  readonly onSuccess: () => void
+}) {
+  const { t } = useTranslation('components')
+  const [givenName, setGivenName] = useState(user.given_name ?? '')
+  const [familyName, setFamilyName] = useState(user.family_name ?? '')
+  const [error, setError] = useState('')
+
+  const updateMutation = useEditUserMutation({
+    user,
+    givenName,
+    familyName,
+    onSuccess,
+    onClose,
+    setError,
+  })
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-4 sm:p-6">
+        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+          <Pencil size={20} className="text-blue-600" />
+          {t('userAdmin.editUser')}
+        </h3>
+
+        <p className="text-sm text-gray-500 mb-4">{user.email}</p>
+
+        <EditUserForm
+          user={user}
+          givenName={givenName}
+          familyName={familyName}
+          error={error}
+          onGivenNameChange={setGivenName}
+          onFamilyNameChange={setFamilyName}
+          onSubmit={() => updateMutation.mutate()}
+          isPending={updateMutation.isPending}
+        />
+
+        <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 mt-2">
+          <button onClick={onClose} className="btn btn-secondary w-full sm:w-auto">
+            {t('userAdmin.cancel')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function EditUserModal({
+  isOpen, user, onClose, onSuccess,
+}: EditUserModalProps) {
+  useEscapeKey(isOpen, onClose)
+
+  if (!isOpen || !user) return null
+
+  return (
+    <EditUserModalContent
+      key={user.username}
+      user={user}
+      onClose={onClose}
+      onSuccess={onSuccess}
+    />
+  )
+}

--- a/voc-datalake/frontend/src/components/UserAdmin/NameFields.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/NameFields.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+
+interface NameFieldsProps {
+  readonly givenName: string
+  readonly familyName: string
+  readonly onGivenNameChange: (value: string) => void
+  readonly onFamilyNameChange: (value: string) => void
+  readonly autoFocusFirst?: boolean
+}
+
+export default function NameFields({
+  givenName, familyName, onGivenNameChange, onFamilyNameChange, autoFocusFirst,
+}: NameFieldsProps) {
+  const { t } = useTranslation('components')
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {t('userAdmin.firstNameLabel')}
+        </label>
+        <input
+          type="text"
+          value={givenName}
+          onChange={(e) => onGivenNameChange(e.target.value)}
+          placeholder="Jane"
+          className="input"
+          autoFocus={autoFocusFirst}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {t('userAdmin.lastNameLabel')}
+        </label>
+        <input
+          type="text"
+          value={familyName}
+          onChange={(e) => onFamilyNameChange(e.target.value)}
+          placeholder="Doe"
+          className="input"
+        />
+      </div>
+    </>
+  )
+}

--- a/voc-datalake/frontend/src/components/UserAdmin/UserAdmin.test.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/UserAdmin.test.tsx
@@ -14,12 +14,14 @@ const mockResetUserPassword = vi.fn()
 const mockEnableUser = vi.fn()
 const mockDisableUser = vi.fn()
 const mockDeleteUser = vi.fn()
+const mockUpdateUser = vi.fn()
 
 vi.mock('../../api/client', () => ({
   api: {
     getUsers: () => mockGetUsers(),
     createUser: (data: unknown) => mockCreateUser(data),
     updateUserGroup: (username: string, group: string) => mockUpdateUserGroup(username, group),
+    updateUser: (username: string, data: unknown) => mockUpdateUser(username, data),
     resetUserPassword: (username: string) => mockResetUserPassword(username),
     enableUser: (username: string) => mockEnableUser(username),
     disableUser: (username: string) => mockDisableUser(username),
@@ -44,6 +46,7 @@ describe('UserAdmin', () => {
     mockGetUsers.mockResolvedValue({ users: [] })
     mockCreateUser.mockResolvedValue({ success: true })
     mockUpdateUserGroup.mockResolvedValue({ success: true })
+    mockUpdateUser.mockResolvedValue({ success: true, message: 'User updated' })
     mockResetUserPassword.mockResolvedValue({ success: true })
     mockEnableUser.mockResolvedValue({ success: true })
     mockDisableUser.mockResolvedValue({ success: true })
@@ -56,6 +59,7 @@ describe('UserAdmin', () => {
       
       render(<UserAdmin />, { wrapper: createWrapper() })
       
+      // eslint-disable-next-line testing-library/no-node-access
       expect(document.querySelector('.animate-spin')).toBeInTheDocument()
     })
   })
@@ -84,8 +88,8 @@ describe('UserAdmin', () => {
     it('displays user count', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'user1@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
-          { username: 'user2', email: 'user2@example.com', status: 'CONFIRMED', enabled: true, groups: ['admins'] },
+          { username: 'user1', email: 'user1@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user2', email: 'user2@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['admins'] },
         ],
       })
       
@@ -123,7 +127,7 @@ describe('UserAdmin', () => {
     it('displays user email', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -139,7 +143,7 @@ describe('UserAdmin', () => {
     it('displays user name when available', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', name: 'John Doe', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: 'John Doe', given_name: 'John', family_name: 'Doe', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -157,7 +161,7 @@ describe('UserAdmin', () => {
     it('shows Active badge for confirmed enabled users', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -173,7 +177,7 @@ describe('UserAdmin', () => {
     it('shows Disabled badge for disabled users', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: false, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: false, groups: ['users'] },
         ],
       })
       
@@ -188,7 +192,7 @@ describe('UserAdmin', () => {
     it('shows Pending badge for users requiring password change', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'FORCE_CHANGE_PASSWORD', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'FORCE_CHANGE_PASSWORD', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -205,7 +209,7 @@ describe('UserAdmin', () => {
     it('displays role dropdown with current role selected', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['admins'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['admins'] },
         ],
       })
       
@@ -223,7 +227,7 @@ describe('UserAdmin', () => {
       const user = userEvent.setup()
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -305,14 +309,16 @@ describe('UserAdmin', () => {
       })
       
       await user.type(screen.getByPlaceholderText('user@example.com'), 'new@example.com')
-      await user.type(screen.getByPlaceholderText('John Doe'), 'New User')
+      await user.type(screen.getByPlaceholderText('Jane'), 'New')
+      await user.type(screen.getByPlaceholderText('Doe'), 'User')
       await user.click(screen.getByRole('button', { name: /send invite/i }))
       
       await waitFor(() => {
         expect(mockCreateUser).toHaveBeenCalledWith({
           username: 'new@example.com',
           email: 'new@example.com',
-          name: 'New User',
+          given_name: 'New',
+          family_name: 'User',
           group: 'users',
         })
       })
@@ -345,7 +351,7 @@ describe('UserAdmin', () => {
       const user = userEvent.setup()
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -368,7 +374,7 @@ describe('UserAdmin', () => {
       const user = userEvent.setup()
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -388,7 +394,7 @@ describe('UserAdmin', () => {
     it('shows enable button for disabled users', async () => {
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: false, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: false, groups: ['users'] },
         ],
       })
       
@@ -403,7 +409,7 @@ describe('UserAdmin', () => {
       const user = userEvent.setup()
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       
@@ -427,7 +433,7 @@ describe('UserAdmin', () => {
       const user = userEvent.setup()
       mockGetUsers.mockResolvedValue({
         users: [
-          { username: 'user1', email: 'test@example.com', status: 'CONFIRMED', enabled: true, groups: ['users'] },
+          { username: 'user1', email: 'test@example.com', name: '', given_name: '', family_name: '', status: 'CONFIRMED', enabled: true, groups: ['users'] },
         ],
       })
       

--- a/voc-datalake/frontend/src/components/UserAdmin/UserAdmin.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/UserAdmin.tsx
@@ -1,6 +1,6 @@
 /**
  * @fileoverview User Administration component for managing Cognito users.
- * 
+ *
  * Features:
  * - List all users with status and group
  * - Create new users (sends invite email)
@@ -8,25 +8,32 @@
  * - Reset password
  * - Enable/disable users
  * - Delete users
- * 
+ *
  * Only visible to users in the 'admins' group.
- * 
+ *
  * @module components/UserAdmin
  */
 
-import { useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { 
-  Users, UserPlus, Shield, Eye, Key, UserX, UserCheck, Trash2, 
-  Loader2, CheckCircle2, AlertCircle, Mail
+import {
+  useQuery, useMutation, useQueryClient,
+} from '@tanstack/react-query'
+import {
+  Users, UserPlus,
+  Loader2, CheckCircle2, AlertCircle,
 } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
-import type { CognitoUser } from '../../api/client'
 import ConfirmModal from '../ConfirmModal'
-import clsx from 'clsx'
+import CreateUserModal from './CreateUserModal'
+import EditUserModal from './EditUserModal'
+import {
+  UsersTable, UsersCards,
+} from './UserAdminComponents'
+import type { ActionType } from './UserAdminComponents'
+import type { CognitoUser } from '../../api/types'
 
 type UserGroup = 'admins' | 'users'
-type ActionType = 'delete' | 'disable' | 'enable' | 'reset'
 
 interface ConfirmActionState {
   type: ActionType
@@ -34,408 +41,43 @@ interface ConfirmActionState {
 }
 
 // Helper functions for confirm modal
-function getConfirmTitle(actionType: ActionType): string {
-  if (actionType === 'delete') return 'Delete User'
-  if (actionType === 'disable') return 'Disable User'
-  if (actionType === 'enable') return 'Enable User'
-  return 'Reset Password'
+function getConfirmTitle(actionType: ActionType, t: (key: string) => string): string {
+  if (actionType === 'delete') return t('userAdmin.deleteUser')
+  if (actionType === 'disable') return t('userAdmin.disableUser')
+  if (actionType === 'enable') return t('userAdmin.enableUser')
+  return t('userAdmin.resetPassword')
 }
 
-function getConfirmMessage(action: ConfirmActionState): string {
+function getConfirmMessage(action: ConfirmActionState, t: (key: string, opts?: Record<string, string>) => string): string {
   const email = action.user.email
-  if (action.type === 'delete') {
-    return `Are you sure you want to delete ${email}? This cannot be undone.`
-  }
-  if (action.type === 'disable') {
-    return `Disable ${email}? They will not be able to log in.`
-  }
-  if (action.type === 'enable') {
-    return `Enable ${email}? They will be able to log in again.`
-  }
-  return `Send a password reset email to ${email}?`
+  if (action.type === 'delete') return t('userAdmin.confirmDelete', { email })
+  if (action.type === 'disable') return t('userAdmin.confirmDisable', { email })
+  if (action.type === 'enable') return t('userAdmin.confirmEnable', { email })
+  return t('userAdmin.confirmReset', { email })
 }
 
-function getConfirmLabel(actionType: ActionType): string {
-  if (actionType === 'delete') return 'Delete'
-  if (actionType === 'disable') return 'Disable'
-  if (actionType === 'enable') return 'Enable'
-  return 'Send Reset Email'
+function getConfirmLabel(actionType: ActionType, t: (key: string) => string): string {
+  if (actionType === 'delete') return t('userAdmin.delete')
+  if (actionType === 'disable') return t('userAdmin.disable')
+  if (actionType === 'enable') return t('userAdmin.enable')
+  return t('userAdmin.sendResetEmail')
 }
 
 function getConfirmVariant(actionType: ActionType): 'danger' | 'info' {
   return actionType === 'delete' ? 'danger' : 'info'
 }
 
-// Status Badge Component
-function StatusBadge({ user }: Readonly<{ user: CognitoUser }>) {
-  if (!user.enabled) {
-    return <span className="px-2 py-0.5 text-xs rounded-full bg-red-100 text-red-700">Disabled</span>
-  }
-  if (user.status === 'CONFIRMED') {
-    return <span className="px-2 py-0.5 text-xs rounded-full bg-green-100 text-green-700">Active</span>
-  }
-  if (user.status === 'FORCE_CHANGE_PASSWORD') {
-    return <span className="px-2 py-0.5 text-xs rounded-full bg-yellow-100 text-yellow-700">Pending</span>
-  }
-  return <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700">{user.status}</span>
-}
-
-// Role Select Component
-interface RoleSelectProps {
-  readonly user: CognitoUser
-  readonly isPending: boolean
-  readonly onChange: (username: string, group: UserGroup) => void
-  readonly size?: 'sm' | 'md'
-}
-
-function RoleSelect({ user, isPending, onChange, size = 'sm' }: RoleSelectProps) {
-  const isAdmin = user.groups.includes('admins')
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value
-    if (value === 'admins' || value === 'users') {
-      onChange(user.username, value)
-    }
-  }
-
-  return (
-    <select
-      value={isAdmin ? 'admins' : 'users'}
-      onChange={handleChange}
-      disabled={isPending}
-      className={clsx(
-        'text-sm border rounded',
-        size === 'sm' ? 'px-2 py-1' : 'px-2 py-1.5',
-        isAdmin 
-          ? 'border-purple-300 bg-purple-50 text-purple-700'
-          : 'border-gray-300 bg-white text-gray-700'
-      )}
-    >
-      <option value="users">User</option>
-      <option value="admins">Admin</option>
-    </select>
-  )
-}
-
-// User Action Buttons Component
-interface UserActionButtonsProps {
-  readonly user: CognitoUser
-  readonly onAction: (type: ActionType, user: CognitoUser) => void
-  readonly iconSize?: number
-  readonly buttonPadding?: string
-}
-
-function UserActionButtons({ user, onAction, iconSize = 16, buttonPadding = 'p-1.5' }: UserActionButtonsProps) {
-  return (
-    <div className="flex items-center gap-1">
-      <button
-        onClick={() => onAction('reset', user)}
-        className={clsx(buttonPadding, 'text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded')}
-        title="Reset password"
-      >
-        <Key size={iconSize} />
-      </button>
-      {user.enabled ? (
-        <button
-          onClick={() => onAction('disable', user)}
-          className={clsx(buttonPadding, 'text-gray-500 hover:text-orange-600 hover:bg-orange-50 rounded')}
-          title="Disable user"
-        >
-          <UserX size={iconSize} />
-        </button>
-      ) : (
-        <button
-          onClick={() => onAction('enable', user)}
-          className={clsx(buttonPadding, 'text-gray-500 hover:text-green-600 hover:bg-green-50 rounded')}
-          title="Enable user"
-        >
-          <UserCheck size={iconSize} />
-        </button>
-      )}
-      <button
-        onClick={() => onAction('delete', user)}
-        className={clsx(buttonPadding, 'text-gray-500 hover:text-red-600 hover:bg-red-50 rounded')}
-        title="Delete user"
-      >
-        <Trash2 size={iconSize} />
-      </button>
-    </div>
-  )
-}
-
-// Create User Modal Component
-interface CreateUserModalProps {
-  readonly isOpen: boolean
-  readonly onClose: () => void
-  readonly onSuccess: () => void
-}
-
-function CreateUserModal({ isOpen, onClose, onSuccess }: CreateUserModalProps) {
-  const [email, setEmail] = useState('')
-  const [name, setName] = useState('')
-  const [group, setGroup] = useState<UserGroup>('users')
-  const [error, setError] = useState('')
-
-  const createMutation = useMutation({
-    mutationFn: () => api.createUser({ username: email, email, name, group }),
-    onSuccess: (data) => {
-      if (data.success) {
-        setEmail('')
-        setName('')
-        setGroup('users')
-        setError('')
-        onSuccess()
-        onClose()
-      } else {
-        setError(data.error || 'Failed to create user')
-      }
-    },
-    onError: (err: Error) => setError(err.message),
-  })
-
-  if (!isOpen) return null
-
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-4 sm:p-6">
-        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-          <UserPlus size={20} className="text-blue-600" />
-          Add New User
-        </h3>
-        
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Email Address *
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="user@example.com"
-              className="input"
-              autoFocus
-            />
-            <p className="text-xs text-gray-500 mt-1">
-              A temporary password will be sent to this email
-            </p>
-          </div>
-          
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Name (optional)
-            </label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="John Doe"
-              className="input"
-            />
-          </div>
-          
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Role
-            </label>
-            <div className="flex gap-4">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  name="group"
-                  value="users"
-                  checked={group === 'users'}
-                  onChange={() => setGroup('users')}
-                  className="text-blue-600"
-                />
-                <Eye size={16} className="text-gray-500" />
-                <span>User</span>
-              </label>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  name="group"
-                  value="admins"
-                  checked={group === 'admins'}
-                  onChange={() => setGroup('admins')}
-                  className="text-blue-600"
-                />
-                <Shield size={16} className="text-purple-500" />
-                <span>Admin</span>
-              </label>
-            </div>
-          </div>
-          
-          {error && (
-            <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 p-3 rounded-lg">
-              <AlertCircle size={16} className="flex-shrink-0" />
-              <span>{error}</span>
-            </div>
-          )}
-        </div>
-        
-        <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 mt-6">
-          <button onClick={onClose} className="btn btn-secondary w-full sm:w-auto">
-            Cancel
-          </button>
-          <button
-            onClick={() => createMutation.mutate()}
-            disabled={!email || createMutation.isPending}
-            className="btn btn-primary flex items-center justify-center gap-2 w-full sm:w-auto"
-          >
-            {createMutation.isPending ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : (
-              <Mail size={16} />
-            )}
-            Send Invite
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// Desktop Table Row Component
-interface UserTableRowProps {
-  readonly user: CognitoUser
-  readonly onRoleChange: (username: string, group: UserGroup) => void
-  readonly onAction: (type: ActionType, user: CognitoUser) => void
-  readonly isRoleChangePending: boolean
-}
-
-function UserTableRow({ user, onRoleChange, onAction, isRoleChangePending }: UserTableRowProps) {
-  return (
-    <tr className="hover:bg-gray-50">
-      <td className="px-4 py-3">
-        <div>
-          <p className="font-medium text-gray-900">{user.email}</p>
-          {user.name && <p className="text-sm text-gray-500">{user.name}</p>}
-        </div>
-      </td>
-      <td className="px-4 py-3">
-        <StatusBadge user={user} />
-      </td>
-      <td className="px-4 py-3">
-        <RoleSelect user={user} isPending={isRoleChangePending} onChange={onRoleChange} />
-      </td>
-      <td className="px-4 py-3">
-        <div className="flex items-center justify-end">
-          <UserActionButtons user={user} onAction={onAction} />
-        </div>
-      </td>
-    </tr>
-  )
-}
-
-// Mobile Card Component
-interface UserCardProps {
-  readonly user: CognitoUser
-  readonly onRoleChange: (username: string, group: UserGroup) => void
-  readonly onAction: (type: ActionType, user: CognitoUser) => void
-  readonly isRoleChangePending: boolean
-}
-
-function UserCard({ user, onRoleChange, onAction, isRoleChangePending }: UserCardProps) {
-  return (
-    <div className="border border-gray-200 rounded-lg p-4 space-y-3">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="font-medium text-gray-900 truncate">{user.email}</p>
-          {user.name && <p className="text-sm text-gray-500">{user.name}</p>}
-        </div>
-        <StatusBadge user={user} />
-      </div>
-      
-      <div className="flex items-center justify-between gap-2">
-        <RoleSelect user={user} isPending={isRoleChangePending} onChange={onRoleChange} size="md" />
-        <UserActionButtons user={user} onAction={onAction} iconSize={18} buttonPadding="p-2" />
-      </div>
-    </div>
-  )
-}
-
-// Desktop Table Component
-interface UsersTableProps {
-  readonly users: CognitoUser[]
-  readonly onRoleChange: (username: string, group: UserGroup) => void
-  readonly onAction: (type: ActionType, user: CognitoUser) => void
-  readonly isRoleChangePending: boolean
-}
-
-function UsersTable({ users, onRoleChange, onAction, isRoleChangePending }: UsersTableProps) {
-  return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden hidden md:block">
-      <table className="w-full">
-        <thead className="bg-gray-50 border-b border-gray-200">
-          <tr>
-            <th className="text-left px-4 py-3 text-sm font-medium text-gray-700">User</th>
-            <th className="text-left px-4 py-3 text-sm font-medium text-gray-700">Status</th>
-            <th className="text-left px-4 py-3 text-sm font-medium text-gray-700">Role</th>
-            <th className="text-right px-4 py-3 text-sm font-medium text-gray-700">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200">
-          {users.map((user) => (
-            <UserTableRow
-              key={user.username}
-              user={user}
-              onRoleChange={onRoleChange}
-              onAction={onAction}
-              isRoleChangePending={isRoleChangePending}
-            />
-          ))}
-        </tbody>
-      </table>
-      
-      {users.length === 0 && (
-        <div className="text-center py-8 text-gray-500">
-          No users found. Add your first user above.
-        </div>
-      )}
-    </div>
-  )
-}
-
-// Mobile Cards Component
-interface UsersCardsProps {
-  readonly users: CognitoUser[]
-  readonly onRoleChange: (username: string, group: UserGroup) => void
-  readonly onAction: (type: ActionType, user: CognitoUser) => void
-  readonly isRoleChangePending: boolean
-}
-
-function UsersCards({ users, onRoleChange, onAction, isRoleChangePending }: UsersCardsProps) {
-  if (users.length === 0) {
-    return (
-      <div className="text-center py-8 text-gray-500 border border-gray-200 rounded-lg">
-        No users found. Add your first user above.
-      </div>
-    )
-  }
-
-  return (
-    <div className="space-y-3">
-      {users.map((user) => (
-        <UserCard
-          key={user.username}
-          user={user}
-          onRoleChange={onRoleChange}
-          onAction={onAction}
-          isRoleChangePending={isRoleChangePending}
-        />
-      ))}
-    </div>
-  )
-}
-
-// Main Component
 export default function UserAdmin() {
+  const { t } = useTranslation('components')
   const queryClient = useQueryClient()
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const [editingUser, setEditingUser] = useState<CognitoUser | null>(null)
   const [confirmAction, setConfirmAction] = useState<ConfirmActionState | null>(null)
   const [actionSuccess, setActionSuccess] = useState<string | null>(null)
 
-  const { data, isLoading, error } = useQuery({
+  const {
+    data, isLoading, error,
+  } = useQuery({
     queryKey: ['users'],
     queryFn: () => api.getUsers(),
   })
@@ -446,19 +88,24 @@ export default function UserAdmin() {
   }
 
   const updateGroupMutation = useMutation({
-    mutationFn: ({ username, group }: { username: string; group: UserGroup }) =>
+    mutationFn: ({
+      username, group,
+    }: {
+      username: string;
+      group: UserGroup
+    }) =>
       api.updateUserGroup(username, group),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
-      showSuccess('User role updated')
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
+      showSuccess(t('userAdmin.roleUpdated'))
     },
   })
 
   const resetPasswordMutation = useMutation({
     mutationFn: (username: string) => api.resetUserPassword(username),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
-      showSuccess('Password reset email sent')
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
+      showSuccess(t('userAdmin.passwordResetSent'))
       setConfirmAction(null)
     },
   })
@@ -466,8 +113,8 @@ export default function UserAdmin() {
   const enableMutation = useMutation({
     mutationFn: (username: string) => api.enableUser(username),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
-      showSuccess('User enabled')
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
+      showSuccess(t('userAdmin.userEnabled'))
       setConfirmAction(null)
     },
   })
@@ -475,8 +122,8 @@ export default function UserAdmin() {
   const disableMutation = useMutation({
     mutationFn: (username: string) => api.disableUser(username),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
-      showSuccess('User disabled')
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
+      showSuccess(t('userAdmin.userDisabled'))
       setConfirmAction(null)
     },
   })
@@ -484,16 +131,18 @@ export default function UserAdmin() {
   const deleteMutation = useMutation({
     mutationFn: (username: string) => api.deleteUser(username),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
-      showSuccess('User deleted')
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
+      showSuccess(t('userAdmin.userDeleted'))
       setConfirmAction(null)
     },
   })
 
   const handleConfirmAction = () => {
     if (!confirmAction) return
-    
-    const { type, user } = confirmAction
+
+    const {
+      type, user,
+    } = confirmAction
     if (type === 'delete') {
       deleteMutation.mutate(user.username)
     } else if (type === 'disable') {
@@ -506,11 +155,21 @@ export default function UserAdmin() {
   }
 
   const handleRoleChange = (username: string, group: UserGroup) => {
-    updateGroupMutation.mutate({ username, group })
+    updateGroupMutation.mutate({
+      username,
+      group,
+    })
   }
 
   const handleAction = (type: ActionType, user: CognitoUser) => {
-    setConfirmAction({ type, user })
+    if (type === 'edit') {
+      setEditingUser(user)
+      return
+    }
+    setConfirmAction({
+      type,
+      user,
+    })
   }
 
   if (isLoading) {
@@ -525,7 +184,7 @@ export default function UserAdmin() {
     return (
       <div className="flex items-center gap-2 text-red-600 bg-red-50 p-4 rounded-lg">
         <AlertCircle size={20} />
-        <span>Failed to load users. Make sure you have admin access.</span>
+        <span>{t('userAdmin.loadError')}</span>
       </div>
     )
   }
@@ -537,24 +196,22 @@ export default function UserAdmin() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Users className="text-blue-600" size={20} />
-          <h3 className="font-semibold">User Management</h3>
-          <span className="text-sm text-gray-500">({users.length} users)</span>
+          <h3 className="font-semibold">{t('userAdmin.userManagement')}</h3>
+          <span className="text-sm text-gray-500">{t('userAdmin.usersCount', { count: users.length })}</span>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
           className="btn btn-primary flex items-center justify-center gap-2 w-full sm:w-auto"
         >
           <UserPlus size={16} />
-          Add User
+          {t('userAdmin.addUser')}
         </button>
       </div>
 
-      {actionSuccess && (
-        <div className="flex items-center gap-2 text-sm text-green-600 bg-green-50 p-3 rounded-lg">
-          <CheckCircle2 size={16} />
-          {actionSuccess}
-        </div>
-      )}
+      {actionSuccess == null || actionSuccess === '' ? null : <div className="flex items-center gap-2 text-sm text-green-600 bg-green-50 p-3 rounded-lg">
+        <CheckCircle2 size={16} />
+        {actionSuccess}
+      </div>}
 
       <UsersTable
         users={users}
@@ -575,20 +232,25 @@ export default function UserAdmin() {
       <CreateUserModal
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
-        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['users'] })}
+        onSuccess={() => void queryClient.invalidateQueries({ queryKey: ['users'] })}
       />
 
-      {confirmAction && (
-        <ConfirmModal
-          isOpen={true}
-          title={getConfirmTitle(confirmAction.type)}
-          message={getConfirmMessage(confirmAction)}
-          confirmLabel={getConfirmLabel(confirmAction.type)}
-          variant={getConfirmVariant(confirmAction.type)}
-          onConfirm={handleConfirmAction}
-          onCancel={() => setConfirmAction(null)}
-        />
-      )}
+      <EditUserModal
+        isOpen={editingUser !== null}
+        user={editingUser}
+        onClose={() => setEditingUser(null)}
+        onSuccess={() => void queryClient.invalidateQueries({ queryKey: ['users'] })}
+      />
+
+      {confirmAction ? <ConfirmModal
+        isOpen
+        title={getConfirmTitle(confirmAction.type, t)}
+        message={getConfirmMessage(confirmAction, t)}
+        confirmLabel={getConfirmLabel(confirmAction.type, t)}
+        variant={getConfirmVariant(confirmAction.type)}
+        onConfirm={handleConfirmAction}
+        onCancel={() => setConfirmAction(null)}
+      /> : null}
     </div>
   )
 }

--- a/voc-datalake/frontend/src/components/UserAdmin/UserAdminComponents.tsx
+++ b/voc-datalake/frontend/src/components/UserAdmin/UserAdminComponents.tsx
@@ -1,0 +1,275 @@
+/**
+ * @fileoverview Sub-components for UserAdmin: table rows, cards, action buttons.
+ * @module components/UserAdmin/UserAdminComponents
+ */
+
+import clsx from 'clsx'
+import {
+  Key, UserX, UserCheck, Trash2, Pencil,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { CognitoUser } from '../../api/types'
+
+type UserGroup = 'admins' | 'users'
+export type ActionType = 'delete' | 'disable' | 'enable' | 'reset' | 'edit'
+
+function getDisplayName(user: CognitoUser): string {
+  const hasGivenName = user.given_name != null && user.given_name !== ''
+  const hasFamilyName = user.family_name != null && user.family_name !== ''
+  return hasGivenName || hasFamilyName
+    ? `${user.given_name ?? ''} ${user.family_name ?? ''}`.trim()
+    : user.name
+}
+
+// Status Badge Component
+export function StatusBadge({ user }: Readonly<{ user: CognitoUser }>) {
+  const { t } = useTranslation('components')
+  if (!user.enabled) {
+    return <span className="px-2 py-0.5 text-xs rounded-full bg-red-100 text-red-700">{t('userAdmin.disabled')}</span>
+  }
+  if (user.status === 'CONFIRMED') {
+    return <span className="px-2 py-0.5 text-xs rounded-full bg-green-100 text-green-700">{t('userAdmin.active')}</span>
+  }
+  if (user.status === 'FORCE_CHANGE_PASSWORD') {
+    return <span className="px-2 py-0.5 text-xs rounded-full bg-yellow-100 text-yellow-700">{t('userAdmin.pendingStatus')}</span>
+  }
+  return <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700">{user.status}</span>
+}
+
+// Role Select Component
+interface RoleSelectProps {
+  readonly user: CognitoUser
+  readonly isPending: boolean
+  readonly onChange: (username: string, group: UserGroup) => void
+  readonly size?: 'sm' | 'md'
+}
+
+export function RoleSelect({
+  user, isPending, onChange, size = 'sm',
+}: RoleSelectProps) {
+  const { t } = useTranslation('components')
+  const isAdmin = user.groups.includes('admins')
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value
+    if (value === 'admins' || value === 'users') {
+      onChange(user.username, value)
+    }
+  }
+
+  return (
+    <select
+      value={isAdmin ? 'admins' : 'users'}
+      onChange={handleChange}
+      disabled={isPending}
+      className={clsx(
+        'text-sm border rounded',
+        size === 'sm' ? 'px-2 py-1' : 'px-2 py-1.5',
+        isAdmin
+          ? 'border-purple-300 bg-purple-50 text-purple-700'
+          : 'border-gray-300 bg-white text-gray-700',
+      )}
+    >
+      <option value="users">{t('userAdmin.userRole')}</option>
+      <option value="admins">{t('userAdmin.adminRole')}</option>
+    </select>
+  )
+}
+
+// User Action Buttons Component
+interface UserActionButtonsProps {
+  readonly user: CognitoUser
+  readonly onAction: (type: ActionType, user: CognitoUser) => void
+  readonly iconSize?: number
+  readonly buttonPadding?: string
+}
+
+export function UserActionButtons({
+  user, onAction, iconSize = 16, buttonPadding = 'p-1.5',
+}: UserActionButtonsProps) {
+  const { t } = useTranslation('components')
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        onClick={() => onAction('edit', user)}
+        className={clsx(buttonPadding, 'text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded')}
+        title={t('userAdmin.editUserTitle')}
+      >
+        <Pencil size={iconSize} />
+      </button>
+      <button
+        onClick={() => onAction('reset', user)}
+        className={clsx(buttonPadding, 'text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded')}
+        title={t('userAdmin.resetPasswordTitle')}
+      >
+        <Key size={iconSize} />
+      </button>
+      {user.enabled ? (
+        <button
+          onClick={() => onAction('disable', user)}
+          className={clsx(buttonPadding, 'text-gray-500 hover:text-orange-600 hover:bg-orange-50 rounded')}
+          title={t('userAdmin.disableUserTitle')}
+        >
+          <UserX size={iconSize} />
+        </button>
+      ) : (
+        <button
+          onClick={() => onAction('enable', user)}
+          className={clsx(buttonPadding, 'text-gray-500 hover:text-green-600 hover:bg-green-50 rounded')}
+          title={t('userAdmin.enableUserTitle')}
+        >
+          <UserCheck size={iconSize} />
+        </button>
+      )}
+      <button
+        onClick={() => onAction('delete', user)}
+        className={clsx(buttonPadding, 'text-gray-500 hover:text-red-600 hover:bg-red-50 rounded')}
+        title={t('userAdmin.deleteUserTitle')}
+      >
+        <Trash2 size={iconSize} />
+      </button>
+    </div>
+  )
+}
+
+// Desktop Table Row Component
+interface UserTableRowProps {
+  readonly user: CognitoUser
+  readonly onRoleChange: (username: string, group: UserGroup) => void
+  readonly onAction: (type: ActionType, user: CognitoUser) => void
+  readonly isRoleChangePending: boolean
+}
+
+function UserTableRow({
+  user, onRoleChange, onAction, isRoleChangePending,
+}: UserTableRowProps) {
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-4 py-3">
+        <div>
+          <p className="font-medium text-gray-900">{user.email}</p>
+          {user.name === '' ? null : <p className="text-sm text-gray-500">{getDisplayName(user)}</p>}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <StatusBadge user={user} />
+      </td>
+      <td className="px-4 py-3">
+        <RoleSelect user={user} isPending={isRoleChangePending} onChange={onRoleChange} />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center justify-end">
+          <UserActionButtons user={user} onAction={onAction} />
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+// Mobile Card Component
+interface UserCardProps {
+  readonly user: CognitoUser
+  readonly onRoleChange: (username: string, group: UserGroup) => void
+  readonly onAction: (type: ActionType, user: CognitoUser) => void
+  readonly isRoleChangePending: boolean
+}
+
+function UserCard({
+  user, onRoleChange, onAction, isRoleChangePending,
+}: UserCardProps) {
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-medium text-gray-900 truncate">{user.email}</p>
+          {user.name === '' ? null : <p className="text-sm text-gray-500">{getDisplayName(user)}</p>}
+        </div>
+        <StatusBadge user={user} />
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <RoleSelect user={user} isPending={isRoleChangePending} onChange={onRoleChange} size="md" />
+        <UserActionButtons user={user} onAction={onAction} iconSize={18} buttonPadding="p-2" />
+      </div>
+    </div>
+  )
+}
+
+// Desktop Table Component
+interface UsersTableProps {
+  readonly users: CognitoUser[]
+  readonly onRoleChange: (username: string, group: UserGroup) => void
+  readonly onAction: (type: ActionType, user: CognitoUser) => void
+  readonly isRoleChangePending: boolean
+}
+
+export function UsersTable({
+  users, onRoleChange, onAction, isRoleChangePending,
+}: UsersTableProps) {
+  const { t } = useTranslation('components')
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden hidden md:block">
+      <table className="w-full">
+        <thead className="bg-gray-50 border-b border-gray-200">
+          <tr>
+            <th className="text-left px-4 py-3 text-sm font-medium text-gray-700">{t('userAdmin.tableUser')}</th>
+            <th className="text-left px-4 py-3 text-sm font-medium text-gray-700">{t('userAdmin.tableStatus')}</th>
+            <th className="text-left px-4 py-3 text-sm font-medium text-gray-700">{t('userAdmin.tableRole')}</th>
+            <th className="text-right px-4 py-3 text-sm font-medium text-gray-700">{t('userAdmin.tableActions')}</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {users.map((user) => (
+            <UserTableRow
+              key={user.username}
+              user={user}
+              onRoleChange={onRoleChange}
+              onAction={onAction}
+              isRoleChangePending={isRoleChangePending}
+            />
+          ))}
+        </tbody>
+      </table>
+
+      {users.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          {t('userAdmin.noUsers')}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Mobile Cards Component
+interface UsersCardsProps {
+  readonly users: CognitoUser[]
+  readonly onRoleChange: (username: string, group: UserGroup) => void
+  readonly onAction: (type: ActionType, user: CognitoUser) => void
+  readonly isRoleChangePending: boolean
+}
+
+export function UsersCards({
+  users, onRoleChange, onAction, isRoleChangePending,
+}: UsersCardsProps) {
+  const { t } = useTranslation('components')
+  if (users.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500 border border-gray-200 rounded-lg">
+        {t('userAdmin.noUsers')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {users.map((user) => (
+        <UserCard
+          key={user.username}
+          user={user}
+          onRoleChange={onRoleChange}
+          onAction={onAction}
+          isRoleChangePending={isRoleChangePending}
+        />
+      ))}
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/components/UserProfileModal/UserProfileModal.test.tsx
+++ b/voc-datalake/frontend/src/components/UserProfileModal/UserProfileModal.test.tsx
@@ -41,6 +41,7 @@ describe('UserProfileModal', () => {
       const { container } = render(
         <UserProfileModal isOpen={false} onClose={mockOnClose} />
       )
+      // eslint-disable-next-line testing-library/no-node-access
       expect(container.firstChild).toBeNull()
     })
 
@@ -52,6 +53,7 @@ describe('UserProfileModal', () => {
       const { container } = render(
         <UserProfileModal isOpen={true} onClose={mockOnClose} />
       )
+      // eslint-disable-next-line testing-library/no-node-access
       expect(container.firstChild).toBeNull()
     })
 
@@ -99,6 +101,7 @@ describe('UserProfileModal', () => {
     it('displays avatar with first letter of name', () => {
       render(<UserProfileModal isOpen={true} onClose={mockOnClose} />)
       // Avatar should show 'T' for 'Test User'
+      // eslint-disable-next-line testing-library/no-node-access
       const avatar = document.querySelector('.rounded-full')
       expect(avatar).toHaveTextContent('T')
     })
@@ -266,7 +269,7 @@ describe('UserProfileModal', () => {
       const closeButton = screen.getByRole('button', { name: '' })
       await user.click(closeButton)
       
-      expect(mockOnClose).toHaveBeenCalled()
+      expect(mockOnClose).toHaveBeenCalledWith()
     })
   })
 })

--- a/voc-datalake/frontend/src/components/UserProfileModal/UserProfileModal.tsx
+++ b/voc-datalake/frontend/src/components/UserProfileModal/UserProfileModal.tsx
@@ -8,35 +8,43 @@
  * @module components/UserProfileModal
  */
 
-import { useState } from 'react'
-import { X, User, Shield, Eye, Lock, Loader2, CheckCircle2, AlertCircle, EyeOff } from 'lucide-react'
-import { useAuthStore } from '../../store/authStore'
-import { authService } from '../../services/auth'
 import clsx from 'clsx'
+import {
+  X, User, Shield, Eye, Lock, Loader2, CheckCircle2, AlertCircle, EyeOff,
+} from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { authService } from '../../services/auth'
+import { useAuthStore } from '../../store/authStore'
 
 interface UserProfileModalProps {
   readonly isOpen: boolean
   readonly onClose: () => void
 }
 
-function getPasswordError(err: unknown): string {
+function getPasswordError(err: unknown, t: (key: string) => string): string {
   if (err instanceof Error) {
-    if (err.message?.includes('Incorrect')) return 'Current password is incorrect'
-    return err.message || 'Failed to change password'
+    if (err.message.includes('Incorrect')) return t('userProfile.incorrectPassword')
+    return err.message === '' ? t('userProfile.failedToChange') : err.message
   }
-  return 'Failed to change password'
+  return t('userProfile.failedToChange')
 }
 
-function validatePasswordChange(current: string, newPwd: string, confirm: string): string | null {
-  if (!current || !newPwd || !confirm) return 'All fields are required'
-  if (newPwd !== confirm) return 'New passwords do not match'
-  if (newPwd.length < 8) return 'Password must be at least 8 characters'
+function validatePasswordChange(current: string, newPwd: string, confirm: string, t: (key: string) => string): string | null {
+  if (current === '' || newPwd === '' || confirm === '') return t('userProfile.allFieldsRequired')
+  if (newPwd !== confirm) return t('userProfile.passwordsMismatch')
+  if (newPwd.length < 8) return t('userProfile.passwordTooShort')
   return null
 }
 
 // Avatar component
-function UserAvatar({ name, email }: Readonly<{ name?: string; email?: string }>) {
-  const initial = name?.charAt(0).toUpperCase() || email?.charAt(0).toUpperCase() || 'U'
+function UserAvatar({
+  name, email,
+}: Readonly<{
+  name?: string;
+  email?: string
+}>) {
+  const initial = (name?.charAt(0).toUpperCase() ?? email?.charAt(0).toUpperCase()) ?? 'U'
   return (
     <div className="flex justify-center">
       <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white text-xl sm:text-2xl font-bold">
@@ -47,7 +55,12 @@ function UserAvatar({ name, email }: Readonly<{ name?: string; email?: string }>
 }
 
 // Info field component
-function InfoField({ label, children }: Readonly<{ label: string; children: React.ReactNode }>) {
+function InfoField({
+  label, children,
+}: Readonly<{
+  label: string;
+  children: React.ReactNode
+}>) {
   return (
     <div>
       <label className="block text-xs text-gray-500 mb-1">{label}</label>
@@ -58,34 +71,36 @@ function InfoField({ label, children }: Readonly<{ label: string; children: Reac
 
 // Role display component
 function RoleDisplay({ isAdmin }: Readonly<{ isAdmin: boolean }>) {
+  const { t } = useTranslation('components')
   if (isAdmin) {
     return (
       <div className="flex items-center gap-2">
         <Shield size={16} className="text-purple-600 flex-shrink-0" />
-        <span className="text-purple-700 font-medium">Administrator</span>
+        <span className="text-purple-700 font-medium">{t('userProfile.administrator')}</span>
       </div>
     )
   }
   return (
     <div className="flex items-center gap-2">
       <Eye size={16} className="text-gray-500 flex-shrink-0" />
-      <span className="text-gray-700">User</span>
+      <span className="text-gray-700">{t('userProfile.user')}</span>
     </div>
   )
 }
 
 // Groups display component
 function GroupsDisplay({ groups }: Readonly<{ groups: string[] }>) {
+  const { t } = useTranslation('components')
   if (groups.length === 0) return null
   return (
-    <InfoField label="Groups">
+    <InfoField label={t('userProfile.groups')}>
       <div className="flex flex-wrap gap-2">
         {groups.map((group) => (
           <span
             key={group}
             className={clsx(
               'px-2 py-1 text-xs rounded-full',
-              group === 'admins' ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-700'
+              group === 'admins' ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-700',
             )}
           >
             {group}
@@ -97,23 +112,32 @@ function GroupsDisplay({ groups }: Readonly<{ groups: string[] }>) {
 }
 
 // Profile tab content
-function ProfileTab({ user, isAdmin }: Readonly<{ user: { name?: string; email?: string; username?: string; groups?: string[] }; isAdmin: boolean }>) {
+function ProfileTab({
+  user, isAdmin,
+}: Readonly<{
+  user: {
+    name?: string;
+    email?: string;
+    username?: string;
+    groups?: string[]
+  };
+  isAdmin: boolean
+}>) {
+  const { t } = useTranslation('components')
   return (
     <div className="space-y-4">
       <UserAvatar name={user.name} email={user.email} />
       <div className="space-y-3">
-        {user.name && (
-          <InfoField label="Name">
-            <p className="text-gray-900 font-medium truncate">{user.name}</p>
-          </InfoField>
-        )}
-        <InfoField label="Email">
+        {user.name != null && user.name !== '' ? <InfoField label={t('userProfile.name')}>
+          <p className="text-gray-900 font-medium truncate">{user.name}</p>
+        </InfoField> : null}
+        <InfoField label={t('userProfile.email')}>
           <p className="text-gray-900 font-medium truncate">{user.email}</p>
         </InfoField>
-        <InfoField label="Username">
+        <InfoField label={t('userProfile.username')}>
           <p className="text-gray-900 truncate">{user.username}</p>
         </InfoField>
-        <InfoField label="Role">
+        <InfoField label={t('userProfile.role')}>
           <RoleDisplay isAdmin={isAdmin} />
         </InfoField>
         <GroupsDisplay groups={user.groups ?? []} />
@@ -183,54 +207,54 @@ function PasswordTab({
   onShowPasswordsChange: (v: boolean) => void
   onSubmit: () => void
 }>) {
+  const { t } = useTranslation('components')
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2 text-sm text-gray-600 mb-4">
         <Lock size={16} />
-        <span>Enter your current password and choose a new one</span>
+        <span>{t('userProfile.passwordIntro')}</span>
       </div>
 
-      <PasswordInput id="current-password" label="Current Password" value={currentPassword} onChange={onCurrentChange} showPassword={showPasswords} placeholder="Enter current password" />
-      <PasswordInput id="new-password" label="New Password" value={newPassword} onChange={onNewChange} showPassword={showPasswords} placeholder="Enter new password" />
-      <PasswordInput id="confirm-password" label="Confirm New Password" value={confirmPassword} onChange={onConfirmChange} showPassword={showPasswords} placeholder="Confirm new password" />
+      <PasswordInput id="current-password" label={t('userProfile.currentPassword')} value={currentPassword} onChange={onCurrentChange} showPassword={showPasswords} placeholder={t('userProfile.currentPasswordPlaceholder')} />
+      <PasswordInput id="new-password" label={t('userProfile.newPassword')} value={newPassword} onChange={onNewChange} showPassword={showPasswords} placeholder={t('userProfile.newPasswordPlaceholder')} />
+      <PasswordInput id="confirm-password" label={t('userProfile.confirmNewPassword')} value={confirmPassword} onChange={onConfirmChange} showPassword={showPasswords} placeholder={t('userProfile.confirmPasswordPlaceholder')} />
 
       <label htmlFor="show-passwords" className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
         <input id="show-passwords" type="checkbox" checked={showPasswords} onChange={(e) => onShowPasswordsChange(e.target.checked)} className="rounded border-gray-300" />
         {showPasswords ? <EyeOff size={14} /> : <Eye size={14} />}
-        Show passwords
+        {t('userProfile.showPasswords')}
       </label>
 
-      {passwordError && (
-        <div className="flex items-start gap-2 text-sm text-red-600 bg-red-50 p-3 rounded-lg">
-          <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
-          <span>{passwordError}</span>
-        </div>
-      )}
+      {passwordError === '' ? null : <div className="flex items-start gap-2 text-sm text-red-600 bg-red-50 p-3 rounded-lg">
+        <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
+        <span>{passwordError}</span>
+      </div>}
 
-      {passwordSuccess && (
-        <div className="flex items-center gap-2 text-sm text-green-600 bg-green-50 p-3 rounded-lg">
-          <CheckCircle2 size={16} className="flex-shrink-0" />
-          Password changed successfully!
-        </div>
-      )}
+      {passwordSuccess ? <div className="flex items-center gap-2 text-sm text-green-600 bg-green-50 p-3 rounded-lg">
+        <CheckCircle2 size={16} className="flex-shrink-0" />
+        {t('userProfile.passwordChanged')}
+      </div> : null}
 
       <button
         onClick={onSubmit}
-        disabled={isChanging || !currentPassword || !newPassword || !confirmPassword}
+        disabled={isChanging || currentPassword === '' || newPassword === '' || confirmPassword === ''}
         className="btn btn-primary w-full flex items-center justify-center gap-2 py-2.5"
       >
         {isChanging ? <Loader2 size={16} className="animate-spin" /> : <Lock size={16} />}
-        {isChanging ? 'Changing...' : 'Change Password'}
+        {isChanging ? t('userProfile.changing') : t('userProfile.changePassword')}
       </button>
 
       <p className="text-xs text-gray-500 text-center">
-        Password must be at least 8 characters with uppercase, lowercase, and numbers
+        {t('userProfile.passwordRequirements')}
       </p>
     </div>
   )
 }
 
-export default function UserProfileModal({ isOpen, onClose }: UserProfileModalProps) {
+export default function UserProfileModal({
+  isOpen, onClose,
+}: UserProfileModalProps) {
+  const { t } = useTranslation('components')
   const { user } = useAuthStore()
   const [activeTab, setActiveTab] = useState<'profile' | 'password'>('profile')
 
@@ -244,14 +268,14 @@ export default function UserProfileModal({ isOpen, onClose }: UserProfileModalPr
 
   if (!isOpen || !user) return null
 
-  const isAdmin = user.groups?.includes('admins') ?? false
+  const isAdmin = user.groups.includes('admins')
 
   const handleChangePassword = async () => {
     setPasswordError('')
     setPasswordSuccess(false)
 
-    const validationError = validatePasswordChange(currentPassword, newPassword, confirmPassword)
-    if (validationError) {
+    const validationError = validatePasswordChange(currentPassword, newPassword, confirmPassword, t)
+    if (validationError != null && validationError !== '') {
       setPasswordError(validationError)
       return
     }
@@ -265,7 +289,7 @@ export default function UserProfileModal({ isOpen, onClose }: UserProfileModalPr
       setConfirmPassword('')
       setTimeout(() => setPasswordSuccess(false), 3000)
     } catch (err) {
-      setPasswordError(getPasswordError(err))
+      setPasswordError(getPasswordError(err, t))
     } finally {
       setIsChanging(false)
     }
@@ -287,7 +311,7 @@ export default function UserProfileModal({ isOpen, onClose }: UserProfileModalPr
         <div className="flex items-center justify-between p-4 border-b border-gray-200 flex-shrink-0">
           <h3 className="text-lg font-semibold flex items-center gap-2">
             <User size={20} className="text-blue-600" />
-            My Profile
+            {t('userProfile.myProfile')}
           </h3>
           <button onClick={handleClose} className="p-1.5 text-gray-400 hover:text-gray-600 rounded">
             <X size={20} />
@@ -299,13 +323,13 @@ export default function UserProfileModal({ isOpen, onClose }: UserProfileModalPr
             onClick={() => setActiveTab('profile')}
             className={clsx('flex-1 px-4 py-3 text-sm font-medium transition-colors', activeTab === 'profile' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700')}
           >
-            Profile
+            {t('userProfile.profile')}
           </button>
           <button
             onClick={() => setActiveTab('password')}
             className={clsx('flex-1 px-4 py-3 text-sm font-medium transition-colors', activeTab === 'password' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700')}
           >
-            Change Password
+            {t('userProfile.changePassword')}
           </button>
         </div>
 
@@ -325,7 +349,7 @@ export default function UserProfileModal({ isOpen, onClose }: UserProfileModalPr
               onNewChange={setNewPassword}
               onConfirmChange={setConfirmPassword}
               onShowPasswordsChange={setShowPasswords}
-              onSubmit={handleChangePassword}
+              onSubmit={() => void handleChangePassword()}
             />
           )}
         </div>

--- a/voc-datalake/frontend/src/hooks/useEscapeKey.ts
+++ b/voc-datalake/frontend/src/hooks/useEscapeKey.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+
+export function useEscapeKey(isOpen: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+}

--- a/voc-datalake/frontend/src/pages/Login/Login.test.tsx
+++ b/voc-datalake/frontend/src/pages/Login/Login.test.tsx
@@ -235,15 +235,13 @@ describe('Login', () => {
       const passwordInput = screen.getByPlaceholderText(/Enter your password/i)
       expect(passwordInput).toHaveAttribute('type', 'password')
       
-      // Find the toggle button by its position relative to the password input
-      const passwordContainer = passwordInput.parentElement
-      const toggleButton = passwordContainer?.querySelector('button')
+      // The toggle button is inside the same container as the password input
+      // eslint-disable-next-line testing-library/no-node-access
+      const toggleButton = passwordInput.parentElement!.querySelector('button')!
       expect(toggleButton).toBeInTheDocument()
       
-      if (toggleButton) {
-        await user.click(toggleButton)
-        expect(passwordInput).toHaveAttribute('type', 'text')
-      }
+      await user.click(toggleButton)
+      expect(passwordInput).toHaveAttribute('type', 'text')
     })
   })
 

--- a/voc-datalake/frontend/src/pages/Login/Login.tsx
+++ b/voc-datalake/frontend/src/pages/Login/Login.tsx
@@ -10,11 +10,16 @@
  * @module pages/Login
  */
 
-import { useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { type CognitoUser } from 'amazon-cognito-identity-js'
 import { MessageSquare } from 'lucide-react'
+import {
+  useState, type SyntheticEvent,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  useNavigate, useLocation,
+} from 'react-router-dom'
 import { authService } from '../../services/auth'
-import { CognitoUser } from 'amazon-cognito-identity-js'
 import {
   LoginForm,
   NewPasswordForm,
@@ -35,7 +40,7 @@ function isCognitoError(err: unknown): err is CognitoError {
 }
 
 function getFromPath(state: unknown): string {
-  if (state && typeof state === 'object' && 'from' in state) {
+  if (state != null && typeof state === 'object' && 'from' in state) {
     const fromValue = state.from
     if (typeof fromValue === 'string') return fromValue
   }
@@ -43,7 +48,7 @@ function getFromPath(state: unknown): string {
 }
 
 function extractErrorMessage(err: unknown, fallback: string): string {
-  if (isCognitoError(err) && err.message) {
+  if (isCognitoError(err) && err.message != null && err.message !== '') {
     return err.message
   }
   return fallback
@@ -68,10 +73,10 @@ interface AuthFormContentProps {
   readonly onVerificationCodeChange: (value: string) => void
   readonly onToggleShowPassword: () => void
   readonly onSetShowPassword: (checked: boolean) => void
-  readonly onLogin: (e: React.SyntheticEvent) => void
-  readonly onNewPassword: (e: React.SyntheticEvent) => void
-  readonly onForgotPassword: (e: React.SyntheticEvent) => void
-  readonly onConfirmPassword: (e: React.SyntheticEvent) => void
+  readonly onLogin: (e: SyntheticEvent) => void
+  readonly onNewPassword: (e: SyntheticEvent) => void
+  readonly onForgotPassword: (e: SyntheticEvent) => void
+  readonly onConfirmPassword: (e: SyntheticEvent) => void
   readonly onSwitchToForgotPassword: () => void
   readonly onBackToLogin: () => void
 }
@@ -167,6 +172,7 @@ function AuthFormContent({
 
 // Main Login Component
 export default function Login() {
+  const { t } = useTranslation('login')
   const navigate = useNavigate()
   const location = useLocation()
   const from = getFromPath(location.state)
@@ -183,43 +189,43 @@ export default function Login() {
   const [message, setMessage] = useState<string | null>(null)
   const [cognitoUser, setCognitoUser] = useState<CognitoUser | null>(null)
 
-  const handleLogin = async (e: React.SyntheticEvent) => {
+  const handleLogin = async (e: SyntheticEvent) => {
     e.preventDefault()
     setError(null)
     setIsLoading(true)
 
     try {
       await authService.signIn(username, password)
-      navigate(from, { replace: true })
+      void navigate(from, { replace: true })
     } catch (err: unknown) {
       if (isCognitoError(err) && err.code === 'NewPasswordRequired') {
         setCognitoUser(err.cognitoUser ?? null)
         setMode('newPassword')
         setError(null)
       } else {
-        setError(extractErrorMessage(err, 'Login failed'))
+        setError(extractErrorMessage(err, t('errors.loginFailed')))
       }
     } finally {
       setIsLoading(false)
     }
   }
 
-  const handleNewPassword = async (e: React.SyntheticEvent) => {
+  const handleNewPassword = async (e: SyntheticEvent) => {
     e.preventDefault()
     setError(null)
 
     if (newPassword !== confirmNewPassword) {
-      setError('Passwords do not match')
+      setError(t('errors.passwordsDoNotMatch'))
       return
     }
 
     if (newPassword.length < 8) {
-      setError('Password must be at least 8 characters')
+      setError(t('errors.passwordTooShort'))
       return
     }
 
     if (cognitoUser == null) {
-      setError('Session expired. Please login again.')
+      setError(t('errors.sessionExpired'))
       setMode('login')
       return
     }
@@ -228,15 +234,15 @@ export default function Login() {
 
     try {
       await authService.completeNewPassword(cognitoUser, newPassword)
-      navigate(from, { replace: true })
+      void navigate(from, { replace: true })
     } catch (err: unknown) {
-      setError(extractErrorMessage(err, 'Failed to set new password'))
+      setError(extractErrorMessage(err, t('errors.failedNewPassword')))
     } finally {
       setIsLoading(false)
     }
   }
 
-  const handleForgotPassword = async (e: React.SyntheticEvent) => {
+  const handleForgotPassword = async (e: SyntheticEvent) => {
     e.preventDefault()
     setError(null)
     setMessage(null)
@@ -244,21 +250,21 @@ export default function Login() {
 
     try {
       await authService.forgotPassword(username)
-      setMessage('Verification code sent to your email')
+      setMessage(t('errors.verificationCodeSent'))
       setMode('confirmPassword')
     } catch (err: unknown) {
-      setError(extractErrorMessage(err, 'Failed to send verification code'))
+      setError(extractErrorMessage(err, t('errors.failedSendCode')))
     } finally {
       setIsLoading(false)
     }
   }
 
-  const handleConfirmPassword = async (e: React.SyntheticEvent) => {
+  const handleConfirmPassword = async (e: SyntheticEvent) => {
     e.preventDefault()
     setError(null)
 
     if (newPassword !== confirmNewPassword) {
-      setError('Passwords do not match')
+      setError(t('errors.passwordsDoNotMatch'))
       return
     }
 
@@ -266,14 +272,14 @@ export default function Login() {
 
     try {
       await authService.confirmPassword(username, verificationCode, newPassword)
-      setMessage('Password reset successful. Please login.')
+      setMessage(t('errors.passwordResetSuccess'))
       setMode('login')
       setPassword('')
       setNewPassword('')
       setConfirmNewPassword('')
       setVerificationCode('')
     } catch (err: unknown) {
-      setError(extractErrorMessage(err, 'Failed to reset password'))
+      setError(extractErrorMessage(err, t('errors.failedResetPassword')))
     } finally {
       setIsLoading(false)
     }
@@ -301,8 +307,8 @@ export default function Login() {
           <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-600 rounded-2xl mb-4">
             <MessageSquare className="w-8 h-8 text-white" />
           </div>
-          <h1 className="text-2xl font-bold text-gray-900">VoC Analytics</h1>
-          <p className="text-gray-500 mt-1">Voice of the Customer Analytics</p>
+          <h1 className="text-2xl font-bold text-gray-900">{t('appName', { ns: 'common' })}</h1>
+          <p className="text-gray-500 mt-1">{t('appTagline', { ns: 'common' })}</p>
         </div>
 
         <div className="bg-white rounded-2xl shadow-xl p-8">
@@ -324,17 +330,17 @@ export default function Login() {
             onVerificationCodeChange={setVerificationCode}
             onToggleShowPassword={handleToggleShowPassword}
             onSetShowPassword={setShowPassword}
-            onLogin={handleLogin}
-            onNewPassword={handleNewPassword}
-            onForgotPassword={handleForgotPassword}
-            onConfirmPassword={handleConfirmPassword}
+            onLogin={(e) => void handleLogin(e)}
+            onNewPassword={(e) => void handleNewPassword(e)}
+            onForgotPassword={(e) => void handleForgotPassword(e)}
+            onConfirmPassword={(e) => void handleConfirmPassword(e)}
             onSwitchToForgotPassword={handleSwitchToForgotPassword}
             onBackToLogin={handleBackToLogin}
           />
         </div>
 
         <p className="text-center text-gray-500 text-sm mt-6">
-          Contact your administrator if you need access.
+          {t('contactAdmin')}
         </p>
       </div>
     </div>

--- a/voc-datalake/frontend/src/pages/Login/LoginForms.tsx
+++ b/voc-datalake/frontend/src/pages/Login/LoginForms.tsx
@@ -3,7 +3,11 @@
  * @module pages/Login/LoginForms
  */
 
-import { ErrorAlert, SuccessMessage, SubmitButton, PasswordInput } from './LoginSharedComponents'
+import { useTranslation } from 'react-i18next'
+import {
+  ErrorAlert, SuccessMessage, SubmitButton, PasswordInput,
+} from './LoginSharedComponents'
+import type { SyntheticEvent } from 'react'
 
 // Login Form Component
 interface LoginFormProps {
@@ -16,7 +20,7 @@ interface LoginFormProps {
   readonly onUsernameChange: (value: string) => void
   readonly onPasswordChange: (value: string) => void
   readonly onToggleShowPassword: () => void
-  readonly onSubmit: (e: React.SyntheticEvent) => void
+  readonly onSubmit: (e: SyntheticEvent) => void
   readonly onForgotPassword: () => void
 }
 
@@ -33,22 +37,22 @@ export function LoginForm({
   onSubmit,
   onForgotPassword,
 }: Readonly<LoginFormProps>) {
+  const { t } = useTranslation('login')
   return (
     <>
-      <h2 className="text-xl font-semibold text-gray-900 mb-6">Sign in</h2>
+      <h2 className="text-xl font-semibold text-gray-900 mb-6">{t('signIn')}</h2>
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Username or Email
+            {t('usernameOrEmail')}
           </label>
           <input
             type="text"
             value={username}
             onChange={(e) => onUsernameChange(e.target.value)}
             className="input"
-            placeholder="Enter your username"
+            placeholder={t('enterUsername')}
             required
-            autoFocus
           />
         </div>
         <PasswordInput
@@ -56,17 +60,17 @@ export function LoginForm({
           onChange={onPasswordChange}
           showPassword={showPassword}
           onToggleShow={onToggleShowPassword}
-          placeholder="Enter your password"
-          label="Password"
+          placeholder={t('enterPassword')}
+          label={t('password')}
         />
 
-        {error && <ErrorAlert message={error} />}
-        {message && <SuccessMessage message={message} />}
+        {error != null && error !== '' ? <ErrorAlert message={error} /> : null}
+        {message != null && message !== '' ? <SuccessMessage message={message} /> : null}
 
         <SubmitButton
           isLoading={isLoading}
-          loadingText="Signing in..."
-          text="Sign in"
+          loadingText={t('signingIn')}
+          text={t('signIn')}
         />
 
         <button
@@ -74,7 +78,7 @@ export function LoginForm({
           onClick={onForgotPassword}
           className="w-full text-sm text-blue-600 hover:text-blue-700"
         >
-          Forgot password?
+          {t('forgotPassword')}
         </button>
       </form>
     </>
@@ -91,7 +95,7 @@ interface NewPasswordFormProps {
   readonly onNewPasswordChange: (value: string) => void
   readonly onConfirmPasswordChange: (value: string) => void
   readonly onToggleShowPassword: (checked: boolean) => void
-  readonly onSubmit: (e: React.SyntheticEvent) => void
+  readonly onSubmit: (e: SyntheticEvent) => void
 }
 
 export function NewPasswordForm({
@@ -105,37 +109,38 @@ export function NewPasswordForm({
   onToggleShowPassword,
   onSubmit,
 }: Readonly<NewPasswordFormProps>) {
+  const { t } = useTranslation('login')
   return (
     <>
-      <h2 className="text-xl font-semibold text-gray-900 mb-2">Set New Password</h2>
+      <h2 className="text-xl font-semibold text-gray-900 mb-2">{t('newPassword.title')}</h2>
       <p className="text-gray-500 text-sm mb-6">
-        You need to set a new password for your account.
+        {t('newPassword.description')}
       </p>
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            New Password
+            {t('newPassword.label')}
           </label>
           <input
             type={showPassword ? 'text' : 'password'}
             value={newPassword}
             onChange={(e) => onNewPasswordChange(e.target.value)}
             className="input"
-            placeholder="Enter new password"
+            placeholder={t('newPassword.placeholder')}
             required
             minLength={8}
           />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Confirm Password
+            {t('newPassword.confirmLabel')}
           </label>
           <input
             type={showPassword ? 'text' : 'password'}
             value={confirmNewPassword}
             onChange={(e) => onConfirmPasswordChange(e.target.value)}
             className="input"
-            placeholder="Confirm new password"
+            placeholder={t('newPassword.confirmPlaceholder')}
             required
           />
         </div>
@@ -147,15 +152,15 @@ export function NewPasswordForm({
             onChange={(e) => onToggleShowPassword(e.target.checked)}
             className="rounded"
           />
-          Show password
+          {t('newPassword.showPassword')}
         </label>
 
-        {error && <ErrorAlert message={error} />}
+        {error != null && error !== '' ? <ErrorAlert message={error} /> : null}
 
         <SubmitButton
           isLoading={isLoading}
-          loadingText="Setting password..."
-          text="Set Password"
+          loadingText={t('newPassword.settingPassword')}
+          text={t('newPassword.submit')}
         />
       </form>
     </>
@@ -168,7 +173,7 @@ interface ForgotPasswordFormProps {
   readonly isLoading: boolean
   readonly error: string | null
   readonly onUsernameChange: (value: string) => void
-  readonly onSubmit: (e: React.SyntheticEvent) => void
+  readonly onSubmit: (e: SyntheticEvent) => void
   readonly onBackToLogin: () => void
 }
 
@@ -180,33 +185,34 @@ export function ForgotPasswordForm({
   onSubmit,
   onBackToLogin,
 }: Readonly<ForgotPasswordFormProps>) {
+  const { t } = useTranslation('login')
   return (
     <>
-      <h2 className="text-xl font-semibold text-gray-900 mb-2">Reset Password</h2>
+      <h2 className="text-xl font-semibold text-gray-900 mb-2">{t('resetPassword.title')}</h2>
       <p className="text-gray-500 text-sm mb-6">
-        Enter your username to receive a verification code.
+        {t('resetPassword.description')}
       </p>
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Username or Email
+            {t('usernameOrEmail')}
           </label>
           <input
             type="text"
             value={username}
             onChange={(e) => onUsernameChange(e.target.value)}
             className="input"
-            placeholder="Enter your username"
+            placeholder={t('enterUsername')}
             required
           />
         </div>
 
-        {error && <ErrorAlert message={error} />}
+        {error != null && error !== '' ? <ErrorAlert message={error} /> : null}
 
         <SubmitButton
           isLoading={isLoading}
-          loadingText="Sending code..."
-          text="Send Code"
+          loadingText={t('resetPassword.sendingCode')}
+          text={t('resetPassword.sendCode')}
         />
 
         <button
@@ -214,7 +220,7 @@ export function ForgotPasswordForm({
           onClick={onBackToLogin}
           className="w-full text-sm text-gray-600 hover:text-gray-700"
         >
-          Back to login
+          {t('resetPassword.backToLogin')}
         </button>
       </form>
     </>
@@ -232,7 +238,7 @@ interface ConfirmPasswordFormProps {
   readonly onVerificationCodeChange: (value: string) => void
   readonly onNewPasswordChange: (value: string) => void
   readonly onConfirmPasswordChange: (value: string) => void
-  readonly onSubmit: (e: React.SyntheticEvent) => void
+  readonly onSubmit: (e: SyntheticEvent) => void
   readonly onBackToLogin: () => void
 }
 
@@ -249,60 +255,61 @@ export function ConfirmPasswordForm({
   onSubmit,
   onBackToLogin,
 }: Readonly<ConfirmPasswordFormProps>) {
+  const { t } = useTranslation('login')
   return (
     <>
-      <h2 className="text-xl font-semibold text-gray-900 mb-2">Enter Verification Code</h2>
+      <h2 className="text-xl font-semibold text-gray-900 mb-2">{t('verifyCode.title')}</h2>
       <p className="text-gray-500 text-sm mb-6">
-        Check your email for the verification code.
+        {t('verifyCode.description')}
       </p>
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Verification Code
+            {t('verifyCode.label')}
           </label>
           <input
             type="text"
             value={verificationCode}
             onChange={(e) => onVerificationCodeChange(e.target.value)}
             className="input"
-            placeholder="Enter code"
+            placeholder={t('verifyCode.placeholder')}
             required
           />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            New Password
+            {t('newPassword.label')}
           </label>
           <input
             type={showPassword ? 'text' : 'password'}
             value={newPassword}
             onChange={(e) => onNewPasswordChange(e.target.value)}
             className="input"
-            placeholder="Enter new password"
+            placeholder={t('newPassword.placeholder')}
             required
             minLength={8}
           />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Confirm Password
+            {t('newPassword.confirmLabel')}
           </label>
           <input
             type={showPassword ? 'text' : 'password'}
             value={confirmNewPassword}
             onChange={(e) => onConfirmPasswordChange(e.target.value)}
             className="input"
-            placeholder="Confirm new password"
+            placeholder={t('newPassword.confirmPlaceholder')}
             required
           />
         </div>
 
-        {error && <ErrorAlert message={error} />}
+        {error != null && error !== '' ? <ErrorAlert message={error} /> : null}
 
         <SubmitButton
           isLoading={isLoading}
-          loadingText="Resetting password..."
-          text="Reset Password"
+          loadingText={t('verifyCode.resettingPassword')}
+          text={t('verifyCode.submit')}
         />
 
         <button
@@ -310,7 +317,7 @@ export function ConfirmPasswordForm({
           onClick={onBackToLogin}
           className="w-full text-sm text-gray-600 hover:text-gray-700"
         >
-          Back to login
+          {t('resetPassword.backToLogin')}
         </button>
       </form>
     </>

--- a/voc-datalake/frontend/src/pages/Login/LoginSharedComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Login/LoginSharedComponents.tsx
@@ -3,13 +3,13 @@
  * @module pages/Login/LoginSharedComponents
  */
 
-import { Loader2, AlertCircle, Eye, EyeOff } from 'lucide-react'
 import clsx from 'clsx'
+import {
+  Loader2, AlertCircle, Eye, EyeOff,
+} from 'lucide-react'
 
 // Error Alert Component
-interface ErrorAlertProps {
-  readonly message: string
-}
+interface ErrorAlertProps { readonly message: string }
 
 export function ErrorAlert({ message }: Readonly<ErrorAlertProps>) {
   return (
@@ -21,9 +21,7 @@ export function ErrorAlert({ message }: Readonly<ErrorAlertProps>) {
 }
 
 // Success Message Component
-interface SuccessMessageProps {
-  readonly message: string
-}
+interface SuccessMessageProps { readonly message: string }
 
 export function SuccessMessage({ message }: Readonly<SuccessMessageProps>) {
   return (
@@ -40,17 +38,19 @@ interface SubmitButtonProps {
   readonly text: string
 }
 
-export function SubmitButton({ isLoading, loadingText, text }: Readonly<SubmitButtonProps>) {
+export function SubmitButton({
+  isLoading, loadingText, text,
+}: Readonly<SubmitButtonProps>) {
   return (
     <button
       type="submit"
       disabled={isLoading}
       className={clsx(
         'w-full btn btn-primary py-3 flex items-center justify-center gap-2',
-        isLoading && 'opacity-75 cursor-not-allowed'
+        isLoading && 'opacity-75 cursor-not-allowed',
       )}
     >
-      {isLoading && <Loader2 size={18} className="animate-spin" />}
+      {isLoading ? <Loader2 size={18} className="animate-spin" /> : null}
       {isLoading ? loadingText : text}
     </button>
   )

--- a/voc-datalake/frontend/src/services/auth.test.ts
+++ b/voc-datalake/frontend/src/services/auth.test.ts
@@ -31,26 +31,24 @@ vi.mock('amazon-cognito-identity-js', () => ({
 }))
 
 // Mock config
-vi.mock('../config', () => ({
-  config: {
-    cognito: {
-      userPoolId: 'us-east-1_test123',
-      clientId: 'testclientid123',
-    },
-  },
-  getConfig: () => ({
+vi.mock('../runtimeConfig', () => ({
+  getRuntimeConfig: () => ({
     apiEndpoint: 'https://api.example.com',
     cognito: {
       userPoolId: 'us-east-1_test123',
       clientId: 'testclientid123',
       region: 'us-east-1',
+      identityPoolId: 'us-east-1:test-pool-id',
     },
   }),
+  isConfigLoaded: () => true,
+  loadRuntimeConfig: vi.fn(),
 }))
 
 // Mock authStore
 const mockSetUser = vi.fn()
 const mockSetTokens = vi.fn()
+const mockSetSessionReady = vi.fn()
 const mockLogout = vi.fn()
 
 vi.mock('../store/authStore', () => ({
@@ -58,6 +56,7 @@ vi.mock('../store/authStore', () => ({
     getState: () => ({
       setUser: mockSetUser,
       setTokens: mockSetTokens,
+      setSessionReady: mockSetSessionReady,
       logout: mockLogout,
       refreshToken: 'mock-refresh-token',
     }),
@@ -91,19 +90,20 @@ describe('authService', () => {
         }),
       }
 
-      mockAuthenticateUser.mockImplementation((authDetails, callbacks) => {
+      mockAuthenticateUser.mockImplementation((_authDetails, callbacks) => {
         callbacks.onSuccess(mockSession)
       })
 
       const result = await authService.signIn('testuser', 'password123')
 
+      // eslint-disable-next-line vitest/prefer-called-with
       expect(mockAuthenticateUser).toHaveBeenCalled()
       expect(result).toBe(mockSession)
     })
 
     it('rejects with error on authentication failure', async () => {
       const error = new Error('Incorrect username or password')
-      mockAuthenticateUser.mockImplementation((authDetails, callbacks) => {
+      mockAuthenticateUser.mockImplementation((_authDetails, callbacks) => {
         callbacks.onFailure(error)
       })
 
@@ -114,7 +114,7 @@ describe('authService', () => {
   describe('signOut', () => {
     it('calls logout on authStore', () => {
       authService.signOut()
-      expect(mockLogout).toHaveBeenCalled()
+      expect(mockLogout).toHaveBeenCalledWith()
     })
   })
 
@@ -125,17 +125,19 @@ describe('authService', () => {
       })
 
       await expect(authService.forgotPassword('testuser')).resolves.not.toThrow()
+      // eslint-disable-next-line vitest/prefer-called-with
       expect(mockForgotPassword).toHaveBeenCalled()
     })
   })
 
   describe('confirmPassword', () => {
     it('confirms new password with verification code', async () => {
-      mockConfirmPassword.mockImplementation((code, newPassword, callbacks) => {
+      mockConfirmPassword.mockImplementation((_code, _newPassword, callbacks) => {
         callbacks.onSuccess()
       })
 
       await expect(authService.confirmPassword('testuser', '123456', 'newpassword')).resolves.not.toThrow()
+      // eslint-disable-next-line vitest/prefer-called-with
       expect(mockConfirmPassword).toHaveBeenCalled()
     })
   })

--- a/voc-datalake/frontend/src/services/auth.ts
+++ b/voc-datalake/frontend/src/services/auth.ts
@@ -1,17 +1,19 @@
 /**
  * @fileoverview AWS Cognito authentication service.
- * 
+ *
  * Provides authentication operations using Amazon Cognito User Pools:
  * - Sign in with username/password
  * - Token refresh with automatic expiration handling
  * - Password reset flow (forgot password + confirmation)
  * - New password challenge handling (first login)
- * 
+ *
  * Security features:
- * - Tokens stored in sessionStorage via authStore
+ * - Short-lived tokens persisted in localStorage for cross-tab UX
+ * - Refresh token kept in memory only (never persisted to disk)
  * - Automatic token refresh 5 minutes before expiration
+ * - Fallback to Cognito getSession() for tabs without in-memory refresh token
  * - Graceful handling of expired sessions
- * 
+ *
  * @module services/auth
  */
 
@@ -19,11 +21,15 @@ import {
   CognitoUserPool,
   CognitoUser,
   AuthenticationDetails,
-  CognitoUserSession,
+  type CognitoUserSession,
   CognitoRefreshToken,
 } from 'amazon-cognito-identity-js'
 import { fetchAuthSession } from 'aws-amplify/auth'
-import { getConfig } from '../config'
+import {
+  AuthError, ConfigError,
+} from '../lib/errors'
+import { isRecord } from '../lib/typeGuards'
+import { getRuntimeConfig } from '../runtimeConfig'
 import { useAuthStore } from '../store/authStore'
 import type { User } from '../store/authStore'
 
@@ -45,19 +51,14 @@ function isStringArray(value: unknown): value is string[] {
  * @returns CognitoUserPool instance or null if not configured
  */
 const getUserPool = (): CognitoUserPool | null => {
-  const cfg = getConfig()
-  if (!cfg.cognito.userPoolId || !cfg.cognito.clientId) {
+  const cfg = getRuntimeConfig()
+  if (cfg.cognito.userPoolId === '' || cfg.cognito.clientId === '') {
     return null
   }
   return new CognitoUserPool({
     UserPoolId: cfg.cognito.userPoolId,
     ClientId: cfg.cognito.clientId,
   })
-}
-
-// Type guard for Record<string, unknown>
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 /**
@@ -68,12 +69,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const parseJwt = (token: string): Record<string, unknown> => {
   try {
     const base64Url = token.split('.')[1]
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const base64 = base64Url.replaceAll('-', '+').replaceAll('_', '/')
     const jsonPayload = decodeURIComponent(
       atob(base64)
         .split('')
         .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-        .join('')
+        .join(''),
     )
     const parsed: unknown = JSON.parse(jsonPayload)
     if (isRecord(parsed)) {
@@ -96,7 +97,7 @@ const extractUser = (idToken: string): User => {
   const email = payload['email']
   const name = payload['name']
   const groups = payload['cognito:groups']
-  
+
   return {
     username: isString(username) ? username : '',
     email: isString(email) ? email : '',
@@ -114,14 +115,14 @@ export const authService = {
    * @returns true if Cognito environment variables are set
    */
   isConfigured: (): boolean => {
-    const cfg = getConfig()
-    return !!(cfg.cognito.userPoolId && cfg.cognito.clientId)
+    const cfg = getRuntimeConfig()
+    return !!(cfg.cognito.userPoolId !== '' && cfg.cognito.clientId !== '')
   },
 
   /**
    * Syncs the current Cognito session with Amplify.
    * This allows Amplify to exchange JWT tokens for AWS credentials.
-   * 
+   *
    * Call this after:
    * - Successful sign in
    * - Token refresh
@@ -140,7 +141,7 @@ export const authService = {
   /**
    * Authenticates a user with username and password.
    * On success, stores tokens in authStore and returns the session.
-   * 
+   *
    * @param username - Cognito username or email
    * @param password - User's password
    * @returns Promise resolving to CognitoUserSession
@@ -151,7 +152,7 @@ export const authService = {
     return new Promise((resolve, reject) => {
       const userPool = getUserPool()
       if (!userPool) {
-        reject(new Error('Cognito not configured'))
+        reject(new ConfigError('Cognito not configured'))
         return
       }
 
@@ -166,32 +167,38 @@ export const authService = {
       })
 
       cognitoUser.authenticateUser(authDetails, {
-        onSuccess: async (session) => {
+        onSuccess: (session) => {
           const idToken = session.getIdToken().getJwtToken()
           const accessToken = session.getAccessToken().getJwtToken()
           const refreshToken = session.getRefreshToken().getToken()
 
           const user = extractUser(idToken)
-          
-          useAuthStore.getState().setTokens({ accessToken, idToken, refreshToken })
+
+          useAuthStore.getState().setTokens({
+            accessToken,
+            idToken,
+            refreshToken,
+          })
           useAuthStore.getState().setUser(user)
-          
+          useAuthStore.getState().setSessionReady(true)
+
           // Sync session with Amplify for IAM signing
-          await authService.syncAmplifySession()
-          
+          void authService.syncAmplifySession()
+
           resolve(session)
         },
-        onFailure: (err) => {
-          reject(err)
+        onFailure: (err: unknown) => {
+          reject(err instanceof Error ? err : new AuthError(String(err)))
         },
         newPasswordRequired: (userAttributes: Record<string, unknown>) => {
           // Handle new password required (first login)
-          reject({ 
-            code: 'NewPasswordRequired', 
-            message: 'New password required',
+          const error = new AuthError('New password required')
+          Object.assign(error, {
+            code: 'NewPasswordRequired',
             userAttributes,
             cognitoUser,
           })
+          reject(error)
         },
       })
     })
@@ -199,7 +206,7 @@ export const authService = {
 
   /**
    * Completes the new password challenge for first-time login.
-   * 
+   *
    * @param cognitoUser - CognitoUser instance from signIn rejection
    * @param newPassword - The new password to set
    * @returns Promise resolving to CognitoUserSession
@@ -207,7 +214,7 @@ export const authService = {
    */
   completeNewPassword: (
     cognitoUser: CognitoUser,
-    newPassword: string
+    newPassword: string,
   ): Promise<CognitoUserSession> => {
     return new Promise((resolve, reject) => {
       cognitoUser.completeNewPasswordChallenge(newPassword, {}, {
@@ -217,14 +224,18 @@ export const authService = {
           const refreshToken = session.getRefreshToken().getToken()
 
           const user = extractUser(idToken)
-          
-          useAuthStore.getState().setTokens({ accessToken, idToken, refreshToken })
+
+          useAuthStore.getState().setTokens({
+            accessToken,
+            idToken,
+            refreshToken,
+          })
           useAuthStore.getState().setUser(user)
-          
+
           resolve(session)
         },
-        onFailure: (err) => {
-          reject(err)
+        onFailure: (err: unknown) => {
+          reject(err instanceof Error ? err : new AuthError(String(err)))
         },
       })
     })
@@ -246,8 +257,11 @@ export const authService = {
 
   /**
    * Refreshes the current session using the stored refresh token.
+   * If no refresh token is in memory (e.g., new tab), falls back to
+   * Cognito's getSession() which uses Cognito's own cookies for
+   * silent re-authentication.
    * Updates all tokens in authStore on success.
-   * 
+   *
    * @returns Promise resolving to new CognitoUserSession
    * @throws Error if refresh fails (triggers logout)
    */
@@ -255,63 +269,84 @@ export const authService = {
     return new Promise((resolve, reject) => {
       const userPool = getUserPool()
       if (!userPool) {
-        reject(new Error('Cognito not configured'))
+        reject(new ConfigError('Cognito not configured'))
         return
       }
 
       const cognitoUser = userPool.getCurrentUser()
       if (!cognitoUser) {
-        reject(new Error('No current user'))
+        useAuthStore.getState().logout()
+        reject(new AuthError('No current user'))
         return
       }
 
       const refreshToken = useAuthStore.getState().refreshToken
-      if (!refreshToken) {
-        reject(new Error('No refresh token'))
-        return
+
+      /**
+       * Handles a successful session by extracting tokens and updating the store.
+       */
+      const handleSession = async (session: CognitoUserSession) => {
+        const idToken = session.getIdToken().getJwtToken()
+        const accessToken = session.getAccessToken().getJwtToken()
+        const newRefreshToken = session.getRefreshToken().getToken()
+
+        const user = extractUser(idToken)
+
+        useAuthStore.getState().setTokens({
+          accessToken,
+          idToken,
+          refreshToken: newRefreshToken,
+        })
+        useAuthStore.getState().setUser(user)
+
+        await authService.syncAmplifySession()
+
+        resolve(session)
       }
 
-      cognitoUser.refreshSession(
-        new CognitoRefreshToken({ RefreshToken: refreshToken }),
-        async (err: Error | null, session: CognitoUserSession | null) => {
-          if (err || !session) {
-            useAuthStore.getState().logout()
-            reject(err ?? new Error('Session refresh failed'))
-            return
-          }
-
-          const idToken = session.getIdToken().getJwtToken()
-          const accessToken = session.getAccessToken().getJwtToken()
-          const newRefreshToken = session.getRefreshToken().getToken()
-
-          const user = extractUser(idToken)
-          
-          useAuthStore.getState().setTokens({ 
-            accessToken, 
-            idToken, 
-            refreshToken: newRefreshToken 
-          })
-          useAuthStore.getState().setUser(user)
-          
-          // Sync with Amplify after refresh
-          await authService.syncAmplifySession()
-          
-          resolve(session)
-        }
-      )
+      if (refreshToken != null && refreshToken !== '') {
+        // Primary path: use the in-memory refresh token
+        cognitoUser.refreshSession(
+          new CognitoRefreshToken({ RefreshToken: refreshToken }),
+          (err: Error | null, session: CognitoUserSession | null) => {
+            if (err || !session) {
+              useAuthStore.getState().logout()
+              reject(err ?? new AuthError('Session refresh failed'))
+              return
+            }
+            void handleSession(session)
+          },
+        )
+      } else {
+        // Fallback: no refresh token in memory (new tab).
+        // Cognito SDK's getSession() uses its own cookies to silently
+        // re-authenticate without requiring the refresh token from our store.
+        cognitoUser.getSession(
+          (err: Error | null, session: CognitoUserSession | null) => {
+            if (err || !session) {
+              useAuthStore.getState().logout()
+              reject(err ?? new AuthError('No session available — please sign in again'))
+              return
+            }
+            void handleSession(session)
+          },
+        )
+      }
     })
   },
 
   /**
    * Gets a valid access token, automatically refreshing if expiring soon.
    * Refreshes if token expires within 5 minutes.
-   * 
+   *
    * @returns Promise resolving to access token string or null if unavailable
    */
   getAccessToken: async (): Promise<string | null> => {
-    const { accessToken, idToken } = useAuthStore.getState()
-    
-    if (!accessToken || !idToken) {
+    const {
+      accessToken, idToken,
+    } = useAuthStore.getState()
+
+    if ((accessToken == null || accessToken === '') || (idToken == null || idToken === '')) {
       return null
     }
 
@@ -321,10 +356,10 @@ export const authService = {
     if (!isNumber(exp)) {
       return accessToken
     }
-    
+
     const expMs = exp * 1000
     const now = Date.now()
-    
+
     if (expMs - now < 5 * 60 * 1000) {
       try {
         const session = await authService.refreshSession()
@@ -347,7 +382,7 @@ export const authService = {
 
   /**
    * Initiates the forgot password flow, sending a verification code to the user's email.
-   * 
+   *
    * @param username - Cognito username or email
    * @returns Promise resolving when code is sent
    * @throws Error if request fails
@@ -356,7 +391,7 @@ export const authService = {
     return new Promise((resolve, reject) => {
       const userPool = getUserPool()
       if (!userPool) {
-        reject(new Error('Cognito not configured'))
+        reject(new ConfigError('Cognito not configured'))
         return
       }
 
@@ -374,7 +409,7 @@ export const authService = {
 
   /**
    * Confirms a password reset using the verification code.
-   * 
+   *
    * @param username - Cognito username or email
    * @param code - Verification code from email
    * @param newPassword - New password to set
@@ -384,12 +419,12 @@ export const authService = {
   confirmPassword: (
     username: string,
     code: string,
-    newPassword: string
+    newPassword: string,
   ): Promise<void> => {
     return new Promise((resolve, reject) => {
       const userPool = getUserPool()
       if (!userPool) {
-        reject(new Error('Cognito not configured'))
+        reject(new ConfigError('Cognito not configured'))
         return
       }
 
@@ -417,13 +452,13 @@ export const authService = {
     return new Promise((resolve, reject) => {
       const userPool = getUserPool()
       if (!userPool) {
-        reject(new Error('Cognito not configured'))
+        reject(new ConfigError('Cognito not configured'))
         return
       }
 
       const cognitoUser = userPool.getCurrentUser()
       if (!cognitoUser) {
-        reject(new Error('No current user'))
+        reject(new AuthError('No current user'))
         return
       }
 
@@ -431,7 +466,7 @@ export const authService = {
       cognitoUser.getSession(
         (err: Error | null, session: CognitoUserSession | null) => {
           if (err || !session) {
-            reject(err ?? new Error('No session'))
+            reject(err ?? new AuthError('No session'))
             return
           }
 
@@ -442,7 +477,7 @@ export const authService = {
             }
             resolve()
           })
-        }
+        },
       )
     })
   },

--- a/voc-datalake/frontend/src/store/authStore.test.ts
+++ b/voc-datalake/frontend/src/store/authStore.test.ts
@@ -22,7 +22,7 @@ describe('authStore', () => {
       setUser(user)
 
       const state = useAuthStore.getState()
-      expect(state.user).toEqual(user)
+      expect(state.user).toStrictEqual(user)
       expect(state.isAuthenticated).toBe(true)
     })
 
@@ -73,6 +73,20 @@ describe('authStore', () => {
       expect(state.accessToken).toBeNull()
       expect(state.idToken).toBeNull()
       expect(state.refreshToken).toBeNull()
+    })
+
+    it('resets authenticated and error state on logout', () => {
+      const { setUser, setTokens, logout } = useAuthStore.getState()
+
+      setUser({ username: 'test', email: 'test@example.com', groups: ['admins'] })
+      setTokens({
+        accessToken: 'access',
+        idToken: 'id',
+        refreshToken: 'refresh',
+      })
+      logout()
+
+      const state = useAuthStore.getState()
       expect(state.isAuthenticated).toBe(false)
       expect(state.error).toBeNull()
     })

--- a/voc-datalake/frontend/src/store/authStore.ts
+++ b/voc-datalake/frontend/src/store/authStore.ts
@@ -1,11 +1,15 @@
 /**
  * @fileoverview Authentication state management using Zustand with localStorage persistence.
- * 
- * Features:
- * - Uses localStorage to persist auth across tabs and browser sessions
- * - Allows multiple tabs to share the same authenticated session
- * - Tokens persist until explicit logout or expiration
- * 
+ *
+ * Security model:
+ * - Short-lived tokens (access, ID) persisted in localStorage for cross-tab UX
+ * - Refresh token kept in memory only (never persisted) to limit XSS blast radius
+ * - Non-secret data (user info, auth state) persisted in localStorage
+ *
+ * When a new tab opens with expired short-lived tokens, the auth service
+ * falls back to Cognito's getSession() which uses Cognito's own cookies
+ * for silent re-authentication — no re-login needed.
+ *
  * @module store/authStore
  */
 
@@ -40,6 +44,8 @@ interface AuthState {
   refreshToken: string | null
   /** Whether the user is currently authenticated */
   isAuthenticated: boolean
+  /** Whether the session has been validated/refreshed after page load */
+  sessionReady: boolean
   /** Loading state for async auth operations */
   isLoading: boolean
   /** Error message from failed auth operations */
@@ -47,7 +53,13 @@ interface AuthState {
   /** Update the current user */
   setUser: (user: User | null) => void
   /** Store all authentication tokens */
-  setTokens: (tokens: { accessToken: string; idToken: string; refreshToken: string }) => void
+  setTokens: (tokens: {
+    accessToken: string;
+    idToken: string;
+    refreshToken: string
+  }) => void
+  /** Mark session as validated and ready for API calls */
+  setSessionReady: (ready: boolean) => void
   /** Set loading state */
   setLoading: (loading: boolean) => void
   /** Set error message */
@@ -64,15 +76,20 @@ export const useAuthStore = create<AuthState>()(
       idToken: null,
       refreshToken: null,
       isAuthenticated: false,
+      sessionReady: false,
       isLoading: false,
       error: null,
-      setUser: (user) => set({ user, isAuthenticated: !!user }),
+      setUser: (user) => set({
+        user,
+        isAuthenticated: !!user,
+      }),
       setTokens: (tokens) => set({
         accessToken: tokens.accessToken,
         idToken: tokens.idToken,
         refreshToken: tokens.refreshToken,
         isAuthenticated: true,
       }),
+      setSessionReady: (sessionReady) => set({ sessionReady }),
       setLoading: (isLoading) => set({ isLoading }),
       setError: (error) => set({ error }),
       logout: () => set({
@@ -81,22 +98,24 @@ export const useAuthStore = create<AuthState>()(
         idToken: null,
         refreshToken: null,
         isAuthenticated: false,
+        sessionReady: false,
         error: null,
       }),
     }),
-    { 
+    {
       name: 'voc-auth',
-      // Use localStorage to persist auth across tabs and browser sessions
-      // This allows opening multiple tabs without re-authenticating
+      // Persist short-lived tokens + user info in localStorage for cross-tab UX.
+      // refreshToken is deliberately excluded — it stays in memory only.
+      // This limits XSS blast radius: stolen access/ID tokens expire in ~1hr,
+      // while the 30-day refresh token is never written to disk.
       partialize: (state) => ({
         user: state.user,
         accessToken: state.accessToken,
         idToken: state.idToken,
-        refreshToken: state.refreshToken,
         isAuthenticated: state.isAuthenticated,
       }),
-    }
-  )
+    },
+  ),
 )
 
 /**
@@ -105,5 +124,5 @@ export const useAuthStore = create<AuthState>()(
  */
 export const useIsAdmin = (): boolean => {
   const user = useAuthStore((state) => state.user)
-  return user?.groups?.includes('admins') ?? false
+  return user?.groups.includes('admins') ?? false
 }

--- a/voc-datalake/lambda/api/test/test_users_handler.py
+++ b/voc-datalake/lambda/api/test/test_users_handler.py
@@ -3,8 +3,7 @@ Tests for users_handler.py - /users/* endpoints.
 Cognito user management for admins.
 """
 import json
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from datetime import datetime, timezone
 
 
@@ -244,6 +243,208 @@ class TestCreateUser:
         assert response['statusCode'] == 409
         assert 'error' in body
         assert 'already exists' in body['error']
+
+
+class TestUpdateUser:
+    """Tests for PUT /users/<username> endpoint."""
+
+    @patch('users_handler.cognito')
+    def test_updates_user_attributes_successfully(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Updates given_name and family_name in Cognito."""
+        mock_cognito.admin_get_user.return_value = {
+            'UserAttributes': [
+                {'Name': 'given_name', 'Value': 'Old'},
+                {'Name': 'family_name', 'Value': 'Name'},
+            ]
+        }
+        mock_cognito.admin_update_user_attributes.return_value = {}
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': 'New', 'family_name': 'Name'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['success'] is True
+        assert body['given_name'] == 'New'
+        assert body['family_name'] == 'Name'
+        assert body['name'] == 'New Name'
+        mock_cognito.admin_update_user_attributes.assert_called_once()
+
+    @patch('users_handler.cognito')
+    def test_partial_update_given_name_only(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Updates only given_name, merges with existing family_name."""
+        mock_cognito.admin_get_user.return_value = {
+            'UserAttributes': [
+                {'Name': 'given_name', 'Value': 'Old'},
+                {'Name': 'family_name', 'Value': 'Smith'},
+            ]
+        }
+        mock_cognito.admin_update_user_attributes.return_value = {}
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': 'New'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['given_name'] == 'New'
+        assert body['family_name'] == 'Smith'
+        assert body['name'] == 'New Smith'
+
+    @patch('users_handler.cognito')
+    def test_partial_update_family_name_only(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Updates only family_name, merges with existing given_name."""
+        mock_cognito.admin_get_user.return_value = {
+            'UserAttributes': [
+                {'Name': 'given_name', 'Value': 'Jane'},
+                {'Name': 'family_name', 'Value': 'Old'},
+            ]
+        }
+        mock_cognito.admin_update_user_attributes.return_value = {}
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'family_name': 'Doe'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['given_name'] == 'Jane'
+        assert body['family_name'] == 'Doe'
+        assert body['name'] == 'Jane Doe'
+
+    @patch('users_handler.cognito')
+    def test_rejects_non_string_given_name(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Returns 400 when given_name is not a string."""
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': 123}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+
+    @patch('users_handler.cognito')
+    def test_returns_error_when_both_names_missing(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Returns 400 when neither given_name nor family_name in body."""
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'some_other_field': 'value'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+
+    @patch('users_handler.cognito')
+    def test_rejects_whitespace_only_names(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Returns 400 when names are whitespace-only and no existing names."""
+        mock_cognito.exceptions.UserNotFoundException = type(
+            'UserNotFoundException', (Exception,), {}
+        )
+        mock_cognito.admin_get_user.return_value = {
+            'UserAttributes': []
+        }
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': '   ', 'family_name': '  '}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+
+    @patch('users_handler.cognito')
+    def test_returns_not_found_for_nonexistent_user(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Returns 404 when user does not exist."""
+        mock_cognito.exceptions.UserNotFoundException = type(
+            'UserNotFoundException', (Exception,), {}
+        )
+        mock_cognito.admin_get_user.side_effect = (
+            mock_cognito.exceptions.UserNotFoundException()
+        )
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/ghost',
+            path_params={'username': 'ghost'},
+            body={'given_name': 'Ghost'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 404
+        assert 'not found' in body['error'].lower()
+
+    @patch('users_handler.cognito')
+    def test_returns_unauthorized_for_non_admins(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """Returns 403 for non-admin callers."""
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': 'New'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'viewers'
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
 
 
 class TestUpdateUserGroup:

--- a/voc-datalake/lambda/api/users_handler.py
+++ b/voc-datalake/lambda/api/users_handler.py
@@ -11,13 +11,10 @@ Provides Cognito user management for admins:
 Only accessible by users in the 'admins' group.
 """
 import os
-import json
-import sys
 import uuid
 import boto3
 from typing import Any
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from botocore.exceptions import ClientError, BotoCoreError
 
 from shared.logging import logger, tracer
 from shared.api import create_api_resolver, api_handler
@@ -95,6 +92,8 @@ def list_users():
                     'username': user['Username'],
                     'email': attrs.get('email', ''),
                     'name': attrs.get('name', ''),
+                    'given_name': attrs.get('given_name', ''),
+                    'family_name': attrs.get('family_name', ''),
                     'status': user['UserStatus'],
                     'enabled': user['Enabled'],
                     'groups': groups,
@@ -122,6 +121,8 @@ def create_user():
     body = app.current_event.json_body or {}
     email = body.get('email', '').strip()
     name = body.get('name', '').strip()
+    given_name = body.get('given_name', '').strip()
+    family_name = body.get('family_name', '').strip()
     group = body.get('group', 'users')  # Default to users
     
     if not email:
@@ -136,8 +137,15 @@ def create_user():
             {'Name': 'email', 'Value': email},
             {'Name': 'email_verified', 'Value': 'true'},
         ]
-        if name:
-            user_attrs.append({'Name': 'name', 'Value': name})
+        # Build display name from given/family name if provided
+        if given_name:
+            user_attrs.append({'Name': 'given_name', 'Value': given_name})
+        if family_name:
+            user_attrs.append({'Name': 'family_name', 'Value': family_name})
+        # Use given_name + family_name as display name, or fall back to provided name
+        display_name = f'{given_name} {family_name}'.strip() if (given_name or family_name) else name
+        if display_name:
+            user_attrs.append({'Name': 'name', 'Value': display_name})
         
         response = cognito.admin_create_user(
             UserPoolId=USER_POOL_ID,
@@ -155,13 +163,16 @@ def create_user():
             GroupName=group
         )
         
+        display_name = f'{given_name} {family_name}'.strip() if (given_name or family_name) else name
         return {
             'success': True,
             'message': f'User created. Temporary password sent to {email}',
             'user': {
                 'username': username,
                 'email': email,
-                'name': name,
+                'name': display_name,
+                'given_name': given_name,
+                'family_name': family_name,
                 'groups': [group],
                 'status': 'FORCE_CHANGE_PASSWORD',
             }
@@ -171,6 +182,73 @@ def create_user():
         raise ConflictError('A user with this email already exists')
     except Exception as e:
         logger.exception(f'Error creating user: {e}')
+        raise ServiceError(str(e))
+
+
+@app.put('/users/<username>')
+@tracer.capture_method
+def update_user(username: str):
+    """Update user attributes (given_name, family_name)."""
+    require_admin(app.current_event._data)
+
+    body = app.current_event.json_body or {}
+
+    if 'given_name' not in body and 'family_name' not in body:
+        raise ValidationError('At least one of given_name or family_name is required')
+
+    # Validate types
+    for field in ('given_name', 'family_name'):
+        if field in body and not isinstance(body[field], str):
+            raise ValidationError(f'{field} must be a string')
+
+    try:
+        # Fetch current attributes to merge with incoming changes
+        current_user = cognito.admin_get_user(
+            UserPoolId=USER_POOL_ID,
+            Username=username,
+        )
+        current_attrs = {
+            attr['Name']: attr['Value']
+            for attr in current_user.get('UserAttributes', [])
+        }
+
+        given_name = body['given_name'].strip() if 'given_name' in body else current_attrs.get('given_name', '')
+        family_name = body['family_name'].strip() if 'family_name' in body else current_attrs.get('family_name', '')
+
+        # After merging, at least one name must be non-empty
+        if not given_name and not family_name:
+            raise ValidationError('At least one of given_name or family_name must be non-empty')
+
+        user_attrs = []
+        if 'given_name' in body:
+            user_attrs.append({'Name': 'given_name', 'Value': given_name})
+        if 'family_name' in body:
+            user_attrs.append({'Name': 'family_name', 'Value': family_name})
+
+        # Compute display name from merged values
+        display_name = f'{given_name} {family_name}'.strip()
+        if display_name:
+            user_attrs.append({'Name': 'name', 'Value': display_name})
+
+        cognito.admin_update_user_attributes(
+            UserPoolId=USER_POOL_ID,
+            Username=username,
+            UserAttributes=user_attrs,
+        )
+
+        return {
+            'success': True,
+            'message': 'User updated',
+            'username': username,
+            'given_name': given_name,
+            'family_name': family_name,
+            'name': display_name,
+        }
+
+    except cognito.exceptions.UserNotFoundException:
+        raise NotFoundError('User not found')
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(f'Error updating user: {e}')
         raise ServiceError(str(e))
 
 

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -342,7 +342,7 @@ export class VocApiStack extends cdk.Stack {
     // Users API
     const usersRole = this.createLambdaRole('UsersLambdaRole');
     usersRole.addToPolicy(new iam.PolicyStatement({
-      actions: ['cognito-idp:ListUsers', 'cognito-idp:AdminListGroupsForUser', 'cognito-idp:AdminCreateUser', 'cognito-idp:AdminAddUserToGroup', 'cognito-idp:AdminRemoveUserFromGroup', 'cognito-idp:AdminResetUserPassword', 'cognito-idp:AdminEnableUser', 'cognito-idp:AdminDisableUser', 'cognito-idp:AdminDeleteUser'],
+      actions: ['cognito-idp:ListUsers', 'cognito-idp:AdminGetUser', 'cognito-idp:AdminListGroupsForUser', 'cognito-idp:AdminCreateUser', 'cognito-idp:AdminUpdateUserAttributes', 'cognito-idp:AdminAddUserToGroup', 'cognito-idp:AdminRemoveUserFromGroup', 'cognito-idp:AdminResetUserPassword', 'cognito-idp:AdminEnableUser', 'cognito-idp:AdminDisableUser', 'cognito-idp:AdminDeleteUser'],
       resources: [userPool.userPoolArn],
     }));
 

--- a/voc-datalake/scripts/test-api.sh
+++ b/voc-datalake/scripts/test-api.sh
@@ -137,9 +137,16 @@ echo -e "\n${BLUE}S3 Import API${NC}"
 tget "/s3-import/files"
 tget "/s3-import/sources"
 
-echo -e "\n${BLUE}Feedback Form (Public)${NC}"
-tpub "/feedback-form/config"
-tpub "/feedback-form/iframe"
+echo -e "\n${BLUE}Feedback Forms${NC}"
+tget "/feedback-forms"
+# Public per-form endpoints require a form id; exercise them only if a form exists
+FORM_ID=$(curl -s -H "Authorization: $AUTH" "$API/feedback-forms" | python3 -c "import sys,json; f=json.load(sys.stdin).get('forms',[]); print(f[0].get('form_id', f[0].get('id','')) if f else '')" 2>/dev/null)
+if [ -n "$FORM_ID" ]; then
+  tpub "/feedback-forms/$FORM_ID/config"
+  tpub "/feedback-forms/$FORM_ID/iframe"
+else
+  echo "  ⚠️  No feedback forms configured, skipping public per-form endpoints"
+fi
 
 echo -e "\n${BLUE}Chat Stream API (Lambda Function URL)${NC}"
 tstream() {


### PR DESCRIPTION
## PR 5/7 — User admin & Cognito hardening

Fifth in the `chrome-extension-rebase` breakdown. Turns user management into an
admin-only, self-service surface backed by server-side authorization, and adds
first/last-name support to Cognito users.

Rebased onto the merged `development`. Diff vs `development`: **22 files** (feature)
plus three small fix commits surfaced during validation.

### What's included

**Backend (`users_handler.py`)**
- `require_admin` guard on every `/users/*` route — admin enforcement at the handler
  layer, not just the API Gateway authorizer claims (defense in depth).
- New `PUT /users/{username}` — updates `given_name`/`family_name` and rebuilds the
  Cognito `name` attribute server-side (merges with stored values).
- `POST /users` now accepts optional `given_name`/`family_name`.

**Frontend**
- `UserAdmin` split into `UserAdmin` + `UserAdminComponents` + `CreateUserModal` +
  **new `EditUserModal`** + shared `NameFields`.
- New `useEscapeKey` hook (Esc-to-close on modals).
- Login refactor (`LoginForms`, `LoginSharedComponents`); `auth.ts` / `authStore.ts`
  hardening — refresh token kept in memory only (not persisted), `sessionReady` gate.
- Touched files use `t()` against translations shipped in PR 1.

**Deliberately excluded:** `core-stack.ts` (source changes there are non-Cognito —
custom domain ACM, CSP `blob:`, avatar cache — and belong to PR2/PR4).

### Commits
1. `feat: user admin & Cognito hardening` — the feature.
2. `fix(i18n): populate empty showingOf_many plural for es/fr/pt` — pre-existing empty
   plural key that failed `i18n:validate`.
3. `fix(api): grant UsersLambda AdminGetUser + AdminUpdateUserAttributes` — the new
   `PUT /users/{username}` calls both; the IAM grant was missing (caught in deploy validation).
4. `test(api): fix stale feedback-form paths in validation script` — `test-api.sh` tooling.

### Validation
- `npm run check` green: lint, typecheck (frontend/CDK/stream), **1454** frontend tests, **564** backend (84% cov). `i18n:validate` green.
- **Deployed + validated** on `777200923596`/us-east-1 (`VocApiStack` redeployed: UsersApi Lambda + IAM policy; frontend rebuilt + published).
- **Programmatic API suite — 19/20**: full CRUD, edge cases (400/404/409), and the
  `require_admin` **403** path for non-admin callers (GET/POST/PUT/DELETE).
- **UI (Playwright)**: login/logout flow (0 console errors on fresh login); UserAdmin
  table + actions; EditUserModal (auto-focus, dirty-tracking, Esc-to-close, save→200→refetch);
  non-admin guard (Settings hidden from nav + `/settings` redirects to `/`).
- Full plan: `.pr-extract/PR5-UI-TEST-PLAN.md`.

### Known limitation (pre-existing, not in PR5 scope)
- `reset-password` returns a generic 500 for non-resettable Cognito states
  (`FORCE_CHANGE_PASSWORD` / unverified email). The endpoint is unchanged by this PR;
  follow-up idea is to map those Cognito errors to a clean 4xx.
