### PR TITLE
fix(ingestion): page through full review/feedback sets (prd-fix #13 / P2)

### DIFF
--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -49,7 +49,7 @@ def _fetch_and_filter(
     categories: list[str],
     sentiments: list[str],
     fetch_ceiling: int,
-    per_day_limit: int,
+    per_day_limit: int,  # deprecated: superseded by LastEvaluatedKey paging
 ) -> list[dict]:
     """Internal: fetch items from DynamoDB and apply in-memory filters.
 
@@ -123,7 +123,9 @@ def query_feedback_by_date(
         sentiments: Optional list of sentiment_label values to keep.
         limit: Maximum number of items to return after filtering.
         offset: Number of items to skip (for pagination).
-        per_day_limit: DynamoDB Limit per date query (default 500).
+        per_day_limit: Deprecated — retained for call-site compatibility.
+            Partition reads now page through LastEvaluatedKey and are bounded
+            by fetch_ceiling / MAX_ITEMS_PER_PARTITION instead.
 
     Returns:
         Filtered list of feedback items, sliced by offset/limit.

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -13,6 +13,34 @@ logger = logging.getLogger(__name__)
 # Maximum number of days to look back when querying by date
 MAX_LOOKBACK_DAYS = 90
 
+# Hard ceiling on how many items a single partition (one date / one category)
+# query will page through, so a huge backfill can't make one query run forever.
+# DynamoDB returns up to 1MB per page; without LastEvaluatedKey paging we'd only
+# ever see the first ~500 items of a partition (the "500개 중" truncation bug).
+MAX_ITEMS_PER_PARTITION = 10000
+
+
+def _query_all_pages(feedback_table, *, index_name, key_expr, max_items):
+    """Query a GSI partition, following LastEvaluatedKey until exhausted or
+    `max_items` collected. DynamoDB caps each page at 1MB, so a single query()
+    only returns a slice of a large partition — this pages through the rest."""
+    collected: list[dict] = []
+    last_key = None
+    while True:
+        kwargs = {
+            'IndexName': index_name,
+            'KeyConditionExpression': key_expr,
+            'ScanIndexForward': False,
+        }
+        if last_key:
+            kwargs['ExclusiveStartKey'] = last_key
+        response = feedback_table.query(**kwargs)
+        collected.extend(response.get('Items', []))
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key or len(collected) >= max_items:
+            break
+    return collected[:max_items]
+
 
 def _fetch_and_filter(
     feedback_table,
@@ -34,28 +62,30 @@ def _fetch_and_filter(
     items: list[dict] = []
     current_date = datetime.now(timezone.utc)
 
+    # Per-partition page cap: honour fetch_ceiling when set (early-break path),
+    # otherwise page through the whole partition up to a safety ceiling so we
+    # don't truncate days/categories that hold more than one DynamoDB page.
+    page_cap = fetch_ceiling if fetch_ceiling else MAX_ITEMS_PER_PARTITION
+
     if categories and not sources:
-        per_cat = max(fetch_ceiling // len(categories) + 1 if fetch_ceiling else 5000, 10)
         for category in categories:
-            response = feedback_table.query(
-                IndexName='gsi2-by-category',
-                KeyConditionExpression=Key('gsi2pk').eq(f'CATEGORY#{category}'),
-                Limit=per_cat,
-                ScanIndexForward=False,
-            )
-            items.extend(response.get('Items', []))
+            items.extend(_query_all_pages(
+                feedback_table,
+                index_name='gsi2-by-category',
+                key_expr=Key('gsi2pk').eq(f'CATEGORY#{category}'),
+                max_items=page_cap,
+            ))
         cutoff_date = (current_date - timedelta(days=days)).strftime('%Y-%m-%d')
         items = [i for i in items if i.get('date', '') >= cutoff_date]
     else:
         for i in range(days):
             date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-            response = feedback_table.query(
-                IndexName='gsi1-by-date',
-                KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
-                Limit=per_day_limit,
-                ScanIndexForward=False,
-            )
-            items.extend(response.get('Items', []))
+            items.extend(_query_all_pages(
+                feedback_table,
+                index_name='gsi1-by-date',
+                key_expr=Key('gsi1pk').eq(f'DATE#{date}'),
+                max_items=page_cap,
+            ))
             if not has_post_filters and fetch_ceiling and len(items) >= fetch_ceiling:
                 break
 

--- a/voc-datalake/lambda/shared/test/test_feedback.py
+++ b/voc-datalake/lambda/shared/test/test_feedback.py
@@ -559,17 +559,28 @@ class TestQueryFeedbackByDate:
 
         assert len(result) == 2
 
-    def test_per_day_limit_is_forwarded(self):
-        """The per_day_limit parameter is passed to DynamoDB Limit."""
+    def test_paginates_via_last_evaluated_key(self):
+        """A date partition larger than one DynamoDB page is fully paged through
+        via LastEvaluatedKey (regression for the '500개 중' truncation bug)."""
         from shared.feedback import query_feedback_by_date
 
         mock_table = MagicMock()
-        mock_table.query.return_value = {'Items': []}
+        # Two pages: first returns 400 items + a continuation key, second
+        # returns 300 items and no key (end of partition).
+        page1 = [{'id': f'a{i}', 'date': '2099-01-01'} for i in range(400)]
+        page2 = [{'id': f'b{i}', 'date': '2099-01-01'} for i in range(300)]
+        mock_table.query.side_effect = [
+            {'Items': page1, 'LastEvaluatedKey': {'pk': 'x'}},
+            {'Items': page2},
+        ]
 
-        query_feedback_by_date(mock_table, days=1, per_day_limit=123, limit=50)
+        result = query_feedback_by_date(mock_table, days=1, limit=10000)
 
-        call_kwargs = mock_table.query.call_args.kwargs
-        assert call_kwargs['Limit'] == 123
+        # Both pages followed → 700 items, not truncated at the first page.
+        assert mock_table.query.call_count == 2
+        # Second query carried the continuation key.
+        assert mock_table.query.call_args_list[1].kwargs['ExclusiveStartKey'] == {'pk': 'x'}
+        assert len(result) == 700
 
     def test_days_capped_at_max_lookback(self):
         """Days parameter is capped at MAX_LOOKBACK_DAYS."""

--- a/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/handler.py
@@ -49,6 +49,8 @@ class AndroidAppReviewsIngestor(BaseIngestor):
                                 package_name=cfg.get("package_name", "").strip(),
                                 enabled=cfg.get("enabled", True),
                                 max_reviews_per_run=parse_int(str(cfg.get("max_reviews_per_run", "500")), 500),
+                                lang=str(cfg.get("lang", "") or "").strip(),
+                                country=str(cfg.get("country", "") or "").strip(),
                             ))
                         except (ValueError, TypeError) as e:
                             logger.warning(f"Skipping invalid Android app config: {e}")
@@ -81,24 +83,34 @@ class AndroidAppReviewsIngestor(BaseIngestor):
 
     def _collect_reviews_for_app(self, app: AndroidAppConfig) -> list[dict]:
         """
-        Collect reviews across countries for a single app.
+        Collect reviews for a single app, deduplicating by review ID and
+        capping at max_reviews_per_run.
 
-        Shuffles countries for fair coverage, deduplicates by review ID,
-        and caps at max_reviews_per_run.
+        Google Play filters reviews BY LANGUAGE (lang="en" returns only
+        English-written reviews). When the app config sets lang/country
+        (e.g. ko/kr for a Korean app), we target that locale directly to get
+        the full review set. Otherwise we fall back to the country sweep with
+        the default lang.
         """
-        countries = list(ANDROID_COUNTRIES)
-        random.shuffle(countries)
-        if self.max_countries and self.max_countries < len(countries):
-            countries = countries[: self.max_countries]
+        if app.lang or app.country:
+            # Targeted single-locale fetch — paginates fully via play_client.
+            locales = [(app.lang or "en", app.country or "us")]
+        else:
+            countries = list(ANDROID_COUNTRIES)
+            random.shuffle(countries)
+            if self.max_countries and self.max_countries < len(countries):
+                countries = countries[: self.max_countries]
+            locales = [("en", c) for c in countries]
 
         all_reviews: dict[str, dict] = {}
 
-        for country in countries:
+        for lang, country in locales:
             reviews = fetch_reviews_for_country(
                 package_name=app.package_name,
                 country=country,
                 count=app.max_reviews_per_run,
                 sort_by=self.sort_by,
+                lang=lang,
             )
             for review in reviews:
                 review_id = review.get("reviewId", "")

--- a/voc-datalake/plugins/app_reviews_android/ingestor/models.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/models.py
@@ -12,6 +12,11 @@ class AndroidAppConfig:
     package_name: str
     enabled: bool = True
     max_reviews_per_run: int = 500
+    # Google Play filters reviews by language: lang="en" only returns
+    # English-written reviews. For a Korean app you MUST set lang="ko" or you
+    # get a tiny English subset. Empty/None = use the ingestor's country sweep.
+    lang: str = ""
+    country: str = ""
 
     @classmethod
     def from_dict(cls, data: dict) -> "AndroidAppConfig":
@@ -29,4 +34,6 @@ class AndroidAppConfig:
             package_name=package_name,
             enabled=data.get("enabled", True),
             max_reviews_per_run=int(data.get("max_reviews_per_run", 500)),
+            lang=str(data.get("lang", "") or "").strip(),
+            country=str(data.get("country", "") or "").strip(),
         )

--- a/voc-datalake/plugins/app_reviews_android/ingestor/play_client.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/play_client.py
@@ -13,32 +13,60 @@ SORT_MAP = {
     "rating": Sort.MOST_RELEVANT,
 }
 
+# Per-request page size. The library returns reviews in pages and hands back a
+# continuation_token to fetch the next page. 200 is a safe page size; we loop
+# until we hit `count` or the token runs out (i.e. all text reviews collected).
+_PAGE_SIZE = 200
+# Backstop so a runaway token loop can't spin forever (well above any real
+# app's text-review count; e.g. Gangnamunni has ~2,376 in ko/kr).
+_MAX_ROUNDS = 200
+
 
 def fetch_reviews_for_country(
     package_name: str,
     country: str,
     count: int = 100,
     sort_by: str = "newest",
+    lang: str = "en",
 ) -> list[dict]:
     """
-    Fetch reviews for a single app in a single country.
+    Fetch up to `count` reviews for a single app in a single country.
+
+    Paginates with the library's continuation_token until `count` is reached or
+    Google Play returns no more reviews. A single reviews() call only returns one
+    page (~200), so without this loop large apps were silently truncated.
 
     Returns list of dicts with keys: reviewId, at, userName, score, content,
     reviewCreatedVersion, replyContent, repliedAt, thumbsUpCount.
     """
     sort_order = SORT_MAP.get(sort_by, Sort.NEWEST)
+    collected: list[dict] = []
+    token = None
 
     try:
-        result, _ = reviews(
-            package_name,
-            lang="en",
-            country=country,
-            sort=sort_order,
-            count=count,
-        )
-        return result or []
+        for _ in range(_MAX_ROUNDS):
+            remaining = count - len(collected)
+            if remaining <= 0:
+                break
+            result, token = reviews(
+                package_name,
+                lang=lang,
+                country=country,
+                sort=sort_order,
+                count=min(_PAGE_SIZE, remaining),
+                continuation_token=token,
+            )
+            if not result:
+                break
+            collected.extend(result)
+            # No further pages — all available reviews collected.
+            if token is None:
+                break
+        return collected[:count]
     except Exception as e:
         logger.warning(
             f"Failed to fetch Android reviews for {package_name} in {country}: {e}"
         )
-        return []
+        # Return whatever we managed to collect before the error rather than
+        # dropping a partial-but-useful result.
+        return collected[:count]

--- a/voc-datalake/plugins/app_reviews_android/ingestor/test_play_client.py
+++ b/voc-datalake/plugins/app_reviews_android/ingestor/test_play_client.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for the Android play_client continuation-token pagination.
+
+Mocks google_play_scraper.reviews so these run offline (no network). Verifies
+that fetch_reviews_for_country paginates until `count` or token exhaustion —
+the bug that previously truncated large apps to a single ~200-review page.
+"""
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+# play_client imports `_shared.base_ingestor.logger`; stub it so the module
+# imports without the full Lambda layer present.
+_shared = types.ModuleType("_shared")
+_base = types.ModuleType("_shared.base_ingestor")
+import logging
+_base.logger = logging.getLogger("test")
+sys.modules.setdefault("_shared", _shared)
+sys.modules.setdefault("_shared.base_ingestor", _base)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import play_client  # noqa: E402
+
+
+def _make_page(n, start=0):
+    return [{"reviewId": f"r{start + i}", "content": f"review {start + i}"} for i in range(n)]
+
+
+class TestPagination:
+    def test_paginates_until_count(self):
+        """Loops via continuation_token across multiple pages up to `count`."""
+        calls = []
+
+        def fake_reviews(pkg, **kwargs):
+            calls.append(kwargs)
+            token = kwargs.get("continuation_token")
+            page = len(calls) - 1
+            # 3 pages of 200, then token=None (exhausted)
+            if page < 3:
+                return _make_page(200, start=page * 200), f"tok{page}"
+            return [], None
+
+        with patch.object(play_client, "reviews", side_effect=fake_reviews):
+            result = play_client.fetch_reviews_for_country(
+                "com.x", country="kr", count=5000, lang="ko"
+            )
+        assert len(result) == 600  # 3 pages × 200
+        # First call has no token, subsequent calls carry the prior token.
+        assert calls[0]["continuation_token"] is None
+        assert calls[1]["continuation_token"] == "tok0"
+
+    def test_respects_count_cap(self):
+        """Stops at `count` even if more reviews are available."""
+        def fake_reviews(pkg, **kwargs):
+            return _make_page(200), "more"
+
+        with patch.object(play_client, "reviews", side_effect=fake_reviews):
+            result = play_client.fetch_reviews_for_country(
+                "com.x", country="kr", count=300, lang="ko"
+            )
+        assert len(result) == 300
+
+    def test_stops_when_token_none(self):
+        """A single page with token=None ends the loop (no infinite spin)."""
+        def fake_reviews(pkg, **kwargs):
+            return _make_page(95), None
+
+        with patch.object(play_client, "reviews", side_effect=fake_reviews):
+            result = play_client.fetch_reviews_for_country(
+                "com.x", country="us", count=5000, lang="en"
+            )
+        assert len(result) == 95
+
+    def test_lang_passed_through(self):
+        """lang is forwarded to the library (Google Play filters by language)."""
+        seen = {}
+
+        def fake_reviews(pkg, **kwargs):
+            seen.update(kwargs)
+            return [], None
+
+        with patch.object(play_client, "reviews", side_effect=fake_reviews):
+            play_client.fetch_reviews_for_country("com.x", country="kr", count=10, lang="ko")
+        assert seen["lang"] == "ko"
+        assert seen["country"] == "kr"
+
+    def test_returns_partial_on_error(self):
+        """An exception mid-pagination returns what was collected so far."""
+        def fake_reviews(pkg, **kwargs):
+            if kwargs.get("continuation_token") is None:
+                return _make_page(200), "tok0"
+            raise RuntimeError("network blip")
+
+        with patch.object(play_client, "reviews", side_effect=fake_reviews):
+            result = play_client.fetch_reviews_for_country(
+                "com.x", country="kr", count=5000, lang="ko"
+            )
+        assert len(result) == 200  # first page kept, error swallowed

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/itunes_client.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/itunes_client.py
@@ -2,10 +2,25 @@
 Apple App Store review client using app-store-web-scraper.
 
 Wraps the library with connection pooling, rate limiting, and error handling.
+
+We page through the RSS customer-reviews feed ourselves (via the library's
+session) instead of using AppStoreEntry.reviews(), because that method STOPS at
+the first page with no "entry" key. Apple's RSS intermittently returns an empty
+page in the middle of a populated feed (e.g. kr page 4 is empty while pages
+5-10 have reviews), so the library terminates early and we lose most reviews.
+We instead skip empty pages and only stop after several consecutive empties.
 """
 
 from app_store_web_scraper import AppStoreEntry, AppStoreSession
+from app_store_web_scraper._errors import AppStoreError
+from app_store_web_scraper._utils import fromisoformat_utc
 from _shared.base_ingestor import logger
+
+# Apple's RSS customer-reviews feed exposes at most 10 pages (~50 each).
+_MAX_PAGES = 10
+# Stop only after this many consecutive empty pages — tolerates the
+# intermittent empty page Apple sometimes returns mid-feed.
+_MAX_CONSECUTIVE_EMPTY = 3
 
 
 def create_session(delay: float = 0.5, jitter: float = 0.2, retries: int = 3) -> AppStoreSession:
@@ -19,6 +34,22 @@ def create_session(delay: float = 0.5, jitter: float = 0.2, retries: int = 3) ->
     )
 
 
+def _parse_entry(entry: dict) -> dict:
+    """Parse one RSS feed entry into our review dict. Returns None on bad shape."""
+    try:
+        return {
+            "id": str(entry["id"]["label"]),
+            "date": fromisoformat_utc(entry["updated"]["label"]),
+            "user_name": entry["author"]["name"]["label"],
+            "rating": int(entry["im:rating"]["label"]),
+            "title": entry["title"]["label"],
+            "review": entry["content"]["label"],
+            "developer_response": None,
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
 def fetch_reviews_for_country(
     app_id: str,
     country: str,
@@ -29,31 +60,52 @@ def fetch_reviews_for_country(
     """
     Fetch reviews for a single app in a single country.
 
-    Returns list of dicts with keys: id, date, user_name, rating, title, review,
-    developer_response.
+    Pages through the RSS feed directly, skipping intermittent empty pages
+    (the library would stop at the first one). Returns list of dicts with keys:
+    id, date, user_name, rating, title, review, developer_response.
     """
+    reviews: list[dict] = []
+    consecutive_empty = 0
+
     try:
-        sort_map = {
-            "most_recent": "mostrecent",
-            "most_critical": "mosthelpful",
-        }
-        app = AppStoreEntry(
-            app_id=int(app_id),
-            country=country,
-            session=session,
-        )
-        reviews = []
-        for review in app.reviews(limit=limit):
-            reviews.append({
-                "id": str(review.id),
-                "date": review.date,
-                "user_name": review.user_name,
-                "rating": review.rating,
-                "title": review.title,
-                "review": review.review,
-                "developer_response": getattr(review, "developer_response", None),
-            })
+        for page in range(1, _MAX_PAGES + 1):
+            if len(reviews) >= limit:
+                break
+            path = (
+                f"/{country}/rss/customerreviews/page={page}"
+                f"/id={app_id}/sortby=mostrecent/json"
+            )
+            try:
+                data = session._get(path)
+            except AppStoreError as e:
+                # Transient HTTP error on one page — skip it, keep paging.
+                logger.warning(
+                    f"iOS RSS page {page} failed for app {app_id} in {country}: {e}"
+                )
+                consecutive_empty += 1
+                if consecutive_empty >= _MAX_CONSECUTIVE_EMPTY:
+                    break
+                continue
+
+            feed = data.get("feed", {})
+            entries = feed.get("entry")
+            if not entries:
+                # Empty page — could be the real end OR an intermittent blank.
+                # Keep going until we've seen several empties in a row.
+                consecutive_empty += 1
+                if consecutive_empty >= _MAX_CONSECUTIVE_EMPTY:
+                    break
+                continue
+
+            consecutive_empty = 0
+            for entry in entries:
+                parsed = _parse_entry(entry)
+                if parsed:
+                    reviews.append(parsed)
+                if len(reviews) >= limit:
+                    break
+
         return reviews
     except Exception as e:
         logger.warning(f"Failed to fetch iOS reviews for app {app_id} in {country}: {e}")
-        return []
+        return reviews

--- a/voc-datalake/plugins/app_reviews_ios/ingestor/test_itunes_client.py
+++ b/voc-datalake/plugins/app_reviews_ios/ingestor/test_itunes_client.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for the iOS itunes_client page-by-page RSS fetch.
+
+Mocks the session so these run offline. Verifies that an intermittent empty
+page in the middle of a populated feed is SKIPPED (not treated as the end) —
+the bug that truncated Korean reviews to ~150 instead of ~450.
+"""
+import sys
+import types
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Stub _shared.base_ingestor.logger so the module imports offline.
+_shared = types.ModuleType("_shared")
+_base = types.ModuleType("_shared.base_ingestor")
+_base.logger = logging.getLogger("test")
+sys.modules.setdefault("_shared", _shared)
+sys.modules.setdefault("_shared.base_ingestor", _base)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import itunes_client  # noqa: E402
+from app_store_web_scraper._errors import AppStoreError  # noqa: E402
+
+
+def _entry(i):
+    return {
+        "id": {"label": str(i)},
+        "updated": {"label": "2024-01-01T00:00:00-07:00"},
+        "author": {"name": {"label": "user"}},
+        "im:rating": {"label": "5"},
+        "title": {"label": f"title {i}"},
+        "content": {"label": f"review {i}"},
+        "im:version": {"label": "1.0"},
+    }
+
+
+def _page(entries):
+    feed = {"link": [{"attributes": {"rel": "self"}}]}
+    if entries is not None:
+        feed["entry"] = entries
+    return {"feed": feed}
+
+
+class TestPagination:
+    def test_skips_intermittent_empty_page(self):
+        """An empty page mid-feed is skipped; later pages still collected."""
+        session = MagicMock()
+        # page1=50, page2=empty(blip), page3=50, page4..=empty end
+        session._get.side_effect = [
+            _page([_entry(i) for i in range(50)]),    # p1
+            _page(None),                               # p2 empty (intermittent)
+            _page([_entry(i) for i in range(50, 100)]),# p3
+            _page(None), _page(None), _page(None),     # p4,5,6 → 3 consecutive empty → stop
+        ]
+        result = itunes_client.fetch_reviews_for_country("1", "kr", session, limit=500)
+        assert len(result) == 100  # NOT truncated at the empty page2
+
+    def test_stops_after_consecutive_empties(self):
+        """Stops once MAX_CONSECUTIVE_EMPTY pages in a row are empty."""
+        session = MagicMock()
+        session._get.side_effect = [
+            _page([_entry(0)]),
+            _page(None), _page(None), _page(None),  # 3 in a row → stop
+            _page([_entry(99)]),  # would-be more, but we already stopped
+        ]
+        result = itunes_client.fetch_reviews_for_country("1", "kr", session, limit=500)
+        assert len(result) == 1
+        # Should not have requested the 5th page.
+        assert session._get.call_count == 4
+
+    def test_respects_limit(self):
+        session = MagicMock()
+        session._get.side_effect = [_page([_entry(i) for i in range(50)]) for _ in range(10)]
+        result = itunes_client.fetch_reviews_for_country("1", "kr", session, limit=120)
+        assert len(result) == 120
+
+    def test_transient_http_error_skips_page(self):
+        """A page that raises AppStoreError is skipped, not fatal."""
+        session = MagicMock()
+        session._get.side_effect = [
+            _page([_entry(i) for i in range(50)]),
+            AppStoreError("503"),                       # transient
+            _page([_entry(i) for i in range(50, 80)]),
+            _page(None), _page(None), _page(None),
+        ]
+        result = itunes_client.fetch_reviews_for_country("1", "kr", session, limit=500)
+        assert len(result) == 80  # both good pages collected despite the error
+
+    def test_malformed_entry_skipped(self):
+        """A malformed entry is dropped without killing the whole page."""
+        session = MagicMock()
+        good = _entry(1)
+        bad = {"id": {"label": "2"}}  # missing required fields
+        session._get.side_effect = [
+            _page([good, bad]),
+            _page(None), _page(None), _page(None),
+        ]
+        result = itunes_client.fetch_reviews_for_country("1", "kr", session, limit=500)
+        assert len(result) == 1


### PR DESCRIPTION
# fix(ingestion): page through full review/feedback sets (prd-fix #13 / P2)

## What & why

Three instances of the same bug class — "one query returns only the first page" — silently truncated ingestion and feedback reads. This is the last member of the reliability cluster started in #128/#129 (prd-fix LESSONS **#13**, tracked as **P2** in `.prdfix-reconcile`).

### 1. Android reviews (`plugins/app_reviews_android`)
- `play_client.py` now loops google-play-scraper's `continuation_token` until the requested count or token exhaustion. A single `reviews()` call returns one page (~200), so large apps were capped at ~200 reviews per locale.
- New optional `lang` / `country` fields on `AndroidAppConfig`: Google Play filters reviews **by language** — `lang="en"` on a Korean app returns only the tiny English-written subset. Setting `ko`/`kr` targets the full set directly; unset keeps the existing country-sweep behavior.
- On mid-pagination errors the client now returns what it collected instead of dropping a partial-but-useful result.
- **Keeps the #134 `enabled`-flag guard** (prd-fix predates it; the port was merged around it — `test_app_reviews_enabled_filter.py` still passes).

### 2. iOS reviews (`plugins/app_reviews_ios`)
- `itunes_client.py` pages Apple's RSS customer-reviews feed directly instead of using the library's `AppStoreEntry.reviews()`, which stops at the **first** page with no entries. Apple intermittently returns an empty page mid-feed, so the library terminated early and lost most reviews.
- New client skips empty pages and stops only after 3 consecutive empties (feed max is 10 pages); transient per-page HTTP errors are skipped, malformed entries dropped without killing the page.

### 3. Feedback queries (`lambda/shared/feedback.py`)
- `_query_all_pages` follows DynamoDB `LastEvaluatedKey` per date/category partition (bounded by `MAX_ITEMS_PER_PARTITION=10000`). Previously a plain `Limit=N` query ignored the cursor, truncating any partition larger than one 1MB page (the "of 500" undercount).

## Tests (verified fail-on-revert)

- NEW `test_play_client.py` (5) — pagination across pages, count cap, token exhaustion, `lang` pass-through, partial-on-error.
- NEW `test_itunes_client.py` (5) — mid-feed empty page skipped, 3-consecutive-empty stop, limit, transient HTTP error, malformed entry.
- `test_feedback.py` — `LastEvaluatedKey` paging test replaces the old Limit-forwarding test.
- Reverting the three source files makes 10 of these 11 tests fail (verified).

## Gate results (branch @ `a014151` base)

| Check | Result |
|---|---|
| `pytest plugins/` | ✅ 205 passed (195 baseline + 10 new) |
| `pytest lambda/` | ✅ 670 passed, 1 skipped |
| `npm run validate:plugins` | ✅ |
| CDK `tsc --noEmit` | ✅ |

Frontend untouched (backend-only PR).

## Live verification (2026-07-13, voc-deploy)

- All 4 stacks deployed clean (Finch bundling); `scripts/test-api.sh` **32/32**.
- **Deployed Android run** (Spotify, `lang=en`/`country=us`, cap 210): `items_found=210`, zero errors — 210 > the old single-page ~200 cap, so the deployed Lambda paginated across pages.
- **Deployed iOS run** (Spotify, cap 25): `items_found=25`, zero errors — proves the new RSS client (incl. its `app-store-web-scraper` private-module imports) works against the deployed layer.
- Full pipeline confirmed: `/metrics/sources` shows `Spotify_Android: 210`, `Spotify_iOS: 25` after processing.
- **Local head-to-head against today's real Apple feed:** old library path returned **0** reviews (Apple's US Spotify feed page 1 is empty mid-feed right now — the exact bug), new client returned **50**. Android local fetch: 450 reviews (> single-page cap).
- Test source configs cleared after verification (`configs="[]"`) so schedules don't re-ingest.

## Notes for reviewers

- The new `lang`/`country` config fields are optional and additive — existing configs behave exactly as before (country sweep with `lang=en`).
- `per_day_limit` is retained in the `query_feedback_by_date` signature for API compatibility; partition paging is now governed by `fetch_ceiling`/`MAX_ITEMS_PER_PARTITION`.
- Squash-merge per repo convention.
