### PR TITLE
feat: mark problems as resolved in Problem Analysis

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -98,6 +98,9 @@ const mockSourcesStatus = {
 };
 
 // Mock categories config
+// Problem resolution state (issue #66) — mutable so the toggle round-trips.
+const mockResolvedProblems = {};
+
 const mockCategoriesConfig = {
   categories: [
     { name: 'delivery', display_name: 'Delivery', description: 'Shipping and delivery issues', color: '#EF4444' },
@@ -161,6 +164,18 @@ const handlers = {
   // Settings - Categories
   'GET /settings/categories': () => mockCategoriesConfig,
   'PUT /settings/categories': () => ({ success: true, message: 'Categories saved' }),
+  'GET /settings/resolved-problems': () => ({ resolved: mockResolvedProblems }),
+  'PUT /settings/resolved-problems': (body) => {
+    if (!body || typeof body.key !== 'string' || body.key.trim() === '' || typeof body.resolved !== 'boolean') {
+      return { success: false, message: 'key and resolved are required' };
+    }
+    if (body.resolved) {
+      mockResolvedProblems[body.key] = { resolved_at: new Date().toISOString() };
+    } else {
+      delete mockResolvedProblems[body.key];
+    }
+    return { success: true, key: body.key, resolved: body.resolved };
+  },
 
   // Data Explorer
   'GET /data-explorer/buckets': () => ({ buckets: mockBuckets }),

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -191,7 +191,9 @@ const handlers = {
   'GET /settings/resolved-problems': () => ({ resolved: mockResolvedProblems }),
   'PUT /settings/resolved-problems': (body) => {
     if (!body || typeof body.key !== 'string' || body.key.trim() === '' || typeof body.resolved !== 'boolean') {
-      return { success: false, message: 'key and resolved are required' };
+      // Mirror the real handler's 400 contract so local dev doesn't mask
+      // client bugs behind a 200.
+      return { __status: 400, body: { success: false, message: 'key and resolved are required' } };
     }
     if (body.resolved) {
       mockResolvedProblems[body.key] = { resolved_at: new Date().toISOString() };
@@ -386,6 +388,13 @@ const server = http.createServer((req, res) => {
         }
       }
       const result = handler(parsedBody, url.searchParams);
+      // Handlers may signal a non-200 status (matching the real API's error
+      // contract) by returning { __status, body }.
+      if (result && typeof result.__status === 'number') {
+        res.writeHead(result.__status);
+        res.end(JSON.stringify(result.body));
+        return;
+      }
       res.writeHead(200);
       res.end(JSON.stringify(result));
     });

--- a/voc-datalake/frontend/public/locales/de/common.json
+++ b/voc-datalake/frontend/public/locales/de/common.json
@@ -78,6 +78,8 @@
     "none": "Keine"
   },
   "problemResolution": {
+    "allResolvedHint": "Aktiviere oben „Gelöste anzeigen ({{total}})\", um sie zu prüfen",
+    "allResolvedTitle": "Alle Probleme in dieser Ansicht sind als gelöst markiert",
     "markResolved": "Als gelöst markieren",
     "markUnresolved": "Als ungelöst markieren",
     "resolved": "Gelöst",

--- a/voc-datalake/frontend/public/locales/de/common.json
+++ b/voc-datalake/frontend/public/locales/de/common.json
@@ -81,6 +81,7 @@
     "markResolved": "Als gelöst markieren",
     "markUnresolved": "Als ungelöst markieren",
     "resolved": "Gelöst",
+    "saveFailed": "Der Status konnte nicht aktualisiert werden. Bitte erneut versuchen.",
     "showResolved": "Gelöste anzeigen ({{total}})"
   },
   "send": "Senden",

--- a/voc-datalake/frontend/public/locales/de/common.json
+++ b/voc-datalake/frontend/public/locales/de/common.json
@@ -77,6 +77,12 @@
     "medium": "Mittel",
     "none": "Keine"
   },
+  "problemResolution": {
+    "markResolved": "Als gelöst markieren",
+    "markUnresolved": "Als ungelöst markieren",
+    "resolved": "Gelöst",
+    "showResolved": "Gelöste anzeigen ({{total}})"
+  },
   "send": "Senden",
   "sentiment": {
     "mixed": "Gemischt",

--- a/voc-datalake/frontend/public/locales/de/common.json
+++ b/voc-datalake/frontend/public/locales/de/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "Abbrechen",
   "configureBrand": "Marke konfigurieren",
+  "dismiss": "Schließen",
   "exportPdf": "PDF exportieren",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "Als PDF exportieren",
@@ -76,6 +77,10 @@
     "low": "Niedrig",
     "medium": "Mittel",
     "none": "Keine"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "Erweitere den Zeitraum oder passe die Filter an",
+    "emptyTitle": "Keine Problemanalyse-Daten für den ausgewählten Zeitraum gefunden"
   },
   "problemResolution": {
     "allResolvedHint": "Aktiviere oben „Gelöste anzeigen ({{total}})\", um sie zu prüfen",

--- a/voc-datalake/frontend/public/locales/en/common.json
+++ b/voc-datalake/frontend/public/locales/en/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "Cancel",
   "configureBrand": "Configure brand",
+  "dismiss": "Dismiss",
   "exportPdf": "Export PDF",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "Export as PDF",
@@ -76,6 +77,10 @@
     "low": "Low",
     "medium": "Medium",
     "none": "None"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "Try expanding the time range or adjusting filters",
+    "emptyTitle": "No problem analysis data found for the selected period"
   },
   "problemResolution": {
     "allResolvedHint": "Enable \"Show resolved ({{total}})\" above to review them",

--- a/voc-datalake/frontend/public/locales/en/common.json
+++ b/voc-datalake/frontend/public/locales/en/common.json
@@ -77,6 +77,12 @@
     "medium": "Medium",
     "none": "None"
   },
+  "problemResolution": {
+    "markResolved": "Mark as resolved",
+    "markUnresolved": "Mark as unresolved",
+    "resolved": "Resolved",
+    "showResolved": "Show resolved ({{total}})"
+  },
   "send": "Send",
   "sentiment": {
     "mixed": "Mixed",

--- a/voc-datalake/frontend/public/locales/en/common.json
+++ b/voc-datalake/frontend/public/locales/en/common.json
@@ -81,6 +81,7 @@
     "markResolved": "Mark as resolved",
     "markUnresolved": "Mark as unresolved",
     "resolved": "Resolved",
+    "saveFailed": "Could not update the resolved status. Try again.",
     "showResolved": "Show resolved ({{total}})"
   },
   "send": "Send",

--- a/voc-datalake/frontend/public/locales/en/common.json
+++ b/voc-datalake/frontend/public/locales/en/common.json
@@ -78,6 +78,8 @@
     "none": "None"
   },
   "problemResolution": {
+    "allResolvedHint": "Enable \"Show resolved ({{total}})\" above to review them",
+    "allResolvedTitle": "All problems in this view are marked resolved",
     "markResolved": "Mark as resolved",
     "markUnresolved": "Mark as unresolved",
     "resolved": "Resolved",

--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -81,6 +81,8 @@
     "none": "Ninguna"
   },
   "problemResolution": {
+    "allResolvedHint": "Activa \"Mostrar resueltos ({{total}})\" arriba para revisarlos",
+    "allResolvedTitle": "Todos los problemas de esta vista están marcados como resueltos",
     "markResolved": "Marcar como resuelto",
     "markUnresolved": "Marcar como no resuelto",
     "resolved": "Resuelto",

--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "Cancelar",
   "configureBrand": "Configurar marca",
+  "dismiss": "Descartar",
   "exportPdf": "Exportar PDF",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "Exportar como PDF",
@@ -79,6 +80,10 @@
     "low": "Baja",
     "medium": "Media",
     "none": "Ninguna"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "Prueba a ampliar el rango de tiempo o ajustar los filtros",
+    "emptyTitle": "No se encontraron datos de análisis de problemas para el período seleccionado"
   },
   "problemResolution": {
     "allResolvedHint": "Activa \"Mostrar resueltos ({{total}})\" arriba para revisarlos",

--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -80,6 +80,12 @@
     "medium": "Media",
     "none": "Ninguna"
   },
+  "problemResolution": {
+    "markResolved": "Marcar como resuelto",
+    "markUnresolved": "Marcar como no resuelto",
+    "resolved": "Resuelto",
+    "showResolved": "Mostrar resueltos ({{total}})"
+  },
   "send": "Enviar",
   "sentiment": {
     "mixed": "Mixto",

--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -84,6 +84,7 @@
     "markResolved": "Marcar como resuelto",
     "markUnresolved": "Marcar como no resuelto",
     "resolved": "Resuelto",
+    "saveFailed": "No se pudo actualizar el estado. Inténtalo de nuevo.",
     "showResolved": "Mostrar resueltos ({{total}})"
   },
   "send": "Enviar",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -84,6 +84,7 @@
     "markResolved": "Marquer comme résolu",
     "markUnresolved": "Marquer comme non résolu",
     "resolved": "Résolu",
+    "saveFailed": "Impossible de mettre à jour le statut. Réessayez.",
     "showResolved": "Afficher les résolus ({{total}})"
   },
   "send": "Envoyer",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -80,6 +80,12 @@
     "medium": "Moyenne",
     "none": "Aucune"
   },
+  "problemResolution": {
+    "markResolved": "Marquer comme résolu",
+    "markUnresolved": "Marquer comme non résolu",
+    "resolved": "Résolu",
+    "showResolved": "Afficher les résolus ({{total}})"
+  },
   "send": "Envoyer",
   "sentiment": {
     "mixed": "Mixte",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -81,6 +81,8 @@
     "none": "Aucune"
   },
   "problemResolution": {
+    "allResolvedHint": "Activez « Afficher les résolus ({{total}}) » ci-dessus pour les consulter",
+    "allResolvedTitle": "Tous les problèmes de cette vue sont marqués comme résolus",
     "markResolved": "Marquer comme résolu",
     "markUnresolved": "Marquer comme non résolu",
     "resolved": "Résolu",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "Annuler",
   "configureBrand": "Configurer la marque",
+  "dismiss": "Fermer",
   "exportPdf": "Exporter en PDF",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "Exporter au format PDF",
@@ -79,6 +80,10 @@
     "low": "Basse",
     "medium": "Moyenne",
     "none": "Aucune"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "Essayez d'élargir la plage de temps ou d'ajuster les filtres",
+    "emptyTitle": "Aucune donnée d'analyse de problèmes trouvée pour la période sélectionnée"
   },
   "problemResolution": {
     "allResolvedHint": "Activez « Afficher les résolus ({{total}}) » ci-dessus pour les consulter",

--- a/voc-datalake/frontend/public/locales/ja/common.json
+++ b/voc-datalake/frontend/public/locales/ja/common.json
@@ -77,6 +77,12 @@
     "medium": "中",
     "none": "なし"
   },
+  "problemResolution": {
+    "markResolved": "解決済みにする",
+    "markUnresolved": "未解決に戻す",
+    "resolved": "解決済み",
+    "showResolved": "解決済みを表示 ({{total}})"
+  },
   "send": "送信",
   "sentiment": {
     "mixed": "混合",

--- a/voc-datalake/frontend/public/locales/ja/common.json
+++ b/voc-datalake/frontend/public/locales/ja/common.json
@@ -81,6 +81,7 @@
     "markResolved": "解決済みにする",
     "markUnresolved": "未解決に戻す",
     "resolved": "解決済み",
+    "saveFailed": "ステータスを更新できませんでした。もう一度お試しください。",
     "showResolved": "解決済みを表示 ({{total}})"
   },
   "send": "送信",

--- a/voc-datalake/frontend/public/locales/ja/common.json
+++ b/voc-datalake/frontend/public/locales/ja/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "キャンセル",
   "configureBrand": "ブランドを設定",
+  "dismiss": "閉じる",
   "exportPdf": "PDFをエクスポート",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "PDFとしてエクスポート",
@@ -76,6 +77,10 @@
     "low": "低",
     "medium": "中",
     "none": "なし"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "期間を広げるかフィルターを調整してください",
+    "emptyTitle": "選択した期間の問題分析データが見つかりません"
   },
   "problemResolution": {
     "allResolvedHint": "上の「解決済みを表示 ({{total}})」を有効にすると確認できます",

--- a/voc-datalake/frontend/public/locales/ja/common.json
+++ b/voc-datalake/frontend/public/locales/ja/common.json
@@ -78,6 +78,8 @@
     "none": "なし"
   },
   "problemResolution": {
+    "allResolvedHint": "上の「解決済みを表示 ({{total}})」を有効にすると確認できます",
+    "allResolvedTitle": "このビューの問題はすべて解決済みです",
     "markResolved": "解決済みにする",
     "markUnresolved": "未解決に戻す",
     "resolved": "解決済み",

--- a/voc-datalake/frontend/public/locales/ko/common.json
+++ b/voc-datalake/frontend/public/locales/ko/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "취소",
   "configureBrand": "브랜드 설정",
+  "dismiss": "닫기",
   "exportPdf": "PDF 내보내기",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "PDF로 내보내기",
@@ -76,6 +77,10 @@
     "low": "낮음",
     "medium": "보통",
     "none": "없음"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "기간을 넓히거나 필터를 조정해 보세요",
+    "emptyTitle": "선택한 기간에 대한 문제 분석 데이터가 없습니다"
   },
   "problemResolution": {
     "allResolvedHint": "위의 \"해결됨 표시 ({{total}})\"를 켜면 확인할 수 있습니다",

--- a/voc-datalake/frontend/public/locales/ko/common.json
+++ b/voc-datalake/frontend/public/locales/ko/common.json
@@ -77,6 +77,12 @@
     "medium": "보통",
     "none": "없음"
   },
+  "problemResolution": {
+    "markResolved": "해결됨으로 표시",
+    "markUnresolved": "미해결로 표시",
+    "resolved": "해결됨",
+    "showResolved": "해결됨 표시 ({{total}})"
+  },
   "send": "보내기",
   "sentiment": {
     "mixed": "혼합",

--- a/voc-datalake/frontend/public/locales/ko/common.json
+++ b/voc-datalake/frontend/public/locales/ko/common.json
@@ -81,6 +81,7 @@
     "markResolved": "해결됨으로 표시",
     "markUnresolved": "미해결로 표시",
     "resolved": "해결됨",
+    "saveFailed": "상태를 업데이트하지 못했습니다. 다시 시도하세요.",
     "showResolved": "해결됨 표시 ({{total}})"
   },
   "send": "보내기",

--- a/voc-datalake/frontend/public/locales/ko/common.json
+++ b/voc-datalake/frontend/public/locales/ko/common.json
@@ -78,6 +78,8 @@
     "none": "없음"
   },
   "problemResolution": {
+    "allResolvedHint": "위의 \"해결됨 표시 ({{total}})\"를 켜면 확인할 수 있습니다",
+    "allResolvedTitle": "이 보기의 모든 문제가 해결됨으로 표시되어 있습니다",
     "markResolved": "해결됨으로 표시",
     "markUnresolved": "미해결로 표시",
     "resolved": "해결됨",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -84,6 +84,7 @@
     "markResolved": "Marcar como resolvido",
     "markUnresolved": "Marcar como não resolvido",
     "resolved": "Resolvido",
+    "saveFailed": "Não foi possível atualizar o status. Tente novamente.",
     "showResolved": "Mostrar resolvidos ({{total}})"
   },
   "send": "Enviar",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -80,6 +80,12 @@
     "medium": "Média",
     "none": "Nenhuma"
   },
+  "problemResolution": {
+    "markResolved": "Marcar como resolvido",
+    "markUnresolved": "Marcar como não resolvido",
+    "resolved": "Resolvido",
+    "showResolved": "Mostrar resolvidos ({{total}})"
+  },
   "send": "Enviar",
   "sentiment": {
     "mixed": "Misto",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "Cancelar",
   "configureBrand": "Configurar marca",
+  "dismiss": "Dispensar",
   "exportPdf": "Exportar PDF",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "Exportar como PDF",
@@ -79,6 +80,10 @@
     "low": "Baixa",
     "medium": "Média",
     "none": "Nenhuma"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "Tente ampliar o intervalo de tempo ou ajustar os filtros",
+    "emptyTitle": "Nenhum dado de análise de problemas encontrado para o período selecionado"
   },
   "problemResolution": {
     "allResolvedHint": "Ative \"Mostrar resolvidos ({{total}})\" acima para revisá-los",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -81,6 +81,8 @@
     "none": "Nenhuma"
   },
   "problemResolution": {
+    "allResolvedHint": "Ative \"Mostrar resolvidos ({{total}})\" acima para revisá-los",
+    "allResolvedTitle": "Todos os problemas desta visualização estão marcados como resolvidos",
     "markResolved": "Marcar como resolvido",
     "markUnresolved": "Marcar como não resolvido",
     "resolved": "Resolvido",

--- a/voc-datalake/frontend/public/locales/zh/common.json
+++ b/voc-datalake/frontend/public/locales/zh/common.json
@@ -77,6 +77,12 @@
     "medium": "中",
     "none": "无"
   },
+  "problemResolution": {
+    "markResolved": "标记为已解决",
+    "markUnresolved": "标记为未解决",
+    "resolved": "已解决",
+    "showResolved": "显示已解决 ({{total}})"
+  },
   "send": "发送",
   "sentiment": {
     "mixed": "混合",

--- a/voc-datalake/frontend/public/locales/zh/common.json
+++ b/voc-datalake/frontend/public/locales/zh/common.json
@@ -78,6 +78,8 @@
     "none": "无"
   },
   "problemResolution": {
+    "allResolvedHint": "启用上方的\"显示已解决 ({{total}})\"即可查看",
+    "allResolvedTitle": "此视图中的所有问题均已标记为已解决",
     "markResolved": "标记为已解决",
     "markUnresolved": "标记为未解决",
     "resolved": "已解决",

--- a/voc-datalake/frontend/public/locales/zh/common.json
+++ b/voc-datalake/frontend/public/locales/zh/common.json
@@ -81,6 +81,7 @@
     "markResolved": "标记为已解决",
     "markUnresolved": "标记为未解决",
     "resolved": "已解决",
+    "saveFailed": "无法更新解决状态，请重试。",
     "showResolved": "显示已解决 ({{total}})"
   },
   "send": "发送",

--- a/voc-datalake/frontend/public/locales/zh/common.json
+++ b/voc-datalake/frontend/public/locales/zh/common.json
@@ -18,6 +18,7 @@
   },
   "cancel": "取消",
   "configureBrand": "配置品牌",
+  "dismiss": "关闭",
   "exportPdf": "导出 PDF",
   "exportPdfShort": "PDF",
   "exportPdfTooltip": "导出为 PDF",
@@ -76,6 +77,10 @@
     "low": "低",
     "medium": "中",
     "none": "无"
+  },
+  "problemAnalysisPage": {
+    "emptyHint": "请尝试扩大时间范围或调整筛选条件",
+    "emptyTitle": "未找到所选时间段的问题分析数据"
   },
   "problemResolution": {
     "allResolvedHint": "启用上方的\"显示已解决 ({{total}})\"即可查看",

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -273,6 +273,17 @@ export const api = {
     body: JSON.stringify(settings)
   }),
 
+  // Problem resolution (Problem Analysis page; shared across users)
+  getResolvedProblems: () => fetchApi<{
+    resolved: Record<string, { resolved_at: string }>
+  }>('/settings/resolved-problems'),
+
+  setProblemResolved: (key: string, resolved: boolean) =>
+    fetchApi<{ success: boolean; key: string; resolved: boolean }>('/settings/resolved-problems', {
+      method: 'PUT',
+      body: JSON.stringify({ key, resolved })
+    }),
+
   // Categories Configuration
   getCategoriesConfig: () => fetchApi<{ 
     categories: Array<{

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.test.tsx
@@ -10,11 +10,15 @@ import { MemoryRouter } from 'react-router-dom'
 // Mock API
 const mockGetFeedback = vi.fn()
 const mockGetEntities = vi.fn()
+const mockGetResolvedProblems = vi.fn()
+const mockSetProblemResolved = vi.fn()
 
 vi.mock('../../api/client', () => ({
   api: {
     getFeedback: (params: unknown) => mockGetFeedback(params),
     getEntities: (params: unknown) => mockGetEntities(params),
+    getResolvedProblems: () => mockGetResolvedProblems(),
+    setProblemResolved: (key: string, resolved: boolean) => mockSetProblemResolved(key, resolved),
   },
   getDaysFromRange: () => 7,
   getDateRangeParams: () => ({ days: 7 }),
@@ -83,6 +87,8 @@ describe('ProblemAnalysis', () => {
     vi.clearAllMocks()
     mockGetFeedback.mockResolvedValue({ items: mockFeedbackItems, count: 2 })
     mockGetEntities.mockResolvedValue(mockEntities)
+    mockGetResolvedProblems.mockResolvedValue({ resolved: {} })
+    mockSetProblemResolved.mockResolvedValue({ success: true })
   })
 
   describe('rendering', () => {
@@ -172,3 +178,56 @@ describe('source filtering', () => {
 
 // Note: Testing "not configured" state requires module re-mocking which is complex
 // The main functionality is tested above
+
+
+describe('problem resolution (issue #66)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetFeedback.mockResolvedValue({ items: mockFeedbackItems, count: 2 })
+    mockGetEntities.mockResolvedValue(mockEntities)
+    mockSetProblemResolved.mockResolvedValue({ success: true })
+    // Both mock feedback items merge into the same "Slow delivery times"
+    // problem group (similarity), which is marked resolved server-side.
+    mockGetResolvedProblems.mockResolvedValue({
+      resolved: {
+        'delivery|shipping_speed|slow delivery times': { resolved_at: '2026-07-01T00:00:00Z' },
+      },
+    })
+  })
+
+  it('hides resolved problems by default and shows them via the toggle', async () => {
+    render(<ProblemAnalysis />, { wrapper: createWrapper() })
+
+    // Resolved group hidden: the page falls back to its empty state.
+    await waitFor(() => {
+      expect(screen.getByText(/show resolved \(1\)/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Slow delivery times')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /show resolved/i }))
+
+    // Visible again, annotated as resolved (category header appears).
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /delivery/i })).toBeInTheDocument()
+    })
+  })
+
+  it('persists an unresolve action through the API', async () => {
+    render(<ProblemAnalysis />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByText(/show resolved \(1\)/i)).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('checkbox', { name: /show resolved/i }))
+
+    // Expand category → subcategory to reach the problem row.
+    await userEvent.click(await screen.findByRole('button', { name: /delivery/i }))
+    await userEvent.click(await screen.findByRole('button', { name: /shipping speed/i }))
+
+    await userEvent.click(await screen.findByRole('button', { name: /mark as unresolved/i }))
+
+    expect(mockSetProblemResolved).toHaveBeenCalledWith(
+      'delivery|shipping_speed|slow delivery times', false,
+    )
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.test.tsx
@@ -200,9 +200,11 @@ describe('problem resolution (issue #66)', () => {
 
     // Resolved group hidden: the page falls back to its empty state.
     await waitFor(() => {
-      expect(screen.getByText(/show resolved \(1\)/i)).toBeInTheDocument()
+      expect(screen.getByRole('checkbox', { name: /show resolved \(1\)/i })).toBeInTheDocument()
     })
     expect(screen.queryByText('Slow delivery times')).not.toBeInTheDocument()
+    // The empty state explains WHY the tree is empty instead of "no data".
+    expect(screen.getByText(/marked resolved/i)).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('checkbox', { name: /show resolved/i }))
 
@@ -216,7 +218,7 @@ describe('problem resolution (issue #66)', () => {
     render(<ProblemAnalysis />, { wrapper: createWrapper() })
 
     await waitFor(() => {
-      expect(screen.getByText(/show resolved \(1\)/i)).toBeInTheDocument()
+      expect(screen.getByRole('checkbox', { name: /show resolved \(1\)/i })).toBeInTheDocument()
     })
     await userEvent.click(screen.getByRole('checkbox', { name: /show resolved/i }))
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { 
   ChevronDown, ChevronRight, AlertTriangle, 
   MessageSquare, TrendingUp, Filter, X, Layers, FileDown
@@ -21,6 +21,7 @@ import { api, getDateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
+import { applyResolution } from './problemResolution'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
 import { getTimeRangeLabel } from '../../utils/dateUtils'
 import { useTranslation } from 'react-i18next'
@@ -32,6 +33,7 @@ interface ProblemGroup {
   items: FeedbackItem[]
   avgSentiment: number
   urgentCount: number
+  resolved?: boolean
 }
 
 interface SubcategoryGroup {
@@ -240,7 +242,9 @@ export default function ProblemAnalysis() {
   const [selectedSubcategory, setSelectedSubcategory] = useState<string | null>(null)
   const [selectedSource, setSelectedSource] = useState<string | null>(null)
   const [showUrgentOnly, setShowUrgentOnly] = useState(false)
+  const [showResolved, setShowResolved] = useState(false)
   const [similarityThreshold, setSimilarityThreshold] = useState(0.4)
+  const queryClient = useQueryClient()
 
   // Fetch entities for dynamic sources and categories
   const { data: entitiesData } = useQuery({
@@ -253,6 +257,22 @@ export default function ProblemAnalysis() {
     queryKey: ['feedback-problems', dateParams],
     queryFn: () => api.getFeedback({ ...dateParams, limit: 500 }),
     enabled: !!config.apiEndpoint,
+  })
+
+  // Resolved problems are shared across users (issue #66); resolving one
+  // clears it from everyone's default view.
+  const { data: resolvedData } = useQuery({
+    queryKey: ['resolved-problems'],
+    queryFn: () => api.getResolvedProblems(),
+    enabled: !!config.apiEndpoint,
+  })
+
+  const toggleResolvedMutation = useMutation({
+    mutationFn: ({ key, resolved }: { key: string; resolved: boolean }) =>
+      api.setProblemResolved(key, resolved),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['resolved-problems'] })
+    },
   })
 
   // Build dynamic sources list from entities
@@ -287,6 +307,19 @@ export default function ProblemAnalysis() {
 
     return buildCategoryGroups(categoryMap)
   }, [feedbackData, showUrgentOnly, selectedCategory, selectedSubcategory, selectedSource, similarityThreshold])
+
+  // Annotate problem groups with their shared resolved status and hide the
+  // resolved ones unless requested; category/subcategory totals are
+  // recomputed so headers reflect what is actually shown (issue #66).
+  const resolvedMap = useMemo(() => resolvedData?.resolved ?? {}, [resolvedData])
+  const { visible: visibleData, resolvedCount } = useMemo(
+    () => applyResolution(groupedData, resolvedMap, showResolved),
+    [groupedData, resolvedMap, showResolved],
+  )
+
+  const handleToggleResolved = (key: string, resolved: boolean) => {
+    toggleResolvedMutation.mutate({ key, resolved })
+  }
 
   // Get unique categories from entities (dynamic)
   const allCategories = useMemo(() => {
@@ -334,10 +367,10 @@ export default function ProblemAnalysis() {
   }
 
   const expandAll = () => {
-    const allCats = new Set(groupedData.map(g => g.category))
+    const allCats = new Set(visibleData.map(g => g.category))
     const allSubs = new Set<string>()
     const allProbs = new Set<string>()
-    for (const g of groupedData) {
+    for (const g of visibleData) {
       for (const s of g.subcategories) {
         allSubs.add(`${g.category}:${s.subcategory}`)
         for (const p of s.problems) {
@@ -356,17 +389,17 @@ export default function ProblemAnalysis() {
     setExpandedProblems(new Set())
   }
 
-  const totalSubcategories = groupedData.reduce((sum, g) => sum + g.subcategories.length, 0)
-  const totalProblems = groupedData.reduce((sum, g) => 
+  const totalSubcategories = visibleData.reduce((sum, g) => sum + g.subcategories.length, 0)
+  const totalProblems = visibleData.reduce((sum, g) => 
     sum + g.subcategories.reduce((s, sub) => s + sub.problems.length, 0), 0)
-  const totalFeedback = groupedData.reduce((sum, g) => sum + g.totalItems, 0)
-  const totalUrgent = groupedData.reduce((sum, g) => sum + g.urgentCount, 0)
+  const totalFeedback = visibleData.reduce((sum, g) => sum + g.totalItems, 0)
+  const totalUrgent = visibleData.reduce((sum, g) => sum + g.urgentCount, 0)
 
   const exportPDF = () => {
-    if (groupedData.length === 0) return
+    if (visibleData.length === 0) return
     try {
       generateProblemAnalysisPDF({
-        categories: toPDFCategories(groupedData),
+        categories: toPDFCategories(visibleData),
         timeRange: getTimeRangeLabel(timeRange, customDays),
         filters: {
           source: selectedSource,
@@ -405,7 +438,7 @@ export default function ProblemAnalysis() {
             <TrendingUp size={14} className="sm:w-4 sm:h-4" />
             <span className="text-xs sm:text-sm">Categories</span>
           </div>
-          <p className="text-xl sm:text-2xl font-bold text-gray-900">{groupedData.length}</p>
+          <p className="text-xl sm:text-2xl font-bold text-gray-900">{visibleData.length}</p>
         </div>
         <div className="bg-white rounded-xl p-3 sm:p-4 border border-gray-200 shadow-sm">
           <div className="flex items-center gap-1.5 sm:gap-2 text-gray-600 mb-1">
@@ -487,9 +520,18 @@ export default function ProblemAnalysis() {
                 />
                 <span>Urgent only</span>
               </label>
-              {(selectedSource || selectedCategory || selectedSubcategory || showUrgentOnly) && (
+              <label className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm">
+                <input
+                  type="checkbox"
+                  checked={showResolved}
+                  onChange={(e) => setShowResolved(e.target.checked)}
+                  className="rounded border-gray-300 w-3.5 h-3.5 sm:w-4 sm:h-4"
+                />
+                <span>{t('problemResolution.showResolved', { total: resolvedCount })}</span>
+              </label>
+              {(selectedSource || selectedCategory || selectedSubcategory || showUrgentOnly || showResolved) && (
                 <button
-                  onClick={() => { setSelectedSource(null); setSelectedCategory(null); setSelectedSubcategory(null); setShowUrgentOnly(false) }}
+                  onClick={() => { setSelectedSource(null); setSelectedCategory(null); setSelectedSubcategory(null); setShowUrgentOnly(false); setShowResolved(false) }}
                   className="text-xs sm:text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1 active:scale-95"
                 >
                   <X size={12} className="sm:w-[14px] sm:h-[14px]" />
@@ -523,7 +565,7 @@ export default function ProblemAnalysis() {
                 </button>
                 <button
                   onClick={exportPDF}
-                  disabled={groupedData.length === 0}
+                  disabled={visibleData.length === 0}
                   className="btn btn-secondary text-xs px-2 py-1 sm:px-3 sm:py-1.5 active:scale-95 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
                   title={t('exportPdfTooltip')}
                 >
@@ -537,7 +579,7 @@ export default function ProblemAnalysis() {
       </div>
 
       {/* Problem Tree */}
-      {groupedData.length === 0 ? (
+      {visibleData.length === 0 ? (
         <div className="card text-center py-8 sm:py-12">
           <AlertTriangle size={36} className="mx-auto text-gray-300 mb-3 sm:mb-4 sm:w-12 sm:h-12" />
           <p className="text-gray-500 text-sm sm:text-base">No problem analysis data found for the selected period</p>
@@ -545,7 +587,7 @@ export default function ProblemAnalysis() {
         </div>
       ) : (
         <div className="space-y-3 sm:space-y-4">
-          {groupedData.map((categoryGroup) => (
+          {visibleData.map((categoryGroup) => (
             <div key={categoryGroup.category} className="card p-0 overflow-hidden">
               {/* Category Header */}
               <button
@@ -586,6 +628,7 @@ export default function ProblemAnalysis() {
                         onToggle={() => toggleSubcategory(subcategoryKey)}
                         expandedProblems={expandedProblems}
                         onToggleProblem={toggleProblem}
+                        onToggleResolved={handleToggleResolved}
                       />
                     )
                   })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -230,6 +230,18 @@ function toPDFCategories(groups: CategoryGroup[]) {
   }))
 }
 
+// Rendered when persisting a resolve/unresolve fails; kept out of the page
+// component so the conditional doesn't count against its complexity budget.
+function ResolveErrorBanner({ show }: { readonly show: boolean }) {
+  const { t } = useTranslation('common')
+  if (!show) return null
+  return (
+    <div className="card bg-red-50 border border-red-200 text-red-700 text-sm py-2 px-3" role="alert">
+      {t('problemResolution.saveFailed')}
+    </div>
+  )
+}
+
 export default function ProblemAnalysis() {
   const { t } = useTranslation('common')
   const { timeRange, customDays, dateBasis, config } = useConfigStore()
@@ -275,6 +287,13 @@ export default function ProblemAnalysis() {
     },
   })
 
+  const handleToggleResolved = (key: string, resolved: boolean) => {
+    // Serialize toggles: a rapid double-click would race SET/REMOVE for the
+    // same key server-side. The mutation error state renders a banner below.
+    if (toggleResolvedMutation.isPending) return
+    toggleResolvedMutation.mutate({ key, resolved })
+  }
+
   // Build dynamic sources list from entities
   const allSources = useMemo(() => {
     if (!entitiesData?.entities?.sources) return []
@@ -316,10 +335,6 @@ export default function ProblemAnalysis() {
     () => applyResolution(groupedData, resolvedMap, showResolved),
     [groupedData, resolvedMap, showResolved],
   )
-
-  const handleToggleResolved = (key: string, resolved: boolean) => {
-    toggleResolvedMutation.mutate({ key, resolved })
-  }
 
   // Get unique categories from entities (dynamic)
   const allCategories = useMemo(() => {
@@ -577,6 +592,8 @@ export default function ProblemAnalysis() {
           </div>
         </div>
       </div>
+
+      <ResolveErrorBanner show={toggleResolvedMutation.isError} />
 
       {/* Problem Tree */}
       {visibleData.length === 0 ? (

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -21,7 +21,7 @@ import { api, getDateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
-import { applyResolution } from './problemResolution'
+import { applyResolution, parseResolvedProblemsResponse } from './problemResolution'
 import type { CategoryGroup, ProblemGroup, SubcategoryGroup } from './problemResolution'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
 import { getTimeRangeLabel } from '../../utils/dateUtils'
@@ -211,6 +211,29 @@ function toPDFCategories(groups: CategoryGroup[]) {
   }))
 }
 
+// Empty state distinguishes "nothing in this window" from "everything here
+// is resolved" — hiding data behind the toggle must not read as no data.
+// Kept out of the page component for its complexity budget.
+function EmptyProblemsState({ resolvedCount }: { readonly resolvedCount: number }) {
+  const { t } = useTranslation('common')
+  return (
+    <div className="card text-center py-8 sm:py-12">
+      <AlertTriangle size={36} className="mx-auto text-gray-300 mb-3 sm:mb-4 sm:w-12 sm:h-12" />
+      {resolvedCount > 0 ? (
+        <>
+          <p className="text-gray-500 text-sm sm:text-base">{t('problemResolution.allResolvedTitle')}</p>
+          <p className="text-xs sm:text-sm text-gray-400 mt-1">{t('problemResolution.allResolvedHint', { total: resolvedCount })}</p>
+        </>
+      ) : (
+        <>
+          <p className="text-gray-500 text-sm sm:text-base">No problem analysis data found for the selected period</p>
+          <p className="text-xs sm:text-sm text-gray-400 mt-1">Try expanding the time range or adjusting filters</p>
+        </>
+      )}
+    </div>
+  )
+}
+
 // Rendered when persisting a resolve/unresolve fails; kept out of the page
 // component so the conditional doesn't count against its complexity budget.
 function ResolveErrorBanner({ show }: { readonly show: boolean }) {
@@ -256,7 +279,7 @@ export default function ProblemAnalysis() {
   // clears it from everyone's default view.
   const { data: resolvedData } = useQuery({
     queryKey: ['resolved-problems'],
-    queryFn: () => api.getResolvedProblems(),
+    queryFn: async () => parseResolvedProblemsResponse(await api.getResolvedProblems()),
     enabled: !!config.apiEndpoint,
     // Resolution state is shared across users, so keep it deliberately
     // fresh: refetch when the tab regains focus and treat it as stale
@@ -403,6 +426,7 @@ export default function ProblemAnalysis() {
       generateProblemAnalysisPDF({
         categories: toPDFCategories(visibleData),
         timeRange: getTimeRangeLabel(timeRange, customDays, dateBasis),
+        resolvedLabel: t('problemResolution.resolved'),
         filters: {
           source: selectedSource,
           category: selectedCategory,
@@ -586,11 +610,7 @@ export default function ProblemAnalysis() {
 
       {/* Problem Tree */}
       {visibleData.length === 0 ? (
-        <div className="card text-center py-8 sm:py-12">
-          <AlertTriangle size={36} className="mx-auto text-gray-300 mb-3 sm:mb-4 sm:w-12 sm:h-12" />
-          <p className="text-gray-500 text-sm sm:text-base">No problem analysis data found for the selected period</p>
-          <p className="text-xs sm:text-sm text-gray-400 mt-1">Try expanding the time range or adjusting filters</p>
-        </div>
+        <EmptyProblemsState resolvedCount={resolvedCount} />
       ) : (
         <div className="space-y-3 sm:space-y-4">
           {visibleData.map((categoryGroup) => (

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -22,33 +22,11 @@ import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
 import { applyResolution } from './problemResolution'
+import type { CategoryGroup, ProblemGroup, SubcategoryGroup } from './problemResolution'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
 import { getTimeRangeLabel } from '../../utils/dateUtils'
 import { useTranslation } from 'react-i18next'
 
-interface ProblemGroup {
-  problem: string
-  similarProblems: string[]  // Original problem texts that were merged
-  rootCause: string | null
-  items: FeedbackItem[]
-  avgSentiment: number
-  urgentCount: number
-  resolved?: boolean
-}
-
-interface SubcategoryGroup {
-  subcategory: string
-  problems: ProblemGroup[]
-  totalItems: number
-  urgentCount: number
-}
-
-interface CategoryGroup {
-  category: string
-  subcategories: SubcategoryGroup[]
-  totalItems: number
-  urgentCount: number
-}
 
 // Normalize text for similarity comparison
 function normalizeText(text: string): string {
@@ -542,6 +520,8 @@ export default function ProblemAnalysis() {
                   onChange={(e) => setShowResolved(e.target.checked)}
                   className="rounded border-gray-300 w-3.5 h-3.5 sm:w-4 sm:h-4"
                 />
+                {/* Counts resolved problems within the CURRENT filters
+                    (what the toggle would reveal), not the global store. */}
                 <span>{t('problemResolution.showResolved', { total: resolvedCount })}</span>
               </label>
               {(selectedSource || selectedCategory || selectedSubcategory || showUrgentOnly || showResolved) && (
@@ -646,6 +626,7 @@ export default function ProblemAnalysis() {
                         expandedProblems={expandedProblems}
                         onToggleProblem={toggleProblem}
                         onToggleResolved={handleToggleResolved}
+                        resolvePending={toggleResolvedMutation.isPending}
                       />
                     )
                   })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState, useMemo } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { 
   ChevronDown, ChevronRight, AlertTriangle, 
   MessageSquare, TrendingUp, Filter, X, Layers, FileDown
@@ -21,7 +21,8 @@ import { api, getDateRangeParams } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
-import { applyResolution, parseResolvedProblemsResponse } from './problemResolution'
+import { applyResolution } from './problemResolution'
+import { useProblemResolution } from './useProblemResolution'
 import type { CategoryGroup, ProblemGroup, SubcategoryGroup } from './problemResolution'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
 import { getTimeRangeLabel } from '../../utils/dateUtils'
@@ -211,6 +212,12 @@ function toPDFCategories(groups: CategoryGroup[]) {
   }))
 }
 
+// Module-level so the operator chain doesn't count against the page
+// component's complexity budget.
+function anyFilterActive(...filters: Array<string | boolean | null>): boolean {
+  return filters.some(Boolean)
+}
+
 // Empty state distinguishes "nothing in this window" from "everything here
 // is resolved" — hiding data behind the toggle must not read as no data.
 // Kept out of the page component for its complexity budget.
@@ -226,8 +233,8 @@ function EmptyProblemsState({ resolvedCount }: { readonly resolvedCount: number 
         </>
       ) : (
         <>
-          <p className="text-gray-500 text-sm sm:text-base">No problem analysis data found for the selected period</p>
-          <p className="text-xs sm:text-sm text-gray-400 mt-1">Try expanding the time range or adjusting filters</p>
+          <p className="text-gray-500 text-sm sm:text-base">{t('problemAnalysisPage.emptyTitle')}</p>
+          <p className="text-xs sm:text-sm text-gray-400 mt-1">{t('problemAnalysisPage.emptyHint')}</p>
         </>
       )}
     </div>
@@ -236,12 +243,15 @@ function EmptyProblemsState({ resolvedCount }: { readonly resolvedCount: number 
 
 // Rendered when persisting a resolve/unresolve fails; kept out of the page
 // component so the conditional doesn't count against its complexity budget.
-function ResolveErrorBanner({ show }: { readonly show: boolean }) {
+function ResolveErrorBanner({ show, onDismiss }: { readonly show: boolean; readonly onDismiss: () => void }) {
   const { t } = useTranslation('common')
   if (!show) return null
   return (
-    <div className="card bg-red-50 border border-red-200 text-red-700 text-sm py-2 px-3" role="alert">
-      {t('problemResolution.saveFailed')}
+    <div className="card bg-red-50 border border-red-200 text-red-700 text-sm py-2 px-3 flex items-center justify-between gap-2" role="alert">
+      <span>{t('problemResolution.saveFailed')}</span>
+      <button type="button" onClick={onDismiss} aria-label={t('dismiss')} className="text-red-500 hover:text-red-700">
+        <X size={14} />
+      </button>
     </div>
   )
 }
@@ -260,7 +270,6 @@ export default function ProblemAnalysis() {
   const [showUrgentOnly, setShowUrgentOnly] = useState(false)
   const [showResolved, setShowResolved] = useState(false)
   const [similarityThreshold, setSimilarityThreshold] = useState(0.4)
-  const queryClient = useQueryClient()
 
   // Fetch entities for dynamic sources and categories
   const { data: entitiesData } = useQuery({
@@ -276,33 +285,12 @@ export default function ProblemAnalysis() {
   })
 
   // Resolved problems are shared across users (issue #66); resolving one
-  // clears it from everyone's default view.
-  const { data: resolvedData } = useQuery({
-    queryKey: ['resolved-problems'],
-    queryFn: async () => parseResolvedProblemsResponse(await api.getResolvedProblems()),
-    enabled: !!config.apiEndpoint,
-    // Resolution state is shared across users, so keep it deliberately
-    // fresh: refetch when the tab regains focus and treat it as stale
-    // after 15s so another user's resolves appear without a remount.
-    staleTime: 15_000,
-    refetchOnWindowFocus: true,
-  })
-
-  const toggleResolvedMutation = useMutation({
-    mutationFn: ({ key, resolved }: { key: string; resolved: boolean }) =>
-      api.setProblemResolved(key, resolved),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['resolved-problems'] })
-    },
-  })
-
-  const handleToggleResolved = (key: string, resolved: boolean) => {
-    // Double defense with the disabled buttons (resolvePending): the guard
-    // covers the render gap before the disabled state paints, so a rapid
-    // double-click can't race SET/REMOVE for the same key server-side.
-    if (toggleResolvedMutation.isPending) return
-    toggleResolvedMutation.mutate({ key, resolved })
-  }
+  // clears it from everyone's default view. All query/mutation wiring lives
+  // in the hook (complexity budget + useSettingsSync convention).
+  const {
+    resolvedMap, resolvedLoading, togglePending, toggleFailed,
+    toggleResolved, dismissToggleError,
+  } = useProblemResolution(!!config.apiEndpoint)
 
   // Build dynamic sources list from entities
   const allSources = useMemo(() => {
@@ -340,7 +328,6 @@ export default function ProblemAnalysis() {
   // Annotate problem groups with their shared resolved status and hide the
   // resolved ones unless requested; category/subcategory totals are
   // recomputed so headers reflect what is actually shown (issue #66).
-  const resolvedMap = useMemo(() => resolvedData?.resolved ?? {}, [resolvedData])
   const { visible: visibleData, resolvedCount } = useMemo(
     () => applyResolution(groupedData, resolvedMap, showResolved),
     [groupedData, resolvedMap, showResolved],
@@ -447,7 +434,9 @@ export default function ProblemAnalysis() {
     )
   }
 
-  if (isLoading) {
+  // Gate on the resolved-state query too: without it, resolved problems
+  // flash as unresolved for a frame and then vanish when the query lands.
+  if (isLoading || resolvedLoading) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
@@ -557,7 +546,7 @@ export default function ProblemAnalysis() {
                     (what the toggle would reveal), not the global store. */}
                 <span>{t('problemResolution.showResolved', { total: resolvedCount })}</span>
               </label>
-              {(selectedSource || selectedCategory || selectedSubcategory || showUrgentOnly || showResolved) && (
+              {anyFilterActive(selectedSource, selectedCategory, selectedSubcategory, showUrgentOnly, showResolved) && (
                 <button
                   onClick={() => { setSelectedSource(null); setSelectedCategory(null); setSelectedSubcategory(null); setShowUrgentOnly(false); setShowResolved(false) }}
                   className="text-xs sm:text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1 active:scale-95"
@@ -606,7 +595,7 @@ export default function ProblemAnalysis() {
         </div>
       </div>
 
-      <ResolveErrorBanner show={toggleResolvedMutation.isError} />
+      <ResolveErrorBanner show={toggleFailed} onDismiss={dismissToggleError} />
 
       {/* Problem Tree */}
       {visibleData.length === 0 ? (
@@ -654,8 +643,8 @@ export default function ProblemAnalysis() {
                         onToggle={() => toggleSubcategory(subcategoryKey)}
                         expandedProblems={expandedProblems}
                         onToggleProblem={toggleProblem}
-                        onToggleResolved={handleToggleResolved}
-                        resolvePending={toggleResolvedMutation.isPending}
+                        onToggleResolved={toggleResolved}
+                        resolvePending={togglePending}
                       />
                     )
                   })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -255,6 +255,11 @@ export default function ProblemAnalysis() {
     queryKey: ['resolved-problems'],
     queryFn: () => api.getResolvedProblems(),
     enabled: !!config.apiEndpoint,
+    // Resolution state is shared across users, so keep it deliberately
+    // fresh: refetch when the tab regains focus and treat it as stale
+    // after 15s so another user's resolves appear without a remount.
+    staleTime: 15_000,
+    refetchOnWindowFocus: true,
   })
 
   const toggleResolvedMutation = useMutation({

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -203,6 +203,9 @@ function toPDFCategories(groups: CategoryGroup[]) {
         itemCount: p.items.length,
         avgSentiment: p.avgSentiment,
         urgentCount: p.urgentCount,
+        // With "Show resolved" on, resolved groups reach the export — the
+        // PDF must annotate them, since strike-through/badge is UI-only.
+        resolved: p.resolved === true,
       })),
     })),
   }))
@@ -271,8 +274,9 @@ export default function ProblemAnalysis() {
   })
 
   const handleToggleResolved = (key: string, resolved: boolean) => {
-    // Serialize toggles: a rapid double-click would race SET/REMOVE for the
-    // same key server-side. The mutation error state renders a banner below.
+    // Double defense with the disabled buttons (resolvePending): the guard
+    // covers the render gap before the disabled state paints, so a rapid
+    // double-click can't race SET/REMOVE for the same key server-side.
     if (toggleResolvedMutation.isPending) return
     toggleResolvedMutation.mutate({ key, resolved })
   }

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.test.tsx
@@ -31,27 +31,27 @@ function makeCategories(): ProblemAnalysisPDFProps['categories'] {
 
 describe('ProblemAnalysisPDFContent', () => {
   it('renders the category name', () => {
-    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    render(<ProblemAnalysisPDFContent resolvedLabel="Resolved" categories={makeCategories()} timeRange="Last 7 days" />)
     expect(screen.getByText('Delivery')).toBeInTheDocument()
   })
 
   it('renders the subcategory name', () => {
-    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    render(<ProblemAnalysisPDFContent resolvedLabel="Resolved" categories={makeCategories()} timeRange="Last 7 days" />)
     expect(screen.getByText('Late shipment')).toBeInTheDocument()
   })
 
   it('renders the problem statement', () => {
-    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    render(<ProblemAnalysisPDFContent resolvedLabel="Resolved" categories={makeCategories()} timeRange="Last 7 days" />)
     expect(screen.getByText(/Package arrived two weeks late/)).toBeInTheDocument()
   })
 
   it('renders the root cause hypothesis', () => {
-    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    render(<ProblemAnalysisPDFContent resolvedLabel="Resolved" categories={makeCategories()} timeRange="Last 7 days" />)
     expect(screen.getByText(/Carrier capacity shortage/)).toBeInTheDocument()
   })
 
   it('indicates similar problems count', () => {
-    render(<ProblemAnalysisPDFContent categories={makeCategories()} timeRange="Last 7 days" />)
+    render(<ProblemAnalysisPDFContent resolvedLabel="Resolved" categories={makeCategories()} timeRange="Last 7 days" />)
     expect(screen.getByText(/\+1 similar/)).toBeInTheDocument()
   })
 })

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
@@ -33,6 +33,9 @@ interface CategoryGroupPDF {
 export interface ProblemAnalysisPDFProps {
   readonly categories: CategoryGroupPDF[]
   readonly timeRange: string
+  /** Translated badge text for resolved problems (the PDF renders outside
+   * the i18n provider, so the page passes the resolved label in). */
+  readonly resolvedLabel?: string
   readonly filters?: {
     source?: string | null
     category?: string | null
@@ -149,7 +152,7 @@ function HeaderSection({
   )
 }
 
-function ProblemItem({ problem }: { readonly problem: ProblemGroupPDF }) {
+function ProblemItem({ problem, resolvedLabel }: { readonly problem: ProblemGroupPDF; readonly resolvedLabel?: string }) {
   const resolved = problem.resolved === true
   return (
     <div data-pdf-section style={{
@@ -184,7 +187,7 @@ function ProblemItem({ problem }: { readonly problem: ProblemGroupPDF }) {
                 padding: '2px 8px',
                 marginLeft: '8px',
               }}>
-                RESOLVED
+                {(resolvedLabel ?? 'Resolved').toUpperCase()}
               </span>
             )}
             {problem.similarProblems.length > 0 && (
@@ -244,10 +247,11 @@ function ProblemItem({ problem }: { readonly problem: ProblemGroupPDF }) {
 }
 
 function SubcategorySection({
-  subcategory, categoryName,
+  subcategory, categoryName, resolvedLabel,
 }: {
   readonly subcategory: SubcategoryGroupPDF;
-  readonly categoryName: string
+  readonly categoryName: string;
+  readonly resolvedLabel?: string
 }) {
   return (
     <div data-pdf-section style={{
@@ -288,13 +292,13 @@ function SubcategorySection({
         )}
       </div>
       {subcategory.problems.map((problem) => (
-        <ProblemItem key={`${categoryName}-${subcategory.subcategory}-${problem.problem}`} problem={problem} />
+        <ProblemItem key={`${categoryName}-${subcategory.subcategory}-${problem.problem}`} problem={problem} resolvedLabel={resolvedLabel} />
       ))}
     </div>
   )
 }
 
-function CategorySection({ category }: { readonly category: CategoryGroupPDF }) {
+function CategorySection({ category, resolvedLabel }: { readonly category: CategoryGroupPDF; readonly resolvedLabel?: string }) {
   return (
     <div data-pdf-section style={{ marginBottom: '28px' }}>
       <div style={{
@@ -344,6 +348,7 @@ function CategorySection({ category }: { readonly category: CategoryGroupPDF }) 
           key={`${category.category}-${sub.subcategory}`}
           subcategory={sub}
           categoryName={category.category}
+          resolvedLabel={resolvedLabel}
         />
       ))}
     </div>
@@ -363,7 +368,7 @@ export default function ProblemAnalysisPDFContent(props: ProblemAnalysisPDFProps
         marginBottom: '24px',
       }} />
       {props.categories.map((category) => (
-        <CategorySection key={category.category} category={category} />
+        <CategorySection key={category.category} category={category} resolvedLabel={props.resolvedLabel} />
       ))}
       <div data-pdf-section>
         <hr style={{

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
@@ -13,6 +13,7 @@ interface ProblemGroupPDF {
   readonly itemCount: number
   readonly avgSentiment: number
   readonly urgentCount: number
+  readonly resolved?: boolean
 }
 
 interface SubcategoryGroupPDF {
@@ -149,13 +150,15 @@ function HeaderSection({
 }
 
 function ProblemItem({ problem }: { readonly problem: ProblemGroupPDF }) {
+  const resolved = problem.resolved === true
   return (
     <div data-pdf-section style={{
       padding: '10px 16px',
-      borderLeft: '3px solid #f59e0b',
+      borderLeft: resolved ? '3px solid #16a34a' : '3px solid #f59e0b',
       marginBottom: '8px',
-      backgroundColor: '#fffbeb',
+      backgroundColor: resolved ? '#f0fdf4' : '#fffbeb',
       borderRadius: '0 6px 6px 0',
+      opacity: resolved ? 0.75 : 1,
     }}>
       <div style={{
         display: 'flex',
@@ -170,7 +173,20 @@ function ProblemItem({ problem }: { readonly problem: ProblemGroupPDF }) {
             color: '#1f2937',
             margin: '0 0 4px 0',
           }}>
-            ⚠️ {problem.problem}
+            {resolved ? '✅' : '⚠️'} {problem.problem}
+            {resolved && (
+              <span style={{
+                fontSize: '10px',
+                fontWeight: '600',
+                color: '#166534',
+                backgroundColor: '#dcfce7',
+                borderRadius: '9999px',
+                padding: '2px 8px',
+                marginLeft: '8px',
+              }}>
+                RESOLVED
+              </span>
+            )}
             {problem.similarProblems.length > 0 && (
               <span style={{
                 fontSize: '11px',

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysisPDFContent.tsx
@@ -34,8 +34,9 @@ export interface ProblemAnalysisPDFProps {
   readonly categories: CategoryGroupPDF[]
   readonly timeRange: string
   /** Translated badge text for resolved problems (the PDF renders outside
-   * the i18n provider, so the page passes the resolved label in). */
-  readonly resolvedLabel?: string
+   * the i18n provider, so the page passes the resolved label in). Required
+   * so a future call site can't silently ship untranslated. */
+  readonly resolvedLabel: string
   readonly filters?: {
     source?: string | null
     category?: string | null
@@ -152,7 +153,7 @@ function HeaderSection({
   )
 }
 
-function ProblemItem({ problem, resolvedLabel }: { readonly problem: ProblemGroupPDF; readonly resolvedLabel?: string }) {
+function ProblemItem({ problem, resolvedLabel }: { readonly problem: ProblemGroupPDF; readonly resolvedLabel: string }) {
   const resolved = problem.resolved === true
   return (
     <div data-pdf-section style={{
@@ -187,7 +188,7 @@ function ProblemItem({ problem, resolvedLabel }: { readonly problem: ProblemGrou
                 padding: '2px 8px',
                 marginLeft: '8px',
               }}>
-                {(resolvedLabel ?? 'Resolved').toUpperCase()}
+                {resolvedLabel.toUpperCase()}
               </span>
             )}
             {problem.similarProblems.length > 0 && (
@@ -251,7 +252,7 @@ function SubcategorySection({
 }: {
   readonly subcategory: SubcategoryGroupPDF;
   readonly categoryName: string;
-  readonly resolvedLabel?: string
+  readonly resolvedLabel: string
 }) {
   return (
     <div data-pdf-section style={{
@@ -298,7 +299,7 @@ function SubcategorySection({
   )
 }
 
-function CategorySection({ category, resolvedLabel }: { readonly category: CategoryGroupPDF; readonly resolvedLabel?: string }) {
+function CategorySection({ category, resolvedLabel }: { readonly category: CategoryGroupPDF; readonly resolvedLabel: string }) {
   return (
     <div data-pdf-section style={{ marginBottom: '28px' }}>
       <div style={{

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.test.tsx
@@ -68,6 +68,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -81,6 +82,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -94,6 +96,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -107,6 +110,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -120,6 +124,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -133,6 +138,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -148,6 +154,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={true}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -162,6 +169,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={true}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -175,6 +183,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={true}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -194,6 +203,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={onToggle}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -212,6 +222,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -227,6 +238,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -242,6 +254,7 @@ describe('ProblemRow', () => {
           problemKey="delivery:shipping:slow"
           isExpanded={false}
           onToggle={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -249,5 +262,56 @@ describe('ProblemRow', () => {
       const badges = screen.getAllByText('2')
       expect(badges).toHaveLength(1)
     })
+  })
+})
+
+
+describe('problem resolution (issue #66)', () => {
+  it('fires onToggleResolved from the resolve control without toggling the row', async () => {
+    const onToggle = vi.fn()
+    const onToggleResolved = vi.fn()
+    renderWithRouter(
+      <ProblemRow
+        problemGroup={mockProblemGroup}
+        problemKey="delivery:shipping:slow"
+        isExpanded={false}
+        onToggle={onToggle}
+        onToggleResolved={onToggleResolved}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /mark as resolved/i }))
+
+    expect(onToggleResolved).toHaveBeenCalledTimes(1)
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('shows the resolved badge and unresolve control for resolved groups', () => {
+    renderWithRouter(
+      <ProblemRow
+        problemGroup={{ ...mockProblemGroup, resolved: true }}
+        problemKey="delivery:shipping:slow"
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onToggleResolved={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /mark as unresolved/i })).toBeInTheDocument()
+  })
+
+  it('shows no resolved badge for unresolved groups', () => {
+    renderWithRouter(
+      <ProblemRow
+        problemGroup={mockProblemGroup}
+        problemKey="delivery:shipping:slow"
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onToggleResolved={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText('Resolved')).not.toBeInTheDocument()
   })
 })

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.tsx
@@ -58,6 +58,7 @@ function ResolveToggleButton({ resolved, onToggleResolved }: Readonly<{ resolved
     : t('problemResolution.markResolved')
   return (
     <button
+      type="button"
       onClick={onToggleResolved}
       title={resolveLabel}
       aria-label={resolveLabel}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom'
-import { ChevronDown, ChevronRight, AlertTriangle, Lightbulb } from 'lucide-react'
+import { ChevronDown, ChevronRight, AlertTriangle, Lightbulb, CheckCircle2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import clsx from 'clsx'
 import SentimentBadge from '../../components/SentimentBadge'
 import type { FeedbackItem } from '../../api/client'
 
@@ -10,6 +12,7 @@ interface ProblemGroup {
   items: FeedbackItem[]
   avgSentiment: number
   urgentCount: number
+  resolved?: boolean
 }
 
 function getSentimentLabel(score: number): 'positive' | 'negative' | 'neutral' {
@@ -23,14 +26,63 @@ interface ProblemRowProps {
   readonly problemKey: string
   readonly isExpanded: boolean
   readonly onToggle: () => void
+  readonly onToggleResolved: () => void
 }
 
-export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle }: ProblemRowProps) {
+function ProblemTitle({ problemGroup, resolved }: Readonly<{ problemGroup: ProblemGroup; resolved: boolean }>) {
+  const { t } = useTranslation('common')
   return (
-    <div key={problemKey} className="bg-white">
+    <div className="flex items-center gap-1.5 sm:gap-2 mb-1 flex-wrap">
+      <AlertTriangle size={12} className="text-orange-500 flex-shrink-0 sm:w-[14px] sm:h-[14px]" />
+      <span className={clsx('font-medium text-gray-800 text-xs sm:text-sm', resolved && 'line-through')}>
+        {problemGroup.problem}
+      </span>
+      {resolved && (
+        <span className="px-1.5 py-0.5 bg-green-100 text-green-700 text-xs rounded-full flex-shrink-0">
+          {t('problemResolution.resolved')}
+        </span>
+      )}
+      {problemGroup.similarProblems.length > 0 && (
+        <span className="px-1.5 py-0.5 bg-blue-100 text-blue-700 text-xs rounded-full" title={problemGroup.similarProblems.join(', ')}>
+          +{problemGroup.similarProblems.length}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function ResolveToggleButton({ resolved, onToggleResolved }: Readonly<{ resolved: boolean; onToggleResolved: () => void }>) {
+  const { t } = useTranslation('common')
+  const resolveLabel = resolved
+    ? t('problemResolution.markUnresolved')
+    : t('problemResolution.markResolved')
+  return (
+    <button
+      onClick={onToggleResolved}
+      title={resolveLabel}
+      aria-label={resolveLabel}
+      className={clsx(
+        'absolute right-2 sm:right-3 top-2.5 sm:top-3 p-1 rounded-full transition-colors',
+        resolved
+          ? 'text-green-600 hover:bg-green-50 active:bg-green-100'
+          : 'text-gray-300 hover:text-green-600 hover:bg-green-50 active:bg-green-100',
+      )}
+    >
+      <CheckCircle2 size={16} className="sm:w-[18px] sm:h-[18px]" />
+    </button>
+  )
+}
+
+export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle, onToggleResolved }: ProblemRowProps) {
+  const resolved = problemGroup.resolved === true
+  return (
+    <div key={problemKey} className="bg-white relative">
       <button
         onClick={onToggle}
-        className="w-full px-3 sm:px-6 py-2.5 sm:py-3 pl-10 sm:pl-16 flex flex-col sm:flex-row sm:items-start justify-between hover:bg-gray-50 active:bg-gray-100 transition-colors text-left gap-2"
+        className={clsx(
+          'w-full px-3 sm:px-6 py-2.5 sm:py-3 pl-10 sm:pl-16 pr-12 sm:pr-14 flex flex-col sm:flex-row sm:items-start justify-between hover:bg-gray-50 active:bg-gray-100 transition-colors text-left gap-2',
+          resolved && 'opacity-60',
+        )}
       >
         <div className="flex items-start gap-2 sm:gap-3 flex-1 min-w-0">
           {isExpanded ? (
@@ -39,15 +91,7 @@ export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle }: P
             <ChevronRight size={16} className="text-gray-400 mt-0.5 flex-shrink-0 sm:w-[18px] sm:h-[18px]" />
           )}
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5 sm:gap-2 mb-1 flex-wrap">
-              <AlertTriangle size={12} className="text-orange-500 flex-shrink-0 sm:w-[14px] sm:h-[14px]" />
-              <span className="font-medium text-gray-800 text-xs sm:text-sm">{problemGroup.problem}</span>
-              {problemGroup.similarProblems.length > 0 && (
-                <span className="px-1.5 py-0.5 bg-blue-100 text-blue-700 text-xs rounded-full" title={problemGroup.similarProblems.join(', ')}>
-                  +{problemGroup.similarProblems.length}
-                </span>
-              )}
-            </div>
+            <ProblemTitle problemGroup={problemGroup} resolved={resolved} />
             {problemGroup.rootCause && (
               <div className="flex items-start gap-1.5 sm:gap-2 text-xs text-gray-600">
                 <Lightbulb size={12} className="text-yellow-500 mt-0.5 flex-shrink-0 sm:w-[14px] sm:h-[14px]" />
@@ -73,6 +117,10 @@ export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle }: P
           <SentimentBadge sentiment={getSentimentLabel(problemGroup.avgSentiment)} score={problemGroup.avgSentiment} />
         </div>
       </button>
+
+      {/* Sibling of the row toggle (never nested inside it) so both stay
+          valid, independently focusable buttons. */}
+      <ResolveToggleButton resolved={resolved} onToggleResolved={onToggleResolved} />
 
       {isExpanded && (
         <div className="px-3 sm:px-6 pb-3 sm:pb-4 pl-12 sm:pl-24 space-y-2 sm:space-y-3">

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemRow.tsx
@@ -4,16 +4,7 @@ import { useTranslation } from 'react-i18next'
 import clsx from 'clsx'
 import SentimentBadge from '../../components/SentimentBadge'
 import type { FeedbackItem } from '../../api/client'
-
-interface ProblemGroup {
-  problem: string
-  similarProblems: string[]
-  rootCause: string | null
-  items: FeedbackItem[]
-  avgSentiment: number
-  urgentCount: number
-  resolved?: boolean
-}
+import type { ProblemGroup } from './problemResolution'
 
 function getSentimentLabel(score: number): 'positive' | 'negative' | 'neutral' {
   if (score > 0) return 'positive'
@@ -27,6 +18,7 @@ interface ProblemRowProps {
   readonly isExpanded: boolean
   readonly onToggle: () => void
   readonly onToggleResolved: () => void
+  readonly resolvePending?: boolean
 }
 
 function ProblemTitle({ problemGroup, resolved }: Readonly<{ problemGroup: ProblemGroup; resolved: boolean }>) {
@@ -51,7 +43,7 @@ function ProblemTitle({ problemGroup, resolved }: Readonly<{ problemGroup: Probl
   )
 }
 
-function ResolveToggleButton({ resolved, onToggleResolved }: Readonly<{ resolved: boolean; onToggleResolved: () => void }>) {
+function ResolveToggleButton({ resolved, onToggleResolved, disabled }: Readonly<{ resolved: boolean; onToggleResolved: () => void; disabled?: boolean }>) {
   const { t } = useTranslation('common')
   const resolveLabel = resolved
     ? t('problemResolution.markUnresolved')
@@ -60,9 +52,11 @@ function ResolveToggleButton({ resolved, onToggleResolved }: Readonly<{ resolved
     <button
       type="button"
       onClick={onToggleResolved}
+      disabled={disabled}
       title={resolveLabel}
       aria-label={resolveLabel}
       className={clsx(
+        disabled && 'opacity-40 cursor-not-allowed',
         'absolute right-2 sm:right-3 top-2.5 sm:top-3 p-1 rounded-full transition-colors',
         resolved
           ? 'text-green-600 hover:bg-green-50 active:bg-green-100'
@@ -74,7 +68,7 @@ function ResolveToggleButton({ resolved, onToggleResolved }: Readonly<{ resolved
   )
 }
 
-export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle, onToggleResolved }: ProblemRowProps) {
+export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle, onToggleResolved, resolvePending }: ProblemRowProps) {
   const resolved = problemGroup.resolved === true
   return (
     <div key={problemKey} className="bg-white relative">
@@ -121,7 +115,7 @@ export function ProblemRow({ problemGroup, problemKey, isExpanded, onToggle, onT
 
       {/* Sibling of the row toggle (never nested inside it) so both stay
           valid, independently focusable buttons. */}
-      <ResolveToggleButton resolved={resolved} onToggleResolved={onToggleResolved} />
+      <ResolveToggleButton resolved={resolved} onToggleResolved={onToggleResolved} disabled={resolvePending} />
 
       {isExpanded && (
         <div className="px-3 sm:px-6 pb-3 sm:pb-4 pl-12 sm:pl-24 space-y-2 sm:space-y-3">

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.test.tsx
@@ -86,6 +86,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={new Set()}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -101,6 +102,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={new Set()}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -117,6 +119,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={new Set()}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -134,6 +137,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={new Set()}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -152,6 +156,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={new Set()}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -173,6 +178,7 @@ describe('SubcategoryRow', () => {
           onToggle={onToggle}
           expandedProblems={new Set()}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -192,6 +198,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={new Set()}
           onToggleProblem={onToggleProblem}
+          onToggleResolved={vi.fn()}
         />
       )
 
@@ -212,6 +219,7 @@ describe('SubcategoryRow', () => {
           onToggle={vi.fn()}
           expandedProblems={expandedProblems}
           onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
         />
       )
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronRight, Layers } from 'lucide-react'
 import { ProblemRow } from './ProblemRow'
+import { buildResolutionKey } from './problemResolution'
 import type { FeedbackItem } from '../../api/client'
 
 interface ProblemGroup {
@@ -9,6 +10,7 @@ interface ProblemGroup {
   items: FeedbackItem[]
   avgSentiment: number
   urgentCount: number
+  resolved?: boolean
 }
 
 interface SubcategoryGroup {
@@ -25,6 +27,7 @@ interface SubcategoryRowProps {
   readonly onToggle: () => void
   readonly expandedProblems: Set<string>
   readonly onToggleProblem: (key: string) => void
+  readonly onToggleResolved: (key: string, resolved: boolean) => void
 }
 
 export function SubcategoryRow({
@@ -34,6 +37,7 @@ export function SubcategoryRow({
   onToggle,
   expandedProblems,
   onToggleProblem,
+  onToggleResolved,
 }: SubcategoryRowProps) {
   const subcategoryKey = `${categoryName}:${subcategoryGroup.subcategory}`
 
@@ -68,6 +72,7 @@ export function SubcategoryRow({
         <div className="divide-y divide-gray-50">
           {subcategoryGroup.problems.map((problemGroup) => {
             const problemKey = `${categoryName}:${subcategoryGroup.subcategory}:${problemGroup.problem}`
+            const resolutionKey = buildResolutionKey(categoryName, subcategoryGroup.subcategory, problemGroup.problem)
             return (
               <ProblemRow
                 key={problemKey}
@@ -75,6 +80,7 @@ export function SubcategoryRow({
                 problemKey={problemKey}
                 isExpanded={expandedProblems.has(problemKey)}
                 onToggle={() => onToggleProblem(problemKey)}
+                onToggleResolved={() => onToggleResolved(resolutionKey, !problemGroup.resolved)}
               />
             )
           })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
@@ -1,24 +1,7 @@
 import { ChevronDown, ChevronRight, Layers } from 'lucide-react'
 import { ProblemRow } from './ProblemRow'
 import { buildResolutionKey } from './problemResolution'
-import type { FeedbackItem } from '../../api/client'
-
-interface ProblemGroup {
-  problem: string
-  similarProblems: string[]
-  rootCause: string | null
-  items: FeedbackItem[]
-  avgSentiment: number
-  urgentCount: number
-  resolved?: boolean
-}
-
-interface SubcategoryGroup {
-  subcategory: string
-  problems: ProblemGroup[]
-  totalItems: number
-  urgentCount: number
-}
+import type { SubcategoryGroup } from './problemResolution'
 
 interface SubcategoryRowProps {
   readonly categoryName: string
@@ -28,6 +11,7 @@ interface SubcategoryRowProps {
   readonly expandedProblems: Set<string>
   readonly onToggleProblem: (key: string) => void
   readonly onToggleResolved: (key: string, resolved: boolean) => void
+  readonly resolvePending: boolean
 }
 
 export function SubcategoryRow({
@@ -38,6 +22,7 @@ export function SubcategoryRow({
   expandedProblems,
   onToggleProblem,
   onToggleResolved,
+  resolvePending,
 }: SubcategoryRowProps) {
   const subcategoryKey = `${categoryName}:${subcategoryGroup.subcategory}`
 
@@ -81,6 +66,7 @@ export function SubcategoryRow({
                 isExpanded={expandedProblems.has(problemKey)}
                 onToggle={() => onToggleProblem(problemKey)}
                 onToggleResolved={() => onToggleResolved(resolutionKey, !problemGroup.resolved)}
+                resolvePending={resolvePending}
               />
             )
           })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
@@ -11,7 +11,7 @@ interface SubcategoryRowProps {
   readonly expandedProblems: Set<string>
   readonly onToggleProblem: (key: string) => void
   readonly onToggleResolved: (key: string, resolved: boolean) => void
-  readonly resolvePending: boolean
+  readonly resolvePending?: boolean
 }
 
 export function SubcategoryRow({

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview Tests for problem-resolution key building and tree filtering.
+ */
+import { describe, it, expect } from 'vitest'
+import { applyResolution, buildResolutionKey } from './problemResolution'
+
+describe('buildResolutionKey', () => {
+  it('joins category, subcategory, and normalized problem text', () => {
+    expect(buildResolutionKey('delivery', 'shipping_speed', 'Slow delivery times'))
+      .toBe('delivery|shipping_speed|slow delivery times')
+  })
+
+  it('normalizes whitespace and case so cosmetic changes keep the key stable', () => {
+    expect(buildResolutionKey('delivery', 'general', '  Slow   DELIVERY  times '))
+      .toBe('delivery|general|slow delivery times')
+  })
+})
+
+const makeProblem = (problem: string, items: number, urgent: number) => ({
+  problem,
+  items: Array.from({ length: items }, (_, i) => ({ id: i })),
+  urgentCount: urgent,
+})
+
+const tree = () => ([
+  {
+    category: 'delivery',
+    totalItems: 5,
+    urgentCount: 3,
+    subcategories: [
+      {
+        subcategory: 'speed',
+        totalItems: 5,
+        urgentCount: 3,
+        problems: [
+          makeProblem('slow delivery', 3, 2),
+          makeProblem('lost packages', 2, 1),
+        ],
+      },
+    ],
+  },
+])
+
+describe('applyResolution', () => {
+  const resolvedMap = {
+    'delivery|speed|slow delivery': { resolved_at: '2026-07-01T00:00:00Z' },
+  }
+
+  it('hides resolved problems and recomputes totals by default', () => {
+    const { visible, resolvedCount } = applyResolution(tree(), resolvedMap, false)
+
+    expect(resolvedCount).toBe(1)
+    expect(visible[0].subcategories[0].problems.map((p) => p.problem)).toEqual(['lost packages'])
+    expect(visible[0].subcategories[0].totalItems).toBe(2)
+    expect(visible[0].subcategories[0].urgentCount).toBe(1)
+    expect(visible[0].totalItems).toBe(2)
+    expect(visible[0].urgentCount).toBe(1)
+  })
+
+  it('drops categories whose problems are all resolved', () => {
+    const allResolved = {
+      'delivery|speed|slow delivery': { resolved_at: '2026-07-01T00:00:00Z' },
+      'delivery|speed|lost packages': { resolved_at: '2026-07-01T00:00:00Z' },
+    }
+    const { visible, resolvedCount } = applyResolution(tree(), allResolved, false)
+
+    expect(visible).toEqual([])
+    expect(resolvedCount).toBe(2)
+  })
+
+  it('keeps resolved problems annotated when showResolved is on', () => {
+    const { visible, resolvedCount } = applyResolution(tree(), resolvedMap, true)
+
+    const problems = visible[0].subcategories[0].problems
+    expect(resolvedCount).toBe(1)
+    expect(problems).toHaveLength(2)
+    expect(problems.find((p) => p.problem === 'slow delivery')?.resolved).toBe(true)
+    expect(problems.find((p) => p.problem === 'lost packages')?.resolved).toBe(false)
+  })
+
+  it('is a no-op with an empty resolved map', () => {
+    const { visible, resolvedCount } = applyResolution(tree(), {}, false)
+
+    expect(resolvedCount).toBe(0)
+    expect(visible[0].subcategories[0].problems).toHaveLength(2)
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
@@ -14,6 +14,13 @@ describe('buildResolutionKey', () => {
     expect(buildResolutionKey(' Delivery ', 'Shipping  Speed', '  Slow   DELIVERY  times '))
       .toBe('delivery|shipping speed|slow delivery times')
   })
+
+  it('strips literal pipes so user-configured category names cannot merge keys', () => {
+    expect(buildResolutionKey('a|b', 'sub', 'problem'))
+      .toBe('a b|sub|problem')
+    expect(buildResolutionKey('a|b', 'sub', 'problem'))
+      .not.toBe(buildResolutionKey('a', 'b|sub', 'problem'))
+  })
 })
 
 const makeProblem = (problem: string, items: number, urgent: number) => ({

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
@@ -21,6 +21,23 @@ describe('buildResolutionKey', () => {
     expect(buildResolutionKey('a|b', 'sub', 'problem'))
       .not.toBe(buildResolutionKey('a', 'b|sub', 'problem'))
   })
+
+  it('truncates deterministically to the server caps (255 chars / 255 UTF-8 bytes)', () => {
+    const longProblem = 'very long problem summary '.repeat(30)
+    const key = buildResolutionKey('delivery', 'speed', longProblem)
+    expect(key.length).toBeLessThanOrEqual(255)
+    expect(new TextEncoder().encode(key).length).toBeLessThanOrEqual(255)
+    // Deterministic: same inputs, same truncated key.
+    expect(buildResolutionKey('delivery', 'speed', longProblem)).toBe(key)
+  })
+
+  it('fits CJK keys to the byte cap without splitting characters', () => {
+    const cjkProblem = '느린 배송 문제 '.repeat(40)
+    const key = buildResolutionKey('배송', '일반', cjkProblem)
+    expect(new TextEncoder().encode(key).length).toBeLessThanOrEqual(255)
+    // Whole characters only — no replacement glyphs from split code points.
+    expect(key.includes('\uFFFD')).toBe(false)
+  })
 })
 
 const makeProblem = (problem: string, items: number, urgent: number) => ({

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
@@ -10,9 +10,9 @@ describe('buildResolutionKey', () => {
       .toBe('delivery|shipping_speed|slow delivery times')
   })
 
-  it('normalizes whitespace and case so cosmetic changes keep the key stable', () => {
-    expect(buildResolutionKey('delivery', 'general', '  Slow   DELIVERY  times '))
-      .toBe('delivery|general|slow delivery times')
+  it('normalizes whitespace and case in all three components', () => {
+    expect(buildResolutionKey(' Delivery ', 'Shipping  Speed', '  Slow   DELIVERY  times '))
+      .toBe('delivery|shipping speed|slow delivery times')
   })
 })
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.test.ts
@@ -38,6 +38,19 @@ describe('buildResolutionKey', () => {
     // Whole characters only — no replacement glyphs from split code points.
     expect(key.includes('\uFFFD')).toBe(false)
   })
+
+  it('never splits surrogate pairs when truncating emoji-heavy text', () => {
+    // 4-byte emoji are two UTF-16 code units: a code-unit slice could cut a
+    // pair in half, leaving a lone surrogate the server rejects as invalid
+    // UTF-8. Every truncation length must stay well-formed.
+    const emojiProblem = '📦🚚💥 delayed '.repeat(30)
+    const key = buildResolutionKey('delivery', 'speed', emojiProblem)
+    expect(new TextEncoder().encode(key).length).toBeLessThanOrEqual(255)
+    // isWellFormed is the real check: a key may legitimately END with a
+    // complete emoji (whose last code unit is a low surrogate) — only
+    // UNPAIRED surrogates make the string malformed.
+    expect(key.isWellFormed()).toBe(true)
+  })
 })
 
 const makeProblem = (problem: string, items: number, urgent: number) => ({

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -14,14 +14,15 @@ export type ResolvedProblemsMap = Record<string, { resolved_at: string }>
 /**
  * Build the stable key a problem group is resolved under.
  *
- * Normalizes the problem text (trim + lowercase + collapsed whitespace) so
- * cosmetic changes in the LLM's problem summary don't orphan a resolution.
- * Uses `|` as separator — it cannot appear in category/subcategory values
- * (they are LLM-classified snake_case tokens).
+ * All three components are normalized (trim + lowercase + collapsed
+ * whitespace): they are LLM-classified values, so casing/whitespace drift
+ * ("Delivery" vs "delivery") must not orphan a resolution. Uses `|` as
+ * separator — it cannot appear in category/subcategory values (they are
+ * snake_case tokens).
  */
 export function buildResolutionKey(category: string, subcategory: string, problem: string): string {
-  const normalized = problem.trim().toLowerCase().replaceAll(/\s+/g, ' ')
-  return `${category}|${subcategory}|${normalized}`
+  const normalize = (value: string) => value.trim().toLowerCase().replaceAll(/\s+/g, ' ')
+  return `${normalize(category)}|${normalize(subcategory)}|${normalize(problem)}`
 }
 
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Resolution-key building for Problem Analysis (issue #66).
+ *
+ * Problems have no server-side identity — they are grouped client-side from
+ * feedback items by category → subcategory → similar problem text. Resolved
+ * status is persisted under a normalized composite key so it survives
+ * reloads and is shared across users.
+ * @module pages/ProblemAnalysis/problemResolution
+ */
+
+/** Map of resolution keys to their resolution metadata, as stored server-side. */
+export type ResolvedProblemsMap = Record<string, { resolved_at: string }>
+
+/**
+ * Build the stable key a problem group is resolved under.
+ *
+ * Normalizes the problem text (trim + lowercase + collapsed whitespace) so
+ * cosmetic changes in the LLM's problem summary don't orphan a resolution.
+ * Uses `|` as separator — it cannot appear in category/subcategory values
+ * (they are LLM-classified snake_case tokens).
+ */
+export function buildResolutionKey(category: string, subcategory: string, problem: string): string {
+  const normalized = problem.trim().toLowerCase().replaceAll(/\s+/g, ' ')
+  return `${category}|${subcategory}|${normalized}`
+}
+
+
+interface ResolvableProblem {
+  problem: string
+  items: unknown[]
+  urgentCount: number
+  resolved?: boolean
+}
+
+interface ResolvableSubcategory<P extends ResolvableProblem> {
+  subcategory: string
+  problems: P[]
+  totalItems: number
+  urgentCount: number
+}
+
+interface ResolvableCategory<P extends ResolvableProblem, S extends ResolvableSubcategory<P>> {
+  category: string
+  subcategories: S[]
+  totalItems: number
+  urgentCount: number
+}
+
+function annotateProblems<P extends ResolvableProblem>(
+  category: string,
+  subcategory: string,
+  problems: P[],
+  resolvedMap: ResolvedProblemsMap,
+): P[] {
+  return problems.map((problemGroup) => ({
+    ...problemGroup,
+    resolved: buildResolutionKey(category, subcategory, problemGroup.problem) in resolvedMap,
+  }))
+}
+
+function withoutResolved<P extends ResolvableProblem, S extends ResolvableSubcategory<P>>(
+  subcategoryGroup: S,
+): S {
+  const problems = subcategoryGroup.problems.filter((problemGroup) => !problemGroup.resolved)
+  return {
+    ...subcategoryGroup,
+    problems,
+    totalItems: problems.reduce((sum, p) => sum + p.items.length, 0),
+    urgentCount: problems.reduce((sum, p) => sum + p.urgentCount, 0),
+  }
+}
+
+/**
+ * Annotate every problem group with its shared resolved status and, unless
+ * `showResolved`, drop resolved groups — recomputing subcategory/category
+ * totals so headers reflect what is actually rendered.
+ */
+export function applyResolution<
+  P extends ResolvableProblem,
+  S extends ResolvableSubcategory<P>,
+  C extends ResolvableCategory<P, S>,
+>(
+  categories: C[],
+  resolvedMap: ResolvedProblemsMap,
+  showResolved: boolean,
+): { visible: C[]; resolvedCount: number } {
+  const annotated = categories.map((categoryGroup) => ({
+    ...categoryGroup,
+    subcategories: categoryGroup.subcategories.map((subcategoryGroup) => ({
+      ...subcategoryGroup,
+      problems: annotateProblems(
+        categoryGroup.category, subcategoryGroup.subcategory,
+        subcategoryGroup.problems, resolvedMap,
+      ),
+    })),
+  }))
+
+  const resolvedCount = annotated.reduce(
+    (total, categoryGroup) => total + categoryGroup.subcategories.reduce(
+      (subtotal, subcategoryGroup) =>
+        subtotal + subcategoryGroup.problems.filter((p) => p.resolved).length,
+      0,
+    ),
+    0,
+  )
+
+  if (showResolved) {
+    return { visible: annotated, resolvedCount }
+  }
+
+  const visible = annotated
+    .map((categoryGroup) => {
+      const subcategories = categoryGroup.subcategories
+        .map((subcategoryGroup) => withoutResolved(subcategoryGroup))
+        .filter((subcategoryGroup) => subcategoryGroup.problems.length > 0)
+      return {
+        ...categoryGroup,
+        subcategories,
+        totalItems: subcategories.reduce((sum, s) => sum + s.totalItems, 0),
+        urgentCount: subcategories.reduce((sum, s) => sum + s.urgentCount, 0),
+      }
+    })
+    .filter((categoryGroup) => categoryGroup.subcategories.length > 0)
+  return { visible, resolvedCount }
+}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -41,6 +41,26 @@ export interface CategoryGroup {
   urgentCount: number
 }
 
+// Server-side caps on stored keys (settings_handler.py): stay in lockstep.
+const MAX_KEY_CHARS = 255
+const MAX_KEY_BYTES = 255
+
+/** Trim from the end until the UTF-8 byte cap fits (CJK text triples the
+ * byte cost). Recursion keeps it mutation-free; depth is bounded by the
+ * char cap applied first. */
+function fitToByteCap(value: string): string {
+  if (value.length === 0 || new TextEncoder().encode(value).length <= MAX_KEY_BYTES) {
+    return value
+  }
+  return fitToByteCap(value.slice(0, -1))
+}
+
+/** Deterministic truncation to the server caps, so every client derives the
+ * same key for the same problem group. */
+function fitToKeyCaps(key: string): string {
+  return fitToByteCap(key.slice(0, MAX_KEY_CHARS))
+}
+
 /**
  * Build the stable key a problem group is resolved under.
  *
@@ -49,12 +69,13 @@ export interface CategoryGroup {
  * ("Delivery" vs "delivery") must not orphan a resolution. `|` is the
  * component separator, and since categories are user-configurable it is
  * normalized out of the values themselves so a literal pipe in a category
- * name can't merge two different problems under one key.
+ * name can't merge two different problems under one key. The result is
+ * deterministically truncated to the server's 255-char/255-byte caps.
  */
 export function buildResolutionKey(category: string, subcategory: string, problem: string): string {
   const normalize = (value: string) =>
     value.replaceAll('|', ' ').trim().toLowerCase().replaceAll(/\s+/g, ' ')
-  return `${normalize(category)}|${normalize(subcategory)}|${normalize(problem)}`
+  return fitToKeyCaps(`${normalize(category)}|${normalize(subcategory)}|${normalize(problem)}`)
 }
 
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -7,61 +7,70 @@
  * reloads and is shared across users.
  * @module pages/ProblemAnalysis/problemResolution
  */
+import type { FeedbackItem } from '../../api/client'
 
 /** Map of resolution keys to their resolution metadata, as stored server-side. */
 export type ResolvedProblemsMap = Record<string, { resolved_at: string }>
+
+/**
+ * Shared shape of the client-side problem tree (issue #66 review feedback:
+ * previously duplicated across ProblemAnalysis/ProblemRow/SubcategoryRow —
+ * a field added to one copy would silently type-check).
+ */
+export interface ProblemGroup {
+  problem: string
+  similarProblems: string[]
+  rootCause: string | null
+  items: FeedbackItem[]
+  avgSentiment: number
+  urgentCount: number
+  resolved?: boolean
+}
+
+export interface SubcategoryGroup {
+  subcategory: string
+  problems: ProblemGroup[]
+  totalItems: number
+  urgentCount: number
+}
+
+export interface CategoryGroup {
+  category: string
+  subcategories: SubcategoryGroup[]
+  totalItems: number
+  urgentCount: number
+}
 
 /**
  * Build the stable key a problem group is resolved under.
  *
  * All three components are normalized (trim + lowercase + collapsed
  * whitespace): they are LLM-classified values, so casing/whitespace drift
- * ("Delivery" vs "delivery") must not orphan a resolution. Uses `|` as
- * separator — it cannot appear in category/subcategory values (they are
- * snake_case tokens).
+ * ("Delivery" vs "delivery") must not orphan a resolution. `|` is the
+ * component separator, and since categories are user-configurable it is
+ * normalized out of the values themselves so a literal pipe in a category
+ * name can't merge two different problems under one key.
  */
 export function buildResolutionKey(category: string, subcategory: string, problem: string): string {
-  const normalize = (value: string) => value.trim().toLowerCase().replaceAll(/\s+/g, ' ')
+  const normalize = (value: string) =>
+    value.replaceAll('|', ' ').trim().toLowerCase().replaceAll(/\s+/g, ' ')
   return `${normalize(category)}|${normalize(subcategory)}|${normalize(problem)}`
 }
 
 
-interface ResolvableProblem {
-  problem: string
-  items: unknown[]
-  urgentCount: number
-  resolved?: boolean
-}
-
-interface ResolvableSubcategory<P extends ResolvableProblem> {
-  subcategory: string
-  problems: P[]
-  totalItems: number
-  urgentCount: number
-}
-
-interface ResolvableCategory<P extends ResolvableProblem, S extends ResolvableSubcategory<P>> {
-  category: string
-  subcategories: S[]
-  totalItems: number
-  urgentCount: number
-}
-
-function annotateProblems<P extends ResolvableProblem>(
+function annotateProblems(
   category: string,
   subcategory: string,
-  problems: P[],
+  problems: ProblemGroup[],
   resolvedMap: ResolvedProblemsMap,
-): P[] {
+): ProblemGroup[] {
   return problems.map((problemGroup) => ({
     ...problemGroup,
     resolved: buildResolutionKey(category, subcategory, problemGroup.problem) in resolvedMap,
   }))
 }
 
-function withoutResolved<P extends ResolvableProblem, S extends ResolvableSubcategory<P>>(
-  subcategoryGroup: S,
-): S {
+function withoutResolved(subcategoryGroup: SubcategoryGroup): SubcategoryGroup {
   const problems = subcategoryGroup.problems.filter((problemGroup) => !problemGroup.resolved)
   return {
     ...subcategoryGroup,
@@ -76,15 +85,11 @@ function withoutResolved<P extends ResolvableProblem, S extends ResolvableSubcat
  * `showResolved`, drop resolved groups — recomputing subcategory/category
  * totals so headers reflect what is actually rendered.
  */
-export function applyResolution<
-  P extends ResolvableProblem,
-  S extends ResolvableSubcategory<P>,
-  C extends ResolvableCategory<P, S>,
->(
-  categories: C[],
+export function applyResolution(
+  categories: CategoryGroup[],
   resolvedMap: ResolvedProblemsMap,
   showResolved: boolean,
-): { visible: C[]; resolvedCount: number } {
+): { visible: CategoryGroup[]; resolvedCount: number } {
   const annotated = categories.map((categoryGroup) => ({
     ...categoryGroup,
     subcategories: categoryGroup.subcategories.map((subcategoryGroup) => ({

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -7,10 +7,29 @@
  * reloads and is shared across users.
  * @module pages/ProblemAnalysis/problemResolution
  */
+import { z } from 'zod'
 import type { FeedbackItem } from '../../api/client'
 
 /** Map of resolution keys to their resolution metadata, as stored server-side. */
 export type ResolvedProblemsMap = Record<string, { resolved_at: string }>
+
+const resolvedProblemsResponseSchema = z.object({
+  resolved: z.record(z.string(), z.object({ resolved_at: z.string() })),
+})
+
+/**
+ * Validate the GET /settings/resolved-problems response at the boundary.
+ * A malformed payload degrades to an empty map (problems simply show as
+ * unresolved) instead of crashing the tree pipeline.
+ */
+export function parseResolvedProblemsResponse(payload: unknown): { resolved: ResolvedProblemsMap } {
+  const parsed = resolvedProblemsResponseSchema.safeParse(payload)
+  if (!parsed.success) {
+    console.error('Invalid resolved-problems response:', parsed.error.message)
+    return { resolved: {} }
+  }
+  return parsed.data
+}
 
 /**
  * Shared shape of the client-side problem tree (issue #66 review feedback:

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -46,19 +46,22 @@ const MAX_KEY_CHARS = 255
 const MAX_KEY_BYTES = 255
 
 /** Trim from the end until the UTF-8 byte cap fits (CJK text triples the
- * byte cost). Recursion keeps it mutation-free; depth is bounded by the
- * char cap applied first. */
-function fitToByteCap(value: string): string {
-  if (value.length === 0 || new TextEncoder().encode(value).length <= MAX_KEY_BYTES) {
+ * byte cost). Trims whole CODE POINTS, never UTF-16 code units — slicing a
+ * surrogate pair in half would leave a lone surrogate that the server's
+ * UTF-8 encoding rejects. Recursion keeps it mutation-free; depth is
+ * bounded by the char cap applied first. */
+function fitToByteCap(codePoints: string[]): string {
+  const value = codePoints.join('')
+  if (codePoints.length === 0 || new TextEncoder().encode(value).length <= MAX_KEY_BYTES) {
     return value
   }
-  return fitToByteCap(value.slice(0, -1))
+  return fitToByteCap(codePoints.slice(0, -1))
 }
 
 /** Deterministic truncation to the server caps, so every client derives the
- * same key for the same problem group. */
+ * same key for the same problem group. Both caps count code points. */
 function fitToKeyCaps(key: string): string {
-  return fitToByteCap(key.slice(0, MAX_KEY_CHARS))
+  return fitToByteCap(Array.from(key).slice(0, MAX_KEY_CHARS))
 }
 
 /**

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -64,23 +64,28 @@ export interface CategoryGroup {
 const MAX_KEY_CHARS = 255
 const MAX_KEY_BYTES = 255
 
-/** Trim from the end until the UTF-8 byte cap fits (CJK text triples the
- * byte cost). Trims whole CODE POINTS, never UTF-16 code units — slicing a
- * surrogate pair in half would leave a lone surrogate that the server's
- * UTF-8 encoding rejects. Recursion keeps it mutation-free; depth is
- * bounded by the char cap applied first. */
-function fitToByteCap(codePoints: string[]): string {
-  const value = codePoints.join('')
-  if (codePoints.length === 0 || new TextEncoder().encode(value).length <= MAX_KEY_BYTES) {
-    return value
-  }
-  return fitToByteCap(codePoints.slice(0, -1))
-}
-
 /** Deterministic truncation to the server caps, so every client derives the
- * same key for the same problem group. Both caps count code points. */
+ * same key for the same problem group. Operates on whole CODE POINTS, never
+ * UTF-16 code units — slicing a surrogate pair in half would leave a lone
+ * surrogate that the server's UTF-8 encoding rejects. Single-pass: each
+ * code point is encoded once and the prefix that fits the byte cap wins. */
 function fitToKeyCaps(key: string): string {
-  return fitToByteCap(Array.from(key).slice(0, MAX_KEY_CHARS))
+  const encoder = new TextEncoder()
+  const codePoints = Array.from(key).slice(0, MAX_KEY_CHARS)
+  const fit = codePoints.reduce(
+    (acc, codePoint) => {
+      // Stop at the FIRST overflow: continuing would let later smaller code
+      // points "fit" the running budget while the prefix slice still
+      // includes the skipped one, breaking the byte cap.
+      if (acc.stopped) return acc
+      const nextBytes = acc.bytes + encoder.encode(codePoint).length
+      return nextBytes <= MAX_KEY_BYTES
+        ? { bytes: nextBytes, count: acc.count + 1, stopped: false }
+        : { ...acc, stopped: true }
+    },
+    { bytes: 0, count: 0, stopped: false },
+  )
+  return codePoints.slice(0, fit.count).join('')
 }
 
 /**

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Hook owning the shared problem-resolution state (issue #66).
+ *
+ * Wraps the resolved-problems query (deliberate freshness policy for shared
+ * state) and the resolve/unresolve mutation, keeping the query/mutation
+ * wiring out of the page component's complexity budget — same convention as
+ * Settings' useSettingsSync.
+ * @module pages/ProblemAnalysis/useProblemResolution
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from '../../api/client'
+import { parseResolvedProblemsResponse } from './problemResolution'
+import type { ResolvedProblemsMap } from './problemResolution'
+
+interface ProblemResolutionState {
+  resolvedMap: ResolvedProblemsMap
+  /** True while the initial resolved-state fetch is in flight — gate the
+   * tree on it so resolved problems don't flash as unresolved. */
+  resolvedLoading: boolean
+  togglePending: boolean
+  toggleFailed: boolean
+  toggleResolved: (key: string, resolved: boolean) => void
+  dismissToggleError: () => void
+}
+
+export function useProblemResolution(enabled: boolean): ProblemResolutionState {
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['resolved-problems'],
+    queryFn: async () => parseResolvedProblemsResponse(await api.getResolvedProblems()),
+    enabled,
+    // Resolution state is shared across users, so keep it deliberately
+    // fresh: refetch when the tab regains focus and treat it as stale
+    // after 15s so another user's resolves appear without a remount.
+    staleTime: 15_000,
+    refetchOnWindowFocus: true,
+  })
+
+  const mutation = useMutation({
+    mutationFn: ({ key, resolved }: { key: string; resolved: boolean }) =>
+      api.setProblemResolved(key, resolved),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['resolved-problems'] })
+    },
+  })
+
+  const toggleResolved = (key: string, resolved: boolean) => {
+    // Double defense with the disabled buttons: covers the render gap before
+    // the disabled state paints, so a rapid double-click can't race
+    // SET/REMOVE for the same key server-side.
+    if (mutation.isPending) return
+    mutation.mutate({ key, resolved })
+  }
+
+  return {
+    resolvedMap: data?.resolved ?? {},
+    resolvedLoading: isLoading,
+    togglePending: mutation.isPending,
+    toggleFailed: mutation.isError,
+    toggleResolved,
+    dismissToggleError: () => mutation.reset(),
+  }
+}

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -33,10 +33,13 @@ RESOLVED_PROBLEMS_SK = "config"
 
 # Problem keys are client-built as "category|subcategory|normalized problem
 # text". Bound their size in characters AND UTF-8 bytes (CJK text triples
-# the byte cost) plus the entry count, so the single config item stays far
-# from DynamoDB's 400KB cap: worst case 500 entries x ~540 bytes ≈ 270KB.
-MAX_PROBLEM_KEY_LEN = 500
-MAX_PROBLEM_KEY_BYTES = 500
+# the byte cost) plus the entry count. 255 bytes keeps every key safely
+# inside DynamoDB's strictest name-length constraints (the documented
+# 255-byte expression limit measures the alias token, but capping the real
+# name too costs nothing and removes the ambiguity) and shrinks the item
+# math: worst case 500 entries x ~295 bytes ≈ 148KB, far under the 400KB cap.
+MAX_PROBLEM_KEY_LEN = 255
+MAX_PROBLEM_KEY_BYTES = 255
 MAX_RESOLVED_ENTRIES = 500
 
 app = create_api_resolver()
@@ -59,8 +62,8 @@ def get_resolved_problems():
         )
         return {'resolved': response.get('Item', {}).get('resolved', {})}
     except Exception as e:
-        logger.exception(f"Failed to get resolved problems: {e}")
-        raise ServiceError('Failed to retrieve resolved problems')
+        logger.exception("Failed to get resolved problems")
+        raise ServiceError('Failed to retrieve resolved problems') from e
 
 
 @app.put("/settings/resolved-problems")
@@ -97,8 +100,8 @@ def set_problem_resolution():
     except ValidationError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to update problem resolution: {e}")
-        raise ServiceError('Failed to update problem resolution')
+        logger.exception("Failed to update problem resolution")
+        raise ServiceError('Failed to update problem resolution') from e
 
 
 def _set_resolved_entry(key: str) -> None:
@@ -150,7 +153,7 @@ def _resolve_problem_key(key: str) -> None:
             raise ValidationError(
                 f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
                 'Unresolve entries you no longer need first.'
-            )
+            ) from e
         raise
 
 

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -10,6 +10,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from botocore.exceptions import ClientError
+
 # Add shared module to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -64,9 +66,10 @@ def get_resolved_problems():
 def set_problem_resolution():
     """Mark a single problem group resolved or unresolved.
 
-    Body: {'key': str, 'resolved': bool}. Each key is updated atomically
-    (nested-attribute SET/REMOVE), so two users resolving different problems
-    concurrently can't clobber each other's writes.
+    Body: {'key': str, 'resolved': bool}. The entry cap is enforced
+    atomically via a ConditionExpression on the same write (no
+    read-then-write race), and the steady state is exactly one write per
+    request: the parent map is only materialized on the first-ever resolve.
     """
     if not aggregates_table:
         raise ConfigurationError('Aggregates table not configured')
@@ -82,46 +85,82 @@ def set_problem_resolution():
         raise ValidationError('resolved must be a boolean')
 
     try:
-        # Ensure the parent map exists so the nested-path update can't fail
-        # with an invalid-document-path error on first use.
-        aggregates_table.update_item(
-            Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
-            UpdateExpression='SET #r = if_not_exists(#r, :empty)',
-            ExpressionAttributeNames={'#r': 'resolved'},
-            ExpressionAttributeValues={':empty': {}},
-        )
         if resolved:
-            # Bound the map so orphaned keys can't grow the single config
-            # item toward DynamoDB's 400KB cap. Overwriting an existing key
-            # is always allowed; only NEW entries count against the cap.
-            current = aggregates_table.get_item(
-                Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK}
-            ).get('Item', {}).get('resolved', {})
-            if key not in current and len(current) >= MAX_RESOLVED_ENTRIES:
-                raise ValidationError(
-                    f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
-                    'Unresolve entries you no longer need first.'
-                )
-            aggregates_table.update_item(
-                Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
-                UpdateExpression='SET #r.#k = :entry',
-                ExpressionAttributeNames={'#r': 'resolved', '#k': key},
-                ExpressionAttributeValues={
-                    ':entry': {'resolved_at': datetime.now(timezone.utc).isoformat()},
-                },
-            )
+            _resolve_problem_key(key)
         else:
-            aggregates_table.update_item(
-                Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
-                UpdateExpression='REMOVE #r.#k',
-                ExpressionAttributeNames={'#r': 'resolved', '#k': key},
-            )
+            _unresolve_problem_key(key)
         return {'success': True, 'key': key, 'resolved': resolved}
     except ValidationError:
         raise
     except Exception as e:
         logger.exception(f"Failed to update problem resolution: {e}")
         raise ServiceError('Failed to update problem resolution')
+
+
+def _set_resolved_entry(key: str) -> None:
+    """Single conditional write: overwrite is always allowed; NEW entries
+    only while the map is under the cap. Atomic — two concurrent resolves
+    at the cap can't both slip through (review feedback on #153)."""
+    aggregates_table.update_item(
+        Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+        UpdateExpression='SET #r.#k = :entry',
+        ConditionExpression='attribute_exists(#r.#k) OR size(#r) < :max',
+        ExpressionAttributeNames={'#r': 'resolved', '#k': key},
+        ExpressionAttributeValues={
+            ':entry': {'resolved_at': datetime.now(timezone.utc).isoformat()},
+            ':max': MAX_RESOLVED_ENTRIES,
+        },
+    )
+
+
+def _ensure_resolved_map() -> None:
+    aggregates_table.update_item(
+        Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+        UpdateExpression='SET #r = if_not_exists(#r, :empty)',
+        ExpressionAttributeNames={'#r': 'resolved'},
+        ExpressionAttributeValues={':empty': {}},
+    )
+
+
+def _resolve_problem_key(key: str) -> None:
+    """Conditionally set the entry, materializing the parent map on first use.
+
+    DynamoDB reports a missing parent map either as a document-path
+    ValidationException or as a failed condition (functions on missing
+    attributes evaluate false), depending on evaluation order — so both
+    first-attempt failures fall through to ensure-parent + one retry, and
+    only a retry failure means the cap was genuinely reached.
+    """
+    try:
+        _set_resolved_entry(key)
+        return
+    except ClientError as e:
+        code = e.response.get('Error', {}).get('Code', '')
+        if code not in ('ConditionalCheckFailedException', 'ValidationException'):
+            raise
+    _ensure_resolved_map()
+    try:
+        _set_resolved_entry(key)
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code', '') == 'ConditionalCheckFailedException':
+            raise ValidationError(
+                f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
+                'Unresolve entries you no longer need first.'
+            )
+        raise
+
+
+def _unresolve_problem_key(key: str) -> None:
+    """REMOVE the entry; a missing parent map just means nothing to remove."""
+    try:
+        aggregates_table.update_item(
+            Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+            UpdateExpression='REMOVE #r.#k',
+            ExpressionAttributeNames={'#r': 'resolved', '#k': key},
+        )
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code', '') != 'ValidationException':
+            raise
 
 
 @app.get("/settings/brand")

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -26,8 +26,92 @@ SETTINGS_PK = "SETTINGS#brand"
 SETTINGS_SK = "config"
 CATEGORIES_PK = "SETTINGS#categories"
 CATEGORIES_SK = "config"
+RESOLVED_PROBLEMS_PK = "SETTINGS#resolved_problems"
+RESOLVED_PROBLEMS_SK = "config"
+
+# Problem keys are client-built as "category|subcategory|normalized problem
+# text". Bound their size so the single config item stays far away from
+# DynamoDB's 400KB item cap even with thousands of resolved problems.
+MAX_PROBLEM_KEY_LEN = 500
 
 app = create_api_resolver()
+
+
+@app.get("/settings/resolved-problems")
+@tracer.capture_method
+def get_resolved_problems():
+    """Get the map of problems marked as resolved on the Problem Analysis page.
+
+    Shape: {'resolved': {problem_key: {'resolved_at': iso8601}}}. Shared
+    across all users by design (issue #66) — resolving a problem clears it
+    from everyone's working view.
+    """
+    if not aggregates_table:
+        raise ConfigurationError('Aggregates table not configured')
+    try:
+        response = aggregates_table.get_item(
+            Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK}
+        )
+        return {'resolved': response.get('Item', {}).get('resolved', {})}
+    except ConfigurationError:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to get resolved problems: {e}")
+        raise ServiceError('Failed to retrieve resolved problems')
+
+
+@app.put("/settings/resolved-problems")
+@tracer.capture_method
+def set_problem_resolution():
+    """Mark a single problem group resolved or unresolved.
+
+    Body: {'key': str, 'resolved': bool}. Each key is updated atomically
+    (nested-attribute SET/REMOVE), so two users resolving different problems
+    concurrently can't clobber each other's writes.
+    """
+    if not aggregates_table:
+        raise ConfigurationError('Aggregates table not configured')
+    body = app.current_event.json_body or {}
+
+    key = body.get('key')
+    if not isinstance(key, str) or not key.strip():
+        raise ValidationError('key must be a non-empty string')
+    if len(key) > MAX_PROBLEM_KEY_LEN:
+        raise ValidationError(f'key must be at most {MAX_PROBLEM_KEY_LEN} characters')
+    resolved = body.get('resolved')
+    if not isinstance(resolved, bool):
+        raise ValidationError('resolved must be a boolean')
+
+    try:
+        # Ensure the parent map exists so the nested-path update can't fail
+        # with an invalid-document-path error on first use.
+        aggregates_table.update_item(
+            Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+            UpdateExpression='SET #r = if_not_exists(#r, :empty)',
+            ExpressionAttributeNames={'#r': 'resolved'},
+            ExpressionAttributeValues={':empty': {}},
+        )
+        if resolved:
+            aggregates_table.update_item(
+                Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+                UpdateExpression='SET #r.#k = :entry',
+                ExpressionAttributeNames={'#r': 'resolved', '#k': key},
+                ExpressionAttributeValues={
+                    ':entry': {'resolved_at': datetime.now(timezone.utc).isoformat()},
+                },
+            )
+        else:
+            aggregates_table.update_item(
+                Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+                UpdateExpression='REMOVE #r.#k',
+                ExpressionAttributeNames={'#r': 'resolved', '#k': key},
+            )
+        return {'success': True, 'key': key, 'resolved': resolved}
+    except (ConfigurationError, ValidationError):
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to update problem resolution: {e}")
+        raise ServiceError('Failed to update problem resolution')
 
 
 @app.get("/settings/brand")

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -32,9 +32,11 @@ RESOLVED_PROBLEMS_PK = "SETTINGS#resolved_problems"
 RESOLVED_PROBLEMS_SK = "config"
 
 # Problem keys are client-built as "category|subcategory|normalized problem
-# text". Bound their size AND count so the single config item stays far away
-# from DynamoDB's 400KB item cap (worst case ~500 entries x ~540 bytes).
+# text". Bound their size in characters AND UTF-8 bytes (CJK text triples
+# the byte cost) plus the entry count, so the single config item stays far
+# from DynamoDB's 400KB cap: worst case 500 entries x ~540 bytes ≈ 270KB.
 MAX_PROBLEM_KEY_LEN = 500
+MAX_PROBLEM_KEY_BYTES = 500
 MAX_RESOLVED_ENTRIES = 500
 
 app = create_api_resolver()
@@ -80,6 +82,8 @@ def set_problem_resolution():
         raise ValidationError('key must be a non-empty string')
     if len(key) > MAX_PROBLEM_KEY_LEN:
         raise ValidationError(f'key must be at most {MAX_PROBLEM_KEY_LEN} characters')
+    if len(key.encode('utf-8')) > MAX_PROBLEM_KEY_BYTES:
+        raise ValidationError(f'key must be at most {MAX_PROBLEM_KEY_BYTES} bytes (UTF-8)')
     resolved = body.get('resolved')
     if not isinstance(resolved, bool):
         raise ValidationError('resolved must be a boolean')
@@ -151,7 +155,12 @@ def _resolve_problem_key(key: str) -> None:
 
 
 def _unresolve_problem_key(key: str) -> None:
-    """REMOVE the entry; a missing parent map just means nothing to remove."""
+    """REMOVE the entry; a missing parent map just means nothing to remove.
+
+    Only the document-path variant of ValidationException is treated as a
+    no-op — any other validation failure (malformed expression, oversized
+    name) is a real error and must not be reported as success.
+    """
     try:
         aggregates_table.update_item(
             Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
@@ -159,7 +168,12 @@ def _unresolve_problem_key(key: str) -> None:
             ExpressionAttributeNames={'#r': 'resolved', '#k': key},
         )
     except ClientError as e:
-        if e.response.get('Error', {}).get('Code', '') != 'ValidationException':
+        error = e.response.get('Error', {})
+        is_missing_path = (
+            error.get('Code', '') == 'ValidationException'
+            and 'document path' in error.get('Message', '').lower()
+        )
+        if not is_missing_path:
             raise
 
 

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -169,23 +169,20 @@ def _resolve_problem_key(key: str) -> None:
 def _unresolve_problem_key(key: str) -> None:
     """REMOVE the entry; a missing parent map just means nothing to remove.
 
-    Only the document-path variant of ValidationException is treated as a
-    no-op — any other validation failure (malformed expression, oversized
-    name) is a real error and must not be reported as success.
+    The no-op is detected by a ConditionExpression on the parent map —
+    ConditionalCheckFailedException is a stable error CODE, unlike the
+    document-path ValidationException message text, which is not
+    contractual across SDK/service versions.
     """
     try:
         aggregates_table.update_item(
             Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
             UpdateExpression='REMOVE #r.#k',
+            ConditionExpression='attribute_exists(#r)',
             ExpressionAttributeNames={'#r': 'resolved', '#k': key},
         )
     except ClientError as e:
-        error = e.response.get('Error', {})
-        is_missing_path = (
-            error.get('Code', '') == 'ValidationException'
-            and 'document path' in error.get('Message', '').lower()
-        )
-        if not is_missing_path:
+        if e.response.get('Error', {}).get('Code', '') != 'ConditionalCheckFailedException':
             raise
 
 

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -30,9 +30,10 @@ RESOLVED_PROBLEMS_PK = "SETTINGS#resolved_problems"
 RESOLVED_PROBLEMS_SK = "config"
 
 # Problem keys are client-built as "category|subcategory|normalized problem
-# text". Bound their size so the single config item stays far away from
-# DynamoDB's 400KB item cap even with thousands of resolved problems.
+# text". Bound their size AND count so the single config item stays far away
+# from DynamoDB's 400KB item cap (worst case ~500 entries x ~540 bytes).
 MAX_PROBLEM_KEY_LEN = 500
+MAX_RESOLVED_ENTRIES = 500
 
 app = create_api_resolver()
 
@@ -53,8 +54,6 @@ def get_resolved_problems():
             Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK}
         )
         return {'resolved': response.get('Item', {}).get('resolved', {})}
-    except ConfigurationError:
-        raise
     except Exception as e:
         logger.exception(f"Failed to get resolved problems: {e}")
         raise ServiceError('Failed to retrieve resolved problems')
@@ -92,6 +91,17 @@ def set_problem_resolution():
             ExpressionAttributeValues={':empty': {}},
         )
         if resolved:
+            # Bound the map so orphaned keys can't grow the single config
+            # item toward DynamoDB's 400KB cap. Overwriting an existing key
+            # is always allowed; only NEW entries count against the cap.
+            current = aggregates_table.get_item(
+                Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK}
+            ).get('Item', {}).get('resolved', {})
+            if key not in current and len(current) >= MAX_RESOLVED_ENTRIES:
+                raise ValidationError(
+                    f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
+                    'Unresolve entries you no longer need first.'
+                )
             aggregates_table.update_item(
                 Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
                 UpdateExpression='SET #r.#k = :entry',
@@ -107,7 +117,7 @@ def set_problem_resolution():
                 ExpressionAttributeNames={'#r': 'resolved', '#k': key},
             )
         return {'success': True, 'key': key, 'resolved': resolved}
-    except (ConfigurationError, ValidationError):
+    except ValidationError:
         raise
     except Exception as e:
         logger.exception(f"Failed to update problem resolution: {e}")

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -85,7 +85,16 @@ def set_problem_resolution():
         raise ValidationError('key must be a non-empty string')
     if len(key) > MAX_PROBLEM_KEY_LEN:
         raise ValidationError(f'key must be at most {MAX_PROBLEM_KEY_LEN} characters')
-    if len(key.encode('utf-8')) > MAX_PROBLEM_KEY_BYTES:
+    try:
+        # JSON happily carries unpaired surrogates ("\ud800"); encoding them
+        # raises, which would 500 here and in the DynamoDB client. Reject
+        # them as the client error they are.
+        key_bytes = len(key.encode('utf-8'))
+    except UnicodeEncodeError as encode_error:
+        raise ValidationError(
+            'key must be valid Unicode (no unpaired surrogates)'
+        ) from encode_error
+    if key_bytes > MAX_PROBLEM_KEY_BYTES:
         raise ValidationError(f'key must be at most {MAX_PROBLEM_KEY_BYTES} bytes (UTF-8)')
     resolved = body.get('resolved')
     if not isinstance(resolved, bool):

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -428,7 +428,7 @@ class TestResolvedProblems:
         {'resolved': True},                          # missing key
         {'key': '', 'resolved': True},               # empty key
         {'key': '  ', 'resolved': True},             # whitespace key
-        {'key': 'x' * 501, 'resolved': True},        # oversized key
+        {'key': 'x' * 256, 'resolved': True},        # over the char cap
         {'key': 'ok', 'resolved': 'yes'},            # non-boolean resolved
         {'key': 'ok'},                               # missing resolved
     ])
@@ -551,9 +551,9 @@ class TestResolvedProblemsRoundThree:
         still blow the byte budget that sizes the 400KB item math."""
         from settings_handler import lambda_handler
 
-        cjk_key = '배송|일반|' + ('느린 배송 문제 ' * 25)  # well under 500 chars, over 500 bytes
-        assert len(cjk_key) <= 500
-        assert len(cjk_key.encode('utf-8')) > 500
+        cjk_key = '배송|일반|' + ('느린 배송 문제 ' * 12)  # under 255 chars, over 255 bytes
+        assert len(cjk_key) <= 255
+        assert len(cjk_key.encode('utf-8')) > 255
 
         event = api_gateway_event(
             method='PUT', path='/settings/resolved-problems',

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -365,7 +365,7 @@ class TestResolvedProblems:
         assert body['resolved'] == {}
 
     @patch('settings_handler.aggregates_table')
-    def test_put_resolve_sets_nested_key_atomically(self, mock_table, api_gateway_event, lambda_context):
+    def test_put_resolve_is_a_single_conditional_write(self, mock_table, api_gateway_event, lambda_context):
         from settings_handler import lambda_handler
 
         event = api_gateway_event(
@@ -377,13 +377,38 @@ class TestResolvedProblems:
 
         assert response['statusCode'] == 200
         assert body == {'success': True, 'key': 'delivery|general|late orders', 'resolved': True}
-        # Two updates: ensure the parent map exists, then set the nested key.
-        assert mock_table.update_item.call_count == 2
-        ensure, set_call = mock_table.update_item.call_args_list
-        assert 'if_not_exists' in ensure.kwargs['UpdateExpression']
+        # Steady state: exactly ONE write, cap enforced on the same call.
+        assert mock_table.update_item.call_count == 1
+        set_call = mock_table.update_item.call_args
         assert set_call.kwargs['UpdateExpression'] == 'SET #r.#k = :entry'
+        assert set_call.kwargs['ConditionExpression'] == 'attribute_exists(#r.#k) OR size(#r) < :max'
         assert set_call.kwargs['ExpressionAttributeNames']['#k'] == 'delivery|general|late orders'
         assert 'resolved_at' in set_call.kwargs['ExpressionAttributeValues'][':entry']
+        # No read-modify-write: the cap does not cost a get_item.
+        mock_table.get_item.assert_not_called()
+
+    @patch('settings_handler.aggregates_table')
+    def test_first_ever_resolve_materializes_the_parent_map(self, mock_table, api_gateway_event, lambda_context):
+        from botocore.exceptions import ClientError
+        from settings_handler import lambda_handler
+
+        missing_parent = ClientError(
+            {'Error': {'Code': 'ValidationException', 'Message': 'document path invalid'}},
+            'UpdateItem',
+        )
+        # First SET fails (no parent map) -> ensure-parent -> retry succeeds.
+        mock_table.update_item.side_effect = [missing_parent, {}, {}]
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'delivery|general|late orders', 'resolved': True},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_table.update_item.call_count == 3
+        exprs = [c.kwargs['UpdateExpression'] for c in mock_table.update_item.call_args_list]
+        assert exprs == ['SET #r.#k = :entry', 'SET #r = if_not_exists(#r, :empty)', 'SET #r.#k = :entry']
 
     @patch('settings_handler.aggregates_table')
     def test_put_unresolve_removes_nested_key(self, mock_table, api_gateway_event, lambda_context):
@@ -422,36 +447,42 @@ class TestResolvedProblems:
 
 
 class TestResolvedProblemsCap:
-    """The single config item is bounded (review feedback on #153)."""
+    """The entry cap is atomic — enforced by ConditionExpression on the same
+    write, not a read-then-check (review feedback on #153)."""
+
+    @staticmethod
+    def _cap_failure():
+        from botocore.exceptions import ClientError
+        return ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'cap'}},
+            'UpdateItem',
+        )
 
     @patch('settings_handler.aggregates_table')
     def test_rejects_new_entries_beyond_the_cap(self, mock_table, api_gateway_event, lambda_context):
-        from settings_handler import MAX_RESOLVED_ENTRIES, lambda_handler
+        from settings_handler import lambda_handler
 
-        full_map = {f'cat|sub|problem {i}': {'resolved_at': 'x'} for i in range(MAX_RESOLVED_ENTRIES)}
-        mock_table.get_item.return_value = {'Item': {'resolved': full_map}}
+        # Both the first attempt and the post-ensure retry fail the condition:
+        # the map genuinely holds MAX_RESOLVED_ENTRIES other keys.
+        mock_table.update_item.side_effect = [self._cap_failure(), {}, self._cap_failure()]
 
         event = api_gateway_event(
             method='PUT', path='/settings/resolved-problems',
             body={'key': 'cat|sub|one too many', 'resolved': True},
         )
         response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
 
         assert response['statusCode'] == 400
-        # Only the ensure-parent update ran; the SET never happened.
-        update_expressions = [
-            c.kwargs['UpdateExpression'] for c in mock_table.update_item.call_args_list
-        ]
-        assert 'SET #r.#k = :entry' not in update_expressions
+        assert 'limit reached' in body['error']
 
     @patch('settings_handler.aggregates_table')
-    def test_overwriting_an_existing_key_is_allowed_at_the_cap(
+    def test_condition_allows_overwriting_existing_keys_at_the_cap(
         self, mock_table, api_gateway_event, lambda_context
     ):
-        from settings_handler import MAX_RESOLVED_ENTRIES, lambda_handler
-
-        full_map = {f'cat|sub|problem {i}': {'resolved_at': 'x'} for i in range(MAX_RESOLVED_ENTRIES)}
-        mock_table.get_item.return_value = {'Item': {'resolved': full_map}}
+        """attribute_exists(#r.#k) short-circuits the size check, so
+        re-resolving an already-resolved problem never trips the cap."""
+        from settings_handler import lambda_handler
 
         event = api_gateway_event(
             method='PUT', path='/settings/resolved-problems',
@@ -460,13 +491,20 @@ class TestResolvedProblemsCap:
         response = lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 200
+        condition = mock_table.update_item.call_args.kwargs['ConditionExpression']
+        assert condition.startswith('attribute_exists(#r.#k)')
 
     @patch('settings_handler.aggregates_table')
-    def test_unresolve_is_never_capped(self, mock_table, api_gateway_event, lambda_context):
-        from settings_handler import MAX_RESOLVED_ENTRIES, lambda_handler
+    def test_unresolve_is_never_capped_and_tolerates_missing_map(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        from botocore.exceptions import ClientError
+        from settings_handler import lambda_handler
 
-        full_map = {f'cat|sub|problem {i}': {'resolved_at': 'x'} for i in range(MAX_RESOLVED_ENTRIES)}
-        mock_table.get_item.return_value = {'Item': {'resolved': full_map}}
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ValidationException', 'Message': 'document path invalid'}},
+            'UpdateItem',
+        )
 
         event = api_gateway_event(
             method='PUT', path='/settings/resolved-problems',
@@ -474,4 +512,5 @@ class TestResolvedProblemsCap:
         )
         response = lambda_handler(event, lambda_context)
 
+        # Missing parent map == nothing to remove == success.
         assert response['statusCode'] == 200

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -498,11 +498,13 @@ class TestResolvedProblemsCap:
     def test_unresolve_is_never_capped_and_tolerates_missing_map(
         self, mock_table, api_gateway_event, lambda_context
     ):
+        """Missing parent map surfaces as a FAILED CONDITION (stable error
+        code), not as message-text sniffing on ValidationException."""
         from botocore.exceptions import ClientError
         from settings_handler import lambda_handler
 
         mock_table.update_item.side_effect = ClientError(
-            {'Error': {'Code': 'ValidationException', 'Message': 'document path invalid'}},
+            {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'no map'}},
             'UpdateItem',
         )
 
@@ -514,18 +516,19 @@ class TestResolvedProblemsCap:
 
         # Missing parent map == nothing to remove == success.
         assert response['statusCode'] == 200
+        assert mock_table.update_item.call_args.kwargs['ConditionExpression'] == 'attribute_exists(#r)' 
 
 
 
-class TestResolvedProblemsRoundThree:
-    """Third review round: narrowed exception swallow + UTF-8 byte cap."""
+class TestResolvedProblemsKeyEncoding:
+    """Key byte-cap validation and unresolve error semantics."""
 
     @patch('settings_handler.aggregates_table')
     def test_unresolve_does_not_swallow_real_validation_errors(
         self, mock_table, api_gateway_event, lambda_context
     ):
-        """Only the missing-document-path variant is a no-op; other
-        ValidationExceptions are genuine failures, not success."""
+        """ValidationExceptions are genuine failures, not success — only the
+        failed parent-map condition (stable code) is the no-op."""
         from botocore.exceptions import ClientError
         from settings_handler import lambda_handler
 

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -563,3 +563,33 @@ class TestResolvedProblemsRoundThree:
 
         assert response['statusCode'] == 400
         mock_table.update_item.assert_not_called()
+
+
+class TestResolvedProblemsSurrogates:
+    """Unpaired surrogates must 400, not 500 (review feedback on #153).
+
+    JSON carries lone surrogates ("\\ud800") happily; encoding them to UTF-8
+    raises, which without the guard would surface as a 500 from the handler
+    or the DynamoDB client.
+    """
+
+    @patch('settings_handler.aggregates_table')
+    def test_lone_surrogate_key_is_a_clean_400(self, mock_table, api_gateway_event, lambda_context):
+        import json as json_module
+        from settings_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'cat|sub|problem', 'resolved': True},
+        )
+        # Inject the lone surrogate at the raw-JSON layer, exactly as a
+        # hostile/buggy client would send it.
+        event['body'] = json_module.dumps(
+            {'key': 'cat|sub|broken \ud83d', 'resolved': True}, ensure_ascii=True
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json_module.loads(response['body'])
+
+        assert response['statusCode'] == 400
+        assert 'surrogate' in body['error']
+        mock_table.update_item.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -330,3 +330,91 @@ class TestGenerateCategories:
         # Assert - now returns 500 with error key
         assert response['statusCode'] == 500
         assert 'error' in body
+
+
+
+class TestResolvedProblems:
+    """Tests for GET/PUT /settings/resolved-problems (issue #66)."""
+
+    @patch('settings_handler.aggregates_table')
+    def test_get_returns_resolved_map(self, mock_table, api_gateway_event, lambda_context):
+        mock_table.get_item.return_value = {
+            'Item': {
+                'pk': 'SETTINGS#resolved_problems',
+                'sk': 'config',
+                'resolved': {'delivery|general|late orders': {'resolved_at': '2026-07-01T00:00:00+00:00'}},
+            }
+        }
+        from settings_handler import lambda_handler
+
+        event = api_gateway_event(method='GET', path='/settings/resolved-problems')
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert 'delivery|general|late orders' in body['resolved']
+
+    @patch('settings_handler.aggregates_table')
+    def test_get_returns_empty_map_when_unset(self, mock_table, api_gateway_event, lambda_context):
+        mock_table.get_item.return_value = {}
+        from settings_handler import lambda_handler
+
+        event = api_gateway_event(method='GET', path='/settings/resolved-problems')
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['resolved'] == {}
+
+    @patch('settings_handler.aggregates_table')
+    def test_put_resolve_sets_nested_key_atomically(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'delivery|general|late orders', 'resolved': True},
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body == {'success': True, 'key': 'delivery|general|late orders', 'resolved': True}
+        # Two updates: ensure the parent map exists, then set the nested key.
+        assert mock_table.update_item.call_count == 2
+        ensure, set_call = mock_table.update_item.call_args_list
+        assert 'if_not_exists' in ensure.kwargs['UpdateExpression']
+        assert set_call.kwargs['UpdateExpression'] == 'SET #r.#k = :entry'
+        assert set_call.kwargs['ExpressionAttributeNames']['#k'] == 'delivery|general|late orders'
+        assert 'resolved_at' in set_call.kwargs['ExpressionAttributeValues'][':entry']
+
+    @patch('settings_handler.aggregates_table')
+    def test_put_unresolve_removes_nested_key(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'delivery|general|late orders', 'resolved': False},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        remove_call = mock_table.update_item.call_args_list[-1]
+        assert remove_call.kwargs['UpdateExpression'] == 'REMOVE #r.#k'
+
+    @pytest.mark.parametrize('payload', [
+        {'resolved': True},                          # missing key
+        {'key': '', 'resolved': True},               # empty key
+        {'key': '  ', 'resolved': True},             # whitespace key
+        {'key': 'x' * 501, 'resolved': True},        # oversized key
+        {'key': 'ok', 'resolved': 'yes'},            # non-boolean resolved
+        {'key': 'ok'},                               # missing resolved
+    ])
+    @patch('settings_handler.aggregates_table')
+    def test_put_rejects_invalid_payloads(self, mock_table, payload, api_gateway_event, lambda_context):
+        from settings_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems', body=payload,
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        mock_table.update_item.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -514,3 +514,52 @@ class TestResolvedProblemsCap:
 
         # Missing parent map == nothing to remove == success.
         assert response['statusCode'] == 200
+
+
+
+class TestResolvedProblemsRoundThree:
+    """Third review round: narrowed exception swallow + UTF-8 byte cap."""
+
+    @patch('settings_handler.aggregates_table')
+    def test_unresolve_does_not_swallow_real_validation_errors(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """Only the missing-document-path variant is a no-op; other
+        ValidationExceptions are genuine failures, not success."""
+        from botocore.exceptions import ClientError
+        from settings_handler import lambda_handler
+
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ValidationException',
+                       'Message': 'ExpressionAttributeNames contains invalid value'}},
+            'UpdateItem',
+        )
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'cat|sub|problem', 'resolved': False},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 500
+
+    @patch('settings_handler.aggregates_table')
+    def test_rejects_keys_over_the_utf8_byte_cap(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """CJK text triples the byte cost: 200 chars under the char cap can
+        still blow the byte budget that sizes the 400KB item math."""
+        from settings_handler import lambda_handler
+
+        cjk_key = '배송|일반|' + ('느린 배송 문제 ' * 25)  # well under 500 chars, over 500 bytes
+        assert len(cjk_key) <= 500
+        assert len(cjk_key.encode('utf-8')) > 500
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': cjk_key, 'resolved': True},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        mock_table.update_item.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -418,3 +418,60 @@ class TestResolvedProblems:
 
         assert response['statusCode'] == 400
         mock_table.update_item.assert_not_called()
+
+
+
+class TestResolvedProblemsCap:
+    """The single config item is bounded (review feedback on #153)."""
+
+    @patch('settings_handler.aggregates_table')
+    def test_rejects_new_entries_beyond_the_cap(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import MAX_RESOLVED_ENTRIES, lambda_handler
+
+        full_map = {f'cat|sub|problem {i}': {'resolved_at': 'x'} for i in range(MAX_RESOLVED_ENTRIES)}
+        mock_table.get_item.return_value = {'Item': {'resolved': full_map}}
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'cat|sub|one too many', 'resolved': True},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        # Only the ensure-parent update ran; the SET never happened.
+        update_expressions = [
+            c.kwargs['UpdateExpression'] for c in mock_table.update_item.call_args_list
+        ]
+        assert 'SET #r.#k = :entry' not in update_expressions
+
+    @patch('settings_handler.aggregates_table')
+    def test_overwriting_an_existing_key_is_allowed_at_the_cap(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        from settings_handler import MAX_RESOLVED_ENTRIES, lambda_handler
+
+        full_map = {f'cat|sub|problem {i}': {'resolved_at': 'x'} for i in range(MAX_RESOLVED_ENTRIES)}
+        mock_table.get_item.return_value = {'Item': {'resolved': full_map}}
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'cat|sub|problem 0', 'resolved': True},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+
+    @patch('settings_handler.aggregates_table')
+    def test_unresolve_is_never_capped(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import MAX_RESOLVED_ENTRIES, lambda_handler
+
+        full_map = {f'cat|sub|problem {i}': {'resolved_at': 'x'} for i in range(MAX_RESOLVED_ENTRIES)}
+        mock_table.get_item.return_value = {'Item': {'resolved': full_map}}
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'cat|sub|problem 3', 'resolved': False},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200


### PR DESCRIPTION
## Summary

Fixes #66 (close manually on merge — base is `development`).

Teams that fix issues need resolved problems out of their working view. This adds a resolve/unresolve control on every problem group, hides resolved groups by default, and a **Show resolved (n)** toggle reveals them (dimmed, struck through, green badge) for historical reference. Resolution state is **shared across users** and persisted in DynamoDB, per the issue.

### Design

- **No identity server-side**: problem groups are built client-side by similarity, so resolution is keyed by a normalized `category|subcategory|problem` composite (trim/lowercase/whitespace-collapse) — cosmetic LLM re-phrasings keep the key stable. Exact-match limitation: if the *representative* text of a similarity group changes materially, the resolution orphans (documented in code).
- **Zero infrastructure changes**: state lives in one `voc-aggregates` config item behind `GET/PUT /settings/resolved-problems` on the existing settings Lambda (aggregates RW already granted; `/settings/*` proxy already routed + Cognito-authed). Per-key atomic nested SET/REMOVE means concurrent resolves can't clobber each other.
- Category/subcategory header totals are recomputed to match the visible tree, and the PDF export follows it.
- All strings translated in the 8 locales; mock server supports the flow for local dev.

## Testing

- Backend: 6 new handler tests (roundtrip, empty state, atomic update shape, 6-case payload validation) — settings suite 22/22
- Frontend: pipeline unit tests (key normalization, hide/annotate/counts), row control tests (fires without toggling the row, badge states), page integration (hidden by default → toggle reveals → unresolve persists) — full suite 1,572/1,572, eslint clean on touched files, tsc clean, `i18n:validate` in sync
- Note: a full-tree `eslint src` shows 8 pre-existing `set-state-in-effect` errors inherited from `development` — they're fixed in #138, not touched here.