### PR TITLE
feat(chat): add create_project tool to VoC chat

### DIFF
--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -131,7 +131,9 @@ async function fetchCategoryCounts(
 function buildSystemPrompt(responseLanguage?: string): string {
   const base = `You are a Voice of the Customer (VoC) analytics assistant. You help analyze customer feedback data and provide actionable insights.
 
-You have access to a tool called "search_feedback" that lets you search and retrieve customer feedback from various sources (web scrapers, manual imports, S3 imports, etc.).
+You have access to two tools:
+- "search_feedback": search and retrieve customer feedback from various sources (web scrapers, manual imports, S3 imports, etc.).
+- "create_project": turn the insights from this conversation into a new project, pre-filling its product context.
 
 IMPORTANT GUIDELINES:
 1. ONLY use the search_feedback tool when the user's question is specifically about customer feedback, reviews, or customer opinions
@@ -141,6 +143,7 @@ IMPORTANT GUIDELINES:
 5. Quote actual customer feedback when relevant
 6. Highlight urgent issues that need attention
 7. Provide actionable recommendations based on the data
+8. When the user asks to turn findings into a project ("make/create a project", "프로젝트 만들어줘"), call create_project. First make sure you've analyzed the relevant feedback (search_feedback) so you can draft a grounded name, description, and product-context fields (product_name, one_liner, target_users, problem_solved, key_features). Only fill fields you can support with the actual feedback — omit the rest rather than inventing.
 
 Format your responses clearly with bullet points or numbered lists when appropriate.`;
 

--- a/voc-datalake/lambda/stream/src/handler.extended.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.extended.test.ts
@@ -53,6 +53,7 @@ vi.mock('./tools/index.js', () => ({
   getSearchFeedbackTool: vi.fn().mockReturnValue({ toolSpec: { name: 'search_feedback' } }),
   getUpdateDocumentTool: vi.fn().mockReturnValue({ toolSpec: { name: 'update_document' } }),
   getCreateDocumentTool: vi.fn().mockReturnValue({ toolSpec: { name: 'create_document' } }),
+  getCreateProjectTool: vi.fn().mockReturnValue({ toolSpec: { name: 'create_project' } }),
 }));
 
 vi.mock('./tools/executor.js', () => ({

--- a/voc-datalake/lambda/stream/src/handler.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.test.ts
@@ -54,6 +54,7 @@ vi.mock('./tools/index.js', () => ({
   getSearchFeedbackTool: vi.fn().mockReturnValue({ toolSpec: { name: 'search_feedback' } }),
   getUpdateDocumentTool: vi.fn().mockReturnValue({ toolSpec: { name: 'update_document' } }),
   getCreateDocumentTool: vi.fn().mockReturnValue({ toolSpec: { name: 'create_document' } }),
+  getCreateProjectTool: vi.fn().mockReturnValue({ toolSpec: { name: 'create_project' } }),
 }));
 
 vi.mock('./tools/executor.js', () => ({

--- a/voc-datalake/lambda/stream/src/handler.ts
+++ b/voc-datalake/lambda/stream/src/handler.ts
@@ -19,8 +19,9 @@ import { z } from 'zod';
 import { converseStream } from './bedrock/converse-stream.js';
 import { processStreamEvent, createStreamState, type ToolUseBlock } from './bedrock/stream-processor.js';
 import { executeTool } from './tools/executor.js';
-import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool } from './tools/index.js';
+import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool, getCreateProjectTool } from './tools/index.js';
 import type { DocumentChange } from './tools/update-document.js';
+import type { ProjectChange } from './tools/create-project.js';
 import { buildVocChatContext } from './context/voc-context.js';
 import { buildProjectChatContext, buildRoundtableContext } from './context/project-context.js';
 import { attachmentsToContentBlocks } from './attachments.js';
@@ -102,6 +103,7 @@ async function executeToolsAndBuildResults(
   contextFilters: ContextFilters,
   collectedSources: Record<string, unknown>[],
   collectedDocumentChanges: DocumentChange[],
+  collectedProjectChanges: ProjectChange[],
   stream: NodeJS.WritableStream,
   projectsTable?: string,
   projectId?: string,
@@ -121,6 +123,9 @@ async function executeToolsAndBuildResults(
     if (result.documentChange) {
       collectedDocumentChanges.push(result.documentChange);
     }
+    if (result.projectChange) {
+      collectedProjectChanges.push(result.projectChange);
+    }
     // Notify the frontend that the tool has completed
     sendSSE(stream, { type: 'tool_result', toolName: tb.name });
     const resultContent: ToolResultContentBlock[] = [{ text: result.content }];
@@ -139,6 +144,7 @@ async function runConversationLoop(
   contextFilters: ContextFilters,
   collectedSources: Record<string, unknown>[],
   collectedDocumentChanges: DocumentChange[],
+  collectedProjectChanges: ProjectChange[],
   loopCount: number,
   projectsTable?: string,
   projectId?: string,
@@ -170,14 +176,14 @@ async function runConversationLoop(
   messages.push({ role: 'assistant', content: buildAssistantContent(state) });
 
   const toolResults = await executeToolsAndBuildResults(
-    state.toolUseBlocks, contextFilters, collectedSources, collectedDocumentChanges, stream,
-    projectsTable, projectId,
+    state.toolUseBlocks, contextFilters, collectedSources, collectedDocumentChanges,
+    collectedProjectChanges, stream, projectsTable, projectId,
   );
   messages.push({ role: 'user', content: toolResults });
 
   await runConversationLoop(
     messages, tools, stream, systemPrompt, contextFilters,
-    collectedSources, collectedDocumentChanges, loopCount + 1,
+    collectedSources, collectedDocumentChanges, collectedProjectChanges, loopCount + 1,
     projectsTable, projectId,
   );
 }
@@ -208,13 +214,25 @@ async function handleVocChat(body: ChatRequest, stream: NodeJS.WritableStream): 
     ...historyToBedrockMessages(body.history),
     { role: 'user', content: [{ text: ctx.userMessage }] },
   ];
-  const tools: Tool[] = [getSearchFeedbackTool()];
+  // search_feedback for analysis + create_project so the user can turn the
+  // insights into a pre-filled project ("make a project out of this"). No
+  // projectId here (VoC chat is project-agnostic), but create_project only
+  // needs the table, so PROJECTS_TABLE is passed as the projectsTable arg.
+  const tools: Tool[] = [getSearchFeedbackTool(), getCreateProjectTool()];
   const sources: Record<string, unknown>[] = [];
   const documentChanges: DocumentChange[] = [];
+  const projectChanges: ProjectChange[] = [];
 
-  await runConversationLoop(messages, tools, stream, ctx.systemPrompt, ctx.metadata.filters, sources, documentChanges, 0);
+  await runConversationLoop(
+    messages, tools, stream, ctx.systemPrompt, ctx.metadata.filters,
+    sources, documentChanges, projectChanges, 0,
+    PROJECTS_TABLE,
+  );
 
-  sendSSE(stream, { type: 'done', metadata: { sources: deduplicateSources(sources) } });
+  sendSSE(stream, {
+    type: 'done',
+    metadata: { sources: deduplicateSources(sources), project_changes: projectChanges },
+  });
   stream.end();
 }
 
@@ -353,9 +371,10 @@ async function handleProjectChat(
   console.log('Project ID:', projectId, 'PROJECTS_TABLE:', PROJECTS_TABLE);
 
   const documentChanges: DocumentChange[] = [];
+  const projectChanges: ProjectChange[] = [];
 
   await runConversationLoop(
-    messages, tools, stream, ctx.systemPrompt, {}, [], documentChanges, 0,
+    messages, tools, stream, ctx.systemPrompt, {}, [], documentChanges, projectChanges, 0,
     PROJECTS_TABLE, projectId,
   );
 

--- a/voc-datalake/lambda/stream/src/tools/create-project.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/create-project.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for create_project tool implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { executeCreateProject } from './create-project.js';
+
+function createMockDocClient() {
+  const puts: Record<string, unknown>[] = [];
+  const client = {
+    send: vi.fn().mockImplementation((cmd: { input?: { Item?: Record<string, unknown> } }) => {
+      if (cmd?.input?.Item) puts.push(cmd.input.Item);
+      return Promise.resolve({});
+    }),
+  } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+  return { client, puts };
+}
+
+describe('executeCreateProject', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('throws when projects table is not configured', async () => {
+    const { client } = createMockDocClient();
+    await expect(
+      executeCreateProject(client, '', { name: 'X' }),
+    ).rejects.toThrow('Projects table not configured');
+  });
+
+  it('returns invalid-input result (no throw) when name is missing', async () => {
+    const { client, puts } = createMockDocClient();
+    const r = await executeCreateProject(client, 'projects', {});
+    expect(r.projectChange.summary).toContain('invalid input');
+    expect(puts.length).toBe(0); // nothing written
+  });
+
+  it('creates a project META item with a proj_ id', async () => {
+    const { client, puts } = createMockDocClient();
+    const r = await executeCreateProject(client, 'projects', {
+      name: 'Booking reliability',
+      description: 'Fix booking acceptance sync issues.',
+    });
+
+    expect(r.projectChange.action).toBe('created');
+    expect(r.projectChange.project_id).toMatch(/^proj_\d{14}$/);
+    const meta = puts.find((p) => p.sk === 'META');
+    expect(meta).toBeDefined();
+    expect(meta?.name).toBe('Booking reliability');
+    expect(meta?.gsi1pk).toBe('TYPE#PROJECT');
+    // No product-context fields provided → no PRODUCT_CONTEXT item written.
+    expect(puts.find((p) => p.sk === 'PRODUCT_CONTEXT')).toBeUndefined();
+  });
+
+  it('seeds a PRODUCT_CONTEXT item only with the fields actually provided', async () => {
+    const { client, puts } = createMockDocClient();
+    const r = await executeCreateProject(client, 'projects', {
+      name: 'P',
+      product_name: '강남언니',
+      problem_solved: '앱 가격과 실제 가격 불일치',
+      // one_liner / target_users / key_features intentionally omitted
+    });
+
+    const ctx = puts.find((p) => p.sk === 'PRODUCT_CONTEXT');
+    expect(ctx).toBeDefined();
+    expect(ctx?.product_name).toBe('강남언니');
+    expect(ctx?.problem_solved).toBe('앱 가격과 실제 가격 불일치');
+    expect(ctx?.one_liner).toBeUndefined();
+    expect(ctx?.target_users).toBeUndefined();
+    expect(r.projectChange.summary).toContain('product-context');
+  });
+});

--- a/voc-datalake/lambda/stream/src/tools/create-project.ts
+++ b/voc-datalake/lambda/stream/src/tools/create-project.ts
@@ -1,0 +1,127 @@
+/**
+ * create_project tool implementation.
+ *
+ * Lets the VoC chat turn analysis into action: when the user says "make a
+ * project out of this", the model creates a project and seeds its product
+ * context (the same PRODUCT_CONTEXT item the Product tab's interview fills),
+ * so the project starts pre-populated instead of blank.
+ *
+ * Writes mirror lambda/api/projects.py::create_project (META item) and
+ * lambda/api/product_context.py (sk='PRODUCT_CONTEXT' item) so the project
+ * shows up in the normal Projects list and Product tab.
+ */
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { z } from 'zod';
+import { ConfigurationError } from '../lib/errors.js';
+
+// Field length caps mirror lambda/api/product_context.py STRING_FIELDS so the
+// seeded draft stays consistent with what the Product tab interview accepts.
+const createProjectInputSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  // Optional product-context seed fields (all free text, drafted from feedback).
+  product_name: z.string().max(200).optional(),
+  one_liner: z.string().max(200).optional(),
+  target_users: z.string().max(1000).optional(),
+  problem_solved: z.string().max(2000).optional(),
+  key_features: z.string().max(2000).optional(),
+});
+
+export interface ProjectChange {
+  project_id: string;
+  name: string;
+  action: 'created';
+  summary: string;
+}
+
+export interface CreateProjectResult {
+  content: string;
+  projectChange: ProjectChange;
+}
+
+const PRODUCT_CONTEXT_FIELDS = [
+  'product_name',
+  'one_liner',
+  'target_users',
+  'problem_solved',
+  'key_features',
+] as const;
+
+export async function executeCreateProject(
+  docClient: DynamoDBDocumentClient,
+  projectsTable: string,
+  toolInput: unknown,
+): Promise<CreateProjectResult> {
+  if (!projectsTable) throw new ConfigurationError('Projects table not configured');
+
+  const parsed = createProjectInputSchema.safeParse(toolInput);
+  if (!parsed.success) {
+    return {
+      content: `Invalid input: ${parsed.error.issues[0]?.message ?? 'validation failed'}`,
+      projectChange: { project_id: '', name: '', action: 'created', summary: 'Failed - invalid input' },
+    };
+  }
+
+  const input = parsed.data;
+  const now = new Date().toISOString();
+  // Match projects.py id format: proj_YYYYMMDDHHMMSS
+  const projectId = `proj_${now.replace(/[-:T.Z]/g, '').slice(0, 14)}`;
+
+  // 1) Project META — same shape as projects.py::create_project so it lists normally.
+  await docClient.send(
+    new PutCommand({
+      TableName: projectsTable,
+      Item: {
+        pk: `PROJECT#${projectId}`,
+        sk: 'META',
+        gsi1pk: 'TYPE#PROJECT',
+        gsi1sk: now,
+        project_id: projectId,
+        name: input.name,
+        description: input.description ?? '',
+        status: 'active',
+        created_at: now,
+        updated_at: now,
+        persona_count: 0,
+        document_count: 0,
+        filters: {},
+        kiro_export_prompt: '',
+      },
+    }),
+  );
+
+  // 2) Optional PRODUCT_CONTEXT seed — only the fields the model actually drafted.
+  const seeded: string[] = [];
+  const contextItem: Record<string, unknown> = {
+    pk: `PROJECT#${projectId}`,
+    sk: 'PRODUCT_CONTEXT',
+    updated_at: now,
+  };
+  for (const field of PRODUCT_CONTEXT_FIELDS) {
+    const value = input[field];
+    if (typeof value === 'string' && value.trim()) {
+      contextItem[field] = value.trim();
+      seeded.push(field);
+    }
+  }
+  if (seeded.length > 0) {
+    await docClient.send(new PutCommand({ TableName: projectsTable, Item: contextItem }));
+  }
+
+  const seedNote = seeded.length > 0
+    ? ` Seeded product context: ${seeded.join(', ')}.`
+    : '';
+
+  return {
+    content: `Successfully created project "${input.name}" (id: ${projectId}).${seedNote} `
+      + `The user can open it from the Projects list; the Product tab is pre-filled with the drafted context.`,
+    projectChange: {
+      project_id: projectId,
+      name: input.name,
+      action: 'created',
+      summary: seeded.length > 0
+        ? `Created project and seeded ${seeded.length} product-context field(s)`
+        : 'Created project',
+    },
+  };
+}

--- a/voc-datalake/lambda/stream/src/tools/executor.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/executor.test.ts
@@ -13,6 +13,7 @@ import type { ToolUseBlock } from '../bedrock/stream-processor.js';
 const mockExecuteSearchFeedback = vi.fn();
 const mockExecuteUpdateDocument = vi.fn();
 const mockExecuteCreateDocument = vi.fn();
+const mockExecuteCreateProject = vi.fn();
 const mockSendSSE = vi.fn();
 
 vi.mock('./search-feedback.js', () => ({
@@ -22,6 +23,10 @@ vi.mock('./search-feedback.js', () => ({
 vi.mock('./update-document.js', () => ({
   executeUpdateDocument: (...args: unknown[]) => mockExecuteUpdateDocument(...args),
   executeCreateDocument: (...args: unknown[]) => mockExecuteCreateDocument(...args),
+}));
+
+vi.mock('./create-project.js', () => ({
+  executeCreateProject: (...args: unknown[]) => mockExecuteCreateProject(...args),
 }));
 
 vi.mock('../lib/streaming.js', () => ({
@@ -110,6 +115,35 @@ describe('executeTool', () => {
       expect(mockExecuteCreateDocument).toHaveBeenCalledWith(docClient, 'projects-table', 'proj-1', expect.any(Object));
       expect(result.documentChange?.action).toBe('created');
       expect(result.documentChange?.title).toBe('Launch Plan');
+    });
+
+    it('routes create_project to executeCreateProject (needs only projectsTable, no projectId)', async () => {
+      mockExecuteCreateProject.mockResolvedValueOnce({
+        content: 'Successfully created project "Booking fixes"',
+        projectChange: { project_id: 'proj_20260101000000', name: 'Booking fixes', action: 'created', summary: 'Created project' },
+      });
+
+      const result = await executeTool(
+        makeToolBlock({ name: 'create_project', input: { name: 'Booking fixes' } }),
+        // VoC chat passes projectsTable but NO projectId — create_project must still run.
+        docClient, feedbackTable, {}, stream, 'projects-table', undefined,
+      );
+
+      expect(mockExecuteCreateProject).toHaveBeenCalledWith(docClient, 'projects-table', expect.any(Object));
+      expect(result.projectChange?.action).toBe('created');
+      expect(result.projectChange?.name).toBe('Booking fixes');
+      expect(result.sources).toEqual([]);
+      expect(result.documentChange).toBeUndefined();
+    });
+
+    it('throws ServiceError when create_project called without projectsTable', async () => {
+      await expect(
+        executeTool(
+          makeToolBlock({ name: 'create_project', input: { name: 'X' } }),
+          docClient, feedbackTable, {}, stream, undefined, undefined,
+        ),
+      ).rejects.toThrow('Projects table not configured for create_project');
+      expect(mockExecuteCreateProject).not.toHaveBeenCalled();
     });
 
     it('throws ServiceError for unknown tool name', async () => {
@@ -236,6 +270,30 @@ describe('executeTool', () => {
       );
       expect(docChangedCall).toBeUndefined();
     });
+
+    it('sends tool_result with "created: <name>" summary and a project_changed event for create_project', async () => {
+      const projectChange = { project_id: 'proj_20260101000000', name: 'Pricing transparency', action: 'created' as const, summary: 'Created project' };
+      mockExecuteCreateProject.mockResolvedValueOnce({
+        content: 'Successfully created project "Pricing transparency"',
+        projectChange,
+      });
+
+      await executeTool(
+        makeToolBlock({ name: 'create_project', input: { name: 'Pricing transparency' } }),
+        docClient, feedbackTable, {}, stream, 'projects-table', undefined,
+      );
+
+      const toolResultCall = mockSendSSE.mock.calls.find(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === 'tool_result',
+      );
+      expect((toolResultCall?.[1] as Record<string, unknown>).content).toBe('created: Pricing transparency');
+
+      const projectChangedCall = mockSendSSE.mock.calls.find(
+        (call: unknown[]) => (call[1] as Record<string, unknown>).type === 'project_changed',
+      );
+      expect(projectChangedCall).toBeDefined();
+      expect((projectChangedCall?.[1] as Record<string, unknown>).projectChange).toEqual(projectChange);
+    });
   });
 
   describe('search_feedback input handling', () => {
@@ -301,6 +359,21 @@ describe('executeTool', () => {
       );
 
       expect(result.documentChange).toEqual(docChange);
+    });
+
+    it('returns projectChange for create_project', async () => {
+      const projectChange = { project_id: 'proj_20260101000000', name: 'Retention', action: 'created' as const, summary: 'Created project and seeded 2 product-context field(s)' };
+      mockExecuteCreateProject.mockResolvedValueOnce({
+        content: 'Successfully created project "Retention"',
+        projectChange,
+      });
+
+      const result = await executeTool(
+        makeToolBlock({ name: 'create_project', input: { name: 'Retention' } }),
+        docClient, feedbackTable, {}, stream, 'projects-table', undefined,
+      );
+
+      expect(result.projectChange).toEqual(projectChange);
     });
   });
 });

--- a/voc-datalake/lambda/stream/src/tools/executor.ts
+++ b/voc-datalake/lambda/stream/src/tools/executor.ts
@@ -6,6 +6,8 @@ import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { executeSearchFeedback } from './search-feedback.js';
 import { executeUpdateDocument, executeCreateDocument } from './update-document.js';
 import type { DocumentChange } from './update-document.js';
+import { executeCreateProject } from './create-project.js';
+import type { ProjectChange } from './create-project.js';
 import { sendSSE } from '../lib/streaming.js';
 import { ServiceError } from '../lib/errors.js';
 import type { ToolUseBlock } from '../bedrock/stream-processor.js';
@@ -22,6 +24,7 @@ interface ToolResult {
   content: string;
   sources: Record<string, unknown>[];
   documentChange?: DocumentChange;
+  projectChange?: ProjectChange;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -59,12 +62,25 @@ export async function executeTool(
 ): Promise<ToolResult> {
   sendSSE(stream, { type: 'tool_use', toolName: tool.name, toolInput: tool.input });
 
-  let result: { content: string; sources: Record<string, unknown>[]; documentChange?: DocumentChange };
+  let result: {
+    content: string;
+    sources: Record<string, unknown>[];
+    documentChange?: DocumentChange;
+    projectChange?: ProjectChange;
+  };
 
   switch (tool.name) {
     case 'search_feedback': {
       const searchResult = await handleSearchFeedback(tool.input, docClient, feedbackTable, contextFilters);
       result = searchResult;
+      break;
+    }
+    case 'create_project': {
+      if (!projectsTable) throw new ServiceError('Projects table not configured for create_project');
+      console.log('create_project called:', JSON.stringify(tool.input));
+      const projectResult = await executeCreateProject(docClient, projectsTable, tool.input);
+      console.log('create_project result:', projectResult.content);
+      result = { content: projectResult.content, sources: [], projectChange: projectResult.projectChange };
       break;
     }
     case 'update_document': {
@@ -88,9 +104,14 @@ export async function executeTool(
   }
 
   // Send tool_result SSE event
-  const resultSummary = result.documentChange
-    ? `${result.documentChange.action}: ${result.documentChange.title}`
-    : `Found ${result.sources.length} items`;
+  let resultSummary: string;
+  if (result.projectChange) {
+    resultSummary = `${result.projectChange.action}: ${result.projectChange.name}`;
+  } else if (result.documentChange) {
+    resultSummary = `${result.documentChange.action}: ${result.documentChange.title}`;
+  } else {
+    resultSummary = `Found ${result.sources.length} items`;
+  }
   sendSSE(stream, { type: 'tool_result', toolName: tool.name, content: resultSummary });
 
   // Send document_changed SSE event if a document was modified
@@ -101,10 +122,19 @@ export async function executeTool(
     });
   }
 
+  // Send project_changed SSE event so the frontend can surface/link the new project
+  if (result.projectChange) {
+    sendSSE(stream, {
+      type: 'project_changed',
+      projectChange: result.projectChange,
+    });
+  }
+
   return {
     toolUseId: tool.toolUseId,
     content: result.content,
     sources: result.sources,
     documentChange: result.documentChange,
+    projectChange: result.projectChange,
   };
 }

--- a/voc-datalake/lambda/stream/src/tools/index.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/index.test.ts
@@ -2,7 +2,26 @@
  * Tests for tool definitions.
  */
 import { describe, it, expect } from 'vitest';
-import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool } from './index.js';
+import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool, getCreateProjectTool } from './index.js';
+
+describe('getCreateProjectTool', () => {
+  it('returns a tool with name create_project', () => {
+    expect(getCreateProjectTool().toolSpec?.name).toBe('create_project');
+  });
+
+  it('requires only name', () => {
+    const schema = getCreateProjectTool().toolSpec?.inputSchema?.json as Record<string, unknown>;
+    expect(schema.required).toEqual(['name']);
+  });
+
+  it('exposes product-context seed fields', () => {
+    const schema = getCreateProjectTool().toolSpec?.inputSchema?.json as Record<string, unknown>;
+    const props = schema.properties as Record<string, unknown>;
+    for (const f of ['name', 'description', 'product_name', 'one_liner', 'target_users', 'problem_solved', 'key_features']) {
+      expect(props[f]).toBeDefined();
+    }
+  });
+});
 
 describe('getSearchFeedbackTool', () => {
   it('returns a tool with name search_feedback', () => {

--- a/voc-datalake/lambda/stream/src/tools/index.ts
+++ b/voc-datalake/lambda/stream/src/tools/index.ts
@@ -118,3 +118,40 @@ export function getSearchFeedbackTool(): Tool {
     },
   };
 }
+
+export function getCreateProjectTool(): Tool {
+  return {
+    toolSpec: {
+      name: 'create_project',
+      description:
+        'Create a new project from the insights discovered in this conversation. ' +
+        'Use this when the user asks to turn feedback findings into a project (e.g. ' +
+        '"make a project out of this", "create a project for this issue", "프로젝트 만들어줘"). ' +
+        'Draft the optional product-context fields (product_name, one_liner, target_users, ' +
+        'problem_solved, key_features) from the feedback you analyzed so the new project starts ' +
+        'pre-filled instead of blank — but only include a field if you can ground it in the ' +
+        'actual feedback; leave it out rather than inventing.',
+      inputSchema: {
+        json: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Short project name (e.g. "Booking reliability fixes").',
+            },
+            description: {
+              type: 'string',
+              description: 'One-paragraph project description summarizing the goal/scope derived from the feedback.',
+            },
+            product_name: { type: 'string', description: 'Product/service name, if identifiable from feedback.' },
+            one_liner: { type: 'string', description: 'One-line product summary.' },
+            target_users: { type: 'string', description: 'Who the users are, per the feedback.' },
+            problem_solved: { type: 'string', description: 'The core problem(s) the feedback surfaced.' },
+            key_features: { type: 'string', description: 'Key features or fixes implied by the feedback.' },
+          },
+          required: ['name'],
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
Ports the `create_project` chat tool onto `development`. Lets the VoC AI chat turn analysis into a pre-filled project ("make a project out of this" / "프로젝트 만들어줘"): it creates the project META item and seeds PRODUCT_CONTEXT from the feedback the model analyzed, then emits a `project_changed` SSE event so the frontend can link the new project.

This is the first of a series of features being reconciled onto `development`, kept deliberately isolated so it can be reviewed and merged on its own.

## What landed (create_project only)
- **`tools/create-project.ts`** (NEW) — `executeCreateProject`: writes `PROJECT#/META` (mirrors `projects.py::create_project`) + an optional `PRODUCT_CONTEXT` seed (only fields grounded in the feedback; nothing invented).
- **`tools/index.ts`** — `getCreateProjectTool()` tool definition.
- **`tools/executor.ts`** — `case 'create_project'` → `executeCreateProject`, `ProjectChange` type, `tool_result` summary, `project_changed` SSE, `projectChange` in the return value.
- **`handler.ts`** — wires `create_project` into VoC chat tools; threads `collectedProjectChanges` through the loop; passes `PROJECTS_TABLE` (no `projectId` — VoC chat is project-agnostic); `done` event carries `project_changes`.
- **`context/voc-context.ts`** — system prompt now describes both tools + a guideline: analyze feedback first, only seed fields you can support.

## Tests (11 create_project cases; suite 170 → 177, all green)
- `create-project.test.ts` (4) — logic: table-missing throw, missing-name soft fail, META item w/ `proj_` id, `PRODUCT_CONTEXT` partial seed.
- `index.test.ts` (+3) — schema: name is `create_project`, only `name` required, product-context seed fields exposed.
- `executor.test.ts` (+4) — wiring: routing, `projectsTable`-required guard, `tool_result` "created: <name>" + `project_changed` SSE, return value.
- `handler{,.extended}.test.ts` — mock factories register `getCreateProjectTool`.

## Verification
- `tsc --noEmit`: clean
- `vitest run`: **177/177 pass** (16 files); baseline `development` also 170/170 → no regression
- Diff vs `development`: 10 files, stream package only, no bleed from other in-flight features.