### PR TITLE
feat(documents): document-generation overhaul — Step Functions PRD/PR-FAQ, product context, HTML prototypes

### DIFF
--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -58,7 +58,29 @@
     "editDocument": "Edit document",
     "newDocument": "New Document",
     "noDocuments": "No documents",
-    "selectDocument": "Select a document"
+    "selectDocument": "Select a document",
+    "prototype": {
+      "previewLabel": "Live preview",
+      "rawLabel": "Raw output (parse failed — please regenerate)",
+      "openNewTab": "Open in new tab",
+      "downloadHtml": "Download .html",
+      "downloadJson": "Download .json",
+      "button": "Build Prototype",
+      "building": "Building…",
+      "buttonTitle": "Generate a clickable HTML prototype from this project's PRD + PR-FAQ",
+      "buttonTitleOne": "Generate a clickable HTML prototype from the available document (PRD or PR-FAQ)",
+      "needsDocs": "Create a PRD or a PR-FAQ first to enable prototype build",
+      "confirmPrdOnly": "No PR-FAQ yet — the prototype will be built from the PRD only. Continue?",
+      "confirmPrfaqOnly": "No PRD yet — the prototype will be built from the PR-FAQ only. Continue?",
+      "timeout": "Prototype build took too long. Check the Documents tab in a moment.",
+      "feedbackButton": "Revise with feedback",
+      "feedbackTitle": "Give feedback to regenerate this prototype",
+      "feedbackHeading": "Revise prototype with feedback",
+      "feedbackHint": "Describe what to change. The PRD/PR-FAQ stays in effect; the prototype is re-centered on your feedback (e.g. “show the admin’s perspective”).",
+      "feedbackPlaceholder": "e.g. Change this to the admin dashboard view — show approvals, user management, and metrics instead of the end-user screens.",
+      "feedbackSubmit": "Regenerate",
+      "feedbackBuilding": "Revising…"
+    }
   },
   "importPersona": {
     "aiImportDesc": "Claude will extract persona information from your {{type}} and create a structured persona with an AI-generated avatar.",
@@ -105,6 +127,8 @@
       "generatePersonas": "Persona Generation",
       "generatePrd": "PRD Generation",
       "generatePrfaq": "PR-FAQ Generation",
+      "generateProductReport": "Product Report Generation",
+      "buildPrototype": "Prototype Build",
       "importPersona": "Persona Import",
       "mergeDocuments": "Document Merge",
       "research": "Research"
@@ -174,11 +198,81 @@
     "generatePrdPrfaq": "Generate PRD / PR-FAQ",
     "generatePrdPrfaqDesc": "Create product documents from feedback",
     "needAtLeast2Docs": "Need at least 2 documents",
+    "openProductTool": "Open",
+    "productDescription": "Product / Service Description",
+    "productDescriptionDesc": "Describe the current product. Feeds PRD and PR/FAQ generation.",
     "remixDocuments": "Remix Documents",
     "remixDocumentsDesc": "Combine and revise documents into new versions",
     "runResearch": "Run Research",
     "runResearchDesc": "Deep dive into feedback with filters",
     "selectAndRemix": "Select & Remix"
+  },
+  "product": {
+    "title": "Product / Service Description",
+    "subtitle": "The information here is automatically injected into PRD & PR/FAQ generation as the current product context.",
+    "modeBoth": "Both",
+    "modeChat": "Chat only",
+    "modeUpload": "Upload only",
+    "loading": "Loading product context…",
+    "fields": {
+      "productName": "Product name",
+      "oneLiner": "One-liner",
+      "currentState": "Current state",
+      "targetUsers": "Target users",
+      "problemSolved": "Problem solved",
+      "keyFeatures": "Key features",
+      "differentiators": "Differentiators",
+      "knownLimitations": "Known limitations",
+      "nonGoals": "Non-goals",
+      "successMetrics": "Success metrics",
+      "freeFormNotes": "Notes (anything else)",
+      "placeholderEmpty": "—"
+    },
+    "lifecycle": {
+      "select": "— select —",
+      "idea": "Idea",
+      "mvp": "MVP",
+      "beta": "Beta",
+      "ga": "Generally available",
+      "mature": "Mature"
+    },
+    "interview": {
+      "heading": "Interview",
+      "hint": "I'll fill the form on the left as you answer.",
+      "greeting": "Hi — I'll help you describe your product or service. Tell me what it is in a sentence or two, and we'll build out the rest from there.",
+      "placeholder": "Tell me about your product…",
+      "thinking": "Thinking…",
+      "captured": "Got it — captured. What else can you tell me about the product?",
+      "elaborate": "Could you tell me more about that?",
+      "send": "Send"
+    },
+    "upload": {
+      "heading": "Internal documents",
+      "hint": "PDF, DOCX, MD, TXT — up to 10 MB each, 20 max",
+      "dropZone": "Drop files here or click to upload",
+      "empty": "No documents yet.",
+      "loading": "Loading…",
+      "delete": "Delete document",
+      "statusReady": "Ready",
+      "statusFailed": "Failed",
+      "statusUploading": "Uploading…",
+      "statusExtracting": "Extracting…",
+      "extractedChars": "{{count}} chars extracted",
+      "errors": {
+        "unsupportedType": "Unsupported type: {{name}} ({{type}})",
+        "tooLarge": "Too large (>10 MB): {{name}}",
+        "uploadFailed": "{{name}}: {{message}}"
+      }
+    },
+    "report": {
+      "title": "Generate report",
+      "description": "Save a polished Product/Service Description document from the inputs above and uploaded files.",
+      "button": "Generate report",
+      "generating": "Generating…",
+      "successTitle": "Report saved",
+      "successMessage": "Open it in the Documents tab.",
+      "errorEmpty": "Add at least one product context field or upload an internal document before generating a report."
+    }
   },
   "personaEdit": {
     "ageRange": "Age Range",
@@ -261,14 +355,37 @@
     "documents": "Documents",
     "mcpAccess": "MCP Access",
     "overview": "Overview",
-    "personas": "Personas"
+    "personas": "Personas",
+    "product": "Product"
   },
   "wizards": {
     "amazonQuestions": "Amazon's 5 Customer Questions",
     "amazonQuestionsHint": "Answer these questions to create a customer-focused PR-FAQ. The more detail you provide, the better the output.",
+    "autofillButton": "AI draft answers",
+    "autofillLoading": "Drafting…",
+    "autofillTitle": "Pre-populate the 5 questions using personas, feedback, and product context",
+    "researchSuggest": "AI suggest",
+    "researchSuggesting": "Suggesting…",
+    "researchSuggestTitle": "Let AI suggest research questions from this project's feedback",
+    "researchSuggestPick": "Tap a suggestion to use it:",
+    "researchSuggestEmpty": "No suggestions — add or collect more feedback first.",
+    "generatePrd": "Generate PRD",
+    "generatePrdTitle": "Generate PRD",
+    "generatePrfaq": "Generate PR-FAQ",
+    "generatePrfaqTitle": "Generate PR-FAQ",
+    "prdLabel": "PRD",
+    "prfaqLabel": "PR-FAQ",
+    "workingBackwards": "Working Backwards",
     "customInstructions": "Custom Instructions (Optional)",
     "customInstructionsPlaceholder": "e.g., Focus on business travelers...",
     "documentType": "Document Type",
+    "documentTypeHint": "Select one or both — both are generated at once.",
+    "generateBoth": "Generate PRD + PR-FAQ",
+    "generateBothTitle": "Generate PRD + PR-FAQ",
+    "briefButton": "AI draft",
+    "briefLoading": "Drafting…",
+    "briefTitle": "Let AI draft the title and description from this project's feedback",
+    "briefEmpty": "No draft — add or collect more feedback first.",
     "featureDescription": "Feature Description",
     "featureDescriptionPlaceholder": "Describe the feature...",
     "featureTitle": "Feature/Product Title",
@@ -310,7 +427,6 @@
     "submitGenerateDoc": "Generate {{type}}",
     "submitGeneratePersonas": "Generate Personas",
     "submitRemixDocuments": "Remix Documents",
-    "submitRunResearch": "Run Research",
-    "workingBackwards": "Working Backwards"
+    "submitRunResearch": "Run Research"
   }
 }

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -58,7 +58,29 @@
     "editDocument": "문서 편집",
     "newDocument": "새 문서",
     "noDocuments": "문서 없음",
-    "selectDocument": "문서를 선택하세요"
+    "selectDocument": "문서를 선택하세요",
+    "prototype": {
+      "previewLabel": "미리보기",
+      "rawLabel": "원본 출력 (파싱 실패 — 다시 생성해 주세요)",
+      "openNewTab": "새 탭에서 열기",
+      "downloadHtml": "HTML 다운로드",
+      "downloadJson": "JSON 다운로드",
+      "button": "프로토타입 생성",
+      "building": "생성 중…",
+      "buttonTitle": "이 프로젝트의 PRD + PR-FAQ로 클릭 가능한 HTML 프로토타입 생성",
+      "buttonTitleOne": "있는 문서(PRD 또는 PR-FAQ)로 클릭 가능한 HTML 프로토타입 생성",
+      "needsDocs": "프로토타입 생성은 PRD 또는 PR-FAQ가 있어야 활성화됩니다",
+      "confirmPrdOnly": "아직 PR-FAQ가 없어 PRD만으로 프로토타입을 생성합니다. 계속할까요?",
+      "confirmPrfaqOnly": "아직 PRD가 없어 PR-FAQ만으로 프로토타입을 생성합니다. 계속할까요?",
+      "timeout": "프로토타입 생성이 너무 오래 걸립니다. 잠시 후 문서 탭에서 확인하세요.",
+      "feedbackButton": "피드백으로 수정",
+      "feedbackTitle": "피드백을 주어 프로토타입을 재생성합니다",
+      "feedbackHeading": "피드백으로 프로토타입 수정",
+      "feedbackHint": "바꿀 내용을 적으세요. PRD/PR-FAQ는 그대로 반영되며, 피드백을 중심으로 프로토타입이 바뀍니다 (예: “관리자 관점으로 보여줘”).",
+      "feedbackPlaceholder": "예: 이걸 관리자 대시보드 화면으로 바꿔줘 — 사용자 화면 대신 승인·사용자관리·지표를 보여줘.",
+      "feedbackSubmit": "재생성",
+      "feedbackBuilding": "수정 중…"
+    }
   },
   "importPersona": {
     "aiImportDesc": "Claude가 {{type}}에서 페르소나 정보를 추출하고 AI 생성 아바타가 포함된 구조화된 페르소나를 생성합니다.",
@@ -105,6 +127,8 @@
       "generatePersonas": "페르소나 생성",
       "generatePrd": "PRD 생성",
       "generatePrfaq": "PR-FAQ 생성",
+      "generateProductReport": "제품 보고서 생성",
+      "buildPrototype": "프로토타입 빌드",
       "importPersona": "페르소나 가져오기",
       "mergeDocuments": "문서 병합",
       "research": "조사"
@@ -174,11 +198,81 @@
     "generatePrdPrfaq": "PRD / PR-FAQ 생성",
     "generatePrdPrfaqDesc": "피드백에서 제품 문서 생성",
     "needAtLeast2Docs": "최소 2개의 문서 필요",
+    "openProductTool": "열기",
+    "productDescription": "제품 / 서비스 설명",
+    "productDescriptionDesc": "현재 제품을 설명합니다. PRD 및 PR/FAQ 생성에 사용됩니다.",
     "remixDocuments": "문서 리믹스",
     "remixDocumentsDesc": "문서를 결합하고 수정하여 새 버전 생성",
     "runResearch": "리서치 실행",
     "runResearchDesc": "필터를 사용하여 피드백 심층 분석",
     "selectAndRemix": "선택 & 리믹스"
+  },
+  "product": {
+    "title": "제품 / 서비스 설명",
+    "subtitle": "여기에 입력된 정보는 PRD 및 PR/FAQ 생성 시 현재 제품 컨텍스트로 자동 주입됩니다.",
+    "modeBoth": "모두",
+    "modeChat": "채팅만",
+    "modeUpload": "업로드만",
+    "loading": "제품 컨텍스트를 불러오는 중…",
+    "fields": {
+      "productName": "제품 이름",
+      "oneLiner": "한 줄 설명",
+      "currentState": "현재 상태",
+      "targetUsers": "대상 사용자",
+      "problemSolved": "해결하는 문제",
+      "keyFeatures": "주요 기능",
+      "differentiators": "차별점",
+      "knownLimitations": "알려진 한계",
+      "nonGoals": "범위 외 항목",
+      "successMetrics": "성공 지표",
+      "freeFormNotes": "기타 메모",
+      "placeholderEmpty": "—"
+    },
+    "lifecycle": {
+      "select": "— 선택 —",
+      "idea": "아이디어",
+      "mvp": "MVP",
+      "beta": "베타",
+      "ga": "정식 출시",
+      "mature": "성숙"
+    },
+    "interview": {
+      "heading": "인터뷰",
+      "hint": "답변하시면 왼쪽 양식이 자동으로 채워집니다.",
+      "greeting": "안녕하세요 — 제품 또는 서비스를 설명하는 데 도움을 드리겠습니다. 한두 문장으로 어떤 제품/서비스인지 알려주시면 거기서부터 함께 정리해 보겠습니다.",
+      "placeholder": "제품에 대해 알려주세요…",
+      "thinking": "생각 중…",
+      "captured": "확인했습니다. 제품에 대해 더 알려주실 내용이 있나요?",
+      "elaborate": "조금 더 자세히 말씀해 주시겠어요?",
+      "send": "보내기"
+    },
+    "upload": {
+      "heading": "내부 문서",
+      "hint": "PDF, DOCX, MD, TXT — 각 파일 최대 10MB, 최대 20개",
+      "dropZone": "파일을 끌어다 놓거나 클릭하여 업로드",
+      "empty": "아직 문서가 없습니다.",
+      "loading": "불러오는 중…",
+      "delete": "문서 삭제",
+      "statusReady": "준비됨",
+      "statusFailed": "실패",
+      "statusUploading": "업로드 중…",
+      "statusExtracting": "추출 중…",
+      "extractedChars": "{{count}}자 추출됨",
+      "errors": {
+        "unsupportedType": "지원되지 않는 형식: {{name}} ({{type}})",
+        "tooLarge": "용량 초과 (10MB 초과): {{name}}",
+        "uploadFailed": "{{name}}: {{message}}"
+      }
+    },
+    "report": {
+      "title": "보고서 생성",
+      "description": "위 입력과 업로드된 파일로부터 정돈된 제품/서비스 설명 문서를 저장합니다.",
+      "button": "보고서 생성",
+      "generating": "생성 중…",
+      "successTitle": "보고서 저장 완료",
+      "successMessage": "문서 탭에서 확인하세요.",
+      "errorEmpty": "보고서를 생성하기 전에 제품 컨텍스트 필드를 하나 이상 입력하거나 내부 문서를 업로드하세요."
+    }
   },
   "personaEdit": {
     "ageRange": "나이대",
@@ -261,14 +355,37 @@
     "documents": "문서",
     "mcpAccess": "MCP 액세스",
     "overview": "개요",
-    "personas": "페르소나"
+    "personas": "페르소나",
+    "product": "제품"
   },
   "wizards": {
     "amazonQuestions": "Amazon의 5가지 고객 질문",
     "amazonQuestionsHint": "이 질문들에 답변하여 고객 중심의 PR-FAQ를 작성하세요. 더 자세한 정보를 제공할수록 더 나은 결과를 얻을 수 있습니다.",
+    "autofillButton": "AI 초안 작성",
+    "autofillLoading": "작성 중…",
+    "autofillTitle": "페르소나, 피드백, 제품 컨텍스트를 사용하여 5가지 질문을 자동으로 채웁니다",
+    "researchSuggest": "AI 추천",
+    "researchSuggesting": "추천 중…",
+    "researchSuggestTitle": "이 프로젝트의 피드백을 바탕으로 AI가 리서치 질문을 추천합니다",
+    "researchSuggestPick": "추천을 눌러 적용하세요:",
+    "researchSuggestEmpty": "추천할 수 없습니다 — 피드백을 먼저 수집/추가하세요.",
+    "generatePrd": "PRD 생성",
+    "generatePrdTitle": "PRD 생성",
+    "generatePrfaq": "PR-FAQ 생성",
+    "generatePrfaqTitle": "PR-FAQ 생성",
+    "prdLabel": "PRD",
+    "prfaqLabel": "PR-FAQ",
+    "workingBackwards": "역방향 작업",
     "customInstructions": "사용자 정의 지침 (선택사항)",
     "customInstructionsPlaceholder": "예: 출장 비즈니스 여행객에 초점...",
     "documentType": "문서 유형",
+    "documentTypeHint": "하나 또는 둘 다 선택 — 둘 다 선택하면 한 번에 생성됩니다.",
+    "generateBoth": "PRD + PR-FAQ 생성",
+    "generateBothTitle": "PRD + PR-FAQ 생성",
+    "briefButton": "AI 초안",
+    "briefLoading": "작성 중…",
+    "briefTitle": "이 프로젝트의 피드백을 바탕으로 AI가 제목과 설명을 작성합니다",
+    "briefEmpty": "초안 없음 — 피드백을 먼저 수집/추가하세요.",
     "featureDescription": "기능 설명",
     "featureDescriptionPlaceholder": "기능을 설명하세요...",
     "featureTitle": "기능/제품 제목",
@@ -310,7 +427,6 @@
     "submitGenerateDoc": "{{type}} 생성",
     "submitGeneratePersonas": "페르소나 생성",
     "submitRemixDocuments": "문서 리믹스",
-    "submitRunResearch": "조사 실행",
-    "workingBackwards": "역방향 작업"
+    "submitRunResearch": "조사 실행"
   }
 }

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -3,6 +3,7 @@
 import { fetchApi } from './client'
 import type {
   Project, ProjectDetail, ProjectPersona, ProjectDocument, ProjectJob,
+  ProductContext, ProductDoc, ProductInterviewTurnResponse,
 } from './types'
 
 export const projectsApi = {
@@ -193,4 +194,103 @@ export const projectsApi = {
 
   deleteDocument: (projectId: string, documentId: string) =>
     fetchApi<{ success: boolean }>(`/projects/${projectId}/documents/${documentId}`, { method: 'DELETE' }),
+
+  // ── Product/Service description input ──
+
+  getProductContext: (projectId: string) =>
+    fetchApi<{ context: ProductContext }>(`/projects/${projectId}/product-context`),
+
+  updateProductContext: (projectId: string, patch: Partial<ProductContext>) =>
+    fetchApi<{ context: ProductContext }>(`/projects/${projectId}/product-context`, {
+      method: 'PUT',
+      body: JSON.stringify(patch),
+    }),
+
+  productContextInterview: (projectId: string, body: {
+    message: string;
+    history?: { role: 'user' | 'assistant'; content: string }[]
+    response_language?: string
+  }) =>
+    fetchApi<ProductInterviewTurnResponse>(`/projects/${projectId}/product-context/interview`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  // Async: returns a job_id that the caller polls via getJobStatus.
+  autofillPrfaqQuestions: (projectId: string, body: {
+    feature_idea?: string;
+    title?: string;
+    response_language?: string
+  }) =>
+    fetchApi<{ answers: string[] }>(`/projects/${projectId}/prfaq-autofill`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  suggestResearchQuestions: (projectId: string, body: { response_language?: string } = {}) =>
+    fetchApi<{ suggestions: Array<{ title: string; question: string }> }>(
+      `/projects/${projectId}/research/suggest-questions`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    ),
+
+  suggestDocumentBrief: (projectId: string, body: { doc_type?: 'prd' | 'prfaq'; response_language?: string } = {}) =>
+    fetchApi<{ title: string; feature_idea: string }>(
+      `/projects/${projectId}/documents/suggest-brief`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    ),
+
+  buildPrototype: (projectId: string, body: {
+    response_language?: string;
+    title?: string;
+    // Feedback-driven regeneration: revise an existing prototype centered on
+    // this feedback while still honoring the PRD/PR-FAQ.
+    feedback?: string;
+    base_prototype_id?: string;
+  }) =>
+    fetchApi<{
+      success: boolean;
+      job_id: string;
+      status: string;
+      message: string
+    }>(`/projects/${projectId}/build-prototype`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  generateProductReport: (projectId: string, body: { response_language?: string; title?: string }) =>
+    fetchApi<{
+      success: boolean;
+      job_id: string;
+      status: string;
+      message: string
+    }>(`/projects/${projectId}/product-report`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  listProductDocs: (projectId: string) =>
+    fetchApi<{ docs: ProductDoc[] }>(`/projects/${projectId}/product-docs`),
+
+  createProductDocUploadUrl: (projectId: string, body: {
+    filename: string;
+    content_type: string;
+    size_bytes: number
+  }) =>
+    fetchApi<{
+      doc_id: string;
+      presigned_url: string;
+      headers: Record<string, string>
+    }>(`/projects/${projectId}/product-docs/upload-url`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  deleteProductDoc: (projectId: string, docId: string) =>
+    fetchApi<{ success: boolean }>(`/projects/${projectId}/product-docs/${docId}`, { method: 'DELETE' }),
 }

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -86,8 +86,15 @@ export interface MetricsSummary {
   total_feedback: number
   avg_sentiment: number
   urgent_count: number
-  daily_totals: { date: string; count: number }[]
-  daily_sentiment: { date: string; avg_sentiment: number; count: number }[]
+  daily_totals: {
+    date: string;
+    count: number
+  }[]
+  daily_sentiment: {
+    date: string;
+    avg_sentiment: number;
+    count: number
+  }[]
 }
 
 export interface SentimentBreakdown {
@@ -167,62 +174,6 @@ export interface ScraperTemplate {
   config: Partial<ScraperConfig>
 }
 
-export interface ChatMessage {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  sources?: FeedbackItem[]
-  timestamp: string
-  filters?: {
-    source?: string
-    category?: string
-    sentiment?: string
-    tags?: string[]
-  }
-}
-
-export interface ChatConversation {
-  id: string
-  title: string
-  messages: ChatMessage[]
-  filters: {
-    source?: string
-    category?: string
-    sentiment?: string
-    tags?: string[]
-  }
-  createdAt: string
-  updatedAt: string
-}
-
-export interface ChatMessage {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  sources?: FeedbackItem[]
-  timestamp: string
-  filters?: {
-    source?: string
-    category?: string
-    sentiment?: string
-    tags?: string[]
-  }
-}
-
-export interface ChatConversation {
-  id: string
-  title: string
-  messages: ChatMessage[]
-  filters: {
-    source?: string
-    category?: string
-    sentiment?: string
-    tags?: string[]
-  }
-  createdAt: string
-  updatedAt: string
-}
-
 export interface EntitiesResponse {
   period_days: number
   feedback_count: number
@@ -238,7 +189,7 @@ export interface EntitiesResponse {
 export interface ProjectJob {
   success?: boolean
   job_id: string
-  job_type: 'research' | 'generate_personas' | 'generate_prd' | 'generate_prfaq' | 'merge_documents' | 'import_persona'
+  job_type: 'research' | 'generate_personas' | 'generate_prd' | 'generate_prfaq' | 'generate_product_report' | 'build_prototype' | 'merge_documents' | 'import_persona'
   status: 'pending' | 'running' | 'completed' | 'failed'
   progress: number
   current_step?: string
@@ -264,28 +215,28 @@ export interface ProjectPersona {
   avatar_url?: string
   avatar_prompt?: string
   // Section 1: Identity & Demographics
-  identity?: { 
+  identity?: {
     age_range?: string
     location?: string
     occupation?: string
     income_bracket?: string
     education?: string
     family_status?: string
-    bio?: string 
+    bio?: string
   }
   // Section 2: Goals & Motivations
-  goals_motivations?: { 
+  goals_motivations?: {
     primary_goal?: string
     secondary_goals?: string[]
     success_definition?: string
-    underlying_motivations?: string[] 
+    underlying_motivations?: string[]
   }
   // Section 3: Pain Points & Frustrations
-  pain_points?: { 
+  pain_points?: {
     current_challenges?: string[]
     blockers?: string[]
     workarounds?: string[]
-    emotional_impact?: string 
+    emotional_impact?: string
   }
   // Section 4: Behaviors & Habits
   behaviors?: {
@@ -296,7 +247,7 @@ export interface ProjectPersona {
     decision_style?: string
   }
   // Section 5: Context & Environment
-  context_environment?: { 
+  context_environment?: {
     usage_context?: string
     devices?: string[]
     time_constraints?: string
@@ -304,16 +255,25 @@ export interface ProjectPersona {
     influencers?: string[]
   }
   // Section 6: Representative Quotes
-  quotes?: Array<{ text: string; context?: string }>
+  quotes?: Array<{
+    text: string;
+    context?: string
+  }>
   // Section 7: Scenario/User Story
-  scenario?: { 
+  scenario?: {
     title?: string
     narrative?: string
     trigger?: string
-    outcome?: string 
+    outcome?: string
   }
   // Section 8: Research Notes
-  research_notes?: Array<string | { note_id?: string; text: string; author?: string; created_at?: string; tags?: string[] }>
+  research_notes?: Array<string | {
+    note_id?: string;
+    text: string;
+    author?: string;
+    created_at?: string;
+    tags?: string[]
+  }>
   // Metadata
   supporting_evidence?: string[]
   source_breakdown?: Record<string, number>
@@ -321,13 +281,58 @@ export interface ProjectPersona {
 
 export interface ProjectDocument {
   document_id: string
-  document_type: 'prd' | 'prfaq' | 'research' | 'custom'
+  document_type: 'prd' | 'prfaq' | 'research' | 'custom' | 'product_report' | 'prototype'
   title: string
   content: string
   feature_idea?: string
   question?: string
+  // For prototypes: 'html' → content is a self-contained HTML document rendered
+  // in a sandboxed iframe. Absent → legacy JSON spec rendered via PrototypeRenderer.
+  prototype_format?: 'html' | string
   created_at: string
   updated_at?: string
+}
+
+export type ProductLifecycleState = '' | 'idea' | 'mvp' | 'beta' | 'ga' | 'mature'
+
+export interface ProductContext {
+  product_name: string
+  one_liner: string
+  target_users: string
+  problem_solved: string
+  current_state: ProductLifecycleState
+  // The following are free-text comments — multi-line strings, not arrays.
+  key_features: string
+  differentiators: string
+  known_limitations: string
+  non_goals: string
+  success_metrics: string
+  free_form_notes: string
+  updated_at?: string
+}
+
+export type ProductDocStatus = 'pending' | 'extracting' | 'ready' | 'failed'
+
+export interface ProductDoc {
+  doc_id: string
+  filename: string
+  content_type: string
+  size_bytes: number
+  status: ProductDocStatus
+  error: string | null
+  extracted_chars: number
+  created_at: string
+}
+
+export interface ProductInterviewTurnResponse {
+  assistant_message: string
+  applied_patch: Partial<ProductContext>
+  context: ProductContext
+}
+
+export interface ProductReportResponse {
+  success: boolean
+  document: ProjectDocument
 }
 
 export interface Project {
@@ -372,8 +377,8 @@ export interface S3ImportFile {
   status: 'pending' | 'processed'
 }
 
-export interface FeedbackFormConfig {
-  enabled: boolean
+/** Shared form configuration fields used by both FeedbackFormConfig and FeedbackForm. */
+interface FeedbackFormFields {
   title: string
   description: string
   question: string
@@ -391,32 +396,23 @@ export interface FeedbackFormConfig {
   }
   collect_email: boolean
   collect_name: boolean
-  custom_fields: Array<{ id: string; label: string; type: string; required: boolean }>
+  custom_fields: Array<{
+    id: string;
+    label: string;
+    type: string;
+    required: boolean
+  }>
+}
+
+export interface FeedbackFormConfig extends FeedbackFormFields {
+  enabled: boolean
   brand_name: string
 }
 
-export interface FeedbackForm {
+export interface FeedbackForm extends FeedbackFormFields {
   form_id: string
   name: string
   enabled: boolean
-  title: string
-  description: string
-  question: string
-  placeholder: string
-  rating_enabled: boolean
-  rating_type: 'stars' | 'numeric' | 'emoji'
-  rating_max: number
-  submit_button_text: string
-  success_message: string
-  theme: {
-    primary_color: string
-    background_color: string
-    text_color: string
-    border_radius: string
-  }
-  collect_email: boolean
-  collect_name: boolean
-  custom_fields: Array<{ id: string; label: string; type: string; required: boolean }>
   category: string
   subcategory: string
   created_at: string

--- a/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
+++ b/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
@@ -1,0 +1,289 @@
+/**
+ * Shared prototype renderer.
+ *
+ * Renders the Bedrock-generated JSON prototype spec natively as React. Used
+ * from the Documents tab inside a project AND from the Prioritization page
+ * (under the PR/FAQ preview, so reviewers see the demo without leaving).
+ *
+ * Spec shape (mirrors lambda/jobs/document_generator/handler.py):
+ *   { title?, banner?, screens: [
+ *       { id, label?, heading?, subheading?, blocks?: [
+ *           { type: 'text' | 'callout' | 'stats' | 'list' | 'form' | 'buttons', ... }
+ *       ] }
+ *   ] }
+ */
+import clsx from 'clsx'
+import { useCallback, useMemo, useState } from 'react'
+
+export interface PrototypeBlock {
+  type: string
+  text?: string
+  tone?: string
+  title?: string
+  items?: Array<{
+    label?: string
+    title?: string
+    subtitle?: string
+    badge?: string
+    value?: string
+    goto?: string
+    tone?: string
+  }>
+  fields?: Array<{ label: string; placeholder?: string; type?: string }>
+  submit?: { label: string; goto?: string }
+}
+
+export interface PrototypeScreen {
+  id: string
+  label?: string
+  heading?: string
+  subheading?: string
+  blocks?: PrototypeBlock[]
+}
+
+export interface PrototypeSpec {
+  title?: string
+  banner?: string
+  screens: PrototypeScreen[]
+}
+
+/**
+ * Heuristic: does this content look like a self-contained HTML document (the
+ * newer Opus-built prototype format) rather than a legacy JSON spec? Used as a
+ * fallback when `prototype_format` isn't present on the document.
+ */
+export function looksLikeHtmlDocument(content: string | null | undefined): boolean {
+  if (!content) return false
+  const head = content.trimStart().slice(0, 200).toLowerCase()
+  return head.startsWith('<!doctype html') || head.startsWith('<html')
+}
+
+/**
+ * Renders a self-contained HTML prototype inside a sandboxed iframe via srcdoc.
+ * sandbox="allow-scripts" lets the prototype's inline navigation JS run while
+ * keeping it isolated from the parent app (no same-origin, no top navigation).
+ * The HTML is offline-first, so nothing external loads inside the frame.
+ */
+export function HtmlPrototypeFrame({
+  html, title, className,
+}: {
+  readonly html: string
+  readonly title?: string
+  readonly className?: string
+}) {
+  return (
+    <iframe
+      title={title || 'Prototype'}
+      srcDoc={html}
+      sandbox="allow-scripts allow-popups allow-forms"
+      className={className ?? 'w-full h-full border-0'}
+    />
+  )
+}
+
+/**
+ * Parse a prototype document's `content` (which is a JSON string) into a spec
+ * object, or return null if it can't be parsed. Caller decides how to display
+ * malformed/legacy prototypes.
+ */
+export function parsePrototypeSpec(content: string | null | undefined): PrototypeSpec | null {
+  if (!content) return null
+  try {
+    const parsed = JSON.parse(content) as unknown
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { screens?: unknown }).screens)) {
+      return parsed as PrototypeSpec
+    }
+  } catch {
+    // not JSON
+  }
+  return null
+}
+
+export default function PrototypeRenderer({ spec }: { readonly spec: PrototypeSpec }) {
+  const screens = useMemo(
+    () => spec.screens.filter((s) => s && typeof s.id === 'string'),
+    [spec.screens],
+  )
+  const [activeId, setActiveId] = useState<string>(screens[0]?.id ?? '')
+
+  const goto = useCallback((id?: string) => {
+    if (id && screens.some((s) => s.id === id)) setActiveId(id)
+  }, [screens])
+
+  if (screens.length === 0) {
+    return <div className="text-sm text-gray-500">No screens in prototype.</div>
+  }
+
+  const active = screens.find((s) => s.id === activeId) ?? screens[0]
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {spec.banner ? (
+        <div className="bg-amber-100 text-amber-900 text-xs text-center py-1.5 rounded-md mb-3 font-medium">
+          {spec.banner}
+        </div>
+      ) : null}
+      <nav className="flex gap-1 mb-4 border-b overflow-x-auto pb-1">
+        {screens.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => setActiveId(s.id)}
+            className={clsx(
+              'px-3 py-1.5 text-sm rounded-t-md whitespace-nowrap transition-colors',
+              s.id === active.id
+                ? 'bg-blue-600 text-white'
+                : 'text-gray-600 hover:bg-gray-100',
+            )}
+          >
+            {s.label || s.id}
+          </button>
+        ))}
+      </nav>
+      <div className="space-y-4">
+        {active.heading ? (
+          <div>
+            <h3 className="text-lg font-semibold">{active.heading}</h3>
+            {active.subheading ? <p className="text-sm text-gray-500 mt-0.5">{active.subheading}</p> : null}
+          </div>
+        ) : null}
+        {(active.blocks ?? []).map((block, i) => (
+          <PrototypeBlockView key={i} block={block} onNavigate={goto} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PrototypeBlockView({
+  block, onNavigate,
+}: {
+  readonly block: PrototypeBlock
+  readonly onNavigate: (id?: string) => void
+}) {
+  switch (block.type) {
+    case 'text':
+      return <p className="text-sm text-gray-700 whitespace-pre-wrap">{block.text}</p>
+
+    case 'callout': {
+      const toneClass = {
+        info: 'bg-blue-50 border-blue-200 text-blue-800',
+        success: 'bg-emerald-50 border-emerald-200 text-emerald-800',
+        warn: 'bg-amber-50 border-amber-200 text-amber-800',
+        error: 'bg-red-50 border-red-200 text-red-800',
+      }[block.tone || 'info'] ?? 'bg-gray-50 border-gray-200 text-gray-800'
+      return <div className={clsx('text-sm p-3 rounded-md border', toneClass)}>{block.text}</div>
+    }
+
+    case 'stats':
+      return (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {(block.items ?? []).map((s, i) => (
+            <div key={i} className="border rounded-lg p-3 bg-gray-50">
+              <div className="text-xs text-gray-500">{s.label}</div>
+              <div className="text-lg font-semibold mt-0.5">{s.value}</div>
+            </div>
+          ))}
+        </div>
+      )
+
+    case 'list':
+      return (
+        <div className="space-y-2">
+          {block.title ? <h4 className="text-sm font-medium text-gray-700">{block.title}</h4> : null}
+          <ul className="divide-y border rounded-lg">
+            {(block.items ?? []).map((item, i) => (
+              <li key={i} className="px-3 py-2 flex items-center justify-between">
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium truncate">{item.title}</div>
+                  {item.subtitle ? <div className="text-xs text-gray-500 truncate">{item.subtitle}</div> : null}
+                </div>
+                {item.badge ? (
+                  <span className="ml-2 text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full whitespace-nowrap">
+                    {item.badge}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )
+
+    case 'form':
+      return <PrototypeFormBlock block={block} onNavigate={onNavigate} />
+
+    case 'buttons':
+      return (
+        <div className="flex flex-wrap gap-2">
+          {(block.items ?? []).map((b, i) => (
+            <button
+              key={i}
+              onClick={() => onNavigate(b.goto)}
+              className={clsx(
+                'px-4 py-2 rounded-md text-sm transition-colors',
+                (b.tone ?? 'primary') === 'secondary'
+                  ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  : 'bg-blue-600 text-white hover:bg-blue-700',
+              )}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+      )
+
+    default:
+      return (
+        <div className="text-xs text-gray-400 italic">
+          (Unsupported block type: {block.type})
+        </div>
+      )
+  }
+}
+
+function PrototypeFormBlock({
+  block, onNavigate,
+}: {
+  readonly block: PrototypeBlock
+  readonly onNavigate: (id?: string) => void
+}) {
+  const [submitted, setSubmitted] = useState(false)
+  const fields = block.fields ?? []
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        setSubmitted(true)
+        if (block.submit?.goto) onNavigate(block.submit.goto)
+      }}
+      className="space-y-3 border rounded-lg p-3 bg-gray-50"
+    >
+      {block.title ? <h4 className="text-sm font-medium text-gray-700">{block.title}</h4> : null}
+      {fields.map((f, i) => (
+        <div key={i}>
+          <label className="block text-xs text-gray-600 mb-1">{f.label}</label>
+          {(f.type ?? 'text') === 'textarea' ? (
+            <textarea
+              placeholder={f.placeholder}
+              rows={3}
+              className="w-full px-3 py-2 border rounded-md text-sm"
+            />
+          ) : (
+            <input
+              type={f.type ?? 'text'}
+              placeholder={f.placeholder}
+              className="w-full px-3 py-2 border rounded-md text-sm"
+            />
+          )}
+        </div>
+      ))}
+      {block.submit ? (
+        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700">
+          {block.submit.label}
+        </button>
+      ) : null}
+      {submitted && !block.submit?.goto ? (
+        <div className="text-xs text-emerald-700 mt-1">✓ Submitted (mock)</div>
+      ) : null}
+    </form>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -1,0 +1,209 @@
+/**
+ * @fileoverview PR/FAQ row component for the prioritization table.
+ * @module pages/Prioritization/PRFAQRow
+ */
+
+import clsx from 'clsx'
+import { format } from 'date-fns'
+import {
+  ChevronDown, ChevronUp, ExternalLink, Wand2,
+} from 'lucide-react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import ReactMarkdown from 'react-markdown'
+import PrototypeRenderer, {
+  parsePrototypeSpec, looksLikeHtmlDocument, HtmlPrototypeFrame,
+} from '../../components/PrototypeRenderer'
+import {
+  calculatePriorityScore, getPriorityLabel,
+} from './prioritizationUtils'
+import ScoreSlider from './ScoreSlider'
+import type { PRFAQWithProject } from './prioritizationUtils'
+import type {
+  PrioritizationScore, ProjectDocument,
+} from '../../api/types'
+import type { PrototypeSpec } from '../../components/PrototypeRenderer'
+import type { TFunction } from 'i18next'
+import type { ReactElement } from 'react'
+
+function QuickScores({ score }: { readonly score: PrioritizationScore }): ReactElement {
+  const { t } = useTranslation('prioritization')
+  const priorityScore = score.impact > 0 ? calculatePriorityScore(score) : 0
+  const showTTM = score.time_to_market !== 3 || score.impact > 0
+  return (
+    <div className="flex items-center justify-between sm:justify-end gap-3 sm:gap-4">
+      <div className="text-center">
+        <div className={clsx('text-base sm:text-lg font-bold', score.impact > 0 ? 'text-blue-600' : 'text-gray-300')}>{score.impact === 0 ? '-' : score.impact}</div>
+        <div className="text-xs text-gray-400">{t('scores.impact')}</div>
+      </div>
+      <div className="text-center">
+        <div className={clsx('text-base sm:text-lg font-bold', showTTM ? 'text-purple-600' : 'text-gray-300')}>{score.impact > 0 ? score.time_to_market : '-'}</div>
+        <div className="text-xs text-gray-400">{t('sort.ttm')}</div>
+      </div>
+      <div className="text-center px-2 sm:px-3 py-1 bg-gray-50 rounded-lg">
+        <div className={clsx('text-lg sm:text-xl font-bold', priorityScore > 0 ? 'text-green-600' : 'text-gray-300')}>{priorityScore > 0 ? priorityScore.toFixed(1) : '-'}</div>
+        <div className="text-xs text-gray-400">{t('scores.score')}</div>
+      </div>
+    </div>
+  )
+}
+
+function PRFAQRowHeader({
+  prfaq,
+  index,
+  priority,
+  score,
+  isExpanded,
+  onToggle,
+}: {
+  readonly prfaq: PRFAQWithProject
+  readonly index: number
+  readonly priority: {
+    label: string;
+    color: string
+  }
+  readonly score: PrioritizationScore
+  readonly isExpanded: boolean
+  readonly onToggle: () => void
+}) {
+  return (
+    <button type="button" className="w-full p-3 sm:p-4 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 cursor-pointer hover:bg-gray-50 text-left" onClick={onToggle}>
+      <div className="flex items-center gap-3 sm:gap-4 flex-1 min-w-0">
+        <div className="text-gray-400 font-mono text-sm w-6 hidden sm:block">#{index + 1}</div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-medium text-gray-900 truncate text-sm sm:text-base">{prfaq.title}</h3>
+            <span className={clsx('text-xs px-2 py-0.5 rounded-full whitespace-nowrap', priority.color)}>{priority.label}</span>
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3 mt-1 text-xs sm:text-sm text-gray-500">
+            <span className="truncate">{prfaq.project_name}</span>
+            <span>•</span>
+            <span className="whitespace-nowrap">{format(new Date(prfaq.created_at), 'MMM d, yyyy')}</span>
+          </div>
+        </div>
+      </div>
+      <QuickScores score={score} />
+      <div className="sm:ml-2">{isExpanded ? <ChevronUp size={20} className="text-gray-400" /> : <ChevronDown size={20} className="text-gray-400" />}</div>
+    </button>
+  )
+}
+
+function PRFAQRowExpanded({
+  prfaq, score, onUpdateScore,
+}: {
+  readonly prfaq: PRFAQWithProject
+  readonly score: PrioritizationScore
+  readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
+}) {
+  const { t } = useTranslation('prioritization')
+  return (
+    <div className="border-t px-3 sm:px-4 py-4 bg-gray-50">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+        <div className="space-y-4">
+          <h4 className="font-medium text-gray-900">{t('scores.title')}</h4>
+          <ScoreSlider label={t('scores.impact')} value={score.impact === 0 ? 3 : score.impact} onChange={(v) => onUpdateScore('impact', v)} description={t('scores.impactDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
+          <ScoreSlider label={t('scores.timeToMarket')} value={score.time_to_market === 0 ? 3 : score.time_to_market} onChange={(v) => onUpdateScore('time_to_market', v)} description={t('scores.timeToMarketDescription')} lowLabel={t('scores.slow')} highLabel={t('scores.fast')} />
+          <ScoreSlider label={t('scores.strategicFit')} value={score.strategic_fit === 0 ? 3 : score.strategic_fit} onChange={(v) => onUpdateScore('strategic_fit', v)} description={t('scores.strategicFitDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
+          <ScoreSlider label={t('scores.confidence')} value={score.confidence === 0 ? 3 : score.confidence} onChange={(v) => onUpdateScore('confidence', v)} description={t('scores.confidenceDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
+          <div>
+            <label className="text-sm font-medium text-gray-700">{t('notes.label')}</label>
+            <textarea value={score.notes} onChange={(e) => onUpdateScore('notes', e.target.value)} placeholder={t('notes.placeholder')} rows={2} className="mt-1 w-full px-3 py-2 border rounded-lg text-sm" />
+          </div>
+        </div>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h4 className="font-medium text-gray-900">{t('preview.title')}</h4>
+            <a href={`/projects/${prfaq.project_id}`} className="text-sm text-blue-600 hover:underline flex items-center gap-1">
+              <span className="hidden sm:inline">{t('preview.viewFull')}</span>
+              <span className="sm:hidden">{t('preview.viewMobile')}</span>
+              <ExternalLink size={14} />
+            </a>
+          </div>
+          <div className="bg-white rounded-lg border p-3 sm:p-4 max-h-48 sm:max-h-64 overflow-y-auto prose prose-sm">
+            <ReactMarkdown>{prfaq.content.slice(0, 1500) + (prfaq.content.length > 1500 ? '...' : '')}</ReactMarkdown>
+          </div>
+          {/* Prototype preview, embedded under the PR/FAQ text. HTML prototypes
+              render in a sandboxed iframe; legacy JSON specs render natively.
+              Hidden gracefully when no prototype exists for the project yet. */}
+          <PrototypePanel prototype={prfaq.prototype} t={t} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Decide how to render a prototype document: as HTML, a JSON spec, or not at all. */
+function resolvePrototypeMode(
+  content: string,
+  protoFormat: string | undefined,
+): { kind: 'html' } | {
+  kind: 'spec';
+  spec: PrototypeSpec
+} | { kind: 'none' } {
+  if (content === '') return { kind: 'none' }
+  const isHtml = protoFormat === 'html' || (protoFormat === undefined && looksLikeHtmlDocument(content))
+  if (isHtml) return { kind: 'html' }
+  const spec = parsePrototypeSpec(content)
+  return spec ? {
+    kind: 'spec',
+    spec,
+  } : { kind: 'none' }
+}
+
+/**
+ * Renders a project's latest prototype under the PR/FAQ preview. Chooses the
+ * iframe (HTML format) or the native JSON-spec renderer, or renders nothing
+ * when there's no usable prototype.
+ */
+function PrototypePanel({
+  prototype, t,
+}: {
+  readonly prototype?: ProjectDocument
+  readonly t: TFunction
+}): ReactElement | null {
+  const content = prototype?.content ?? ''
+  const protoFormat = prototype?.prototype_format
+  const mode = useMemo(() => resolvePrototypeMode(content, protoFormat), [content, protoFormat])
+  if (mode.kind === 'none') return null
+  return (
+    <div>
+      <div className="flex items-center justify-between mt-2">
+        <h4 className="font-medium text-gray-900 flex items-center gap-1.5">
+          <Wand2 size={14} className="text-orange-500" />
+          {t('preview.prototypeTitle', { defaultValue: 'Prototype' })}
+        </h4>
+      </div>
+      {mode.kind === 'html' ? (
+        <div className="bg-white rounded-lg border overflow-hidden mt-2 h-96">
+          <HtmlPrototypeFrame html={content} title={prototype?.title} className="w-full h-full border-0" />
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg border p-3 sm:p-4 max-h-96 overflow-y-auto mt-2">
+          <PrototypeRenderer spec={mode.spec} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function PRFAQRow({
+  prfaq, index, score, isExpanded, onToggle, onUpdateScore,
+}: {
+  readonly prfaq: PRFAQWithProject
+  readonly index: number
+  readonly score: PrioritizationScore
+  readonly isExpanded: boolean
+  readonly onToggle: () => void
+  readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
+}) {
+  const { t } = useTranslation('prioritization')
+  const priorityScore = score.impact > 0 ? calculatePriorityScore(score) : 0
+  const priority = getPriorityLabel(priorityScore, t)
+
+  return (
+    <div className="bg-white rounded-lg border shadow-sm">
+      <PRFAQRowHeader prfaq={prfaq} index={index} priority={priority} score={score} isExpanded={isExpanded} onToggle={onToggle} />
+      {isExpanded ? <PRFAQRowExpanded prfaq={prfaq} score={score} onUpdateScore={onUpdateScore} /> : null}
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -11,15 +11,18 @@ import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 const mockGetProjects = vi.fn()
 const mockGetProject = vi.fn()
 const mockGetPrioritizationScores = vi.fn()
-const mockSavePrioritizationScores = vi.fn()
 const mockPatchPrioritizationScores = vi.fn()
+
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    getProjects: () => mockGetProjects(),
+    getProject: (id: string) => mockGetProject(id),
+  },
+}))
 
 vi.mock('../../api/client', () => ({
   api: {
-    getProjects: () => mockGetProjects(),
-    getProject: (id: string) => mockGetProject(id),
     getPrioritizationScores: () => mockGetPrioritizationScores(),
-    savePrioritizationScores: (scores: unknown) => mockSavePrioritizationScores(scores),
     patchPrioritizationScores: (scores: unknown) => mockPatchPrioritizationScores(scores),
   },
 }))
@@ -35,22 +38,6 @@ vi.mock('react-markdown', () => ({
 }))
 
 import Prioritization from './Prioritization'
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  })
-  
-  const router = createMemoryRouter([
-    { path: '/', element: <Prioritization /> },
-  ])
-  
-  return ({ children }: { children?: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  )
-}
 
 const mockProjects = [
   { project_id: 'p1', name: 'Project 1', status: 'active', created_at: '2025-01-01', updated_at: '2025-01-01', persona_count: 2, document_count: 3 },
@@ -81,8 +68,12 @@ describe('Prioritization', () => {
       const detail = mockProjectDetails.find(d => d.project_id === id)
       return Promise.resolve(detail || { documents: [] })
     })
-    mockGetPrioritizationScores.mockResolvedValue({ scores: {} })
-    mockSavePrioritizationScores.mockResolvedValue({ success: true })
+    mockGetPrioritizationScores.mockResolvedValue({
+      scores: {
+        d1: { document_id: 'd1', impact: 0, time_to_market: 3, confidence: 0, strategic_fit: 0, notes: '' },
+        d3: { document_id: 'd3', impact: 0, time_to_market: 3, confidence: 0, strategic_fit: 0, notes: '' },
+      },
+    })
     mockPatchPrioritizationScores.mockResolvedValue({ success: true, updated_count: 1 })
   })
 
@@ -107,7 +98,6 @@ describe('Prioritization', () => {
       renderPrioritization()
 
       expect(screen.getByText('PR/FAQ Prioritization')).toBeInTheDocument()
-      expect(screen.getByText(/score and prioritize/i)).toBeInTheDocument()
     })
 
     it('renders stats cards', async () => {
@@ -208,12 +198,43 @@ describe('Prioritization', () => {
         expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
       })
 
-      // Click on Impact sort button
-      const impactButton = screen.getByRole('button', { name: /impact/i })
-      await user.click(impactButton)
+      // Click on Impact sort button (multiple matches due to mobile/desktop spans)
+      const impactButtons = screen.getAllByRole('button', { name: /impact/i })
+      await user.click(impactButtons[0])
 
       // Button should be highlighted
-      expect(impactButton).toHaveClass('bg-blue-100')
+      expect(impactButtons[0]).toHaveClass('bg-blue-100')
+    })
+  })
+
+  describe('regression: missing scores do not crash', () => {
+    /**
+     * Regression test for: TypeError: Cannot read properties of undefined (reading 'impact')
+     * When the API returns no saved scores, StatsCards must not crash accessing scores[id].impact.
+     */
+    it('renders stats cards when scores API returns empty object', async () => {
+      mockGetPrioritizationScores.mockResolvedValue({ scores: {} })
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+      })
+
+      // StatsCards should render without crashing
+      expect(screen.getByText('Total PR/FAQs')).toBeInTheDocument()
+    })
+
+    it('renders stats cards when scores API returns no scores key', async () => {
+      mockGetPrioritizationScores.mockResolvedValue({})
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Total PR/FAQs')).toBeInTheDocument()
     })
   })
 
@@ -230,6 +251,3 @@ describe('Prioritization', () => {
     })
   })
 })
-
-// Note: Testing "not configured" state requires module re-mocking which is complex
-// The main functionality is tested above

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -3,133 +3,96 @@
  * @module pages/Prioritization
  */
 
-import { useState, useMemo, type ReactElement } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useBlocker } from 'react-router-dom'
-import { ArrowUpDown, FileText, Sparkles, ChevronDown, ChevronUp, ExternalLink, Save, RotateCcw } from 'lucide-react'
-import { api } from '../../api/client'
-import type { Project, ProjectDocument, PrioritizationScore } from '../../api/client'
-import { useConfigStore } from '../../store/configStore'
-import { format } from 'date-fns'
+import {
+  useQuery, useMutation, useQueryClient,
+} from '@tanstack/react-query'
 import clsx from 'clsx'
-import ReactMarkdown from 'react-markdown'
+import {
+  ArrowUpDown, FileText, Sparkles, Save, RotateCcw,
+} from 'lucide-react'
+import {
+  useState, useMemo,
+} from 'react'
+import {
+  useTranslation, Trans,
+} from 'react-i18next'
+import { useBlocker } from 'react-router-dom'
+import { api } from '../../api/client'
+import { projectsApi } from '../../api/projectsApi'
 import ConfirmModal from '../../components/ConfirmModal'
+import { useConfigStore } from '../../store/configStore'
+import PRFAQRow from './PRFAQRow'
+import {
+  calculatePriorityScore, getScore, collectPRFAQs, comparePRFAQs,
+} from './prioritizationUtils'
+import type {
+  PRFAQWithProject, SortField, SortDirection,
+} from './prioritizationUtils'
+import type {
+  Project, PrioritizationScore,
+} from '../../api/types'
 
-interface PRFAQWithProject extends ProjectDocument {
-  project_id: string
-  project_name: string
-}
-
-type SortField = 'priority_score' | 'impact' | 'time_to_market' | 'created_at' | 'title'
-type SortDirection = 'asc' | 'desc'
-
-const calculatePriorityScore = (score: PrioritizationScore): number => {
-  return (score.impact * 0.4) + (score.time_to_market * 0.3) + (score.strategic_fit * 0.2) + (score.confidence * 0.1)
-}
-
-const getScoreColor = (score: number, max: number = 5): string => {
-  const ratio = score / max
-  if (ratio >= 0.8) return 'text-green-600 bg-green-50'
-  if (ratio >= 0.6) return 'text-blue-600 bg-blue-50'
-  if (ratio >= 0.4) return 'text-yellow-600 bg-yellow-50'
-  return 'text-red-600 bg-red-50'
-}
-
-const getPriorityLabel = (score: number): { label: string; color: string } => {
-  if (score >= 4) return { label: 'High Priority', color: 'bg-green-100 text-green-800' }
-  if (score >= 3) return { label: 'Medium Priority', color: 'bg-blue-100 text-blue-800' }
-  if (score >= 2) return { label: 'Low Priority', color: 'bg-yellow-100 text-yellow-800' }
-  return { label: 'Not Scored', color: 'bg-gray-100 text-gray-600' }
-}
-
-interface ScoreSliderProps {
-  readonly label: string
-  readonly value: number
-  readonly onChange: (v: number) => void
-  readonly description?: string
-  readonly lowLabel?: string
-  readonly highLabel?: string
-  readonly inverted?: boolean
-}
-
-function ScoreSlider({ label, value, onChange, description, lowLabel = '1', highLabel = '5', inverted = false }: ScoreSliderProps) {
-  return (
-    <div className="space-y-2">
-      <div className="flex justify-between items-center">
-        <label className="text-sm font-medium text-gray-700">{label}</label>
-        <span className={clsx('text-sm font-bold px-2 py-0.5 rounded', getScoreColor(inverted ? 6 - value : value))}>{value}</span>
-      </div>
-      {description && <p className="text-xs text-gray-500">{description}</p>}
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-gray-400 w-16">{lowLabel}</span>
-        <input type="range" min={1} max={5} value={value} onChange={(e) => onChange(Number(e.target.value))} className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600" />
-        <span className="text-xs text-gray-400 w-16 text-right">{highLabel}</span>
-      </div>
-    </div>
-  )
-}
-
-const DEFAULT_SCORE: PrioritizationScore = { document_id: '', impact: 0, time_to_market: 3, confidence: 0, strategic_fit: 0, notes: '' }
-
-function getScore(scores: Record<string, PrioritizationScore>, docId: string): PrioritizationScore {
-  return scores[docId] ?? { ...DEFAULT_SCORE, document_id: docId }
-}
-
-function collectPRFAQs(allProjectDetails: Array<{ documents?: ProjectDocument[] }> | undefined, projects: Project[] | undefined): PRFAQWithProject[] {
-  if (!allProjectDetails || !projects) return []
-  
-  const result: PRFAQWithProject[] = []
-  allProjectDetails.forEach((detail, index) => {
-    if (!detail?.documents) return
-    const project = projects[index]
-    detail.documents
-      .filter((doc: ProjectDocument) => doc.document_type === 'prfaq')
-      .forEach((doc: ProjectDocument) => {
-        result.push({ ...doc, project_id: project.project_id, project_name: project.name })
-      })
-  })
-  return result
-}
-
-function comparePRFAQs(a: PRFAQWithProject, b: PRFAQWithProject, scores: Record<string, PrioritizationScore>, sortField: SortField): number {
-  const scoreA = getScore(scores, a.document_id)
-  const scoreB = getScore(scores, b.document_id)
-  
-  switch (sortField) {
-    case 'priority_score': return calculatePriorityScore(scoreA) - calculatePriorityScore(scoreB)
-    case 'impact': return scoreA.impact - scoreB.impact
-    case 'time_to_market': return scoreA.time_to_market - scoreB.time_to_market
-    case 'created_at': return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-    case 'title': return a.title.localeCompare(b.title)
-  }
-}
-
-function StatsCards({ allPRFAQs, scores }: { readonly allPRFAQs: PRFAQWithProject[]; readonly scores: Record<string, PrioritizationScore> }) {
-  const highPriority = allPRFAQs.filter(p => { const s = scores[p.document_id]; return s && calculatePriorityScore(s) >= 4 }).length
-  const mediumPriority = allPRFAQs.filter(p => { const s = scores[p.document_id]; return s && calculatePriorityScore(s) >= 3 && calculatePriorityScore(s) < 4 }).length
-  const notScored = allPRFAQs.filter(p => !scores[p.document_id] || scores[p.document_id].impact === 0).length
+function StatsCards({
+  allPRFAQs, scores,
+}: {
+  readonly allPRFAQs: PRFAQWithProject[];
+  readonly scores: Record<string, PrioritizationScore>
+}) {
+  const { t } = useTranslation('prioritization')
+  const highPriority = allPRFAQs.filter((p) => {
+    const s = getScore(scores, p.document_id); return calculatePriorityScore(s) >= 4
+  }).length
+  const mediumPriority = allPRFAQs.filter((p) => {
+    const s = getScore(scores, p.document_id); return calculatePriorityScore(s) >= 3 && calculatePriorityScore(s) < 4
+  }).length
+  const notScored = allPRFAQs.filter((p) => getScore(scores, p.document_id).impact === 0).length
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
-      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-gray-900">{allPRFAQs.length}</div><div className="text-sm text-gray-500">Total PR/FAQs</div></div>
-      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-green-600">{highPriority}</div><div className="text-sm text-gray-500">High Priority</div></div>
-      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-blue-600">{mediumPriority}</div><div className="text-sm text-gray-500">Medium Priority</div></div>
-      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-gray-400">{notScored}</div><div className="text-sm text-gray-500">Not Scored</div></div>
+      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-gray-900">{allPRFAQs.length}</div><div className="text-sm text-gray-500">{t('stats.totalPrfaqs')}</div></div>
+      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-green-600">{highPriority}</div><div className="text-sm text-gray-500">{t('stats.highPriority')}</div></div>
+      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-blue-600">{mediumPriority}</div><div className="text-sm text-gray-500">{t('stats.mediumPriority')}</div></div>
+      <div className="bg-white rounded-lg border p-4"><div className="text-2xl font-bold text-gray-400">{notScored}</div><div className="text-sm text-gray-500">{t('stats.notScored')}</div></div>
     </div>
   )
 }
 
-function SortControls({ sortField, sortDirection, onToggleSort }: { readonly sortField: SortField; readonly sortDirection: SortDirection; readonly onToggleSort: (f: SortField) => void }) {
+function SortControls({
+  sortField, sortDirection, onToggleSort,
+}: {
+  readonly sortField: SortField;
+  readonly sortDirection: SortDirection;
+  readonly onToggleSort: (f: SortField) => void
+}) {
+  const { t } = useTranslation('prioritization')
   const options = [
-    { field: 'priority_score' as const, label: 'Priority', fullLabel: 'Priority Score' },
-    { field: 'impact' as const, label: 'Impact', fullLabel: 'Impact' },
-    { field: 'time_to_market' as const, label: 'TTM', fullLabel: 'Time to Market' },
-    { field: 'created_at' as const, label: 'Date', fullLabel: 'Date Created' },
+    {
+      field: 'priority_score' as const,
+      label: t('sort.priority'),
+      fullLabel: t('sort.priorityFull'),
+    },
+    {
+      field: 'impact' as const,
+      label: t('sort.impact'),
+      fullLabel: t('sort.impact'),
+    },
+    {
+      field: 'time_to_market' as const,
+      label: t('sort.ttm'),
+      fullLabel: t('sort.ttmFull'),
+    },
+    {
+      field: 'created_at' as const,
+      label: t('sort.date'),
+      fullLabel: t('sort.dateFull'),
+    },
   ]
   return (
     <div className="flex flex-wrap items-center gap-2 text-sm">
-      <span className="text-gray-500 w-full sm:w-auto">Sort by:</span>
-      {options.map(({ field, label, fullLabel }) => (
+      <span className="text-gray-500 w-full sm:w-auto">{t('sort.label')}</span>
+      {options.map(({
+        field, label, fullLabel,
+      }) => (
         <button key={field} onClick={() => onToggleSort(field)} className={clsx('px-2 sm:px-3 py-1.5 rounded-lg flex items-center gap-1 text-xs sm:text-sm', sortField === field ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200')}>
           <span className="sm:hidden">{label}</span>
           <span className="hidden sm:inline">{fullLabel}</span>
@@ -140,94 +103,9 @@ function SortControls({ sortField, sortDirection, onToggleSort }: { readonly sor
   )
 }
 
-function QuickScores({ score }: { readonly score: PrioritizationScore }): ReactElement {
-  const priorityScore = score.impact > 0 ? calculatePriorityScore(score) : 0
-  const showTTM = score.time_to_market !== 3 || score.impact > 0
-  return (
-    <div className="flex items-center justify-between sm:justify-end gap-3 sm:gap-4">
-      <div className="text-center">
-        <div className={clsx('text-base sm:text-lg font-bold', score.impact > 0 ? 'text-blue-600' : 'text-gray-300')}>{score.impact || '-'}</div>
-        <div className="text-xs text-gray-400">Impact</div>
-      </div>
-      <div className="text-center">
-        <div className={clsx('text-base sm:text-lg font-bold', showTTM ? 'text-purple-600' : 'text-gray-300')}>{score.impact > 0 ? score.time_to_market : '-'}</div>
-        <div className="text-xs text-gray-400">TTM</div>
-      </div>
-      <div className="text-center px-2 sm:px-3 py-1 bg-gray-50 rounded-lg">
-        <div className={clsx('text-lg sm:text-xl font-bold', priorityScore > 0 ? 'text-green-600' : 'text-gray-300')}>{priorityScore > 0 ? priorityScore.toFixed(1) : '-'}</div>
-        <div className="text-xs text-gray-400">Score</div>
-      </div>
-    </div>
-  )
-}
-
-function PRFAQRow({ prfaq, index, score, isExpanded, onToggle, onUpdateScore }: {
-  readonly prfaq: PRFAQWithProject
-  readonly index: number
-  readonly score: PrioritizationScore
-  readonly isExpanded: boolean
-  readonly onToggle: () => void
-  readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
-}) {
-  const priorityScore = score.impact > 0 ? calculatePriorityScore(score) : 0
-  const priority = getPriorityLabel(priorityScore)
-
-  return (
-    <div className="bg-white rounded-lg border shadow-sm">
-      <div className="p-3 sm:p-4 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 cursor-pointer hover:bg-gray-50" onClick={onToggle}>
-        <div className="flex items-center gap-3 sm:gap-4 flex-1 min-w-0">
-          <div className="text-gray-400 font-mono text-sm w-6 hidden sm:block">#{index + 1}</div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h3 className="font-medium text-gray-900 truncate text-sm sm:text-base">{prfaq.title}</h3>
-              <span className={clsx('text-xs px-2 py-0.5 rounded-full whitespace-nowrap', priority.color)}>{priority.label}</span>
-            </div>
-            <div className="flex items-center gap-2 sm:gap-3 mt-1 text-xs sm:text-sm text-gray-500">
-              <span className="truncate">{prfaq.project_name}</span>
-              <span>•</span>
-              <span className="whitespace-nowrap">{format(new Date(prfaq.created_at), 'MMM d, yyyy')}</span>
-            </div>
-          </div>
-        </div>
-        <QuickScores score={score} />
-        <div className="sm:ml-2">{isExpanded ? <ChevronUp size={20} className="text-gray-400" /> : <ChevronDown size={20} className="text-gray-400" />}</div>
-      </div>
-
-      {isExpanded && (
-        <div className="border-t px-3 sm:px-4 py-4 bg-gray-50">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
-            <div className="space-y-4">
-              <h4 className="font-medium text-gray-900">Prioritization Scores</h4>
-              <ScoreSlider label="Impact" value={score.impact || 3} onChange={(v) => onUpdateScore('impact', v)} description="Business value and customer benefit" lowLabel="Low" highLabel="High" />
-              <ScoreSlider label="Time to Market" value={score.time_to_market || 3} onChange={(v) => onUpdateScore('time_to_market', v)} description="How quickly can this be delivered?" lowLabel="Slow" highLabel="Fast" />
-              <ScoreSlider label="Strategic Fit" value={score.strategic_fit || 3} onChange={(v) => onUpdateScore('strategic_fit', v)} description="Alignment with company goals" lowLabel="Low" highLabel="High" />
-              <ScoreSlider label="Confidence" value={score.confidence || 3} onChange={(v) => onUpdateScore('confidence', v)} description="Certainty in impact and TTM estimates" lowLabel="Low" highLabel="High" />
-              <div>
-                <label className="text-sm font-medium text-gray-700">Notes</label>
-                <textarea value={score.notes || ''} onChange={(e) => onUpdateScore('notes', e.target.value)} placeholder="Add notes about this prioritization decision..." rows={2} className="mt-1 w-full px-3 py-2 border rounded-lg text-sm" />
-              </div>
-            </div>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h4 className="font-medium text-gray-900">PR/FAQ Preview</h4>
-                <a href={`/projects/${prfaq.project_id}`} className="text-sm text-blue-600 hover:underline flex items-center gap-1">
-                  <span className="hidden sm:inline">View Full Document</span>
-                  <span className="sm:hidden">View</span>
-                  <ExternalLink size={14} />
-                </a>
-              </div>
-              <div className="bg-white rounded-lg border p-3 sm:p-4 max-h-48 sm:max-h-64 overflow-y-auto prose prose-sm">
-                <ReactMarkdown>{prfaq.content?.slice(0, 1500) + (prfaq.content && prfaq.content.length > 1500 ? '...' : '')}</ReactMarkdown>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-function PRFAQList({ isLoading, prfaqs, scores, expandedId, onToggleExpand, onUpdateScore }: {
+function PRFAQList({
+  isLoading, prfaqs, scores, expandedId, onToggleExpand, onUpdateScore,
+}: {
   readonly isLoading: boolean
   readonly prfaqs: PRFAQWithProject[]
   readonly scores: Record<string, PrioritizationScore>
@@ -235,11 +113,13 @@ function PRFAQList({ isLoading, prfaqs, scores, expandedId, onToggleExpand, onUp
   readonly onToggleExpand: (id: string) => void
   readonly onUpdateScore: (docId: string, field: keyof PrioritizationScore, value: number | string) => void
 }) {
+  const { t } = useTranslation('prioritization')
+
   if (isLoading) {
-    return <div className="text-center py-12"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div><p className="text-gray-500 mt-4">Loading PR/FAQs...</p></div>
+    return <div className="text-center py-12"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto" /><p className="text-gray-500 mt-4">{t('loading')}</p></div>
   }
   if (prfaqs.length === 0) {
-    return <div className="text-center py-12 bg-white rounded-lg border"><FileText size={48} className="mx-auto text-gray-300 mb-4" /><h3 className="text-lg font-medium text-gray-900">No PR/FAQs Found</h3><p className="text-gray-500 mt-1">Create PR/FAQs in your projects to start prioritizing.</p></div>
+    return <div className="text-center py-12 bg-white rounded-lg border"><FileText size={48} className="mx-auto text-gray-300 mb-4" /><h3 className="text-lg font-medium text-gray-900">{t('empty.title')}</h3><p className="text-gray-500 mt-1">{t('empty.description')}</p></div>
   }
   return (
     <div className="space-y-3">
@@ -258,7 +138,37 @@ function PRFAQList({ isLoading, prfaqs, scores, expandedId, onToggleExpand, onUp
   )
 }
 
+function PrioritizationHeader({
+  hasChanges, isPending, onReset, onSave,
+}: {
+  readonly hasChanges: boolean
+  readonly isPending: boolean
+  readonly onReset: () => void
+  readonly onSave: () => void
+}) {
+  const { t } = useTranslation('prioritization')
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div>
+        <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
+        <p className="text-sm sm:text-base text-gray-500 mt-1">{t('subtitle')}</p>
+      </div>
+      <div className="flex items-center gap-2 sm:gap-3">
+        {hasChanges ? <button onClick={onReset} className="flex items-center gap-2 px-3 sm:px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg text-sm">
+          <RotateCcw size={16} /><span className="hidden sm:inline">{t('actions.reset')}</span>
+        </button> : null}
+        <button onClick={onSave} disabled={!hasChanges || isPending} className={clsx('flex items-center gap-2 px-3 sm:px-4 py-2 rounded-lg font-medium text-sm', hasChanges ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-gray-100 text-gray-400 cursor-not-allowed')}>
+          <Save size={16} />
+          <span className="hidden sm:inline">{isPending ? t('actions.saving') : t('actions.save')}</span>
+          <span className="sm:hidden">{isPending ? t('actions.savingMobile') : t('actions.saveMobile')}</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export default function Prioritization() {
+  const { t } = useTranslation('prioritization')
   const { config } = useConfigStore()
   const queryClient = useQueryClient()
   const [expandedId, setExpandedId] = useState<string | null>(null)
@@ -270,28 +180,31 @@ export default function Prioritization() {
 
   const hasChanges = changedDocIds.size > 0
 
-  const { data: projectsData, isLoading: loadingProjects } = useQuery({
+  const {
+    data: projectsData, isLoading: loadingProjects,
+  } = useQuery({
     queryKey: ['projects'],
-    queryFn: () => api.getProjects(),
-    enabled: !!config.apiEndpoint,
+    queryFn: () => projectsApi.getProjects(),
+    enabled: config.apiEndpoint.length > 0,
   })
 
   const projects = projectsData?.projects
   const projectIds = Array.isArray(projects) ? projects.map((p: Project) => p.project_id) : []
 
-  const { data: allProjectDetails, isLoading: loadingDetails } = useQuery({
+  const {
+    data: allProjectDetails, isLoading: loadingDetails,
+  } = useQuery({
     queryKey: ['all-project-details', projectIds],
-    queryFn: () => Promise.all(projectIds.map(id => api.getProject(id))),
+    queryFn: () => Promise.all(projectIds.map((id) => projectsApi.getProject(id))),
     enabled: projectIds.length > 0,
   })
 
   const { data: savedScores } = useQuery({
     queryKey: ['prioritization-scores'],
     queryFn: () => api.getPrioritizationScores(),
-    enabled: !!config.apiEndpoint,
+    enabled: config.apiEndpoint.length > 0,
   })
 
-  // Initialize scores from saved data - only on first load
   const initialScores = useMemo(() => {
     if (!initialized && savedScores?.scores) {
       return savedScores.scores
@@ -299,7 +212,6 @@ export default function Prioritization() {
     return null
   }, [savedScores, initialized])
 
-  // Apply initial scores once
   if (initialScores && !initialized) {
     setScores(initialScores)
     setInitialized(true)
@@ -314,34 +226,34 @@ export default function Prioritization() {
 
   const saveMutation = useMutation({
     mutationFn: () => {
-      // Only send the scores that were actually changed
       const changedScores: Record<string, PrioritizationScore> = {}
-      changedDocIds.forEach(docId => {
-        if (scores[docId]) {
-          changedScores[docId] = scores[docId]
-        }
-      })
+      for (const docId of changedDocIds) {
+        changedScores[docId] = getScore(scores, docId)
+      }
       return api.patchPrioritizationScores(changedScores)
     },
-    onSuccess: () => { 
+    onSuccess: () => {
       setChangedDocIds(new Set())
-      queryClient.invalidateQueries({ queryKey: ['prioritization-scores'] }) 
+      void queryClient.invalidateQueries({ queryKey: ['prioritization-scores'] })
     },
   })
 
   const blocker = useBlocker(hasChanges)
 
   const updateScore = (docId: string, field: keyof PrioritizationScore, value: number | string) => {
-    setScores(prev => ({
+    setScores((prev) => ({
       ...prev,
-      [docId]: { ...getScore(prev, docId), [field]: value }
+      [docId]: {
+        ...getScore(prev, docId),
+        [field]: value,
+      },
     }))
-    setChangedDocIds(prev => new Set(prev).add(docId))
+    setChangedDocIds((prev) => new Set(prev).add(docId))
   }
 
   const toggleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection(d => d === 'asc' ? 'desc' : 'asc')
+      setSortDirection((d) => d === 'asc' ? 'desc' : 'asc')
     } else {
       setSortField(field)
       setSortDirection('desc')
@@ -353,39 +265,26 @@ export default function Prioritization() {
     setChangedDocIds(new Set())
   }
 
-  if (!config.apiEndpoint) {
-    return <div className="text-center py-12"><p className="text-gray-500">Configure API endpoint in Settings to view prioritization.</p></div>
+  if (config.apiEndpoint === '') {
+    return <div className="text-center py-12"><p className="text-gray-500">{t('configureApiEndpoint')}</p></div>
   }
 
   const isLoading = loadingProjects || loadingDetails
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <h1 className="text-xl sm:text-2xl font-bold text-gray-900">PR/FAQ Prioritization</h1>
-          <p className="text-sm sm:text-base text-gray-500 mt-1">Score and prioritize PR/FAQs across all projects</p>
-        </div>
-        <div className="flex items-center gap-2 sm:gap-3">
-          {hasChanges && (
-            <button onClick={handleReset} className="flex items-center gap-2 px-3 sm:px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg text-sm">
-              <RotateCcw size={16} /><span className="hidden sm:inline">Reset</span>
-            </button>
-          )}
-          <button onClick={() => saveMutation.mutate()} disabled={!hasChanges || saveMutation.isPending} className={clsx('flex items-center gap-2 px-3 sm:px-4 py-2 rounded-lg font-medium text-sm', hasChanges ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-gray-100 text-gray-400 cursor-not-allowed')}>
-            <Save size={16} />
-            <span className="hidden sm:inline">{saveMutation.isPending ? 'Saving...' : 'Save Scores'}</span>
-            <span className="sm:hidden">{saveMutation.isPending ? '...' : 'Save'}</span>
-          </button>
-        </div>
-      </div>
+      <PrioritizationHeader hasChanges={hasChanges} isPending={saveMutation.isPending} onReset={handleReset} onSave={() => saveMutation.mutate()} />
 
       <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg p-3 sm:p-4 border border-blue-100">
         <div className="flex items-start gap-3">
           <Sparkles className="text-blue-600 mt-0.5 flex-shrink-0" size={20} />
           <div>
-            <h3 className="font-medium text-blue-900 text-sm sm:text-base">Prioritization Framework</h3>
-            <p className="text-xs sm:text-sm text-blue-700 mt-1">Score each PR/FAQ on: <strong>Impact</strong>, <strong>Time to Market</strong>, <strong>Strategic Fit</strong>, and <strong>Confidence</strong>.</p>
+            <h3 className="font-medium text-blue-900 text-sm sm:text-base">{t('framework.title')}</h3>
+            <p className="text-xs sm:text-sm text-blue-700 mt-1">
+              <Trans i18nKey="framework.description" ns="prioritization">
+                Score each PR/FAQ on: <strong>Impact</strong>, <strong>Time to Market</strong>, <strong>Strategic Fit</strong>, and <strong>Confidence</strong>.
+              </Trans>
+            </p>
           </div>
         </div>
       </div>
@@ -404,10 +303,10 @@ export default function Prioritization() {
 
       <ConfirmModal
         isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved prioritization scores. Do you want to discard your changes and leave this page?"
-        confirmLabel="Discard Changes"
-        cancelLabel="Stay on Page"
+        title={t('unsavedChanges.title')}
+        message={t('unsavedChanges.message')}
+        confirmLabel={t('unsavedChanges.confirm')}
+        cancelLabel={t('unsavedChanges.cancel')}
         variant="warning"
         onConfirm={() => blocker.proceed?.()}
         onCancel={() => blocker.reset?.()}

--- a/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Score slider component for prioritization scoring.
+ * @module pages/Prioritization/ScoreSlider
+ */
+
+import clsx from 'clsx'
+import { getScoreColor } from './prioritizationUtils'
+
+interface ScoreSliderProps {
+  readonly label: string
+  readonly value: number
+  readonly onChange: (v: number) => void
+  readonly description?: string
+  readonly lowLabel?: string
+  readonly highLabel?: string
+  readonly inverted?: boolean
+}
+
+export default function ScoreSlider({
+  label, value, onChange, description, lowLabel = '1', highLabel = '5', inverted = false,
+}: ScoreSliderProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between items-center">
+        <label className="text-sm font-medium text-gray-700">{label}</label>
+        <span className={clsx('text-sm font-bold px-2 py-0.5 rounded', getScoreColor(inverted ? 6 - value : value))}>{value}</span>
+      </div>
+      {description != null && description !== '' ? <p className="text-xs text-gray-500">{description}</p> : null}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-400 w-16">{lowLabel}</span>
+        <input type="range" min={1} max={5} value={value} onChange={(e) => onChange(Number(e.target.value))} className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600" />
+        <span className="text-xs text-gray-400 w-16 text-right">{highLabel}</span>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Tests for prioritizationUtils — safe score access and calculations.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  getScore, calculatePriorityScore, collectPRFAQs, comparePRFAQs, DEFAULT_SCORE,
+} from './prioritizationUtils'
+import type { PrioritizationScore } from '../../api/types'
+
+describe('getScore', () => {
+  it('returns stored score when document_id exists', () => {
+    const scores: Record<string, PrioritizationScore> = {
+      'd1': { document_id: 'd1', impact: 4, time_to_market: 2, confidence: 3, strategic_fit: 5, notes: 'test' },
+    }
+
+    const result = getScore(scores, 'd1')
+
+    expect(result.impact).toBe(4)
+    expect(result.notes).toBe('test')
+  })
+
+  it('returns DEFAULT_SCORE with document_id when key is missing', () => {
+    const scores: Record<string, PrioritizationScore> = {}
+
+    const result = getScore(scores, 'missing-id')
+
+    expect(result.impact).toBe(0)
+    expect(result.time_to_market).toBe(3)
+    expect(result.confidence).toBe(0)
+    expect(result.document_id).toBe('missing-id')
+  })
+
+  it('returns DEFAULT_SCORE for empty scores object', () => {
+    const result = getScore({}, 'any-id')
+
+    expect(result).toStrictEqual({ ...DEFAULT_SCORE, document_id: 'any-id' })
+  })
+})
+
+describe('calculatePriorityScore', () => {
+  it('returns 0 for default unscored item', () => {
+    const score = { ...DEFAULT_SCORE, document_id: 'd1' }
+
+    // impact=0*0.4 + ttm=3*0.3 + strategic=0*0.2 + confidence=0*0.1 = 0.9
+    expect(calculatePriorityScore(score)).toBeCloseTo(0.9)
+  })
+
+  it('computes weighted score correctly', () => {
+    const score: PrioritizationScore = {
+      document_id: 'd1', impact: 5, time_to_market: 4, confidence: 3, strategic_fit: 2, notes: '',
+    }
+
+    // 5*0.4 + 4*0.3 + 2*0.2 + 3*0.1 = 2.0 + 1.2 + 0.4 + 0.3 = 3.9
+    expect(calculatePriorityScore(score)).toBeCloseTo(3.9)
+  })
+
+  it('returns max score for all-5 ratings', () => {
+    const score: PrioritizationScore = {
+      document_id: 'd1', impact: 5, time_to_market: 5, confidence: 5, strategic_fit: 5, notes: '',
+    }
+
+    expect(calculatePriorityScore(score)).toBeCloseTo(5.0)
+  })
+})
+
+describe('collectPRFAQs', () => {
+  it('returns empty array when no project details', () => {
+    expect(collectPRFAQs(undefined, undefined)).toStrictEqual([])
+    expect(collectPRFAQs([], [])).toStrictEqual([])
+  })
+
+  it('only includes prfaq document types', () => {
+    const details = [{
+      documents: [
+        { document_id: 'd1', document_type: 'prfaq' as const, title: 'A', content: '', created_at: '2025-01-01' },
+        { document_id: 'd2', document_type: 'prd' as const, title: 'B', content: '', created_at: '2025-01-01' },
+      ],
+    }]
+    const projects = [{ project_id: 'p1', name: 'P1', description: '', status: 'active' as const, created_at: '', updated_at: '', persona_count: 0, document_count: 0 }]
+
+    const result = collectPRFAQs(details, projects)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].document_id).toBe('d1')
+    expect(result[0].project_name).toBe('P1')
+  })
+})
+
+describe('comparePRFAQs', () => {
+  const prfaqA = { document_id: 'a', project_id: 'p1', project_name: 'P1', document_type: 'prfaq' as const, title: 'Alpha', content: '', created_at: '2025-01-01' }
+  const prfaqB = { document_id: 'b', project_id: 'p1', project_name: 'P1', document_type: 'prfaq' as const, title: 'Beta', content: '', created_at: '2025-01-02' }
+
+  it('sorts by impact when field is impact', () => {
+    const scores: Record<string, PrioritizationScore> = {
+      'a': { document_id: 'a', impact: 2, time_to_market: 3, confidence: 0, strategic_fit: 0, notes: '' },
+      'b': { document_id: 'b', impact: 5, time_to_market: 3, confidence: 0, strategic_fit: 0, notes: '' },
+    }
+
+    expect(comparePRFAQs(prfaqA, prfaqB, scores, 'impact')).toBeLessThan(0)
+  })
+
+  it('handles missing scores gracefully via getScore fallback', () => {
+    // Both missing from scores — should not crash, both get DEFAULT_SCORE
+    expect(() => comparePRFAQs(prfaqA, prfaqB, {}, 'impact')).not.toThrow()
+    expect(comparePRFAQs(prfaqA, prfaqB, {}, 'impact')).toBe(0)
+  })
+})
+
+describe('StatsCards regression: scores with missing document_id', () => {
+  /**
+   * Regression test for: TypeError: Cannot read properties of undefined (reading 'impact')
+   * When scores object doesn't contain an entry for a PR/FAQ's document_id,
+   * direct access scores[id].impact crashes. getScore() must be used instead.
+   */
+  it('getScore does not crash when accessing impact on missing score', () => {
+    const scores: Record<string, PrioritizationScore> = {}
+    const docId = 'nonexistent-doc'
+
+    // This is what the buggy code did: scores[docId].impact
+    // This is what the fixed code does:
+    const score = getScore(scores, docId)
+    expect(score.impact).toBe(0)
+  })
+
+  it('calculatePriorityScore works with getScore fallback', () => {
+    const scores: Record<string, PrioritizationScore> = {}
+
+    const score = getScore(scores, 'missing')
+    expect(() => calculatePriorityScore(score)).not.toThrow()
+    expect(calculatePriorityScore(score)).toBeCloseTo(0.9)
+  })
+})

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Shared utilities for the prioritization feature.
+ * @module pages/Prioritization/prioritizationUtils
+ */
+
+import type {
+  Project, ProjectDocument, PrioritizationScore,
+} from '../../api/types'
+
+export interface PRFAQWithProject extends ProjectDocument {
+  project_id: string
+  project_name: string
+  // Latest prototype (if any) for the same project. Surfaced under the PR/FAQ
+  // preview row so reviewers can see the demo without leaving the page.
+  prototype?: ProjectDocument
+}
+
+export type SortField = 'priority_score' | 'impact' | 'time_to_market' | 'created_at' | 'title'
+export type SortDirection = 'asc' | 'desc'
+
+export const DEFAULT_SCORE: PrioritizationScore = {
+  document_id: '',
+  impact: 0,
+  time_to_market: 3,
+  confidence: 0,
+  strategic_fit: 0,
+  notes: '',
+}
+
+export const calculatePriorityScore = (score: PrioritizationScore): number => {
+  return (score.impact * 0.4) + (score.time_to_market * 0.3) + (score.strategic_fit * 0.2) + (score.confidence * 0.1)
+}
+
+export const getScoreColor = (score: number, max: number = 5): string => {
+  const ratio = score / max
+  if (ratio >= 0.8) return 'text-green-600 bg-green-50'
+  if (ratio >= 0.6) return 'text-blue-600 bg-blue-50'
+  if (ratio >= 0.4) return 'text-yellow-600 bg-yellow-50'
+  return 'text-red-600 bg-red-50'
+}
+
+export const getPriorityLabel = (score: number, t: (key: string) => string): {
+  label: string;
+  color: string
+} => {
+  if (score >= 4) return {
+    label: t('priority.high'),
+    color: 'bg-green-100 text-green-800',
+  }
+  if (score >= 3) return {
+    label: t('priority.medium'),
+    color: 'bg-blue-100 text-blue-800',
+  }
+  if (score >= 2) return {
+    label: t('priority.low'),
+    color: 'bg-yellow-100 text-yellow-800',
+  }
+  return {
+    label: t('priority.none'),
+    color: 'bg-gray-100 text-gray-600',
+  }
+}
+
+export function getScore(scores: Record<string, PrioritizationScore>, docId: string): PrioritizationScore {
+  return scores[docId] ?? {
+    ...DEFAULT_SCORE,
+    document_id: docId,
+  }
+}
+
+export function collectPRFAQs(allProjectDetails: Array<{ documents?: ProjectDocument[] }> | undefined, projects: Project[] | undefined): PRFAQWithProject[] {
+  if (!allProjectDetails || !projects) return []
+
+  const result: PRFAQWithProject[] = []
+  for (const [index, detail] of allProjectDetails.entries()) {
+    if (!detail.documents) continue
+    const project = projects[index]
+    const prfaqDocs = detail.documents.filter((doc: ProjectDocument) => doc.document_type === 'prfaq')
+    // Pick the most-recent prototype for this project — that's the one the
+    // user just generated from the latest PRD/PR-FAQ.
+    const prototypes = detail.documents
+      .filter((doc: ProjectDocument) => doc.document_type === 'prototype')
+      .slice()
+      .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+    const latestPrototype = prototypes[0]
+    for (const doc of prfaqDocs) {
+      result.push({
+        ...doc,
+        project_id: project.project_id,
+        project_name: project.name,
+        prototype: latestPrototype,
+      })
+    }
+  }
+  return result
+}
+
+export function comparePRFAQs(a: PRFAQWithProject, b: PRFAQWithProject, scores: Record<string, PrioritizationScore>, sortField: SortField): number {
+  const scoreA = getScore(scores, a.document_id)
+  const scoreB = getScore(scores, b.document_id)
+
+  switch (sortField) {
+    case 'priority_score': return calculatePriorityScore(scoreA) - calculatePriorityScore(scoreB)
+    case 'impact': return scoreA.impact - scoreB.impact
+    case 'time_to_market': return scoreA.time_to_market - scoreB.time_to_market
+    case 'created_at': return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    case 'title': return a.title.localeCompare(b.title)
+  }
+}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/BuildPrototypeButton.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/BuildPrototypeButton.tsx
@@ -1,0 +1,109 @@
+/**
+ * BuildPrototypeButton — kicks off an Opus 4.8 HTML prototype build for the
+ * whole project, then polls the job to completion.
+ *
+ * The backend references the project's latest PRD *and* PR-FAQ: if both exist
+ * it uses both, if only one exists it uses that one. So the button is enabled
+ * once at least one of them exists. When only one is present, clicking it first
+ * confirms with the user that the build will use just that document.
+ *
+ * Lives in the project tab bar (top-right).
+ */
+import { AlertCircle, Loader2, Wand2 } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { projectsApi } from '../../api/projectsApi'
+
+export default function BuildPrototypeButton({
+  projectId, hasPrd, hasPrfaq, onDocumentChanged,
+}: {
+  readonly projectId: string
+  readonly hasPrd: boolean
+  readonly hasPrfaq: boolean
+  readonly onDocumentChanged?: () => void
+}) {
+  const { t, i18n } = useTranslation('projectDetail')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const disabled = !hasPrd && !hasPrfaq
+
+  const onClick = useCallback(async () => {
+    // Both → use both. Only one → confirm we'll build from just that document.
+    if (hasPrd && !hasPrfaq) {
+      if (!window.confirm(t('documents.prototype.confirmPrdOnly', { defaultValue: 'No PR-FAQ yet — the prototype will be built from the PRD only. Continue?' }))) return
+    } else if (!hasPrd && hasPrfaq) {
+      if (!window.confirm(t('documents.prototype.confirmPrfaqOnly', { defaultValue: 'No PRD yet — the prototype will be built from the PR-FAQ only. Continue?' }))) return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      const start = await projectsApi.buildPrototype(projectId, { response_language: i18n.language })
+      const jobId = start.job_id
+      const deadline = Date.now() + 5 * 60_000
+      // Resilient polling: a single Wi-Fi hiccup or a brief CloudFront edge
+      // glitch shouldn't kill the whole flow with "Failed to fetch". Allow up
+      // to 5 consecutive transient errors before giving up — that's >15 seconds
+      // of network trouble, by which point something is genuinely wrong.
+      let consecutiveErrors = 0
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 3000))
+        let job
+        try {
+          job = await projectsApi.getJobStatus(projectId, jobId)
+          consecutiveErrors = 0
+        } catch (pollErr) {
+          consecutiveErrors += 1
+          if (consecutiveErrors >= 5) throw pollErr
+          // eslint-disable-next-line no-console -- diagnostic for transient poll failures
+          console.warn(`Job poll error ${consecutiveErrors}/5 — retrying`, pollErr)
+          continue
+        }
+        if (job.status === 'completed') {
+          onDocumentChanged?.()
+          return
+        }
+        if (job.status === 'failed') {
+          throw new Error(job.error || 'Prototype build failed')
+        }
+      }
+      throw new Error(t('documents.prototype.timeout', { defaultValue: 'Prototype build took too long. Check the Documents tab in a moment.' }))
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Prototype failed'
+      setError(msg)
+    } finally {
+      setBusy(false)
+    }
+  }, [projectId, i18n.language, onDocumentChanged, t, hasPrd, hasPrfaq])
+
+  const isDisabled = disabled || busy
+  let title: string
+  if (disabled) {
+    title = t('documents.prototype.needsDocs', { defaultValue: 'Create a PRD or a PR-FAQ first to enable prototype build' })
+  } else if (hasPrd && hasPrfaq) {
+    title = t('documents.prototype.buttonTitle', { defaultValue: 'Generate a clickable HTML prototype from this project’s PRD + PR-FAQ' })
+  } else {
+    title = t('documents.prototype.buttonTitleOne', { defaultValue: 'Generate a clickable HTML prototype from the available document (PRD or PR-FAQ)' })
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {error ? (
+        <span className="text-xs text-red-600 inline-flex items-center gap-1 max-w-[200px] truncate" title={error}>
+          <AlertCircle size={12} /> {error}
+        </span>
+      ) : null}
+      <button
+        onClick={onClick}
+        disabled={isDisabled}
+        className="inline-flex items-center gap-1.5 px-3 py-2 bg-orange-500 hover:bg-orange-600 text-white rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
+        title={title}
+      >
+        {busy ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+        {busy
+          ? t('documents.prototype.building', { defaultValue: 'Building…' })
+          : t('documents.prototype.button', { defaultValue: 'Build Prototype' })}
+      </button>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
@@ -1,15 +1,20 @@
 /**
- * DocumentsTab - Documents list and detail view
+ * DocumentsTab - Documents list and detail view, plus the prototype builder.
  */
 import clsx from 'clsx'
 import { format } from 'date-fns'
 import {
-  FileText, Pencil, Trash2, Loader2,
+  FileText, Pencil, Trash2, Loader2, Wand2, AlertCircle,
 } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { projectsApi } from '../../api/projectsApi'
 import DocumentExportMenu from '../../components/DocumentExportMenu'
+import PrototypeRenderer, {
+  parsePrototypeSpec, looksLikeHtmlDocument, HtmlPrototypeFrame,
+} from '../../components/PrototypeRenderer'
 import type {
   ProjectDocument, Project,
 } from '../../api/types'
@@ -22,6 +27,7 @@ interface DocumentsTabProps {
   readonly onEditDoc: () => void
   readonly onDeleteDoc: () => void
   readonly onCreateDoc: () => void
+  readonly onDocumentChanged?: () => void
   readonly isDeleting: boolean
 }
 
@@ -33,6 +39,7 @@ export default function DocumentsTab({
   onEditDoc,
   onDeleteDoc,
   onCreateDoc,
+  onDocumentChanged,
   isDeleting,
 }: DocumentsTabProps) {
   const { t } = useTranslation('projectDetail')
@@ -81,9 +88,9 @@ export default function DocumentsTab({
         <div className="lg:col-span-2 bg-white rounded-xl border p-4 sm:p-6 min-h-[400px] lg:min-h-[500px] overflow-hidden">
           {selectedDoc ? (
             <div className="h-full flex flex-col">
-              <div className="flex items-start justify-between mb-4">
+              <div className="flex items-start justify-between mb-4 gap-2">
                 <h2 className="text-xl font-bold">{selectedDoc.title}</h2>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap justify-end">
                   <DocumentExportMenu document={selectedDoc} project={project} />
                   <button
                     onClick={onEditDoc}
@@ -102,12 +109,23 @@ export default function DocumentsTab({
                   </button>
                 </div>
               </div>
-              <div className="prose prose-sm max-w-none overflow-y-auto flex-1" style={{
-                overflowWrap: 'break-word',
-                wordBreak: 'break-word',
-              }}>
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{selectedDoc.content}</ReactMarkdown>
-              </div>
+              {selectedDoc.document_type === 'prototype' ? (
+                <PrototypeView
+                  projectId={project.project_id}
+                  documentId={selectedDoc.document_id}
+                  html={selectedDoc.content}
+                  title={selectedDoc.title}
+                  prototypeFormat={selectedDoc.prototype_format}
+                  onDocumentChanged={onDocumentChanged}
+                />
+              ) : (
+                <div className="prose prose-sm max-w-none overflow-y-auto flex-1" style={{
+                  overflowWrap: 'break-word',
+                  wordBreak: 'break-word',
+                }}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{selectedDoc.content}</ReactMarkdown>
+                </div>
+              )}
             </div>
           ) : (
             <div className="flex items-center justify-center h-full text-gray-400">{t('documents.selectDocument')}</div>
@@ -118,17 +136,239 @@ export default function DocumentsTab({
   )
 }
 
+// ── Prototype feedback → regenerate ──────────────────────────────────────────
+// The generated prototype is usually a user-facing view. This lets the reviewer
+// give feedback (e.g. "show the admin's perspective") and get a revised
+// prototype that still honors the PRD/PR-FAQ but is re-centered on the feedback.
+
+type TFunc = (key: string, opts?: Record<string, unknown>) => string
+
+function PrototypeFeedbackButton({
+  projectId, basePrototypeId, title, onRegenerated, t,
+}: {
+  readonly projectId: string
+  readonly basePrototypeId: string
+  readonly title: string
+  readonly onRegenerated?: () => void
+  readonly t: TFunc
+}) {
+  const { i18n } = useTranslation('projectDetail')
+  const [open, setOpen] = useState(false)
+  const [feedback, setFeedback] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onSubmit = useCallback(async () => {
+    const fb = feedback.trim()
+    if (fb === '') return
+    setBusy(true)
+    setError(null)
+    try {
+      const start = await projectsApi.buildPrototype(projectId, {
+        response_language: i18n.language,
+        title,
+        feedback: fb,
+        base_prototype_id: basePrototypeId,
+      })
+      const jobId = start.job_id
+      const deadline = Date.now() + 5 * 60_000
+      let consecutiveErrors = 0
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 3000))
+        let job
+        try {
+          job = await projectsApi.getJobStatus(projectId, jobId)
+          consecutiveErrors = 0
+        } catch (pollErr) {
+          consecutiveErrors += 1
+          if (consecutiveErrors >= 5) throw pollErr
+          continue
+        }
+        if (job.status === 'completed') {
+          setOpen(false)
+          setFeedback('')
+          onRegenerated?.()
+          return
+        }
+        if (job.status === 'failed') {
+          throw new Error(job.error || 'Prototype revision failed')
+        }
+      }
+      throw new Error(t('documents.prototype.timeout', { defaultValue: 'Prototype build took too long. Check the Documents tab in a moment.' }))
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Revision failed')
+    } finally {
+      setBusy(false)
+    }
+  }, [feedback, projectId, basePrototypeId, title, i18n.language, onRegenerated, t])
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1 text-orange-600 hover:underline"
+        title={t('documents.prototype.feedbackTitle', { defaultValue: 'Give feedback to regenerate this prototype' })}
+      >
+        <Wand2 size={12} /> {t('documents.prototype.feedbackButton', { defaultValue: 'Revise with feedback' })}
+      </button>
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => !busy && setOpen(false)}>
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg p-5" onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-base font-semibold mb-1">{t('documents.prototype.feedbackHeading', { defaultValue: 'Revise prototype with feedback' })}</h3>
+        <p className="text-xs text-gray-500 mb-3">{t('documents.prototype.feedbackHint', { defaultValue: 'Describe what to change. The PRD/PR-FAQ stays in effect; the prototype is re-centered on your feedback (e.g. “show the admin’s perspective”).' })}</p>
+        <textarea
+          value={feedback}
+          onChange={(e) => setFeedback(e.target.value)}
+          rows={5}
+          autoFocus
+          placeholder={t('documents.prototype.feedbackPlaceholder', { defaultValue: 'e.g. Change this to the admin dashboard view — show approvals, user management, and metrics instead of the end-user screens.' })}
+          className="w-full px-3 py-2 border rounded-lg text-sm"
+          disabled={busy}
+        />
+        {error ? <p className="text-xs text-red-600 mt-2 inline-flex items-center gap-1"><AlertCircle size={12} /> {error}</p> : null}
+        <div className="flex items-center justify-end gap-2 mt-4">
+          <button onClick={() => setOpen(false)} disabled={busy} className="px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg disabled:opacity-50">
+            {t('common.cancel', { defaultValue: 'Cancel', ns: 'common' })}
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={busy || feedback.trim() === ''}
+            className="inline-flex items-center gap-1.5 px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {busy ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+            {busy
+              ? t('documents.prototype.feedbackBuilding', { defaultValue: 'Revising…' })
+              : t('documents.prototype.feedbackSubmit', { defaultValue: 'Regenerate' })}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Prototype view: render the JSON spec natively (no iframe) ────────────────
+// PrototypeRenderer/parsePrototypeSpec moved to components/PrototypeRenderer
+// so the Prioritization page can reuse it.
+
+function PrototypeView({
+  projectId, documentId, html, title, prototypeFormat, onDocumentChanged,
+}: {
+  readonly projectId: string
+  readonly documentId: string
+  readonly html: string
+  readonly title: string
+  readonly prototypeFormat?: string
+  readonly onDocumentChanged?: () => void
+}) {
+  const { t } = useTranslation('projectDetail')
+
+  const isHtml = prototypeFormat === 'html' || (prototypeFormat === undefined && looksLikeHtmlDocument(html))
+  const spec = useMemo(() => (isHtml ? null : parsePrototypeSpec(html)), [isHtml, html])
+
+  const safeName = title.replace(/[^\w\-가-힣]+/g, '_')
+  const onDownloadHtml = useCallback(() => {
+    const blob = new Blob([html], { type: 'text/html;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${safeName}.html`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [html, safeName])
+  const onOpenInNewTab = useCallback(() => {
+    const blob = new Blob([html], { type: 'text/html;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    window.open(url, '_blank', 'noopener,noreferrer')
+    // Revoke after a tick so the new tab has time to load.
+    setTimeout(() => URL.revokeObjectURL(url), 60_000)
+  }, [html])
+  const onDownload = useCallback(() => {
+    const blob = new Blob([html], { type: 'application/json;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${safeName}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [html, safeName])
+
+  // Newer format: a self-contained HTML document → render in a sandboxed iframe.
+  if (isHtml) {
+    return (
+      <div className="flex-1 overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between mb-2 text-xs text-gray-500">
+          <span>{t('documents.prototype.previewLabel', { defaultValue: 'Live preview' })}</span>
+          <div className="flex items-center gap-3">
+            <PrototypeFeedbackButton
+              projectId={projectId}
+              basePrototypeId={documentId}
+              title={title}
+              onRegenerated={onDocumentChanged}
+              t={t}
+            />
+            <button onClick={onOpenInNewTab} className="text-blue-600 hover:underline">
+              {t('documents.prototype.openNewTab', { defaultValue: 'Open in new tab' })}
+            </button>
+            <button onClick={onDownloadHtml} className="text-blue-600 hover:underline">
+              {t('documents.prototype.downloadHtml', { defaultValue: 'Download .html' })}
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-hidden border rounded-lg bg-white">
+          <HtmlPrototypeFrame html={html} title={title} className="w-full h-full border-0 rounded-lg" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!spec) {
+    // Legacy / malformed prototype — show as plain text so the user can still inspect.
+    return (
+      <div className="flex-1 overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between mb-2 text-xs text-gray-500">
+          <span>{t('documents.prototype.rawLabel', { defaultValue: 'Raw output (parse failed — please regenerate)' })}</span>
+          <button onClick={onDownload} className="text-blue-600 hover:underline">
+            {t('documents.prototype.downloadHtml', { defaultValue: 'Download' })}
+          </button>
+        </div>
+        <pre className="flex-1 overflow-auto bg-gray-50 text-xs p-3 rounded-lg border whitespace-pre-wrap break-all">{html}</pre>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col">
+      <div className="flex items-center justify-between mb-2 text-xs text-gray-500">
+        <span>{t('documents.prototype.previewLabel', { defaultValue: 'Live preview' })}</span>
+        <button onClick={onDownload} className="text-blue-600 hover:underline">
+          {t('documents.prototype.downloadJson', { defaultValue: 'Download .json' })}
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto border rounded-lg bg-white p-4">
+        <PrototypeRenderer spec={spec} />
+      </div>
+    </div>
+  )
+}
+
+// ── Badge ───────────────────────────────────────────────────────────────────
+
 function DocumentTypeBadge({ type }: { readonly type: string }) {
   const styles: Record<string, string> = {
     prd: 'bg-blue-100 text-blue-700',
     prfaq: 'bg-green-100 text-green-700',
     custom: 'bg-purple-100 text-purple-700',
+    product_report: 'bg-indigo-100 text-indigo-700',
+    prototype: 'bg-orange-100 text-orange-700',
   }
   const style = styles[type] ?? 'bg-amber-100 text-amber-700'
 
   return (
     <span className={clsx('text-xs font-medium px-2 py-0.5 rounded', style)}>
-      {type.toUpperCase()}
+      {type.toUpperCase().replace('_', ' ')}
     </span>
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/JobsSection.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/JobsSection.tsx
@@ -112,9 +112,11 @@ function JobItemContent({
     generate_prd: 'jobs.types.generatePrd',
     generate_prfaq: 'jobs.types.generatePrfaq',
     generate_personas: 'jobs.types.generatePersonas',
+    generate_product_report: 'jobs.types.generateProductReport',
+    build_prototype: 'jobs.types.buildPrototype',
     import_persona: 'jobs.types.importPersona',
     merge_documents: 'jobs.types.mergeDocuments',
-  }[job.job_type]
+  }[job.job_type] ?? 'jobs.types.research'
 
   return (
     <div className="flex-1 min-w-0">

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
@@ -2,7 +2,7 @@
  * OverviewTab - Project overview with action cards and jobs
  */
 import {
-  Users, FileText, Search, Sparkles, Shuffle,
+  Users, FileText, Search, Sparkles, Shuffle, Package,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import KiroExportSettings from './KiroExportSettings'
@@ -18,6 +18,7 @@ interface OverviewTabProps {
   readonly onGenerateDoc: () => void
   readonly onRunResearch: () => void
   readonly onRemixDocuments: () => void
+  readonly onOpenProductTool: () => void
   readonly onSaveKiroPrompt: (prompt: string) => void
 }
 
@@ -28,6 +29,7 @@ export default function OverviewTab({
   onGenerateDoc,
   onRunResearch,
   onRemixDocuments,
+  onOpenProductTool,
   onSaveKiroPrompt,
 }: OverviewTabProps) {
   const { t } = useTranslation('projectDetail')
@@ -36,6 +38,17 @@ export default function OverviewTab({
     <div className="space-y-6">
       {/* Action Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+        <ActionCard
+          icon={<Package size={20} className="text-indigo-600" />}
+          iconBg="bg-indigo-100"
+          title={t('overview.productDescription')}
+          description={t('overview.productDescriptionDesc')}
+          buttonColor="bg-indigo-600 hover:bg-indigo-700"
+          buttonIcon={<Package size={16} />}
+          buttonLabel={t('overview.openProductTool')}
+          configureLabel=""
+          onClick={onOpenProductTool}
+        />
         <ActionCard
           icon={<Users size={20} className="text-purple-600" />}
           iconBg="bg-purple-100"

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProductTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProductTab.tsx
@@ -1,0 +1,757 @@
+/**
+ * ProductTab — capture the current product/service description that downstream
+ * PRD / PR-FAQ generation will use as context.
+ *
+ * Three operating modes (segmented control, persisted in localStorage per-project):
+ *   - chat:   AI interview only
+ *   - upload: internal-doc upload only
+ *   - both:   side-by-side
+ *
+ * After inputs are filled, "Generate report" calls a backend endpoint that
+ * synthesizes everything into a saved ProjectDocument (visible in Documents tab).
+ *
+ * All user-facing strings come from the projectDetail i18n namespace, and every
+ * Bedrock-backed call passes response_language: i18n.language so output matches
+ * the language picked in Settings.
+ */
+import {
+  MessageSquare, Upload, FileText, Trash2, Send, Loader2,
+  CheckCircle2, AlertCircle, Sparkles, FileOutput,
+} from 'lucide-react'
+import {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { projectsApi } from '../../api/projectsApi'
+import type {
+  ProductContext, ProductDoc, ProductLifecycleState,
+} from '../../api/types'
+
+const ALLOWED_MIME = {
+  'application/pdf': '.pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'text/markdown': '.md',
+  'text/plain': '.txt',
+} as const
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024
+
+const emptyContext = (): ProductContext => ({
+  product_name: '',
+  one_liner: '',
+  target_users: '',
+  problem_solved: '',
+  current_state: '',
+  key_features: '',
+  differentiators: '',
+  known_limitations: '',
+  non_goals: '',
+  success_metrics: '',
+  free_form_notes: '',
+})
+
+type Mode = 'both' | 'chat' | 'upload'
+
+const modeKey = (projectId: string) => `voc:productTabMode:${projectId}`
+
+interface ProductTabProps {
+  readonly projectId: string
+  readonly onDocumentChanged?: () => void
+}
+
+export default function ProductTab({ projectId, onDocumentChanged }: ProductTabProps) {
+  const { t, i18n } = useTranslation('projectDetail')
+  const [mode, setMode] = useState<Mode>('both')
+  const [context, setContext] = useState<ProductContext>(emptyContext)
+  const [loading, setLoading] = useState(true)
+  const [savingField, setSavingField] = useState<string | null>(null)
+  const [highlightFields, setHighlightFields] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const saved = localStorage.getItem(modeKey(projectId))
+    if (saved === 'chat' || saved === 'upload' || saved === 'both') setMode(saved)
+  }, [projectId])
+
+  const setModePersist = useCallback((m: Mode) => {
+    setMode(m)
+    localStorage.setItem(modeKey(projectId), m)
+  }, [projectId])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    projectsApi.getProductContext(projectId).then((r) => {
+      if (!cancelled) setContext({ ...emptyContext(), ...r.context })
+    }).catch((e) => {
+      console.error('Failed to load product context', e)
+    }).finally(() => {
+      if (!cancelled) setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [projectId])
+
+  const persistField = useCallback(async <K extends keyof ProductContext>(
+    field: K, value: ProductContext[K],
+  ) => {
+    setSavingField(field as string)
+    try {
+      const r = await projectsApi.updateProductContext(projectId, { [field]: value } as Partial<ProductContext>)
+      setContext({ ...emptyContext(), ...r.context })
+    } catch (e) {
+      console.error(`Failed to save ${String(field)}`, e)
+    } finally {
+      setSavingField(null)
+    }
+  }, [projectId])
+
+  const onPatchFromChat = useCallback((patch: Partial<ProductContext>, fresh: ProductContext) => {
+    setContext({ ...emptyContext(), ...fresh })
+    const keys = Object.keys(patch)
+    if (keys.length) {
+      setHighlightFields(new Set(keys))
+      setTimeout(() => setHighlightFields(new Set()), 1800)
+    }
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-gray-500">
+        <Loader2 size={20} className="animate-spin mr-2" /> {t('product.loading')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Sparkles size={18} className="text-blue-600" />
+            {t('product.title')}
+          </h2>
+          <p className="text-sm text-gray-500">{t('product.subtitle')}</p>
+        </div>
+        <ModeToggle mode={mode} onChange={setModePersist} t={t} />
+      </div>
+
+      <div className={`grid gap-4 ${mode === 'both' ? 'lg:grid-cols-2' : 'grid-cols-1'}`}>
+        <ProductForm
+          context={context}
+          savingField={savingField}
+          highlightFields={highlightFields}
+          onPersistField={persistField}
+          t={t}
+        />
+
+        <div className="space-y-4">
+          {(mode === 'chat' || mode === 'both') && (
+            <InterviewChat
+              projectId={projectId}
+              language={i18n.language}
+              onPatch={onPatchFromChat}
+              t={t}
+            />
+          )}
+          {(mode === 'upload' || mode === 'both') && (
+            <DocsUpload projectId={projectId} t={t} />
+          )}
+          <ReportCard
+            projectId={projectId}
+            language={i18n.language}
+            onDocumentChanged={onDocumentChanged}
+            t={t}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Mode toggle ─────────────────────────────────────────────────────────────
+
+type TFunc = (key: string, opts?: Record<string, unknown>) => string
+
+function ModeToggle({ mode, onChange, t }: { readonly mode: Mode; readonly onChange: (m: Mode) => void; readonly t: TFunc }) {
+  const opts: { id: Mode; labelKey: string; icon: typeof MessageSquare }[] = [
+    { id: 'both', labelKey: 'product.modeBoth', icon: Sparkles },
+    { id: 'chat', labelKey: 'product.modeChat', icon: MessageSquare },
+    { id: 'upload', labelKey: 'product.modeUpload', icon: Upload },
+  ]
+  return (
+    <div className="inline-flex rounded-lg border bg-white p-0.5 text-xs">
+      {opts.map((o) => (
+        <button
+          key={o.id}
+          onClick={() => onChange(o.id)}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md whitespace-nowrap ${
+            mode === o.id ? 'bg-blue-600 text-white' : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          <o.icon size={14} />
+          {t(o.labelKey)}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ── Form ────────────────────────────────────────────────────────────────────
+
+function ProductForm({
+  context, savingField, highlightFields, onPersistField, t,
+}: {
+  readonly context: ProductContext
+  readonly savingField: string | null
+  readonly highlightFields: Set<string>
+  readonly onPersistField: <K extends keyof ProductContext>(field: K, value: ProductContext[K]) => void
+  readonly t: TFunc
+}) {
+  const lifecycleOptions: { value: ProductLifecycleState; labelKey: string }[] = [
+    { value: '', labelKey: 'product.lifecycle.select' },
+    { value: 'idea', labelKey: 'product.lifecycle.idea' },
+    { value: 'mvp', labelKey: 'product.lifecycle.mvp' },
+    { value: 'beta', labelKey: 'product.lifecycle.beta' },
+    { value: 'ga', labelKey: 'product.lifecycle.ga' },
+    { value: 'mature', labelKey: 'product.lifecycle.mature' },
+  ]
+
+  return (
+    <div className="bg-white border rounded-xl p-4 sm:p-6 space-y-4">
+      <TextField
+        label={t('product.fields.productName')} field="product_name" value={context.product_name}
+        max={200} savingField={savingField} highlight={highlightFields.has('product_name')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('product_name', v)}
+      />
+      <TextField
+        label={t('product.fields.oneLiner')} field="one_liner" value={context.one_liner}
+        max={200} savingField={savingField} highlight={highlightFields.has('one_liner')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('one_liner', v)}
+      />
+      <SelectField
+        label={t('product.fields.currentState')} field="current_state" value={context.current_state}
+        options={lifecycleOptions.map((o) => ({ value: o.value, label: t(o.labelKey) }))}
+        savingField={savingField} highlight={highlightFields.has('current_state')}
+        onSave={(v) => onPersistField('current_state', v as ProductLifecycleState)}
+      />
+      <TextAreaField
+        label={t('product.fields.targetUsers')} field="target_users" value={context.target_users}
+        max={1000} rows={2} savingField={savingField}
+        highlight={highlightFields.has('target_users')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('target_users', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.problemSolved')} field="problem_solved" value={context.problem_solved}
+        max={2000} rows={3} savingField={savingField}
+        highlight={highlightFields.has('problem_solved')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('problem_solved', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.keyFeatures')} field="key_features" value={context.key_features}
+        max={2000} rows={3} savingField={savingField}
+        highlight={highlightFields.has('key_features')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('key_features', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.differentiators')} field="differentiators" value={context.differentiators}
+        max={2000} rows={3} savingField={savingField}
+        highlight={highlightFields.has('differentiators')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('differentiators', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.knownLimitations')} field="known_limitations" value={context.known_limitations}
+        max={2000} rows={3} savingField={savingField}
+        highlight={highlightFields.has('known_limitations')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('known_limitations', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.nonGoals')} field="non_goals" value={context.non_goals}
+        max={2000} rows={3} savingField={savingField}
+        highlight={highlightFields.has('non_goals')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('non_goals', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.successMetrics')} field="success_metrics" value={context.success_metrics}
+        max={2000} rows={3} savingField={savingField}
+        highlight={highlightFields.has('success_metrics')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('success_metrics', v)}
+      />
+      <TextAreaField
+        label={t('product.fields.freeFormNotes')} field="free_form_notes" value={context.free_form_notes}
+        max={4000} rows={4} savingField={savingField}
+        highlight={highlightFields.has('free_form_notes')}
+        placeholder={t('product.fields.placeholderEmpty')}
+        onSave={(v) => onPersistField('free_form_notes', v)}
+      />
+    </div>
+  )
+}
+
+function FieldShell({
+  label, field, savingField, highlight, children,
+}: {
+  readonly label: string
+  readonly field: string
+  readonly savingField: string | null
+  readonly highlight: boolean
+  readonly children: React.ReactNode
+}) {
+  return (
+    <div className={`transition-colors rounded-md ${highlight ? 'ring-2 ring-yellow-300 ring-offset-2 ring-offset-white' : ''}`}>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-xs font-medium text-gray-700">{label}</label>
+        {savingField === field && <Loader2 size={12} className="animate-spin text-gray-400" />}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function TextField({
+  label, field, value, max, savingField, highlight, placeholder, onSave,
+}: {
+  readonly label: string; readonly field: string; readonly value: string; readonly max: number
+  readonly savingField: string | null; readonly highlight: boolean; readonly placeholder: string
+  readonly onSave: (v: string) => void
+}) {
+  const [draft, setDraft] = useState(value)
+  useEffect(() => { setDraft(value) }, [value])
+  return (
+    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
+      <input
+        type="text"
+        value={draft}
+        maxLength={max}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { if (draft !== value) onSave(draft) }}
+        className="w-full px-3 py-2 border rounded-md text-sm"
+        placeholder={placeholder}
+      />
+    </FieldShell>
+  )
+}
+
+function TextAreaField({
+  label, field, value, max, rows, savingField, highlight, placeholder, onSave,
+}: {
+  readonly label: string; readonly field: string; readonly value: string; readonly max: number; readonly rows: number
+  readonly savingField: string | null; readonly highlight: boolean; readonly placeholder: string
+  readonly onSave: (v: string) => void
+}) {
+  const [draft, setDraft] = useState(value)
+  useEffect(() => { setDraft(value) }, [value])
+  return (
+    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
+      <textarea
+        value={draft}
+        rows={rows}
+        maxLength={max}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { if (draft !== value) onSave(draft) }}
+        className="w-full px-3 py-2 border rounded-md text-sm"
+        placeholder={placeholder}
+      />
+    </FieldShell>
+  )
+}
+
+function SelectField({
+  label, field, value, options, savingField, highlight, onSave,
+}: {
+  readonly label: string; readonly field: string; readonly value: string
+  readonly options: { value: string; label: string }[]
+  readonly savingField: string | null; readonly highlight: boolean
+  readonly onSave: (v: string) => void
+}) {
+  return (
+    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
+      <select
+        value={value}
+        onChange={(e) => onSave(e.target.value)}
+        className="w-full px-3 py-2 border rounded-md text-sm bg-white"
+      >
+        {options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+    </FieldShell>
+  )
+}
+
+// ── Interview chat ──────────────────────────────────────────────────────────
+
+interface ChatTurn { role: 'user' | 'assistant'; content: string }
+
+function InterviewChat({
+  projectId, language, onPatch, t,
+}: {
+  readonly projectId: string
+  readonly language: string
+  readonly onPatch: (patch: Partial<ProductContext>, fresh: ProductContext) => void
+  readonly t: TFunc
+}) {
+  const [history, setHistory] = useState<ChatTurn[]>([{
+    role: 'assistant',
+    content: t('product.interview.greeting'),
+  }])
+  const [input, setInput] = useState('')
+  const [busy, setBusy] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // When the language flips after mount, refresh the greeting (only if nothing else has been said).
+  useEffect(() => {
+    setHistory((prev) => (prev.length === 1
+      ? [{ role: 'assistant', content: t('product.interview.greeting') }]
+      : prev))
+    // t identity changes when language changes, so depending on it is enough.
+  }, [t])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [history])
+
+  const decode = useCallback((message: string) => {
+    if (message === '__captured__') return t('product.interview.captured')
+    if (message === '__elaborate__') return t('product.interview.elaborate')
+    return message
+  }, [t])
+
+  const send = useCallback(async () => {
+    const message = input.trim()
+    if (!message || busy) return
+    setInput('')
+    setBusy(true)
+    const nextHistory: ChatTurn[] = [...history, { role: 'user', content: message }]
+    setHistory(nextHistory)
+    try {
+      const r = await projectsApi.productContextInterview(projectId, {
+        message,
+        history: nextHistory.slice(-12),
+        response_language: language,
+      })
+      setHistory([...nextHistory, { role: 'assistant', content: decode(r.assistant_message) }])
+      if (r.applied_patch && Object.keys(r.applied_patch).length > 0) {
+        onPatch(r.applied_patch, r.context)
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Interview failed'
+      setHistory([...nextHistory, { role: 'assistant', content: `⚠️ ${msg}` }])
+    } finally {
+      setBusy(false)
+    }
+  }, [input, busy, history, projectId, onPatch, language, decode])
+
+  return (
+    <div className="bg-white border rounded-xl p-4 flex flex-col" style={{ height: 480 }}>
+      <div className="flex items-center gap-2 mb-3">
+        <MessageSquare size={16} className="text-blue-600" />
+        <h3 className="text-sm font-semibold">{t('product.interview.heading')}</h3>
+        <span className="text-xs text-gray-400">— {t('product.interview.hint')}</span>
+      </div>
+      <div ref={scrollRef} className="flex-1 overflow-y-auto space-y-3 pr-1">
+        {history.map((m, i) => (
+          <div key={i} className={`text-sm ${m.role === 'user' ? 'text-right' : ''}`}>
+            <div className={`inline-block max-w-[90%] rounded-lg px-3 py-2 whitespace-pre-wrap ${
+              m.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-800'
+            }`}>
+              {m.content}
+            </div>
+          </div>
+        ))}
+        {busy && (
+          <div className="text-xs text-gray-400 inline-flex items-center gap-1">
+            <Loader2 size={12} className="animate-spin" /> {t('product.interview.thinking')}
+          </div>
+        )}
+      </div>
+      <div className="mt-3 flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }}
+          disabled={busy}
+          placeholder={t('product.interview.placeholder')}
+          className="flex-1 px-3 py-2 border rounded-md text-sm"
+        />
+        <button
+          onClick={send}
+          disabled={busy || !input.trim()}
+          aria-label={t('product.interview.send')}
+          className="px-3 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50 inline-flex items-center gap-1"
+        >
+          <Send size={14} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Document upload ─────────────────────────────────────────────────────────
+
+function DocsUpload({ projectId, t }: { readonly projectId: string; readonly t: TFunc }) {
+  const [docs, setDocs] = useState<ProductDoc[]>([])
+  const [loading, setLoading] = useState(true)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [dragActive, setDragActive] = useState(false)
+  const fileInput = useRef<HTMLInputElement>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await projectsApi.listProductDocs(projectId)
+      setDocs(r.docs)
+    } catch (e) {
+      console.error('Failed to list product docs', e)
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const inFlight = useMemo(() => docs.some((d) => d.status === 'pending' || d.status === 'extracting'), [docs])
+  useEffect(() => {
+    if (!inFlight) return
+    const start = Date.now()
+    const id = setInterval(() => {
+      if (Date.now() - start > 60_000) { clearInterval(id); return }
+      refresh()
+    }, 3000)
+    return () => clearInterval(id)
+  }, [inFlight, refresh])
+
+  const handleFiles = useCallback(async (files: FileList | null) => {
+    if (!files) return
+    setUploadError(null)
+    for (const file of Array.from(files)) {
+      if (!(file.type in ALLOWED_MIME)) {
+        setUploadError(t('product.upload.errors.unsupportedType', { name: file.name, type: file.type || 'unknown' }))
+        continue
+      }
+      if (file.size > MAX_FILE_BYTES) {
+        setUploadError(t('product.upload.errors.tooLarge', { name: file.name }))
+        continue
+      }
+      try {
+        const presigned = await projectsApi.createProductDocUploadUrl(projectId, {
+          filename: file.name,
+          content_type: file.type,
+          size_bytes: file.size,
+        })
+        const putResp = await fetch(presigned.presigned_url, {
+          method: 'PUT',
+          headers: presigned.headers,
+          body: file,
+        })
+        if (!putResp.ok) throw new Error(`S3 PUT ${putResp.status}`)
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : 'Upload failed'
+        setUploadError(t('product.upload.errors.uploadFailed', { name: file.name, message: msg }))
+      }
+    }
+    refresh()
+    if (fileInput.current) fileInput.current.value = ''
+  }, [projectId, refresh, t])
+
+  const onDelete = useCallback(async (docId: string) => {
+    try {
+      await projectsApi.deleteProductDoc(projectId, docId)
+      refresh()
+    } catch (e) {
+      console.error('Delete failed', e)
+    }
+  }, [projectId, refresh])
+
+  return (
+    <div className="bg-white border rounded-xl p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <Upload size={16} className="text-blue-600" /> {t('product.upload.heading')}
+        </h3>
+        <span className="text-xs text-gray-400">{t('product.upload.hint')}</span>
+      </div>
+
+      {/*
+        Drag-and-drop wrapper. preventDefault on dragOver/dragEnter is required:
+        without it the browser falls back to "open the dropped file" and navigates
+        away from the app. The hidden file input still handles click-to-pick.
+      */}
+      <label
+        className={`block border-2 border-dashed rounded-lg p-4 text-center cursor-pointer transition-colors ${
+          dragActive ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-blue-400 hover:bg-blue-50'
+        }`}
+        onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true) }}
+        onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true) }}
+        onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false) }}
+        onDrop={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setDragActive(false)
+          handleFiles(e.dataTransfer.files)
+        }}
+      >
+        <input
+          ref={fileInput}
+          type="file"
+          multiple
+          accept={Object.values(ALLOWED_MIME).join(',')}
+          onChange={(e) => handleFiles(e.target.files)}
+          className="hidden"
+        />
+        <div className="text-sm text-gray-600">
+          <Upload size={20} className="mx-auto text-gray-400 mb-1" />
+          {t('product.upload.dropZone')}
+        </div>
+      </label>
+
+      {uploadError && (
+        <div className="mt-2 text-xs text-red-600 inline-flex items-center gap-1">
+          <AlertCircle size={12} /> {uploadError}
+        </div>
+      )}
+
+      <ul className="mt-3 space-y-2">
+        {loading && <li className="text-xs text-gray-400">{t('product.upload.loading')}</li>}
+        {!loading && docs.length === 0 && (
+          <li className="text-xs text-gray-400">{t('product.upload.empty')}</li>
+        )}
+        {docs.map((d) => (
+          <li key={d.doc_id} className="flex items-center justify-between border rounded-md px-3 py-2 text-sm">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <FileText size={14} className="text-gray-400 flex-shrink-0" />
+                <span className="truncate">{d.filename}</span>
+                <DocStatusBadge status={d.status} error={d.error} t={t} />
+              </div>
+              <div className="text-xs text-gray-400 mt-0.5">
+                {/* size_bytes can be 0/missing on legacy records — hide the KB
+                    label rather than rendering "0.0 KB", which reads as broken */}
+                {d.size_bytes > 0 ? `${(d.size_bytes / 1024).toFixed(1)} KB` : null}
+                {d.status === 'ready' && (d.size_bytes > 0 ? ' · ' : '') + t('product.upload.extractedChars', { count: d.extracted_chars })}
+                {d.status === 'failed' && d.error && ` · ${d.error}`}
+              </div>
+            </div>
+            <button
+              onClick={() => onDelete(d.doc_id)}
+              className="ml-2 text-gray-400 hover:text-red-600"
+              aria-label={t('product.upload.delete')}
+            >
+              <Trash2 size={14} />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function DocStatusBadge({ status, error, t }: { readonly status: ProductDoc['status']; readonly error: string | null; readonly t: TFunc }) {
+  if (status === 'ready') {
+    return <span className="inline-flex items-center gap-1 text-xs text-green-700"><CheckCircle2 size={12} /> {t('product.upload.statusReady')}</span>
+  }
+  if (status === 'failed') {
+    return <span className="inline-flex items-center gap-1 text-xs text-red-600" title={error || ''}><AlertCircle size={12} /> {t('product.upload.statusFailed')}</span>
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+      <Loader2 size={12} className="animate-spin" />
+      {status === 'pending' ? t('product.upload.statusUploading') : t('product.upload.statusExtracting')}
+    </span>
+  )
+}
+
+// ── Generate report ─────────────────────────────────────────────────────────
+
+function ReportCard({
+  projectId, language, onDocumentChanged, t,
+}: {
+  readonly projectId: string
+  readonly language: string
+  readonly onDocumentChanged?: () => void
+  readonly t: TFunc
+}) {
+  const [busy, setBusy] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Async: kick off the job, then poll until completed/failed. Polling beats a
+  // long-running fetch because API Gateway caps requests at 29s and Bedrock can
+  // take ~40s to produce a Korean report. Tolerate transient network errors so
+  // a Wi-Fi blip mid-poll doesn't kill the flow.
+  const onGenerate = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const start = await projectsApi.generateProductReport(projectId, { response_language: language })
+      const jobId = start.job_id
+      const deadline = Date.now() + 5 * 60_000
+      let consecutiveErrors = 0
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 2500))
+        let job
+        try {
+          job = await projectsApi.getJobStatus(projectId, jobId)
+          consecutiveErrors = 0
+        } catch (pollErr) {
+          consecutiveErrors += 1
+          if (consecutiveErrors >= 5) throw pollErr
+          // eslint-disable-next-line no-console -- diagnostic for transient poll failures
+          console.warn(`Job poll error ${consecutiveErrors}/5 — retrying`, pollErr)
+          continue
+        }
+        if (job.status === 'completed') {
+          setSuccess(true)
+          onDocumentChanged?.()
+          return
+        }
+        if (job.status === 'failed') {
+          throw new Error(job.error || 'Report generation failed')
+        }
+      }
+      throw new Error(t('product.report.timeout', { defaultValue: 'Report generation took too long. Check the Documents tab in a moment.' }))
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Report failed'
+      setError(msg.includes('at least one product context') || msg.includes('one product') || msg.toLowerCase().includes('add at least')
+        ? t('product.report.errorEmpty')
+        : msg)
+    } finally {
+      setBusy(false)
+    }
+  }, [projectId, language, onDocumentChanged, t])
+
+  return (
+    <div className="bg-white border rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <FileOutput size={16} className="text-emerald-600" />
+        <h3 className="text-sm font-semibold">{t('product.report.title')}</h3>
+      </div>
+      <p className="text-xs text-gray-500 mb-3">{t('product.report.description')}</p>
+      <button
+        onClick={onGenerate}
+        disabled={busy}
+        className="w-full py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg flex items-center justify-center gap-2 text-sm disabled:opacity-50"
+      >
+        {busy ? <Loader2 size={14} className="animate-spin" /> : <FileOutput size={14} />}
+        {busy ? t('product.report.generating') : t('product.report.button')}
+      </button>
+      {success && (
+        <div className="mt-2 text-xs text-emerald-700 inline-flex items-center gap-1">
+          <CheckCircle2 size={12} />
+          <span><strong>{t('product.report.successTitle')}.</strong> {t('product.report.successMessage')}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mt-2 text-xs text-red-600 inline-flex items-center gap-1">
+          <AlertCircle size={12} /> {error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-router-dom'
 import { projectsApi } from '../../api/projectsApi'
 import { useConfigStore } from '../../store/configStore'
+import BuildPrototypeButton from './BuildPrototypeButton'
 import JobsSection from './JobsSection'
 import ProjectHeader from './ProjectHeader'
 import {
@@ -174,6 +175,11 @@ export default function ProjectDetail() {
   } = data
   const jobs = jobsData?.jobs ?? []
 
+  // Prototype builds reference the project's latest PRD and PR-FAQ: both if
+  // present, otherwise whichever one exists. Enabled once at least one exists.
+  const hasPrd = documents.some((d) => d.document_type === 'prd')
+  const hasPrfaq = documents.some((d) => d.document_type === 'prfaq')
+
   return (
     <div className="space-y-6">
       <ProjectHeader
@@ -183,10 +189,26 @@ export default function ProjectDetail() {
           void navigate('/projects')
         }}
       />
-      <ProjectTabs activeTab={activeTab} personasCount={personas.length} documentsCount={documents.length} onTabChange={setActiveTab} />
+      <ProjectTabs
+        activeTab={activeTab}
+        personasCount={personas.length}
+        documentsCount={documents.length}
+        onTabChange={setActiveTab}
+        rightSlot={(
+          <BuildPrototypeButton
+            projectId={project.project_id}
+            hasPrd={hasPrd}
+            hasPrfaq={hasPrfaq}
+            onDocumentChanged={() => {
+              void queryClient.invalidateQueries({ queryKey: ['project', id] })
+            }}
+          />
+        )}
+      />
 
       <WizardSection
         activeWizard={wizard.activeWizard}
+        projectId={project.project_id}
         personas={personas}
         documents={documents}
         contextConfig={wizard.contextConfig}
@@ -231,6 +253,7 @@ export default function ProjectDetail() {
         onGenerateDoc={() => wizard.setActiveWizard('doc')}
         onRunResearch={() => wizard.setActiveWizard('research')}
         onRemixDocuments={wizard.openMergeWizard}
+        onOpenProductTool={() => setActiveTab('product')}
         onSaveKiroPrompt={handleSaveKiroPrompt}
         onSelectPersona={selection.setSelectedPersona}
         onEditPersona={() => selection.selectedPersona && selection.setEditingPersona(selection.selectedPersona)}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProjectTabs.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProjectTabs.tsx
@@ -3,10 +3,11 @@
  */
 import clsx from 'clsx'
 import {
-  Users, FileText, MessageSquare, Sparkles, Key,
+  Users, FileText, MessageSquare, Sparkles, Key, Package,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { Tab } from './types'
+import type { ReactNode } from 'react'
 
 const TABS: readonly {
   id: Tab;
@@ -22,6 +23,11 @@ const TABS: readonly {
     id: 'personas',
     labelKey: 'tabs.personas',
     icon: Users,
+  },
+  {
+    id: 'product',
+    labelKey: 'tabs.product',
+    icon: Package,
   },
   {
     id: 'documents',
@@ -45,33 +51,38 @@ interface ProjectTabsProps {
   readonly personasCount: number
   readonly documentsCount: number
   readonly onTabChange: (tab: Tab) => void
+  // Rendered at the far right of the tab row (e.g. the Build Prototype button).
+  readonly rightSlot?: ReactNode
 }
 
 export default function ProjectTabs({
-  activeTab, personasCount, documentsCount, onTabChange,
+  activeTab, personasCount, documentsCount, onTabChange, rightSlot,
 }: ProjectTabsProps) {
   const { t } = useTranslation('projectDetail')
 
   return (
-    <div className="border-b border-gray-200 -mx-4 px-4 sm:mx-0 sm:px-0 overflow-x-auto">
-      <nav className="flex gap-4 sm:gap-6 min-w-max">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => onTabChange(tab.id)}
-            className={clsx(
-              'flex items-center gap-1.5 sm:gap-2 py-3 border-b-2 text-xs sm:text-sm font-medium whitespace-nowrap',
-              activeTab === tab.id
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700',
-            )}
-          >
-            <tab.icon size={16} />
-            {t(tab.labelKey)} {tab.id === 'personas' && `(${personasCount})`}
-            {tab.id === 'documents' && `(${documentsCount})`}
-          </button>
-        ))}
-      </nav>
+    <div className="border-b border-gray-200 -mx-4 px-4 sm:mx-0 sm:px-0">
+      <div className="flex items-center justify-between gap-3">
+        <nav className="flex gap-4 sm:gap-6 min-w-max overflow-x-auto">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => onTabChange(tab.id)}
+              className={clsx(
+                'flex items-center gap-1.5 sm:gap-2 py-3 border-b-2 text-xs sm:text-sm font-medium whitespace-nowrap',
+                activeTab === tab.id
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700',
+              )}
+            >
+              <tab.icon size={16} />
+              {t(tab.labelKey)} {tab.id === 'personas' && `(${personasCount})`}
+              {tab.id === 'documents' && `(${documentsCount})`}
+            </button>
+          ))}
+        </nav>
+        {rightSlot == null ? null : <div className="flex-shrink-0 py-1.5">{rightSlot}</div>}
+      </div>
     </div>
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/TabContent.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/TabContent.tsx
@@ -6,6 +6,7 @@ import DocumentsTab from './DocumentsTab'
 import McpAccessTab from './McpAccessTab'
 import OverviewTab from './OverviewTab'
 import PersonasTab from './PersonasTab'
+import ProductTab from './ProductTab'
 import type {
   Tab, NoteItem,
 } from './types'
@@ -26,6 +27,7 @@ interface TabContentProps {
   readonly onGenerateDoc: () => void
   readonly onRunResearch: () => void
   readonly onRemixDocuments: () => void
+  readonly onOpenProductTool: () => void
   readonly onSaveKiroPrompt: (prompt: string) => void
   readonly onSelectPersona: (p: ProjectPersona | null) => void
   readonly onEditPersona: () => void
@@ -53,6 +55,7 @@ export default function TabContent({
   onGenerateDoc,
   onRunResearch,
   onRemixDocuments,
+  onOpenProductTool,
   onSaveKiroPrompt,
   onSelectPersona,
   onEditPersona,
@@ -76,6 +79,7 @@ export default function TabContent({
         onGenerateDoc={onGenerateDoc}
         onRunResearch={onRunResearch}
         onRemixDocuments={onRemixDocuments}
+        onOpenProductTool={onOpenProductTool}
         onSaveKiroPrompt={onSaveKiroPrompt}
       />
     )
@@ -98,6 +102,10 @@ export default function TabContent({
     )
   }
 
+  if (activeTab === 'product') {
+    return <ProductTab projectId={project.project_id} onDocumentChanged={onDocumentChanged} />
+  }
+
   if (activeTab === 'documents') {
     return (
       <DocumentsTab
@@ -108,6 +116,7 @@ export default function TabContent({
         onEditDoc={onEditDoc}
         onDeleteDoc={onDeleteDoc}
         onCreateDoc={onCreateDoc}
+        onDocumentChanged={onDocumentChanged}
         isDeleting={isDeleting}
       />
     )

--- a/voc-datalake/frontend/src/pages/ProjectDetail/WizardSection.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/WizardSection.tsx
@@ -16,6 +16,7 @@ type WizardType = 'persona' | 'research' | 'doc' | 'merge' | null
 
 interface WizardSectionProps {
   readonly activeWizard: WizardType
+  readonly projectId: string
   readonly personas: ProjectPersona[]
   readonly documents: ProjectDocument[]
   readonly contextConfig: ContextConfig
@@ -38,6 +39,7 @@ interface WizardSectionProps {
 
 export default function WizardSection({
   activeWizard,
+  projectId,
   personas,
   documents,
   contextConfig,
@@ -76,6 +78,7 @@ export default function WizardSection({
   if (activeWizard === 'research') {
     return (
       <ResearchWizard
+        projectId={projectId}
         personas={personas}
         documents={documents}
         contextConfig={contextConfig}
@@ -92,6 +95,7 @@ export default function WizardSection({
   if (activeWizard === 'doc') {
     return (
       <DocWizard
+        projectId={projectId}
         personas={personas}
         documents={documents}
         contextConfig={contextConfig}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -3,8 +3,11 @@
  */
 import clsx from 'clsx'
 import {
-  Users, FileText, Search, Shuffle, Sparkles,
+  Users, FileText, Search, Shuffle, Sparkles, Loader2, Wand2,
 } from 'lucide-react'
+import { useState, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { projectsApi } from '../../api/projectsApi'
 import DataSourceWizard from '../../components/DataSourceWizard'
 import ContextSummary from '../../components/DataSourceWizard/ContextSummary'
 import type {
@@ -68,6 +71,7 @@ export function PersonaWizard({
 }
 
 interface ResearchWizardProps {
+  readonly projectId: string
   readonly personas: ProjectPersona[]
   readonly documents: ProjectDocument[]
   readonly contextConfig: ContextConfig
@@ -80,8 +84,38 @@ interface ResearchWizardProps {
 }
 
 export function ResearchWizard({
-  personas, documents, contextConfig, researchConfig, generating, onContextChange, onResearchConfigChange, onClose, onSubmit,
+  projectId, personas, documents, contextConfig, researchConfig, generating, onContextChange, onResearchConfigChange, onClose, onSubmit,
 }: ResearchWizardProps) {
+  const { t, i18n } = useTranslation('projectDetail')
+  const [suggesting, setSuggesting] = useState(false)
+  const [suggestError, setSuggestError] = useState<string | null>(null)
+  const [suggestions, setSuggestions] = useState<Array<{ title: string; question: string }>>([])
+
+  const onSuggest = useCallback(async () => {
+    setSuggesting(true)
+    setSuggestError(null)
+    try {
+      const r = await projectsApi.suggestResearchQuestions(projectId, { response_language: i18n.language })
+      const list = r.suggestions ?? []
+      setSuggestions(list)
+      if (list.length === 0) {
+        setSuggestError(t('wizards.researchSuggestEmpty', { defaultValue: 'No suggestions — add or collect more feedback first.' }))
+      }
+    } catch (e: unknown) {
+      setSuggestError(e instanceof Error ? e.message : 'Failed to suggest questions')
+    } finally {
+      setSuggesting(false)
+    }
+  }, [projectId, i18n.language, t])
+
+  const applySuggestion = useCallback((s: { title: string; question: string }) => {
+    onResearchConfigChange({
+      ...researchConfig,
+      question: s.question,
+      title: researchConfig.title.trim() === '' ? s.title : researchConfig.title,
+    })
+  }, [researchConfig, onResearchConfigChange])
+
   return (
     <DataSourceWizard
       title="Run Research"
@@ -94,18 +128,49 @@ export function ResearchWizard({
       renderFinalStep={() => (
         <div className="space-y-6">
           <div>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="font-medium">Research Question</h3>
+              <button
+                type="button"
+                onClick={onSuggest}
+                disabled={suggesting}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-sm text-amber-700 bg-amber-50 hover:bg-amber-100 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                title={t('wizards.researchSuggestTitle', { defaultValue: 'Let AI suggest research questions from this project’s feedback' })}
+              >
+                {suggesting ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+                {suggesting
+                  ? t('wizards.researchSuggesting', { defaultValue: 'Suggesting…' })
+                  : t('wizards.researchSuggest', { defaultValue: 'AI suggest' })}
+              </button>
+            </div>
+            <textarea value={researchConfig.question} onChange={(e) => onResearchConfigChange({
+              ...researchConfig,
+              question: e.target.value,
+            })} placeholder="e.g., What are the main pain points..." rows={4} className="w-full px-3 py-2 border rounded-lg" />
+            {suggestError ? <p className="text-xs text-red-600 mt-1">{suggestError}</p> : null}
+            {suggestions.length > 0 ? (
+              <div className="mt-3 space-y-2">
+                <p className="text-xs text-gray-500">{t('wizards.researchSuggestPick', { defaultValue: 'Tap a suggestion to use it:' })}</p>
+                {suggestions.map((s, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => applySuggestion(s)}
+                    className="block w-full text-left p-2.5 border rounded-lg hover:border-amber-400 hover:bg-amber-50 transition-colors"
+                  >
+                    <span className="block text-sm font-medium text-gray-800">{s.title || s.question}</span>
+                    {s.title ? <span className="block text-xs text-gray-500 mt-0.5">{s.question}</span> : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <div>
             <h3 className="font-medium mb-3">Research Title</h3>
             <input type="text" value={researchConfig.title} onChange={(e) => onResearchConfigChange({
               ...researchConfig,
               title: e.target.value,
             })} placeholder="e.g., Delivery Pain Points Analysis" className="w-full px-3 py-2 border rounded-lg" />
-          </div>
-          <div>
-            <h3 className="font-medium mb-3">Research Question</h3>
-            <textarea value={researchConfig.question} onChange={(e) => onResearchConfigChange({
-              ...researchConfig,
-              question: e.target.value,
-            })} placeholder="e.g., What are the main pain points..." rows={4} className="w-full px-3 py-2 border rounded-lg" />
           </div>
           <ContextSummary config={contextConfig} personas={personas} documents={documents} />
         </div>
@@ -120,6 +185,7 @@ export function ResearchWizard({
 }
 
 interface DocWizardProps {
+  readonly projectId: string
   readonly personas: ProjectPersona[]
   readonly documents: ProjectDocument[]
   readonly contextConfig: ContextConfig
@@ -132,8 +198,25 @@ interface DocWizardProps {
 }
 
 export function DocWizard({
-  personas, documents, contextConfig, docConfig, generating, onContextChange, onDocConfigChange, onClose, onSubmit,
+  projectId, personas, documents, contextConfig, docConfig, generating, onContextChange, onDocConfigChange, onClose, onSubmit,
 }: DocWizardProps) {
+  const { t, i18n } = useTranslation('projectDetail')
+  const [autofilling, setAutofilling] = useState(false)
+  const [autofillError, setAutofillError] = useState<string | null>(null)
+  const [briefing, setBriefing] = useState(false)
+  const [briefError, setBriefError] = useState<string | null>(null)
+
+  const docTypes = docConfig.docTypes
+  const hasPrfaq = docTypes.includes('prfaq')
+  const hasPrd = docTypes.includes('prd')
+
+  const toggleDocType = (type: 'prd' | 'prfaq') => {
+    const next = docTypes.includes(type)
+      ? docTypes.filter((d) => d !== type)
+      : [...docTypes, type]
+    onDocConfigChange({ ...docConfig, docTypes: next })
+  }
+
   const updateQuestion = (index: number, value: string) => {
     const newQuestions = [...docConfig.customerQuestions]
     newQuestions[index] = value
@@ -143,38 +226,68 @@ export function DocWizard({
     })
   }
 
-  // Amazon's 5 Customer Questions for Working Backwards PR-FAQ
-  const amazonQuestions = [
-    {
-      title: 'Who is the customer?',
-      description: 'Define your target customer segment. Be specific about demographics, behaviors, and characteristics.',
-      placeholder: 'e.g., Busy professionals aged 25-45 who order food delivery at least 3x per week...',
-    },
-    {
-      title: 'What is the customer problem or opportunity?',
-      description: 'Describe the pain point or unmet need. What frustrates them today? What opportunity exists?',
-      placeholder: 'e.g., Customers waste 10+ minutes tracking multiple delivery apps and often miss deliveries...',
-    },
-    {
-      title: 'What is the most important customer benefit?',
-      description: 'State the single most compelling benefit. How will their life improve? Be specific and measurable.',
-      placeholder: 'e.g., Save 15 minutes per order with unified tracking and never miss a delivery again...',
-    },
-    {
-      title: 'How do you know what customers need or want?',
-      description: 'Provide evidence: customer research, feedback data, surveys, interviews, or market analysis.',
-      placeholder: 'e.g., 78% of surveyed users reported frustration with tracking across multiple apps...',
-    },
-    {
-      title: 'What does the customer experience look like?',
-      description: 'Walk through the end-to-end experience. How will customers discover, use, and benefit from this?',
-      placeholder: 'e.g., Customer opens the app, sees all deliveries in one view, gets smart notifications...',
-    },
-  ]
+  // AI-draft the feature title + description from project context so the user
+  // doesn't start from an empty box.
+  const onSuggestBrief = useCallback(async () => {
+    setBriefing(true)
+    setBriefError(null)
+    try {
+      const r = await projectsApi.suggestDocumentBrief(projectId, {
+        doc_type: docConfig.docTypes.includes('prd') ? 'prd' : 'prfaq',
+        response_language: i18n.language,
+      })
+      onDocConfigChange({
+        ...docConfig,
+        title: r.title || docConfig.title,
+        featureIdea: r.feature_idea || docConfig.featureIdea,
+      })
+      if (!r.title && !r.feature_idea) {
+        setBriefError(t('wizards.briefEmpty', { defaultValue: 'No draft — add or collect more feedback first.' }))
+      }
+    } catch (e: unknown) {
+      setBriefError(e instanceof Error ? e.message : 'Draft failed')
+    } finally {
+      setBriefing(false)
+    }
+  }, [projectId, docConfig, i18n.language, onDocConfigChange, t])
+
+  // Amazon's 5 Customer Questions for Working Backwards PR-FAQ. Pulled from
+  // i18n so the entire wizard matches the user's chosen language (the labels
+  // were hardcoded English even when the rest of the UI was Korean).
+  const amazonQuestions = [1, 2, 3, 4, 5].map((n) => ({
+    title: t(`wizards.question${n}Title`),
+    description: t(`wizards.question${n}Desc`),
+    placeholder: t(`wizards.question${n}Placeholder`),
+  }))
+
+  const onAutofill = useCallback(async () => {
+    setAutofilling(true)
+    setAutofillError(null)
+    try {
+      const r = await projectsApi.autofillPrfaqQuestions(projectId, {
+        feature_idea: docConfig.featureIdea,
+        title: docConfig.title,
+        response_language: i18n.language,
+      })
+      const answers = (r.answers || []).slice(0, 5)
+      const padded: string[] = [...answers, '', '', '', '', ''].slice(0, 5)
+      onDocConfigChange({ ...docConfig, customerQuestions: padded })
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Autofill failed'
+      setAutofillError(msg)
+    } finally {
+      setAutofilling(false)
+    }
+  }, [projectId, docConfig, i18n.language, onDocConfigChange])
+
+  const docCount = docTypes.length
+  const bothSelected = hasPrd && hasPrfaq
 
   return (
     <DataSourceWizard
-      title={`Generate ${docConfig.docType === 'prd' ? 'PRD' : 'PR-FAQ'}`}
+      title={bothSelected
+        ? t('wizards.generateBothTitle', { defaultValue: 'Generate PRD + PR-FAQ' })
+        : t(hasPrd ? 'wizards.generatePrdTitle' : 'wizards.generatePrfaqTitle', { defaultValue: hasPrd ? 'Generate PRD' : 'Generate PR-FAQ' })}
       accentColor="blue"
       icon={<div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center"><FileText size={20} className="text-blue-600" /></div>}
       personas={personas}
@@ -184,47 +297,73 @@ export function DocWizard({
       renderFinalStep={() => (
         <div className="space-y-6">
           <div>
-            <h3 className="font-medium mb-3">Document Type</h3>
+            <h3 className="font-medium mb-1">{t('wizards.documentType', { defaultValue: 'Document Type' })}</h3>
+            <p className="text-xs text-gray-500 mb-3">{t('wizards.documentTypeHint', { defaultValue: 'Select one or both — both are generated at once.' })}</p>
             <div className="grid grid-cols-2 gap-3">
-              <button onClick={() => onDocConfigChange({
-                ...docConfig,
-                docType: 'prfaq',
-              })} className={clsx('p-4 rounded-lg border text-left', docConfig.docType === 'prfaq' ? 'bg-green-50 border-green-300' : 'bg-white border-gray-200')}>
-                <div className="font-medium">PR-FAQ</div>
-                <div className="text-sm text-gray-500">Amazon-style Press Release & FAQ</div>
+              <button type="button" onClick={() => toggleDocType('prfaq')} className={clsx('p-4 rounded-lg border text-left relative', hasPrfaq ? 'bg-green-50 border-green-300' : 'bg-white border-gray-200')}>
+                {hasPrfaq ? <span className="absolute top-2 right-2 text-green-600 text-xs">✓</span> : null}
+                <div className="font-medium">{t('wizards.prfaqLabel', { defaultValue: 'PR-FAQ' })}</div>
+                <div className="text-sm text-gray-500">{t('wizards.prfaqDesc', { defaultValue: 'Amazon-style Press Release & FAQ' })}</div>
               </button>
-              <button onClick={() => onDocConfigChange({
-                ...docConfig,
-                docType: 'prd',
-              })} className={clsx('p-4 rounded-lg border text-left', docConfig.docType === 'prd' ? 'bg-blue-50 border-blue-300' : 'bg-white border-gray-200')}>
-                <div className="font-medium">PRD</div>
-                <div className="text-sm text-gray-500">Product Requirements Document</div>
+              <button type="button" onClick={() => toggleDocType('prd')} className={clsx('p-4 rounded-lg border text-left relative', hasPrd ? 'bg-blue-50 border-blue-300' : 'bg-white border-gray-200')}>
+                {hasPrd ? <span className="absolute top-2 right-2 text-blue-600 text-xs">✓</span> : null}
+                <div className="font-medium">{t('wizards.prdLabel', { defaultValue: 'PRD' })}</div>
+                <div className="text-sm text-gray-500">{t('wizards.prdDesc', { defaultValue: 'Product Requirements Document' })}</div>
               </button>
             </div>
           </div>
           <div>
-            <h3 className="font-medium mb-3">Feature/Product Title</h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="font-medium">{t('wizards.featureTitle', { defaultValue: 'Feature/Product Title' })}</h3>
+              <button
+                type="button"
+                onClick={onSuggestBrief}
+                disabled={briefing}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-sm text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                title={t('wizards.briefTitle', { defaultValue: 'Let AI draft the title and description from this project’s feedback' })}
+              >
+                {briefing ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+                {briefing
+                  ? t('wizards.briefLoading', { defaultValue: 'Drafting…' })
+                  : t('wizards.briefButton', { defaultValue: 'AI draft' })}
+              </button>
+            </div>
             <input type="text" value={docConfig.title} onChange={(e) => onDocConfigChange({
               ...docConfig,
               title: e.target.value,
-            })} placeholder="e.g., Real-time Delivery Tracking" className="w-full px-3 py-2 border rounded-lg" />
+            })} placeholder={t('wizards.featureTitlePlaceholder', { defaultValue: 'e.g., Real-time Delivery Tracking' })} className="w-full px-3 py-2 border rounded-lg" />
+            {briefError ? <p className="text-xs text-red-600 mt-1">{briefError}</p> : null}
           </div>
           <div>
-            <h3 className="font-medium mb-3">Feature Description</h3>
+            <h3 className="font-medium mb-3">{t('wizards.featureDescription', { defaultValue: 'Feature Description' })}</h3>
             <textarea value={docConfig.featureIdea} onChange={(e) => onDocConfigChange({
               ...docConfig,
               featureIdea: e.target.value,
-            })} placeholder="Describe the feature..." rows={3} className="w-full px-3 py-2 border rounded-lg" />
+            })} placeholder={t('wizards.featureDescriptionPlaceholder', { defaultValue: 'Describe the feature...' })} rows={3} className="w-full px-3 py-2 border rounded-lg" />
           </div>
-          {docConfig.docType === 'prfaq' && (
+          {hasPrfaq && (
             <div className="border-t pt-6">
-              <div className="flex items-center gap-2 mb-4">
-                <h3 className="font-medium">Amazon's 5 Customer Questions</h3>
-                <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded">Working Backwards</span>
+              <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">
+                <div className="flex items-center gap-2">
+                  <h3 className="font-medium">{t('wizards.amazonQuestions')}</h3>
+                  <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded">{t('wizards.workingBackwards', { defaultValue: 'Working Backwards' })}</span>
+                </div>
+                <button
+                  onClick={onAutofill}
+                  disabled={autofilling}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 hover:bg-purple-700 text-white rounded-md text-xs disabled:opacity-50"
+                  title={t('wizards.autofillTitle', { defaultValue: 'Pre-populate the 5 questions using personas, feedback, and product context' })}
+                >
+                  {autofilling ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
+                  {autofilling
+                    ? t('wizards.autofillLoading', { defaultValue: 'Drafting…' })
+                    : t('wizards.autofillButton', { defaultValue: 'AI draft answers' })}
+                </button>
               </div>
-              <p className="text-sm text-gray-500 mb-4">
-                Answer these questions to create a customer-focused PR-FAQ. The more detail you provide, the better the output.
-              </p>
+              <p className="text-sm text-gray-500 mb-4">{t('wizards.amazonQuestionsHint')}</p>
+              {autofillError ? (
+                <p className="text-xs text-red-600 mb-3">⚠ {autofillError}</p>
+              ) : null}
               <div className="space-y-4">
                 {amazonQuestions.map((q, index) => (
                   <div key={q.title} className="bg-gray-50 rounded-lg p-4">
@@ -241,7 +380,7 @@ export function DocWizard({
                       value={docConfig.customerQuestions[index] ?? ''}
                       onChange={(e) => updateQuestion(index, e.target.value)}
                       placeholder={q.placeholder}
-                      rows={2}
+                      rows={3}
                       className="w-full px-3 py-2 border rounded-lg text-sm mt-2"
                     />
                   </div>
@@ -252,11 +391,13 @@ export function DocWizard({
           <ContextSummary config={contextConfig} personas={personas} documents={documents} />
         </div>
       )}
-      finalStepValid={docConfig.title.trim() !== '' && docConfig.featureIdea.trim() !== ''}
+      finalStepValid={docConfig.title.trim() !== '' && docConfig.featureIdea.trim() !== '' && docCount > 0}
       onClose={onClose}
       onSubmit={onSubmit}
       isSubmitting={generating === 'doc'}
-      submitLabel={<><FileText size={16} />Generate {docConfig.docType === 'prd' ? 'PRD' : 'PR-FAQ'}</>}
+      submitLabel={<><FileText size={16} />{bothSelected
+        ? t('wizards.generateBoth', { defaultValue: 'Generate PRD + PR-FAQ' })
+        : t(hasPrd ? 'wizards.generatePrd' : 'wizards.generatePrfaq', { defaultValue: hasPrd ? 'Generate PRD' : 'Generate PR-FAQ' })}</>}
     />
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/chatFinalize.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/chatFinalize.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure helpers for turning a finished chat stream into committed ChatMessages.
+ * Extracted from chatTabHooks.ts to keep that file under the max-lines limit.
+ */
+import type {
+  ChatMessage, DocumentChangeInfo, ActivePersonaInfo,
+} from './ChatBubbles'
+import type { ToolStep } from '../../hooks/useStreamChat'
+
+export interface CompletedTurn {
+  persona: {
+    persona_id: string;
+    name: string;
+    avatar_url?: string
+  }
+  content: string
+  thinking?: string
+}
+
+export interface StreamSnapshot {
+  text: string
+  thinking: string
+  error: string | null
+  changes: DocumentChangeInfo[]
+  toolSteps: ToolStep[]
+  persona: ActivePersonaInfo | undefined
+  turns: CompletedTurn[]
+  curPersona: {
+    persona_id: string;
+    name: string;
+    avatar_url?: string
+  } | null
+}
+
+function buildRoundtableMessages(snapshot: StreamSnapshot): ChatMessage[] {
+  const {
+    text, turns, curPersona,
+  } = snapshot
+  const newMessages: ChatMessage[] = turns.map((turn) => ({
+    role: 'assistant' as const,
+    content: turn.content,
+    activePersona: {
+      name: turn.persona.name,
+      avatar_url: turn.persona.avatar_url,
+    },
+  }))
+  if (text !== '' && curPersona) {
+    newMessages.push({
+      role: 'assistant',
+      content: text,
+      activePersona: {
+        name: curPersona.name,
+        avatar_url: curPersona.avatar_url,
+      },
+    })
+  }
+  return newMessages
+}
+
+export function buildFinalizedMessages(snapshot: StreamSnapshot): ChatMessage[] {
+  const {
+    text, error, changes, toolSteps, persona, turns, curPersona,
+  } = snapshot
+  const isRoundtable = turns.length > 0 || curPersona !== null
+
+  if (isRoundtable) return buildRoundtableMessages(snapshot)
+  if (text !== '') {
+    return [{
+      role: 'assistant',
+      content: text,
+      documentChanges: changes.length > 0 ? changes : undefined,
+      toolSteps: toolSteps.length > 0 ? toolSteps : undefined,
+      activePersona: persona,
+    }]
+  }
+  if (error != null && error !== '') return [{
+    role: 'assistant',
+    content: `Error: ${error}`,
+  }]
+  return []
+}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/chatTabHooks.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/chatTabHooks.ts
@@ -4,6 +4,9 @@
 import {
   useState, useCallback, useRef, useEffect,
 } from 'react'
+import {
+  buildFinalizedMessages, type CompletedTurn, type StreamSnapshot,
+} from './chatFinalize'
 import type {
   ChatMessage, ChatAttachment, DocumentChangeInfo, ActivePersonaInfo,
 } from './ChatBubbles'
@@ -198,79 +201,6 @@ export function resolveActivePersona(
 
 // ── Stream finalize hook ──
 
-interface CompletedTurn {
-  persona: {
-    persona_id: string;
-    name: string;
-    avatar_url?: string
-  }
-  content: string
-  thinking?: string
-}
-
-interface StreamSnapshot {
-  text: string
-  thinking: string
-  error: string | null
-  changes: DocumentChangeInfo[]
-  toolSteps: ToolStep[]
-  persona: ActivePersonaInfo | undefined
-  turns: CompletedTurn[]
-  curPersona: {
-    persona_id: string;
-    name: string;
-    avatar_url?: string
-  } | null
-}
-
-function buildRoundtableMessages(snapshot: StreamSnapshot): ChatMessage[] {
-  const {
-    text, turns, curPersona,
-  } = snapshot
-  const newMessages: ChatMessage[] = turns.map((turn) => ({
-    role: 'assistant' as const,
-    content: turn.content,
-    activePersona: {
-      name: turn.persona.name,
-      avatar_url: turn.persona.avatar_url,
-    },
-  }))
-  if (text !== '' && curPersona) {
-    newMessages.push({
-      role: 'assistant',
-      content: text,
-      activePersona: {
-        name: curPersona.name,
-        avatar_url: curPersona.avatar_url,
-      },
-    })
-  }
-  return newMessages
-}
-
-function buildFinalizedMessages(snapshot: StreamSnapshot): ChatMessage[] {
-  const {
-    text, error, changes, toolSteps, persona, turns, curPersona,
-  } = snapshot
-  const isRoundtable = turns.length > 0 || curPersona !== null
-
-  if (isRoundtable) return buildRoundtableMessages(snapshot)
-  if (text !== '') {
-    return [{
-      role: 'assistant',
-      content: text,
-      documentChanges: changes.length > 0 ? changes : undefined,
-      toolSteps: toolSteps.length > 0 ? toolSteps : undefined,
-      activePersona: persona,
-    }]
-  }
-  if (error != null && error !== '') return [{
-    role: 'assistant',
-    content: `Error: ${error}`,
-  }]
-  return []
-}
-
 interface UseStreamFinalizeOptions {
   isStreaming: boolean
   streamingText: string
@@ -304,6 +234,7 @@ export function useStreamFinalize(options: UseStreamFinalizeOptions) {
     activePersona,
     completedTurns,
     currentPersona,
+    onDocumentChanged,
   })
   useEffect(() => {
     latestRef.current = {
@@ -315,9 +246,13 @@ export function useStreamFinalize(options: UseStreamFinalizeOptions) {
       activePersona,
       completedTurns,
       currentPersona,
+      onDocumentChanged,
     }
   })
 
+  // onDocumentChanged lives in latestRef (not a finalize-effect dependency):
+  // the parent's inline callback changes identity every render and would
+  // otherwise re-run the effect mid-stream, dropping the reply ("응답 안 뜨고 멈춤").
   const prevStreamingRef = useRef(false)
   useEffect(() => {
     const ref = latestRef.current
@@ -334,10 +269,12 @@ export function useStreamFinalize(options: UseStreamFinalizeOptions) {
       }
       const newMessages = buildFinalizedMessages(snapshot)
       if (newMessages.length > 0) setMessages((prev) => [...prev, ...newMessages])
-      if (onDocumentChanged) onDocumentChanged()
+      // Refetch project data only when a document actually changed — avoids an
+      // invalidate→re-render storm on every plain chat reply.
+      if (ref.documentChanges.length > 0 && ref.onDocumentChanged) ref.onDocumentChanged()
     }
     prevStreamingRef.current = isStreaming
-  }, [isStreaming, setMessages, onDocumentChanged])
+  }, [isStreaming, setMessages])
 }
 
 // ── Attachments hook ──

--- a/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
@@ -5,7 +5,7 @@ import type {
   ProjectPersona, Project,
 } from '../../api/types'
 
-export type Tab = 'overview' | 'personas' | 'documents' | 'chat' | 'mcp'
+export type Tab = 'overview' | 'personas' | 'product' | 'documents' | 'chat' | 'mcp'
 
 export type NoteItem = string | {
   note_id?: string;
@@ -23,8 +23,12 @@ export interface ResearchToolConfig {
   title: string
 }
 
+export type DocType = 'prd' | 'prfaq'
+
 export interface DocToolConfig {
-  docType: 'prd' | 'prfaq'
+  // Which documents to generate. Both can be selected to generate PRD + PR-FAQ
+  // in one go (each runs as its own async job).
+  docTypes: DocType[]
   title: string
   featureIdea: string
   customerQuestions: string[]

--- a/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
@@ -110,24 +110,29 @@ export function useProjectMutations({
   })
 
   const docMut = useMutation({
-    mutationFn: () => projectsApi.generateDocument(projectId, {
-      doc_type: docConfig.docType,
-      title: docConfig.title,
-      feature_idea: docConfig.featureIdea,
-      data_sources: {
-        feedback: contextConfig.useFeedback,
-        personas: contextConfig.usePersonas,
-        documents: contextConfig.useDocuments,
-        research: contextConfig.useResearch,
-      },
-      selected_persona_ids: contextConfig.selectedPersonaIds,
-      selected_document_ids: [...contextConfig.selectedDocumentIds, ...contextConfig.selectedResearchIds],
-      feedback_sources: contextConfig.sources,
-      feedback_categories: contextConfig.categories,
-      days: contextConfig.days,
-      customer_questions: docConfig.customerQuestions.filter((q) => q.trim() !== ''),
-      response_language: i18n.language,
-    }),
+    // One or both of PRD / PR-FAQ may be selected. Each fires as its own async
+    // job (they run in parallel server-side), so the user can request both at once.
+    mutationFn: async () => {
+      const types = docConfig.docTypes.length > 0 ? docConfig.docTypes : ['prfaq' as const]
+      const base = {
+        title: docConfig.title,
+        feature_idea: docConfig.featureIdea,
+        data_sources: {
+          feedback: contextConfig.useFeedback,
+          personas: contextConfig.usePersonas,
+          documents: contextConfig.useDocuments,
+          research: contextConfig.useResearch,
+        },
+        selected_persona_ids: contextConfig.selectedPersonaIds,
+        selected_document_ids: [...contextConfig.selectedDocumentIds, ...contextConfig.selectedResearchIds],
+        feedback_sources: contextConfig.sources,
+        feedback_categories: contextConfig.categories,
+        days: contextConfig.days,
+        customer_questions: docConfig.customerQuestions.filter((q) => q.trim() !== ''),
+        response_language: i18n.language,
+      }
+      return Promise.all(types.map((doc_type) => projectsApi.generateDocument(projectId, { doc_type, ...base })))
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['project-jobs', id] })
       onSuccess()

--- a/voc-datalake/frontend/src/pages/ProjectDetail/useProjectWizardState.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/useProjectWizardState.ts
@@ -22,7 +22,7 @@ const DEFAULT_RESEARCH_CONFIG: ResearchToolConfig = {
   title: '',
 }
 const DEFAULT_DOC_CONFIG: DocToolConfig = {
-  docType: 'prfaq',
+  docTypes: ['prfaq'],
   title: '',
   featureIdea: '',
   customerQuestions: ['', '', '', '', ''],

--- a/voc-datalake/lambda/api/product_context.py
+++ b/voc-datalake/lambda/api/product_context.py
@@ -1,0 +1,704 @@
+"""
+Product/service description input — per-project context that feeds PRD/PR-FAQ generation.
+
+Three pieces:
+  1. ProductContext  — single mutable record per project (structured fields + free-form notes).
+  2. ProductDoc      — internal documents uploaded by the user; extracted to text by an
+                       S3-triggered extractor lambda (see lambda/product_doc_extractor).
+  3. interview_turn  — one round of AI interview chat. The model uses a `update_product_context`
+                       tool to patch the structured record; the assistant text is the user-facing
+                       reply. Synchronous, returns {assistant_message, applied_patch} for simplicity.
+
+`build_product_context_block(project_id) -> str` is consumed by projects.generate_prd /
+generate_prfaq and substituted into the {product_context} placeholder.
+"""
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+
+from boto3.dynamodb.conditions import Key
+
+from shared.logging import logger, tracer
+from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from shared.exceptions import (
+    ConfigurationError, NotFoundError, ValidationError, ServiceError,
+)
+from shared.tables import get_projects_table
+
+
+projects_table = get_projects_table()
+dynamodb = get_dynamodb_resource()
+s3 = None
+
+
+def _s3():
+    """
+    Lazy S3 client. Forces SigV4 + the bucket's actual region:
+    KMS-encrypted buckets reject SigV2 presigned URLs with HTTP 400
+    ("Requests specifying Server Side Encryption with AWS KMS managed keys
+    require AWS Signature Version 4."), and boto3's default signature in some
+    legacy paths is SigV2. Specifying region_name also avoids the path-style
+    redirect that breaks browser PUTs.
+    """
+    global s3
+    if s3 is None:
+        import boto3
+        from botocore.config import Config
+        s3 = boto3.client(
+            's3',
+            region_name=os.environ.get('AWS_REGION', 'us-east-1'),
+            config=Config(signature_version='s3v4'),
+        )
+    return s3
+
+
+# ── Schema ────────────────────────────────────────────────────────────────────
+
+CONTEXT_SK = 'PRODUCT_CONTEXT'
+
+# Free-text fields, each with a character cap. Lists were removed because they
+# read as a file-list / upload control in the UI; comment-style textareas are
+# clearer when the field is descriptive prose.
+STRING_FIELDS = {
+    'product_name': 200,
+    'one_liner': 200,
+    'target_users': 1000,
+    'problem_solved': 2000,
+    'key_features': 2000,
+    'differentiators': 2000,
+    'known_limitations': 2000,
+    'non_goals': 2000,
+    'success_metrics': 2000,
+    'free_form_notes': 4000,
+}
+
+# Single-choice enum
+LIFECYCLE_STATES = {'idea', 'mvp', 'beta', 'ga', 'mature'}
+
+# (List fields removed — see note above.)
+LIST_FIELDS: dict[str, tuple[int, int]] = {}
+
+ALL_FIELDS = set(STRING_FIELDS) | set(LIST_FIELDS) | {'current_state'}
+
+# Upload limits
+MAX_FILE_BYTES = 10 * 1024 * 1024
+MAX_DOCS_PER_PROJECT = 20
+MAX_EXTRACTED_INJECTION_CHARS = 50_000
+ALLOWED_CONTENT_TYPES = {
+    'application/pdf': 'pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+    'text/markdown': 'md',
+    'text/plain': 'txt',
+}
+
+
+def _empty_context() -> dict:
+    """Default-empty context shape returned when no record exists yet."""
+    out: dict[str, object] = {f: '' for f in STRING_FIELDS}
+    out['current_state'] = ''
+    for f in LIST_FIELDS:
+        out[f] = []
+    return out
+
+
+def _coerce_legacy_list(value) -> str:
+    """Convert legacy list-field DDB values (from the prior schema) to a string."""
+    if isinstance(value, list):
+        return '\n'.join(str(v) for v in value if v).strip()
+    return value if isinstance(value, str) else ''
+
+
+def _validate_patch(patch: dict) -> dict:
+    """
+    Validate + truncate a partial product-context update.
+    Unknown keys are dropped silently (the LLM sometimes invents fields).
+    Over-length strings are truncated; over-count lists are clipped.
+    """
+    if not isinstance(patch, dict):
+        raise ValidationError('patch must be an object')
+
+    clean: dict = {}
+    for key, value in patch.items():
+        if key not in ALL_FIELDS:
+            continue
+
+        if key == 'current_state':
+            if value in LIFECYCLE_STATES:
+                clean[key] = value
+            continue
+
+        if key in STRING_FIELDS:
+            if value is None:
+                clean[key] = ''
+                continue
+            if not isinstance(value, str):
+                continue
+            clean[key] = value[: STRING_FIELDS[key]]
+            continue
+
+        if key in LIST_FIELDS:
+            max_items, max_len = LIST_FIELDS[key]
+            if not isinstance(value, list):
+                continue
+            cleaned_items = []
+            for item in value[:max_items]:
+                if isinstance(item, str) and item.strip():
+                    cleaned_items.append(item.strip()[:max_len])
+            clean[key] = cleaned_items
+            continue
+
+    return clean
+
+
+# ── ProductContext CRUD ──────────────────────────────────────────────────────
+
+@tracer.capture_method
+def get_context(project_id: str) -> dict:
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    resp = projects_table.get_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': CONTEXT_SK}
+    )
+    item = resp.get('Item')
+    if not item:
+        return {'context': _empty_context()}
+
+    out = _empty_context()
+    for k in ALL_FIELDS:
+        if k not in item:
+            continue
+        # Coerce legacy list values written by the previous schema into newline-joined strings.
+        if k in STRING_FIELDS and isinstance(item[k], list):
+            out[k] = _coerce_legacy_list(item[k])
+        else:
+            out[k] = item[k]
+    out['updated_at'] = item.get('updated_at')
+    return {'context': out}
+
+
+@tracer.capture_method
+def update_context(project_id: str, body: dict) -> dict:
+    """Apply a validated patch to the product context. Creates the record on first PUT."""
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    patch = _validate_patch(body or {})
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Build UpdateExpression for whatever fields are present in the patch.
+    # Always set updated_at; ensure base item exists with put_item if missing.
+    resp = projects_table.get_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': CONTEXT_SK},
+        ProjectionExpression='pk',
+    )
+    if not resp.get('Item'):
+        base = {
+            'pk': f'PROJECT#{project_id}',
+            'sk': CONTEXT_SK,
+            'created_at': now,
+            'updated_at': now,
+        }
+        base.update(_empty_context())
+        base.update(patch)
+        projects_table.put_item(Item=base)
+        return get_context(project_id)
+
+    if not patch:
+        # No-op patch; just bump updated_at so clients can detect activity.
+        projects_table.update_item(
+            Key={'pk': f'PROJECT#{project_id}', 'sk': CONTEXT_SK},
+            UpdateExpression='SET updated_at = :now',
+            ExpressionAttributeValues={':now': now},
+        )
+        return get_context(project_id)
+
+    set_parts = ['updated_at = :now']
+    expr_vals: dict[str, Any] = {':now': now}
+    expr_names: dict[str, str] = {}
+    for i, (key, value) in enumerate(patch.items()):
+        # Use placeholders to avoid clashing with reserved words.
+        placeholder = f':v{i}'
+        name_alias = f'#k{i}'
+        set_parts.append(f'{name_alias} = {placeholder}')
+        expr_vals[placeholder] = value
+        expr_names[name_alias] = key
+
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': CONTEXT_SK},
+        UpdateExpression='SET ' + ', '.join(set_parts),
+        ExpressionAttributeValues=expr_vals,
+        ExpressionAttributeNames=expr_names,
+    )
+    return get_context(project_id)
+
+
+# ── Interview chat (synchronous, single Bedrock turn with tool-use) ──────────
+
+INTERVIEW_TOOL_NAME = 'update_product_context'
+
+
+def _build_interview_tool() -> dict:
+    """JSON-schema for the update tool the LLM calls during the interview.
+
+    All fields are plain strings — comment-style, multi-line allowed. Each tool call
+    REPLACES the field; if the user adds to existing content the model should send
+    the merged value.
+    """
+    properties: dict = {k: {'type': 'string', 'maxLength': max_len}
+                        for k, max_len in STRING_FIELDS.items()}
+    properties['current_state'] = {
+        'type': 'string',
+        'enum': sorted(LIFECYCLE_STATES),
+    }
+    return {
+        'toolSpec': {
+            'name': INTERVIEW_TOOL_NAME,
+            'description': (
+                'Patch the structured product context with concrete information the '
+                'user just shared. Only include fields you have new information for. '
+                'Each field REPLACES the prior value — if the user is adding to an '
+                'existing field, include the merged combined text in the patch.'
+            ),
+            'inputSchema': {
+                'json': {
+                    'type': 'object',
+                    'properties': properties,
+                    'additionalProperties': False,
+                }
+            },
+        }
+    }
+
+
+def _format_context_for_prompt(ctx: dict) -> str:
+    """Render the current context for the system prompt — only filled fields."""
+    lines: list[str] = []
+    for k in ('product_name', 'one_liner', 'current_state',
+              'target_users', 'problem_solved',
+              'key_features', 'differentiators', 'known_limitations',
+              'non_goals', 'success_metrics', 'free_form_notes'):
+        v = ctx.get(k)
+        if not v:
+            continue
+        if isinstance(v, str) and len(v) > 500:
+            v = v[:500] + '...'
+        lines.append(f'{k}: {v}')
+    return '\n'.join(lines) if lines else '(empty)'
+
+
+@tracer.capture_method
+def interview_turn(project_id: str, body: dict) -> dict:
+    """
+    One round of interview. Body: {message: str, history?: [{role, content}], response_language?: str}
+    Returns: {assistant_message, applied_patch, context}
+    """
+    from shared.prompts import get_response_language_instruction
+
+    message = (body or {}).get('message', '').strip()
+    if not message:
+        raise ValidationError('message is required')
+
+    history = (body or {}).get('history') or []
+    if not isinstance(history, list):
+        history = []
+    response_language = (body or {}).get('response_language')
+
+    current_ctx = get_context(project_id)['context']
+
+    base_instructions = (
+        "You are interviewing the user about their product/service to fill a structured "
+        "context record that downstream PRD and PR/FAQ generators will consume. "
+        "Ask ONE focused question at a time, prioritizing fields that are still empty. "
+        "When the user gives concrete information, you MUST call the "
+        f"`{INTERVIEW_TOOL_NAME}` tool with a patch of just the fields you learned BEFORE "
+        "writing your reply text. Don't invent — only patch fields with information the "
+        "user actually provided. Each field REPLACES the prior value, so if the user is "
+        "adding to an existing field include the merged combined text in the patch. After "
+        "the tool call, briefly confirm what was captured and ask the next most useful question.\n\n"
+        f"CURRENT CONTEXT:\n{_format_context_for_prompt(current_ctx)}\n\n"
+        "Fields you can patch (all are free-text strings):\n"
+        f"- product_name (≤{STRING_FIELDS['product_name']} chars)\n"
+        f"- one_liner (≤{STRING_FIELDS['one_liner']} chars)\n"
+        "- target_users, problem_solved (free text)\n"
+        f"- current_state (one of: {sorted(LIFECYCLE_STATES)})\n"
+        "- key_features, differentiators, known_limitations, non_goals, success_metrics (free text comments)\n"
+        "- free_form_notes (anything that doesn't fit above)\n"
+    )
+    language_instruction = get_response_language_instruction(response_language)
+    system_prompt = (f"{base_instructions}\n\n{language_instruction}".strip()
+                     if language_instruction else base_instructions)
+
+    # Build messages: prior history + new user turn.
+    messages: list[dict] = []
+    for m in history[-12:]:
+        role = m.get('role')
+        content = m.get('content', '')
+        if role in ('user', 'assistant') and isinstance(content, str) and content.strip():
+            messages.append({'role': role, 'content': [{'text': content}]})
+    messages.append({'role': 'user', 'content': [{'text': message}]})
+
+    client = get_bedrock_client()
+    try:
+        resp = client.converse(
+            modelId=BEDROCK_MODEL_ID,
+            messages=messages,
+            system=[{'text': system_prompt}],
+            inferenceConfig={'maxTokens': 1024, 'temperature': 0.3},
+            toolConfig={'tools': [_build_interview_tool()]},
+        )
+    except Exception as e:
+        logger.exception(f'Interview Bedrock call failed: {e}')
+        raise ServiceError('AI interview unavailable. Please try again.')
+
+    output_blocks = resp.get('output', {}).get('message', {}).get('content', [])
+
+    assistant_text_parts: list[str] = []
+    raw_patch: dict | None = None
+    for block in output_blocks:
+        if 'text' in block:
+            assistant_text_parts.append(block['text'])
+        elif 'toolUse' in block:
+            tu = block['toolUse']
+            if tu.get('name') == INTERVIEW_TOOL_NAME:
+                raw_patch = tu.get('input') or {}
+
+    applied: dict = {}
+    if raw_patch is not None:
+        cleaned = _validate_patch(raw_patch)
+        if cleaned:
+            update_context(project_id, cleaned)
+            applied = cleaned
+
+    assistant_message = '\n'.join(p for p in assistant_text_parts if p).strip()
+    if not assistant_message:
+        # Tool-only turn — return a stable code; the frontend localizes it.
+        assistant_message = '__captured__' if applied else '__elaborate__'
+
+    fresh_ctx = get_context(project_id)['context']
+    return {
+        'assistant_message': assistant_message,
+        'applied_patch': applied,
+        'context': fresh_ctx,
+    }
+
+
+# ── ProductDoc — uploads, listing, deletion ──────────────────────────────────
+
+DOC_SK_PREFIX = 'PRODUCT_DOC#'
+
+
+def _doc_pk(project_id: str) -> str:
+    return f'PROJECT#{project_id}'
+
+
+def _new_doc_id() -> str:
+    # 16 hex chars; collision-free per project for our scale.
+    return secrets.token_hex(8)
+
+
+def _list_doc_items(project_id: str) -> list[dict]:
+    if not projects_table:
+        return []
+    items: list[dict] = []
+    last_evaluated = None
+    while True:
+        kwargs = dict(
+            KeyConditionExpression=(
+                Key('pk').eq(_doc_pk(project_id)) &
+                Key('sk').begins_with(DOC_SK_PREFIX)
+            )
+        )
+        if last_evaluated:
+            kwargs['ExclusiveStartKey'] = last_evaluated
+        resp = projects_table.query(**kwargs)
+        items.extend(resp.get('Items', []))
+        last_evaluated = resp.get('LastEvaluatedKey')
+        if not last_evaluated:
+            break
+    return items
+
+
+def _doc_to_dto(item: dict) -> dict:
+    return {
+        'doc_id': item.get('doc_id'),
+        'filename': item.get('filename'),
+        'content_type': item.get('content_type'),
+        'size_bytes': int(item.get('size_bytes', 0)),
+        'status': item.get('status', 'pending'),
+        'error': item.get('error'),
+        'extracted_chars': int(item.get('extracted_chars', 0)),
+        'created_at': item.get('created_at'),
+    }
+
+
+@tracer.capture_method
+def list_docs(project_id: str) -> dict:
+    items = _list_doc_items(project_id)
+    items.sort(key=lambda i: i.get('created_at', ''), reverse=True)
+    return {'docs': [_doc_to_dto(i) for i in items]}
+
+
+@tracer.capture_method
+def create_upload_url(project_id: str, body: dict) -> dict:
+    """
+    Validate caps and content type, create a pending DDB record, return a presigned PUT URL.
+    Frontend uploads the file directly to S3, which triggers the extractor lambda.
+    """
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    bucket = os.environ.get('RAW_DATA_BUCKET')
+    if not bucket:
+        raise ConfigurationError('RAW_DATA_BUCKET not configured')
+
+    filename = (body or {}).get('filename', '').strip()
+    content_type = (body or {}).get('content_type', '').strip()
+    size_bytes = int((body or {}).get('size_bytes') or 0)
+
+    if not filename:
+        raise ValidationError('filename is required')
+    if content_type not in ALLOWED_CONTENT_TYPES:
+        raise ValidationError(
+            f'Unsupported file type. Allowed: {sorted(ALLOWED_CONTENT_TYPES)}'
+        )
+    if size_bytes <= 0 or size_bytes > MAX_FILE_BYTES:
+        raise ValidationError(
+            f'File size must be between 1 byte and {MAX_FILE_BYTES} bytes'
+        )
+
+    existing = _list_doc_items(project_id)
+    if len(existing) >= MAX_DOCS_PER_PROJECT:
+        raise ValidationError(
+            f'Maximum {MAX_DOCS_PER_PROJECT} documents per project. Delete some first.'
+        )
+
+    doc_id = _new_doc_id()
+    ext = ALLOWED_CONTENT_TYPES[content_type]
+    s3_raw_key = f'projects/{project_id}/product_docs/raw/{doc_id}.{ext}'
+    now = datetime.now(timezone.utc).isoformat()
+
+    item = {
+        'pk': _doc_pk(project_id),
+        'sk': f'{DOC_SK_PREFIX}{doc_id}',
+        'doc_id': doc_id,
+        'filename': filename[:255],
+        'content_type': content_type,
+        'size_bytes': size_bytes,
+        's3_raw_key': s3_raw_key,
+        's3_extracted_key': None,
+        'status': 'pending',
+        'error': None,
+        'extracted_chars': 0,
+        'created_at': now,
+    }
+    projects_table.put_item(Item=item)
+
+    presigned = _s3().generate_presigned_url(
+        ClientMethod='put_object',
+        Params={
+            'Bucket': bucket,
+            'Key': s3_raw_key,
+            'ContentType': content_type,
+        },
+        ExpiresIn=600,
+    )
+    return {
+        'doc_id': doc_id,
+        'presigned_url': presigned,
+        'headers': {'Content-Type': content_type},
+    }
+
+
+@tracer.capture_method
+def delete_doc(project_id: str, doc_id: str) -> dict:
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+    bucket = os.environ.get('RAW_DATA_BUCKET')
+
+    resp = projects_table.get_item(
+        Key={'pk': _doc_pk(project_id), 'sk': f'{DOC_SK_PREFIX}{doc_id}'}
+    )
+    item = resp.get('Item')
+    if not item:
+        raise NotFoundError('document not found')
+
+    if bucket:
+        for key in (item.get('s3_raw_key'), item.get('s3_extracted_key')):
+            if key:
+                try:
+                    _s3().delete_object(Bucket=bucket, Key=key)
+                except Exception as e:
+                    logger.warning(f'Failed to delete s3://{bucket}/{key}: {e}')
+
+    projects_table.delete_item(
+        Key={'pk': _doc_pk(project_id), 'sk': f'{DOC_SK_PREFIX}{doc_id}'}
+    )
+    return {'success': True}
+
+
+# ── PRD/PR-FAQ injection helper ──────────────────────────────────────────────
+
+@tracer.capture_method
+def generate_report(project_id: str, body: dict) -> dict:
+    """
+    Synthesize the structured product context + uploaded internal docs into a polished
+    'Product/Service Description' report and persist it as a ProjectDocument that shows
+    up in the Documents tab. The report is what other generators (PRD, PR/FAQ) implicitly
+    reference, but having it as a saved doc lets the user read, edit, share, and export it.
+    """
+    from shared.converse import converse
+
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    response_language = (body or {}).get('response_language')
+    title_override = ((body or {}).get('title') or '').strip()
+
+    ctx = get_context(project_id)['context']
+    has_any = any(ctx.get(k) for k in STRING_FIELDS) or ctx.get('current_state')
+    if not has_any:
+        # No documents either? then nothing to summarize.
+        ready_docs = [d for d in _list_doc_items(project_id) if d.get('status') == 'ready']
+        if not ready_docs:
+            raise ValidationError(
+                'Add at least one product context field or upload an internal document before generating a report.'
+            )
+
+    context_block = build_product_context_block(project_id)
+
+    from shared.prompts import get_response_language_instruction
+    language_instruction = get_response_language_instruction(response_language)
+
+    system_prompt = (
+        "You are a senior product manager writing a clear, concise Product/Service "
+        "Description report. The report describes the CURRENT state of the product — "
+        "not future features or aspirations. Use the structured input verbatim where "
+        "possible; do not invent details that aren't in the input.\n\n"
+        + (language_instruction or "")
+    ).strip()
+
+    user_prompt = (
+        "Write a Product/Service Description report in well-structured Markdown using the input below.\n\n"
+        "Required sections (omit a section only if the input has nothing for it):\n"
+        "1. **Product overview** — name, one-liner, current state\n"
+        "2. **Target users**\n"
+        "3. **Problem it solves**\n"
+        "4. **Key features**\n"
+        "5. **Differentiators**\n"
+        "6. **Known limitations**\n"
+        "7. **Non-goals**\n"
+        "8. **Success metrics**\n"
+        "9. **Additional notes** (anything from internal documents that adds context)\n\n"
+        "Keep the tone factual and specific. Don't include sections like \"future roadmap\" "
+        "or \"go-to-market\" — those belong in PRD/PR-FAQ, not here.\n\n"
+        f"INPUT:\n{context_block}"
+    )
+
+    try:
+        content = converse(
+            prompt=user_prompt,
+            system_prompt=system_prompt,
+            max_tokens=4000,
+            temperature=0.2,
+            step_name='product_report',
+        )
+    except Exception as e:
+        logger.exception(f"Product report generation failed: {e}")
+        raise ServiceError('Failed to generate report. Please try again.')
+
+    now = datetime.now(timezone.utc).isoformat()
+    report_id = f"product_report_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    product_name = ctx.get('product_name') or 'Product'
+    title = title_override or f"Product description: {product_name[:80]}"
+
+    item = {
+        'pk': f'PROJECT#{project_id}',
+        'sk': f'PRODUCT_REPORT#{report_id}',
+        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS',
+        'gsi1sk': now,
+        'document_id': report_id,
+        'document_type': 'product_report',
+        'title': title,
+        'content': content,
+        'created_at': now,
+    }
+    projects_table.put_item(Item=item)
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
+        UpdateExpression='SET document_count = if_not_exists(document_count, :zero) + :one, updated_at = :now',
+        ExpressionAttributeValues={':one': 1, ':zero': 0, ':now': now},
+    )
+    return {'success': True, 'document': item}
+
+
+def build_product_context_block(project_id: str) -> str:
+    """
+    Build the {product_context} string that is injected into the PRD/PR-FAQ chains.
+    Combines the structured context with the extracted text of READY uploaded docs,
+    truncated to MAX_EXTRACTED_INJECTION_CHARS total.
+    """
+    ctx_resp = get_context(project_id)
+    ctx = ctx_resp['context']
+
+    sections: list[str] = []
+
+    structured_lines: list[str] = []
+    field_labels = (
+        ('product_name', 'Product'),
+        ('one_liner', 'One-liner'),
+        ('current_state', 'Current state'),
+        ('target_users', 'Target users'),
+        ('problem_solved', 'Problem solved'),
+        ('key_features', 'Key features'),
+        ('differentiators', 'Differentiators'),
+        ('known_limitations', 'Known limitations'),
+        ('non_goals', 'Non-goals'),
+        ('success_metrics', 'Success metrics'),
+        ('free_form_notes', 'Notes'),
+    )
+    for key, label in field_labels:
+        v = ctx.get(key)
+        if not v:
+            continue
+        if isinstance(v, str) and '\n' in v:
+            structured_lines.append(f"**{label}**:\n{v}")
+        else:
+            structured_lines.append(f"**{label}**: {v}")
+
+    if structured_lines:
+        sections.append("### Structured product context\n" + '\n\n'.join(structured_lines))
+
+    bucket = os.environ.get('RAW_DATA_BUCKET')
+    if bucket:
+        ready = [d for d in _list_doc_items(project_id) if d.get('status') == 'ready' and d.get('s3_extracted_key')]
+        ready.sort(key=lambda d: d.get('created_at', ''))
+        budget = MAX_EXTRACTED_INJECTION_CHARS
+        doc_blocks: list[str] = []
+        skipped: list[str] = []
+        for d in ready:
+            if budget <= 0:
+                skipped.append(d.get('filename', ''))
+                continue
+            try:
+                obj = _s3().get_object(Bucket=bucket, Key=d['s3_extracted_key'])
+                text = obj['Body'].read().decode('utf-8', errors='replace')
+            except Exception as e:
+                logger.warning(f'Failed reading extracted text for {d.get("doc_id")}: {e}')
+                continue
+            chunk = text[:budget]
+            budget -= len(chunk)
+            doc_blocks.append(f"#### {d.get('filename')}\n{chunk}")
+        if doc_blocks:
+            sections.append("### Internal documents\n\n" + '\n\n'.join(doc_blocks))
+        if skipped:
+            sections.append(
+                "### Additional documents (not included due to size budget)\n- "
+                + '\n- '.join(skipped)
+            )
+
+    if not sections:
+        return "(No product context provided.)"
+    return '\n\n'.join(sections)

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -100,7 +100,7 @@ def list_projects() -> dict:
             sk = proj_item.get('sk', '')
             if sk.startswith('PERSONA#'):
                 persona_count += 1
-            elif sk.startswith('PRD#') or sk.startswith('PRFAQ#') or sk.startswith('RESEARCH#') or sk.startswith('DOC#'):
+            elif sk.startswith('PRD#') or sk.startswith('PRFAQ#') or sk.startswith('RESEARCH#') or sk.startswith('DOC#') or sk.startswith('PRODUCT_REPORT#') or sk.startswith('PROTOTYPE#'):
                 document_count += 1
         
         projects.append({
@@ -176,7 +176,7 @@ def get_project(project_id: str) -> dict:
             if item.get('avatar_url') and item['avatar_url'].startswith('s3://'):
                 item['avatar_url'] = get_avatar_cdn_url(item['avatar_url'])
             personas.append(item)
-        elif sk.startswith('PRD#') or sk.startswith('PRFAQ#') or sk.startswith('RESEARCH#') or sk.startswith('DOC#'):
+        elif sk.startswith('PRD#') or sk.startswith('PRFAQ#') or sk.startswith('RESEARCH#') or sk.startswith('DOC#') or sk.startswith('PRODUCT_REPORT#') or sk.startswith('PROTOTYPE#'):
             documents.append(item)
     
     if not project:
@@ -383,7 +383,27 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
         
         logger.info("[PERSONA] Step 6/6: Saving personas to database...")
         update_progress(80, 'saving_personas')
-        
+
+        # Replace semantics: delete any existing personas for this project first,
+        # so re-running generation doesn't accumulate duplicates (e.g. "김지수" x2).
+        # Without this, each generation appended a fresh set and @all roundtable
+        # chat would have the same persona answer multiple times.
+        existing_count = 0
+        try:
+            existing = projects_table.query(
+                KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}')
+                & Key('sk').begins_with('PERSONA#'),
+                ProjectionExpression='pk, sk',
+            ).get('Items', [])
+            if existing:
+                with projects_table.batch_writer() as batch:
+                    for it in existing:
+                        batch.delete_item(Key={'pk': it['pk'], 'sk': it['sk']})
+                existing_count = len(existing)
+                logger.info(f"[PERSONA] Cleared {existing_count} existing persona(s) before regeneration")
+        except Exception as e:
+            logger.warning(f"[PERSONA] Failed to clear existing personas (continuing): {e}")
+
         # Calculate source breakdown
         source_breakdown = {}
         for item in feedback_items:
@@ -447,10 +467,11 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
             saved_personas.append(item)
             logger.info(f"[PERSONA] Saved persona: {persona.get('name')}")
         
-        # Update persona count
+        # Set persona count to the new total (we cleared the old set above, so
+        # this is a replace, not an increment — keeps the count accurate).
         projects_table.update_item(
             Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
-            UpdateExpression='SET persona_count = persona_count + :count, updated_at = :now',
+            UpdateExpression='SET persona_count = :count, updated_at = :now',
             ExpressionAttributeValues={':count': len(saved_personas), ':now': now}
         )
         
@@ -505,12 +526,21 @@ def generate_prd(project_id: str, body: dict) -> dict:
 """
     
     feature_idea = body.get('feature_idea', 'Improve customer experience based on feedback')
-    
+
+    # Inject the per-project product/service context (structured fields + uploaded internal docs).
+    try:
+        from product_context import build_product_context_block
+        product_context = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context = "(No product context provided.)"
+
     # Build chain steps from external prompt files
     chain_steps = get_prd_generation_steps(
         feature_idea=feature_idea,
         personas_context=personas_context,
         feedback_context=feedback_context,
+        product_context=product_context,
         response_language=body.get('response_language'),
     )
 
@@ -554,6 +584,271 @@ def generate_prd(project_id: str, body: dict) -> dict:
 
 
 @tracer.capture_method
+def autofill_prfaq_questions(project_id: str, body: dict) -> dict:
+    """
+    Pre-populate the 5 Working-Backwards customer questions from existing project
+    context (personas, feedback, uploaded product context). Synchronous because
+    the user is interactively waiting in the wizard; runs in well under 30s.
+
+    Returns: {"answers": [str, str, str, str, str]} — empty strings for any
+    field the model can't reasonably draft.
+    """
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    from shared.converse import converse
+
+    project_data = get_project(project_id)
+    personas = project_data.get('personas', [])
+    filters = project_data.get('project', {}).get('filters', {})
+
+    feedback_items = get_feedback_context(filters, limit=20)
+    feedback_context = format_feedback_for_llm(feedback_items)
+
+    personas_context = ""
+    for p in personas:
+        personas_context += (
+            f"\n**{p.get('name')}** — {p.get('tagline', '')}\n"
+            f"Quote: \"{p.get('quote', '')}\"\n"
+            f"Goals: {', '.join(p.get('goals', [])[:3])}\n"
+            f"Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n"
+        )
+
+    feature_idea = (body or {}).get('feature_idea', '').strip()
+    title = (body or {}).get('title', '').strip()
+    response_language = (body or {}).get('response_language')
+
+    try:
+        from product_context import build_product_context_block
+        product_context = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context = "(No product context provided.)"
+
+    from shared.prompts import get_response_language_instruction
+    language_instruction = get_response_language_instruction(response_language)
+
+    system_prompt = (
+        "You are a senior product manager drafting answers to Amazon's 5 "
+        "Working-Backwards customer questions for a PR/FAQ. Use the provided "
+        "personas, customer feedback, and product context — DO NOT invent "
+        "details that aren't supported. If a question can't be answered from "
+        "the available context, return an empty string for that question.\n\n"
+        "Return STRICT JSON in this exact shape (no prose, no markdown fences):\n"
+        '{"answers": ["...", "...", "...", "...", "..."]}\n'
+        "Each answer should be 2-5 sentences, concrete, and grounded in the inputs.\n\n"
+        + (language_instruction or "")
+    ).strip()
+
+    user_prompt = (
+        f"FEATURE TITLE: {title or '(unspecified)'}\n"
+        f"FEATURE IDEA: {feature_idea or '(unspecified)'}\n\n"
+        f"PRODUCT CONTEXT:\n{product_context}\n\n"
+        f"PERSONAS:\n{personas_context or '(none)'}\n\n"
+        f"CUSTOMER FEEDBACK SAMPLE:\n{feedback_context or '(none)'}\n\n"
+        "Draft answers (in order) for these 5 questions:\n"
+        "1. Who is the customer?\n"
+        "2. What is the customer problem or opportunity?\n"
+        "3. What is the most important customer benefit?\n"
+        "4. How do you know what customers need or want? (cite the feedback/personas above)\n"
+        "5. What does the customer experience look like?"
+    )
+
+    raw = converse(
+        prompt=user_prompt,
+        system_prompt=system_prompt,
+        max_tokens=2500,
+        temperature=0.3,
+        step_name='prfaq_autofill',
+    )
+
+    # Parse JSON, tolerating fences if the model includes them.
+    text = (raw or '').strip()
+    if text.startswith('```'):
+        lines = [ln for ln in text.splitlines() if not ln.strip().startswith('```')]
+        text = '\n'.join(lines).strip()
+    try:
+        parsed = json.loads(text)
+        answers = parsed.get('answers', [])
+    except json.JSONDecodeError:
+        logger.warning(f"Autofill JSON parse failed; returning best-effort. raw={text[:200]}")
+        answers = []
+
+    if not isinstance(answers, list):
+        answers = []
+    cleaned = [(a if isinstance(a, str) else '').strip() for a in answers]
+    while len(cleaned) < 5:
+        cleaned.append('')
+    return {'answers': cleaned[:5]}
+
+
+@tracer.capture_method
+def suggest_document_brief(project_id: str, body: dict) -> dict:
+    """Draft a feature title + description for a PRD/PR-FAQ from project context.
+
+    A single fast LLM call (within API Gateway's 29s budget). Looks at the
+    project's product context and a sample of its customer feedback, then
+    proposes a concise feature/product title and a 2-4 sentence description so
+    the user doesn't have to write the PRD/PR-FAQ brief from scratch.
+    Returns {"title": str, "feature_idea": str}.
+    """
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    from shared.converse import converse
+
+    project_data = get_project(project_id)
+    filters = (body or {}).get('filters') or project_data.get('project', {}).get('filters', {})
+
+    feedback_items = get_feedback_context(filters, limit=40)
+    feedback_context = format_feedback_for_llm(feedback_items)
+    feedback_stats = get_feedback_statistics(feedback_items) if feedback_items else "(no feedback yet)"
+
+    try:
+        from product_context import build_product_context_block
+        product_context = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context = "(No product context provided.)"
+
+    doc_type = (body or {}).get('doc_type', 'prd')
+    doc_label = 'PR-FAQ' if doc_type == 'prfaq' else 'PRD'
+    response_language = (body or {}).get('response_language')
+    from shared.prompts import get_response_language_instruction
+    language_instruction = get_response_language_instruction(response_language)
+
+    system_prompt = (
+        f"You are a senior product manager about to write a {doc_label}. Based on "
+        "the product context and the most salient customer feedback, propose ONE "
+        "concrete feature or product improvement worth documenting. The title "
+        "should name the feature crisply; the description should explain what it "
+        "is and the customer problem it solves, grounded in the feedback. Do not "
+        "invent problems that aren't supported by the feedback.\n\n"
+        "Return STRICT JSON in this exact shape (no prose, no markdown fences):\n"
+        '{"title": "feature/product title", "feature_idea": "2-4 sentence description"}\n'
+        "Title <= 10 words. Description 2-4 sentences.\n\n"
+        + (language_instruction or "")
+    ).strip()
+
+    user_prompt = (
+        f"PRODUCT CONTEXT:\n{product_context}\n\n"
+        f"FEEDBACK STATISTICS:\n{feedback_stats}\n\n"
+        f"CUSTOMER FEEDBACK SAMPLE ({len(feedback_items)} reviews):\n{feedback_context or '(none)'}\n\n"
+        f"Propose one feature worth writing a {doc_label} for."
+    )
+
+    raw = converse(
+        prompt=user_prompt,
+        system_prompt=system_prompt,
+        max_tokens=1200,
+        temperature=0.4,
+        step_name='document_brief_suggest',
+    )
+
+    text = (raw or '').strip()
+    if text.startswith('```'):
+        lines = [ln for ln in text.splitlines() if not ln.strip().startswith('```')]
+        text = '\n'.join(lines).strip()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning(f"Document-brief JSON parse failed; raw={text[:200]}")
+        parsed = {}
+
+    title = (parsed.get('title') or '').strip() if isinstance(parsed, dict) else ''
+    feature_idea = (parsed.get('feature_idea') or '').strip() if isinstance(parsed, dict) else ''
+    return {'title': title, 'feature_idea': feature_idea}
+
+
+@tracer.capture_method
+def suggest_research_questions(project_id: str, body: dict) -> dict:
+    """Suggest research questions tailored to this project's feedback + context.
+
+    A single fast LLM call (well within API Gateway's 29s budget) that looks at
+    the project's product context and a sample of its actual customer feedback,
+    then proposes 3 concrete, decision-oriented research questions. Used by the
+    "AI suggest" button in the Research wizard so users don't start from a blank
+    box. Returns {"suggestions": [{"title": str, "question": str}, ...]}.
+    """
+    if not projects_table:
+        raise ConfigurationError('Projects table not configured')
+
+    from shared.converse import converse
+
+    project_data = get_project(project_id)
+    project = project_data.get('project', {})
+    filters = (body or {}).get('filters') or project.get('filters', {})
+
+    # Sample real feedback so suggestions are grounded in what was actually said.
+    feedback_items = get_feedback_context(filters, limit=40)
+    feedback_context = format_feedback_for_llm(feedback_items)
+    feedback_stats = get_feedback_statistics(feedback_items) if feedback_items else "(no feedback yet)"
+
+    try:
+        from product_context import build_product_context_block
+        product_context = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context = "(No product context provided.)"
+
+    response_language = (body or {}).get('response_language')
+    from shared.prompts import get_response_language_instruction
+    language_instruction = get_response_language_instruction(response_language)
+
+    system_prompt = (
+        "You are a senior UX researcher helping a PM frame a research study on "
+        "their product's customer feedback. Propose research questions that are "
+        "specific, decision-oriented, and answerable from the customer feedback "
+        "provided — favor questions about root causes, priorities, frequency/"
+        "severity, and opportunities for new features. Avoid vague questions "
+        "like 'what do customers think?'. Ground every suggestion in the actual "
+        "feedback themes and product context provided; do not invent topics that "
+        "aren't supported by the data.\n\n"
+        "Return STRICT JSON in this exact shape (no prose, no markdown fences):\n"
+        '{"suggestions": [{"title": "short report title", "question": "the research question"}, ...]}\n'
+        "Provide exactly 3 suggestions. Titles <= 8 words. Questions 1-2 sentences.\n\n"
+        + (language_instruction or "")
+    ).strip()
+
+    user_prompt = (
+        f"PRODUCT CONTEXT:\n{product_context}\n\n"
+        f"FEEDBACK STATISTICS:\n{feedback_stats}\n\n"
+        f"CUSTOMER FEEDBACK SAMPLE ({len(feedback_items)} reviews):\n{feedback_context or '(none)'}\n\n"
+        "Based on the above, propose 3 research questions worth running on this feedback."
+    )
+
+    raw = converse(
+        prompt=user_prompt,
+        system_prompt=system_prompt,
+        max_tokens=1500,
+        temperature=0.4,
+        step_name='research_suggest',
+    )
+
+    text = (raw or '').strip()
+    if text.startswith('```'):
+        lines = [ln for ln in text.splitlines() if not ln.strip().startswith('```')]
+        text = '\n'.join(lines).strip()
+    try:
+        parsed = json.loads(text)
+        suggestions = parsed.get('suggestions', [])
+    except json.JSONDecodeError:
+        logger.warning(f"Research-suggest JSON parse failed; raw={text[:200]}")
+        suggestions = []
+
+    cleaned = []
+    if isinstance(suggestions, list):
+        for s in suggestions:
+            if not isinstance(s, dict):
+                continue
+            q = (s.get('question') or '').strip()
+            t = (s.get('title') or '').strip()
+            if q:
+                cleaned.append({'title': t, 'question': q})
+    return {'suggestions': cleaned[:3]}
+
+
+@tracer.capture_method
 def generate_prfaq(project_id: str, body: dict) -> dict:
     """Generate an Amazon-style PR/FAQ document using multi-step LLM chain."""
     if not projects_table:
@@ -578,12 +873,21 @@ Quote: "{p.get('quote', '')}"
 """
     
     feature_idea = body.get('feature_idea', 'New feature based on customer feedback')
-    
+
+    # Inject the per-project product/service context (structured fields + uploaded internal docs).
+    try:
+        from product_context import build_product_context_block
+        product_context = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context = "(No product context provided.)"
+
     # Build chain steps from external prompt files
     chain_steps = get_prfaq_generation_steps(
         feature_idea=feature_idea,
         personas_context=personas_context,
         feedback_context=feedback_context,
+        product_context=product_context,
         response_language=body.get('response_language'),
     )
 

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -28,6 +28,18 @@ from projects import (
     add_persona_note, update_persona_note, delete_persona_note,
     regenerate_persona_avatar,
     autoseed_project,
+    autofill_prfaq_questions,
+    suggest_research_questions,
+    suggest_document_brief,
+)
+from product_context import (
+    get_context as pc_get_context,
+    update_context as pc_update_context,
+    interview_turn as pc_interview_turn,
+    list_docs as pc_list_docs,
+    create_upload_url as pc_create_upload_url,
+    delete_doc as pc_delete_doc,
+    generate_report as pc_generate_report,
 )
 
 # API resolver with standard CORS
@@ -171,6 +183,11 @@ def api_generate_personas(project_id: str):
         'days': validate_days(body.get('days'), default=30),
         'persona_count': validate_persona_count(body.get('persona_count')),
         'custom_instructions': body.get('custom_instructions', ''),
+        # Forward the user's selected language so the persona generator's Bedrock
+        # call emits Korean (or whatever locale) names + descriptions, matching
+        # the rest of the project. Without this, generated personas were always
+        # English even when Settings → Language was set to 한국어.
+        'response_language': body.get('response_language'),
     }
     job_id, _ = create_job(project_id, 'generate_personas', 'filters', filters, ttl_minutes=30*24*60)
     invoke_lambda_async(PERSONA_GENERATOR_FUNCTION, {
@@ -220,15 +237,35 @@ def api_run_research(project_id: str):
 @app.post("/projects/<project_id>/document")
 @tracer.capture_method
 def api_generate_document(project_id: str):
-    """Generate PRD or PR-FAQ document via async Lambda invocation."""
+    """Generate PRD or PR-FAQ document.
+
+    Runs as a Step Functions workflow when DOCUMENT_STATE_MACHINE_ARN is set:
+    each LLM step is its own Lambda invocation, so long CJK documents don't
+    overrun the 15-minute Lambda ceiling. Falls back to the legacy single-shot
+    async Lambda invoke when the state machine isn't configured.
+
+    `build_prototype` and `product_report` doc_types stay on the single-shot
+    Lambda path (they aren't multi-step LLM chains).
+    """
     body = app.current_event.json_body or {}
     doc_type = body.get('doc_type', 'prd')
     job_id, _ = create_job(project_id, f'generate_{doc_type}', 'doc_config', body, status='pending')
-    invoke_lambda_async(DOCUMENT_GENERATOR_FUNCTION, {
-        'project_id': project_id,
-        'job_id': job_id,
-        'doc_config': body
-    })
+
+    state_machine_arn = os.environ.get('DOCUMENT_STATE_MACHINE_ARN', '')
+    is_chain = doc_type in ('prd', 'prfaq')
+
+    if state_machine_arn and is_chain:
+        boto3.client('stepfunctions').start_execution(
+            stateMachineArn=state_machine_arn,
+            name=job_id,
+            input=json.dumps({'job_id': job_id, 'project_id': project_id, 'doc_config': body})
+        )
+    else:
+        invoke_lambda_async(DOCUMENT_GENERATOR_FUNCTION, {
+            'project_id': project_id,
+            'job_id': job_id,
+            'doc_config': body
+        })
     return {'success': True, 'job_id': job_id, 'status': 'pending', 'message': f'{doc_type.upper()} generation started.'}
 
 
@@ -462,6 +499,122 @@ def api_delete_token(project_id: str, token_id: str):
     logger.info(f"Deleted API token {token_id} from project {project_id}")
 
     return {'success': True, 'message': f'Token {token_id} revoked'}
+
+
+# ============================================
+# Product Context Routes
+# ============================================
+
+@app.get("/projects/<project_id>/product-context")
+@tracer.capture_method
+def api_get_product_context(project_id: str):
+    return pc_get_context(project_id)
+
+
+@app.put("/projects/<project_id>/product-context")
+@tracer.capture_method
+def api_update_product_context(project_id: str):
+    return pc_update_context(project_id, app.current_event.json_body)
+
+
+@app.post("/projects/<project_id>/product-context/interview")
+@tracer.capture_method
+def api_product_context_interview(project_id: str):
+    return pc_interview_turn(project_id, app.current_event.json_body)
+
+
+@app.get("/projects/<project_id>/product-docs")
+@tracer.capture_method
+def api_list_product_docs(project_id: str):
+    return pc_list_docs(project_id)
+
+
+@app.post("/projects/<project_id>/product-docs/upload-url")
+@tracer.capture_method
+def api_create_product_doc_upload_url(project_id: str):
+    return pc_create_upload_url(project_id, app.current_event.json_body)
+
+
+@app.delete("/projects/<project_id>/product-docs/<doc_id>")
+@tracer.capture_method
+def api_delete_product_doc(project_id: str, doc_id: str):
+    return pc_delete_doc(project_id, doc_id)
+
+
+@app.post("/projects/<project_id>/prfaq-autofill")
+@tracer.capture_method
+def api_autofill_prfaq_questions(project_id: str):
+    """Synchronous: returns 5 drafted answers for the Amazon Working-Backwards questions."""
+    return autofill_prfaq_questions(project_id, app.current_event.json_body)
+
+
+@app.post("/projects/<project_id>/research/suggest-questions")
+@tracer.capture_method
+def api_suggest_research_questions(project_id: str):
+    """Synchronous: returns up to 3 AI-suggested research questions for this project."""
+    return suggest_research_questions(project_id, app.current_event.json_body or {})
+
+
+@app.post("/projects/<project_id>/documents/suggest-brief")
+@tracer.capture_method
+def api_suggest_document_brief(project_id: str):
+    """Synchronous: drafts a feature title + description for a PRD/PR-FAQ."""
+    return suggest_document_brief(project_id, app.current_event.json_body or {})
+
+
+@app.post("/projects/<project_id>/build-prototype")
+@tracer.capture_method
+def api_build_prototype(project_id: str):
+    """
+    Kick off a build-prototype job. The document-generator lambda reads the
+    latest PRD and/or PR-FAQ for this project and asks Bedrock to produce a
+    self-contained HTML React prototype, saved as a ProjectDocument of type
+    'prototype'. The frontend polls job status, then displays the HTML in an
+    iframe via srcdoc (sandboxed, no parent-page access).
+    """
+    body = app.current_event.json_body or {}
+    doc_config = {
+        'doc_type': 'build_prototype',
+        'title': body.get('title') or 'Prototype',
+        'response_language': body.get('response_language'),
+        # Optional brand targeting (e.g. "UNNI" / a domain). Blank → neutral defaults.
+        'brand': body.get('brand'),
+        # Optional feedback-driven regeneration: revise an existing prototype
+        # centered on this feedback while still honoring the PRD/PR-FAQ.
+        'feedback': body.get('feedback'),
+        'base_prototype_id': body.get('base_prototype_id'),
+    }
+    job_id, _ = create_job(project_id, 'build_prototype', 'doc_config', doc_config, status='pending')
+    invoke_lambda_async(DOCUMENT_GENERATOR_FUNCTION, {
+        'project_id': project_id,
+        'job_id': job_id,
+        'doc_config': doc_config,
+    })
+    return {'success': True, 'job_id': job_id, 'status': 'pending', 'message': 'Prototype build started.'}
+
+
+@app.post("/projects/<project_id>/product-report")
+@tracer.capture_method
+def api_generate_product_report(project_id: str):
+    """
+    Start an async product-report generation job. The actual Bedrock call (which
+    can take 30+ seconds for Korean output) runs in the document-generator job
+    lambda; this endpoint returns immediately with a job_id so API Gateway's
+    29-second timeout can't trip the request.
+    """
+    body = app.current_event.json_body or {}
+    doc_config = {
+        'doc_type': 'product_report',
+        'title': body.get('title') or 'Product description report',
+        'response_language': body.get('response_language'),
+    }
+    job_id, _ = create_job(project_id, 'generate_product_report', 'doc_config', doc_config, status='pending')
+    invoke_lambda_async(DOCUMENT_GENERATOR_FUNCTION, {
+        'project_id': project_id,
+        'job_id': job_id,
+        'doc_config': doc_config,
+    })
+    return {'success': True, 'job_id': job_id, 'status': 'pending', 'message': 'Product report generation started.'}
 
 
 # ============================================

--- a/voc-datalake/lambda/api/prompts/prd-generation.json
+++ b/voc-datalake/lambda/api/prompts/prd-generation.json
@@ -5,21 +5,21 @@
     "problem_analysis": {
       "name": "problem_analysis",
       "description": "Deep analysis of customer problems to define product requirements",
-      "max_tokens": 3000,
+      "max_tokens": 6000,
       "system_prompt": "You are a product manager analyzing customer problems to define product requirements.\nBe specific, data-driven, and focus on measurable outcomes.",
-      "user_prompt_template": "Analyze the customer feedback and personas to deeply understand the problem space.\n\nFEATURE IDEA: {feature_idea}\n\nUSER PERSONAS:\n{personas_context}\n\nCUSTOMER FEEDBACK:\n{feedback_context}\n\nProvide a thorough problem analysis:\n1. What are the core problems customers are experiencing?\n2. How do these problems affect different personas?\n3. What is the business impact of not solving these problems?\n4. What are the root causes?\n5. What constraints should we consider?"
+      "user_prompt_template": "Analyze the customer feedback and personas to deeply understand the problem space.\n\nFEATURE IDEA: {feature_idea}\n\nCURRENT PRODUCT CONTEXT (existing product/service the feature is being added to):\n{product_context}\n\nUSER PERSONAS:\n{personas_context}\n\nCUSTOMER FEEDBACK:\n{feedback_context}\n\nProvide a thorough problem analysis grounded in the existing product context above:\n1. What are the core problems customers are experiencing?\n2. How do these problems affect different personas?\n3. What is the business impact of not solving these problems given the current product state?\n4. What are the root causes?\n5. What constraints should we consider (product limitations, non-goals, etc.)?"
     },
     "solution_design": {
       "name": "solution_design",
       "description": "Design solutions that address real customer needs",
-      "max_tokens": 3000,
+      "max_tokens": 12000,
       "system_prompt": "You are a senior product manager designing solutions that address real customer needs.\nFocus on feasibility, impact, and user-centered design.",
       "user_prompt_template": "Based on the problem analysis, design a solution.\n\nPrevious analysis:\n{previous}\n\nDefine:\n1. **Solution Overview**: High-level description\n2. **Key Features**: 3-5 core features with descriptions\n3. **User Stories**: For each persona, write 2-3 user stories\n4. **Success Metrics**: How will we measure success?\n5. **Risks & Mitigations**: What could go wrong?"
     },
     "prd_document": {
       "name": "prd_document",
       "description": "Create the final PRD document",
-      "max_tokens": 5000,
+      "max_tokens": 32000,
       "system_prompt": "You are creating a professional Product Requirements Document.\nBe comprehensive but concise. Use clear formatting.",
       "user_prompt_template": "Create a complete PRD document.\n\nPrevious analysis and solution design:\n{previous}\n\nGenerate a PRD with these sections:\n1. **Executive Summary**\n2. **Problem Statement**\n3. **Goals & Success Metrics**\n4. **User Personas** (reference the personas)\n5. **Requirements**\n   - Functional Requirements (prioritized P0/P1/P2)\n   - Non-Functional Requirements\n6. **User Stories & Acceptance Criteria**\n7. **Out of Scope**\n8. **Dependencies & Risks**\n9. **Timeline Considerations**\n\nFormat as a professional document in Markdown."
     }

--- a/voc-datalake/lambda/api/prompts/prfaq-generation.json
+++ b/voc-datalake/lambda/api/prompts/prfaq-generation.json
@@ -5,28 +5,28 @@
     "customer_thinking": {
       "name": "customer_thinking",
       "description": "Deep customer-centric thinking about needs and wants",
-      "max_tokens": 2000,
+      "max_tokens": 8000,
       "system_prompt": "You are thinking deeply about customers and their needs.\nChannel the voice of real customers based on the feedback data.",
-      "user_prompt_template": "Think deeply about what customers really want and need.\n\nFEATURE IDEA: {feature_idea}\n\nUSER PERSONAS:\n{personas_context}\n\nCUSTOMER FEEDBACK:\n{feedback_context}\n\nAnswer these questions from the customer's perspective:\n1. What problem does this solve for me?\n2. Why should I care about this?\n3. How will this make my life better?\n4. What would make me skeptical?\n5. What would delight me about this?"
+      "user_prompt_template": "Think deeply about what customers really want and need.\n\nFEATURE IDEA: {feature_idea}\n\nCURRENT PRODUCT CONTEXT (existing product/service the feature is being added to):\n{product_context}\n\nUSER PERSONAS:\n{personas_context}\n\nCUSTOMER FEEDBACK:\n{feedback_context}\n\nAnswer these questions from the customer's perspective, grounded in the current product context:\n1. What problem does this solve for me?\n2. Why should I care about this?\n3. How will this make my life better?\n4. What would make me skeptical?\n5. What would delight me about this?"
     },
     "press_release": {
       "name": "press_release",
       "description": "Write Amazon-style press release announcing the feature",
-      "max_tokens": 2500,
-      "system_prompt": "You are writing an Amazon-style press release announcing a new feature.\nWrite as if the feature is already launched and successful. Be specific and customer-focused.",
-      "user_prompt_template": "Write a press release for this feature.\n\nCustomer insights:\n{previous}\n\nThe press release should include:\n1. **Headline**: Attention-grabbing, customer-benefit focused\n2. **Subheadline**: Expand on the headline\n3. **City, Date**: [City, Date]\n4. **Opening Paragraph**: Who, what, when, where, why\n5. **Problem Paragraph**: The customer problem being solved\n6. **Solution Paragraph**: How the feature solves it\n7. **Quote from Leadership**: Vision and commitment\n8. **Customer Quote**: From one of the personas\n9. **How It Works**: Brief explanation\n10. **Call to Action**: How to get started\n\nWrite in professional press release style."
+      "max_tokens": 8000,
+      "system_prompt": "You are writing a substantial Amazon-style press release announcing a new feature. Write as if the feature has just launched and is already gaining real traction. Be specific, concrete, and customer-focused. Aim for ~700-1000 words across all sections — this is a real release, not a stub.",
+      "user_prompt_template": "Write a complete press release for this feature.\n\nCustomer insights:\n{previous}\n\nUSE THIS LAUNCH DATE in the dateline (do NOT use today's date and do NOT use any past date): {launch_date}\n\nThe press release MUST include ALL of the following sections, each fleshed out properly (not one-line stubs):\n\n1. **Headline** — Attention-grabbing, customer-benefit focused (one strong line).\n2. **Subheadline** — Expands on the headline with the most compelling specific.\n3. **Dateline** — Use the format \"CITY — {launch_date}\" (e.g. \"SEOUL — 2026-09-15\"). Pick a city appropriate to the brand and personas.\n4. **Opening paragraph** — 3-5 sentences covering who/what/when/where/why with concrete numbers.\n5. **Problem paragraph** — 4-6 sentences describing the pain point, grounded in real persona behavior or feedback. Include at least one specific scenario.\n6. **Solution paragraph** — 4-6 sentences explaining how the feature solves it. Be concrete about what happens step-by-step from the customer's perspective.\n7. **Leadership quote** — A 2-3 sentence quote attributed to a named executive role (e.g. 'Head of [relevant area]'). Vision + commitment, NOT marketing fluff.\n8. **Customer quote** — A 2-3 sentence quote from one of the personas, using their own voice and one concrete benefit they experienced.\n9. **How it works** — A short numbered or bulleted walk-through (4-6 steps) of the customer journey.\n10. **Availability** — Where, when, who is eligible, on which platforms. Use {launch_date} as the launch date.\n11. **Call to action** — Clear next step for customers (download, opt-in, contact).\n\nWrite in professional press release style. Match the source language. Avoid hype words. Use concrete numbers wherever possible. The full press release should read like a real, detailed announcement — NOT a one-paragraph teaser."
     },
     "customer_faq": {
       "name": "customer_faq",
       "description": "Generate customer-facing FAQ section",
-      "max_tokens": 2000,
+      "max_tokens": 4000,
       "system_prompt": "You are anticipating customer questions about a new feature.\nThink like a skeptical but interested customer.",
       "user_prompt_template": "Generate the Customer FAQ section.\n\nPress Release:\n{previous}\n\nCreate 5-7 customer FAQs covering:\n- How does this work?\n- How much does it cost?\n- When is it available?\n- What if I have problems?\n- How is this different from alternatives?\n- Questions specific to each persona\n\nFormat as Q&A pairs."
     },
     "internal_faq": {
       "name": "internal_faq",
       "description": "Generate internal stakeholder FAQ section",
-      "max_tokens": 2000,
+      "max_tokens": 8000,
       "system_prompt": "You are anticipating internal stakeholder questions.\nThink like executives, engineers, and business partners.",
       "user_prompt_template": "Generate the Internal FAQ section.\n\nPress Release and Customer FAQ:\n{previous}\n\nCreate 5-7 internal FAQs covering:\n- Why now? Why this?\n- What are the technical requirements?\n- What are the risks?\n- How do we measure success?\n- What resources are needed?\n- What's the timeline?\n\nFormat as Q&A pairs."
     }

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -6,6 +6,7 @@ Uses the same prompt templates and chain patterns as the synchronous projects.py
 """
 
 import os
+import re
 import sys
 from datetime import datetime, timezone
 
@@ -15,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from boto3.dynamodb.conditions import Key
 
 from shared.logging import logger, tracer, metrics
-from shared.jobs import job_handler, JobContext
+from shared.jobs import job_handler, JobContext, update_job_status
 from shared.aws import get_dynamodb_resource
 from shared.converse import converse_chain
 from shared.feedback import query_feedback_by_date
@@ -24,6 +25,11 @@ from shared.prompts import get_prd_generation_steps, get_prfaq_generation_steps
 # Environment
 PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
 FEEDBACK_TABLE = os.environ.get('FEEDBACK_TABLE', '')
+# Scratch bucket for the claim-check pattern (see step handlers below). Step
+# Functions state has a 256KB ceiling; PRD/PR-FAQ step outputs (long CJK docs,
+# 30-90KB each, accumulated across 3-4 steps) blow past it. So intermediate
+# step text lives in S3 and only the small S3 keys travel through SF state.
+SCRATCH_BUCKET = os.environ.get('RAW_DATA_BUCKET', '')
 
 
 def _gather_context(
@@ -104,7 +110,8 @@ def _gather_context(
 
 
 def _generate_prd(ctx: JobContext, feature_idea: str, feedback_context: str,
-                  personas_context: str, doc_config: dict) -> tuple[str, dict]:
+                  personas_context: str, doc_config: dict,
+                  product_context: str = "(No product context provided.)") -> tuple[str, dict]:
     """Generate PRD using multi-step LLM chain.
 
     Returns:
@@ -114,6 +121,7 @@ def _generate_prd(ctx: JobContext, feature_idea: str, feedback_context: str,
         feature_idea=feature_idea,
         personas_context=personas_context,
         feedback_context=feedback_context,
+        product_context=product_context,
         response_language=doc_config.get('response_language'),
     )
 
@@ -134,7 +142,8 @@ def _generate_prd(ctx: JobContext, feature_idea: str, feedback_context: str,
 
 
 def _generate_prfaq(ctx: JobContext, feature_idea: str, feedback_context: str,
-                    personas_context: str, doc_config: dict) -> tuple[str, dict]:
+                    personas_context: str, doc_config: dict,
+                    product_context: str = "(No product context provided.)") -> tuple[str, dict]:
     """Generate PR-FAQ using multi-step LLM chain.
 
     Returns:
@@ -144,6 +153,7 @@ def _generate_prfaq(ctx: JobContext, feature_idea: str, feedback_context: str,
         feature_idea=feature_idea,
         personas_context=personas_context,
         feedback_context=feedback_context,
+        product_context=product_context,
         response_language=doc_config.get('response_language'),
     )
 
@@ -185,6 +195,270 @@ def _generate_prfaq(ctx: JobContext, feature_idea: str, feedback_context: str,
     return full_document, sections
 
 
+# ── Prototype builder ────────────────────────────────────────────────────────
+#
+# The prototype generator returns a STRUCTURED JSON SPEC — not HTML, not React
+# code. The frontend renders the spec using its own React components. This
+# eliminates a stack of failures that plagued previous attempts to render
+# arbitrary HTML inside an iframe (CSP blocks, sandbox attribute permutations,
+# Babel auto-scanner timing, srcDoc/blob URL inconsistency).
+#
+# Spec shape (all fields optional except `screens`):
+# {
+#   "title": "...",
+#   "banner": "Prototype demo — Feature Name",
+#   "screens": [
+#     {
+#       "id": "home",
+#       "label": "홈",                    # tab label
+#       "heading": "...",
+#       "subheading": "...",
+#       "blocks": [                       # rendered top-to-bottom
+#         { "type": "text", "text": "..." },
+#         { "type": "list", "title": "...", "items": [{ "title": "...", "subtitle": "...", "badge": "..." }] },
+#         { "type": "stats", "items": [{ "label": "...", "value": "..." }] },
+#         { "type": "form", "title": "...", "fields": [{ "label": "...", "placeholder": "..." }],
+#                                          "submit": { "label": "Submit", "goto": "screen-id" } },
+#         { "type": "callout", "tone": "info|success|warn|error", "text": "..." },
+#         { "type": "buttons", "items": [{ "label": "...", "goto": "screen-id", "tone": "primary|secondary" }] }
+#       ]
+#     }
+#   ]
+# }
+
+# ── HTML prototype builder (Opus 4.8) ─────────────────────────────────────────
+#
+# Newer path: instead of a constrained JSON spec, ask the model for a single,
+# self-contained, offline-first HTML file (inline CSS + minimal vanilla JS, no
+# external CDNs/fonts/scripts). The frontend renders it in a sandboxed <iframe
+# srcdoc>. The offline-first constraint is exactly what sidesteps the old
+# iframe/CSP failures that pushed us to the JSON spec: no external loads means
+# nothing to block, and sandbox="allow-scripts" runs the inline nav JS safely.
+#
+# Adapted from the "Prototype Builder" CLAUDE.md. Brand is resolved from
+# doc_config (named brand → use it; otherwise neutral defaults) and the brief.
+PROTOTYPE_HTML_SYSTEM_PROMPT = """You are a clickable prototype builder. The user brings a PRD / PR-FAQ / brief; you produce a SINGLE, self-contained, clickable HTML prototype that looks and feels like a real product.
+
+You are NOT building a real application — only a visual, click-through mockup a stakeholder can open in a browser and tap through.
+
+OUTPUT FORMAT (strict):
+- Output ONE complete HTML document and NOTHING else. Start with <!DOCTYPE html> and end with </html>.
+- No prose, no explanation, no markdown code fences before or after the HTML.
+
+THE HARD RULES:
+- Everything in one HTML file: inline <style> and inline <script>. No separate files.
+- OFFLINE-FIRST — this is mandatory and non-negotiable: NO external CDNs, NO external fonts (system font stack only), NO external scripts, NO external images, NO API/network calls, NO tracking. Icons and logos as inline SVG. Anything external will be blocked by the sandbox and break the demo.
+- No frameworks, no build tooling, no router. Plain HTML + a little vanilla JS only.
+- Make it clickable: buttons/tabs/links navigate between screens via simple show/hide or in-page anchors with a tiny bit of inline vanilla JS. Multiple screens in one file, toggled by JS.
+- Use realistic placeholder content drawn from the brief so the demo feels real. No "Lorem ipsum".
+- If the brief needs a real backend (login, payment, booking, chat), FAKE it visually — success screen, confirmation modal, or a fake spinner. Never wire real services.
+- Match the language of the source documents (Korean source → Korean UI text).
+
+LOOK & FEEL:
+- Theme everything from CSS :root custom properties: --primary, --primary-light, --soft, --tint, --bg, --ink, --gray, --surface. Use --primary boldly for primary CTAs and active states against the soft bg/tint with generous whitespace.
+- System font stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif.
+- Rounded corners (12-20px), soft shadows, gentle hover transitions. Clean and premium.
+- Render the wordmark as inline SVG or styled text — never an external image.
+
+LAYOUT:
+- Default to a mobile phone-shell: center content in a ~420px shell with a sticky bottom tab bar, unless the brief is clearly a desktop/web product (then use a full-width top-nav layout).
+- Mobile-first CSS with a @media (min-width: 768px) refinement so it also looks good on desktop.
+
+BRAND:
+- If a brand is specified below, infer and apply that brand's palette, wordmark style, product nouns, and whether it's a mobile app or web product.
+- If no brand is specified, use neutral defaults: an indigo primary (#4F46E5 / light #818CF8 / soft #E0E7FF / tint #EEF2FF / bg #FBFBFD / ink #1A1A1A / gray #6B7280 / surface #FFFFFF), a clean modern SaaS aesthetic, generic tabs (Home, Explore, Activity, Profile), and pull all content from the brief.
+
+Produce a polished, tap-through prototype. Remember: ONE HTML document, output nothing but the HTML."""
+
+PROTOTYPE_HTML_USER_TEMPLATE = """Build a clickable HTML prototype for the product/feature below. Output ONE complete HTML document only — no prose, no code fences.
+
+PROJECT: {project_name}
+{brand_section}{prd_section}{prfaq_section}
+
+Requirements:
+- Single self-contained HTML file (inline CSS + vanilla JS), offline-first, no external resources.
+- 3-6 clickable screens toggled by inline JS, with a navigation bar.
+- Realistic placeholder content from the brief above.
+- {lang_hint}"""
+
+
+def _strip_html_fences(s: str) -> str:
+    """The model sometimes wraps output in ``` fences; strip them."""
+    s = s.strip()
+    if s.startswith('```'):
+        lines = s.splitlines()
+        if lines and lines[0].startswith('```'):
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith('```'):
+            lines = lines[:-1]
+        s = '\n'.join(lines).strip()
+    return s
+
+
+def _extract_html(raw: str) -> str:
+    """Pull a complete HTML document out of the model's reply.
+
+    Tolerates ``` fences and any stray prose before/after the document by
+    slicing from the first <!DOCTYPE/<html to the last </html>. Returns '' if
+    no recognizable HTML is present.
+    """
+    s = _strip_html_fences(raw or '')
+    low = s.lower()
+    start = low.find('<!doctype html')
+    if start == -1:
+        start = low.find('<html')
+    if start == -1:
+        return ''
+    end = low.rfind('</html>')
+    if end == -1:
+        # Truncated output — keep from the start anyway; the iframe is tolerant.
+        return s[start:].strip()
+    return s[start:end + len('</html>')].strip()
+
+
+def _latest_doc_by_prefix(projects_table, project_id: str, sk_prefix: str) -> dict | None:
+    """
+    Return the most recently created document of a given type for the project,
+    or None if none exist. We can't use a GSI here because prefixes are encoded
+    in `sk` directly; small project tables make a query+filter cheap enough.
+    """
+    from boto3.dynamodb.conditions import Key
+    resp = projects_table.query(
+        KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}') & Key('sk').begins_with(sk_prefix),
+        ScanIndexForward=False,  # newest first by sk
+        Limit=20,
+    )
+    items = resp.get('Items') or []
+    if not items:
+        return None
+    items.sort(key=lambda i: i.get('created_at', ''), reverse=True)
+    return items[0]
+
+
+def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_config: dict) -> dict:
+    """
+    Build a self-contained, offline-first HTML prototype from the latest PRD and
+    PR/FAQ for this project, save it as a ProjectDocument of type 'prototype' with
+    prototype_format='html'. The frontend renders the HTML in a sandboxed
+    <iframe srcdoc> so inline CSS/JS run in isolation. Opus 4.8 builds the HTML.
+    """
+    from shared.converse import converse
+
+    prd = _latest_doc_by_prefix(projects_table, project_id, 'PRD#')
+    prfaq = _latest_doc_by_prefix(projects_table, project_id, 'PRFAQ#')
+
+    if not prd and not prfaq:
+        raise RuntimeError('No PRD or PR/FAQ found for this project. Generate at least one first.')
+
+    proj_resp = projects_table.get_item(Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'})
+    project_name = (proj_resp.get('Item') or {}).get('name') or 'Project'
+
+    title = doc_config.get('title') or f"Prototype: {project_name}"
+
+    PER_DOC_CAP = 12000
+    prd_text = (prd or {}).get('content', '')[:PER_DOC_CAP]
+    prfaq_text = (prfaq or {}).get('content', '')[:PER_DOC_CAP]
+
+    prd_section = f'\n\nPRD:\n{prd_text}' if prd_text else ''
+    prfaq_section = f'\n\nPR/FAQ:\n{prfaq_text}' if prfaq_text else ''
+
+    lang = (doc_config.get('response_language') or 'en')[:5]
+    lang_hint = 'Write the UI text in Korean.' if lang.startswith('ko') else 'Match the language of the brief.'
+
+    # Optional brand targeting: doc_config.brand (e.g. "UNNI" or a domain). When
+    # absent, the system prompt's neutral defaults apply.
+    brand = (doc_config.get('brand') or '').strip()
+    brand_section = f'BRAND: {brand}\n' if brand else ''
+
+    # Optional feedback-driven regeneration: when the user gives feedback on an
+    # existing prototype, we re-generate CENTERED on that feedback while still
+    # honoring the PRD/PR-FAQ. We include the prior prototype HTML so the model
+    # revises it (e.g. "switch to an admin-facing view") rather than starting over.
+    feedback = (doc_config.get('feedback') or '').strip()
+    base_prototype_id = (doc_config.get('base_prototype_id') or '').strip()
+    feedback_section = ''
+    system_prompt = PROTOTYPE_HTML_SYSTEM_PROMPT
+    if feedback:
+        prior_html = ''
+        if base_prototype_id:
+            base = projects_table.get_item(
+                Key={'pk': f'PROJECT#{project_id}', 'sk': f'PROTOTYPE#{base_prototype_id}'}
+            ).get('Item')
+            prior_html = (base or {}).get('content', '')
+        # Cap the prior HTML so the prompt stays within budget; the model gets
+        # enough to understand structure/style and revise it toward the feedback.
+        PRIOR_CAP = 24000
+        prior_block = f'\n\nEXISTING PROTOTYPE (revise this):\n{prior_html[:PRIOR_CAP]}' if prior_html else ''
+        feedback_section = (
+            f'\n\nUSER FEEDBACK — make this the PRIMARY focus of the revision:\n{feedback}\n'
+            'Revise the prototype to center on this feedback (e.g. change perspective, add/replace '
+            'screens, adjust flows) while STILL staying consistent with the PRD/PR-FAQ above. '
+            'Keep the offline-first single-HTML rules. Output the full revised HTML document.'
+            f'{prior_block}'
+        )
+
+    user_prompt = PROTOTYPE_HTML_USER_TEMPLATE.format(
+        project_name=project_name,
+        brand_section=brand_section,
+        prd_section=prd_section,
+        prfaq_section=prfaq_section,
+        lang_hint=lang_hint,
+    ) + feedback_section
+
+    ctx.update_progress(40, 'invoking_bedrock')
+    # Opus 4.8 for the prototype build — stronger frontend/design instincts than
+    # the default chat model. converse() accepts a per-call model override.
+    raw = converse(
+        prompt=user_prompt,
+        system_prompt=system_prompt,
+        model_id='global.anthropic.claude-opus-4-8',
+        max_tokens=32000,
+        temperature=None,  # Opus 4.8 deprecates the temperature inference param.
+        step_name='build_prototype',
+    )
+
+    html = _extract_html(raw)
+    if not html:
+        raise RuntimeError('Prototype model did not return an HTML document.')
+
+    content = html
+
+    ctx.update_progress(90, 'saving_prototype')
+
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.isoformat()
+    doc_id = f"prototype_{now_dt.strftime('%Y%m%d%H%M%S')}"
+    item = {
+        'pk': f'PROJECT#{project_id}',
+        'sk': f'PROTOTYPE#{doc_id}',
+        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS',
+        'gsi1sk': now,
+        'document_id': doc_id,
+        'document_type': 'prototype',
+        'title': title,
+        'content': content,
+        # 'html' → frontend renders content as a sandboxed <iframe srcdoc>.
+        # Older prototypes have no prototype_format and are JSON specs (legacy).
+        'prototype_format': 'html',
+        'job_id': job_id,
+        'source_prd_id': (prd or {}).get('document_id'),
+        'source_prfaq_id': (prfaq or {}).get('document_id'),
+        'created_at': now,
+    }
+    if feedback:
+        # Record that this prototype is a feedback-driven revision of a prior one.
+        item['revised_from_id'] = base_prototype_id or None
+        item['revision_feedback'] = feedback[:2000]
+    projects_table.put_item(Item=item)
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
+        UpdateExpression='SET document_count = if_not_exists(document_count, :zero) + :one, updated_at = :now',
+        ExpressionAttributeValues={':one': 1, ':zero': 0, ':now': now},
+    )
+    ctx.update_progress(100, 'saved')
+    return {'document_id': doc_id, 'title': title}
+
+
 @job_handler(error_message='Document generation failed')
 def handle_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) -> dict:
     """Handle async document generation job (PRD/PRFAQ).
@@ -211,16 +485,51 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) 
     title = doc_config.get('title', 'Untitled')
     feature_idea = doc_config.get('feature_idea', '')
 
+    # Product/Service Description report — reuse the existing generate_report
+    # function (which already does its own Bedrock call + DynamoDB write).
+    # We branch here so the Generate-report button can run async without API
+    # Gateway's 29s ceiling tripping it.
+    if doc_type == 'product_report':
+        try:
+            from api.product_context import generate_report as pc_generate_report
+        except Exception as e:
+            raise RuntimeError(f'product_context module not available: {e}')
+        ctx.update_progress(50, 'generating_report')
+        result = pc_generate_report(project_id, {
+            'response_language': doc_config.get('response_language'),
+            'title': title or doc_config.get('title'),
+        })
+        ctx.update_progress(100, 'saved')
+        doc_item = result.get('document', {})
+        return {
+            'document_id': doc_item.get('document_id'),
+            'title': doc_item.get('title'),
+        }
+
+    # Build Prototype — generate a single-file HTML React/Tailwind demo from
+    # the source PRD/PR-FAQ. Display via iframe srcdoc; no compile step.
+    if doc_type == 'build_prototype':
+        ctx.update_progress(20, 'loading_source_documents')
+        return _generate_prototype(ctx, projects_table, project_id, job_id, doc_config)
+
     feedback_context, personas_context = _gather_context(
         ctx, projects_table, feedback_table, project_id, doc_config
     )
 
+    # Inject the per-project product/service context (structured fields + uploaded internal docs).
+    try:
+        from api.product_context import build_product_context_block
+        product_context_str = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context_str = "(No product context provided.)"
+
     ctx.update_progress(50, 'generating_document')
 
     if doc_type == 'prd':
-        content, analysis = _generate_prd(ctx, feature_idea, feedback_context, personas_context, doc_config)
+        content, analysis = _generate_prd(ctx, feature_idea, feedback_context, personas_context, doc_config, product_context_str)
     else:
-        content, analysis = _generate_prfaq(ctx, feature_idea, feedback_context, personas_context, doc_config)
+        content, analysis = _generate_prfaq(ctx, feature_idea, feedback_context, personas_context, doc_config, product_context_str)
 
     ctx.update_progress(90, 'saving_document')
     now_dt = datetime.now(timezone.utc)
@@ -253,10 +562,272 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) 
     return {'document_id': doc_id, 'title': title}
 
 
+# ── Step Functions step handlers ─────────────────────────────────────────────
+#
+# PRD/PR-FAQ generation is a multi-step LLM chain where each step can itself run
+# for minutes (each step's output is long, and the converse() auto-continuation
+# resumes truncated output across several Bedrock calls). Running the whole chain
+# in one Lambda invocation overruns the 15-minute Lambda ceiling for long CJK
+# documents. So we split the chain across Lambda invocations orchestrated by a
+# Step Functions state machine — each LLM step gets its own fresh 15-minute
+# budget, and output is never truncated to fit. This mirrors the research
+# workflow (research_step_handler.py).
+#
+# State flow (Step Functions passes results between invocations):
+#   gather   → build chain steps + context  → {steps, doc_type, title, feature_idea}
+#   run_step → execute ONE chain step (index i), return its text
+#   save     → assemble final document, persist to DynamoDB
+#
+# `steps` carries each chain step's system/user/max_tokens. `results` accumulates
+# each step's output text. `{previous}` in a step's user prompt is substituted
+# with the prior step's result, exactly like converse_chain does.
+
+from shared.converse import converse  # noqa: E402  (used by run_step)
+
+
+# ── Claim-check S3 helpers ───────────────────────────────────────────────────
+# Step Functions state is capped at 256KB; long step prompts/outputs don't fit.
+# We stash them in S3 under a per-job prefix and pass only the key in SF state.
+# The whole prefix is best-effort cleaned at save time.
+
+def _scratch_key(job_id: str, name: str) -> str:
+    return f"scratch/document_jobs/{job_id}/{name}.txt"
+
+
+def _s3():
+    import boto3
+    return boto3.client('s3')
+
+
+def _put_text(key: str, text: str) -> str:
+    _s3().put_object(Bucket=SCRATCH_BUCKET, Key=key, Body=text.encode('utf-8'))
+    return key
+
+
+def _get_text(key: str) -> str:
+    return _s3().get_object(Bucket=SCRATCH_BUCKET, Key=key)['Body'].read().decode('utf-8')
+
+
+def _build_steps(project_id: str, job_id: str, doc_config: dict) -> dict:
+    """gather step: fetch context, build chain steps, stash them in S3.
+
+    Each chain step (system/user prompt with context injected) can be tens of KB,
+    so the step list goes to S3 and only its key rides through SF state.
+    """
+    dynamodb = get_dynamodb_resource()
+    projects_table = dynamodb.Table(PROJECTS_TABLE)
+    feedback_table = dynamodb.Table(FEEDBACK_TABLE)
+
+    ctx = JobContext(project_id, job_id)
+    ctx.update_progress(10, 'gathering_context')
+
+    doc_type = doc_config.get('doc_type', 'prd')
+    feature_idea = doc_config.get('feature_idea', '')
+
+    feedback_context, personas_context = _gather_context(
+        ctx, projects_table, feedback_table, project_id, doc_config
+    )
+
+    try:
+        from api.product_context import build_product_context_block
+        product_context_str = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        product_context_str = "(No product context provided.)"
+
+    builder = get_prd_generation_steps if doc_type == 'prd' else get_prfaq_generation_steps
+    chain_steps = builder(
+        feature_idea=feature_idea,
+        personas_context=personas_context,
+        feedback_context=feedback_context,
+        product_context=product_context_str,
+        response_language=doc_config.get('response_language'),
+    )
+
+    import json as _json
+    _put_text(_scratch_key(job_id, 'steps'), _json.dumps(chain_steps))
+
+    ctx.update_progress(15, 'context_ready')
+    # S3 keys are deterministic from (job_id, index), so SF state carries only
+    # scalars — no growing arrays — which keeps every state transition tiny.
+    return {
+        'doc_type': doc_type,
+        'title': doc_config.get('title', 'Untitled'),
+        'feature_idea': feature_idea,
+        'num_steps': len(chain_steps),
+    }
+
+
+def _run_one_step(project_id: str, job_id: str, index: int) -> None:
+    """run_step: execute a single chain step in its own Lambda invocation.
+
+    Reads the step list and the previous step's output from S3 (deterministic
+    keys), runs converse() (which auto-continues past maxTokens internally, with
+    a full 15-min Lambda budget to itself), writes this step's output to S3.
+    """
+    import json as _json
+    steps = _json.loads(_get_text(_scratch_key(job_id, 'steps')))
+    step = steps[index]
+    total = len(steps)
+    step_name = step.get('step_name', f'llm_step_{index + 1}')
+
+    # Map step progress into the 15-85% band so the UI shows steady movement.
+    progress = 15 + int((index / total) * 70)
+    JobContext(project_id, job_id).update_progress(progress, step_name)
+
+    previous = _get_text(_scratch_key(job_id, f'result_{index - 1}')) if index > 0 else ''
+    user = step.get('user', '').replace('{previous}', previous)
+
+    logger.info(f"[DOCSTEP] step {index + 1}/{total} '{step_name}': max_tokens={step.get('max_tokens', 4096)}")
+    result = converse(
+        prompt=user,
+        system_prompt=step.get('system', ''),
+        max_tokens=step.get('max_tokens', 4096),
+        thinking_budget=step.get('thinking_budget', 0),
+        step_name=step_name,
+    )
+    logger.info(f"[DOCSTEP] step '{step_name}' produced {len(result)} chars")
+    _put_text(_scratch_key(job_id, f'result_{index}'), result)
+
+
+def _assemble_and_save(project_id: str, job_id: str, doc_type: str, title: str,
+                       feature_idea: str, num_steps: int) -> dict:
+    """save step: read step outputs from S3, assemble the document, persist."""
+    dynamodb = get_dynamodb_resource()
+    projects_table = dynamodb.Table(PROJECTS_TABLE)
+    JobContext(project_id, job_id).update_progress(90, 'saving_document')
+
+    results = [_get_text(_scratch_key(job_id, f'result_{i}')) for i in range(num_steps)]
+
+    analysis = {}
+    if doc_type == 'prd':
+        # results = [problem_analysis, solution_design, prd_document]
+        content = results[2] if len(results) >= 3 else results[-1]
+        if len(results) >= 3:
+            analysis = {'problem': results[0], 'solution': results[1]}
+    else:
+        # results = [customer_thinking, press_release, customer_faq, internal_faq]
+        content = f"""# PR/FAQ: {feature_idea}
+
+## Press Release
+
+{results[1] if len(results) > 1 else ''}
+
+---
+
+## Frequently Asked Questions
+
+### Customer FAQ
+
+{results[2] if len(results) > 2 else ''}
+
+### Internal FAQ
+
+{results[3] if len(results) > 3 else ''}
+"""
+        if len(results) >= 4:
+            analysis = {
+                'customer_insights': results[0],
+                'press_release': results[1],
+                'customer_faq': results[2],
+                'internal_faq': results[3],
+            }
+
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.isoformat()
+    doc_id = f"{doc_type}_{now_dt.strftime('%Y%m%d%H%M%S')}"
+    item = {
+        'pk': f'PROJECT#{project_id}',
+        'sk': f'{doc_type.upper()}#{doc_id}',
+        'gsi1pk': f'PROJECT#{project_id}#DOCUMENTS',
+        'gsi1sk': now,
+        'document_id': doc_id,
+        'document_type': doc_type,
+        'title': title,
+        'feature_idea': feature_idea,
+        'content': content,
+        'job_id': job_id,
+        'created_at': now,
+    }
+    if analysis:
+        item['analysis'] = analysis
+
+    projects_table.put_item(Item=item)
+    projects_table.update_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'},
+        UpdateExpression='SET document_count = if_not_exists(document_count, :zero) + :one, updated_at = :now',
+        ExpressionAttributeValues={':one': 1, ':zero': 0, ':now': now}
+    )
+
+    # Best-effort cleanup of the scratch prefix for this job.
+    try:
+        keys = [{'Key': _scratch_key(job_id, 'steps')}] + \
+               [{'Key': _scratch_key(job_id, f'result_{i}')} for i in range(num_steps)]
+        _s3().delete_objects(Bucket=SCRATCH_BUCKET, Delete={'Objects': keys})
+    except Exception as e:
+        logger.warning(f"Scratch cleanup failed (non-fatal): {e}")
+
+    update_job_status(
+        project_id, job_id, 'completed', 100, 'complete',
+        result={'document_id': doc_id, 'title': title}
+    )
+    return {'document_id': doc_id, 'title': title}
+
+
+def _handle_step_error(event: dict) -> dict:
+    """error step: mark the job failed (mirrors research step_error)."""
+    project_id = event['project_id']
+    job_id = event['job_id']
+    error = event.get('error', {})
+    raw_cause = error.get('Cause', '{}') if isinstance(error, dict) else str(error)
+    try:
+        import json as _json
+        cause = _json.loads(raw_cause)
+        error_message = cause.get('errorMessage') or raw_cause
+    except (ValueError, TypeError):
+        error_message = raw_cause or 'Unknown error'
+    logger.error(f"Document job {job_id} failed: {error_message}")
+    update_job_status(project_id, job_id, 'failed', 0, 'error', error=str(error_message)[:500])
+    return {'success': False, 'error': str(error_message)[:500]}
+
+
 @logger.inject_lambda_context
 @tracer.capture_lambda_handler
 @metrics.log_metrics(capture_cold_start_metric=True)
 def lambda_handler(event: dict, context) -> dict:
-    """Lambda entry point."""
-    logger.info(f"Document generator invoked with event keys: {list(event.keys())}")
-    return handle_job(event)
+    """Lambda entry point.
+
+    Two invocation shapes:
+      1. Step Functions step  — event has a 'step' key ('gather'|'run_step'|'save'|'error').
+         Used for PRD/PR-FAQ so each LLM step gets its own 15-min Lambda budget.
+      2. Direct async invoke   — legacy single-shot path (product_report,
+         build_prototype, and any caller not going through the state machine).
+    """
+    step = event.get('step')
+    logger.info(f"Document generator invoked: step={step}, keys={list(event.keys())}")
+
+    if step is None:
+        # Legacy single-invocation path (prototype, product_report, or fallback).
+        return handle_job(event)
+
+    project_id = event['project_id']
+    job_id = event['job_id']
+
+    if step == 'gather':
+        return _build_steps(project_id, job_id, event['doc_config'])
+
+    if step == 'run_step':
+        _run_one_step(project_id, job_id, event['index'])
+        return {'index': event['index']}
+
+    if step == 'save':
+        return _assemble_and_save(
+            project_id, job_id,
+            event['doc_type'], event['title'], event['feature_idea'],
+            event['num_steps'],
+        )
+
+    if step == 'error':
+        return _handle_step_error(event)
+
+    raise ValueError(f"Unknown step: {step}")

--- a/voc-datalake/lambda/jobs/document_generator/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_handler.py
@@ -271,3 +271,158 @@ class TestDocumentGeneratorHandler:
         steps = chain_call_args[0][0]  # First positional arg
         assert len(steps) == 3  # problem_analysis, solution_design, prd_document
         assert steps[0]['step_name'] == 'problem_analysis'
+
+
+class TestExtractHtml:
+    """Tests for the _extract_html helper (pulls an HTML doc from model output)."""
+
+    def test_extracts_plain_document(self):
+        from jobs.document_generator.handler import _extract_html
+        html = '<!DOCTYPE html><html><body>Hi</body></html>'
+        assert _extract_html(html) == html
+
+    def test_strips_code_fences(self):
+        from jobs.document_generator.handler import _extract_html
+        raw = '```html\n<!DOCTYPE html><html></html>\n```'
+        assert _extract_html(raw) == '<!DOCTYPE html><html></html>'
+
+    def test_strips_preamble_and_trailing_prose(self):
+        from jobs.document_generator.handler import _extract_html
+        raw = 'Sure! Here it is:\n<!DOCTYPE html><html></html>\nHope this helps.'
+        assert _extract_html(raw) == '<!DOCTYPE html><html></html>'
+
+    def test_matches_html_tag_without_doctype(self):
+        from jobs.document_generator.handler import _extract_html
+        raw = '<html lang="ko"><body></body></html>'
+        assert _extract_html(raw) == raw
+
+    def test_returns_empty_when_no_html(self):
+        from jobs.document_generator.handler import _extract_html
+        assert _extract_html('{"screens": []}') == ''
+        assert _extract_html('') == ''
+
+
+class TestBuildPrototype:
+    """Tests for the HTML prototype build path (Opus 4.8, iframe-rendered)."""
+
+    HTML = '<!DOCTYPE html><html><head><style>:root{--primary:#FF540F}</style></head><body><h1>Demo</h1></body></html>'
+
+    def _prototype_event(self, sample_job_event, **config):
+        return {
+            **sample_job_event,
+            'doc_config': {'doc_type': 'build_prototype', 'title': 'Test Prototype', **config},
+        }
+
+    def _wire_tables(self, mock_dynamodb):
+        """A PRD exists so the prototype build has source material; META returns a name."""
+        mock_dynamodb['table'].query.return_value = {
+            'Items': [{'document_id': 'prd_1', 'content': 'PRD body', 'created_at': '2026-01-01'}],
+        }
+        mock_dynamodb['table'].get_item.return_value = {'Item': {'name': 'My Project'}}
+
+    def test_build_prototype_saves_html_with_format_marker(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, sample_job_event, lambda_context
+    ):
+        self._wire_tables(mock_dynamodb)
+        mock_converse.return_value = self.HTML
+
+        from jobs.document_generator.handler import lambda_handler
+        result = lambda_handler(self._prototype_event(sample_job_event), lambda_context)
+
+        assert result['success'] is True
+        assert result['document_id'].startswith('prototype_')
+        put_item = mock_dynamodb['table'].put_item.call_args.kwargs['Item']
+        assert put_item['document_type'] == 'prototype'
+        assert put_item['prototype_format'] == 'html'
+        assert put_item['content'] == self.HTML
+
+    def test_build_prototype_uses_opus(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, sample_job_event, lambda_context
+    ):
+        self._wire_tables(mock_dynamodb)
+        mock_converse.return_value = self.HTML
+
+        from jobs.document_generator.handler import lambda_handler
+        lambda_handler(self._prototype_event(sample_job_event), lambda_context)
+
+        assert mock_converse.call_args.kwargs['model_id'] == 'global.anthropic.claude-opus-4-8'
+
+    def test_build_prototype_passes_brand_and_language(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, sample_job_event, lambda_context
+    ):
+        self._wire_tables(mock_dynamodb)
+        mock_converse.return_value = self.HTML
+
+        from jobs.document_generator.handler import lambda_handler
+        lambda_handler(
+            self._prototype_event(sample_job_event, brand='UNNI', response_language='ko'),
+            lambda_context,
+        )
+
+        prompt = mock_converse.call_args.kwargs['prompt']
+        assert 'UNNI' in prompt
+        assert 'Korean' in prompt  # ko → Korean UI-text hint
+
+    def test_build_prototype_feedback_revision(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, sample_job_event, lambda_context
+    ):
+        """Feedback + base_prototype_id → prompt includes feedback + prior HTML; item records lineage."""
+        mock_dynamodb['table'].query.return_value = {
+            'Items': [{'document_id': 'prd_1', 'content': 'PRD body', 'created_at': '2026-01-01'}],
+        }
+        prior = '<!DOCTYPE html><html><body>OLD user-facing screens</body></html>'
+
+        def get_item(Key=None, **kwargs):
+            sk = (Key or {}).get('sk', '')
+            if sk == 'META':
+                return {'Item': {'name': 'My Project'}}
+            if sk.startswith('PROTOTYPE#'):
+                return {'Item': {'content': prior}}
+            return {}
+        mock_dynamodb['table'].get_item.side_effect = get_item
+        mock_converse.return_value = self.HTML
+
+        from jobs.document_generator.handler import lambda_handler
+        lambda_handler(
+            self._prototype_event(
+                sample_job_event,
+                feedback='Switch to the admin perspective',
+                base_prototype_id='prototype_20260101000000',
+            ),
+            lambda_context,
+        )
+
+        prompt = mock_converse.call_args.kwargs['prompt']
+        assert 'Switch to the admin perspective' in prompt  # feedback is in the prompt
+        assert 'OLD user-facing screens' in prompt          # prior HTML included for revision
+        assert 'PRD body' in prompt                          # PRD still honored
+        put_item = mock_dynamodb['table'].put_item.call_args.kwargs['Item']
+        assert put_item['revised_from_id'] == 'prototype_20260101000000'
+        assert put_item['revision_feedback'] == 'Switch to the admin perspective'
+
+    def test_build_prototype_fails_without_source_documents(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, sample_job_event, lambda_context
+    ):
+        # No PRD/PRFAQ found → query returns empty.
+        mock_dynamodb['table'].query.return_value = {'Items': []}
+        mock_dynamodb['table'].get_item.return_value = {'Item': {'name': 'Empty'}}
+
+        from jobs.document_generator.handler import lambda_handler
+        from shared.exceptions import ServiceError
+
+        with pytest.raises(ServiceError, match="Document generation failed"):
+            lambda_handler(self._prototype_event(sample_job_event), lambda_context)
+
+        mock_converse.assert_not_called()
+
+    def test_build_prototype_fails_when_model_returns_no_html(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, sample_job_event, lambda_context
+    ):
+        self._wire_tables(mock_dynamodb)
+        mock_converse.return_value = 'I cannot build that.'  # no HTML doc
+
+        from jobs.document_generator.handler import lambda_handler
+        from shared.exceptions import ServiceError
+
+        with pytest.raises(ServiceError, match="Document generation failed"):
+            lambda_handler(self._prototype_event(sample_job_event), lambda_context)

--- a/voc-datalake/lambda/shared/prompts.py
+++ b/voc-datalake/lambda/shared/prompts.py
@@ -186,12 +186,14 @@ def get_prd_generation_steps(
     personas_context: str,
     feedback_context: str,
     response_language: str | None = None,
+    product_context: str = "(No product context provided.)",
 ) -> list[dict]:
     """Build PRD generation chain steps."""
     context = {
         'feature_idea': feature_idea,
         'personas_context': personas_context,
         'feedback_context': feedback_context,
+        'product_context': product_context,
         'previous': '{previous}',
         'response_language': response_language,
     }
@@ -208,16 +210,26 @@ def get_prfaq_generation_steps(
     personas_context: str,
     feedback_context: str,
     response_language: str | None = None,
+    product_context: str = "(No product context provided.)",
 ) -> list[dict]:
     """Build PR/FAQ generation chain steps."""
+    # Pin the launch date roughly three months out from today. Without this,
+    # the model defaults to its training-cutoff date and produces dates in the
+    # past — confusing for "Working Backwards" docs, which are supposed to
+    # describe a near-future launch.
+    from datetime import datetime, timedelta, timezone
+    launch_date = (datetime.now(timezone.utc) + timedelta(days=90)).strftime('%Y-%m-%d')
+
     context = {
         'feature_idea': feature_idea,
         'personas_context': personas_context,
         'feedback_context': feedback_context,
+        'product_context': product_context,
+        'launch_date': launch_date,
         'previous': '{previous}',
         'response_language': response_language,
     }
-    
+
     return build_chain_steps(
         'prfaq-generation.json',
         ['customer_thinking', 'press_release', 'customer_faq', 'internal_faq'],

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -11,6 +11,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import * as tasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import * as path from 'path';
 import { Construct } from 'constructs';
 import { NagSuppressions } from 'cdk-nag';
@@ -132,6 +133,7 @@ export class VocApiStack extends cdk.Stack {
             `cp /asset-input/api/${handlerFileName} /asset-output/ && ` +
             `cp -r /asset-input/shared /asset-output/ && ` +
             `if [ -f /asset-input/api/projects.py ]; then cp /asset-input/api/projects.py /asset-output/; fi && ` +
+            `if [ -f /asset-input/api/product_context.py ]; then cp /asset-input/api/product_context.py /asset-output/; fi && ` +
             `if [ -d /asset-input/api/prompts ]; then cp -r /asset-input/api/prompts /asset-output/; fi && ` +
             `if [ -d /asset-input/api/static ]; then cp -r /asset-input/api/static /asset-output/; fi`
           ],
@@ -147,8 +149,8 @@ export class VocApiStack extends cdk.Stack {
     // Metrics API
     const metricsRole = this.createLambdaRole('MetricsLambdaRole');
     feedbackTable.grantReadData(metricsRole);
-    aggregatesTable.grantReadData(metricsRole);
-    kmsKey.grantDecrypt(metricsRole);
+    aggregatesTable.grantReadWriteData(metricsRole);
+    kmsKey.grantEncryptDecrypt(metricsRole);
 
     const metricsLambda = new lambda.Function(this, 'MetricsApi', {
       functionName: uniqueName('voc-metrics-api'),
@@ -235,7 +237,10 @@ export class VocApiStack extends cdk.Stack {
       handler: 'scrapers_handler.lambda_handler',
       code: createApiLambdaCode('scrapers_handler.py'),
       role: scrapersRole,
-      timeout: cdk.Duration.seconds(60),
+      // 120s headroom for large CSV uploads (batched SQS sends). The API
+      // Gateway 29s integration limit is the real ceiling on sync uploads;
+      // this just keeps the Lambda from dying before that.
+      timeout: cdk.Duration.seconds(120),
       memorySize: 512,
       environment: { SECRETS_ARN: secretsArn, AGGREGATES_TABLE: aggregatesTable.tableName, WEBSCRAPER_FUNCTION_NAME: uniqueName('voc-ingestor-webscraper'), ALLOWED_ORIGIN: allowedOrigin, POWERTOOLS_SERVICE_NAME: 'voc-scrapers-api', LOG_LEVEL: 'INFO' },
       layers: [apiLayer],
@@ -423,9 +428,10 @@ export class VocApiStack extends cdk.Stack {
         'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0',
       ],
     }));
-    projectsRole.addToPolicy(new iam.PolicyStatement({ actions: ['lambda:InvokeFunction'], resources: [`arn:aws:lambda:${this.region}:${this.account}:function:voc-projects-api-*`] }));
-    NagSuppressions.addResourceSuppressions(projectsRole, pluginSystemSuppressions, true);
+
     rawDataBucket.grantReadWrite(projectsRole, 'avatars/*');
+    // Product context: projects API needs to issue presigned PUT URLs, read extracted text, delete docs.
+    rawDataBucket.grantReadWrite(projectsRole, 'projects/*/product_docs/*');
 
     const projectsLambda = new lambda.Function(this, 'ProjectsApi', {
       functionName: uniqueName('voc-projects-api'),
@@ -434,8 +440,8 @@ export class VocApiStack extends cdk.Stack {
       handler: 'projects_handler.lambda_handler',
       code: createApiLambdaCode('projects_handler.py'),
       role: projectsRole,
-      timeout: cdk.Duration.minutes(15),
-      memorySize: 1024,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 512,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
@@ -520,8 +526,15 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(documentGeneratorRole);
     documentGeneratorRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: claudeModelResources,
+      resources: [
+        ...claudeModelResources,
+        // Opus 4.8 powers the HTML prototype builder (_generate_prototype).
+        `arn:aws:bedrock:*:${this.account}:inference-profile/global.anthropic.claude-opus-4-8`,
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-8',
+      ],
     }));
+    // Product context: read extracted product-doc text when generating PRD/PR-FAQ.
+    rawDataBucket.grantRead(documentGeneratorRole, 'projects/*/product_docs/extracted/*');
 
     const documentGeneratorLambda = new lambda.Function(this, 'DocumentGeneratorJob', {
       functionName: uniqueName('voc-job-document-generator'),
@@ -536,6 +549,7 @@ export class VocApiStack extends cdk.Stack {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
         JOBS_TABLE: jobsTable.tableName,
+        RAW_DATA_BUCKET: rawDataBucket.bucketName,
         POWERTOOLS_SERVICE_NAME: 'voc-job-document-generator',
         LOG_LEVEL: 'INFO',
       },
@@ -615,6 +629,16 @@ export class VocApiStack extends cdk.Stack {
     documentGeneratorLambda.grantInvoke(projectsRole);
     documentMergerLambda.grantInvoke(projectsRole);
     personaImporterLambda.grantInvoke(projectsRole);
+
+    // PRD/PR-FAQ generation runs as a Step Functions workflow: each LLM step is
+    // its own Lambda invocation, so a long CJK document (whose steps auto-continue
+    // past maxTokens and can run minutes each) never overruns the single 15-min
+    // Lambda budget. Intermediate step text is stashed in S3 (claim-check) under
+    // scratch/document_jobs/* — SF state stays well under its 256KB ceiling.
+    rawDataBucket.grantReadWrite(documentGeneratorRole, 'scratch/document_jobs/*');
+    const documentStateMachine = this.createDocumentStateMachine(documentGeneratorLambda);
+    documentStateMachine.grantStartExecution(projectsRole);
+    projectsLambda.addEnvironment('DOCUMENT_STATE_MACHINE_ARN', documentStateMachine.stateMachineArn);
 
     // Chat Stream (Node.js — API Gateway response streaming, replaces Python Function URL)
     const chatStreamLambda = new NodejsFunction(this, 'ChatStreamApi', {
@@ -725,6 +749,32 @@ export class VocApiStack extends cdk.Stack {
       logGroup: this.createLogGroup('DataExplorerApiLogs', uniqueName('voc-data-explorer-api')),
     });
 
+    // Chrome Extension API
+    const extensionRole = this.createLambdaRole('ExtensionLambdaRole');
+    rawDataBucket.grantReadWrite(extensionRole);
+    kmsKey.grantEncryptDecrypt(extensionRole);
+    extensionRole.addToPolicy(new iam.PolicyStatement({ actions: ['sqs:SendMessage'], resources: [processingQueueArn] }));
+
+    const extensionLambda = new lambda.Function(this, 'ExtensionApi', {
+      functionName: uniqueName('voc-extension-api'),
+      runtime: lambda.Runtime.PYTHON_3_14,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'extension_handler.lambda_handler',
+      code: createApiLambdaCode('extension_handler.py'),
+      role: extensionRole,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 256,
+      environment: {
+        RAW_DATA_BUCKET: rawDataBucket.bucketName,
+        PROCESSING_QUEUE_URL: processingQueueUrl,
+        ALLOWED_ORIGIN: allowedOrigin,
+        POWERTOOLS_SERVICE_NAME: 'voc-extension-api',
+        LOG_LEVEL: 'INFO',
+      },
+      layers: [apiLayer],
+      logGroup: this.createLogGroup('ExtensionApiLogs', uniqueName('voc-extension-api')),
+    });
+
     // ============================================
     // WEBHOOKS
     // ============================================
@@ -759,7 +809,7 @@ export class VocApiStack extends cdk.Stack {
 
     this.api = new apigateway.RestApi(this, 'VocAnalyticsApi', {
       restApiName: uniqueName('voc-analytics-api'),
-      description: 'Voice of the Customer Analytics API',
+      description: 'Voice of the Customer Analytics API v2',
       deployOptions: {
         stageName: 'v1',
         throttlingRateLimit: 100,
@@ -814,6 +864,7 @@ export class VocApiStack extends cdk.Stack {
     const logsIntegration = new apigateway.LambdaIntegration(logsLambda, { proxy: true });
     const s3ImportIntegration = new apigateway.LambdaIntegration(s3ImportLambda, { proxy: true });
     const dataExplorerIntegration = new apigateway.LambdaIntegration(dataExplorerLambda, { proxy: true });
+    const extensionIntegration = new apigateway.LambdaIntegration(extensionLambda, { proxy: true });
 
     // ============================================
     // API ROUTES
@@ -827,14 +878,17 @@ export class VocApiStack extends cdk.Stack {
     feedbackIdResource.addResource('similar').addMethod('GET', metricsIntegration, authMethodOptions);
     feedbackResource.addResource('urgent').addMethod('GET', metricsIntegration, authMethodOptions);
     feedbackResource.addResource('entities').addMethod('GET', metricsIntegration, authMethodOptions);
+    feedbackResource.addResource('search').addMethod('GET', metricsIntegration, authMethodOptions);
+    const problemsResource = feedbackResource.addResource('problems');
+    problemsResource.addResource('resolved').addMethod('GET', metricsIntegration, authMethodOptions);
+    const problemIdResource = problemsResource.addResource('{problemId}');
+    const problemResolveResource = problemIdResource.addResource('resolve');
+    problemResolveResource.addMethod('PUT', metricsIntegration, authMethodOptions);
+    problemResolveResource.addMethod('DELETE', metricsIntegration, authMethodOptions);
 
-    // /metrics/*
+    // /metrics/* — proxy to metrics Lambda
     const metricsResource = this.api.root.addResource('metrics');
-    metricsResource.addResource('summary').addMethod('GET', metricsIntegration, authMethodOptions);
-    metricsResource.addResource('sentiment').addMethod('GET', metricsIntegration, authMethodOptions);
-    metricsResource.addResource('categories').addMethod('GET', metricsIntegration, authMethodOptions);
-    metricsResource.addResource('sources').addMethod('GET', metricsIntegration, authMethodOptions);
-    metricsResource.addResource('personas').addMethod('GET', metricsIntegration, authMethodOptions);
+    metricsResource.addProxy({ defaultIntegration: metricsIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
     // /chat/*
     const chatResource = this.api.root.addResource('chat');
@@ -886,46 +940,21 @@ export class VocApiStack extends cdk.Stack {
     manualResource.addResource('json-upload').addMethod('POST', manualImportIntegration, authMethodOptions);
     scrapersResource.addProxy({ defaultIntegration: scrapersIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
-    // /s3-import/*
+    // /s3-import/* — proxy to s3 import Lambda
     const s3ImportResource = this.api.root.addResource('s3-import');
-    s3ImportResource.addResource('files').addMethod('GET', s3ImportIntegration, authMethodOptions);
-    const s3SourcesResource = s3ImportResource.addResource('sources');
-    s3SourcesResource.addMethod('GET', s3ImportIntegration, authMethodOptions);
-    s3SourcesResource.addMethod('POST', s3ImportIntegration, authMethodOptions);
-    s3ImportResource.addResource('upload-url').addMethod('POST', s3ImportIntegration, authMethodOptions);
-    s3ImportResource.addResource('file').addResource('{key}').addMethod('DELETE', s3ImportIntegration, authMethodOptions);
+    s3ImportResource.addProxy({ defaultIntegration: s3ImportIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
-    // /data-explorer/*
+    // /data-explorer/* — proxy to data explorer Lambda
     const dataExplorerResource = this.api.root.addResource('data-explorer');
-    const dataExplorerS3Resource = dataExplorerResource.addResource('s3');
-    dataExplorerS3Resource.addMethod('GET', dataExplorerIntegration, authMethodOptions);
-    dataExplorerS3Resource.addMethod('PUT', dataExplorerIntegration, authMethodOptions);
-    dataExplorerS3Resource.addMethod('DELETE', dataExplorerIntegration, authMethodOptions);
-    dataExplorerS3Resource.addResource('preview').addMethod('GET', dataExplorerIntegration, authMethodOptions);
-    const dataExplorerFeedbackResource = dataExplorerResource.addResource('feedback');
-    dataExplorerFeedbackResource.addMethod('PUT', dataExplorerIntegration, authMethodOptions);
-    dataExplorerFeedbackResource.addMethod('DELETE', dataExplorerIntegration, authMethodOptions);
-    dataExplorerResource.addResource('stats').addMethod('GET', dataExplorerIntegration, authMethodOptions);
-    dataExplorerResource.addResource('buckets').addMethod('GET', dataExplorerIntegration, authMethodOptions);
+    dataExplorerResource.addProxy({ defaultIntegration: dataExplorerIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
-    // /settings/*
+    // /settings/* — proxy to settings Lambda
     const settingsResource = this.api.root.addResource('settings');
-    const brandResource = settingsResource.addResource('brand');
-    brandResource.addMethod('GET', settingsIntegration, authMethodOptions);
-    brandResource.addMethod('PUT', settingsIntegration, authMethodOptions);
-    const settingsCategoriesResource = settingsResource.addResource('categories');
-    settingsCategoriesResource.addMethod('GET', settingsIntegration, authMethodOptions);
-    settingsCategoriesResource.addMethod('PUT', settingsIntegration, authMethodOptions);
-    settingsCategoriesResource.addResource('generate').addMethod('POST', settingsIntegration, authMethodOptions);
+    settingsResource.addProxy({ defaultIntegration: settingsIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
-    // /logs/*
+    // /logs/* — proxy to logs Lambda
     const logsResource = this.api.root.addResource('logs');
-    const logsValidationResource = logsResource.addResource('validation');
-    logsValidationResource.addMethod('GET', logsIntegration, authMethodOptions);
-    logsValidationResource.addResource('{source}').addMethod('DELETE', logsIntegration, authMethodOptions);
-    logsResource.addResource('processing').addMethod('GET', logsIntegration, authMethodOptions);
-    logsResource.addResource('summary').addMethod('GET', logsIntegration, authMethodOptions);
-    logsResource.addResource('scraper').addResource('{scraper_id}').addMethod('GET', logsIntegration, authMethodOptions);
+    logsResource.addProxy({ defaultIntegration: logsIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
     // /users/*
     const usersResource = this.api.root.addResource('users');
@@ -933,19 +962,10 @@ export class VocApiStack extends cdk.Stack {
     usersResource.addMethod('POST', usersIntegration, authMethodOptions);
     usersResource.addProxy({ defaultIntegration: usersIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
-    // /feedback-form/* (legacy single form - public endpoints)
+    // /feedback-form/* (legacy single form - public endpoints, proxy to feedback form Lambda)
     const feedbackFormResource = this.api.root.addResource('feedback-form');
-    const feedbackFormConfigResource = feedbackFormResource.addResource('config');
-    const feedbackFormConfigGet = feedbackFormConfigResource.addMethod('GET', feedbackFormIntegration);
-    feedbackFormConfigResource.addMethod('PUT', feedbackFormIntegration, authMethodOptions);
-    const feedbackFormSubmit = feedbackFormResource.addResource('submit').addMethod('POST', feedbackFormIntegration);
-    const feedbackFormEmbed = feedbackFormResource.addResource('embed').addMethod('GET', feedbackFormIntegration);
-    const feedbackFormIframe = feedbackFormResource.addResource('iframe').addMethod('GET', feedbackFormIntegration);
-
-    NagSuppressions.addResourceSuppressions(feedbackFormConfigGet, publicFeedbackEndpointSuppressions);
-    NagSuppressions.addResourceSuppressions(feedbackFormSubmit, publicFeedbackEndpointSuppressions);
-    NagSuppressions.addResourceSuppressions(feedbackFormEmbed, publicFeedbackEndpointSuppressions);
-    NagSuppressions.addResourceSuppressions(feedbackFormIframe, publicFeedbackEndpointSuppressions);
+    const feedbackFormProxy = feedbackFormResource.addProxy({ defaultIntegration: feedbackFormIntegration, anyMethod: true });
+    NagSuppressions.addResourceSuppressions(feedbackFormProxy, publicFeedbackEndpointSuppressions, true);
 
     // /feedback-forms/* (multiple forms)
     const feedbackFormsResource = this.api.root.addResource('feedback-forms');
@@ -959,6 +979,10 @@ export class VocApiStack extends cdk.Stack {
     projectsResource.addMethod('GET', projectsIntegration, authMethodOptions);
     projectsResource.addMethod('POST', projectsIntegration, authMethodOptions);
     projectsResource.addProxy({ defaultIntegration: projectsIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
+
+    // /extension/* — proxy to extension Lambda
+    const extensionResource = this.api.root.addResource('extension');
+    extensionResource.addProxy({ defaultIntegration: extensionIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
     // /webhooks/{pluginId}
     const webhooksResource = this.api.root.addResource('webhooks');
@@ -1139,6 +1163,130 @@ exports.handler = async (event) => {
       logGroupName: `/aws/lambda/${name}`,
       retention: logs.RetentionDays.TWO_WEEKS,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+  }
+
+  /**
+   * PRD/PR-FAQ generation state machine. Splits the multi-step LLM chain across
+   * Lambda invocations so each step gets its own fresh 15-minute budget — long
+   * CJK documents (whose steps auto-continue past maxTokens over several Bedrock
+   * calls) no longer overrun a single Lambda. Mirrors the research workflow.
+   *
+   * Flow: gather → step0 → step1 → step2 → [step3 if PR-FAQ] → save
+   * PRD has 3 chain steps, PR-FAQ has 4 — a Choice on num_steps runs the 4th
+   * step only for PR-FAQ. Each step's index drives which chain step runs; the
+   * step handler reads/writes intermediate text in S3 (claim-check), so SF state
+   * carries only scalars. Every LLM step has its own retry on throttling.
+   */
+  private createDocumentStateMachine(documentStepLambda: lambda.Function): sfn.StateMachine {
+    const llmRetry = (t: tasks.LambdaInvoke) => {
+      t.addRetry({
+        errors: ['Lambda.ServiceException', 'Lambda.TooManyRequestsException', 'States.Timeout', 'BedrockThrottlingException'],
+        interval: cdk.Duration.seconds(5), maxAttempts: 3, backoffRate: 2,
+      });
+      return t;
+    };
+
+    // gather: build chain steps + context, stash to S3. Returns scalars
+    // (doc_type, title, feature_idea, num_steps) used by later states.
+    const gather = new tasks.LambdaInvoke(this, 'DocGather', {
+      lambdaFunction: documentStepLambda,
+      payload: sfn.TaskInput.fromObject({
+        step: 'gather',
+        'job_id.$': '$.job_id',
+        'project_id.$': '$.project_id',
+        'doc_config.$': '$.doc_config',
+      }),
+      resultPath: '$.gathered',
+      resultSelector: {
+        'doc_type.$': '$.Payload.doc_type',
+        'title.$': '$.Payload.title',
+        'feature_idea.$': '$.Payload.feature_idea',
+        'num_steps.$': '$.Payload.num_steps',
+      },
+    });
+
+    // One run_step state per fixed index. converse() auto-continues internally.
+    const runStep = (index: number) => {
+      const t = new tasks.LambdaInvoke(this, `DocStep${index}`, {
+        lambdaFunction: documentStepLambda,
+        payload: sfn.TaskInput.fromObject({
+          step: 'run_step',
+          index,
+          'job_id.$': '$.job_id',
+          'project_id.$': '$.project_id',
+        }),
+        resultPath: sfn.JsonPath.DISCARD, // output lives in S3; nothing to thread
+      });
+      return llmRetry(t);
+    };
+
+    const save = new tasks.LambdaInvoke(this, 'DocSave', {
+      lambdaFunction: documentStepLambda,
+      payload: sfn.TaskInput.fromObject({
+        step: 'save',
+        'job_id.$': '$.job_id',
+        'project_id.$': '$.project_id',
+        'doc_type.$': '$.gathered.doc_type',
+        'title.$': '$.gathered.title',
+        'feature_idea.$': '$.gathered.feature_idea',
+        'num_steps.$': '$.gathered.num_steps',
+      }),
+      resultPath: '$.save_result',
+    });
+    save.addRetry({ errors: ['Lambda.ServiceException', 'Lambda.TooManyRequestsException', 'States.Timeout'], interval: cdk.Duration.seconds(2), maxAttempts: 3, backoffRate: 2 });
+
+    const handleError = new tasks.LambdaInvoke(this, 'DocHandleError', {
+      lambdaFunction: documentStepLambda,
+      payload: sfn.TaskInput.fromObject({
+        step: 'error',
+        'job_id.$': '$.job_id',
+        'project_id.$': '$.project_id',
+        'error.$': '$.error',
+      }),
+    });
+
+    const success = new sfn.Succeed(this, 'DocComplete');
+    const fail = new sfn.Fail(this, 'DocFailed', { cause: 'Document job failed', error: 'DocumentError' });
+    handleError.next(fail);
+    // addCatch mutates the state's Catch list, so call it exactly once per state.
+    const addCatch = (s: tasks.LambdaInvoke) => s.addCatch(handleError, { resultPath: '$.error' });
+
+    // Attach the error catch to every state ONCE, up front.
+    addCatch(gather);
+    const s0 = addCatch(runStep(0));
+    const s1 = addCatch(runStep(1));
+    const s2 = addCatch(runStep(2));
+    const s3 = addCatch(runStep(3));
+    addCatch(save);
+    save.next(success);
+
+    // PR-FAQ has a 4th chain step; PRD stops at 3. Branch on num_steps.
+    // Both branches converge on the same (already-catch-wired) save state.
+    const maybeStep3 = new sfn.Choice(this, 'NeedsFourthStep')
+      .when(sfn.Condition.numberGreaterThan('$.gathered.num_steps', 3),
+            s3.next(save))
+      .otherwise(save);
+
+    const definition = gather
+      .next(s0)
+      .next(s1)
+      .next(s2)
+      .next(maybeStep3);
+
+    return new sfn.StateMachine(this, 'DocumentStateMachine', {
+      stateMachineName: uniqueName('voc-document-workflow'),
+      definitionBody: sfn.DefinitionBody.fromChainable(definition),
+      timeout: cdk.Duration.hours(2),
+      tracingEnabled: true,
+      logs: {
+        destination: new logs.LogGroup(this, 'DocumentStateMachineLogs', {
+          logGroupName: uniqueName('/aws/stepfunctions/voc-document-workflow'),
+          retention: logs.RetentionDays.TWO_WEEKS,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+        level: sfn.LogLevel.ALL,
+      },
     });
   }
 

--- a/voc-datalake/lib/utils/nag-suppressions.ts
+++ b/voc-datalake/lib/utils/nag-suppressions.ts
@@ -141,6 +141,9 @@ export const bedrockModelSuppressions: NagPackSuppression[] = [
     appliesTo: [
       'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
       'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
+      // Opus 4.8 powers the HTML prototype builder (document-generator Lambda).
+      'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-8',
+      { regex: '/Resource::arn:aws:bedrock:\\*:.*:inference-profile/global\\.anthropic\\.claude-opus-4-8/' },
     ],
   },
 ];
@@ -160,7 +163,7 @@ export const pluginSystemSuppressions: NagPackSuppression[] = [
   },
   {
     id: 'AwsSolutions-IAM5',
-    reason: 'Lambda version/alias wildcard required for Step Functions state machine invocations',
+    reason: 'Lambda version/alias wildcard required for Step Functions state machine invocations and async job Lambda invocations',
     appliesTo: [
       { regex: '/Resource::<.*ResearchStepLambda.*\.Arn>:\*/' },
       { regex: '/Resource::<.*ModelAgreementLambda.*\.Arn>:\*/' },


### PR DESCRIPTION
Ports the document-generation feature set onto `development` as one coherent change. The three pieces share `document_generator/handler.py` and the DocumentsTab UI, so splitting them would create artificial conflicts — they land together, isolated from everything else in the reconciliation queue.

## 1) PRD/PR-FAQ generation as a Step Functions workflow
Long CJK documents were overrunning the single 15-minute Lambda: with auto-continuation (#129) each LLM step can run minutes, and a 3–4 step chain in one invocation hits the ceiling.

- **`document_generator/handler.py`** — step router (`gather` → `run_step` ×N → `save`, plus an error handler). Each LLM step now gets its own 15-min Lambda budget. Intermediate step text is stashed in S3 (claim-check) under `scratch/document_jobs/*`, keeping Step Functions state far below its 256KB cap. The legacy single-shot path remains for prototype/report jobs.
- **`api-stack.ts`** — `createDocumentStateMachine` (DocGather → DocStep0..3 with Choice gates and an LLM retry policy → DocSave, error catch-all), `grantStartExecution` to the Projects API, `DOCUMENT_STATE_MACHINE_ARN` env, S3 scratch permissions.
- **`projects_handler.py`** — generate-document starts the state machine for `prd`/`prfaq` and falls back to a direct Lambda invoke when the ARN is absent.
- **prompts** — `max_tokens` rebalanced (solution 12k, prd_document 32k, prfaq steps 8k) so steps complete without continuation loops.

## 2) Product context workspace
- **`product_context.py`** (NEW) — PRODUCT_CONTEXT store, interview flow, product-doc upload/extract, and `build_product_context_block` used by the PRD/PR-FAQ chains so generated documents are grounded in the product profile.
- `shared/prompts.py` — generation steps take `product_context`; PR-FAQ pins `launch_date` ~90 days out (prevents past launch dates in Working-Backwards docs).
- Routes: `/product-context` (get/put/interview), `/product-docs`, `/prfaq-autofill`, `/research/suggest-questions`, `/documents/suggest-brief`.
- Frontend: ProductTab (interview + doc upload), AI-draft brief & research-question suggestions in the wizards.

## 3) Clickable HTML prototypes
- `_generate_prototype` emits a **self-contained offline-first HTML document** via Opus 4.8 (inline CSS/JS, no external CDN/fonts/network), with **feedback-driven regeneration** — a reviewer comments and gets a revised prototype that still honors the PRD/PR-FAQ. Saved with `prototype_format='html'`.
- IAM: DocumentGeneratorRole gains Opus 4.8 inference-profile + foundation-model ARNs (nag suppressions updated).
- Frontend: sandboxed-iframe PrototypeRenderer (`srcdoc` + `sandbox`), DocumentsTab prototype view + feedback→regenerate, BuildPrototypeButton, Prioritization PRFAQRow prototype panel, i18n (en/ko).

## Deliberately excluded
- **INSTANCE multi-deployment prefixes** from the source branch — upstream is single-deployment; all resource names keep the plain `voc-*` form.
- **Model bump sonnet-4-5 → 4-6** — model upgrades are a separate decision; every ARN/env here stays on `development`'s sonnet-4-5. (Only Opus 4.8 is added, scoped to the prototype builder.)
- ProblemAnalysis types and the Kiro-export refactor — separate reconciliation items.

## Tests
- `document_generator`: **32 passed** (11 new: step router, claim-check, HTML extraction, prototype regeneration)
- `lambda/api`: **284 passed** (product_context suite included)
- stream (regression): **183 passed** · frontend: **1507 passed** (93 files) · `tsc` clean
- `cdk synth` (assembly-only): StateMachine present with the DocGather/DocStep/DocSave chain; **0 cdk-nag errors**
- Pre-existing `test_http.py` failures reproduce on clean `development` (unrelated `http_utils` import issue)