### PR TITLE
feat(chat): search improvements — aggregate mode, urgency sort, coerce/pagination fixes

### DIFF
--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -139,11 +139,13 @@ IMPORTANT GUIDELINES:
 1. ONLY use the search_feedback tool when the user's question is specifically about customer feedback, reviews, or customer opinions
 2. For general questions, greetings, or non-feedback topics, respond directly WITHOUT using the tool
 3. When you DO use the tool, be specific with your search query to get relevant results
-4. Base your answers on the actual data returned by the tool
-5. Quote actual customer feedback when relevant
-6. Highlight urgent issues that need attention
-7. Provide actionable recommendations based on the data
-8. When the user asks to turn findings into a project ("make/create a project", "프로젝트 만들어줘"), call create_project. First make sure you've analyzed the relevant feedback (search_feedback) so you can draft a grounded name, description, and product-context fields (product_name, one_liner, target_users, problem_solved, key_features). Only fill fields you can support with the actual feedback — omit the rest rather than inventing.
+4. For broad questions (summarize, count, trends, "top/most urgent/biggest issues"), call search_feedback with mode="aggregate" — it returns stats over the ENTIRE dataset in one call. Do NOT repeatedly page through individual items.
+5. To find urgent/critical feedback, pass urgency="high" and/or sort_by="urgency". The query field is a literal substring match on review text, so words like "urgent" in the query will NOT filter by urgency level.
+6. Base your answers on the actual data returned by the tool
+7. Quote actual customer feedback when relevant
+8. Highlight urgent issues that need attention
+9. Provide actionable recommendations based on the data
+10. When the user asks to turn findings into a project ("make/create a project", "프로젝트 만들어줘"), call create_project. First make sure you've analyzed the relevant feedback (search_feedback) so you can draft a grounded name, description, and product-context fields (product_name, one_liner, target_users, problem_solved, key_features). Only fill fields you can support with the actual feedback — omit the rest rather than inventing.
 
 Format your responses clearly with bullet points or numbered lists when appropriate.`;
 

--- a/voc-datalake/lambda/stream/src/handler.extended.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.extended.test.ts
@@ -213,8 +213,8 @@ describe('handler - extended', () => {
 
       await (handler as Function)(event, stream);
 
-      // Should stop at MAX_TOOL_LOOPS (5) and send a warning
-      expect(mockConverseStream).toHaveBeenCalledTimes(5);
+      // Should stop at MAX_TOOL_LOOPS (15) and send a warning
+      expect(mockConverseStream).toHaveBeenCalledTimes(15);
       const maxLoopCall = mockSendSSE.mock.calls.find(
         (c: unknown[]) => {
           const payload = c[1] as Record<string, unknown>;

--- a/voc-datalake/lambda/stream/src/handler.ts
+++ b/voc-datalake/lambda/stream/src/handler.ts
@@ -37,7 +37,13 @@ const FEEDBACK_TABLE = process.env.FEEDBACK_TABLE ?? '';
 const AGGREGATES_TABLE = process.env.AGGREGATES_TABLE ?? '';
 const PROJECTS_TABLE = process.env.PROJECTS_TABLE ?? '';
 
-const MAX_TOOL_LOOPS = 5;
+// Max agentic tool-call rounds before we stop and ask the user to narrow the
+// question. Each round = 1 Bedrock call + 1 tool execution (~6-15s observed),
+// so the real ceiling is the Lambda's 300s timeout, not this number. 15 rounds
+// (~225s worst case) leaves headroom while letting multi-step questions
+// converge. Broad questions ("summarize all" / "most urgent") are answered in a
+// single round via search_feedback mode="aggregate", so they shouldn't loop.
+const MAX_TOOL_LOOPS = 15;
 
 // Roundtable tuning: one turn per persona, generous budget for a full perspective.
 const ROUNDTABLE_MAX_TOKENS = 4000;
@@ -150,6 +156,9 @@ async function runConversationLoop(
   projectId?: string,
 ): Promise<void> {
   if (loopCount >= MAX_TOOL_LOOPS) {
+    // Log so CloudWatch shows WHY the loop exhausted (which tools kept getting
+    // called). The user-facing SSE message alone leaves no server-side trace.
+    console.warn(`Tool loop hit MAX_TOOL_LOOPS=${MAX_TOOL_LOOPS}; stopping.`);
     sendSSE(stream, {
       type: 'text',
       content: '\n\n_Reached maximum tool iterations. Please try a more specific question._',
@@ -172,6 +181,13 @@ async function runConversationLoop(
   }
 
   if (state.stopReason !== 'tool_use' || state.toolUseBlocks.length === 0) return;
+
+  // Trace which tools were requested this round — makes loop exhaustion (and
+  // repeated identical searches) diagnosable from CloudWatch.
+  console.log(
+    `Tool round ${loopCount + 1}/${MAX_TOOL_LOOPS}:`,
+    JSON.stringify(state.toolUseBlocks.map((tb) => ({ name: tb.name, input: tb.input }))),
+  );
 
   messages.push({ role: 'assistant', content: buildAssistantContent(state) });
 

--- a/voc-datalake/lambda/stream/src/tools/index.ts
+++ b/voc-datalake/lambda/stream/src/tools/index.ts
@@ -79,7 +79,13 @@ export function getSearchFeedbackTool(): Tool {
         'Search and retrieve customer feedback/reviews from the database. ' +
         'Use this tool ONLY when the user is asking about customer feedback, reviews, complaints, or opinions. ' +
         'Do NOT use for greetings, general questions, or non-feedback topics. ' +
-        'You can also look up a specific review by its ID (32-character hex string).',
+        'You can also look up a specific review by its ID (32-character hex string).\n\n' +
+        'IMPORTANT for broad questions: when the user asks to summarize, count, find trends, ' +
+        'or surface "the most urgent / top / biggest issues" across feedback, set mode="aggregate" — ' +
+        'it returns distribution stats over the ENTIRE match set in ONE call (no need to page). ' +
+        'To rank by urgency, also use filters/sorting rather than free-text: pass urgency="high" and/or ' +
+        'sort_by="urgency" instead of putting words like "urgent" in the query (query is a literal ' +
+        'substring match against review text and will NOT find items by urgency level).',
       inputSchema: {
         json: {
           type: 'object',
@@ -109,7 +115,17 @@ export function getSearchFeedbackTool(): Tool {
             },
             limit: {
               type: 'integer',
-              description: 'Maximum number of feedback items to return (default: 15, max: 30).',
+              description: 'Maximum number of feedback items to return (default: 15, max: 30). In aggregate mode this only caps the example items shown alongside the stats.',
+            },
+            mode: {
+              type: 'string',
+              enum: ['list', 'aggregate'],
+              description: 'list (default) returns individual feedback items. aggregate returns distribution stats (counts by urgency/sentiment/category/source + average rating) over ALL matches plus top examples — use for "summarize", "trends", "top/most urgent issues", or any whole-dataset question.',
+            },
+            sort_by: {
+              type: 'string',
+              enum: ['recent', 'urgency'],
+              description: 'recent (default) or urgency (high→medium→low, most negative first). Use urgency when the user wants the most urgent/critical items.',
             },
           },
           required: [],

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -175,4 +175,134 @@ describe('executeSearchFeedback', () => {
     // Should not throw, falls back to empty input
     expect(result.items.length).toBeGreaterThanOrEqual(0);
   });
+
+  it('sort_by=urgency orders high → medium → low', async () => {
+    const items = [
+      makeFeedbackItem({ urgency: 'low', feedback_id: 'l'.repeat(32) }),
+      makeFeedbackItem({ urgency: 'high', feedback_id: 'h'.repeat(32) }),
+      makeFeedbackItem({ urgency: 'medium', feedback_id: 'm'.repeat(32) }),
+    ];
+    const docClient = createMockDocClient([items]);
+
+    const result = await executeSearchFeedback(
+      docClient,
+      'test-feedback-table',
+      { sort_by: 'urgency' },
+      { days: 7 },
+    );
+
+    expect(result.items.map((i) => i.urgency)).toEqual(['high', 'medium', 'low']);
+  });
+
+  it('aggregate mode returns distribution over ALL matches, not a capped list', async () => {
+    // 40 items: 10 high, 30 low — more than the 30-item list cap.
+    const items = Array.from({ length: 40 }, (_, i) =>
+      makeFeedbackItem({
+        feedback_id: `id${String(i).padStart(30, '0')}`,
+        urgency: i < 10 ? 'high' : 'low',
+        sentiment_label: i < 10 ? 'negative' : 'positive',
+      }),
+    );
+    const docClient = createMockDocClient([items]);
+
+    const result = await executeSearchFeedback(
+      docClient,
+      'test-feedback-table',
+      { mode: 'aggregate' },
+      { days: 7 },
+    );
+
+    // Stats reflect the full set of 40, even though only example items are listed.
+    expect(result.formatted).toContain('ALL 40');
+    expect(result.formatted).toContain('high: 10');
+    expect(result.formatted).toContain('low: 30');
+    // Examples are urgency-sorted, so the first shown is a high-urgency item.
+    expect(result.items[0].urgency).toBe('high');
+  });
+
+  it('paginates via LastEvaluatedKey so a day larger than one page is not truncated', async () => {
+    // Regression: a day with thousands of rows was truncated to the first page
+    // (DynamoDB 1MB cap) → "987 negative but tool only saw 116". The fetch must
+    // follow LastEvaluatedKey to collect every row.
+    const page1 = Array.from({ length: 5 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `p1${String(i).padStart(30, '0')}`, sentiment_label: 'negative' }),
+    );
+    const page2 = Array.from({ length: 5 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `p2${String(i).padStart(30, '0')}`, sentiment_label: 'negative' }),
+    );
+    let call = 0;
+    const docClient = {
+      send: vi.fn().mockImplementation(() => {
+        call++;
+        if (call === 1) return Promise.resolve({ Items: page1, LastEvaluatedKey: { k: 'next' } });
+        if (call === 2) return Promise.resolve({ Items: page2 }); // no LastEvaluatedKey → stop
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(
+      docClient,
+      'test-feedback-table',
+      { sentiment: 'negative', limit: 30 },
+      { days: 1 },
+    );
+
+    // Both pages collected (10 total), not just page 1's 5.
+    expect(result.items.length).toBe(10);
+  });
+
+  it('parses items whose numerics are stored as DynamoDB strings (regression: every search returned 0)', async () => {
+    // The ingestion pipeline stores rating/sentiment_score as strings ("5",
+    // "0.95"). A strict z.number() rejected these, dropping all candidates.
+    const items = [
+      makeFeedbackItem({ rating: '5' as unknown as number, sentiment_score: '0.95' as unknown as number, urgency: 'high' }),
+      makeFeedbackItem({ rating: '2' as unknown as number, sentiment_score: '-0.8' as unknown as number, urgency: 'high', feedback_id: 'x'.repeat(32) }),
+    ];
+    const docClient = createMockDocClient([items]);
+
+    const result = await executeSearchFeedback(
+      docClient,
+      'test-feedback-table',
+      { urgency: 'high' },
+      { days: 7 },
+    );
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].sentiment_score).toBe(0.95);
+    expect(result.items[0].rating).toBe(5);
+  });
+
+  it('skips a malformed row without discarding the rest of the day', async () => {
+    const items = [
+      makeFeedbackItem({ feedback_id: 'good1'.padEnd(32, '0') }),
+      { not: 'a feedback item', original_text: 12345 }, // unparseable shape
+      makeFeedbackItem({ feedback_id: 'good2'.padEnd(32, '0') }),
+    ];
+    const docClient = createMockDocClient([items as Record<string, unknown>[]]);
+
+    const result = await executeSearchFeedback(
+      docClient,
+      'test-feedback-table',
+      {},
+      { days: 7 },
+    );
+
+    // The two valid rows survive even though the middle one is malformed.
+    expect(result.items.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('aggregate mode reports no-match cleanly', async () => {
+    const items = [makeFeedbackItem({ original_text: 'ok', title: 'ok', problem_summary: '' })];
+    const docClient = createMockDocClient([items]);
+
+    const result = await executeSearchFeedback(
+      docClient,
+      'test-feedback-table',
+      { mode: 'aggregate', query: 'zzz_nope_zzz' },
+      { days: 7 },
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.formatted).toContain('No feedback found');
+  });
 });

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -13,7 +13,30 @@ const searchInputSchema = z.object({
   sentiment: z.string().optional(),
   urgency: z.string().optional(),
   limit: z.number().optional(),
+  // 'aggregate' returns distribution stats over ALL matches in one call
+  // (counts by urgency/sentiment/category + a few examples) instead of a
+  // capped list — answers "summarize all" / "top issues" without looping.
+  mode: z.enum(['list', 'aggregate']).optional(),
+  // 'urgency' sorts matches high→medium→low (most negative first within a
+  // tier) so "most urgent" surfaces the right items even past the list cap.
+  sort_by: z.enum(['recent', 'urgency']).optional(),
 }).passthrough();
+
+const URGENCY_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+function urgencyRank(item: FeedbackItem): number {
+  return URGENCY_RANK[item.urgency ?? ''] ?? 0;
+}
+
+// high→medium→low; within a tier, most negative sentiment first, then newest.
+function compareByUrgency(a: FeedbackItem, b: FeedbackItem): number {
+  const byUrgency = urgencyRank(b) - urgencyRank(a);
+  if (byUrgency !== 0) return byUrgency;
+  const sa = a.sentiment_score ?? 0;
+  const sb = b.sentiment_score ?? 0;
+  if (sa !== sb) return sa - sb;
+  return (b.date ?? '').localeCompare(a.date ?? '');
+}
 
 type SearchInput = z.infer<typeof searchInputSchema>;
 
@@ -29,9 +52,13 @@ const feedbackItemSchema = z.object({
   source_platform: z.string().optional(),
   source_created_at: z.string().optional(),
   sentiment_label: z.string().optional(),
-  sentiment_score: z.number().optional(),
+  // The ingestion pipeline stores these numerics as DynamoDB strings (S) for
+  // ~all items, so a strict z.number() rejected nearly every row — which made
+  // fetchCandidatesByDate silently drop them all and every search return 0
+  // results. coerce accepts both "0.95"/0.95 and "5"/5.
+  sentiment_score: z.coerce.number().optional(),
   category: z.string().optional(),
-  rating: z.number().nullable().optional(),
+  rating: z.coerce.number().nullable().optional(),
   original_text: z.string().optional(),
   title: z.string().optional(),
   problem_summary: z.string().optional(),
@@ -102,6 +129,14 @@ async function lookupByFeedbackId(
   return null;
 }
 
+// Upper bound on candidates collected across all days. A DynamoDB Query caps
+// each page at 1MB (often far fewer than 1000 large items), so we MUST follow
+// LastEvaluatedKey to page through a day — otherwise a day with thousands of
+// rows is silently truncated to the first ~500 (this caused "987 negative but
+// tool only saw 116"). Bound the total so aggregate mode can summarize the full
+// set without unbounded memory/time on a huge table.
+const MAX_CANDIDATES = 10000;
+
 async function fetchCandidatesByDate(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
@@ -114,22 +149,32 @@ async function fetchCandidatesByDate(
     const d = new Date(now);
     d.setUTCDate(d.getUTCDate() - i);
     const dateStr = d.toISOString().slice(0, 10);
+    let lastKey: Record<string, unknown> | undefined;
     try {
-      const resp = await docClient.send(
-        new QueryCommand({
-          TableName: feedbackTable,
-          IndexName: 'gsi1-by-date',
-          KeyConditionExpression: 'gsi1pk = :pk',
-          ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
-          Limit: 300,
-          ScanIndexForward: false,
-        }),
-      );
-      candidates.push(...(resp.Items ?? []).map((raw) => feedbackItemSchema.parse(raw)));
-      if (candidates.length >= 1000) break;
+      // Page through the whole day via LastEvaluatedKey, not just the first page.
+      do {
+        const resp = await docClient.send(
+          new QueryCommand({
+            TableName: feedbackTable,
+            IndexName: 'gsi1-by-date',
+            KeyConditionExpression: 'gsi1pk = :pk',
+            ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
+            ScanIndexForward: false,
+            ExclusiveStartKey: lastKey,
+          }),
+        );
+        // Per-row safeParse: a single malformed item must not throw and discard
+        // the whole day's results (the outer catch would skip the entire date).
+        for (const raw of resp.Items ?? []) {
+          const parsed = feedbackItemSchema.safeParse(raw);
+          if (parsed.success) candidates.push(parsed.data);
+        }
+        lastKey = resp.LastEvaluatedKey;
+      } while (lastKey && candidates.length < MAX_CANDIDATES);
     } catch {
-      // continue
+      // continue to the next day
     }
+    if (candidates.length >= MAX_CANDIDATES) break;
   }
   return candidates;
 }
@@ -145,6 +190,9 @@ export async function executeSearchFeedback(
   const parsed = searchInputSchema.safeParse(toolInput);
   const input: SearchInput = parsed.success ? parsed.data : {};
   const query = input.query ?? '';
+  const mode = input.mode ?? 'list';
+  // aggregate mode returns stats over the whole match set, so a small list cap
+  // there is fine (only used for the handful of examples we show).
   const limit = Math.min(input.limit ?? 15, 30);
   const days = contextFilters.days ?? 30;
 
@@ -169,9 +217,21 @@ export async function executeSearchFeedback(
   cutoff.setUTCDate(cutoff.getUTCDate() - days);
   const cutoffDate = cutoff.toISOString().slice(0, 10);
 
-  const matched = candidates
-    .filter((item) => matchesFeedbackItem(item, query, filters, cutoffDate))
-    .slice(0, limit);
+  const allMatched = candidates.filter((item) =>
+    matchesFeedbackItem(item, query, filters, cutoffDate),
+  );
+
+  // aggregate mode: summarize the WHOLE match set in one call (no list cap),
+  // so "summarize all feedback" / "top issues" don't force the model to loop.
+  if (mode === 'aggregate') {
+    const examples = [...allMatched].sort(compareByUrgency).slice(0, limit);
+    return { items: examples, formatted: formatAggregate(allMatched, examples) };
+  }
+
+  if (input.sort_by === 'urgency') {
+    allMatched.sort(compareByUrgency);
+  }
+  const matched = allMatched.slice(0, limit);
 
   return { items: matched, formatted: formatToolResults(matched) };
 }
@@ -198,4 +258,51 @@ function formatToolResults(items: FeedbackItem[]): string {
   if (items.length === 0) return 'No feedback found matching the search criteria.';
   const header = `Found ${items.length} relevant feedback items:\n\n`;
   return header + items.map((item, i) => formatSingleItem(item, i)).join('');
+}
+
+// ── Aggregate formatting ──
+
+function countBy(items: FeedbackItem[], field: keyof FeedbackItem): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const key = String(item[field] ?? 'unknown');
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+function formatDistribution(label: string, dist: [string, number][], total: number): string {
+  if (dist.length === 0) return '';
+  const lines = dist
+    .map(([k, n]) => `- ${k}: ${n} (${((n / Math.max(total, 1)) * 100).toFixed(0)}%)`)
+    .join('\n');
+  return `**${label}:**\n${lines}\n\n`;
+}
+
+// One-call summary over the ENTIRE match set: total, distributions by urgency /
+// sentiment / category / source, average rating, plus the top examples (already
+// urgency-sorted) so the model can quote specifics without another search.
+function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[]): string {
+  const total = all.length;
+  if (total === 0) return 'No feedback found matching the search criteria.';
+
+  const ratings = all.map((i) => i.rating).filter((r): r is number => typeof r === 'number');
+  const avgRating = ratings.length > 0
+    ? (ratings.reduce((s, r) => s + r, 0) / ratings.length).toFixed(2)
+    : 'N/A';
+
+  let out = `Aggregate summary over ALL ${total} matching feedback items `;
+  out += `(this is the COMPLETE set, not a sample — base your answer on these numbers):\n\n`;
+  out += `**Total matches:** ${total}\n`;
+  out += `**Average rating:** ${avgRating}\n\n`;
+  out += formatDistribution('By urgency', countBy(all, 'urgency'), total);
+  out += formatDistribution('By sentiment', countBy(all, 'sentiment_label'), total);
+  out += formatDistribution('By category', countBy(all, 'category').slice(0, 10), total);
+  out += formatDistribution('By source', countBy(all, 'source_platform'), total);
+
+  if (examples.length > 0) {
+    out += `**Top ${examples.length} examples (most urgent first):**\n\n`;
+    out += examples.map((item, i) => formatSingleItem(item, i)).join('');
+  }
+  return out;
 }


### PR DESCRIPTION
Ports the `search_feedback` improvements onto `development`, isolated from `create_project` (#127, already merged) so it reviews and merges on its own. Three fixes that compound on large datasets:

## What landed
**`tools/search-feedback.ts`**
- **Zero-results bug** — `sentiment_score`/`rating` are stored as DynamoDB strings (`S`) for ~all rows, so a strict `z.number()` rejected nearly every item and `fetchCandidatesByDate` silently dropped whole days → **every search returned 0 results**. Fixed with `z.coerce.number()` + per-row `safeParse` (one malformed row no longer discards the entire day).
- **Pagination** — a DynamoDB Query caps each page at 1MB (often ~500 large items), so a single query truncated big days (symptom: "987 negative items but the tool only saw 116"). Added `LastEvaluatedKey` do-while paging bounded by `MAX_CANDIDATES = 10000`.
- **Broad-question loop** — added `mode="aggregate"` (distribution stats over the ENTIRE match set — counts by urgency/sentiment/category/source + avg rating + top examples — in ONE call) and `sort_by="urgency"` (high→medium→low, most negative first) so "summarize all" / "most urgent issues" resolve in a single round instead of exhausting the tool loop.

**Wiring**
- `tools/index.ts` — `search_feedback` gains `mode` + `sort_by` params and aggregate/urgency guidance.
- `context/voc-context.ts` — system-prompt guidelines steer broad questions to `mode="aggregate"` and urgency filtering (the `query` field is a literal substring match, so "urgent" in the query won't filter by level).
- `handler.ts` — `MAX_TOOL_LOOPS` 5 → 15 (the real ceiling is the 300s Lambda timeout; broad questions now resolve in one round via aggregate) + per-round CloudWatch trace and a loop-exhaustion warning.

## Tests (search suite; 170 → 183, all green)
- `search-feedback.test.ts` (+130): string-number coercion, bad-row skip, `LastEvaluatedKey` pagination, aggregate stats, urgency sort.
- `handler.extended.test.ts`: loop-cap assertion 5 → 15.

## Verification
- `tsc --noEmit`: clean
- `vitest run`: **183/183 pass** (16 files), no regression
- `search-feedback.ts`/`.test.ts` are identical to the source branch; wiring files carry only the search-related lines (verified via diff vs `development`).

## Deliberately excluded
- `create_project` — already on `development` via #127; not re-touched.
- The source branch's older roundtable multi-round rework — `development` already has the newer single-turn design, so porting the old version would regress it.