### PR TITLE
feat(plugins): Synthetic Data Review Generator plugin (PR #108 P1)

### DIFF
--- a/voc-datalake/cdk.context.json
+++ b/voc-datalake/cdk.context.json
@@ -8,7 +8,8 @@
     "webscraper": true,
     "app_reviews_ios": true,
     "app_reviews_android": true,
-    "s3_import": true
+    "s3_import": true,
+    "synthetic_reviews": true
   },
   "menuStatus": {
     "dashboard": true,

--- a/voc-datalake/frontend/public/locales/de/scrapers.json
+++ b/voc-datalake/frontend/public/locales/de/scrapers.json
@@ -63,6 +63,15 @@
     "description": "Erstellen Sie einen Scraper, um Feedback von Websites zu sammeln",
     "title": "Keine Scraper konfiguriert"
   },
+  "generator": {
+    "completed": "{{count}} synthetische Bewertungen generiert. Sie erscheinen kurz nach der Verarbeitung.",
+    "completed_one": "{{count}} synthetische Bewertung generiert. Sie erscheint kurz nach der Verarbeitung.",
+    "completed_other": "{{count}} synthetische Bewertungen generiert. Sie erscheinen kurz nach der Verarbeitung.",
+    "generate": "Generieren",
+    "generating": "Wird generiert…",
+    "runningNote": "Bewertungen werden mit KI generiert. Das kann bis zu einer Minute dauern.",
+    "startFailed": "Generierung konnte nicht gestartet werden."
+  },
   "jsonUpload": {
     "cancel": "Abbrechen",
     "done": "Fertig",
@@ -168,6 +177,7 @@
     "manualImport": "Manueller Import",
     "manualImportDescription": "Fügen Sie Bewertungen von einer Website ein und importieren Sie sie mit KI-Parsing.",
     "manualInput": "Manuelle Eingabe",
+    "syntheticData": "Synthetische Daten",
     "title": "Datenquelle hinzufügen",
     "webScraperTemplates": "Web-Scraper-Vorlagen"
   },

--- a/voc-datalake/frontend/public/locales/en/scrapers.json
+++ b/voc-datalake/frontend/public/locales/en/scrapers.json
@@ -63,6 +63,15 @@
     "description": "Create a scraper to start collecting feedback from websites",
     "title": "No scrapers configured"
   },
+  "generator": {
+    "completed": "Generated {{count}} synthetic reviews. They'll appear shortly after processing.",
+    "completed_one": "Generated {{count}} synthetic review. It'll appear shortly after processing.",
+    "completed_other": "Generated {{count}} synthetic reviews. They'll appear shortly after processing.",
+    "generate": "Generate",
+    "generating": "Generating…",
+    "runningNote": "Generating reviews with AI. This can take up to a minute.",
+    "startFailed": "Failed to start generation."
+  },
   "jsonUpload": {
     "cancel": "Cancel",
     "done": "Done",
@@ -168,6 +177,7 @@
     "manualImport": "Manual Import",
     "manualImportDescription": "Paste reviews from any website and import them with AI parsing.",
     "manualInput": "Manual Input",
+    "syntheticData": "Synthetic Data",
     "title": "Add Data Source",
     "webScraperTemplates": "Web Scraper Templates"
   },

--- a/voc-datalake/frontend/public/locales/es/scrapers.json
+++ b/voc-datalake/frontend/public/locales/es/scrapers.json
@@ -64,6 +64,16 @@
     "description": "Cree un scraper para comenzar a recopilar feedback de sitios web",
     "title": "No hay scrapers configurados"
   },
+  "generator": {
+    "completed": "Se generaron {{count}} reseñas sintéticas. Aparecerán poco después del procesamiento.",
+    "completed_one": "Se generó {{count}} reseña sintética. Aparecerá poco después del procesamiento.",
+    "completed_many": "Se generaron {{count}} reseñas sintéticas. Aparecerán poco después del procesamiento.",
+    "completed_other": "Se generaron {{count}} reseñas sintéticas. Aparecerán poco después del procesamiento.",
+    "generate": "Generar",
+    "generating": "Generando…",
+    "runningNote": "Generando reseñas con IA. Esto puede tardar hasta un minuto.",
+    "startFailed": "No se pudo iniciar la generación."
+  },
   "jsonUpload": {
     "cancel": "Cancelar",
     "done": "Listo",
@@ -177,6 +187,7 @@
     "manualImport": "Importación manual",
     "manualImportDescription": "Pegue reseñas de cualquier sitio web e impórtelas con análisis de IA.",
     "manualInput": "Entrada manual",
+    "syntheticData": "Datos sintéticos",
     "title": "Agregar fuente de datos",
     "webScraperTemplates": "Plantillas de web scraper"
   },

--- a/voc-datalake/frontend/public/locales/fr/scrapers.json
+++ b/voc-datalake/frontend/public/locales/fr/scrapers.json
@@ -64,6 +64,16 @@
     "description": "Créez un scraper pour commencer à collecter les retours des sites web",
     "title": "Aucun scraper configuré"
   },
+  "generator": {
+    "completed": "{{count}} avis synthétiques générés. Ils apparaîtront peu après le traitement.",
+    "completed_one": "{{count}} avis synthétique généré. Il apparaîtra peu après le traitement.",
+    "completed_many": "{{count}} avis synthétiques générés. Ils apparaîtront peu après le traitement.",
+    "completed_other": "{{count}} avis synthétiques générés. Ils apparaîtront peu après le traitement.",
+    "generate": "Générer",
+    "generating": "Génération…",
+    "runningNote": "Génération d'avis avec l'IA. Cela peut prendre jusqu'à une minute.",
+    "startFailed": "Échec du démarrage de la génération."
+  },
   "jsonUpload": {
     "cancel": "Annuler",
     "done": "Terminé",
@@ -177,6 +187,7 @@
     "manualImport": "Import manuel",
     "manualImportDescription": "Collez des avis de n'importe quel site web et importez-les avec l'analyse IA.",
     "manualInput": "Saisie manuelle",
+    "syntheticData": "Données synthétiques",
     "title": "Ajouter une source de données",
     "webScraperTemplates": "Modèles de web scraper"
   },

--- a/voc-datalake/frontend/public/locales/ja/scrapers.json
+++ b/voc-datalake/frontend/public/locales/ja/scrapers.json
@@ -63,6 +63,15 @@
     "description": "スクレイパーを作成してWebサイトからフィードバックの収集を開始",
     "title": "スクレイパーが設定されていません"
   },
+  "generator": {
+    "completed": "{{count}} 件の合成レビューを生成しました。処理後まもなく表示されます。",
+    "completed_one": "{{count}} 件の合成レビューを生成しました。処理後まもなく表示されます。",
+    "completed_other": "{{count}} 件の合成レビューを生成しました。処理後まもなく表示されます。",
+    "generate": "生成",
+    "generating": "生成中…",
+    "runningNote": "AIでレビューを生成しています。最大1分ほどかかる場合があります。",
+    "startFailed": "生成を開始できませんでした。"
+  },
   "jsonUpload": {
     "cancel": "キャンセル",
     "done": "完了",
@@ -168,6 +177,7 @@
     "manualImport": "手動インポート",
     "manualImportDescription": "任意のWebサイトからレビューを貼り付けてAI解析でインポート。",
     "manualInput": "手動入力",
+    "syntheticData": "合成データ",
     "title": "データソースを追加",
     "webScraperTemplates": "Webスクレイパーテンプレート"
   },

--- a/voc-datalake/frontend/public/locales/ko/scrapers.json
+++ b/voc-datalake/frontend/public/locales/ko/scrapers.json
@@ -63,6 +63,15 @@
     "description": "스크레이퍼를 만들어 웹사이트에서 피드백 수집 시작",
     "title": "구성된 스크레이퍼 없음"
   },
+  "generator": {
+    "completed": "{{count}}개의 합성 리뷰를 생성했습니다. 처리 후 곧 표시됩니다.",
+    "completed_one": "{{count}}개의 합성 리뷰를 생성했습니다. 처리 후 곧 표시됩니다.",
+    "completed_other": "{{count}}개의 합성 리뷰를 생성했습니다. 처리 후 곧 표시됩니다.",
+    "generate": "생성",
+    "generating": "생성 중…",
+    "runningNote": "AI로 리뷰를 생성하고 있습니다. 최대 1분 정도 걸릴 수 있습니다.",
+    "startFailed": "생성을 시작하지 못했습니다."
+  },
   "jsonUpload": {
     "cancel": "취소",
     "done": "완료",
@@ -168,6 +177,7 @@
     "manualImport": "수동 가져오기",
     "manualImportDescription": "웹사이트에서 리뷰를 붙여넣고 AI 분석으로 가져오기.",
     "manualInput": "수동 입력",
+    "syntheticData": "합성 데이터",
     "title": "데이터 소스 추가",
     "webScraperTemplates": "웹 스크레이퍼 템플릿"
   },

--- a/voc-datalake/frontend/public/locales/pt/scrapers.json
+++ b/voc-datalake/frontend/public/locales/pt/scrapers.json
@@ -64,6 +64,16 @@
     "description": "Crie um scraper para começar a coletar feedback de sites",
     "title": "Nenhum scraper configurado"
   },
+  "generator": {
+    "completed": "{{count}} avaliações sintéticas geradas. Elas aparecerão logo após o processamento.",
+    "completed_one": "{{count}} avaliação sintética gerada. Ela aparecerá logo após o processamento.",
+    "completed_many": "{{count}} avaliações sintéticas geradas. Elas aparecerão logo após o processamento.",
+    "completed_other": "{{count}} avaliações sintéticas geradas. Elas aparecerão logo após o processamento.",
+    "generate": "Gerar",
+    "generating": "Gerando…",
+    "runningNote": "Gerando avaliações com IA. Isso pode levar até um minuto.",
+    "startFailed": "Falha ao iniciar a geração."
+  },
   "jsonUpload": {
     "cancel": "Cancelar",
     "done": "Concluído",
@@ -177,6 +187,7 @@
     "manualImport": "Importação manual",
     "manualImportDescription": "Cole avaliações de qualquer site e importe-as com análise de IA.",
     "manualInput": "Entrada manual",
+    "syntheticData": "Dados sintéticos",
     "title": "Adicionar fonte de dados",
     "webScraperTemplates": "Modelos de web scraper"
   },

--- a/voc-datalake/frontend/public/locales/zh/scrapers.json
+++ b/voc-datalake/frontend/public/locales/zh/scrapers.json
@@ -63,6 +63,15 @@
     "description": "创建抓取器以开始从网站收集反馈",
     "title": "未配置抓取器"
   },
+  "generator": {
+    "completed": "已生成 {{count}} 条合成评论。处理后将很快显示。",
+    "completed_one": "已生成 {{count}} 条合成评论。处理后将很快显示。",
+    "completed_other": "已生成 {{count}} 条合成评论。处理后将很快显示。",
+    "generate": "生成",
+    "generating": "生成中…",
+    "runningNote": "正在使用 AI 生成评论。这可能需要长达一分钟。",
+    "startFailed": "无法开始生成。"
+  },
   "jsonUpload": {
     "cancel": "取消",
     "done": "完成",
@@ -168,6 +177,7 @@
     "manualImport": "手动导入",
     "manualImportDescription": "从任何网站粘贴评论并使用AI解析导入。",
     "manualInput": "手动输入",
+    "syntheticData": "合成数据",
     "title": "添加数据源",
     "webScraperTemplates": "网页抓取器模板"
   },

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -318,6 +318,8 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify(credentials)
     }),
+  getIntegrationCredentials: (source: string, keys: string[]) =>
+    fetchApi<Record<string, string>>(`/integrations/${source}/credentials?keys=${keys.join(',')}`),
   
   testIntegration: (source: string) => 
     fetchApi<{ success: boolean; message?: string; error?: string; details?: Record<string, unknown> }>(`/integrations/${source}/test`, {

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.test.tsx
@@ -1,0 +1,111 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest'
+import {
+  render, screen, waitFor,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  QueryClient, QueryClientProvider,
+} from '@tanstack/react-query'
+import GeneratorConfigModal from './GeneratorConfigModal'
+import type { PluginManifest } from '../../plugins/types'
+
+const mockGetIntegrationCredentials = vi.fn()
+const mockUpdateIntegrationCredentials = vi.fn()
+const mockRunSource = vi.fn()
+const mockGetSourceRunStatus = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getIntegrationCredentials: (s: string, keys: string[]) => mockGetIntegrationCredentials(s, keys),
+    updateIntegrationCredentials: (s: string, creds: Record<string, string>) => mockUpdateIntegrationCredentials(s, creds),
+    runSource: (s: string) => mockRunSource(s),
+    getSourceRunStatus: (s: string) => mockGetSourceRunStatus(s),
+  },
+}))
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+const plugin: PluginManifest = {
+  id: 'synthetic_reviews',
+  name: 'Synthetic Data Review Generator',
+  icon: '🧪',
+  description: 'Generate realistic synthetic customer reviews with AI.',
+  category: 'synthetic',
+  config: [
+    {
+      key: 'company_name', label: 'Company / Brand Name', type: 'text', required: true, placeholder: 'Acme Corp', secret: false,
+    },
+    {
+      key: 'product_name', label: 'Product / Service Name', type: 'text', required: true, placeholder: 'Acme App', secret: false,
+    },
+    {
+      key: 'num_reviews', label: 'Number of Reviews', type: 'text', required: false, placeholder: '10', secret: false,
+    },
+  ],
+  setup: {
+    title: 'Synthetic Setup', color: 'blue', steps: ['Step 1'],
+  },
+  hasIngestor: true,
+  hasWebhook: false,
+  hasS3Trigger: false,
+  version: '1.0.0',
+  enabled: true,
+}
+
+describe('GeneratorConfigModal', () => {
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetIntegrationCredentials.mockResolvedValue({})
+    mockUpdateIntegrationCredentials.mockResolvedValue({ success: true })
+    mockRunSource.mockResolvedValue({
+      success: true, message: 'Triggered', source: 'synthetic_reviews', execution_id: 'e1',
+    })
+    mockGetSourceRunStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'running', items_found: 0 })
+  })
+
+  it('renders the plugin name and config fields from the manifest', () => {
+    render(<GeneratorConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
+    expect(screen.getByText('Company / Brand Name')).toBeInTheDocument()
+    expect(screen.getByText('Product / Service Name')).toBeInTheDocument()
+  })
+
+  it('disables Generate until required fields are filled', () => {
+    render(<GeneratorConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    expect(screen.getByRole('button', { name: /generat/i })).toBeDisabled()
+  })
+
+  it('saves config and triggers a run when Generate is clicked', async () => {
+    const user = userEvent.setup()
+    render(<GeneratorConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+
+    await user.type(screen.getByPlaceholderText('Acme Corp'), 'Acme Corp')
+    await user.type(screen.getByPlaceholderText('Acme App'), 'Acme App')
+
+    const generateButton = screen.getByRole('button', { name: /generat/i })
+    expect(generateButton).not.toBeDisabled()
+    await user.click(generateButton)
+
+    await waitFor(() => {
+      expect(mockUpdateIntegrationCredentials).toHaveBeenCalledWith(
+        'synthetic_reviews',
+        expect.objectContaining({ company_name: 'Acme Corp', product_name: 'Acme App' }),
+      )
+    })
+    expect(mockRunSource).toHaveBeenCalledWith('synthetic_reviews')
+  })
+
+  it('calls onClose when the Close button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<GeneratorConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
@@ -1,0 +1,182 @@
+/**
+ * @fileoverview Manifest-driven config + run modal for on-demand "generator" plugins
+ * (e.g. the Synthetic Data Review Generator).
+ * @module pages/Scrapers/GeneratorConfigModal
+ *
+ * Renders the plugin's config[] fields generically, saves them via
+ * /integrations/{id}/credentials, triggers a run via /sources/{id}/run, and polls
+ * run status. There is no plugin-specific UI — everything is driven by the manifest.
+ */
+
+import {
+  useMutation, useQuery,
+} from '@tanstack/react-query'
+import {
+  Loader2, Sparkles,
+} from 'lucide-react'
+import {
+  useState, useEffect,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import {
+  PluginField, SetupInstructions, ResultMessage,
+} from './PluginConfigParts'
+import type { PluginManifest } from '../../plugins/types'
+
+interface GeneratorConfigModalProps {
+  readonly plugin: PluginManifest
+  readonly onClose: () => void
+}
+
+type RunPhase = 'idle' | 'running' | 'completed' | 'error'
+
+const TERMINAL_STATUSES = new Set(['completed', 'error', 'failed'])
+const POLL_INTERVAL_MS = 2000
+
+function GeneratorHeader({
+  plugin, onClose,
+}: {
+  readonly plugin: PluginManifest;
+  readonly onClose: () => void
+}) {
+  const hasDescription = plugin.description != null && plugin.description !== ''
+  return (
+    <div className="p-4 border-b flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        <span className="w-10 h-10 rounded-lg bg-indigo-100 text-indigo-600 flex items-center justify-center text-xl flex-shrink-0">{plugin.icon.slice(0, 2)}</span>
+        <div>
+          <h3 className="font-semibold text-lg">{plugin.name}</h3>
+          {hasDescription ? <p className="text-sm text-gray-500">{plugin.description}</p> : null}
+        </div>
+      </div>
+      <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl">&times;</button>
+    </div>
+  )
+}
+
+function RunStatusBanner({
+  phase, runningNote, completedMsg, errorMsg,
+}: {
+  readonly phase: RunPhase
+  readonly runningNote: string
+  readonly completedMsg: string
+  readonly errorMsg: string
+}) {
+  if (phase === 'running') {
+    return (
+      <div className="flex items-center gap-2 text-sm text-indigo-700 bg-indigo-50 rounded-lg p-3">
+        <Loader2 size={16} className="animate-spin" />
+        <span>{runningNote}</span>
+      </div>
+    )
+  }
+  if (phase === 'completed') return <ResultMessage success message={completedMsg} />
+  if (phase === 'error') return <ResultMessage success={false} message={errorMsg} />
+  return null
+}
+
+export default function GeneratorConfigModal({
+  plugin, onClose,
+}: GeneratorConfigModalProps) {
+  const { t } = useTranslation('scrapers')
+  const fieldKeys = plugin.config.map((f) => f.key)
+
+  const [edits, setEdits] = useState<Record<string, string>>({})
+  const [phase, setPhase] = useState<RunPhase>('idle')
+  const [itemsFound, setItemsFound] = useState(0)
+
+  const { data: savedConfig } = useQuery({
+    queryKey: ['generator-config', plugin.id],
+    queryFn: () => api.getIntegrationCredentials(plugin.id, fieldKeys),
+  })
+
+  // Derive form values from saved config + local edits (no init effect needed).
+  const values: Record<string, string> = {
+    ...(savedConfig ?? {}),
+    ...edits,
+  }
+
+  useEffect(() => {
+    if (phase !== 'running') return
+    const poll = () => {
+      void api.getSourceRunStatus(plugin.id)
+        .then((res) => {
+          setItemsFound(res.items_found ?? 0)
+          if (TERMINAL_STATUSES.has(res.status)) {
+            setPhase(res.status === 'completed' ? 'completed' : 'error')
+          }
+          return null
+        })
+        .catch(() => null)
+    }
+    const interval = setInterval(poll, POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [phase, plugin.id])
+
+  const generateMutation = useMutation({
+    mutationFn: async () => {
+      await api.updateIntegrationCredentials(plugin.id, values)
+      return await api.runSource(plugin.id)
+    },
+    onSuccess: () => {
+      setItemsFound(0)
+      setPhase('running')
+    },
+    onError: () => setPhase('error'),
+  })
+
+  const hasRequired = plugin.config
+    .filter((f) => f.required === true)
+    .every((f) => (values[f.key] ?? '').trim() !== '')
+  const isBusy = generateMutation.isPending || phase === 'running'
+  const runningNote = itemsFound > 0
+    ? `${t('generator.runningNote')} (${itemsFound})`
+    : t('generator.runningNote')
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-2 sm:p-4">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[95vh] sm:max-h-[90vh] overflow-hidden flex flex-col">
+        <GeneratorHeader plugin={plugin} onClose={onClose} />
+
+        <div className="p-4 overflow-y-auto flex-1 space-y-4">
+          <div className="grid gap-3">
+            {plugin.config.map((field) => (
+              <PluginField
+                key={field.key}
+                field={field}
+                value={values[field.key] ?? ''}
+                showSecrets={false}
+                onChange={(v) => setEdits((prev) => ({
+                  ...prev,
+                  [field.key]: v,
+                }))}
+              />
+            ))}
+          </div>
+
+          <RunStatusBanner
+            phase={phase}
+            runningNote={runningNote}
+            completedMsg={t('generator.completed', { count: itemsFound })}
+            errorMsg={t('generator.startFailed')}
+          />
+
+          {plugin.setup == null ? null : <SetupInstructions setup={plugin.setup} />}
+        </div>
+
+        <div className="p-4 border-t flex items-center gap-2">
+          <button
+            onClick={() => generateMutation.mutate()}
+            disabled={isBusy || !hasRequired}
+            className="btn btn-primary flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isBusy ? <Loader2 size={16} className="animate-spin" /> : <Sparkles size={16} />}
+            {isBusy ? t('generator.generating') : t('generator.generate')}
+          </button>
+          <button onClick={onClose} className="btn btn-secondary text-sm ml-auto">{t('pluginConfig.close')}</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -20,6 +20,7 @@ import { getPluginManifests } from '../../plugins'
 import { useConfigStore } from '../../store/configStore'
 import { useManualImportStore } from '../../store/manualImportStore'
 import { AppConfigCard } from './AppConfigComponents'
+import GeneratorConfigModal from './GeneratorConfigModal'
 import JsonUploadModal from './JsonUploadModal'
 import ManualImportModal from './ManualImportModal'
 import PluginConfigModal from './PluginConfigModal'
@@ -36,7 +37,7 @@ import type { PluginManifest } from '../../plugins/types'
 type AppConfig = Record<string, string>
 
 function getAppConfigPlugins(): PluginManifest[] {
-  return getPluginManifests().filter((p) => p.id !== 'webscraper' && p.id !== 's3_import' && p.hasIngestor)
+  return getPluginManifests().filter((p) => p.id !== 'webscraper' && p.id !== 's3_import' && p.category !== 'synthetic' && p.hasIngestor)
 }
 
 function AppConfigList({
@@ -272,6 +273,7 @@ export default function Scrapers() {
   const [deleteScraperId, setDeleteScraperId] = useState<string | null>(null)
   const [selectedTemplate, setSelectedTemplate] = useState<ScraperTemplate | null>(null)
   const [selectedPlugin, setSelectedPlugin] = useState<PluginManifest | null>(null)
+  const [selectedGenerator, setSelectedGenerator] = useState<PluginManifest | null>(null)
   const [showJsonUpload, setShowJsonUpload] = useState(false)
   const [deleteAppInfo, setDeleteAppInfo] = useState<{
     pluginId: string;
@@ -375,7 +377,9 @@ export default function Scrapers() {
       <ManualImportModal />
       <JsonUploadModal isOpen={showJsonUpload} onClose={() => setShowJsonUpload(false)} />
 
-      {showTemplates ? <TemplateSelector onSelect={handleSelectTemplate} onSelectPlugin={handleSelectPlugin} onManualImport={() => {
+      {showTemplates ? <TemplateSelector onSelect={handleSelectTemplate} onSelectPlugin={handleSelectPlugin} onSelectGenerator={(plugin) => {
+        setShowTemplates(false); setSelectedGenerator(plugin)
+      }} onManualImport={() => {
         setShowTemplates(false); setIsModalOpen(true)
       }} onJsonUpload={() => {
         setShowTemplates(false); setShowJsonUpload(true)
@@ -384,6 +388,11 @@ export default function Scrapers() {
       {selectedPlugin == null ? null : <PluginConfigModal
         plugin={selectedPlugin}
         onClose={() => setSelectedPlugin(null)}
+      />}
+
+      {selectedGenerator == null ? null : <GeneratorConfigModal
+        plugin={selectedGenerator}
+        onClose={() => setSelectedGenerator(null)}
       />}
 
       {(isCreating || editingScraper != null) ? <ScraperEditor scraper={editingScraper} template={selectedTemplate} onSave={handleSaveScraper} onClose={handleCloseEditor} /> : null}

--- a/voc-datalake/frontend/src/pages/Scrapers/TemplateSelector.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/TemplateSelector.tsx
@@ -9,7 +9,7 @@
 import { useQuery } from '@tanstack/react-query'
 import clsx from 'clsx'
 import {
-  Loader2, FileJson, Globe, Smartphone, ClipboardPaste, Upload,
+  Loader2, FileJson, Globe, Smartphone, ClipboardPaste, Upload, Sparkles,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { scrapersApi } from '../../api/scrapersApi'
@@ -21,6 +21,7 @@ import type { PluginManifest } from '../../plugins/types'
 interface TemplateSelectorProps {
   readonly onSelect: (template: ScraperTemplate) => void
   readonly onSelectPlugin: (plugin: PluginManifest) => void
+  readonly onSelectGenerator: (plugin: PluginManifest) => void
   readonly onManualImport: () => void
   readonly onJsonUpload: () => void
   readonly onClose: () => void
@@ -102,13 +103,21 @@ function getPluginBorderClass(category?: string): string {
 
 /**
  * Get auto-discovered plugins that should appear in the template selector.
- * Excludes the webscraper plugin (it has its own templates) and only includes
- * plugins with an ingestor (scheduled data collection).
+ * Excludes the webscraper plugin (it has its own templates), synthetic generators
+ * (shown in their own section), and only includes plugins with an ingestor.
  */
 function getDiscoverablePlugins(): PluginManifest[] {
   return getPluginManifests().filter(
-    (p) => p.id !== 'webscraper' && p.hasIngestor,
+    (p) => p.id !== 'webscraper' && p.category !== 'synthetic' && p.hasIngestor,
   )
+}
+
+/**
+ * Get synthetic data generator plugins (category 'synthetic'). These are on-demand
+ * generators configured via a dedicated modal rather than the multi-app plugin config.
+ */
+function getSyntheticPlugins(): PluginManifest[] {
+  return getPluginManifests().filter((p) => p.category === 'synthetic')
 }
 
 /**
@@ -121,7 +130,7 @@ function mergeTemplates(apiTemplates: ScraperTemplate[]): ScraperTemplate[] {
 }
 
 export default function TemplateSelector({
-  onSelect, onSelectPlugin, onManualImport, onJsonUpload, onClose,
+  onSelect, onSelectPlugin, onSelectGenerator, onManualImport, onJsonUpload, onClose,
 }: TemplateSelectorProps) {
   const { t } = useTranslation('scrapers')
   const { config } = useConfigStore()
@@ -136,6 +145,7 @@ export default function TemplateSelector({
 
   const templates = mergeTemplates(data?.templates ?? [])
   const discoverablePlugins = getDiscoverablePlugins()
+  const syntheticPlugins = getSyntheticPlugins()
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-2 sm:p-4">
@@ -238,6 +248,28 @@ export default function TemplateSelector({
               </button>
             </div>
           </div>
+
+          {/* Synthetic Data section */}
+          {syntheticPlugins.length > 0 && (
+            <div>
+              <h4 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">{t('templateSelector.syntheticData')}</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+                {syntheticPlugins.map((plugin) => (
+                  <button
+                    key={plugin.id}
+                    onClick={() => onSelectGenerator(plugin)}
+                    className="p-3 sm:p-4 border-2 rounded-lg text-left transition-all hover:border-indigo-400 hover:bg-indigo-50 border-indigo-200 bg-indigo-50/30"
+                  >
+                    <div className="flex items-center gap-2 sm:gap-3 mb-2">
+                      <Sparkles size={24} className="text-indigo-600" />
+                      <div className="font-medium text-sm sm:text-base">{plugin.name}</div>
+                    </div>
+                    <p className="text-xs sm:text-sm text-gray-600">{plugin.description}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="p-3 sm:p-4 border-t">

--- a/voc-datalake/frontend/src/plugins/manifests.json
+++ b/voc-datalake/frontend/src/plugins/manifests.json
@@ -261,6 +261,129 @@
     "enabled": true
   },
   {
+    "id": "synthetic_reviews",
+    "name": "Synthetic Data Review Generator",
+    "icon": "🧪",
+    "description": "Generate realistic synthetic customer reviews with AI (Amazon Bedrock) for demos, testing, and modeling. Ingested through the normal pipeline and tagged as synthetic data.",
+    "category": "synthetic",
+    "config": [
+      {
+        "key": "company_name",
+        "label": "Company / Brand Name",
+        "type": "text",
+        "required": true,
+        "placeholder": "Acme Corp",
+        "secret": false
+      },
+      {
+        "key": "product_name",
+        "label": "Product / Service Name",
+        "type": "text",
+        "required": true,
+        "placeholder": "Acme Mobile App",
+        "secret": false
+      },
+      {
+        "key": "product_description",
+        "label": "Product Description",
+        "type": "textarea",
+        "required": false,
+        "placeholder": "What the product does, who it's for, key features...",
+        "secret": false
+      },
+      {
+        "key": "target_customer",
+        "label": "Target Customer / Persona",
+        "type": "textarea",
+        "required": false,
+        "placeholder": "e.g. busy parents who shop on mobile, price-sensitive small businesses...",
+        "secret": false
+      },
+      {
+        "key": "focus_areas",
+        "label": "Focus Areas (comma separated)",
+        "type": "textarea",
+        "required": false,
+        "placeholder": "delivery, pricing, customer support, app performance, checkout",
+        "secret": false
+      },
+      {
+        "key": "num_reviews",
+        "label": "Number of Reviews to Generate (max 50)",
+        "type": "text",
+        "required": false,
+        "placeholder": "10",
+        "secret": false
+      },
+      {
+        "key": "sentiment_mix",
+        "label": "Sentiment Mix",
+        "type": "select",
+        "required": false,
+        "secret": false,
+        "options": [
+          {
+            "value": "balanced",
+            "label": "Balanced (realistic mix)"
+          },
+          {
+            "value": "mostly_positive",
+            "label": "Mostly Positive"
+          },
+          {
+            "value": "mostly_negative",
+            "label": "Mostly Negative"
+          },
+          {
+            "value": "mixed",
+            "label": "Polarized (very positive + very negative)"
+          }
+        ]
+      },
+      {
+        "key": "language",
+        "label": "Review Language",
+        "type": "select",
+        "required": false,
+        "secret": false,
+        "options": [
+          {
+            "value": "en",
+            "label": "English"
+          },
+          {
+            "value": "de",
+            "label": "German"
+          },
+          {
+            "value": "es",
+            "label": "Spanish"
+          },
+          {
+            "value": "fr",
+            "label": "French"
+          }
+        ]
+      }
+    ],
+    "setup": {
+      "title": "Synthetic Data Review Generator",
+      "color": "blue",
+      "steps": [
+        "Enter your company/brand and product details so reviews sound realistic.",
+        "Optionally describe your target customer and the focus areas to cover (e.g. delivery, pricing, support).",
+        "Choose how many reviews to generate (max 50 per run) and the sentiment mix.",
+        "Click Generate. Reviews are created with AI and ingested through the normal pipeline.",
+        "Generated items are tagged as synthetic (source: synthetic_reviews) so you can filter them out anytime."
+      ]
+    },
+    "hasIngestor": true,
+    "hasWebhook": false,
+    "hasS3Trigger": false,
+    "version": "1.0.0",
+    "enabled": true
+  },
+  {
     "id": "webscraper",
     "name": "Web Scraper",
     "icon": "Web",

--- a/voc-datalake/frontend/src/plugins/types.ts
+++ b/voc-datalake/frontend/src/plugins/types.ts
@@ -42,7 +42,7 @@ export const PluginManifestSchema = z.object({
   name: z.string(),
   icon: z.string(),
   description: z.string().optional(),
-  category: z.enum(['reviews', 'social', 'import', 'search', 'scraper']).optional(),
+  category: z.enum(['reviews', 'social', 'import', 'search', 'scraper', 'synthetic']).optional(),
   config: z.array(ConfigFieldSchema),
   webhooks: z.array(WebhookInfoSchema).optional(),
   setup: SetupSchema.optional(),

--- a/voc-datalake/lib/plugin-loader.test.ts
+++ b/voc-datalake/lib/plugin-loader.test.ts
@@ -190,7 +190,7 @@ describe('Plugin Loader', () => {
       expect(() => loadPlugins('/test/plugins')).toThrow();
     });
 
-    it('rejects timeout exceeding 300 seconds', async () => {
+    it('rejects timeout exceeding 900 seconds', async () => {
       mockFs.existsSync.mockReturnValue(true);
       mockFs.readdirSync.mockReturnValue(mockDirents('slow_plugin'));
 
@@ -201,7 +201,7 @@ describe('Plugin Loader', () => {
         infrastructure: {
           ingestor: {
             enabled: true,
-            timeout: 600,  // Exceeds 300
+            timeout: 901,  // Exceeds 900 (Lambda hard max)
           },
         },
       }));

--- a/voc-datalake/lib/plugin-loader.test.ts
+++ b/voc-datalake/lib/plugin-loader.test.ts
@@ -211,6 +211,29 @@ describe('Plugin Loader', () => {
       expect(() => loadPlugins('/test/plugins')).toThrow();
     });
 
+    it('accepts timeout of exactly 900 seconds (Lambda hard max)', async () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(mockDirents('max_timeout_plugin'));
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        id: 'max_timeout_plugin',
+        name: 'Max Timeout Plugin',
+        icon: '⏱️',
+        infrastructure: {
+          ingestor: {
+            enabled: true,
+            timeout: 900,  // inclusive boundary — Lambda hard max
+          },
+        },
+      }));
+
+      const { loadPlugins } = await import('./plugin-loader');
+      const result = loadPlugins('/test/plugins');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].infrastructure.ingestor?.timeout).toBe(900);
+    });
+
     it('rejects memory exceeding 1024 MB', async () => {
       mockFs.existsSync.mockReturnValue(true);
       mockFs.readdirSync.mockReturnValue(mockDirents('big_plugin'));

--- a/voc-datalake/lib/plugin-loader.test.ts
+++ b/voc-datalake/lib/plugin-loader.test.ts
@@ -252,6 +252,48 @@ describe('Plugin Loader', () => {
 
       expect(() => loadPlugins('/test/plugins')).toThrow();
     });
+
+    it('accepts the synthetic category and the ingestor.bedrock capability flag', async () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(mockDirents('synthetic_reviews'));
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        id: 'synthetic_reviews',
+        name: 'Synthetic Data Review Generator',
+        icon: '🧪',
+        category: 'synthetic',
+        infrastructure: {
+          ingestor: { enabled: true, timeout: 300, memory: 512, bedrock: true },
+        },
+        config: [],
+      }));
+
+      const { loadPlugins } = await import('./plugin-loader');
+      const result = loadPlugins('/test/plugins');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe('synthetic');
+      expect(result[0].infrastructure.ingestor?.bedrock).toBe(true);
+    });
+
+    it('defaults ingestor.bedrock to false so non-opted-in plugins never get a Bedrock role', async () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(mockDirents('webscraper'));
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        id: 'webscraper',
+        name: 'Web Scraper',
+        icon: '🌐',
+        infrastructure: { ingestor: { enabled: true } },
+      }));
+
+      const { loadPlugins } = await import('./plugin-loader');
+      const result = loadPlugins('/test/plugins');
+
+      // The dedicated Bedrock role in ingestion-stack keys off `bedrock === true`,
+      // so the default MUST be false to keep the shared least-privilege role.
+      expect(result[0].infrastructure.ingestor?.bedrock).toBe(false);
+    });
   });
 
   describe('Helper Functions', () => {

--- a/voc-datalake/lib/plugin-loader.ts
+++ b/voc-datalake/lib/plugin-loader.ts
@@ -78,7 +78,7 @@ const SetupSchema = z.object({
 const IngestorInfraSchema = z.object({
   enabled: z.boolean(),
   schedule: ScheduleSchema.optional(),
-  timeout: z.number().int().min(1).max(300).default(120),
+  timeout: z.number().int().min(1).max(900).default(120), // 900s = AWS Lambda hard max
   memory: z.number().int().min(128).max(1024).default(256),
   // Opt-in capability: when true, the plugin's Lambda gets a dedicated IAM role
   // with a scoped bedrock:InvokeModel grant (Claude models only) instead of the
@@ -215,8 +215,8 @@ function validateManifestLimits(manifest: PluginManifest): void {
   const infra = manifest.infrastructure;
 
   if (infra.ingestor) {
-    if (infra.ingestor.timeout > 300) {
-      throw new Error(`Plugin ${manifest.id}: timeout cannot exceed 300 seconds`);
+    if (infra.ingestor.timeout > 900) {
+      throw new Error(`Plugin ${manifest.id}: timeout cannot exceed 900 seconds`);
     }
     if (infra.ingestor.memory > 1024) {
       throw new Error(`Plugin ${manifest.id}: memory cannot exceed 1024 MB`);

--- a/voc-datalake/lib/plugin-loader.ts
+++ b/voc-datalake/lib/plugin-loader.ts
@@ -80,6 +80,11 @@ const IngestorInfraSchema = z.object({
   schedule: ScheduleSchema.optional(),
   timeout: z.number().int().min(1).max(300).default(120),
   memory: z.number().int().min(128).max(1024).default(256),
+  // Opt-in capability: when true, the plugin's Lambda gets a dedicated IAM role
+  // with a scoped bedrock:InvokeModel grant (Claude models only) instead of the
+  // shared ingestion role. Keeps least-privilege: only plugins that declare this
+  // can call Bedrock. See ingestion-stack.ts createIngestorLambda().
+  bedrock: z.boolean().optional().default(false),
 });
 
 const WebhookInfraSchema = z.object({
@@ -113,7 +118,7 @@ const ManifestSchema = z.object({
   name: SafeStringSchema,
   icon: IconSchema,
   description: SafeStringSchema.optional(),
-  category: z.enum(['reviews', 'social', 'import', 'search', 'scraper']).optional(),
+  category: z.enum(['reviews', 'social', 'import', 'search', 'scraper', 'synthetic']).optional(),
   infrastructure: InfrastructureSchema,
   config: z.array(ConfigFieldSchema).max(20).default([]),
   webhooks: z.array(WebhookInfoSchema).max(5).optional(),

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -23,7 +23,7 @@ import {
 } from '../plugin-loader';
 import { uniqueName } from '../utils/naming';
 import { NagSuppressions } from 'cdk-nag';
-import { apiSecretsSuppressions } from '../utils/nag-suppressions';
+import { apiSecretsSuppressions, bedrockModelSuppressions } from '../utils/nag-suppressions';
 
 export interface VocIngestionStackProps extends cdk.StackProps {
   feedbackTable: dynamodb.Table;
@@ -46,6 +46,16 @@ export class VocIngestionStack extends cdk.Stack {
   public readonly processingQueue: sqs.Queue;
   public readonly secretsArn: string;
   public readonly s3ImportBucket: s3.Bucket;
+
+  // Grant targets captured in the constructor so per-plugin roles (e.g. for
+  // Bedrock-capable plugins) can be granted the same base permissions.
+  private ingestRoleGrants!: {
+    watermarksTable: dynamodb.Table;
+    aggregatesTable: dynamodb.Table;
+    rawDataBucket: s3.Bucket;
+    kmsKey: kms.Key;
+    apiSecrets: secretsmanager.Secret;
+  };
 
   constructor(scope: Construct, id: string, props: VocIngestionStackProps) {
     super(scope, id, props);
@@ -73,14 +83,11 @@ export class VocIngestionStack extends cdk.Stack {
     const dlq = this.createDLQ(kmsKey);
     this.processingQueue = this.createProcessingQueue(kmsKey, dlq);
 
-    // Common Lambda execution role
-    const ingestionRole = this.createIngestionRole(
-      watermarksTable,
-      aggregatesTable,
-      rawDataBucket,
-      kmsKey,
-      apiSecrets
-    );
+    // Grant targets reused when building per-plugin roles (e.g. Bedrock-capable plugins)
+    this.ingestRoleGrants = { watermarksTable, aggregatesTable, rawDataBucket, kmsKey, apiSecrets };
+
+    // Common Lambda execution role (shared by plugins that don't need extra permissions)
+    const ingestionRole = this.createIngestionRole();
 
     // Common environment variables
     const commonEnv = this.buildCommonEnv(watermarksTable, rawDataBucket, apiSecrets, config);
@@ -242,13 +249,7 @@ export class VocIngestionStack extends cdk.Stack {
     return queue;
   }
 
-  private createIngestionRole(
-    watermarksTable: dynamodb.Table,
-    aggregatesTable: dynamodb.Table,
-    rawDataBucket: s3.Bucket,
-    kmsKey: kms.Key,
-    apiSecrets: secretsmanager.Secret
-  ): iam.Role {
+  private createIngestionRole(): iam.Role {
     const role = new iam.Role(this, 'IngestionLambdaRole', {
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
       managedPolicies: [
@@ -256,12 +257,53 @@ export class VocIngestionStack extends cdk.Stack {
       ],
     });
 
+    this.applyBaseIngestionGrants(role);
+
+    return role;
+  }
+
+  /** Apply the standard ingestion permissions: watermarks, aggregates, queue, raw bucket, KMS, secrets. */
+  private applyBaseIngestionGrants(role: iam.Role): void {
+    const { watermarksTable, aggregatesTable, rawDataBucket, kmsKey, apiSecrets } = this.ingestRoleGrants;
     watermarksTable.grantReadWriteData(role);
     aggregatesTable.grantReadWriteData(role);
     this.processingQueue.grantSendMessages(role);
     rawDataBucket.grantReadWrite(role);
     kmsKey.grantEncryptDecrypt(role);
     apiSecrets.grantRead(role);
+  }
+
+  /**
+   * Build a dedicated role for a plugin that opts in via `infrastructure.ingestor.bedrock`.
+   * It gets the same base ingestion permissions PLUS a scoped bedrock:InvokeModel grant
+   * (Claude Sonnet only). This keeps least-privilege intact: only opted-in plugins can
+   * reach Bedrock, rather than widening the shared role for the whole plugin fleet.
+   *
+   * The model ARNs must match the model shared/converse.py actually invokes
+   * (shared.aws.BEDROCK_MODEL_ID = global.anthropic.claude-sonnet-4-5-...); a `global.`
+   * inference profile requires BOTH the inference-profile and foundation-model ARNs.
+   */
+  private createBedrockIngestorRole(pluginId: string): iam.Role {
+    const role = new iam.Role(this, `IngestorRole${capitalize(pluginId)}`, {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+
+    this.applyBaseIngestionGrants(role);
+
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel'],
+      resources: [
+        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
+      ],
+    }));
+
+    // The stack-level suppressions in bin/ cover the base grants but not Bedrock,
+    // so attach the Bedrock model suppression to this dedicated role explicitly.
+    NagSuppressions.addResourceSuppressions(role, bedrockModelSuppressions, true);
 
     return role;
   }
@@ -331,13 +373,16 @@ export class VocIngestionStack extends cdk.Stack {
     // Parse schedule from manifest
     const schedule = this.parseSchedule(infra.schedule);
 
+    // Bedrock-capable plugins get a dedicated, scoped role; all others share the common role.
+    const role = infra.bedrock === true ? this.createBedrockIngestorRole(plugin.id) : ingestionRole;
+
     const fn = new lambda.Function(this, `Ingestor${capitalize(plugin.id)}`, {
       functionName: uniqueName(`voc-ingestor-${plugin.id}`),
       runtime: lambda.Runtime.PYTHON_3_14,
       architecture: lambda.Architecture.ARM_64,
       handler: 'handler.lambda_handler',
       code: ingestorCode,
-      role: ingestionRole,
+      role,
       timeout: cdk.Duration.seconds(infra.timeout),
       memorySize: infra.memory,
       environment: lambdaEnv,

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -89,6 +89,7 @@ class BaseIngestor(ABC):
         return [
             "webscraper", "s3_import", "manual_import",
             "app_reviews_ios", "app_reviews_android",
+            "synthetic_reviews",
         ]
 
     def get_watermark(self, key: str, default: str = None) -> str:

--- a/voc-datalake/plugins/_shared/test/test_base_ingestor.py
+++ b/voc-datalake/plugins/_shared/test/test_base_ingestor.py
@@ -39,6 +39,44 @@ class TestBaseIngestorInit:
     @patch('_shared.base_ingestor.get_s3_client')
     @patch('_shared.base_ingestor.get_sqs_client')
     @patch('_shared.base_ingestor.get_secret')
+    def test_does_not_leak_other_known_plugin_secrets(
+        self, mock_get_secret, mock_sqs, mock_s3, mock_dynamo
+    ):
+        """Keys prefixed for another KNOWN plugin must not leak into this plugin's secrets.
+
+        Regression guard for per-plugin secret isolation: every plugin id must be
+        listed in BaseIngestor._get_known_prefixes(). If a plugin (e.g. synthetic_reviews)
+        is missing from that list, its `<plugin>_*` keys in the shared secret are treated
+        as unprefixed shared/legacy keys and leak into every other plugin's loaded config.
+        This test fails if a known plugin is dropped from the prefix list.
+        """
+        from _shared.base_ingestor import BaseIngestor
+
+        mock_get_secret.return_value = {
+            'test_source_api_key': 'mine',            # this plugin's own key
+            'synthetic_reviews_api_key': 'not-mine',  # another known plugin's key
+            'shared_legacy_key': 'shared',            # no known prefix -> shared/legacy
+        }
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+
+        class TestIngestor(BaseIngestor):
+            def fetch_new_items(self):
+                yield from []
+
+        ingestor = TestIngestor()  # source_platform = 'test_source' (conftest env)
+
+        # own key: present and prefix-stripped
+        assert ingestor.secrets.get('api_key') == 'mine'
+        # unprefixed key: kept as a shared/legacy value
+        assert ingestor.secrets.get('shared_legacy_key') == 'shared'
+        # another known plugin's key: excluded entirely, and never surfaced under any name
+        assert 'synthetic_reviews_api_key' not in ingestor.secrets
+        assert 'not-mine' not in ingestor.secrets.values()
+
+    @patch('_shared.base_ingestor.get_dynamodb_resource')
+    @patch('_shared.base_ingestor.get_s3_client')
+    @patch('_shared.base_ingestor.get_sqs_client')
+    @patch('_shared.base_ingestor.get_secret')
     def test_initializes_circuit_breaker(
         self, mock_get_secret, mock_sqs, mock_s3, mock_dynamo
     ):

--- a/voc-datalake/plugins/synthetic_reviews/README.md
+++ b/voc-datalake/plugins/synthetic_reviews/README.md
@@ -31,7 +31,7 @@ You can filter synthetic data in/out anywhere the source is selectable.
 | Product Description | no | Improves relevance |
 | Target Customer / Persona | no | Shapes voice and concerns |
 | Focus Areas | no | Comma-separated topics (e.g. `delivery, pricing, support`) |
-| Number of Reviews | no | 1–50 per run (default 10) |
+| Number of Reviews | no | 1–150 per run (default 10) |
 | Sentiment Mix | no | balanced / mostly positive / mostly negative / polarized |
 | Review Language | no | en, de, es, fr |
 

--- a/voc-datalake/plugins/synthetic_reviews/README.md
+++ b/voc-datalake/plugins/synthetic_reviews/README.md
@@ -1,0 +1,54 @@
+# Synthetic Data Review Generator
+
+Generates realistic **synthetic** customer reviews with Amazon Bedrock (Claude Sonnet) and
+ingests them through the normal VoC processing pipeline, tagged as synthetic data.
+
+Use it to seed demos, test dashboards/alerts, or model how feedback flows through the platform
+without needing real customer data.
+
+## What it does
+
+1. You provide context about your company, product, target customer, the focus areas to cover,
+   how many reviews to generate, the sentiment mix, and the language.
+2. On **Generate**, the plugin Lambda calls Bedrock to produce that many distinct reviews
+   (in batches), then sends each through the standard pipeline (S3 raw → SQS → processor).
+3. The processor enriches them exactly like real feedback (sentiment, category, persona), so they
+   appear in the dashboard — but clearly marked as synthetic.
+
+## How items are tagged as synthetic
+
+- `source_platform = "synthetic_reviews"` — a distinct, filterable source.
+- `metadata.is_synthetic = true` plus `generator`, `generator_model`, and `focus_area`.
+
+You can filter synthetic data in/out anywhere the source is selectable.
+
+## Configuration
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| Company / Brand Name | yes | Makes generated reviews sound realistic |
+| Product / Service Name | yes | |
+| Product Description | no | Improves relevance |
+| Target Customer / Persona | no | Shapes voice and concerns |
+| Focus Areas | no | Comma-separated topics (e.g. `delivery, pricing, support`) |
+| Number of Reviews | no | 1–50 per run (default 10) |
+| Sentiment Mix | no | balanced / mostly positive / mostly negative / polarized |
+| Review Language | no | en, de, es, fr |
+
+Configuration is stored per-plugin in AWS Secrets Manager (isolated by the `synthetic_reviews_` prefix).
+
+## How it runs
+
+On-demand only — there is **no schedule**. Trigger it from the dashboard
+("Synthetic Data" card in the Add Data Source modal) or via `POST /sources/synthetic_reviews/run`,
+which async-invokes the ingestor Lambda.
+
+## Bedrock access (least privilege)
+
+This plugin declares `infrastructure.ingestor.bedrock: true` in its manifest. The platform grants
+a **dedicated** IAM role with a scoped `bedrock:InvokeModel` permission (Claude Sonnet only) to
+*this* Lambda — the shared plugin role is left unchanged, so no other plugin gains Bedrock access.
+
+## Enable / disable
+
+Set `pluginStatus.synthetic_reviews` in `cdk.context.json`, run `npm run generate:config`, and deploy.

--- a/voc-datalake/plugins/synthetic_reviews/ingestor/handler.py
+++ b/voc-datalake/plugins/synthetic_reviews/ingestor/handler.py
@@ -1,0 +1,246 @@
+"""
+Synthetic Data Review Generator - Ingestor
+
+Generates realistic synthetic customer reviews with Amazon Bedrock (Claude Sonnet)
+from operator-provided company/product/customer context, then ingests them through
+the standard processing pipeline tagged as synthetic data:
+  - source_platform = "synthetic_reviews" (its own filterable source)
+  - metadata.is_synthetic = true (plus generator/focus_area for traceability)
+
+This plugin is on-demand only (no EventBridge schedule). It is triggered from the
+dashboard ("Synthetic Data" in the Add Data Source modal) or via
+POST /sources/synthetic_reviews/run, which async-invokes this Lambda.
+
+Configuration (company, product, focus areas, count, sentiment, language) is stored
+per-plugin in Secrets Manager and loaded via BaseIngestor secrets isolation.
+"""
+
+import json
+import os
+import random
+import re
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+
+# Add shared module path (mirrors plugin template); _shared/shared resolve as
+# top-level packages in the bundled Lambda and via conftest in tests.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
+from shared.converse import converse
+
+# Generation limits (kept conservative to stay within the Lambda timeout/token budget)
+MAX_REVIEWS = 50
+DEFAULT_REVIEWS = 10
+BATCH_SIZE = 10
+MAX_FOCUS_AREAS = 12
+GENERATION_WINDOW_DAYS = 90
+
+SENTIMENT_GUIDANCE = {
+    "balanced": "a realistic balanced mix (roughly 55% positive, 25% neutral, 20% negative)",
+    "mostly_positive": "mostly positive (about 80% positive) with a few critical reviews",
+    "mostly_negative": "mostly negative (about 70% negative) reflecting customers facing problems",
+    "mixed": "highly polarized — a mix of very positive and very negative reviews",
+}
+
+SYSTEM_PROMPT = (
+    "You are a data generation assistant that produces realistic, diverse synthetic "
+    "customer reviews for software/product testing and analytics. "
+    "Never use real people's names or real personal data; invent plausible but "
+    "fictional reviewer first names with a last initial. "
+    "Return ONLY a valid JSON array with no markdown fences or commentary."
+)
+
+
+class SyntheticReviewsIngestor(BaseIngestor):
+    """Generates synthetic customer reviews via Bedrock and ingests them as synthetic data."""
+
+    def __init__(self):
+        super().__init__()
+        self.company_name = (self.secrets.get("company_name") or "").strip()
+        self.product_name = (self.secrets.get("product_name") or "").strip()
+        self.product_description = (self.secrets.get("product_description") or "").strip()
+        self.target_customer = (self.secrets.get("target_customer") or "").strip()
+        self.focus_areas = self._parse_focus_areas(self.secrets.get("focus_areas") or "")
+        self.num_reviews = self._parse_count(self.secrets.get("num_reviews"))
+        self.sentiment_mix = (self.secrets.get("sentiment_mix") or "balanced").strip() or "balanced"
+        self.language = (self.secrets.get("language") or "en").strip() or "en"
+
+    @staticmethod
+    def _parse_count(raw) -> int:
+        """Parse and clamp the requested review count to [1, MAX_REVIEWS]."""
+        try:
+            value = int(str(raw).strip())
+        except (TypeError, ValueError):
+            return DEFAULT_REVIEWS
+        return max(1, min(value, MAX_REVIEWS))
+
+    @staticmethod
+    def _parse_focus_areas(raw: str) -> list[str]:
+        """Split a comma/newline separated string into a trimmed, capped list of areas."""
+        parts = re.split(r"[,\n]", raw)
+        areas = [p.strip() for p in parts if p.strip()]
+        return areas[:MAX_FOCUS_AREAS]
+
+    def fetch_new_items(self) -> Generator[dict, None, None]:
+        """Generate reviews in batches and yield normalized-ready items."""
+        if not self.company_name or not self.product_name:
+            logger.warning(
+                "Synthetic generator not configured: company_name and product_name are required"
+            )
+            return
+
+        logger.info(
+            f"Generating {self.num_reviews} synthetic reviews for "
+            f"'{self.company_name}' / '{self.product_name}' (lang={self.language})"
+        )
+
+        remaining = self.num_reviews
+        generated = 0
+        while remaining > 0:
+            batch_n = min(BATCH_SIZE, remaining)
+            reviews = self._generate_batch(batch_n)
+            if not reviews:
+                logger.warning("Batch returned no parseable reviews; stopping early")
+                break
+            for review in reviews:
+                item = self._build_item(review)
+                if item is not None:
+                    yield item
+                    generated += 1
+            remaining -= batch_n
+
+        logger.info(f"Synthetic generation produced {generated} reviews")
+        metrics.add_metric(name="SyntheticReviewsGenerated", unit="Count", value=generated)
+
+    @tracer.capture_method
+    def _generate_batch(self, count: int) -> list[dict]:
+        """Call Bedrock to generate a batch of reviews; returns [] on failure."""
+        prompt = self._build_prompt(count)
+        try:
+            response_text = converse(
+                prompt=prompt,
+                system_prompt=SYSTEM_PROMPT,
+                max_tokens=4096,
+                temperature=0.9,
+                step_name="synthetic_reviews",
+            )
+        except Exception as e:
+            logger.exception(f"Bedrock generation failed: {e}")
+            return []
+        return self._parse_reviews(response_text)
+
+    def _build_prompt(self, count: int) -> str:
+        sentiment = SENTIMENT_GUIDANCE.get(self.sentiment_mix, SENTIMENT_GUIDANCE["balanced"])
+        areas = ", ".join(self.focus_areas) if self.focus_areas else "general product experience"
+
+        context_lines = [f"Company: {self.company_name}", f"Product: {self.product_name}"]
+        if self.product_description:
+            context_lines.append(f"Product description: {self.product_description}")
+        if self.target_customer:
+            context_lines.append(f"Target customer: {self.target_customer}")
+        context = "\n".join(context_lines)
+
+        return (
+            f"Generate {count} realistic, distinct customer reviews written in language code "
+            f"'{self.language}'.\n\n"
+            f"{context}\n\n"
+            f"Spread the reviews across these areas/topics: {areas}.\n"
+            f"Sentiment distribution: {sentiment}.\n\n"
+            "Make each review specific and varied in length, tone, and detail. "
+            "Ratings must align with sentiment (1-2 = negative, 3 = neutral/mixed, 4-5 = positive).\n\n"
+            "Return ONLY a JSON array. Each element must be an object with keys: "
+            '"text" (2-5 sentences), "rating" (integer 1-5), "title" (short string), '
+            '"author" (fictional first name + last initial), '
+            '"focus_area" (one of the listed areas).'
+        )
+
+    @staticmethod
+    def _parse_reviews(response_text: str) -> list[dict]:
+        """Extract and parse the JSON array of reviews from the model response."""
+        match = re.search(r"\[[\s\S]*\]", response_text)
+        if not match:
+            logger.warning("No JSON array found in synthetic reviews response")
+            return []
+        try:
+            data = json.loads(match.group())
+        except json.JSONDecodeError as e:
+            logger.warning(f"Failed to parse synthetic reviews JSON: {e}")
+            return []
+        if not isinstance(data, list):
+            return []
+        return [r for r in data if isinstance(r, dict) and r.get("text")]
+
+    def _build_item(self, review: dict) -> dict | None:
+        """Convert a raw model review object into an ingestor item dict."""
+        text = str(review.get("text", "")).strip()
+        if not text:
+            return None
+
+        focus_area = str(review.get("focus_area", "") or "").strip() or "general"
+        author = str(review.get("author", "") or "").strip() or None
+        title = str(review.get("title", "") or "").strip() or None
+
+        return {
+            "id": f"synthetic-{uuid.uuid4().hex}",
+            "text": text[:50000],
+            "rating": self._coerce_rating(review.get("rating")),
+            "created_at": self._random_created_at(),
+            "channel": "review",
+            "author": author,
+            "title": title,
+            "language": self.language,
+            "metadata": {
+                "is_synthetic": True,
+                "generator": "synthetic_reviews",
+                "generator_model": "claude-sonnet-4-5",
+                "focus_area": focus_area,
+            },
+        }
+
+    @staticmethod
+    def _coerce_rating(raw) -> float | None:
+        """Coerce a rating into a 1-5 float, or None if not parseable."""
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return float(max(1, min(5, round(value))))
+
+    @staticmethod
+    def _random_created_at() -> str:
+        """Spread synthetic reviews over a recent window (non-cryptographic jitter)."""
+        now = datetime.now(timezone.utc)
+        offset = timedelta(
+            days=random.randint(0, GENERATION_WINDOW_DAYS),  # noqa: S311 - synthetic timestamps, not security-sensitive
+            hours=random.randint(0, 23),  # noqa: S311
+            minutes=random.randint(0, 59),  # noqa: S311
+        )
+        return (now - offset).isoformat()
+
+    def normalize_item(self, item: dict, raw_content: str = None) -> dict:
+        """Extend base normalization to carry synthetic tagging fields through to SQS.
+
+        author/title/language/metadata are accepted by the IngestMessage schema
+        (metadata permits extra primitive keys), so the synthetic markers survive
+        validation and reach the raw S3 record and downstream processing.
+        """
+        normalized = super().normalize_item(item, raw_content)
+        for key in ("author", "title", "language", "metadata"):
+            value = item.get(key)
+            if value is not None:
+                normalized[key] = value
+        return normalized
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event, context):
+    """Lambda entry point. Honors execution_id from the manual-run payload for status tracking."""
+    ingestor = SyntheticReviewsIngestor()
+    if isinstance(event, dict) and event.get("execution_id"):
+        ingestor.execution_id = event["execution_id"]
+    return ingestor.run()

--- a/voc-datalake/plugins/synthetic_reviews/ingestor/handler.py
+++ b/voc-datalake/plugins/synthetic_reviews/ingestor/handler.py
@@ -31,8 +31,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics
 from shared.converse import converse
 
-# Generation limits (kept conservative to stay within the Lambda timeout/token budget)
-MAX_REVIEWS = 50
+# Generation limits. Generation is SEQUENTIAL — one Bedrock call per BATCH_SIZE inside a
+# single ingestor invocation — so the cap is bounded by the Lambda timeout (900s in the
+# manifest): ~15 batches of 10 fit with margin at the same per-batch budget as the old
+# 50/300s. Beyond this, Bedrock TPM/RPM quota (not Lambda time) becomes the real ceiling;
+# to scale further, fan out via SQS / Step Functions rather than raising this again.
+MAX_REVIEWS = 150
 DEFAULT_REVIEWS = 10
 BATCH_SIZE = 10
 MAX_FOCUS_AREAS = 12

--- a/voc-datalake/plugins/synthetic_reviews/manifest.json
+++ b/voc-datalake/plugins/synthetic_reviews/manifest.json
@@ -1,0 +1,117 @@
+{
+  "id": "synthetic_reviews",
+  "name": "Synthetic Data Review Generator",
+  "icon": "🧪",
+  "description": "Generate realistic synthetic customer reviews with AI (Amazon Bedrock) for demos, testing, and modeling. Ingested through the normal pipeline and tagged as synthetic data.",
+  "category": "synthetic",
+  "version": "1.0.0",
+
+  "infrastructure": {
+    "ingestor": {
+      "enabled": true,
+      "timeout": 300,
+      "memory": 512,
+      "bedrock": true
+    }
+  },
+
+  "config": [
+    {
+      "key": "company_name",
+      "label": "Company / Brand Name",
+      "type": "text",
+      "required": true,
+      "placeholder": "Acme Corp",
+      "secret": false
+    },
+    {
+      "key": "product_name",
+      "label": "Product / Service Name",
+      "type": "text",
+      "required": true,
+      "placeholder": "Acme Mobile App",
+      "secret": false
+    },
+    {
+      "key": "product_description",
+      "label": "Product Description",
+      "type": "textarea",
+      "required": false,
+      "placeholder": "What the product does, who it's for, key features...",
+      "secret": false
+    },
+    {
+      "key": "target_customer",
+      "label": "Target Customer / Persona",
+      "type": "textarea",
+      "required": false,
+      "placeholder": "e.g. busy parents who shop on mobile, price-sensitive small businesses...",
+      "secret": false
+    },
+    {
+      "key": "focus_areas",
+      "label": "Focus Areas (comma separated)",
+      "type": "textarea",
+      "required": false,
+      "placeholder": "delivery, pricing, customer support, app performance, checkout",
+      "secret": false
+    },
+    {
+      "key": "num_reviews",
+      "label": "Number of Reviews to Generate (max 50)",
+      "type": "text",
+      "required": false,
+      "placeholder": "10",
+      "secret": false
+    },
+    {
+      "key": "sentiment_mix",
+      "label": "Sentiment Mix",
+      "type": "select",
+      "required": false,
+      "secret": false,
+      "options": [
+        { "value": "balanced", "label": "Balanced (realistic mix)" },
+        { "value": "mostly_positive", "label": "Mostly Positive" },
+        { "value": "mostly_negative", "label": "Mostly Negative" },
+        { "value": "mixed", "label": "Polarized (very positive + very negative)" }
+      ]
+    },
+    {
+      "key": "language",
+      "label": "Review Language",
+      "type": "select",
+      "required": false,
+      "secret": false,
+      "options": [
+        { "value": "en", "label": "English" },
+        { "value": "de", "label": "German" },
+        { "value": "es", "label": "Spanish" },
+        { "value": "fr", "label": "French" }
+      ]
+    }
+  ],
+
+  "setup": {
+    "title": "Synthetic Data Review Generator",
+    "color": "blue",
+    "steps": [
+      "Enter your company/brand and product details so reviews sound realistic.",
+      "Optionally describe your target customer and the focus areas to cover (e.g. delivery, pricing, support).",
+      "Choose how many reviews to generate (max 50 per run) and the sentiment mix.",
+      "Click Generate. Reviews are created with AI and ingested through the normal pipeline.",
+      "Generated items are tagged as synthetic (source: synthetic_reviews) so you can filter them out anytime."
+    ]
+  },
+
+  "secrets": {
+    "company_name": "",
+    "product_name": "",
+    "product_description": "",
+    "target_customer": "",
+    "focus_areas": "",
+    "num_reviews": "",
+    "sentiment_mix": "",
+    "language": ""
+  }
+}

--- a/voc-datalake/plugins/synthetic_reviews/manifest.json
+++ b/voc-datalake/plugins/synthetic_reviews/manifest.json
@@ -9,7 +9,7 @@
   "infrastructure": {
     "ingestor": {
       "enabled": true,
-      "timeout": 300,
+      "timeout": 900,
       "memory": 512,
       "bedrock": true
     }
@@ -58,7 +58,7 @@
     },
     {
       "key": "num_reviews",
-      "label": "Number of Reviews to Generate (max 50)",
+      "label": "Number of Reviews to Generate (max 150)",
       "type": "text",
       "required": false,
       "placeholder": "10",
@@ -98,7 +98,7 @@
     "steps": [
       "Enter your company/brand and product details so reviews sound realistic.",
       "Optionally describe your target customer and the focus areas to cover (e.g. delivery, pricing, support).",
-      "Choose how many reviews to generate (max 50 per run) and the sentiment mix.",
+      "Choose how many reviews to generate (max 150 per run) and the sentiment mix.",
       "Click Generate. Reviews are created with AI and ingested through the normal pipeline.",
       "Generated items are tagged as synthetic (source: synthetic_reviews) so you can filter them out anytime."
     ]

--- a/voc-datalake/plugins/test_plugin_imports.py
+++ b/voc-datalake/plugins/test_plugin_imports.py
@@ -35,3 +35,9 @@ class TestSharedModuleImports:
         """Webscraper plugin must import without errors (no Lambda layer deps)."""
         mod = importlib.import_module('webscraper.ingestor.handler')
         assert hasattr(mod, 'WebScraperIngestor')
+
+    def test_synthetic_reviews_handler_imports_successfully(self):
+        """Synthetic reviews plugin must import without errors (uses shared.converse)."""
+        mod = importlib.import_module('synthetic_reviews.ingestor.handler')
+        assert hasattr(mod, 'SyntheticReviewsIngestor')
+        assert callable(mod.lambda_handler)

--- a/voc-datalake/plugins/test_synthetic_reviews.py
+++ b/voc-datalake/plugins/test_synthetic_reviews.py
@@ -1,0 +1,249 @@
+"""Unit tests for the Synthetic Data Review Generator plugin handler.
+
+Covers the pure parsing/building logic and the Bedrock-backed generation loop
+(with `converse` mocked at the import boundary). AWS clients used by BaseIngestor
+are mocked so no network calls occur.
+"""
+import json
+from contextlib import contextmanager
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@contextmanager
+def _make_ingestor(secrets: dict):
+    """Instantiate SyntheticReviewsIngestor with AWS deps + secrets mocked."""
+    with patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
+            patch('_shared.base_ingestor.get_s3_client'), \
+            patch('_shared.base_ingestor.get_sqs_client'), \
+            patch('_shared.base_ingestor.get_secret', return_value=secrets):
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+        from synthetic_reviews.ingestor.handler import SyntheticReviewsIngestor
+        yield SyntheticReviewsIngestor()
+
+
+def _configured_secrets(**overrides) -> dict:
+    base = {
+        'company_name': 'Acme Corp',
+        'product_name': 'Acme App',
+        'product_description': 'A mobile shopping app',
+        'target_customer': 'Busy parents',
+        'focus_areas': 'delivery, pricing',
+        'num_reviews': '3',
+        'sentiment_mix': 'balanced',
+        'language': 'en',
+    }
+    base.update(overrides)
+    return base
+
+
+def _reviews_json(count: int) -> str:
+    reviews = [
+        {
+            'text': f'This is synthetic review number {i}.',
+            'rating': (i % 5) + 1,
+            'title': f'Title {i}',
+            'author': f'User {i}',
+            'focus_area': 'delivery',
+        }
+        for i in range(count)
+    ]
+    return json.dumps(reviews)
+
+
+class TestParseCount:
+    """SyntheticReviewsIngestor._parse_count clamps the requested review count."""
+
+    def _parse(self, raw):
+        from synthetic_reviews.ingestor.handler import SyntheticReviewsIngestor
+        return SyntheticReviewsIngestor._parse_count(raw)
+
+    def test_returns_default_for_invalid_value(self):
+        from synthetic_reviews.ingestor.handler import DEFAULT_REVIEWS
+        assert self._parse('not-a-number') == DEFAULT_REVIEWS
+
+    def test_returns_default_for_none(self):
+        from synthetic_reviews.ingestor.handler import DEFAULT_REVIEWS
+        assert self._parse(None) == DEFAULT_REVIEWS
+
+    def test_clamps_to_max(self):
+        from synthetic_reviews.ingestor.handler import MAX_REVIEWS
+        assert self._parse('9999') == MAX_REVIEWS
+
+    def test_clamps_to_minimum_of_one(self):
+        assert self._parse('0') == 1
+
+    def test_parses_valid_value(self):
+        assert self._parse('7') == 7
+
+
+class TestParseFocusAreas:
+    """SyntheticReviewsIngestor._parse_focus_areas splits and caps the list."""
+
+    def _parse(self, raw):
+        from synthetic_reviews.ingestor.handler import SyntheticReviewsIngestor
+        return SyntheticReviewsIngestor._parse_focus_areas(raw)
+
+    def test_splits_on_commas_and_newlines(self):
+        assert self._parse('delivery, pricing\nsupport') == ['delivery', 'pricing', 'support']
+
+    def test_ignores_blank_entries(self):
+        assert self._parse('delivery,, ,pricing') == ['delivery', 'pricing']
+
+    def test_returns_empty_list_for_empty_string(self):
+        assert self._parse('') == []
+
+    def test_caps_number_of_areas(self):
+        from synthetic_reviews.ingestor.handler import MAX_FOCUS_AREAS
+        raw = ','.join(f'area{i}' for i in range(MAX_FOCUS_AREAS + 5))
+        assert len(self._parse(raw)) == MAX_FOCUS_AREAS
+
+
+class TestCoerceRating:
+    """SyntheticReviewsIngestor._coerce_rating normalizes ratings to 1-5 floats."""
+
+    def _coerce(self, raw):
+        from synthetic_reviews.ingestor.handler import SyntheticReviewsIngestor
+        return SyntheticReviewsIngestor._coerce_rating(raw)
+
+    def test_returns_none_for_invalid(self):
+        assert self._coerce('abc') is None
+
+    def test_returns_none_for_none(self):
+        assert self._coerce(None) is None
+
+    def test_clamps_above_five(self):
+        assert self._coerce(9) == 5.0
+
+    def test_clamps_below_one(self):
+        assert self._coerce(0) == 1.0
+
+    def test_passes_through_valid_rating(self):
+        assert self._coerce(4) == 4.0
+
+
+class TestParseReviews:
+    """SyntheticReviewsIngestor._parse_reviews extracts the JSON array safely."""
+
+    def _parse(self, text):
+        from synthetic_reviews.ingestor.handler import SyntheticReviewsIngestor
+        return SyntheticReviewsIngestor._parse_reviews(text)
+
+    def test_parses_array_with_surrounding_text(self):
+        result = self._parse('Here are the reviews: [{"text": "Great"}] done')
+        assert result == [{'text': 'Great'}]
+
+    def test_returns_empty_for_malformed_json(self):
+        assert self._parse('[{"text": "Great",}]') == []
+
+    def test_returns_empty_when_no_array_present(self):
+        assert self._parse('no json here') == []
+
+    def test_drops_entries_without_text(self):
+        result = self._parse('[{"text": "ok"}, {"rating": 5}, {"text": ""}]')
+        assert result == [{'text': 'ok'}]
+
+
+class TestBuildItem:
+    """SyntheticReviewsIngestor._build_item produces normalized-ready items tagged synthetic."""
+
+    def test_builds_item_with_synthetic_metadata(self):
+        with _make_ingestor(_configured_secrets()) as ingestor:
+            item = ingestor._build_item({
+                'text': 'Loved the fast delivery',
+                'rating': 5,
+                'title': 'Great',
+                'author': 'Sam P.',
+                'focus_area': 'delivery',
+            })
+        assert item is not None
+        assert item['id'].startswith('synthetic-')
+        assert item['text'] == 'Loved the fast delivery'
+        assert item['rating'] == 5.0
+        assert item['channel'] == 'review'
+        assert item['metadata']['is_synthetic'] is True
+        assert item['metadata']['focus_area'] == 'delivery'
+
+    def test_returns_none_for_empty_text(self):
+        with _make_ingestor(_configured_secrets()) as ingestor:
+            assert ingestor._build_item({'text': '   '}) is None
+
+    def test_defaults_focus_area_when_missing(self):
+        with _make_ingestor(_configured_secrets()) as ingestor:
+            item = ingestor._build_item({'text': 'ok'})
+        assert item['metadata']['focus_area'] == 'general'
+
+
+class TestNormalizeItem:
+    """normalize_item override carries synthetic tagging fields through to the queue."""
+
+    def test_forwards_metadata_author_title_language(self):
+        with _make_ingestor(_configured_secrets()) as ingestor:
+            ingestor.store_raw_to_s3 = MagicMock(return_value='s3://bucket/key.json')
+            normalized = ingestor.normalize_item({
+                'id': 'synthetic-1',
+                'text': 'ok',
+                'channel': 'review',
+                'author': 'Sam P.',
+                'title': 'Great',
+                'language': 'en',
+                'metadata': {'is_synthetic': True},
+            })
+        assert normalized['author'] == 'Sam P.'
+        assert normalized['title'] == 'Great'
+        assert normalized['language'] == 'en'
+        assert normalized['metadata'] == {'is_synthetic': True}
+
+
+class TestFetchNewItems:
+    """fetch_new_items generates reviews via Bedrock and yields synthetic items."""
+
+    def test_yields_generated_reviews(self):
+        with _make_ingestor(_configured_secrets(num_reviews='3')) as ingestor:
+            with patch(
+                'synthetic_reviews.ingestor.handler.converse',
+                return_value=_reviews_json(3),
+            ) as mock_converse:
+                items = list(ingestor.fetch_new_items())
+        assert len(items) == 3
+        assert mock_converse.called
+        assert all(i['metadata']['is_synthetic'] is True for i in items)
+        assert all(i['id'].startswith('synthetic-') for i in items)
+
+    def test_yields_nothing_when_not_configured(self):
+        with _make_ingestor(_configured_secrets(company_name='', product_name='')) as ingestor:
+            with patch('synthetic_reviews.ingestor.handler.converse') as mock_converse:
+                items = list(ingestor.fetch_new_items())
+        assert items == []
+        assert not mock_converse.called
+
+    def test_stops_early_when_generation_fails(self):
+        with _make_ingestor(_configured_secrets(num_reviews='20')) as ingestor:
+            with patch(
+                'synthetic_reviews.ingestor.handler.converse',
+                side_effect=RuntimeError('bedrock down'),
+            ):
+                items = list(ingestor.fetch_new_items())
+        assert items == []
+
+
+class TestLambdaHandler:
+    """lambda_handler wires execution_id and runs the ingestor."""
+
+    def test_sets_execution_id_from_event(self):
+        import types
+        ctx = types.SimpleNamespace(
+            function_name='voc-ingestor-synthetic_reviews',
+            function_version='$LATEST',
+            invoked_function_arn='arn:aws:lambda:us-east-1:123456789012:function:voc-ingestor-synthetic_reviews',
+            memory_limit_in_mb=512,
+            aws_request_id='req-1',
+        )
+        with _make_ingestor(_configured_secrets()) as ingestor:
+            from synthetic_reviews.ingestor import handler as handler_mod
+            with patch.object(handler_mod, 'SyntheticReviewsIngestor', return_value=ingestor):
+                ingestor.run = MagicMock(return_value={'status': 'success'})
+                result = handler_mod.lambda_handler({'execution_id': 'run-123'}, ctx)
+        assert ingestor.execution_id == 'run-123'
+        assert result == {'status': 'success'}

--- a/voc-datalake/scripts/test-api.sh
+++ b/voc-datalake/scripts/test-api.sh
@@ -1,12 +1,35 @@
 #!/bin/bash
 # VoC API Deployment Validation Script
-# Tests all API endpoints after deployment
+# Tests all API endpoints after deployment.
+#
+# Usage: test-api.sh [API_URL] [STREAM_URL]
+#
+# Environment:
+#   VOC_TEST_USER / VOC_TEST_PASS - Cognito test creds (default: deployment-test / DeployTest!2025)
+#   RUN_SYNTHETIC=1               - also fire a synthetic_reviews generation run (SIDE EFFECTS:
+#                                   writes synthetic feedback + incurs Bedrock cost). Off by default.
+#
+# Flags (may appear anywhere in args):
+#   --run-synthetic   - same as RUN_SYNTHETIC=1
+#   --synthetic-only  - only run the synthetic generation test (skip the endpoint sweep)
 set -e
+
+# --- Parse flags, keep positional args (API_URL, STREAM_URL) ---
+RUN_SYNTHETIC="${RUN_SYNTHETIC:-0}"
+SYNTHETIC_ONLY=0
+POSITIONAL=()
+for arg in "$@"; do
+  case "$arg" in
+    --run-synthetic)  RUN_SYNTHETIC=1 ;;
+    --synthetic-only) RUN_SYNTHETIC=1; SYNTHETIC_ONLY=1 ;;
+    *) POSITIONAL+=("$arg") ;;
+  esac
+done
+set -- "${POSITIONAL[@]:-}"
 
 # Fetch configuration from CloudFormation outputs
 echo "📋 Fetching deployment configuration..."
 
-# Get Cognito Client ID from VocCoreStack
 CLIENT_ID=$(aws cloudformation describe-stacks \
   --stack-name VocCoreStack \
   --query 'Stacks[0].Outputs[?OutputKey==`UserPoolClientId`].OutputValue' \
@@ -18,13 +41,13 @@ if [ -z "$CLIENT_ID" ] || [ "$CLIENT_ID" = "None" ]; then
   exit 1
 fi
 
-# Get API Gateway URL from VocApiStack
 DEFAULT_API=$(aws cloudformation describe-stacks \
   --stack-name VocApiStack \
   --query 'Stacks[0].Outputs[?OutputKey==`ApiEndpoint`].OutputValue' \
   --output text 2>/dev/null)
 
-# Get Chat Stream URL from VocApiStack
+# Legacy: a dedicated chat-stream Function URL. Newer deployments serve streaming
+# from the main API Gateway at /chat/stream, so this output may not exist.
 DEFAULT_STREAM_URL=$(aws cloudformation describe-stacks \
   --stack-name VocApiStack \
   --query 'Stacks[0].Outputs[?OutputKey==`ChatStreamUrl`].OutputValue' \
@@ -41,6 +64,11 @@ API="${1:-$DEFAULT_API}"
 API="${API%/}"
 STREAM_URL="${2:-$DEFAULT_STREAM_URL}"
 STREAM_URL="${STREAM_URL%/}"
+# Fall back to the main API Gateway for streaming (/chat/stream) when there is no
+# dedicated Function URL output.
+if [ -z "$STREAM_URL" ] || [ "$STREAM_URL" = "None" ]; then
+  STREAM_URL="$API"
+fi
 
 if [ -z "$API" ] || [ "$API" = "None" ]; then
   echo "❌ Could not find API endpoint. Is VocApiStack deployed?"
@@ -50,13 +78,15 @@ fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
 echo -e "${BLUE}=== VoC API Validation ===${NC}"
 echo "API Endpoint: $API"
-echo "Stream URL: $STREAM_URL"
+echo "Stream URL:   $STREAM_URL"
 echo "Cognito Client ID: $CLIENT_ID"
+echo "Run synthetic generation: $([ "$RUN_SYNTHETIC" = "1" ] && echo yes || echo 'no (pass --run-synthetic to enable)')"
 
 echo -n "Authenticating... "
 # Use single quotes around auth-parameters to prevent bash ! expansion
@@ -80,116 +110,157 @@ PASS=0
 FAIL=0
 
 tget() {
-  printf "  GET  %-45s " "$1"
+  printf "  GET  %-48s " "$1"
   c=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $AUTH" "$API$1")
   if [ "$c" = "200" ]; then echo -e "${GREEN}$c${NC}"; PASS=$((PASS+1))
   else echo -e "${RED}$c${NC}"; FAIL=$((FAIL+1)); fi
 }
 
 tpost() {
-  printf "  POST %-45s " "$1"
+  printf "  POST %-48s " "$1"
   c=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: $AUTH" -H "Content-Type: application/json" -d "$2" "$API$1")
   if [ "$c" = "200" ]; then echo -e "${GREEN}$c${NC}"; PASS=$((PASS+1))
   else echo -e "${RED}$c${NC}"; FAIL=$((FAIL+1)); fi
 }
 
 tpub() {
-  printf "  GET  %-45s " "$1 (public)"
+  printf "  GET  %-48s " "$1 (public)"
   c=$(curl -s -o /dev/null -w "%{http_code}" "$API$1")
   if [ "$c" = "200" ]; then echo -e "${GREEN}$c${NC}"; PASS=$((PASS+1))
   else echo -e "${RED}$c${NC}"; FAIL=$((FAIL+1)); fi
 }
 
-echo -e "\n${BLUE}Metrics API${NC}"
-tget "/metrics/summary?days=7"
-tget "/metrics/sentiment?days=7"
-tget "/metrics/categories?days=7"
-tget "/metrics/sources?days=7"
-tget "/metrics/personas?days=7"
+run_endpoint_sweep() {
+  echo -e "\n${BLUE}Metrics API${NC}"
+  tget "/metrics/summary?days=7"
+  tget "/metrics/sentiment?days=7"
+  tget "/metrics/categories?days=7"
+  tget "/metrics/sources?days=7"
+  tget "/metrics/personas?days=7"
 
-echo -e "\n${BLUE}Feedback API${NC}"
-tget "/feedback?days=7&limit=5"
-tget "/feedback/urgent?days=7&limit=5"
-tget "/feedback/entities?days=7"
-
-echo -e "\n${BLUE}Chat API${NC}"
-tpost "/chat" '{"message":"test"}'
-
-echo -e "\n${BLUE}Integrations API${NC}"
-tget "/integrations/status"
-tget "/sources/status"
-
-echo -e "\n${BLUE}Settings API${NC}"
-tget "/settings/brand"
-tget "/settings/categories"
-
-echo -e "\n${BLUE}Scrapers API${NC}"
-tget "/scrapers"
-tget "/scrapers/templates"
-
-echo -e "\n${BLUE}Projects API${NC}"
-tget "/projects"
-
-# PR #131: document-generation (Step Functions) + product-context workspace.
-# Project-scoped read endpoints, exercised only if a project exists. GET-only on
-# purpose — POST routes here (documents, prfaq-autofill, suggest-*, product-report)
-# trigger Bedrock generation and/or create documents, so they're left out of the
-# smoke test.
-echo -e "\n${BLUE}Document Gen & Product Context (PR #131)${NC}"
-PROJECT_ID=$(curl -s -H "Authorization: $AUTH" "$API/projects" | python3 -c "import sys,json; d=json.load(sys.stdin); items=d.get('items') or d.get('projects') or (d if isinstance(d,list) else []); print((items[0].get('project_id') or items[0].get('id','')) if items else '')" 2>/dev/null)
-if [ -n "$PROJECT_ID" ]; then
-  tget "/projects/$PROJECT_ID/product-context"
-  tget "/projects/$PROJECT_ID/product-docs"
-else
-  echo "  ⚠️  No projects found, skipping product-context/document endpoints"
-fi
-
-echo -e "\n${BLUE}Users API (Admin)${NC}"
-tget "/users"
-
-echo -e "\n${BLUE}S3 Import API${NC}"
-tget "/s3-import/files"
-tget "/s3-import/sources"
-
-echo -e "\n${BLUE}Feedback Forms${NC}"
-tget "/feedback-forms"
-# Public per-form endpoints require a form id; exercise them only if a form exists
-FORM_ID=$(curl -s -H "Authorization: $AUTH" "$API/feedback-forms" | python3 -c "import sys,json; f=json.load(sys.stdin).get('forms',[]); print(f[0].get('form_id', f[0].get('id','')) if f else '')" 2>/dev/null)
-if [ -n "$FORM_ID" ]; then
-  tpub "/feedback-forms/$FORM_ID/config"
-  tpub "/feedback-forms/$FORM_ID/iframe"
-else
-  echo "  ⚠️  No feedback forms configured, skipping public per-form endpoints"
-fi
-
-echo -e "\n${BLUE}Chat Stream API (Lambda Function URL)${NC}"
-tstream() {
-  printf "  POST %-45s " "$1"
-  # Stream API uses Lambda Function URL directly (bypasses API Gateway 29s timeout)
-  resp=$(curl -s -X POST \
-    -H "Authorization: Bearer $TOKEN" \
-    -H "Content-Type: application/json" \
-    -d "$2" \
-    "${STREAM_URL}$1" 2>&1)
-  # Check if response contains error or success
-  if echo "$resp" | grep -q '"response"'; then
-    echo -e "${GREEN}200${NC}"
-    PASS=$((PASS+1))
-  elif echo "$resp" | grep -q '"error"'; then
-    echo -e "${RED}ERR${NC}"
-    echo "    Response: $resp"
-    FAIL=$((FAIL+1))
+  echo -e "\n${BLUE}Feedback API${NC}"
+  tget "/feedback?days=7&limit=5"
+  tget "/feedback/urgent?days=7&limit=5"
+  tget "/feedback/entities?days=7"
+  tget "/feedback/search?q=test&days=30"
+  # Per-item endpoints need a real id; fetch one (90d window) and exercise if present
+  FID=$(curl -s -H "Authorization: $AUTH" "$API/feedback?days=90&limit=1" | python3 -c "import sys,json
+d=json.load(sys.stdin)
+items=d.get('items', d if isinstance(d,list) else [])
+print(items[0].get('id','') if items else '')" 2>/dev/null || echo "")
+  if [ -n "$FID" ]; then
+    tget "/feedback/$FID"
+    tget "/feedback/$FID/similar"
   else
-    echo -e "${RED}???${NC}"
-    echo "    Response: $resp"
-    FAIL=$((FAIL+1))
+    echo -e "  ${YELLOW}⚠️  No feedback items found, skipping /feedback/{id} + /similar${NC}"
+  fi
+
+  echo -e "\n${BLUE}Chat API${NC}"
+  tpost "/chat" '{"message":"test"}'
+
+  echo -e "\n${BLUE}Integrations API${NC}"
+  tget "/integrations/status"
+  tget "/sources/status"
+
+  echo -e "\n${BLUE}Settings API${NC}"
+  tget "/settings/brand"
+  tget "/settings/categories"
+
+  echo -e "\n${BLUE}Scrapers API${NC}"
+  tget "/scrapers"
+  tget "/scrapers/templates"
+
+  echo -e "\n${BLUE}Projects API${NC}"
+  tget "/projects"
+  tget "/projects/config"
+  tget "/projects/prioritization"
+
+  # PR #131: document-generation (Step Functions) + product-context workspace.
+  # Project-scoped read endpoints, exercised only if a project exists. GET-only on
+  # purpose — POST routes here (documents, prfaq-autofill, suggest-*, product-report)
+  # trigger Bedrock generation and/or create documents, so they're left out of the
+  # smoke test.
+  echo -e "\n${BLUE}Document Gen & Product Context (PR #131)${NC}"
+  PROJECT_ID=$(curl -s -H "Authorization: $AUTH" "$API/projects" | python3 -c "import sys,json; d=json.load(sys.stdin); items=d.get('items') or d.get('projects') or (d if isinstance(d,list) else []); print((items[0].get('project_id') or items[0].get('id','')) if items else '')" 2>/dev/null)
+  if [ -n "$PROJECT_ID" ]; then
+    tget "/projects/$PROJECT_ID/product-context"
+    tget "/projects/$PROJECT_ID/product-docs"
+  else
+    echo -e "  ${YELLOW}⚠️  No projects found, skipping product-context/document endpoints${NC}"
+  fi
+
+  echo -e "\n${BLUE}Logs API${NC}"
+  tget "/logs/validation"
+  tget "/logs/processing"
+  tget "/logs/summary"
+
+  echo -e "\n${BLUE}Data Explorer API${NC}"
+  tget "/data-explorer/s3"
+  tget "/data-explorer/buckets"
+  tget "/data-explorer/stats"
+
+  echo -e "\n${BLUE}Users API (Admin)${NC}"
+  tget "/users"
+
+  echo -e "\n${BLUE}S3 Import API${NC}"
+  tget "/s3-import/files"
+  tget "/s3-import/sources"
+
+  echo -e "\n${BLUE}Feedback Forms${NC}"
+  tget "/feedback-forms"
+  # Public per-form endpoints require a form id; exercise them only if a form exists
+  FORM_ID=$(curl -s -H "Authorization: $AUTH" "$API/feedback-forms" | python3 -c "import sys,json; f=json.load(sys.stdin).get('forms',[]); print(f[0].get('form_id', f[0].get('id','')) if f else '')" 2>/dev/null || echo "")
+  if [ -n "$FORM_ID" ]; then
+    tpub "/feedback-forms/$FORM_ID/config"
+    tpub "/feedback-forms/$FORM_ID/iframe"
+  else
+    echo -e "  ${YELLOW}⚠️  No feedback forms configured, skipping public per-form endpoints${NC}"
+  fi
+
+  echo -e "\n${BLUE}Chat Stream API (${STREAM_URL}/chat/stream)${NC}"
+  printf "  POST %-48s " "/chat/stream"
+  # Streaming (SSE) response — assert on HTTP status; curl consumes the full stream.
+  sc=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"message":"hello"}' "${STREAM_URL}/chat/stream")
+  if [ "$sc" = "200" ]; then echo -e "${GREEN}$sc${NC}"; PASS=$((PASS+1))
+  else echo -e "${RED}$sc${NC}"; FAIL=$((FAIL+1)); fi
+}
+
+run_synthetic_test() {
+  echo -e "\n${BLUE}Synthetic Reviews Generation (end-to-end)${NC}"
+  echo -e "  ${YELLOW}Firing on-demand run — generates synthetic feedback + Bedrock cost${NC}"
+  printf "  POST %-48s " "/sources/synthetic_reviews/run"
+  resp=$(curl -s -X POST -H "Authorization: $AUTH" -H "Content-Type: application/json" -d '{}' "$API/sources/synthetic_reviews/run")
+  if echo "$resp" | grep -q '"success"'; then
+    echo -e "${GREEN}200${NC}"; PASS=$((PASS+1))
+  else
+    echo -e "${RED}ERR${NC}"; echo "    Response: $resp"; FAIL=$((FAIL+1)); return
+  fi
+
+  echo "  Polling /sources/status?run_status=synthetic_reviews (up to ~120s)..."
+  status="unknown"; items="0"; last=""
+  for i in $(seq 1 12); do
+    sleep 10
+    last=$(curl -s -H "Authorization: $AUTH" "$API/sources/status?run_status=synthetic_reviews")
+    status=$(echo "$last" | python3 -c "import sys,json;print(json.load(sys.stdin).get('status','?'))" 2>/dev/null || echo "?")
+    items=$(echo "$last" | python3 -c "import sys,json;print(json.load(sys.stdin).get('items_found',0))" 2>/dev/null || echo "0")
+    printf "    [%2d] status=%-10s items_found=%s\n" "$i" "$status" "$items"
+    if [ "$status" = "completed" ] || [ "$status" = "error" ]; then break; fi
+  done
+
+  if [ "$status" = "completed" ]; then
+    echo -e "  ${GREEN}Synthetic run completed (items_found=$items)${NC}"; PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}Synthetic run ended status=$status${NC}"; echo "    Last: $last"; FAIL=$((FAIL+1))
   fi
 }
 
-if [ -n "$STREAM_URL" ] && [ "$STREAM_URL" != "None" ]; then
-  tstream "/chat/stream" '{"message":"hello"}'
-else
-  echo "  ⚠️  Stream URL not configured, skipping"
+if [ "$SYNTHETIC_ONLY" != "1" ]; then
+  run_endpoint_sweep
+fi
+if [ "$RUN_SYNTHETIC" = "1" ]; then
+  run_synthetic_test
 fi
 
 echo ""


### PR DESCRIPTION
Ports the **Synthetic Data Review Generator** plugin from GitHub PR #108 onto `development`, isolated as the first PR #108 reconcile slice (P1). Sibling chat/backend slices #127/#128/#129 are already merged; the remaining PR #108 fixes (P2–P5) will follow as separate small PRs.

## What it enables
An opt-in `synthetic_reviews` data-source plugin that uses Amazon Bedrock (Claude Sonnet) to generate realistic synthetic customer reviews from operator-supplied company/product/persona context — for demos, testing, and modeling. Items flow through the normal pipeline tagged `source_platform="synthetic_reviews"` and `metadata.is_synthetic=true`, so they stay filterable. On-demand only (no EventBridge schedule) — triggered from the "Synthetic Data" card in the Add Data Source modal or `POST /sources/synthetic_reviews/run`.

## What landed
**Plugin (net-new)**
- `plugins/synthetic_reviews/manifest.json` — config fields (company, product, description, target customer, focus areas, `num_reviews` ≤ 50, sentiment mix, language) plus `infrastructure.ingestor.bedrock: true` — a capability flag so the plugin-loader wires a dedicated Bedrock policy without core-stack edits.
- `plugins/synthetic_reviews/ingestor/handler.py` — `SyntheticReviewsIngestor(BaseIngestor)`; batched generation (BATCH_SIZE=10, MAX_REVIEWS=50), Bedrock system prompt forbids real PII, strict JSON-array output; per-plugin config loaded from Secrets Manager via `BaseIngestor` isolation.
- `plugins/synthetic_reviews/README.md`, `plugins/test_synthetic_reviews.py`.
- `frontend/src/pages/Scrapers/GeneratorConfigModal.tsx` (+ `.test.tsx`) — the "synthetic" category config modal.

**Wiring (diffed against dev)**
- `lib/plugin-loader.ts` — support the `infrastructure.ingestor.bedrock` capability.
- `lib/stacks/ingestion-stack.ts` — dedicated IAM role with `bedrock:InvokeModel` scoped to the Sonnet model, granted **only when the manifest declares the capability** (the shared ingestion role is not widened).
- `plugins/_shared/base_ingestor.py` — register `synthetic_reviews` in `_get_known_prefixes()`. Required for per-plugin secret isolation: without it, `synthetic_reviews_*` keys in the shared secret are treated as shared/legacy and leak into every other plugin's loaded config. Ships with a regression test.
- `cdk.context.json` — enable `pluginStatus.synthetic_reviews`.
- i18n `frontend/public/locales/*/scrapers.json` (8 locales) — "synthetic" category strings.

## Tests
- **189 plugin tests pass**, including `test_synthetic_reviews.py` and the new `test_base_ingestor.py::test_does_not_leak_other_known_plugin_secrets` regression guard (verified it fails if the prefix line is reverted).
- **22 CDK** plugin-loader tests, **4 frontend** GeneratorConfigModal tests.
- CDK + frontend `tsc --noEmit` clean; `validate-plugins` OK (synthetic_reviews recognized as a valid ingestor).

## Notes
- Model ID/ARNs pinned to Claude Sonnet 4-5 to match `development`'s `BEDROCK_MODEL_ID` (avoids Bedrock `AccessDenied`).
- Enabled by default in `cdk.context.json`; operators can flip it off.
- Rebased onto current `development` (`cd2dc47`); files are disjoint from the merged #127/#128/#129 work.
