### PR TITLE
fix(bedrock): auto-continue on max_tokens + allow omitting temperature

### DIFF
--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -16,6 +16,26 @@ DEFAULT_MAX_RETRIES = 5
 DEFAULT_BASE_DELAY = 1.0  # seconds
 DEFAULT_MAX_DELAY = 30.0  # seconds
 
+# Auto-continuation: when the model stops because it hit the maxTokens ceiling,
+# the output is truncated mid-document. We transparently resume the generation up
+# to this many times, concatenating the chunks, so callers never persist a
+# half-written PRD/PR-FAQ/report (the document-cutoff bug).
+#
+# Tuning note: keep per-call max_tokens MODEST (≈6-8K) rather than huge. A single
+# huge maxTokens (e.g. 24K) makes one Bedrock call run many minutes for slow CJK
+# output and can blow the Lambda timeout on its own; many small calls each finish
+# in ~1-2 min and resume cleanly. This ceiling must therefore be generous enough
+# to assemble a long document from those small chunks (8 × ~8K ≈ 64K tokens).
+DEFAULT_MAX_CONTINUATIONS = 8
+
+# Nudge sent as the user turn when resuming a truncated response. Kept terse and
+# explicit so the model picks up exactly where it stopped without re-emitting text.
+_CONTINUE_PROMPT = (
+    "Continue the document exactly where you left off. "
+    "Do not repeat any text you already wrote and do not add a preamble — "
+    "resume from the next character."
+)
+
 # Retryable error codes
 RETRYABLE_ERROR_CODES = frozenset({
     'ThrottlingException',
@@ -33,12 +53,13 @@ def converse(
     prompt: str,
     system_prompt: str = "",
     max_tokens: int = 2048,
-    temperature: float = 0.1,
+    temperature: float | None = 0.1,
     thinking_budget: int = 0,
     model_id: str | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
+    max_continuations: int = DEFAULT_MAX_CONTINUATIONS,
 ) -> str:
     """
     Simple text completion using Bedrock Converse API with retry support.
@@ -47,15 +68,22 @@ def converse(
         prompt: User message/prompt
         system_prompt: Optional system prompt
         max_tokens: Maximum tokens in response (default: 2048)
-        temperature: Model temperature (default: 0.1)
+        temperature: Model temperature (default: 0.1). Pass None to omit it
+            entirely — required for models like Opus 4.8 that reject/deprecate
+            the `temperature` inference parameter.
         thinking_budget: If > 0, enables extended thinking with this token budget
         model_id: Optional model ID override
         max_retries: Maximum retry attempts for throttling (default: 5)
         raise_on_throttle: If True, raise BedrockThrottlingError after max retries
         step_name: Name of the current step for logging
+        max_continuations: When the model stops at the maxTokens ceiling, resume
+            and concatenate up to this many times so long documents aren't
+            silently truncated. Set to 0 to disable. Ignored when extended
+            thinking is enabled (multi-turn replay of thinking blocks is
+            unsupported here).
 
     Returns:
-        Model response text
+        Model response text (concatenated across any continuations)
 
     Raises:
         BedrockThrottlingError: If throttled after max retries and raise_on_throttle=True
@@ -76,13 +104,15 @@ def converse(
     messages = [{'role': 'user', 'content': [{'text': prompt}]}]
     system = [{'text': system_prompt}] if system_prompt else None
     
+    inference_config = {'maxTokens': max_tokens}
+    # Some models (e.g. Opus 4.8) reject `temperature` as deprecated. Pass
+    # temperature=None to omit it; otherwise include it as before.
+    if temperature is not None:
+        inference_config['temperature'] = temperature
     kwargs = {
         'modelId': used_model,
         'messages': messages,
-        'inferenceConfig': {
-            'maxTokens': max_tokens,
-            'temperature': temperature,
-        }
+        'inferenceConfig': inference_config,
     }
     if system:
         kwargs['system'] = system
@@ -98,15 +128,56 @@ def converse(
     
     logger.info(f"[BEDROCK] Invoking Bedrock converse API for step '{step_name}'...")
     start_time = time.time()
-    
+
+    # Continuation is incompatible with extended thinking: resuming a truncated
+    # turn requires replaying the assistant message, and thinking blocks have
+    # signing/ordering rules we don't handle here. Disable it in that case.
+    allow_continuation = max_continuations > 0 and thinking_budget <= 0
+
     try:
-        result = _invoke_with_retry(
+        result, stop_reason = _invoke_with_retry(
             client=client,
             kwargs=kwargs,
             max_retries=max_retries,
             raise_on_throttle=raise_on_throttle,
             step_name=step_name,
         )
+
+        # Auto-continue while the model is hitting the maxTokens ceiling. Each
+        # turn appends the prior (truncated) assistant text plus a resume nudge,
+        # so the model picks up exactly where it stopped. Without this, a long
+        # PRD/PR-FAQ is saved half-written (the document-cutoff bug).
+        continuations = 0
+        while allow_continuation and stop_reason == 'max_tokens' and continuations < max_continuations:
+            continuations += 1
+            logger.warning(
+                f"[BEDROCK] Step '{step_name}' hit maxTokens — auto-continuing "
+                f"({continuations}/{max_continuations}), {len(result)} chars so far"
+            )
+            cont_messages = [
+                {'role': 'user', 'content': [{'text': prompt}]},
+                {'role': 'assistant', 'content': [{'text': result}]},
+                {'role': 'user', 'content': [{'text': _CONTINUE_PROMPT}]},
+            ]
+            cont_kwargs = {**kwargs, 'messages': cont_messages}
+            chunk, stop_reason = _invoke_with_retry(
+                client=client,
+                kwargs=cont_kwargs,
+                max_retries=max_retries,
+                raise_on_throttle=raise_on_throttle,
+                step_name=f"{step_name}_cont{continuations}",
+            )
+            if not chunk:
+                logger.warning(f"[BEDROCK] Step '{step_name}' continuation returned no text; stopping")
+                break
+            result += chunk
+
+        if stop_reason == 'max_tokens':
+            logger.warning(
+                f"[BEDROCK] Step '{step_name}' still truncated after {continuations} "
+                f"continuation(s); output may be incomplete ({len(result)} chars)"
+            )
+
         elapsed = time.time() - start_time
         logger.info(f"[BEDROCK] Step '{step_name}' completed in {elapsed:.2f}s, response length: {len(result)} chars")
         return result
@@ -224,9 +295,10 @@ def _invoke_with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
-) -> str:
+) -> tuple[str, str]:
     """
-    Invoke Bedrock converse with exponential backoff retry, returning extracted text.
+    Invoke Bedrock converse with exponential backoff retry, returning extracted
+    text and the stop reason.
 
     Args:
         client: Bedrock runtime client
@@ -236,7 +308,8 @@ def _invoke_with_retry(
         step_name: Name of the current step for logging
 
     Returns:
-        Model response text
+        (text, stop_reason). stop_reason is the raw Bedrock value
+        (e.g. 'end_turn', 'max_tokens') or '' when no response was returned.
 
     Raises:
         BedrockThrottlingError: If throttled after max retries and raise_on_throttle=True
@@ -250,11 +323,12 @@ def _invoke_with_retry(
         step_name=step_name,
     )
     if not response:
-        return ""
+        return "", ""
     content = response.get('output', {}).get('message', {}).get('content', [])
     result = _extract_text(content)
-    logger.info(f"[BEDROCK] Extracted {len(result)} chars from response for step '{step_name}'")
-    return result
+    stop_reason = response.get('stopReason', '')
+    logger.info(f"[BEDROCK] Extracted {len(result)} chars from response for step '{step_name}' (stop_reason={stop_reason})")
+    return result, stop_reason
 
 
 def _calculate_backoff(attempt: int) -> float:

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -73,9 +73,40 @@ class TestConverse:
         
         from shared.converse import converse
         converse('Simple question', thinking_budget=0)
-        
+
         call_args = mock_client.converse.call_args
         assert 'additionalModelRequestFields' not in call_args.kwargs
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_includes_temperature_by_default(self, mock_get_client):
+        """Temperature is sent in inferenceConfig when a float is given."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'R'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        converse('Hi', temperature=0.4)
+
+        cfg = mock_client.converse.call_args.kwargs['inferenceConfig']
+        assert cfg['temperature'] == 0.4
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_omits_temperature_when_none(self, mock_get_client):
+        """temperature=None omits the param entirely (e.g. for Opus 4.8)."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'R'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        converse('Hi', temperature=None)
+
+        cfg = mock_client.converse.call_args.kwargs['inferenceConfig']
+        assert 'temperature' not in cfg
+        assert cfg['maxTokens']  # other config still present
 
 
 class TestConverseRetry:
@@ -477,14 +508,99 @@ class TestConverseChainEdgeCases:
     def test_passes_max_retries_to_converse(self, mock_converse):
         """Passes max_retries parameter to converse calls."""
         mock_converse.return_value = 'Result'
-        
+
         from shared.converse import converse_chain
         steps = [{'system': 'S1', 'user': 'U1'}]
-        
+
         converse_chain(steps, max_retries=10)
-        
+
         call_args = mock_converse.call_args
         assert call_args.kwargs['max_retries'] == 10
+
+
+class TestConverseAutoContinuation:
+    """Tests for auto-continuation when the model hits the maxTokens ceiling."""
+
+    @staticmethod
+    def _resp(text, stop_reason='end_turn'):
+        return {
+            'output': {'message': {'content': [{'text': text}]}},
+            'stopReason': stop_reason,
+        }
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_resumes_when_truncated_then_concatenates(self, mock_get_client):
+        """A max_tokens stop triggers a continuation; chunks are concatenated."""
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = [
+            self._resp('Part one ', stop_reason='max_tokens'),
+            self._resp('and part two.', stop_reason='end_turn'),
+        ]
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        result = converse('Write a long doc', step_name='prd_document')
+
+        assert result == 'Part one and part two.'
+        assert mock_client.converse.call_count == 2
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_continuation_replays_prior_text(self, mock_get_client):
+        """The continuation turn includes the prior assistant text and a resume nudge."""
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = [
+            self._resp('First chunk', stop_reason='max_tokens'),
+            self._resp(' done', stop_reason='end_turn'),
+        ]
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        converse('prompt text', step_name='prd_document')
+
+        second_call_messages = mock_client.converse.call_args_list[1].kwargs['messages']
+        roles = [m['role'] for m in second_call_messages]
+        assert roles == ['user', 'assistant', 'user']
+        assert second_call_messages[1]['content'][0]['text'] == 'First chunk'
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_stops_at_max_continuations(self, mock_get_client):
+        """Never loops forever: stops after max_continuations even if still truncated."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = self._resp('x', stop_reason='max_tokens')
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        result = converse('Write a long doc', step_name='prd_document', max_continuations=2)
+
+        # 1 initial call + 2 continuations
+        assert mock_client.converse.call_count == 3
+        assert result == 'xxx'
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_no_continuation_on_normal_stop(self, mock_get_client):
+        """A normal end_turn does not trigger any continuation."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = self._resp('Complete answer', stop_reason='end_turn')
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        result = converse('Hello', step_name='test')
+
+        assert result == 'Complete answer'
+        mock_client.converse.assert_called_once()
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_continuation_disabled_with_thinking_budget(self, mock_get_client):
+        """Continuation is skipped when extended thinking is enabled."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = self._resp('partial', stop_reason='max_tokens')
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        result = converse('Hello', step_name='test', thinking_budget=5000)
+
+        assert result == 'partial'
+        mock_client.converse.assert_called_once()
 
 
 

--- a/voc-datalake/lambda/shared/test/test_converse_coverage.py
+++ b/voc-datalake/lambda/shared/test/test_converse_coverage.py
@@ -34,7 +34,7 @@ class TestRetryExhaustion:
             'Converse'
         )
 
-        result = _invoke_with_retry(
+        result, stop_reason = _invoke_with_retry(
             client=mock_client,
             kwargs={'modelId': 'test', 'messages': []},
             max_retries=2,
@@ -43,6 +43,7 @@ class TestRetryExhaustion:
         )
 
         assert result == ""
+        assert stop_reason == ""
         assert mock_client.converse.call_count == 2
 
     @patch('shared.converse.time.sleep')


### PR DESCRIPTION
Hardens `converse()` against two issues that surface on long generations and newer models. Both live in the same function, so they land together.

## What landed (`lambda/shared/converse.py`)
- **Auto-continuation** — PRDs (and other long outputs) were being **silently truncated** at the `maxTokens` ceiling: the code read the text but ignored `stopReason`, so a `stopReason=="max_tokens"` response was saved as-is. `converse()` now takes `max_continuations` (default 8); when a call stops at the token ceiling it replays the prior output + a continue-prompt as an assistant turn and concatenates, preserving the full document. Disabled when extended thinking is on (`thinking_budget>0`) since thinking-block replay isn't supported. `_invoke_with_retry` now returns `(text, stop_reason)` — it's only called inside `converse.py`, so no external caller changes.
- **Optional temperature** — `temperature` is now `float | None`. Passing `None` omits it from `inferenceConfig` entirely, which is required for models like Opus 4.8 that deprecate/reject the param. Existing float callers are unchanged (default stays `0.1`).

## Why both in one PR
Both edit the same `converse()` signature/body; splitting them would create an artificial signature conflict. `temperature=None` is a 7-line independent addition.

## Tests
- `test_converse.py`: adds `TestConverseAutoContinuation` (max_tokens replay, continuation cap, thinking-disabled path, concatenation) + temperature-omit assertions.
- `test_converse_coverage.py`: updated for the `(text, stop_reason)` tuple.
- **converse: 43/43 pass.** `document_generator` (a `converse_chain` consumer): **21/21** — no signature regression.

## Verification
- `converse.py` is identical to the source branch; `prd-cutoff-fix` was already built on `development`'s latest `converse` (`_converse_with_retry` present in both), so the copy keeps dev's raw-response refactor.
- Pre-existing `test_http.py` failures (`module 'shared' has no attribute 'http_utils'`) reproduce on clean `development` too — unrelated to this change.