### PR TITLE
fix: green eslint on dev + 3 small verified fixes (enabled flag, logs days filter, import modal state)

### DIFF
--- a/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
+++ b/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
@@ -5,58 +5,11 @@
  * from the Documents tab inside a project AND from the Prioritization page
  * (under the PR/FAQ preview, so reviewers see the demo without leaving).
  *
- * Spec shape (mirrors lambda/jobs/document_generator/handler.py):
- *   { title?, banner?, screens: [
- *       { id, label?, heading?, subheading?, blocks?: [
- *           { type: 'text' | 'callout' | 'stats' | 'list' | 'form' | 'buttons', ... }
- *       ] }
- *   ] }
+ * Spec parsing/types live in ./prototypeSpec (Zod-validated).
  */
 import clsx from 'clsx'
 import { useCallback, useMemo, useState } from 'react'
-
-export interface PrototypeBlock {
-  type: string
-  text?: string
-  tone?: string
-  title?: string
-  items?: Array<{
-    label?: string
-    title?: string
-    subtitle?: string
-    badge?: string
-    value?: string
-    goto?: string
-    tone?: string
-  }>
-  fields?: Array<{ label: string; placeholder?: string; type?: string }>
-  submit?: { label: string; goto?: string }
-}
-
-export interface PrototypeScreen {
-  id: string
-  label?: string
-  heading?: string
-  subheading?: string
-  blocks?: PrototypeBlock[]
-}
-
-export interface PrototypeSpec {
-  title?: string
-  banner?: string
-  screens: PrototypeScreen[]
-}
-
-/**
- * Heuristic: does this content look like a self-contained HTML document (the
- * newer Opus-built prototype format) rather than a legacy JSON spec? Used as a
- * fallback when `prototype_format` isn't present on the document.
- */
-export function looksLikeHtmlDocument(content: string | null | undefined): boolean {
-  if (!content) return false
-  const head = content.trimStart().slice(0, 200).toLowerCase()
-  return head.startsWith('<!doctype html') || head.startsWith('<html')
-}
+import type { PrototypeBlock, PrototypeSpec } from './prototypeSpec'
 
 /**
  * Renders a self-contained HTML prototype inside an iframe.
@@ -100,24 +53,6 @@ export function HtmlPrototypeFrame({
       className={className ?? 'w-full h-full border-0'}
     />
   )
-}
-
-/**
- * Parse a prototype document's `content` (which is a JSON string) into a spec
- * object, or return null if it can't be parsed. Caller decides how to display
- * malformed/legacy prototypes.
- */
-export function parsePrototypeSpec(content: string | null | undefined): PrototypeSpec | null {
-  if (!content) return null
-  try {
-    const parsed = JSON.parse(content) as unknown
-    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { screens?: unknown }).screens)) {
-      return parsed as PrototypeSpec
-    }
-  } catch {
-    // not JSON
-  }
-  return null
 }
 
 export default function PrototypeRenderer({ spec }: { readonly spec: PrototypeSpec }) {
@@ -184,74 +119,16 @@ function PrototypeBlockView({
   switch (block.type) {
     case 'text':
       return <p className="text-sm text-gray-700 whitespace-pre-wrap">{block.text}</p>
-
-    case 'callout': {
-      const toneClass = {
-        info: 'bg-blue-50 border-blue-200 text-blue-800',
-        success: 'bg-emerald-50 border-emerald-200 text-emerald-800',
-        warn: 'bg-amber-50 border-amber-200 text-amber-800',
-        error: 'bg-red-50 border-red-200 text-red-800',
-      }[block.tone || 'info'] ?? 'bg-gray-50 border-gray-200 text-gray-800'
-      return <div className={clsx('text-sm p-3 rounded-md border', toneClass)}>{block.text}</div>
-    }
-
+    case 'callout':
+      return <PrototypeCalloutBlock block={block} />
     case 'stats':
-      return (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          {(block.items ?? []).map((s, i) => (
-            <div key={i} className="border rounded-lg p-3 bg-gray-50">
-              <div className="text-xs text-gray-500">{s.label}</div>
-              <div className="text-lg font-semibold mt-0.5">{s.value}</div>
-            </div>
-          ))}
-        </div>
-      )
-
+      return <PrototypeStatsBlock block={block} />
     case 'list':
-      return (
-        <div className="space-y-2">
-          {block.title ? <h4 className="text-sm font-medium text-gray-700">{block.title}</h4> : null}
-          <ul className="divide-y border rounded-lg">
-            {(block.items ?? []).map((item, i) => (
-              <li key={i} className="px-3 py-2 flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-medium truncate">{item.title}</div>
-                  {item.subtitle ? <div className="text-xs text-gray-500 truncate">{item.subtitle}</div> : null}
-                </div>
-                {item.badge ? (
-                  <span className="ml-2 text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full whitespace-nowrap">
-                    {item.badge}
-                  </span>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )
-
+      return <PrototypeListBlock block={block} />
     case 'form':
       return <PrototypeFormBlock block={block} onNavigate={onNavigate} />
-
     case 'buttons':
-      return (
-        <div className="flex flex-wrap gap-2">
-          {(block.items ?? []).map((b, i) => (
-            <button
-              key={i}
-              onClick={() => onNavigate(b.goto)}
-              className={clsx(
-                'px-4 py-2 rounded-md text-sm transition-colors',
-                (b.tone ?? 'primary') === 'secondary'
-                  ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  : 'bg-blue-600 text-white hover:bg-blue-700',
-              )}
-            >
-              {b.label}
-            </button>
-          ))}
-        </div>
-      )
-
+      return <PrototypeButtonsBlock block={block} onNavigate={onNavigate} />
     default:
       return (
         <div className="text-xs text-gray-400 italic">
@@ -259,6 +136,78 @@ function PrototypeBlockView({
         </div>
       )
   }
+}
+
+function PrototypeCalloutBlock({ block }: { readonly block: PrototypeBlock }) {
+  const toneClass = {
+    info: 'bg-blue-50 border-blue-200 text-blue-800',
+    success: 'bg-emerald-50 border-emerald-200 text-emerald-800',
+    warn: 'bg-amber-50 border-amber-200 text-amber-800',
+    error: 'bg-red-50 border-red-200 text-red-800',
+  }[block.tone || 'info'] ?? 'bg-gray-50 border-gray-200 text-gray-800'
+  return <div className={clsx('text-sm p-3 rounded-md border', toneClass)}>{block.text}</div>
+}
+
+function PrototypeStatsBlock({ block }: { readonly block: PrototypeBlock }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {(block.items ?? []).map((s, i) => (
+        <div key={i} className="border rounded-lg p-3 bg-gray-50">
+          <div className="text-xs text-gray-500">{s.label}</div>
+          <div className="text-lg font-semibold mt-0.5">{s.value}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PrototypeListBlock({ block }: { readonly block: PrototypeBlock }) {
+  return (
+    <div className="space-y-2">
+      {block.title ? <h4 className="text-sm font-medium text-gray-700">{block.title}</h4> : null}
+      <ul className="divide-y border rounded-lg">
+        {(block.items ?? []).map((item, i) => (
+          <li key={i} className="px-3 py-2 flex items-center justify-between">
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium truncate">{item.title}</div>
+              {item.subtitle ? <div className="text-xs text-gray-500 truncate">{item.subtitle}</div> : null}
+            </div>
+            {item.badge ? (
+              <span className="ml-2 text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full whitespace-nowrap">
+                {item.badge}
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function PrototypeButtonsBlock({
+  block, onNavigate,
+}: {
+  readonly block: PrototypeBlock
+  readonly onNavigate: (id?: string) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {(block.items ?? []).map((b, i) => (
+        <button
+          key={i}
+          onClick={() => onNavigate(b.goto)}
+          className={clsx(
+            'px-4 py-2 rounded-md text-sm transition-colors',
+            (b.tone ?? 'primary') === 'secondary'
+              ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              : 'bg-blue-600 text-white hover:bg-blue-700',
+          )}
+        >
+          {b.label}
+        </button>
+      ))}
+    </div>
+  )
 }
 
 function PrototypeFormBlock({

--- a/voc-datalake/frontend/src/components/prototypeSpec.ts
+++ b/voc-datalake/frontend/src/components/prototypeSpec.ts
@@ -1,0 +1,84 @@
+/**
+ * Prototype spec parsing + detection helpers.
+ *
+ * Extracted from PrototypeRenderer.tsx so the component file only exports
+ * components (react-refresh), and so the JSON parsing is validated with Zod
+ * instead of type assertions.
+ *
+ * Spec shape (mirrors lambda/jobs/document_generator/handler.py):
+ *   { title?, banner?, screens: [
+ *       { id, label?, heading?, subheading?, blocks?: [
+ *           { type: 'text' | 'callout' | 'stats' | 'list' | 'form' | 'buttons', ... }
+ *       ] }
+ *   ] }
+ */
+import { z } from 'zod'
+
+const prototypeItemSchema = z.object({
+  label: z.string().optional(),
+  title: z.string().optional(),
+  subtitle: z.string().optional(),
+  badge: z.string().optional(),
+  value: z.string().optional(),
+  goto: z.string().optional(),
+  tone: z.string().optional(),
+})
+
+const prototypeBlockSchema = z.object({
+  type: z.string(),
+  text: z.string().optional(),
+  tone: z.string().optional(),
+  title: z.string().optional(),
+  items: z.array(prototypeItemSchema).optional(),
+  fields: z.array(z.object({
+    label: z.string(),
+    placeholder: z.string().optional(),
+    type: z.string().optional(),
+  })).optional(),
+  submit: z.object({ label: z.string(), goto: z.string().optional() }).optional(),
+})
+
+const prototypeScreenSchema = z.object({
+  id: z.string(),
+  label: z.string().optional(),
+  heading: z.string().optional(),
+  subheading: z.string().optional(),
+  blocks: z.array(prototypeBlockSchema).optional(),
+})
+
+export const prototypeSpecSchema = z.object({
+  title: z.string().optional(),
+  banner: z.string().optional(),
+  screens: z.array(prototypeScreenSchema),
+})
+
+export type PrototypeBlock = z.infer<typeof prototypeBlockSchema>
+export type PrototypeScreen = z.infer<typeof prototypeScreenSchema>
+export type PrototypeSpec = z.infer<typeof prototypeSpecSchema>
+
+/**
+ * Heuristic: does this content look like a self-contained HTML document (the
+ * newer Opus-built prototype format) rather than a legacy JSON spec? Used as a
+ * fallback when `prototype_format` isn't present on the document.
+ */
+export function looksLikeHtmlDocument(content: string | null | undefined): boolean {
+  if (!content) return false
+  const head = content.trimStart().slice(0, 200).toLowerCase()
+  return head.startsWith('<!doctype html') || head.startsWith('<html')
+}
+
+/**
+ * Parse a prototype document's `content` (which is a JSON string) into a
+ * validated spec object, or return null if it can't be parsed/validated.
+ * Caller decides how to display malformed/legacy prototypes.
+ */
+export function parsePrototypeSpec(content: string | null | undefined): PrototypeSpec | null {
+  if (!content) return null
+  try {
+    const result = prototypeSpecSchema.safeParse(JSON.parse(content))
+    return result.success ? result.data : null
+  } catch {
+    // not JSON
+    return null
+  }
+}

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -11,9 +11,8 @@ import {
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
-import PrototypeRenderer, {
-  parsePrototypeSpec, looksLikeHtmlDocument, HtmlPrototypeFrame,
-} from '../../components/PrototypeRenderer'
+import PrototypeRenderer, { HtmlPrototypeFrame } from '../../components/PrototypeRenderer'
+import { parsePrototypeSpec, looksLikeHtmlDocument } from '../../components/prototypeSpec'
 import {
   calculatePriorityScore, getPriorityLabel,
 } from './prioritizationUtils'
@@ -22,7 +21,7 @@ import type { PRFAQWithProject } from './prioritizationUtils'
 import type {
   PrioritizationScore, ProjectDocument,
 } from '../../api/types'
-import type { PrototypeSpec } from '../../components/PrototypeRenderer'
+import type { PrototypeSpec } from '../../components/prototypeSpec'
 import type { TFunction } from 'i18next'
 import type { ReactElement } from 'react'
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/BuildPrototypeButton.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/BuildPrototypeButton.tsx
@@ -13,6 +13,7 @@ import { AlertCircle, Loader2, Wand2 } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { projectsApi } from '../../api/projectsApi'
+import { pollJobToCompletion } from './jobPolling'
 
 export default function BuildPrototypeButton({
   projectId, hasPrd, hasPrfaq, onDocumentChanged,
@@ -28,44 +29,30 @@ export default function BuildPrototypeButton({
 
   const disabled = !hasPrd && !hasPrfaq
 
-  const onClick = useCallback(async () => {
-    // Both → use both. Only one → confirm we'll build from just that document.
+  // Both → use both. Only one → confirm we'll build from just that document.
+  const confirmSingleDocBuild = useCallback((): boolean => {
     if (hasPrd && !hasPrfaq) {
-      if (!window.confirm(t('documents.prototype.confirmPrdOnly', { defaultValue: 'No PR-FAQ yet — the prototype will be built from the PRD only. Continue?' }))) return
-    } else if (!hasPrd && hasPrfaq) {
-      if (!window.confirm(t('documents.prototype.confirmPrfaqOnly', { defaultValue: 'No PRD yet — the prototype will be built from the PR-FAQ only. Continue?' }))) return
+      return window.confirm(t('documents.prototype.confirmPrdOnly', { defaultValue: 'No PR-FAQ yet — the prototype will be built from the PRD only. Continue?' }))
     }
+    if (!hasPrd && hasPrfaq) {
+      return window.confirm(t('documents.prototype.confirmPrfaqOnly', { defaultValue: 'No PRD yet — the prototype will be built from the PR-FAQ only. Continue?' }))
+    }
+    return true
+  }, [hasPrd, hasPrfaq, t])
+
+  const onClick = useCallback(async () => {
+    if (!confirmSingleDocBuild()) return
     setBusy(true)
     setError(null)
     try {
       const start = await projectsApi.buildPrototype(projectId, { response_language: i18n.language })
-      const jobId = start.job_id
-      const deadline = Date.now() + 5 * 60_000
-      // Resilient polling: a single Wi-Fi hiccup or a brief CloudFront edge
-      // glitch shouldn't kill the whole flow with "Failed to fetch". Allow up
-      // to 5 consecutive transient errors before giving up — that's >15 seconds
-      // of network trouble, by which point something is genuinely wrong.
-      let consecutiveErrors = 0
-      while (Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 3000))
-        let job
-        try {
-          job = await projectsApi.getJobStatus(projectId, jobId)
-          consecutiveErrors = 0
-        } catch (pollErr) {
-          consecutiveErrors += 1
-          if (consecutiveErrors >= 5) throw pollErr
-          // eslint-disable-next-line no-console -- diagnostic for transient poll failures
-          console.warn(`Job poll error ${consecutiveErrors}/5 — retrying`, pollErr)
-          continue
-        }
-        if (job.status === 'completed') {
-          onDocumentChanged?.()
-          return
-        }
-        if (job.status === 'failed') {
-          throw new Error(job.error || 'Prototype build failed')
-        }
+      const outcome = await pollJobToCompletion(projectId, start.job_id)
+      if (outcome.status === 'completed') {
+        onDocumentChanged?.()
+        return
+      }
+      if (outcome.status === 'failed') {
+        throw new Error(outcome.job.error || 'Prototype build failed')
       }
       throw new Error(t('documents.prototype.timeout', { defaultValue: 'Prototype build took too long. Check the Documents tab in a moment.' }))
     } catch (e: unknown) {
@@ -74,17 +61,15 @@ export default function BuildPrototypeButton({
     } finally {
       setBusy(false)
     }
-  }, [projectId, i18n.language, onDocumentChanged, t, hasPrd, hasPrfaq])
+  }, [projectId, i18n.language, onDocumentChanged, t, confirmSingleDocBuild])
 
   const isDisabled = disabled || busy
-  let title: string
-  if (disabled) {
-    title = t('documents.prototype.needsDocs', { defaultValue: 'Create a PRD or a PR-FAQ first to enable prototype build' })
-  } else if (hasPrd && hasPrfaq) {
-    title = t('documents.prototype.buttonTitle', { defaultValue: 'Generate a clickable HTML prototype from this project’s PRD + PR-FAQ' })
-  } else {
-    title = t('documents.prototype.buttonTitleOne', { defaultValue: 'Generate a clickable HTML prototype from the available document (PRD or PR-FAQ)' })
-  }
+  const buttonTitleKey = hasPrd && hasPrfaq
+    ? { key: 'documents.prototype.buttonTitle', defaultValue: 'Generate a clickable HTML prototype from this project’s PRD + PR-FAQ' }
+    : { key: 'documents.prototype.buttonTitleOne', defaultValue: 'Generate a clickable HTML prototype from the available document (PRD or PR-FAQ)' }
+  const title = disabled
+    ? t('documents.prototype.needsDocs', { defaultValue: 'Create a PRD or a PR-FAQ first to enable prototype build' })
+    : t(buttonTitleKey.key, { defaultValue: buttonTitleKey.defaultValue })
 
   return (
     <div className="flex items-center gap-2">

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
@@ -11,10 +11,10 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { projectsApi } from '../../api/projectsApi'
+import { pollJobToCompletion } from './jobPolling'
 import DocumentExportMenu from '../../components/DocumentExportMenu'
-import PrototypeRenderer, {
-  parsePrototypeSpec, looksLikeHtmlDocument, HtmlPrototypeFrame,
-} from '../../components/PrototypeRenderer'
+import PrototypeRenderer, { HtmlPrototypeFrame } from '../../components/PrototypeRenderer'
+import { parsePrototypeSpec, looksLikeHtmlDocument } from '../../components/prototypeSpec'
 import type {
   ProjectDocument, Project,
 } from '../../api/types'
@@ -171,29 +171,15 @@ function PrototypeFeedbackButton({
         feedback: fb,
         base_prototype_id: basePrototypeId,
       })
-      const jobId = start.job_id
-      const deadline = Date.now() + 5 * 60_000
-      let consecutiveErrors = 0
-      while (Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 3000))
-        let job
-        try {
-          job = await projectsApi.getJobStatus(projectId, jobId)
-          consecutiveErrors = 0
-        } catch (pollErr) {
-          consecutiveErrors += 1
-          if (consecutiveErrors >= 5) throw pollErr
-          continue
-        }
-        if (job.status === 'completed') {
-          setOpen(false)
-          setFeedback('')
-          onRegenerated?.()
-          return
-        }
-        if (job.status === 'failed') {
-          throw new Error(job.error || 'Prototype revision failed')
-        }
+      const outcome = await pollJobToCompletion(projectId, start.job_id)
+      if (outcome.status === 'completed') {
+        setOpen(false)
+        setFeedback('')
+        onRegenerated?.()
+        return
+      }
+      if (outcome.status === 'failed') {
+        throw new Error(outcome.job.error || 'Prototype revision failed')
       }
       throw new Error(t('documents.prototype.timeout', { defaultValue: 'Prototype build took too long. Check the Documents tab in a moment.' }))
     } catch (e: unknown) {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProductFormFields.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProductFormFields.tsx
@@ -1,0 +1,95 @@
+/**
+ * Form-field building blocks for the ProductTab context form.
+ * Extracted from ProductTab.tsx to keep that file under the max-lines budget.
+ */
+import { Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+export function FieldShell({
+  label, field, savingField, highlight, children,
+}: {
+  readonly label: string
+  readonly field: string
+  readonly savingField: string | null
+  readonly highlight: boolean
+  readonly children: React.ReactNode
+}) {
+  return (
+    <div className={`transition-colors rounded-md ${highlight ? 'ring-2 ring-yellow-300 ring-offset-2 ring-offset-white' : ''}`}>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-xs font-medium text-gray-700">{label}</label>
+        {savingField === field && <Loader2 size={12} className="animate-spin text-gray-400" />}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export function TextField({
+  label, field, value, max, savingField, highlight, placeholder, onSave,
+}: {
+  readonly label: string; readonly field: string; readonly value: string; readonly max: number
+  readonly savingField: string | null; readonly highlight: boolean; readonly placeholder: string
+  readonly onSave: (v: string) => void
+}) {
+  const [draft, setDraft] = useState(value)
+  useEffect(() => { setDraft(value) }, [value])
+  return (
+    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
+      <input
+        type="text"
+        value={draft}
+        maxLength={max}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { if (draft !== value) onSave(draft) }}
+        className="w-full px-3 py-2 border rounded-md text-sm"
+        placeholder={placeholder}
+      />
+    </FieldShell>
+  )
+}
+
+export function TextAreaField({
+  label, field, value, max, rows, savingField, highlight, placeholder, onSave,
+}: {
+  readonly label: string; readonly field: string; readonly value: string; readonly max: number; readonly rows: number
+  readonly savingField: string | null; readonly highlight: boolean; readonly placeholder: string
+  readonly onSave: (v: string) => void
+}) {
+  const [draft, setDraft] = useState(value)
+  useEffect(() => { setDraft(value) }, [value])
+  return (
+    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
+      <textarea
+        value={draft}
+        rows={rows}
+        maxLength={max}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { if (draft !== value) onSave(draft) }}
+        className="w-full px-3 py-2 border rounded-md text-sm"
+        placeholder={placeholder}
+      />
+    </FieldShell>
+  )
+}
+
+export function SelectField({
+  label, field, value, options, savingField, highlight, onSave,
+}: {
+  readonly label: string; readonly field: string; readonly value: string
+  readonly options: { value: string; label: string }[]
+  readonly savingField: string | null; readonly highlight: boolean
+  readonly onSave: (v: string) => void
+}) {
+  return (
+    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
+      <select
+        value={value}
+        onChange={(e) => onSave(e.target.value)}
+        className="w-full px-3 py-2 border rounded-md text-sm bg-white"
+      >
+        {options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+    </FieldShell>
+  )
+}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProductTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProductTab.tsx
@@ -23,9 +23,26 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { projectsApi } from '../../api/projectsApi'
+import { pollJobToCompletion } from './jobPolling'
+import {
+  SelectField, TextAreaField, TextField,
+} from './ProductFormFields'
 import type {
   ProductContext, ProductDoc, ProductLifecycleState,
 } from '../../api/types'
+
+const LIFECYCLE_STATES: readonly ProductLifecycleState[] = ['', 'idea', 'mvp', 'beta', 'ga', 'mature']
+
+function isLifecycleState(value: string): value is ProductLifecycleState {
+  return LIFECYCLE_STATES.some((state) => state === value)
+}
+
+/** Build a single-field patch without a type assertion (computed generic keys widen otherwise). */
+function singleFieldPatch<K extends keyof ProductContext>(field: K, value: ProductContext[K]): Partial<ProductContext> {
+  const patch: Partial<ProductContext> = {}
+  patch[field] = value
+  return patch
+}
 
 const ALLOWED_MIME = {
   'application/pdf': '.pdf',
@@ -78,24 +95,24 @@ export default function ProductTab({ projectId, onDocumentChanged }: ProductTabP
   }, [projectId])
 
   useEffect(() => {
-    let cancelled = false
+    const lifecycle = { cancelled: false }
     setLoading(true)
     projectsApi.getProductContext(projectId).then((r) => {
-      if (!cancelled) setContext({ ...emptyContext(), ...r.context })
+      if (!lifecycle.cancelled) setContext({ ...emptyContext(), ...r.context })
     }).catch((e) => {
       console.error('Failed to load product context', e)
     }).finally(() => {
-      if (!cancelled) setLoading(false)
+      if (!lifecycle.cancelled) setLoading(false)
     })
-    return () => { cancelled = true }
+    return () => { lifecycle.cancelled = true }
   }, [projectId])
 
   const persistField = useCallback(async <K extends keyof ProductContext>(
     field: K, value: ProductContext[K],
   ) => {
-    setSavingField(field as string)
+    setSavingField(field)
     try {
-      const r = await projectsApi.updateProductContext(projectId, { [field]: value } as Partial<ProductContext>)
+      const r = await projectsApi.updateProductContext(projectId, singleFieldPatch(field, value))
       setContext({ ...emptyContext(), ...r.context })
     } catch (e) {
       console.error(`Failed to save ${String(field)}`, e)
@@ -233,7 +250,7 @@ function ProductForm({
         label={t('product.fields.currentState')} field="current_state" value={context.current_state}
         options={lifecycleOptions.map((o) => ({ value: o.value, label: t(o.labelKey) }))}
         savingField={savingField} highlight={highlightFields.has('current_state')}
-        onSave={(v) => onPersistField('current_state', v as ProductLifecycleState)}
+        onSave={(v) => { if (isLifecycleState(v)) onPersistField('current_state', v) }}
       />
       <TextAreaField
         label={t('product.fields.targetUsers')} field="target_users" value={context.target_users}
@@ -292,95 +309,6 @@ function ProductForm({
         onSave={(v) => onPersistField('free_form_notes', v)}
       />
     </div>
-  )
-}
-
-function FieldShell({
-  label, field, savingField, highlight, children,
-}: {
-  readonly label: string
-  readonly field: string
-  readonly savingField: string | null
-  readonly highlight: boolean
-  readonly children: React.ReactNode
-}) {
-  return (
-    <div className={`transition-colors rounded-md ${highlight ? 'ring-2 ring-yellow-300 ring-offset-2 ring-offset-white' : ''}`}>
-      <div className="flex items-center justify-between mb-1">
-        <label className="text-xs font-medium text-gray-700">{label}</label>
-        {savingField === field && <Loader2 size={12} className="animate-spin text-gray-400" />}
-      </div>
-      {children}
-    </div>
-  )
-}
-
-function TextField({
-  label, field, value, max, savingField, highlight, placeholder, onSave,
-}: {
-  readonly label: string; readonly field: string; readonly value: string; readonly max: number
-  readonly savingField: string | null; readonly highlight: boolean; readonly placeholder: string
-  readonly onSave: (v: string) => void
-}) {
-  const [draft, setDraft] = useState(value)
-  useEffect(() => { setDraft(value) }, [value])
-  return (
-    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
-      <input
-        type="text"
-        value={draft}
-        maxLength={max}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => { if (draft !== value) onSave(draft) }}
-        className="w-full px-3 py-2 border rounded-md text-sm"
-        placeholder={placeholder}
-      />
-    </FieldShell>
-  )
-}
-
-function TextAreaField({
-  label, field, value, max, rows, savingField, highlight, placeholder, onSave,
-}: {
-  readonly label: string; readonly field: string; readonly value: string; readonly max: number; readonly rows: number
-  readonly savingField: string | null; readonly highlight: boolean; readonly placeholder: string
-  readonly onSave: (v: string) => void
-}) {
-  const [draft, setDraft] = useState(value)
-  useEffect(() => { setDraft(value) }, [value])
-  return (
-    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
-      <textarea
-        value={draft}
-        rows={rows}
-        maxLength={max}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => { if (draft !== value) onSave(draft) }}
-        className="w-full px-3 py-2 border rounded-md text-sm"
-        placeholder={placeholder}
-      />
-    </FieldShell>
-  )
-}
-
-function SelectField({
-  label, field, value, options, savingField, highlight, onSave,
-}: {
-  readonly label: string; readonly field: string; readonly value: string
-  readonly options: { value: string; label: string }[]
-  readonly savingField: string | null; readonly highlight: boolean
-  readonly onSave: (v: string) => void
-}) {
-  return (
-    <FieldShell label={label} field={field} savingField={savingField} highlight={highlight}>
-      <select
-        value={value}
-        onChange={(e) => onSave(e.target.value)}
-        className="w-full px-3 py-2 border rounded-md text-sm bg-white"
-      >
-        {options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-      </select>
-    </FieldShell>
   )
 }
 
@@ -690,30 +618,14 @@ function ReportCard({
     setSuccess(false)
     try {
       const start = await projectsApi.generateProductReport(projectId, { response_language: language })
-      const jobId = start.job_id
-      const deadline = Date.now() + 5 * 60_000
-      let consecutiveErrors = 0
-      while (Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 2500))
-        let job
-        try {
-          job = await projectsApi.getJobStatus(projectId, jobId)
-          consecutiveErrors = 0
-        } catch (pollErr) {
-          consecutiveErrors += 1
-          if (consecutiveErrors >= 5) throw pollErr
-          // eslint-disable-next-line no-console -- diagnostic for transient poll failures
-          console.warn(`Job poll error ${consecutiveErrors}/5 — retrying`, pollErr)
-          continue
-        }
-        if (job.status === 'completed') {
-          setSuccess(true)
-          onDocumentChanged?.()
-          return
-        }
-        if (job.status === 'failed') {
-          throw new Error(job.error || 'Report generation failed')
-        }
+      const outcome = await pollJobToCompletion(projectId, start.job_id, { intervalMs: 2500 })
+      if (outcome.status === 'completed') {
+        setSuccess(true)
+        onDocumentChanged?.()
+        return
+      }
+      if (outcome.status === 'failed') {
+        throw new Error(outcome.job.error || 'Report generation failed')
       }
       throw new Error(t('product.report.timeout', { defaultValue: 'Report generation took too long. Check the Documents tab in a moment.' }))
     } catch (e: unknown) {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -283,11 +283,23 @@ export function DocWizard({
   const docCount = docTypes.length
   const bothSelected = hasPrd && hasPrfaq
 
+  const singleTitle = hasPrd
+    ? t('wizards.generatePrdTitle', { defaultValue: 'Generate PRD' })
+    : t('wizards.generatePrfaqTitle', { defaultValue: 'Generate PR-FAQ' })
+  const wizardTitle = bothSelected
+    ? t('wizards.generateBothTitle', { defaultValue: 'Generate PRD + PR-FAQ' })
+    : singleTitle
+
+  const singleSubmitLabel = hasPrd
+    ? t('wizards.generatePrd', { defaultValue: 'Generate PRD' })
+    : t('wizards.generatePrfaq', { defaultValue: 'Generate PR-FAQ' })
+  const submitLabelText = bothSelected
+    ? t('wizards.generateBoth', { defaultValue: 'Generate PRD + PR-FAQ' })
+    : singleSubmitLabel
+
   return (
     <DataSourceWizard
-      title={bothSelected
-        ? t('wizards.generateBothTitle', { defaultValue: 'Generate PRD + PR-FAQ' })
-        : t(hasPrd ? 'wizards.generatePrdTitle' : 'wizards.generatePrfaqTitle', { defaultValue: hasPrd ? 'Generate PRD' : 'Generate PR-FAQ' })}
+      title={wizardTitle}
       accentColor="blue"
       icon={<div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center"><FileText size={20} className="text-blue-600" /></div>}
       personas={personas}
@@ -395,9 +407,7 @@ export function DocWizard({
       onClose={onClose}
       onSubmit={onSubmit}
       isSubmitting={generating === 'doc'}
-      submitLabel={<><FileText size={16} />{bothSelected
-        ? t('wizards.generateBoth', { defaultValue: 'Generate PRD + PR-FAQ' })
-        : t(hasPrd ? 'wizards.generatePrd' : 'wizards.generatePrfaq', { defaultValue: hasPrd ? 'Generate PRD' : 'Generate PR-FAQ' })}</>}
+      submitLabel={<><FileText size={16} />{submitLabelText}</>}
     />
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/jobPolling.test.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/jobPolling.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the shared job-polling helper.
+ *
+ * Uses fake timers: pollJobToCompletion sleeps between polls, so tests
+ * advance the clock instead of waiting. projectsApi is mocked at the
+ * import boundary.
+ */
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest'
+import { pollJobToCompletion } from './jobPolling'
+import type { ProjectJob } from '../../api/types'
+
+const mockGetJobStatus = vi.fn()
+
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    getJobStatus: (projectId: string, jobId: string) => mockGetJobStatus(projectId, jobId),
+  },
+}))
+
+function job(status: ProjectJob['status'], error?: string): ProjectJob {
+  return {
+    job_id: 'job-1',
+    job_type: 'build_prototype',
+    status,
+    progress: 0,
+    created_at: '2026-07-13T00:00:00Z',
+    ...(error ? { error } : {}),
+  }
+}
+
+describe('pollJobToCompletion', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockGetJobStatus.mockReset()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns completed with the job when the job completes', async () => {
+    mockGetJobStatus.mockResolvedValue(job('completed'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1')
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await expect(promise).resolves.toEqual({ status: 'completed', job: job('completed') })
+    expect(mockGetJobStatus).toHaveBeenCalledWith('proj-1', 'job-1')
+  })
+
+  it('returns failed with the job (and its error) when the job fails', async () => {
+    mockGetJobStatus.mockResolvedValue(job('failed', 'boom'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1')
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await expect(promise).resolves.toEqual({ status: 'failed', job: job('failed', 'boom') })
+  })
+
+  it('keeps polling while the job is running, then resolves on completion', async () => {
+    mockGetJobStatus
+      .mockResolvedValueOnce(job('running'))
+      .mockResolvedValueOnce(job('running'))
+      .mockResolvedValueOnce(job('completed'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1')
+    await vi.advanceTimersByTimeAsync(3 * 3000)
+
+    await expect(promise).resolves.toMatchObject({ status: 'completed' })
+    expect(mockGetJobStatus).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns timeout when the deadline passes without a terminal status', async () => {
+    mockGetJobStatus.mockResolvedValue(job('running'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1', { timeoutMs: 10_000, intervalMs: 3000 })
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    await expect(promise).resolves.toEqual({ status: 'timeout' })
+  })
+
+  it('tolerates transient poll errors below the threshold and still resolves', async () => {
+    mockGetJobStatus
+      .mockRejectedValueOnce(new Error('net down'))
+      .mockRejectedValueOnce(new Error('net down'))
+      .mockResolvedValueOnce(job('completed'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1')
+    // 1 poll sleep + 2 retry sleeps
+    await vi.advanceTimersByTimeAsync(3 * 3000)
+
+    await expect(promise).resolves.toMatchObject({ status: 'completed' })
+    expect(mockGetJobStatus).toHaveBeenCalledTimes(3)
+  })
+
+  it('rethrows after the configured number of consecutive poll errors', async () => {
+    mockGetJobStatus.mockRejectedValue(new Error('net down'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1', { maxConsecutiveErrors: 3 })
+    // Attach the rejection expectation BEFORE advancing timers to avoid an unhandled rejection.
+    const assertion = expect(promise).rejects.toThrow('net down')
+    await vi.advanceTimersByTimeAsync(4 * 3000)
+
+    await assertion
+    expect(mockGetJobStatus).toHaveBeenCalledTimes(3)
+  })
+
+  it('resets the error count after a successful poll', async () => {
+    // 4 errors, success (running), 4 errors, success (completed):
+    // never hits 5 consecutive, so it must resolve rather than throw.
+    mockGetJobStatus
+      .mockRejectedValueOnce(new Error('e1'))
+      .mockRejectedValueOnce(new Error('e2'))
+      .mockRejectedValueOnce(new Error('e3'))
+      .mockRejectedValueOnce(new Error('e4'))
+      .mockResolvedValueOnce(job('running'))
+      .mockRejectedValueOnce(new Error('e5'))
+      .mockRejectedValueOnce(new Error('e6'))
+      .mockRejectedValueOnce(new Error('e7'))
+      .mockRejectedValueOnce(new Error('e8'))
+      .mockResolvedValueOnce(job('completed'))
+
+    const promise = pollJobToCompletion('proj-1', 'job-1')
+    await vi.advanceTimersByTimeAsync(10 * 3000)
+
+    await expect(promise).resolves.toMatchObject({ status: 'completed' })
+    expect(mockGetJobStatus).toHaveBeenCalledTimes(10)
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProjectDetail/jobPolling.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/jobPolling.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared resilient job polling for async project jobs (prototype builds,
+ * product reports, document generation).
+ *
+ * Kicked-off jobs are polled via projectsApi.getJobStatus until they reach
+ * `completed` or `failed`, or the deadline passes. A single Wi-Fi hiccup or a
+ * brief CloudFront edge glitch shouldn't kill the whole flow with "Failed to
+ * fetch", so up to `maxConsecutiveErrors` transient poll failures are
+ * tolerated before giving up — at the default cadence that's >15 seconds of
+ * network trouble, by which point something is genuinely wrong.
+ *
+ * Extracted from the three copies that previously lived in
+ * BuildPrototypeButton, DocumentsTab's revision form, and ProductTab's
+ * ReportCard.
+ */
+import { projectsApi } from '../../api/projectsApi'
+import type { ProjectJob } from '../../api/types'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export interface PollJobOptions {
+  /** Total time budget before giving up (default 5 minutes). */
+  readonly timeoutMs?: number
+  /** Delay between polls (default 3 seconds). */
+  readonly intervalMs?: number
+  /** Consecutive transient poll errors tolerated before rethrowing (default 5). */
+  readonly maxConsecutiveErrors?: number
+}
+
+export type PollJobResult =
+  | { status: 'completed'; job: ProjectJob }
+  | { status: 'failed'; job: ProjectJob }
+  | { status: 'timeout' }
+
+/**
+ * Poll a project job to a terminal state. Returns the outcome instead of
+ * throwing on failure/timeout so callers keep control of their user-facing
+ * error messages. Transient network errors during polling are retried up to
+ * `maxConsecutiveErrors` times (with the normal poll delay between attempts),
+ * then rethrown. The error count resets on every successful poll, matching
+ * the original inline implementations.
+ */
+export async function pollJobToCompletion(
+  projectId: string,
+  jobId: string,
+  options: PollJobOptions = {},
+): Promise<PollJobResult> {
+  const { timeoutMs = 5 * 60_000, intervalMs = 3000, maxConsecutiveErrors = 5 } = options
+  const deadline = Date.now() + timeoutMs
+
+  const fetchWithTolerance = async (consecutiveErrors = 0): Promise<ProjectJob> => {
+    try {
+      return await projectsApi.getJobStatus(projectId, jobId)
+    } catch (pollErr) {
+      const attempt = consecutiveErrors + 1
+      if (attempt >= maxConsecutiveErrors) throw pollErr
+      console.warn(`Job poll error ${attempt}/${maxConsecutiveErrors} — retrying`, pollErr)
+      await sleep(intervalMs)
+      return fetchWithTolerance(attempt)
+    }
+  }
+
+  while (Date.now() < deadline) {
+    await sleep(intervalMs)
+    const job = await fetchWithTolerance()
+    if (job.status === 'completed') return { status: 'completed', job }
+    if (job.status === 'failed') return { status: 'failed', job }
+  }
+  return { status: 'timeout' }
+}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
@@ -131,7 +131,7 @@ export function useProjectMutations({
         customer_questions: docConfig.customerQuestions.filter((q) => q.trim() !== ''),
         response_language: i18n.language,
       }
-      return Promise.all(types.map((doc_type) => projectsApi.generateDocument(projectId, { doc_type, ...base })))
+      return Promise.all(types.map((docType) => projectsApi.generateDocument(projectId, { doc_type: docType, ...base })))
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['project-jobs', id] })

--- a/voc-datalake/frontend/src/pages/Scrapers/ManualImportModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ManualImportModal.test.tsx
@@ -434,6 +434,60 @@ describe('ManualImportModal', () => {
 
       expect(mockConfirmManualImport).not.toHaveBeenCalled()
     })
+
+    it('shows Importing... state while confirm is in flight', async () => {
+      // Regression: previously isConfirming was tracked via useRef, which
+      // mutates without re-rendering, so the button never showed the loading
+      // state. After moving to useState, the button should re-render to show
+      // the spinner + "Importing..." label while the API call is pending.
+      const user = userEvent.setup()
+      let resolveConfirm: ((value: { success: boolean }) => void) | null = null
+      mockConfirmManualImport.mockReturnValue(
+        new Promise((resolve) => {
+          resolveConfirm = resolve
+        })
+      )
+
+      render(<ManualImportModal />)
+
+      const importButton = screen.getByRole('button', { name: /import 1 review/i })
+      await user.click(importButton)
+
+      // While the promise is unresolved, the button label should change.
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /importing/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByRole('button', { name: /import 1 review/i })).not.toBeInTheDocument()
+
+      // Resolve so the test can clean up.
+      resolveConfirm?.({ success: false })
+    })
+
+    it('prevents double-submit when import button is clicked twice rapidly', async () => {
+      // The disabled + "Importing…" button (driven by the isConfirming state)
+      // is what blocks the second click; the in-handler guard alone can't,
+      // because the second click's closure still sees the pre-update state.
+      const user = userEvent.setup()
+      let resolveConfirm: ((value: { success: boolean }) => void) | null = null
+      mockConfirmManualImport.mockReturnValue(
+        new Promise((resolve) => {
+          resolveConfirm = resolve
+        })
+      )
+
+      render(<ManualImportModal />)
+
+      const importButton = screen.getByRole('button', { name: /import 1 review/i })
+      await user.click(importButton)
+
+      // Second click should be a no-op while the first is in flight.
+      const importingButton = await screen.findByRole('button', { name: /importing/i })
+      await user.click(importingButton)
+
+      expect(mockConfirmManualImport).toHaveBeenCalledTimes(1)
+
+      resolveConfirm?.({ success: false })
+    })
   })
 
   describe('polling', () => {

--- a/voc-datalake/frontend/src/pages/Scrapers/ManualImportModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ManualImportModal.tsx
@@ -2,7 +2,7 @@ import {
   X, Loader2, AlertCircle, CheckCircle, Plus, ArrowLeft, Upload, ClipboardPaste,
 } from 'lucide-react'
 import {
-  useEffect, useRef, useCallback,
+  useEffect, useRef, useCallback, useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { scrapersApi } from '../../api/scrapersApi'
@@ -221,7 +221,10 @@ export default function ManualImportModal() {
   } = useManualImportStore()
 
   const pollIntervalRef = useRef<number | null>(null)
-  const isConfirmingRef = useRef(false)
+  // State (not a ref): the value is read during render to drive the disabled +
+  // "Importing…" button UI, and mutating a ref never re-renders — with a ref
+  // the in-flight state silently never showed.
+  const [isConfirming, setIsConfirming] = useState(false)
 
   // Check for stale draft on mount
   useEffect(() => {
@@ -311,8 +314,8 @@ export default function ManualImportModal() {
   }
 
   const handleConfirm = async () => {
-    if (isConfirmingRef.current || (jobId == null || jobId === '')) return
-    isConfirmingRef.current = true
+    if (isConfirming || (jobId == null || jobId === '')) return
+    setIsConfirming(true)
 
     try {
       const validReviews = parsedReviews.filter((r) => r.text.trim().length > 0)
@@ -329,7 +332,7 @@ export default function ManualImportModal() {
     } catch {
       setProcessingError('Failed to import reviews')
     } finally {
-      isConfirmingRef.current = false
+      setIsConfirming(false)
     }
   }
 
@@ -356,7 +359,7 @@ export default function ManualImportModal() {
         <div className="flex-1 overflow-y-auto p-6">
           {step === 'input' && <InputStep />}
           {step === 'processing' && <ProcessingStep />}
-          {step === 'preview' && <PreviewStep onConfirm={() => void handleConfirm()} isConfirming={isConfirmingRef.current} />}
+          {step === 'preview' && <PreviewStep onConfirm={() => void handleConfirm()} isConfirming={isConfirming} />}
         </div>
 
         {step === 'input' && (

--- a/voc-datalake/frontend/src/plugins/manifests.json
+++ b/voc-datalake/frontend/src/plugins/manifests.json
@@ -309,7 +309,7 @@
       },
       {
         "key": "num_reviews",
-        "label": "Number of Reviews to Generate (max 50)",
+        "label": "Number of Reviews to Generate (max 150)",
         "type": "text",
         "required": false,
         "placeholder": "10",
@@ -372,7 +372,7 @@
       "steps": [
         "Enter your company/brand and product details so reviews sound realistic.",
         "Optionally describe your target customer and the focus areas to cover (e.g. delivery, pricing, support).",
-        "Choose how many reviews to generate (max 50 per run) and the sentiment mix.",
+        "Choose how many reviews to generate (max 150 per run) and the sentiment mix.",
         "Click Generate. Reviews are created with AI and ingested through the normal pipeline.",
         "Generated items are tagged as synthetic (source: synthetic_reviews) so you can filter them out anytime."
       ]

--- a/voc-datalake/lambda/api/logs_handler.py
+++ b/voc-datalake/lambda/api/logs_handler.py
@@ -151,10 +151,16 @@ def get_scraper_logs(scraper_id: str):
         
         logs = []
         for item in response.get('Items', []):
+            # Filter by lookback window — items older than `cutoff` are skipped.
+            # (`cutoff` was previously computed but never applied, making the
+            # `days` query param a no-op.) Runs missing `started_at` are kept.
+            started_at = item.get('started_at', '')
+            if started_at and started_at < cutoff:
+                continue
             logs.append({
                 'run_id': item.get('sk', ''),
                 'status': item.get('status'),
-                'started_at': item.get('started_at'),
+                'started_at': started_at,
                 'completed_at': item.get('completed_at'),
                 'pages_scraped': item.get('pages_scraped', 0),
                 'items_found': item.get('items_found', 0),

--- a/voc-datalake/lambda/api/test/test_logs_handler.py
+++ b/voc-datalake/lambda/api/test/test_logs_handler.py
@@ -8,6 +8,12 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone, timedelta
 
 
+def _today_iso() -> str:
+    """Today as ISO timestamp. Used for scraper_run started_at fixtures so they
+    fall within the default 7-day lookback regardless of when tests run."""
+    return datetime.now(timezone.utc).isoformat()
+
+
 class TestGetValidationLogs:
     """Tests for GET /logs/validation endpoint."""
 
@@ -236,14 +242,15 @@ class TestGetScraperLogs:
     ):
         """Returns run history for specific scraper."""
         # Arrange
+        recent = _today_iso()
         mock_table.query.return_value = {
             'Items': [
                 {
                     'pk': 'SCRAPER#scraper-123',
-                    'sk': 'RUN#2025-01-01T12:00:00Z',
+                    'sk': f'RUN#{recent}',
                     'status': 'completed',
-                    'started_at': '2025-01-01T12:00:00Z',
-                    'completed_at': '2025-01-01T12:05:00Z',
+                    'started_at': recent,
+                    'completed_at': recent,
                     'pages_scraped': 10,
                     'items_found': 50,
                     'errors': []
@@ -269,6 +276,88 @@ class TestGetScraperLogs:
         assert body['logs'][0]['status'] == 'completed'
         assert body['logs'][0]['pages_scraped'] == 10
         assert body['logs'][0]['items_found'] == 50
+
+    @patch('logs_handler.aggregates_table')
+    def test_excludes_runs_older_than_lookback_window(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """Runs whose started_at predates the `days` window are filtered out.
+
+        Regression: the cutoff was previously computed but never applied, so the
+        `days` query param was a no-op and every run was returned. This test
+        fails if that filter is removed again.
+        """
+        # Arrange: one recent run (kept) and one a year old (must be dropped).
+        recent = _today_iso()
+        old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+        mock_table.query.return_value = {
+            'Items': [
+                {
+                    'pk': 'SCRAPER#scraper-123', 'sk': f'RUN#{recent}',
+                    'status': 'completed', 'started_at': recent,
+                    'completed_at': recent, 'pages_scraped': 5,
+                    'items_found': 20, 'errors': [],
+                },
+                {
+                    'pk': 'SCRAPER#scraper-123', 'sk': f'RUN#{old}',
+                    'status': 'completed', 'started_at': old,
+                    'completed_at': old, 'pages_scraped': 99,
+                    'items_found': 999, 'errors': [],
+                },
+            ]
+        }
+
+        from logs_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/logs/scraper/scraper-123',
+            path_params={'scraper_id': 'scraper-123'},
+            query_params={'days': '7'},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert: only the recent run survives the cutoff.
+        assert response['statusCode'] == 200
+        assert body['count'] == 1
+        assert body['logs'][0]['started_at'] == recent
+        returned_started = [log['started_at'] for log in body['logs']]
+        assert old not in returned_started
+
+    @patch('logs_handler.aggregates_table')
+    def test_keeps_runs_missing_started_at(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """Runs without a started_at are kept (not silently dropped by the filter)."""
+        # Arrange
+        mock_table.query.return_value = {
+            'Items': [
+                {
+                    'pk': 'SCRAPER#scraper-123', 'sk': 'RUN#legacy',
+                    'status': 'completed', 'pages_scraped': 1,
+                    'items_found': 2, 'errors': [],
+                },
+            ]
+        }
+
+        from logs_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/logs/scraper/scraper-123',
+            path_params={'scraper_id': 'scraper-123'},
+            query_params={'days': '7'},
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert: the run with no timestamp is preserved.
+        assert response['statusCode'] == 200
+        assert body['count'] == 1
+        assert body['logs'][0]['run_id'] == 'RUN#legacy'
 
     @patch('logs_handler.aggregates_table')
     def test_returns_empty_list_for_unknown_scraper(

--- a/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
@@ -166,6 +166,9 @@ class AndroidAppReviewsIngestor(BaseIngestor):
             return
 
         for app in self.app_configs:
+            if not app.enabled:
+                logger.info(f"Skipping disabled Android app: {app.name} ({app.package_name})")
+                continue
             yield from process_app_reviews(
                 app_config=app,
                 app_name=app.name,

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/handler.py
@@ -161,6 +161,9 @@ class IOSAppReviewsIngestor(BaseIngestor):
             return
 
         for app in self.app_configs:
+            if not app.enabled:
+                logger.info(f"Skipping disabled iOS app: {app.name} ({app.app_id})")
+                continue
             yield from process_app_reviews(
                 app_config=app,
                 app_name=app.name,

--- a/voc-datalake/plugins/test_app_reviews_enabled_filter.py
+++ b/voc-datalake/plugins/test_app_reviews_enabled_filter.py
@@ -1,0 +1,184 @@
+"""Regression tests for the per-app `enabled` flag in app_reviews ingestors.
+
+Both Android and iOS handlers parse an `enabled` boolean per app config
+(`models.py` defaults it to True) but historically iterated all configs in
+`fetch_new_items` without honoring the flag, so disabled apps were still
+scraped. These tests pin down the fix: disabled apps must be skipped before
+any review collection happens.
+
+Import mechanics: the handlers use flat sibling imports (`from models import
+...`, `from countries import ...`) that mirror the Lambda bundle layout, and
+BOTH plugins ship same-named flat modules. Each import helper therefore puts
+the right ingestor dir at the front of sys.path and drops any cached flat
+modules first, so the second plugin's handler doesn't pick up the first
+plugin's `models`/`countries`.
+
+Ported from GitHub PR #108 (cluster 2, `.pr108-reconcile` P2).
+"""
+import os
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+_PLUGINS_DIR = os.path.dirname(os.path.abspath(__file__))
+ANDROID_DIR = os.path.join(_PLUGINS_DIR, "app_reviews_android", "ingestor")
+IOS_DIR = os.path.join(_PLUGINS_DIR, "app_reviews_ios", "ingestor")
+
+_FLAT_MODULES = ["models", "countries", "play_client", "itunes_client"]
+
+
+@contextmanager
+def _patched_aws():
+    """Mock the AWS client factories used by BaseIngestor.__init__."""
+    with patch("_shared.base_ingestor.get_dynamodb_resource") as mock_dynamo, \
+            patch("_shared.base_ingestor.get_s3_client"), \
+            patch("_shared.base_ingestor.get_sqs_client"), \
+            patch("_shared.base_ingestor.get_secret", return_value={}):
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+        yield
+
+
+def _prepare_flat_imports(ingestor_dir: str) -> None:
+    """Point the flat sibling imports at the given plugin's ingestor dir."""
+    for mod in _FLAT_MODULES:
+        sys.modules.pop(mod, None)
+    if ingestor_dir in sys.path:
+        sys.path.remove(ingestor_dir)
+    sys.path.insert(0, ingestor_dir)
+
+
+def _import_android_handler():
+    _prepare_flat_imports(ANDROID_DIR)
+    sys.modules.pop("app_reviews_android.ingestor.handler", None)
+    from app_reviews_android.ingestor import handler as android_handler
+    return android_handler
+
+
+def _import_ios_handler():
+    _prepare_flat_imports(IOS_DIR)
+    sys.modules.pop("app_reviews_ios.ingestor.handler", None)
+    from app_reviews_ios.ingestor import handler as ios_handler
+    return ios_handler
+
+
+class TestAndroidEnabledFilter:
+    """app_reviews_android fetch_new_items honors the per-app enabled flag."""
+
+    def test_skips_disabled_app(self):
+        with _patched_aws():
+            android_handler = _import_android_handler()
+            from models import AndroidAppConfig
+
+            ingestor = android_handler.AndroidAppReviewsIngestor()
+            ingestor.app_configs = [
+                AndroidAppConfig(name="Disabled", package_name="com.disabled", enabled=False),
+            ]
+
+            with patch.object(android_handler, "process_app_reviews") as mock_process:
+                items = list(ingestor.fetch_new_items())
+
+            assert items == []
+            assert mock_process.call_count == 0
+
+    def test_processes_enabled_app(self):
+        with _patched_aws():
+            android_handler = _import_android_handler()
+            from models import AndroidAppConfig
+
+            ingestor = android_handler.AndroidAppReviewsIngestor()
+            ingestor.app_configs = [
+                AndroidAppConfig(name="Enabled", package_name="com.enabled", enabled=True),
+            ]
+
+            with patch.object(
+                android_handler, "process_app_reviews",
+                return_value=iter([{"id": "r1"}]),
+            ) as mock_process:
+                items = list(ingestor.fetch_new_items())
+
+            assert items == [{"id": "r1"}]
+            assert mock_process.call_count == 1
+
+    def test_skips_only_disabled_in_mixed_list(self):
+        """Disabled apps are filtered out without affecting enabled neighbors."""
+        with _patched_aws():
+            android_handler = _import_android_handler()
+            from models import AndroidAppConfig
+
+            ingestor = android_handler.AndroidAppReviewsIngestor()
+            ingestor.app_configs = [
+                AndroidAppConfig(name="A", package_name="com.a", enabled=True),
+                AndroidAppConfig(name="B", package_name="com.b", enabled=False),
+                AndroidAppConfig(name="C", package_name="com.c", enabled=True),
+            ]
+
+            with patch.object(
+                android_handler, "process_app_reviews",
+                side_effect=lambda **kw: iter([{"app": kw["app_name"]}]),
+            ) as mock_process:
+                items = list(ingestor.fetch_new_items())
+
+            processed_names = [c.kwargs["app_name"] for c in mock_process.call_args_list]
+            assert processed_names == ["A", "C"]
+            assert items == [{"app": "A"}, {"app": "C"}]
+
+
+class TestIOSEnabledFilter:
+    """app_reviews_ios fetch_new_items honors the per-app enabled flag."""
+
+    def test_skips_disabled_app(self):
+        ios_handler = _import_ios_handler()
+        with _patched_aws(), patch.object(ios_handler, "create_session", return_value=MagicMock()):
+            from models import IOSAppConfig
+
+            ingestor = ios_handler.IOSAppReviewsIngestor()
+            ingestor.app_configs = [
+                IOSAppConfig(name="Disabled", app_id="111", enabled=False),
+            ]
+
+            with patch.object(ios_handler, "process_app_reviews") as mock_process:
+                items = list(ingestor.fetch_new_items())
+
+            assert items == []
+            assert mock_process.call_count == 0
+
+    def test_processes_enabled_app(self):
+        ios_handler = _import_ios_handler()
+        with _patched_aws(), patch.object(ios_handler, "create_session", return_value=MagicMock()):
+            from models import IOSAppConfig
+
+            ingestor = ios_handler.IOSAppReviewsIngestor()
+            ingestor.app_configs = [
+                IOSAppConfig(name="Enabled", app_id="222", enabled=True),
+            ]
+
+            with patch.object(
+                ios_handler, "process_app_reviews",
+                return_value=iter([{"id": "r1"}]),
+            ) as mock_process:
+                items = list(ingestor.fetch_new_items())
+
+            assert items == [{"id": "r1"}]
+            assert mock_process.call_count == 1
+
+    def test_skips_only_disabled_in_mixed_list(self):
+        ios_handler = _import_ios_handler()
+        with _patched_aws(), patch.object(ios_handler, "create_session", return_value=MagicMock()):
+            from models import IOSAppConfig
+
+            ingestor = ios_handler.IOSAppReviewsIngestor()
+            ingestor.app_configs = [
+                IOSAppConfig(name="A", app_id="1", enabled=True),
+                IOSAppConfig(name="B", app_id="2", enabled=False),
+                IOSAppConfig(name="C", app_id="3", enabled=True),
+            ]
+
+            with patch.object(
+                ios_handler, "process_app_reviews",
+                side_effect=lambda **kw: iter([{"app": kw["app_name"]}]),
+            ) as mock_process:
+                items = list(ingestor.fetch_new_items())
+
+            processed_names = [c.kwargs["app_name"] for c in mock_process.call_args_list]
+            assert processed_names == ["A", "C"]
+            assert items == [{"app": "A"}, {"app": "C"}]


### PR DESCRIPTION
## What

One stacked branch, four small concerns (per-commit review recommended):

**1. `7116206` — fix(lint): resolve all 24 eslint errors left by #132**
`eslint .` (and therefore the root `npm run check`) has been red on `development` since #132 merged. Pure refactors, no behavior change:
- NEW `ProjectDetail/jobPolling.ts` — shared `pollJobToCompletion()` extracted from the **three copy-pasted** resilient job-poll loops (BuildPrototypeButton, DocumentsTab revision form, ProductTab ReportCard); root cause of most `let`/`max-depth`/`complexity` violations. Cadence + 5-error tolerance preserved.
- NEW `components/prototypeSpec.ts` — prototype spec parsing moved out of the component file and validated with **Zod** instead of `as` assertions; malformed specs fall back to the existing raw view. Clears the react-refresh warnings too.
- `PrototypeRenderer.tsx` block sub-components (complexity 13 → <12); NEW `ProductFormFields.tsx` (ProductTab 676 → under the 600-line budget); `Wizards.tsx` nested ternaries hoisted; `useProjectData.ts` `doc_type`→`docType`.

**2. `ab9829f` — fix(plugins): honor the per-app `enabled` flag (PR #108 cluster 2)**
Both app-review handlers parsed `enabled` per app config but `fetch_new_items` never checked it — disabled apps were still scraped every run. Adds the skip guard + info log. NEW `test_app_reviews_enabled_filter.py` (6 tests; the 4 disabled-app tests verified to FAIL with the guard reverted).

**3. `939f263` — fix(logs): apply the computed cutoff so `/logs/scraper/{id}?days=N` works (PR #108 cluster 3)**
`get_scraper_logs` computed the lookback cutoff then never used it, so the `days` param the Settings LogsSection passes was a no-op. In-memory `started_at` filter; runs missing `started_at` kept. 2 regression tests (exclusion verified to fail with the filter removed).

**4. `6192166` — fix(frontend): show the ManualImportModal "Importing…" state (PR #108 cluster 5)**
`isConfirming` was a `useRef` read during render — never re-renders, so the fully built loading UX (disabled button + spinner + translated label) was dead code. Switched to `useState`. 2 regression tests (verified to fail with the ref restored).

Plus `f4fcd80`: 7 fake-timer unit tests for the new `jobPolling.ts` helper.

(#108 cluster 4 — admin-password shuffle + Cognito `signInCaseSensitive` — was evaluated and deliberately **excluded**: the Cognito hunk is fork-history-specific and risks user-pool replacement on this line; the shuffle is greenfield-only and parked for a future core-stack PR.)

## Verification

**Unit/static:** `eslint .` exit 0 (was 24 errors/4 warnings) · `tsc -b` clean · frontend vitest **1529/1529** · `lambda/api` pytest **286** · plugins pytest **195** · CDK vitest 30. Every behavioral fix ships with regression tests **verified to fail with the fix reverted**.

**Live on a test AWS account (all stacks deployed via CDK/Finch + frontend):**
- `scripts/test-api.sh`: **32/32** endpoints green
- **Enabled flag:** seeded an app config with `enabled:false`, triggered `POST /sources/app_reviews_android/run` → run completed `items_found=0` with the CloudWatch log `Skipping disabled Android app: … (com.e2e.disabled)`
- **Logs filter:** seeded one recent + one year-old `SCRAPER_RUN` row → `?days=7` returned only the recent run, `?days=3650` returned both (seeds cleaned up)
- **Import modal:** full paste → AI parse → preview → import flow in the browser; the disabled **"Importing…"** button state now visibly renders during flight; the imported item flowed through the whole pipeline (Bedrock-enriched) and was removed after
- **Lint refactor smoke (browser):** project tabs, Documents, Product tab (field-save round-trip persisted), Create Document wizard all render; prototypes render on **both** paths — legacy `srcDoc` fallback and new `/prototypes/*` `src=` — and in-prototype navigation still switches screens (inline JS executes, no CSP errors)

## Notes for reviewers

- `npm run typecheck:tests` has pre-existing failures in `src/test/test-utils.tsx` (untouched here; also failing on `development`; not part of `npm run check`).
- Two **pre-existing** bugs surfaced during live testing (not addressed here, happy to file issues): `DELETE /data-explorer/feedback` queries a non-existent `feedback-id-index` GSI and always fails; the Scrapers app-config card delete didn't persist in testing.
