### PR TITLE
fix: hide auto-detect button for JSON-LD scrapers

### DIFF
--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
@@ -84,4 +84,12 @@ describe('ScraperEditor auto-detect visibility', () => {
 
     expect(screen.getByRole('button', { name: AUTO_DETECT_LABEL })).toBeInTheDocument()
   })
+
+  it('keeps auto-detect for legacy configs without an extraction_method', () => {
+    // Configs saved before JSON-LD support predate the field and are CSS
+    // scrapers — the positive === check must not hide their button.
+    renderEditor(makeScraper({ extraction_method: undefined }))
+
+    expect(screen.getByRole('button', { name: AUTO_DETECT_LABEL })).toBeInTheDocument()
+  })
 })

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
@@ -3,13 +3,17 @@
  *
  * Auto-detect discovers CSS selectors; JSON-LD scrapers take their extraction
  * config from the structured data itself, so the button must not appear there
- * and suggest an extra required step.
+ * and suggest an extra required step. The extraction method is fixed by the
+ * template chosen before the editor opens (there is no in-editor switch), so
+ * the "create scraper from JSON-LD" flow from the issue is covered via the
+ * template prop.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import ScraperEditor from './ScraperEditor'
-import { DEFAULT_SCRAPER_CONFIG } from './constants'
-import type { ScraperConfig } from '../../api/types'
+import { DEFAULT_SCRAPER } from './constants'
+import enScrapers from '../../../public/locales/en/scrapers.json'
+import type { ScraperConfig, ScraperTemplate } from '../../api/types'
 
 vi.mock('../../api/scrapersApi', () => ({
   scrapersApi: {
@@ -17,9 +21,14 @@ vi.mock('../../api/scrapersApi', () => ({
   },
 }))
 
+// Match on the shipped translation strings so a fallback to raw keys
+// ("editor.autoDetect") fails loudly instead of passing by accident.
+const AUTO_DETECT_LABEL = enScrapers.editor.autoDetect
+const AUTO_DETECT_HINT = enScrapers.editor.autoDetectHint
+
 function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
   return {
-    ...DEFAULT_SCRAPER_CONFIG,
+    ...DEFAULT_SCRAPER,
     id: 's-1',
     name: 'Test scraper',
     base_url: 'https://example.com/reviews',
@@ -27,22 +36,52 @@ function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
   }
 }
 
-function renderEditor(scraper: ScraperConfig) {
+function renderEditor(scraper: ScraperConfig | null, template?: ScraperTemplate) {
   return render(
-    <ScraperEditor scraper={scraper} onSave={vi.fn()} onClose={vi.fn()} />
+    <ScraperEditor scraper={scraper} template={template} onSave={vi.fn()} onClose={vi.fn()} />
   )
 }
 
 describe('ScraperEditor auto-detect visibility', () => {
-  it('shows the auto-detect button for CSS scrapers', () => {
+  it('shows the auto-detect button and hint for CSS scrapers', () => {
     renderEditor(makeScraper({ extraction_method: 'css' }))
 
-    expect(screen.getByRole('button', { name: /auto-detect/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: AUTO_DETECT_LABEL })).toBeInTheDocument()
+    expect(screen.getByText(AUTO_DETECT_HINT)).toBeInTheDocument()
   })
 
   it('hides the auto-detect button and hint for JSON-LD scrapers', () => {
     renderEditor(makeScraper({ extraction_method: 'jsonld' }))
 
-    expect(screen.queryByRole('button', { name: /auto-detect/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: AUTO_DETECT_LABEL })).not.toBeInTheDocument()
+    expect(screen.queryByText(AUTO_DETECT_HINT)).not.toBeInTheDocument()
+  })
+
+  it('hides auto-detect when creating a new scraper from a JSON-LD template', () => {
+    // The user flow from issue #18: "create scraper from LD Json" — the
+    // template fixes the extraction method before the editor opens.
+    const jsonLdTemplate: ScraperTemplate = {
+      id: 'generic-jsonld',
+      name: 'Generic (JSON-LD)',
+      description: 'Structured data scraper',
+      icon: '🧩',
+      extraction_method: 'jsonld',
+      url_pattern: 'example.com',
+      url_placeholder: 'https://example.com/reviews',
+      supports_pagination: true,
+      pagination: DEFAULT_SCRAPER.pagination,
+      config: {},
+    }
+
+    renderEditor(null, jsonLdTemplate)
+
+    expect(screen.queryByRole('button', { name: AUTO_DETECT_LABEL })).not.toBeInTheDocument()
+    expect(screen.queryByText(AUTO_DETECT_HINT)).not.toBeInTheDocument()
+  })
+
+  it('shows auto-detect when creating a new scraper without a template (CSS default)', () => {
+    renderEditor(null)
+
+    expect(screen.getByRole('button', { name: AUTO_DETECT_LABEL })).toBeInTheDocument()
   })
 })

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Tests for ScraperEditor — auto-detect visibility (issue #18).
+ *
+ * Auto-detect discovers CSS selectors; JSON-LD scrapers take their extraction
+ * config from the structured data itself, so the button must not appear there
+ * and suggest an extra required step.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ScraperEditor from './ScraperEditor'
+import { DEFAULT_SCRAPER_CONFIG } from './constants'
+import type { ScraperConfig } from '../../api/types'
+
+vi.mock('../../api/scrapersApi', () => ({
+  scrapersApi: {
+    analyzeUrlForSelectors: vi.fn(),
+  },
+}))
+
+function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
+  return {
+    ...DEFAULT_SCRAPER_CONFIG,
+    id: 's-1',
+    name: 'Test scraper',
+    base_url: 'https://example.com/reviews',
+    ...overrides,
+  }
+}
+
+function renderEditor(scraper: ScraperConfig) {
+  return render(
+    <ScraperEditor scraper={scraper} onSave={vi.fn()} onClose={vi.fn()} />
+  )
+}
+
+describe('ScraperEditor auto-detect visibility', () => {
+  it('shows the auto-detect button for CSS scrapers', () => {
+    renderEditor(makeScraper({ extraction_method: 'css' }))
+
+    expect(screen.getByRole('button', { name: /auto-detect/i })).toBeInTheDocument()
+  })
+
+  it('hides the auto-detect button and hint for JSON-LD scrapers', () => {
+    renderEditor(makeScraper({ extraction_method: 'jsonld' }))
+
+    expect(screen.queryByRole('button', { name: /auto-detect/i })).not.toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
@@ -10,21 +10,27 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import i18n from 'i18next'
 import ScraperEditor from './ScraperEditor'
 import { DEFAULT_SCRAPER } from './constants'
-import enScrapers from '../../../public/locales/en/scrapers.json'
 import type { ScraperConfig, ScraperTemplate } from '../../api/types'
 
-vi.mock('../../api/scrapersApi', () => ({
-  scrapersApi: {
-    analyzeUrlForSelectors: vi.fn(),
-  },
-}))
+vi.mock('../../api/scrapersApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/scrapersApi')>()
+  // Stub the WHOLE real API surface: a future call from the component hits
+  // an assertable vi.fn() instead of an opaque "x is not a function", and
+  // newly added methods are covered automatically.
+  const stubs = Object.fromEntries(
+    Object.keys(actual.scrapersApi).map((name) => [name, vi.fn()]),
+  )
+  return { scrapersApi: stubs }
+})
 
-// Match on the shipped translation strings so a fallback to raw keys
-// ("editor.autoDetect") fails loudly instead of passing by accident.
-const AUTO_DETECT_LABEL = enScrapers.editor.autoDetect
-const AUTO_DETECT_HINT = enScrapers.editor.autoDetectHint
+// Derive the shipped strings from the shared i18n test setup (the single
+// owner of locale loading — src/test/setup.ts) instead of coupling this file
+// to the locale directory layout.
+const AUTO_DETECT_LABEL = i18n.t('editor.autoDetect', { ns: 'scrapers' })
+const AUTO_DETECT_HINT = i18n.t('editor.autoDetectHint', { ns: 'scrapers' })
 
 function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
   return {
@@ -43,6 +49,14 @@ function renderEditor(scraper: ScraperConfig | null, template?: ScraperTemplate)
 }
 
 describe('ScraperEditor auto-detect visibility', () => {
+  it('resolves the shipped strings from the i18n test setup', () => {
+    // Guard against vacuous passes: if the namespace/keys stop resolving,
+    // t() returns the raw key — which a broken component would also render,
+    // letting every assertion below "agree" on the wrong thing.
+    expect(AUTO_DETECT_LABEL).not.toContain('editor.autoDetect')
+    expect(AUTO_DETECT_HINT).not.toContain('editor.autoDetectHint')
+  })
+
   it('shows the auto-detect button and hint for CSS scrapers', () => {
     renderEditor(makeScraper({ extraction_method: 'css' }))
 

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.tsx
@@ -206,6 +206,10 @@ function UrlInput({
   readonly onAutoDetect: () => void
 }) {
   const { t } = useTranslation('scrapers')
+  // Auto-detect exists to discover CSS selectors; JSON-LD scrapers get their
+  // extraction config from the structured data itself, so the button is
+  // hidden there to avoid suggesting an extra required step (issue #18).
+  const showAutoDetect = config.extraction_method !== 'jsonld'
   return (
     <div>
       <label className="block text-sm font-medium mb-1">{t('editor.websiteUrl')}</label>
@@ -214,11 +218,13 @@ function UrlInput({
           ...config,
           base_url: e.target.value,
         })} className="input flex-1" placeholder={t('editor.websiteUrlPlaceholder')} />
-        <button onClick={onAutoDetect} disabled={isAnalyzing || config.base_url === ''} className="btn btn-secondary flex items-center justify-center gap-2 whitespace-nowrap text-sm">
-          {isAnalyzing ? <><Loader2 size={16} className="animate-spin" /> {t('editor.analyzing')}</> : <><Wand2 size={16} /> {t('editor.autoDetect')}</>}
-        </button>
+        {showAutoDetect && (
+          <button onClick={onAutoDetect} disabled={isAnalyzing || config.base_url === ''} className="btn btn-secondary flex items-center justify-center gap-2 whitespace-nowrap text-sm">
+            {isAnalyzing ? <><Loader2 size={16} className="animate-spin" /> {t('editor.analyzing')}</> : <><Wand2 size={16} /> {t('editor.autoDetect')}</>}
+          </button>
+        )}
       </div>
-      <p className="text-xs text-gray-500 mt-1">{t('editor.autoDetectHint')}</p>
+      {showAutoDetect && <p className="text-xs text-gray-500 mt-1">{t('editor.autoDetectHint')}</p>}
     </div>
   )
 }

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.tsx
@@ -206,10 +206,12 @@ function UrlInput({
   readonly onAutoDetect: () => void
 }) {
   const { t } = useTranslation('scrapers')
-  // Auto-detect exists to discover CSS selectors; JSON-LD scrapers get their
-  // extraction config from the structured data itself, so the button is
-  // hidden there to avoid suggesting an extra required step (issue #18).
-  const showAutoDetect = config.extraction_method !== 'jsonld'
+  // Auto-detect exists to discover CSS selectors, so it renders only for
+  // the CSS extraction method — JSON-LD scrapers get their extraction
+  // config from the structured data itself, and any future method defaults
+  // to hidden rather than shown. Legacy configs without the field predate
+  // JSON-LD support and are CSS scrapers.
+  const showAutoDetect = (config.extraction_method ?? 'css') === 'css'
   return (
     <div>
       <label className="block text-sm font-medium mb-1">{t('editor.websiteUrl')}</label>


### PR DESCRIPTION
## Summary

Fixes #18 (close manually on merge — base is `development`).

Auto-detect discovers **CSS selectors**; JSON-LD scrapers get their extraction config from the page's structured data, so the button implied an extra required step where none exists. The editor already hides the CSS-selector section when `extraction_method === 'jsonld'` — the auto-detect button and its hint now follow the same rule, and remain exactly as before for CSS scrapers.

One-component change (`ScraperEditor.tsx`), no API or type changes.

## Testing

- New `ScraperEditor.test.tsx`: button visible for CSS scrapers, absent for JSON-LD
- Scrapers suite: 110 tests pass; eslint + tsc clean

## Notes

- The issue predates the Scrapers UI rebuild; re-reading it, the ask was specifically "hidden on create scraper from LD Json" — which is what this implements (conditional on extraction method, not a collapsed disclosure). @svozza flagging in case the rebuilt UI changed what you had in mind.