### PR TITLE
feat: opt-in public web search via Bedrock AgentCore (chat + research)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -313,6 +313,28 @@ Enable/disable menu items in `voc-datalake/cdk.context.json`:
 }
 ```
 
+### Web Search (Amazon Bedrock AgentCore)
+
+AI Chat and Projects research can optionally ground answers with public web
+results via the AWS-managed [Web Search Tool connector](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-target-connector-web-search-tool.html)
+behind an AgentCore Gateway (`VocWebSearchStack`). Queries are served
+entirely within AWS and are billed at $7 per 1,000 searches; the feature is
+opt-in per request in both UIs (chat toggle, research wizard checkbox).
+
+The connector only exists in **us-east-1**, so the stack always deploys
+there:
+
+- App deployed to us-east-1: the gateway deploys by default. Disable with
+  `"enableWebSearch": false` in `cdk.context.json`.
+- App deployed to any other region: opt in with `"enableWebSearch": true`.
+  This uses CDK cross-region references and additionally requires a
+  us-east-1 bootstrap (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`).
+
+The frontend discovers availability through the `features.webSearch` flag in
+`config.json` (set by CDK and by `scripts/deploy.sh` from the
+`WebSearchAvailable` stack output). For local development against the mock,
+set `VITE_ENABLE_WEB_SEARCH=true`.
+
 After changing configuration:
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -330,6 +330,12 @@ is new — enable it with `"enableWebSearch": true` in `cdk.context.json`:
   (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`); CDK cross-region references
   carry the gateway URL/ARN to the app region.
 
+**Data residency note:** search queries are processed by the connector in
+us-east-1 regardless of where the app is deployed. Queries are derived from
+user input — the research question is sent as-is, and in chat the model
+composes queries from the conversation — so deployments with regional
+data-handling requirements should factor this in before enabling the flag.
+
 The frontend discovers availability through the `features.webSearch` flag in
 `config.json` (set by CDK and by `scripts/deploy.sh` from the
 `WebSearchAvailable` stack output). For local development against the mock,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -322,13 +322,13 @@ entirely within AWS and are billed at $7 per 1,000 searches; the feature is
 opt-in per request in both UIs (chat toggle, research wizard checkbox).
 
 The connector only exists in **us-east-1**, so the stack always deploys
-there:
+there. Deployment is **explicitly opt-in** while the connector integration
+is new — enable it with `"enableWebSearch": true` in `cdk.context.json`:
 
-- App deployed to us-east-1: the gateway deploys by default. Disable with
-  `"enableWebSearch": false` in `cdk.context.json`.
-- App deployed to any other region: opt in with `"enableWebSearch": true`.
-  This uses CDK cross-region references and additionally requires a
-  us-east-1 bootstrap (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`).
+- App deployed to us-east-1: the flag is all that's needed.
+- App deployed to any other region: the flag plus a us-east-1 bootstrap
+  (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`); CDK cross-region references
+  carry the gateway URL/ARN to the app region.
 
 The frontend discovers availability through the `features.webSearch` flag in
 `config.json` (set by CDK and by `scripts/deploy.sh` from the

--- a/voc-datalake/bin/voc-datalake.ts
+++ b/voc-datalake/bin/voc-datalake.ts
@@ -41,22 +41,22 @@ const env = {
 };
 
 // ============================================
-// Stack 0a: VocWebSearchStack (Optional)
+// Stack 0a: VocWebSearchStack (Optional, opt-in)
 // AgentCore Gateway for the AWS-managed web-search connector.
 // ============================================
-// The connector only exists in us-east-1, so the stack always deploys there.
-// Default: on when the app itself deploys to us-east-1 (no standing cost —
-// searches are opt-in per request at $7/1k queries). For other app regions
-// it must be explicitly enabled with `"enableWebSearch": true` because it
-// additionally requires a us-east-1 bootstrap and cross-region references.
+// Explicitly opt-in via `"enableWebSearch": true` in cdk.context.json (or
+// `-c enableWebSearch=true`). The gateway itself has no standing cost and
+// searches are opt-in per request ($7/1k queries), but the connector
+// integration is new — keep deployment a conscious choice until a real
+// gateway round-trip has been validated post-release, then consider
+// defaulting it on for us-east-1.
+//
+// The connector only exists in us-east-1, so the stack always deploys
+// there. When the app itself lives in another region this additionally
+// requires a us-east-1 bootstrap and CDK cross-region references.
 const webSearchContextRaw = app.node.tryGetContext('enableWebSearch');
-const webSearchExplicitlyEnabled = webSearchContextRaw === true || webSearchContextRaw === 'true';
-const webSearchExplicitlyDisabled = webSearchContextRaw === false || webSearchContextRaw === 'false';
-const appRegionIsUsEast1 = env.region === 'us-east-1';
-const deployWebSearch = !webSearchExplicitlyDisabled && (appRegionIsUsEast1 || webSearchExplicitlyEnabled);
-// Cross-region references (SSM-backed) are only needed when the app lives
-// outside us-east-1; keep the flag off otherwise to avoid template churn.
-const webSearchCrossRegion = deployWebSearch && !appRegionIsUsEast1;
+const deployWebSearch = webSearchContextRaw === true || webSearchContextRaw === 'true';
+const webSearchCrossRegion = deployWebSearch && env.region !== 'us-east-1';
 
 let webSearchStack: VocWebSearchStack | undefined;
 if (deployWebSearch) {

--- a/voc-datalake/bin/voc-datalake.ts
+++ b/voc-datalake/bin/voc-datalake.ts
@@ -7,6 +7,7 @@ import { VocCoreStack } from '../lib/stacks/core-stack';
 import { VocIngestionStack } from '../lib/stacks/ingestion-stack';
 import { VocProcessingStack } from '../lib/stacks/processing-stack-consolidated';
 import { VocApiStack } from '../lib/stacks/api-stack';
+import { VocWebSearchStack } from '../lib/stacks/web-search-stack';
 import { BedrockAccessStack, AnthropicUseCaseSchema } from '../lib/stacks/bedrock-access-stack';
 import { lambdaBasicExecutionRoleSuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, comprehendSuppressions, translateSuppressions, apiGatewayPushToCloudwatchLogsRoleSuppressions } from '../lib/utils/nag-suppressions';
 
@@ -38,6 +39,34 @@ const env = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
   region: process.env.CDK_DEFAULT_REGION || 'us-east-1',
 };
+
+// ============================================
+// Stack 0a: VocWebSearchStack (Optional)
+// AgentCore Gateway for the AWS-managed web-search connector.
+// ============================================
+// The connector only exists in us-east-1, so the stack always deploys there.
+// Default: on when the app itself deploys to us-east-1 (no standing cost —
+// searches are opt-in per request at $7/1k queries). For other app regions
+// it must be explicitly enabled with `"enableWebSearch": true` because it
+// additionally requires a us-east-1 bootstrap and cross-region references.
+const webSearchContextRaw = app.node.tryGetContext('enableWebSearch');
+const webSearchExplicitlyEnabled = webSearchContextRaw === true || webSearchContextRaw === 'true';
+const webSearchExplicitlyDisabled = webSearchContextRaw === false || webSearchContextRaw === 'false';
+const appRegionIsUsEast1 = env.region === 'us-east-1';
+const deployWebSearch = !webSearchExplicitlyDisabled && (appRegionIsUsEast1 || webSearchExplicitlyEnabled);
+// Cross-region references (SSM-backed) are only needed when the app lives
+// outside us-east-1; keep the flag off otherwise to avoid template churn.
+const webSearchCrossRegion = deployWebSearch && !appRegionIsUsEast1;
+
+let webSearchStack: VocWebSearchStack | undefined;
+if (deployWebSearch) {
+  webSearchStack = new VocWebSearchStack(app, 'VocWebSearchStack', {
+    env: { account: env.account, region: 'us-east-1' },
+    crossRegionReferences: webSearchCrossRegion,
+    description: 'VoC Data Lake - Web Search (AgentCore Gateway, web-search connector) (uksb-0q2jyqfvlm)(tag:VocWebSearchStack)',
+  });
+  tagStack(webSearchStack, 'WebSearch');
+}
 
 // ============================================
 // Stack 0: BedrockAccessStack (Optional)
@@ -107,6 +136,7 @@ tagStack(ingestionStack, 'Ingestion');
 // ============================================
 const processingStack = new VocProcessingStack(app, 'VocProcessingStack', {
   env,
+  crossRegionReferences: webSearchCrossRegion,
   description: 'VoC Data Lake - Processing Layer (Lambda, Bedrock, Step Functions) (uksb-0q2jyqfvlm)(tag:VocProcessingStack)',
   feedbackTable: coreStack.feedbackTable,
   aggregatesTable: coreStack.aggregatesTable,
@@ -115,6 +145,9 @@ const processingStack = new VocProcessingStack(app, 'VocProcessingStack', {
   idempotencyTable: coreStack.idempotencyTable,
   processingQueue: ingestionStack.processingQueue,
   kmsKey: coreStack.kmsKey,
+  webSearchGatewayUrl: webSearchStack?.gatewayUrl,
+  webSearchGatewayArn: webSearchStack?.gatewayArn,
+  webSearchToolName: webSearchStack?.toolName,
   config,
 });
 processingStack.addDependency(coreStack);
@@ -127,6 +160,7 @@ tagStack(processingStack, 'Processing');
 // ============================================
 const apiStack = new VocApiStack(app, 'VocApiStack', {
   env,
+  crossRegionReferences: webSearchCrossRegion,
   description: 'VoC Data Lake - API & Frontend (API Gateway, Lambda, S3 Deploy) (uksb-0q2jyqfvlm)(tag:VocApiStack)',
   feedbackTable: coreStack.feedbackTable,
   aggregatesTable: coreStack.aggregatesTable,
@@ -149,6 +183,9 @@ const apiStack = new VocApiStack(app, 'VocApiStack', {
   secretsArn: ingestionStack.secretsArn,
   s3ImportBucket: ingestionStack.s3ImportBucket,
   researchStateMachine: processingStack.researchStateMachine,
+  webSearchGatewayUrl: webSearchStack?.gatewayUrl,
+  webSearchGatewayArn: webSearchStack?.gatewayArn,
+  webSearchToolName: webSearchStack?.toolName,
   brandName: config.brandName,
   enabledSources,
 });

--- a/voc-datalake/frontend/public/locales/de/chat.json
+++ b/voc-datalake/frontend/public/locales/de/chat.json
@@ -40,5 +40,10 @@
     "sentimentTrend": "Wie hat sich die Stimmung im letzten Monat verändert?",
     "topComplaints": "Was sind die häufigsten Kundenbeschwerden diese Woche?",
     "urgentIssues": "Zeige mir die dringendsten Probleme"
+  },
+  "webSearch": {
+    "sourcesTitle": "Webquellen",
+    "toggle": "Websuche",
+    "tooltip": "Der Assistent darf im öffentlichen Web nach aktuellen Informationen suchen (Quellen werden zitiert)"
   }
 }

--- a/voc-datalake/frontend/public/locales/de/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/de/projectDetail.json
@@ -423,6 +423,8 @@
     "researchSuggestTitle": "Forschungsfragen von der KI aus dem Projekt-Feedback vorschlagen lassen",
     "researchTitle": "Recherche-Titel",
     "researchTitlePlaceholder": "z.B. Analyse der Lieferschmerzpunkte",
+    "researchWebSearch": "Öffentliche Websuche einbeziehen",
+    "researchWebSearchHint": "Stützt die Analyse mit aktuellen Ergebnissen aus dem öffentlichen Web zu Ihrer Forschungsfrage (innerhalb von AWS bereitgestellt, Quellen werden zitiert).",
     "runResearch": "Recherche starten",
     "selectAtLeast2": "⚠️ Wählen Sie mindestens 2 Dokumente zum Remixen aus.",
     "submitGenerateDoc": "{{type}} generieren",

--- a/voc-datalake/frontend/public/locales/en/chat.json
+++ b/voc-datalake/frontend/public/locales/en/chat.json
@@ -40,5 +40,10 @@
     "sentimentTrend": "How has sentiment changed over the past month?",
     "topComplaints": "What are the top customer complaints this week?",
     "urgentIssues": "Show me the most urgent issues right now"
+  },
+  "webSearch": {
+    "sourcesTitle": "Web sources",
+    "toggle": "Web search",
+    "tooltip": "Let the assistant search the public web for current information (sources are cited)"
   }
 }

--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -423,6 +423,8 @@
     "researchSuggestTitle": "Let AI suggest research questions from this project's feedback",
     "researchTitle": "Research Title",
     "researchTitlePlaceholder": "e.g., Delivery Pain Points Analysis",
+    "researchWebSearch": "Include public web search",
+    "researchWebSearchHint": "Ground the analysis with current public-web results for your research question (served within AWS, sources cited).",
     "runResearch": "Run Research",
     "selectAtLeast2": "⚠️ Select at least 2 documents to remix.",
     "submitGenerateDoc": "Generate {{type}}",

--- a/voc-datalake/frontend/public/locales/es/chat.json
+++ b/voc-datalake/frontend/public/locales/es/chat.json
@@ -41,5 +41,10 @@
     "sentimentTrend": "¿Cómo ha cambiado el sentimiento en el último mes?",
     "topComplaints": "¿Cuáles son las principales quejas de los clientes esta semana?",
     "urgentIssues": "Muéstrame los problemas más urgentes"
+  },
+  "webSearch": {
+    "sourcesTitle": "Fuentes web",
+    "toggle": "Búsqueda web",
+    "tooltip": "Permite que el asistente busque información actual en la web pública (se citan las fuentes)"
   }
 }

--- a/voc-datalake/frontend/public/locales/es/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/es/projectDetail.json
@@ -426,6 +426,8 @@
     "researchSuggestTitle": "Dejar que la IA sugiera preguntas de investigación a partir del feedback del proyecto",
     "researchTitle": "Título de Investigación",
     "researchTitlePlaceholder": "p. ej., Análisis de Puntos de Dolor en Entregas",
+    "researchWebSearch": "Incluir búsqueda web pública",
+    "researchWebSearchHint": "Fundamenta el análisis con resultados actuales de la web pública para tu pregunta de investigación (servido dentro de AWS, con fuentes citadas).",
     "runResearch": "Ejecutar Investigación",
     "selectAtLeast2": "⚠️ Selecciona al menos 2 documentos para remezlar.",
     "submitGenerateDoc": "Generar {{type}}",

--- a/voc-datalake/frontend/public/locales/fr/chat.json
+++ b/voc-datalake/frontend/public/locales/fr/chat.json
@@ -41,5 +41,10 @@
     "sentimentTrend": "Comment le sentiment a-t-il évolué au cours du dernier mois ?",
     "topComplaints": "Quelles sont les principales plaintes des clients cette semaine ?",
     "urgentIssues": "Montre-moi les problèmes les plus urgents"
+  },
+  "webSearch": {
+    "sourcesTitle": "Sources web",
+    "toggle": "Recherche web",
+    "tooltip": "Autorise l'assistant à rechercher des informations actuelles sur le web public (les sources sont citées)"
   }
 }

--- a/voc-datalake/frontend/public/locales/fr/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/fr/projectDetail.json
@@ -426,6 +426,8 @@
     "researchSuggestTitle": "Laisser l’IA suggérer des questions de recherche à partir des retours du projet",
     "researchTitle": "Titre de la recherche",
     "researchTitlePlaceholder": "ex. : Analyse des points de friction de livraison",
+    "researchWebSearch": "Inclure la recherche web publique",
+    "researchWebSearchHint": "Ancre l'analyse avec des résultats actuels du web public pour votre question de recherche (servi au sein d'AWS, sources citées).",
     "runResearch": "Lancer la recherche",
     "selectAtLeast2": "⚠️ Sélectionnez au moins 2 documents à remixer.",
     "submitGenerateDoc": "Générer {{type}}",

--- a/voc-datalake/frontend/public/locales/ja/chat.json
+++ b/voc-datalake/frontend/public/locales/ja/chat.json
@@ -40,5 +40,10 @@
     "sentimentTrend": "先月の感情はどのように変化しましたか？",
     "topComplaints": "今週の顧客の主な苦情は何ですか？",
     "urgentIssues": "最も緊急な問題を表示してください"
+  },
+  "webSearch": {
+    "sourcesTitle": "ウェブ出典",
+    "toggle": "ウェブ検索",
+    "tooltip": "アシスタントが公開ウェブで最新情報を検索できるようにします（出典を引用します）"
   }
 }

--- a/voc-datalake/frontend/public/locales/ja/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ja/projectDetail.json
@@ -423,6 +423,8 @@
     "researchSuggestTitle": "プロジェクトのフィードバックから調査の問いを AI に提案させる",
     "researchTitle": "リサーチタイトル",
     "researchTitlePlaceholder": "例：配達のペインポイント分析",
+    "researchWebSearch": "公開ウェブ検索を含める",
+    "researchWebSearchHint": "リサーチ課題に関する公開ウェブの最新結果で分析を裏付けます（AWS内で処理され、出典を引用します）。",
     "runResearch": "リサーチを実行",
     "selectAtLeast2": "⚠️ リミックスするには最低2つのドキュメントを選択してください。",
     "submitGenerateDoc": "{{type}}を生成",

--- a/voc-datalake/frontend/public/locales/ko/chat.json
+++ b/voc-datalake/frontend/public/locales/ko/chat.json
@@ -40,5 +40,10 @@
     "sentimentTrend": "지난 한 달간 감정 추세는 어떻게 변했나요?",
     "topComplaints": "이번 주 주요 고객 불만은 무엇인가요?",
     "urgentIssues": "가장 긴급한 문제를 보여주세요"
+  },
+  "webSearch": {
+    "sourcesTitle": "웹 출처",
+    "toggle": "웹 검색",
+    "tooltip": "어시스턴트가 공개 웹에서 최신 정보를 검색하도록 허용합니다(출처가 인용됩니다)"
   }
 }

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -423,6 +423,8 @@
     "researchSuggestTitle": "이 프로젝트의 피드백을 바탕으로 AI가 리서치 질문을 추천합니다",
     "researchTitle": "조사 제목",
     "researchTitlePlaceholder": "예: 배달 Pain Point 분석",
+    "researchWebSearch": "공개 웹 검색 포함",
+    "researchWebSearchHint": "연구 질문에 대한 공개 웹의 최신 결과로 분석을 뒷받침합니다(AWS 내에서 처리되며 출처가 인용됩니다).",
     "runResearch": "조사 실행",
     "selectAtLeast2": "⚠️ 리믹스할 문서를 최소 2개 이상 선택하세요.",
     "submitGenerateDoc": "{{type}} 생성",

--- a/voc-datalake/frontend/public/locales/pt/chat.json
+++ b/voc-datalake/frontend/public/locales/pt/chat.json
@@ -41,5 +41,10 @@
     "sentimentTrend": "Como o sentimento mudou no último mês?",
     "topComplaints": "Quais são as principais reclamações dos clientes esta semana?",
     "urgentIssues": "Mostre-me os problemas mais urgentes"
+  },
+  "webSearch": {
+    "sourcesTitle": "Fontes da web",
+    "toggle": "Pesquisa na web",
+    "tooltip": "Permite que o assistente pesquise informações atuais na web pública (as fontes são citadas)"
   }
 }

--- a/voc-datalake/frontend/public/locales/pt/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/pt/projectDetail.json
@@ -426,6 +426,8 @@
     "researchSuggestTitle": "Deixar a IA sugerir perguntas de pesquisa a partir do feedback do projeto",
     "researchTitle": "Título da Pesquisa",
     "researchTitlePlaceholder": "ex: Análise de Pontos de Dor em Delivery",
+    "researchWebSearch": "Incluir pesquisa na web pública",
+    "researchWebSearchHint": "Fundamenta a análise com resultados atuais da web pública para sua pergunta de pesquisa (servido dentro da AWS, com fontes citadas).",
     "runResearch": "Executar Pesquisa",
     "selectAtLeast2": "⚠️ Selecione pelo menos 2 documentos para remixar.",
     "submitGenerateDoc": "Gerar {{type}}",

--- a/voc-datalake/frontend/public/locales/zh/chat.json
+++ b/voc-datalake/frontend/public/locales/zh/chat.json
@@ -40,5 +40,10 @@
     "sentimentTrend": "过去一个月情感趋势如何变化？",
     "topComplaints": "本周客户的主要投诉是什么？",
     "urgentIssues": "显示最紧急的问题"
+  },
+  "webSearch": {
+    "sourcesTitle": "网络来源",
+    "toggle": "网页搜索",
+    "tooltip": "允许助手在公共网络中搜索最新信息（会注明来源）"
   }
 }

--- a/voc-datalake/frontend/public/locales/zh/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/zh/projectDetail.json
@@ -423,6 +423,8 @@
     "researchSuggestTitle": "让 AI 根据项目反馈提出研究问题",
     "researchTitle": "研究标题",
     "researchTitlePlaceholder": "例如，配送痛点分析",
+    "researchWebSearch": "包含公共网页搜索",
+    "researchWebSearchHint": "使用与您的研究问题相关的最新公共网页结果为分析提供依据（在 AWS 内部处理，并注明来源）。",
     "runResearch": "运行研究",
     "selectAtLeast2": "⚠️ 至少选择2个文档进行重新组合。",
     "submitGenerateDoc": "生成{{type}}",

--- a/voc-datalake/frontend/scripts/deploy.sh
+++ b/voc-datalake/frontend/scripts/deploy.sh
@@ -47,6 +47,8 @@ IDENTITY_POOL_ID=$(echo "$CORE_OUTPUTS" | jq -r '.[] | select(.OutputKey=="Ident
 API_ENDPOINT=$(echo "$API_OUTPUTS" | jq -r '.[] | select(.OutputKey=="ApiEndpoint") | .OutputValue')
 STREAM_ENDPOINT=$(echo "$API_OUTPUTS" | jq -r '.[] | select(.OutputKey=="ChatStreamUrl") | .OutputValue // empty')
 AVATARS_CDN_URL=$(echo "$CORE_OUTPUTS" | jq -r '.[] | select(.OutputKey=="AvatarsCdnUrl") | .OutputValue // empty')
+# "true" when the AgentCore web search gateway is deployed (drives the UI toggles)
+WEB_SEARCH_AVAILABLE=$(echo "$API_OUTPUTS" | jq -r '.[] | select(.OutputKey=="WebSearchAvailable") | .OutputValue // "false"')
 
 # Validate required values
 if [ -z "$BUCKET_NAME" ] || [ "$BUCKET_NAME" = "null" ]; then
@@ -92,6 +94,7 @@ jq -n \
   --arg clientId "$COGNITO_CLIENT_ID" \
   --arg region "$COGNITO_REGION" \
   --arg identityPoolId "$IDENTITY_POOL_ID" \
+  --argjson webSearch "$([ "$WEB_SEARCH_AVAILABLE" = "true" ] && echo true || echo false)" \
   '{
     apiEndpoint: $apiEndpoint,
     streamEndpoint: $streamEndpoint,
@@ -101,6 +104,9 @@ jq -n \
       clientId: $clientId,
       region: $region,
       identityPoolId: $identityPoolId
+    },
+    features: {
+      webSearch: $webSearch
     }
   }' > dist/config.json
 

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -57,6 +57,7 @@ export type {
   LogsSummary,
   ApiToken,
   CreateApiTokenResponse,
+  WebSource,
 } from './types'
 export type { ProjectJob, ProjectDocument, ProjectDetail } from './types'
 

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -98,6 +98,7 @@ export const projectsApi = {
     selected_persona_ids?: string[]
     selected_document_ids?: string[]
     response_language?: string
+    use_web_search?: boolean
   }) =>
     fetchApi<{
       success: boolean;

--- a/voc-datalake/frontend/src/api/streamClient.ts
+++ b/voc-datalake/frontend/src/api/streamClient.ts
@@ -144,6 +144,7 @@ interface VocChatOptions {
   context?: string
   days?: number
   responseLanguage?: string
+  useWebSearch?: boolean
   history?: Array<{
     role: string;
     content: string
@@ -161,6 +162,7 @@ export function streamVocChat(options: VocChatOptions): AsyncGenerator<StreamEve
     ...getDateBasisBodyParams(),
     response_language: options.responseLanguage,
     history: options.history,
+    ...(options.useWebSearch === true ? { use_web_search: true } : {}),
   }, options.signal)
 }
 

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -517,3 +517,16 @@ export interface CreateApiTokenResponse {
   name: string
   message?: string
 }
+
+
+/**
+ * A public-web search result returned by the AI chat web_search tool
+ * (Amazon Bedrock AgentCore Web Search). Acceptable use requires surfacing
+ * these citations alongside any answer that draws on them.
+ */
+export interface WebSource {
+  title: string
+  url: string
+  text: string
+  published_date: string
+}

--- a/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.test.tsx
+++ b/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.test.tsx
@@ -22,6 +22,12 @@ vi.mock('../../api/client', () => ({
   },
 }))
 
+// Web search availability is a runtime-config capability flag
+const mockIsWebSearchAvailable = vi.fn()
+vi.mock('../../runtimeConfig', () => ({
+  isWebSearchAvailable: () => mockIsWebSearchAvailable(),
+}))
+
 describe('ChatFilters', () => {
   const mockOnChange = vi.fn()
   const defaultFilters: ChatFiltersType = {}
@@ -31,6 +37,7 @@ describe('ChatFilters', () => {
     ;(useConfigStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       config: { apiEndpoint: 'https://api.example.com' },
     })
+    mockIsWebSearchAvailable.mockReturnValue(false)
   })
 
   describe('basic rendering', () => {
@@ -348,6 +355,52 @@ describe('ChatFilters', () => {
       render(<ChatFilters filters={defaultFilters} onChange={mockOnChange} />)
       
       expect(screen.getByText(/max 30 reviews/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('web search toggle', () => {
+    it('is hidden when the deployment has no web search gateway', () => {
+      mockIsWebSearchAvailable.mockReturnValue(false)
+      render(<ChatFilters filters={defaultFilters} onChange={mockOnChange} />)
+
+      expect(screen.queryByRole('button', { name: /web search/i })).not.toBeInTheDocument()
+    })
+
+    it('renders unpressed by default when available', () => {
+      mockIsWebSearchAvailable.mockReturnValue(true)
+      render(<ChatFilters filters={defaultFilters} onChange={mockOnChange} />)
+
+      const toggle = screen.getByRole('button', { name: /web search/i })
+      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('enables web search on click', async () => {
+      mockIsWebSearchAvailable.mockReturnValue(true)
+      const user = userEvent.setup()
+      render(<ChatFilters filters={defaultFilters} onChange={mockOnChange} />)
+
+      await user.click(screen.getByRole('button', { name: /web search/i }))
+
+      expect(mockOnChange).toHaveBeenCalledWith({ useWebSearch: true })
+    })
+
+    it('disables web search on click when active, dropping the key', async () => {
+      mockIsWebSearchAvailable.mockReturnValue(true)
+      const user = userEvent.setup()
+      render(<ChatFilters filters={{ useWebSearch: true }} onChange={mockOnChange} />)
+
+      const toggle = screen.getByRole('button', { name: /web search/i })
+      expect(toggle).toHaveAttribute('aria-pressed', 'true')
+      await user.click(toggle)
+
+      expect(mockOnChange).toHaveBeenCalledWith({ useWebSearch: undefined })
+    })
+
+    it('does not count toward active filters (no clear button for it alone)', () => {
+      mockIsWebSearchAvailable.mockReturnValue(true)
+      render(<ChatFilters filters={{ useWebSearch: true }} onChange={mockOnChange} />)
+
+      expect(screen.queryByText(/clear/i)).not.toBeInTheDocument()
     })
   })
 })

--- a/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.test.tsx
+++ b/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.test.tsx
@@ -402,5 +402,15 @@ describe('ChatFilters', () => {
 
       expect(screen.queryByText(/clear/i)).not.toBeInTheDocument()
     })
+
+    it('survives clearing the data filters', async () => {
+      mockIsWebSearchAvailable.mockReturnValue(true)
+      const user = userEvent.setup()
+      render(<ChatFilters filters={{ source: 'webscraper', useWebSearch: true }} onChange={mockOnChange} />)
+
+      await user.click(screen.getByText(/clear/i))
+
+      expect(mockOnChange).toHaveBeenCalledWith({ useWebSearch: true })
+    })
   })
 })

--- a/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.tsx
+++ b/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.tsx
@@ -172,7 +172,9 @@ export default function ChatFilters({ filters, onChange }: ChatFiltersProps) {
   }
 
   const clearFilters = () => {
-    onChange({})
+    // "Clear" resets the data filters (source/category/sentiment); the web
+    // search capability toggle is a separate concern and survives it.
+    onChange(filters.useWebSearch === true ? { useWebSearch: true } : {})
   }
 
   return (

--- a/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.tsx
+++ b/voc-datalake/frontend/src/components/ChatFilters/ChatFilters.tsx
@@ -10,10 +10,12 @@
  */
 
 import { useState, useEffect } from 'react'
-import { Filter, X, ChevronDown } from 'lucide-react'
+import { Filter, X, ChevronDown, Globe } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import type { ChatFilters as ChatFiltersType } from '../../store/chatStore'
 import { api } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
+import { isWebSearchAvailable } from '../../runtimeConfig'
 import clsx from 'clsx'
 
 // Default options as fallback
@@ -115,6 +117,33 @@ function FilterSelect({
   )
 }
 
+/** Opt-in public web search toggle. Only rendered when the deployment has
+ * the AgentCore web search gateway (runtime config feature flag). */
+function WebSearchToggle({
+  enabled,
+  onToggle,
+}: Readonly<{
+  enabled: boolean
+  onToggle: (enabled: boolean) => void
+}>) {
+  const { t } = useTranslation('chat')
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(!enabled)}
+      aria-pressed={enabled}
+      title={t('webSearch.tooltip')}
+      className={clsx(
+        'flex items-center gap-1.5 text-xs px-2 py-2 sm:py-1.5 rounded border cursor-pointer transition-colors',
+        enabled ? 'bg-sky-50 border-sky-300 text-sky-700' : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+      )}
+    >
+      <Globe size={12} className={enabled ? 'text-sky-600' : 'text-gray-400'} />
+      <span>{t('webSearch.toggle')}</span>
+    </button>
+  )
+}
+
 export default function ChatFilters({ filters, onChange }: ChatFiltersProps) {
   const [sources, setSources] = useState(defaultSources)
   const [categories, setCategories] = useState(defaultCategories)
@@ -181,6 +210,12 @@ export default function ChatFilters({ filters, onChange }: ChatFiltersProps) {
           onChange={(v) => updateFilter('sentiment', v)}
           activeColorClass="bg-green-50 border-green-200 text-green-700"
         />
+        {isWebSearchAvailable() && (
+          <WebSearchToggle
+            enabled={filters.useWebSearch === true}
+            onToggle={(enabled) => onChange({ ...filters, useWebSearch: enabled || undefined })}
+          />
+        )}
       </div>
 
       {hasActiveFilters && (

--- a/voc-datalake/frontend/src/components/ChatMessage/ChatMessage.tsx
+++ b/voc-datalake/frontend/src/components/ChatMessage/ChatMessage.tsx
@@ -12,14 +12,67 @@
 
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Bot, User, Copy, Check } from 'lucide-react'
+import { Bot, User, Copy, Check, Globe } from 'lucide-react'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { ChatMessage as ChatMessageType } from '../../store/chatStore'
+import type { WebSource } from '../../api/client'
 import FeedbackCarousel from '../FeedbackCarousel'
 import clsx from 'clsx'
 
 interface ChatMessageProps {
   message: ChatMessageType
+}
+
+/** Cited web sources (acceptable use of the web search tool requires the
+ * source links to reach the user, even if the model forgot inline cites). */
+function WebSourceList({ webSources }: Readonly<{ webSources: WebSource[] }>) {
+  const { t } = useTranslation('chat')
+  return (
+    <div className="mt-2 bg-sky-50/60 border border-sky-100 rounded-lg p-2.5">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-sky-700 mb-1.5">
+        <Globe size={12} />
+        <span>{t('webSearch.sourcesTitle')}</span>
+      </div>
+      <ul className="space-y-1">
+        {webSources.map((source) => (
+          <li key={source.url} className="text-xs truncate">
+            <a
+              href={source.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sky-700 hover:underline"
+              title={source.text.slice(0, 300)}
+            >
+              {source.title === '' ? source.url : source.title}
+            </a>
+            {source.published_date !== '' && (
+              <span className="text-gray-400 ml-1.5">({source.published_date})</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/** Feedback + web citations shown under an assistant message. */
+function MessageSources({ message }: Readonly<ChatMessageProps>) {
+  return (
+    <>
+      {/* Source feedback carousel - constrained to parent width */}
+      {message.sources && message.sources.length > 0 && (
+        <div className="w-full max-w-full overflow-hidden">
+          <FeedbackCarousel items={message.sources} title="Related feedback:" />
+        </div>
+      )}
+
+      {/* Cited public web sources */}
+      {message.webSources && message.webSources.length > 0 && (
+        <WebSourceList webSources={message.webSources} />
+      )}
+    </>
+  )
 }
 
 export default function ChatMessage({ message }: Readonly<ChatMessageProps>) {
@@ -119,12 +172,7 @@ export default function ChatMessage({ message }: Readonly<ChatMessageProps>) {
           </button>
         </div>
 
-        {/* Source feedback carousel - constrained to parent width */}
-        {message.sources && message.sources.length > 0 && (
-          <div className="w-full max-w-full overflow-hidden">
-            <FeedbackCarousel items={message.sources} title="Related feedback:" />
-          </div>
-        )}
+        <MessageSources message={message} />
 
         <p className="text-xs text-gray-400 mt-1">
           {formatTime(message.timestamp)}

--- a/voc-datalake/frontend/src/hooks/useStreamChat.ts
+++ b/voc-datalake/frontend/src/hooks/useStreamChat.ts
@@ -95,9 +95,22 @@ function isWebSource(value: unknown): value is WebSource {
   return typeof value.url === 'string' && typeof value.title === 'string' && typeof value.text === 'string'
 }
 
+/** Normalize a guard-passing record into a complete WebSource: WebSource
+ * declares published_date as a required string (the renderer compares it to
+ * ''), so a backend payload omitting it must default rather than leak
+ * undefined through the type. */
+function toWebSource(value: WebSource): WebSource {
+  return {
+    title: value.title,
+    url: value.url,
+    text: value.text,
+    published_date: typeof value.published_date === 'string' ? value.published_date : '',
+  }
+}
+
 function extractWebSources(meta: Record<string, unknown> | undefined): WebSource[] {
   const raw = meta?.web_sources
-  return Array.isArray(raw) ? raw.filter((item) => isWebSource(item)) : []
+  return Array.isArray(raw) ? raw.filter((item) => isWebSource(item)).map((item) => toWebSource(item)) : []
 }
 
 function applyMetadataEvent(prev: StreamChatState, event: StreamEvent): StreamChatState {

--- a/voc-datalake/frontend/src/hooks/useStreamChat.ts
+++ b/voc-datalake/frontend/src/hooks/useStreamChat.ts
@@ -9,7 +9,7 @@ import {
 } from '../api/streamClient'
 import { isRecord } from '../lib/typeGuards'
 import type { StreamEvent } from '../api/streamClient'
-import type { FeedbackItem } from '../api/types'
+import type { FeedbackItem, WebSource } from '../api/types'
 
 interface ChatOptions {
   projectId?: string
@@ -18,6 +18,7 @@ interface ChatOptions {
   selectedPersonas?: string[]
   selectedDocuments?: string[]
   responseLanguage?: string
+  useWebSearch?: boolean
   attachments?: Array<{
     name: string;
     media_type: string;
@@ -48,6 +49,7 @@ interface StreamChatState {
   activeTools: string[]
   toolSteps: ToolStep[]
   sources: FeedbackItem[]
+  webSources: WebSource[]
   metadata: Record<string, unknown>
   documentChanges: Array<{
     document_id: string;
@@ -71,6 +73,7 @@ const initialState: StreamChatState = {
   activeTools: [],
   toolSteps: [],
   sources: [],
+  webSources: [],
   metadata: {},
   documentChanges: [],
   error: null,
@@ -87,8 +90,19 @@ function extractSources(meta: Record<string, unknown> | undefined): FeedbackItem
   return isFeedbackArray(raw) ? raw : []
 }
 
+function isWebSource(value: unknown): value is WebSource {
+  if (!isRecord(value)) return false
+  return typeof value.url === 'string' && typeof value.title === 'string' && typeof value.text === 'string'
+}
+
+function extractWebSources(meta: Record<string, unknown> | undefined): WebSource[] {
+  const raw = meta?.web_sources
+  return Array.isArray(raw) ? raw.filter((item) => isWebSource(item)) : []
+}
+
 function applyMetadataEvent(prev: StreamChatState, event: StreamEvent): StreamChatState {
   const sources = extractSources(event.metadata)
+  const webSources = extractWebSources(event.metadata)
   return {
     ...prev,
     metadata: {
@@ -96,14 +110,17 @@ function applyMetadataEvent(prev: StreamChatState, event: StreamEvent): StreamCh
       ...event.metadata,
     },
     sources: sources.length > 0 ? sources : prev.sources,
+    webSources: webSources.length > 0 ? webSources : prev.webSources,
   }
 }
 
 function applyDoneEvent(prev: StreamChatState, event: StreamEvent): StreamChatState {
   const sources = extractSources(event.metadata)
+  const webSources = extractWebSources(event.metadata)
   return {
     ...prev,
     sources: sources.length > 0 ? sources : prev.sources,
+    webSources: webSources.length > 0 ? webSources : prev.webSources,
     metadata: event.metadata ? {
       ...prev.metadata,
       ...event.metadata,
@@ -261,6 +278,7 @@ function createStream(message: string, options: ChatOptions | undefined, signal:
     context: options?.context,
     days: options?.days,
     responseLanguage: options?.responseLanguage,
+    useWebSearch: options?.useWebSearch,
     history: options?.history,
     signal,
   })

--- a/voc-datalake/frontend/src/pages/Chat/Chat.tsx
+++ b/voc-datalake/frontend/src/pages/Chat/Chat.tsx
@@ -218,6 +218,7 @@ export default function Chat() {
     thinkingText,
     activeTools,
     sources,
+    webSources,
     error: streamError,
     sendMessage: sendStreamMessage,
     cancel,
@@ -237,6 +238,7 @@ export default function Chat() {
     thinkingText,
     streamError,
     sources,
+    webSources,
     filters,
     activeConversationId,
     addMessage,
@@ -248,6 +250,7 @@ export default function Chat() {
       thinkingText,
       streamError,
       sources,
+      webSources,
       filters,
       activeConversationId,
       addMessage,
@@ -259,7 +262,7 @@ export default function Chat() {
   const prevStreamingRef = useRef(false)
   useEffect(() => {
     const {
-      streamingText: text, thinkingText: thinking, streamError: error, sources: src, filters: f, activeConversationId: convId, addMessage: add, t: translate,
+      streamingText: text, thinkingText: thinking, streamError: error, sources: src, webSources: webSrc, filters: f, activeConversationId: convId, addMessage: add, t: translate,
     } = latestRef.current
     if (prevStreamingRef.current && !isStreaming && convId != null && convId !== '') {
       if (text !== '') {
@@ -267,6 +270,7 @@ export default function Chat() {
           role: 'assistant',
           content: text,
           sources: src.length > 0 ? src : undefined,
+          webSources: webSrc.length > 0 ? webSrc : undefined,
           thinking: thinking === '' ? undefined : thinking,
           filters: f,
         })
@@ -310,6 +314,7 @@ export default function Chat() {
       context,
       days,
       responseLanguage: i18n.language,
+      useWebSearch: filters.useWebSearch,
       history,
     })
     setInput('')

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -3,13 +3,14 @@
  */
 import clsx from 'clsx'
 import {
-  Users, FileText, Search, Shuffle, Sparkles, Loader2, Wand2,
+  Users, FileText, Search, Shuffle, Sparkles, Loader2, Wand2, Globe,
 } from 'lucide-react'
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { projectsApi } from '../../api/projectsApi'
 import DataSourceWizard from '../../components/DataSourceWizard'
 import ContextSummary from '../../components/DataSourceWizard/ContextSummary'
+import { isWebSearchAvailable } from '../../runtimeConfig'
 import type {
   PersonaToolConfig, ResearchToolConfig, DocToolConfig, MergeToolConfig,
 } from './types'
@@ -172,6 +173,28 @@ export function ResearchWizard({
               title: e.target.value,
             })} placeholder="e.g., Delivery Pain Points Analysis" className="w-full px-3 py-2 border rounded-lg" />
           </div>
+          {isWebSearchAvailable() ? (
+            <label className="flex items-start gap-2.5 p-3 border rounded-lg cursor-pointer hover:border-sky-300 hover:bg-sky-50/40 transition-colors">
+              <input
+                type="checkbox"
+                checked={researchConfig.useWebSearch}
+                onChange={(e) => onResearchConfigChange({
+                  ...researchConfig,
+                  useWebSearch: e.target.checked,
+                })}
+                className="mt-0.5"
+              />
+              <span className="min-w-0">
+                <span className="flex items-center gap-1.5 text-sm font-medium text-gray-800">
+                  <Globe size={14} className="text-sky-600" />
+                  {t('wizards.researchWebSearch', { defaultValue: 'Include public web search' })}
+                </span>
+                <span className="block text-xs text-gray-500 mt-0.5">
+                  {t('wizards.researchWebSearchHint', { defaultValue: 'Ground the analysis with current public-web results for your research question (served within AWS, sources cited).' })}
+                </span>
+              </span>
+            </label>
+          ) : null}
           <ContextSummary config={contextConfig} personas={personas} documents={documents} />
         </div>
       )}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
@@ -21,6 +21,9 @@ export interface PersonaToolConfig {
 export interface ResearchToolConfig {
   question: string
   title: string
+  // Opt-in public web search grounding (only offered when the deployment
+  // has the AgentCore web search gateway).
+  useWebSearch: boolean
 }
 
 export type DocType = 'prd' | 'prfaq'

--- a/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/useProjectData.ts
@@ -151,6 +151,7 @@ export function useProjectMutations({
       selected_persona_ids: contextConfig.selectedPersonaIds,
       selected_document_ids: [...contextConfig.selectedDocumentIds, ...contextConfig.selectedResearchIds],
       response_language: i18n.language,
+      use_web_search: researchConfig.useWebSearch,
     }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['project-jobs', id] })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/useProjectWizardState.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/useProjectWizardState.ts
@@ -20,6 +20,7 @@ const DEFAULT_PERSONA_CONFIG: PersonaToolConfig = {
 const DEFAULT_RESEARCH_CONFIG: ResearchToolConfig = {
   question: '',
   title: '',
+  useWebSearch: false,
 }
 const DEFAULT_DOC_CONFIG: DocToolConfig = {
   docTypes: ['prfaq'],

--- a/voc-datalake/frontend/src/runtimeConfig.test.ts
+++ b/voc-datalake/frontend/src/runtimeConfig.test.ts
@@ -75,3 +75,81 @@ describe('loadRuntimeConfig env fallback', () => {
     expect(config.apiEndpoint).toBe('https://real-api.example.com')
   })
 })
+
+
+describe('isWebSearchAvailable', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  const baseConfig = {
+    apiEndpoint: 'https://real-api.example.com',
+    cognito: {
+      userPoolId: 'us-east-1_pool',
+      clientId: 'client123',
+      region: 'us-east-1',
+      identityPoolId: 'us-east-1:identity',
+    },
+  }
+
+  function stubConfigJson(config: Record<string, unknown>) {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(config),
+    }))
+  }
+
+  it('is false before the config loads', async () => {
+    const { isWebSearchAvailable } = await import('./runtimeConfig')
+    expect(isWebSearchAvailable()).toBe(false)
+  })
+
+  it('is true when the deployment reports the feature', async () => {
+    stubConfigJson({ ...baseConfig, features: { webSearch: true } })
+
+    const { loadRuntimeConfig, isWebSearchAvailable } = await import('./runtimeConfig')
+    await loadRuntimeConfig()
+
+    expect(isWebSearchAvailable()).toBe(true)
+  })
+
+  it('is false when the deployment reports webSearch: false', async () => {
+    stubConfigJson({ ...baseConfig, features: { webSearch: false } })
+
+    const { loadRuntimeConfig, isWebSearchAvailable } = await import('./runtimeConfig')
+    await loadRuntimeConfig()
+
+    expect(isWebSearchAvailable()).toBe(false)
+  })
+
+  it('is false for older config.json files without a features block', async () => {
+    stubConfigJson(baseConfig)
+
+    const { loadRuntimeConfig, isWebSearchAvailable } = await import('./runtimeConfig')
+    await loadRuntimeConfig()
+
+    expect(isWebSearchAvailable()).toBe(false)
+  })
+
+  it('honors VITE_ENABLE_WEB_SEARCH in the env fallback for local development', async () => {
+    vi.stubEnv('VITE_API_ENDPOINT', 'http://localhost:9999')
+    vi.stubEnv('VITE_COGNITO_USER_POOL_ID', 'us-east-1_pool')
+    vi.stubEnv('VITE_COGNITO_CLIENT_ID', 'client123')
+    vi.stubEnv('VITE_IDENTITY_POOL_ID', 'us-east-1:identity')
+    vi.stubEnv('VITE_ENABLE_WEB_SEARCH', 'true')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('config.json unavailable')))
+
+    const { loadRuntimeConfig, isWebSearchAvailable } = await import('./runtimeConfig')
+    await loadRuntimeConfig()
+
+    expect(isWebSearchAvailable()).toBe(true)
+  })
+})

--- a/voc-datalake/frontend/src/runtimeConfig.ts
+++ b/voc-datalake/frontend/src/runtimeConfig.ts
@@ -22,6 +22,11 @@ const RuntimeConfigSchema = z.object({
     region: z.string().min(1),
     identityPoolId: z.string().min(1),
   }),
+  // Optional capability flags: deployments without a given capability omit
+  // the flag (or the whole block) and the UI hides the feature.
+  features: z.object({
+    webSearch: z.boolean().optional(),
+  }).optional(),
 })
 
 export type RuntimeConfig = z.infer<typeof RuntimeConfigSchema>
@@ -71,6 +76,15 @@ export function isConfigLoaded(): boolean {
   return configState.config !== null
 }
 
+/**
+ * Whether this deployment has the AgentCore web search gateway, i.e. the
+ * chat/research "search the web" options should be offered at all.
+ * Safe to call before config load (returns false).
+ */
+export function isWebSearchAvailable(): boolean {
+  return configState.config?.features?.webSearch === true
+}
+
 async function fetchConfig(): Promise<RuntimeConfig> {
   try {
     const response = await fetch('/config.json', {
@@ -115,6 +129,11 @@ function getEnvConfig(): RuntimeConfig {
       clientId: getEnvString('VITE_COGNITO_CLIENT_ID'),
       region: getEnvString('VITE_COGNITO_REGION', 'us-east-1'),
       identityPoolId: getEnvString('VITE_IDENTITY_POOL_ID'),
+    },
+    // Local development: VITE_ENABLE_WEB_SEARCH=true surfaces the web search
+    // toggles without a deployed config.json.
+    features: {
+      webSearch: getEnvString('VITE_ENABLE_WEB_SEARCH') === 'true',
     },
   }
 

--- a/voc-datalake/frontend/src/store/chatStore.ts
+++ b/voc-datalake/frontend/src/store/chatStore.ts
@@ -1,12 +1,13 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { FeedbackItem } from '../api/client'
+import type { FeedbackItem, WebSource } from '../api/client'
 
 export interface ChatMessage {
   id: string
   role: 'user' | 'assistant'
   content: string
   sources?: FeedbackItem[]
+  webSources?: WebSource[]
   thinking?: string
   timestamp: Date
   filters?: ChatFilters
@@ -16,6 +17,9 @@ export interface ChatFilters {
   source?: string
   category?: string
   sentiment?: string
+  // Opt-in public web search for this conversation (only offered when the
+  // deployment has the AgentCore web search gateway).
+  useWebSearch?: boolean
 }
 
 export interface Conversation {

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -219,7 +219,10 @@ def api_run_research(project_id: str):
         'selected_persona_ids': body.get('selected_persona_ids', []),
         'selected_document_ids': body.get('selected_document_ids', []),
         'response_language': body.get('response_language'),
-        'use_web_search': bool(body.get('use_web_search', False)),
+        # Strict boolean check (mirrors the stream side's Zod validation):
+        # bool() coercion would turn the string "false" into True and
+        # silently enable a billed feature.
+        'use_web_search': body.get('use_web_search') is True,
         'filters': body
     }
     job_id, _ = create_job(project_id, 'research', 'research_config', research_config, status='pending')

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -219,6 +219,7 @@ def api_run_research(project_id: str):
         'selected_persona_ids': body.get('selected_persona_ids', []),
         'selected_document_ids': body.get('selected_document_ids', []),
         'response_language': body.get('response_language'),
+        'use_web_search': bool(body.get('use_web_search', False)),
         'filters': body
     }
     job_id, _ = create_job(project_id, 'research', 'research_config', research_config, status='pending')

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -351,7 +351,9 @@ def step_save(event: dict) -> dict:
     now = datetime.now(timezone.utc).isoformat()
     research_id = f"research_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     
-    web_search_note = ' | Web search: enabled' if config.get('use_web_search') else ''
+    # Strict boolean for parity with step_initialize's gating: a foreign
+    # "false" string skips the search, so it must not stamp the disclosure.
+    web_search_note = ' | Web search: enabled' if config.get('use_web_search') is True else ''
     # Build comprehensive report
     full_report = f"""# Research Report: {research_question}
 

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -144,8 +144,11 @@ def step_initialize(event: dict) -> dict:
     # enrichment — a search failure must never fail the research job, and the
     # 'web_context' key must ALWAYS be present in the return value because the
     # Step Functions resultSelector references it unconditionally.
+    # Strict boolean: the state machine can be started by other producers or
+    # execution replays, where a string "false" must not enable a billed
+    # feature (parity with projects_handler's normalization).
     web_context = ''
-    if config.get('use_web_search'):
+    if config.get('use_web_search') is True:
         if is_web_search_configured():
             update_job_status(project_id, job_id, 'running', 19, 'searching_web')
             question = config.get('question', '')

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -23,6 +23,12 @@ from shared.feedback import (
 )
 from shared.tables import get_projects_table, get_feedback_table
 from shared.jobs import update_job_status
+from shared.web_search import (
+    WebSearchError,
+    format_web_results_for_llm,
+    is_web_search_configured,
+    search_web,
+)
 
 # AWS Clients (using shared module for connection reuse)
 dynamodb = get_dynamodb_resource()
@@ -134,6 +140,24 @@ def step_initialize(event: dict) -> dict:
                 content = d.get('content', '')[:5000]  # Truncate long docs
                 documents_context += f"### {d.get('title', 'Untitled')} ({d.get('document_type', 'doc').upper()})\n\n{content}\n\n---\n\n"
     
+    # Optional: web search grounding (AgentCore Web Search Tool). Always an
+    # enrichment — a search failure must never fail the research job, and the
+    # 'web_context' key must ALWAYS be present in the return value because the
+    # Step Functions resultSelector references it unconditionally.
+    web_context = ''
+    if config.get('use_web_search'):
+        if is_web_search_configured():
+            update_job_status(project_id, job_id, 'running', 19, 'searching_web')
+            question = config.get('question', '')
+            try:
+                web_results = search_web(question)
+                web_context = format_web_results_for_llm(web_results)
+                logger.info(f"Web search grounding: {len(web_results)} results")
+            except WebSearchError as e:
+                logger.warning(f"Web search failed, continuing without web context: {e}")
+        else:
+            logger.warning("use_web_search requested but web search is not configured; skipping")
+
     update_job_status(project_id, job_id, 'running', 20, 'data_ready')
     
     return {
@@ -141,7 +165,8 @@ def step_initialize(event: dict) -> dict:
         'feedback_stats': feedback_stats,
         'feedback_count': len(feedback_items),
         'personas_context': personas_context,
-        'documents_context': documents_context
+        'documents_context': documents_context,
+        'web_context': web_context
     }
 @tracer.capture_method
 def step_analyze(event: dict) -> dict:
@@ -153,6 +178,7 @@ def step_analyze(event: dict) -> dict:
     feedback_stats = event['feedback_stats']
     personas_context = event.get('personas_context', '')
     documents_context = event.get('documents_context', '')
+    web_context = event.get('web_context', '')
     
     research_question = config.get('question', 'What are the main customer pain points?')
     
@@ -177,6 +203,17 @@ Be thorough, data-driven, and cite specific examples."""
         additional_context += f"\n{personas_context}\n"
     if documents_context:
         additional_context += f"\n{documents_context}\n"
+    if web_context:
+        additional_context += f"""
+## PUBLIC WEB SEARCH RESULTS
+
+The following results come from a public web search, NOT from customer
+feedback. Use them only to add market/industry context. When you draw on a
+web result, cite its source URL inline and clearly attribute the finding to
+"public web sources" rather than to customers.
+
+{web_context}
+"""
     
     user_prompt = f"""Conduct a thorough analysis to answer this research question based on the ACTUAL CUSTOMER FEEDBACK DATA provided below.
 
@@ -311,12 +348,13 @@ def step_save(event: dict) -> dict:
     now = datetime.now(timezone.utc).isoformat()
     research_id = f"research_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     
+    web_search_note = ' | Web search: enabled' if config.get('use_web_search') else ''
     # Build comprehensive report
     full_report = f"""# Research Report: {research_question}
 
 **Generated:** {now[:10]}
 **Feedback Analyzed:** {feedback_count} items
-**Filters:** Sources: {', '.join(filters.get('sources', [])) or 'All'} | Categories: {', '.join(filters.get('categories', [])) or 'All'} | Sentiments: {', '.join(filters.get('sentiments', [])) or 'All'} | Days: {filters.get('days', 30)}
+**Filters:** Sources: {', '.join(filters.get('sources', [])) or 'All'} | Categories: {', '.join(filters.get('categories', [])) or 'All'} | Sentiments: {', '.join(filters.get('sentiments', [])) or 'All'} | Days: {filters.get('days', 30)}{web_search_note}
 
 ---
 

--- a/voc-datalake/lambda/research/test/test_research_steps.py
+++ b/voc-datalake/lambda/research/test/test_research_steps.py
@@ -425,6 +425,27 @@ class TestStepInitializeWebSearch:
         assert result['feedback_count'] == 2  # research proceeded
 
     @patch('research_step_handler.search_web')
+    @patch('research_step_handler.is_web_search_configured', return_value=True)
+    @patch('research_step_handler.get_feedback_context')
+    @patch('research_step_handler.format_feedback_for_llm', return_value='fb')
+    @patch('research_step_handler.get_feedback_statistics', return_value='s')
+    def test_non_boolean_truthy_values_do_not_enable_web_search(self, mock_stats, mock_format, mock_get_fb,
+                                                                mock_configured, mock_search,
+                                                                mock_tables, mock_job_status, feedback_items):
+        """Strict-boolean parity with projects_handler: replayed or foreign
+        state-machine inputs carrying the STRING \"false\" (or \"true\") must
+        not trigger a billed search."""
+        from research_step_handler import step_initialize
+        mock_get_fb.return_value = feedback_items
+
+        for value in ('false', 'true', 1, 'yes'):
+            event = self._event(use_web_search=value)
+            result = step_initialize(event)
+            assert result['web_context'] == ''
+
+        mock_search.assert_not_called()
+
+    @patch('research_step_handler.search_web')
     @patch('research_step_handler.is_web_search_configured', return_value=False)
     @patch('research_step_handler.get_feedback_context')
     @patch('research_step_handler.format_feedback_for_llm', return_value='fb')

--- a/voc-datalake/lambda/research/test/test_research_steps.py
+++ b/voc-datalake/lambda/research/test/test_research_steps.py
@@ -352,3 +352,147 @@ class TestTableAccessors:
         result = rsh._get_projects_table()
         assert result is not None
         mock_get.assert_called_once()
+
+
+
+class TestStepInitializeWebSearch:
+    """Web search grounding in step_initialize (issue #68 / AgentCore).
+
+    Contract pinned here: 'web_context' is ALWAYS present in the return
+    value — the Step Functions resultSelector references it unconditionally,
+    so a missing key would fail the whole state, and a web search failure
+    must degrade to '' instead of failing the research job.
+    """
+
+    def _event(self, use_web_search):
+        return {
+            'project_id': 'p1', 'job_id': 'j1',
+            'research_config': {
+                'question': 'What are pain points?',
+                'sources': [], 'categories': [], 'sentiments': [], 'days': 30,
+                'selected_persona_ids': [], 'selected_document_ids': [],
+                'use_web_search': use_web_search,
+            }
+        }
+
+    @patch('research_step_handler.get_feedback_context')
+    @patch('research_step_handler.format_feedback_for_llm', return_value='fb')
+    @patch('research_step_handler.get_feedback_statistics', return_value='s')
+    def test_web_context_key_always_present_when_disabled(self, mock_stats, mock_format, mock_get_fb,
+                                                          mock_tables, mock_job_status, feedback_items):
+        from research_step_handler import step_initialize
+        mock_get_fb.return_value = feedback_items
+
+        result = step_initialize(self._event(use_web_search=False))
+
+        assert result['web_context'] == ''
+
+    @patch('research_step_handler.search_web')
+    @patch('research_step_handler.is_web_search_configured', return_value=True)
+    @patch('research_step_handler.get_feedback_context')
+    @patch('research_step_handler.format_feedback_for_llm', return_value='fb')
+    @patch('research_step_handler.get_feedback_statistics', return_value='s')
+    def test_searches_the_research_question_when_enabled(self, mock_stats, mock_format, mock_get_fb,
+                                                         mock_configured, mock_search,
+                                                         mock_tables, mock_job_status, feedback_items):
+        from research_step_handler import step_initialize
+        mock_get_fb.return_value = feedback_items
+        mock_search.return_value = [
+            {'title': 'T', 'url': 'https://t.example', 'text': 'Snippet', 'published_date': '2026-01-01'},
+        ]
+
+        result = step_initialize(self._event(use_web_search=True))
+
+        mock_search.assert_called_once_with('What are pain points?')
+        assert 'https://t.example' in result['web_context']
+
+    @patch('research_step_handler.search_web')
+    @patch('research_step_handler.is_web_search_configured', return_value=True)
+    @patch('research_step_handler.get_feedback_context')
+    @patch('research_step_handler.format_feedback_for_llm', return_value='fb')
+    @patch('research_step_handler.get_feedback_statistics', return_value='s')
+    def test_search_failure_degrades_to_empty_context(self, mock_stats, mock_format, mock_get_fb,
+                                                      mock_configured, mock_search,
+                                                      mock_tables, mock_job_status, feedback_items):
+        from research_step_handler import step_initialize
+        from shared.web_search import WebSearchError
+        mock_get_fb.return_value = feedback_items
+        mock_search.side_effect = WebSearchError('gateway down')
+
+        result = step_initialize(self._event(use_web_search=True))
+
+        assert result['web_context'] == ''
+        assert result['feedback_count'] == 2  # research proceeded
+
+    @patch('research_step_handler.search_web')
+    @patch('research_step_handler.is_web_search_configured', return_value=False)
+    @patch('research_step_handler.get_feedback_context')
+    @patch('research_step_handler.format_feedback_for_llm', return_value='fb')
+    @patch('research_step_handler.get_feedback_statistics', return_value='s')
+    def test_requested_but_unconfigured_skips_without_calling(self, mock_stats, mock_format, mock_get_fb,
+                                                              mock_configured, mock_search,
+                                                              mock_tables, mock_job_status, feedback_items):
+        from research_step_handler import step_initialize
+        mock_get_fb.return_value = feedback_items
+
+        result = step_initialize(self._event(use_web_search=True))
+
+        mock_search.assert_not_called()
+        assert result['web_context'] == ''
+
+
+class TestStepAnalyzeWebContext:
+    """Web results reach the analysis prompt with attribution rules."""
+
+    def _event(self, web_context):
+        return {
+            'project_id': 'p1', 'job_id': 'j1',
+            'research_config': {'question': 'Q?'},
+            'feedback_context': 'fb', 'feedback_stats': 's',
+            'web_context': web_context,
+        }
+
+    def test_web_section_included_with_citation_instructions(self, mock_job_status, mock_converse):
+        from research_step_handler import step_analyze
+
+        step_analyze(self._event('1. [Title](https://t.example)\n   Snippet'))
+
+        prompt = mock_converse.call_args.kwargs['prompt']
+        assert 'PUBLIC WEB SEARCH RESULTS' in prompt
+        assert 'https://t.example' in prompt
+        assert 'cite its source URL' in prompt
+
+    def test_no_web_section_when_context_empty(self, mock_job_status, mock_converse):
+        from research_step_handler import step_analyze
+
+        step_analyze(self._event(''))
+
+        prompt = mock_converse.call_args.kwargs['prompt']
+        assert 'PUBLIC WEB SEARCH RESULTS' not in prompt
+
+
+class TestStepSaveWebSearchNote:
+    """The saved report header discloses that web search was used."""
+
+    def _event(self, use_web_search):
+        return {
+            'project_id': 'p1', 'job_id': 'j1',
+            'research_config': {'question': 'Q?', 'title': 'T', 'filters': {}, 'use_web_search': use_web_search},
+            'feedback_count': 2, 'analysis': 'a', 'synthesis': 's', 'validation': 'v',
+        }
+
+    def test_report_notes_web_search_when_enabled(self, mock_tables, mock_job_status):
+        from research_step_handler import step_save
+
+        step_save(self._event(use_web_search=True))
+
+        saved = mock_tables['projects'].put_item.call_args.kwargs['Item']
+        assert 'Web search: enabled' in saved['content']
+
+    def test_report_silent_when_disabled(self, mock_tables, mock_job_status):
+        from research_step_handler import step_save
+
+        step_save(self._event(use_web_search=False))
+
+        saved = mock_tables['projects'].put_item.call_args.kwargs['Item']
+        assert 'Web search' not in saved['content']

--- a/voc-datalake/lambda/research/test/test_research_steps.py
+++ b/voc-datalake/lambda/research/test/test_research_steps.py
@@ -517,3 +517,14 @@ class TestStepSaveWebSearchNote:
 
         saved = mock_tables['projects'].put_item.call_args.kwargs['Item']
         assert 'Web search' not in saved['content']
+
+    def test_report_silent_for_string_false(self, mock_tables, mock_job_status):
+        """Disclosure parity with the strict gating in step_initialize: a
+        foreign \"false\" string skips the search, so the report must not
+        claim web search was used."""
+        from research_step_handler import step_save
+
+        step_save(self._event(use_web_search='false'))
+
+        saved = mock_tables['projects'].put_item.call_args.kwargs['Item']
+        assert 'Web search' not in saved['content']

--- a/voc-datalake/lambda/shared/test/test_web_search.py
+++ b/voc-datalake/lambda/shared/test/test_web_search.py
@@ -158,6 +158,23 @@ class TestToolNameDiscoveryFallback:
         assert web_search._resolved_tool_name['name'] == actual_name
 
     @patch.object(web_search, '_signed_post')
+    def test_stale_cached_name_re_triggers_discovery(self, mock_post):
+        """A target rename mid-container must self-heal: the cached name
+        failing with unknown-tool re-runs discovery instead of raising."""
+        web_search._resolved_tool_name['name'] = 'stale-target___WebSearch'
+        fresh = 'fresh-target___WebSearch'
+        mock_post.side_effect = [
+            {'error': {'message': "tool 'stale-target___WebSearch' not found"}},
+            {'result': {'tools': [{'name': fresh}]}},
+            {'result': _tool_result(SAMPLE_RESULTS)},
+        ]
+
+        results = search_web('query')
+
+        assert len(results) == 2
+        assert web_search._resolved_tool_name['name'] == fresh
+
+    @patch.object(web_search, '_signed_post')
     def test_non_name_errors_do_not_trigger_discovery(self, mock_post):
         mock_post.return_value = {'error': {'message': 'access denied'}}
         with pytest.raises(WebSearchError, match='access denied'):

--- a/voc-datalake/lambda/shared/test/test_web_search.py
+++ b/voc-datalake/lambda/shared/test/test_web_search.py
@@ -1,0 +1,218 @@
+"""Tests for shared/web_search.py — AgentCore Gateway web search client.
+
+The gateway is an external HTTP boundary, so these tests stub the signed
+transport (_signed_post) and pin the protocol handling around it: JSON-RPC
+envelopes, SSE-vs-JSON response bodies, the MCP result unwrapping, the
+tool-name discovery fallback, input clamping, and LLM formatting.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from shared import web_search
+from shared.web_search import (
+    MAX_QUERY_LENGTH,
+    WebSearchError,
+    format_web_results_for_llm,
+    is_web_search_configured,
+    search_web,
+)
+
+GATEWAY_URL = 'https://gw-abc123.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp'
+TOOL_NAME = 'web-search-tool___WebSearch'
+
+
+def _tool_result(results: list[dict]) -> dict:
+    """The gateway's tools/call result: results doc serialized inside
+    content[0].text (the MCP envelope from the AWS docs)."""
+    return {
+        'isError': False,
+        'content': [{'type': 'text', 'text': json.dumps({'id': 'abc', 'results': results})}],
+    }
+
+
+SAMPLE_RESULTS = [
+    {
+        'title': 'Python 3.13 Release Highlights',
+        'url': 'https://example.com/python/releases/3.13',
+        'text': 'Python 3.13 was released on October 7, 2024...',
+        'publishedDate': '2024-10-07',
+    },
+    # Knowledge-graph observation: null title/url, structured facts in text.
+    {'title': None, 'url': None, 'text': 'Founded: 1994. Founder: Jeff Bezos.'},
+]
+
+
+@pytest.fixture(autouse=True)
+def _configure(monkeypatch):
+    monkeypatch.setenv('WEB_SEARCH_GATEWAY_URL', GATEWAY_URL)
+    monkeypatch.setenv('WEB_SEARCH_TOOL_NAME', TOOL_NAME)
+    # The tool-name cache is per-container state; isolate every test.
+    web_search._resolved_tool_name['name'] = None
+    yield
+    web_search._resolved_tool_name['name'] = None
+
+
+class TestConfiguration:
+    def test_configured_when_gateway_url_set(self):
+        assert is_web_search_configured() is True
+
+    def test_not_configured_without_gateway_url(self, monkeypatch):
+        monkeypatch.delenv('WEB_SEARCH_GATEWAY_URL')
+        assert is_web_search_configured() is False
+
+    def test_search_refuses_when_unconfigured(self, monkeypatch):
+        monkeypatch.delenv('WEB_SEARCH_GATEWAY_URL')
+        with pytest.raises(WebSearchError, match='not configured'):
+            search_web('anything')
+
+    def test_region_parsed_from_gateway_url(self):
+        assert web_search._region_from_gateway_url(GATEWAY_URL) == 'us-east-1'
+
+    def test_region_falls_back_to_lambda_region(self, monkeypatch):
+        monkeypatch.setenv('AWS_REGION', 'eu-west-1')
+        assert web_search._region_from_gateway_url('https://unrelated.example.com/mcp') == 'eu-west-1'
+
+
+class TestSearchWeb:
+    @patch.object(web_search, '_signed_post')
+    def test_calls_the_configured_tool_and_normalizes_results(self, mock_post):
+        mock_post.return_value = {'jsonrpc': '2.0', 'id': 1, 'result': _tool_result(SAMPLE_RESULTS)}
+
+        results = search_web('python 3.13 release', max_results=5)
+
+        payload = mock_post.call_args[0][1]
+        assert payload['method'] == 'tools/call'
+        assert payload['params']['name'] == TOOL_NAME
+        assert payload['params']['arguments'] == {'query': 'python 3.13 release', 'maxResults': 5}
+        assert results == [
+            {
+                'title': 'Python 3.13 Release Highlights',
+                'url': 'https://example.com/python/releases/3.13',
+                'text': 'Python 3.13 was released on October 7, 2024...',
+                'published_date': '2024-10-07',
+            },
+            # Knowledge-graph fact kept, with empty (not None) title/url.
+            {'title': '', 'url': '', 'text': 'Founded: 1994. Founder: Jeff Bezos.', 'published_date': ''},
+        ]
+
+    @patch.object(web_search, '_signed_post')
+    def test_query_is_trimmed_and_clamped_to_connector_limit(self, mock_post):
+        mock_post.return_value = {'result': _tool_result([])}
+
+        search_web('  ' + 'q' * 500 + '  ', max_results=99)
+
+        arguments = mock_post.call_args[0][1]['params']['arguments']
+        assert len(arguments['query']) == MAX_QUERY_LENGTH
+        assert arguments['maxResults'] == web_search.MAX_RESULTS_CAP
+
+    def test_empty_query_is_rejected_without_a_network_call(self):
+        with patch.object(web_search, '_signed_post') as mock_post:
+            with pytest.raises(WebSearchError, match='empty'):
+                search_web('   ')
+        mock_post.assert_not_called()
+
+    @patch.object(web_search, '_signed_post')
+    def test_jsonrpc_error_raises(self, mock_post):
+        mock_post.return_value = {'error': {'code': -32000, 'message': 'throttled'}}
+        with pytest.raises(WebSearchError, match='throttled'):
+            search_web('query')
+
+    @patch.object(web_search, '_signed_post')
+    def test_tool_level_error_raises(self, mock_post):
+        mock_post.return_value = {
+            'result': {'isError': True, 'content': [{'type': 'text', 'text': 'quota exceeded'}]},
+        }
+        with pytest.raises(WebSearchError, match='quota exceeded'):
+            search_web('query')
+
+    @patch.object(web_search, '_signed_post')
+    def test_results_missing_text_are_dropped(self, mock_post):
+        mock_post.return_value = {
+            'result': _tool_result([{'title': 'No text', 'url': 'https://x.example'}, SAMPLE_RESULTS[0]]),
+        }
+        results = search_web('query')
+        assert len(results) == 1
+        assert results[0]['title'] == 'Python 3.13 Release Highlights'
+
+
+class TestToolNameDiscoveryFallback:
+    @patch.object(web_search, '_signed_post')
+    def test_unknown_tool_triggers_one_discovery_then_retry(self, mock_post):
+        actual_name = 'renamed-target___WebSearch'
+        mock_post.side_effect = [
+            {'error': {'message': "tool 'web-search-tool___WebSearch' not found"}},
+            {'result': {'tools': [{'name': 'other___Thing'}, {'name': actual_name}]}},
+            {'result': _tool_result(SAMPLE_RESULTS)},
+        ]
+
+        results = search_web('query')
+
+        methods = [call.args[1]['method'] for call in mock_post.call_args_list]
+        assert methods == ['tools/call', 'tools/list', 'tools/call']
+        assert mock_post.call_args_list[2].args[1]['params']['name'] == actual_name
+        assert len(results) == 2
+        # Cached for the rest of the container lifetime.
+        assert web_search._resolved_tool_name['name'] == actual_name
+
+    @patch.object(web_search, '_signed_post')
+    def test_non_name_errors_do_not_trigger_discovery(self, mock_post):
+        mock_post.return_value = {'error': {'message': 'access denied'}}
+        with pytest.raises(WebSearchError, match='access denied'):
+            search_web('query')
+        assert mock_post.call_count == 1
+
+    @patch.object(web_search, '_signed_post')
+    def test_discovery_without_websearch_tool_raises(self, mock_post):
+        mock_post.side_effect = [
+            {'error': {'message': 'unknown tool'}},
+            {'result': {'tools': [{'name': 'other___Thing'}]}},
+        ]
+        with pytest.raises(WebSearchError, match='No WebSearch tool'):
+            search_web('query')
+
+
+class TestResponseParsing:
+    def test_plain_json_body(self):
+        parsed = web_search._parse_jsonrpc_response('{"result": {"ok": true}}', 'application/json')
+        assert parsed == {'result': {'ok': True}}
+
+    def test_sse_framed_body(self):
+        raw = 'event: message\ndata: {"result": {"ok": true}}\n\n'
+        parsed = web_search._parse_jsonrpc_response(raw, 'text/event-stream')
+        assert parsed == {'result': {'ok': True}}
+
+    def test_sse_detected_without_content_type(self):
+        raw = 'data: {"result": 1}'
+        assert web_search._parse_jsonrpc_response(raw, '') == {'result': 1}
+
+    def test_non_json_raises(self):
+        with pytest.raises(WebSearchError, match='non-JSON'):
+            web_search._parse_jsonrpc_response('<html>502</html>', 'text/html')
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(WebSearchError, match='unexpected'):
+            web_search._parse_jsonrpc_response('[1, 2]', 'application/json')
+
+
+class TestFormatting:
+    def test_formats_citations_with_urls_and_dates(self):
+        results = [
+            {'title': 'A Title', 'url': 'https://a.example', 'text': 'Snippet A', 'published_date': '2026-01-01'},
+            {'title': '', 'url': '', 'text': 'A knowledge graph fact', 'published_date': ''},
+        ]
+        formatted = format_web_results_for_llm(results)
+        assert '1. A Title (2026-01-01)' in formatted
+        assert 'Source: https://a.example' in formatted
+        assert '2. Knowledge graph fact' in formatted
+        assert 'A knowledge graph fact' in formatted
+
+    def test_empty_results_format_to_empty_string(self):
+        assert format_web_results_for_llm([]) == ''
+
+    def test_snippets_are_truncated(self):
+        results = [{'title': 'T', 'url': 'https://t.example', 'text': 'x' * 5000, 'published_date': ''}]
+        formatted = format_web_results_for_llm(results)
+        assert len(formatted) < 1500

--- a/voc-datalake/lambda/shared/web_search.py
+++ b/voc-datalake/lambda/shared/web_search.py
@@ -1,0 +1,257 @@
+"""
+Web search via the Amazon Bedrock AgentCore Gateway Web Search Tool.
+
+The gateway exposes the AWS-managed `web-search` connector as a standard MCP
+tool. This module calls it directly over the gateway's streamable-HTTP MCP
+endpoint with a SigV4-signed JSON-RPC `tools/call` request — no MCP SDK or
+third-party search API needed, and queries never leave AWS.
+
+Configuration (both set by CDK when the feature is deployed):
+    WEB_SEARCH_GATEWAY_URL   e.g. https://gw-x.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp
+    WEB_SEARCH_TOOL_NAME     gateway-prefixed MCP tool name (target___tool)
+
+Acceptable use: callers surfacing results to end users MUST retain the
+source URLs/titles (see format_web_results_for_llm, which embeds them).
+"""
+
+import json
+import os
+import re
+import urllib.request
+from urllib.parse import urlparse
+
+import boto3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+from shared.logging import logger, tracer
+
+# The web-search connector caps queries at 200 characters.
+MAX_QUERY_LENGTH = 200
+# The connector allows up to 25 results; keep the default modest for
+# context economy ($7 / 1k queries — results size is a token cost, not a
+# query cost, but oversized snippets crowd out feedback context).
+DEFAULT_MAX_RESULTS = 8
+MAX_RESULTS_CAP = 10
+
+_REQUEST_TIMEOUT_SECONDS = 20
+
+# Resolved lazily and cached: the configured name is used as-is, but if the
+# gateway reports it unknown (target renamed, prefix convention change), we
+# fall back to one tools/list discovery per container.
+_resolved_tool_name: dict = {'name': None}
+
+
+class WebSearchError(Exception):
+    """Raised when a web search request fails. Callers should degrade
+    gracefully — web search is always an enrichment, never a hard
+    dependency."""
+
+
+def is_web_search_configured() -> bool:
+    """True when the AgentCore web search gateway is deployed and wired."""
+    return bool(os.environ.get('WEB_SEARCH_GATEWAY_URL', ''))
+
+
+def _gateway_url() -> str:
+    return os.environ.get('WEB_SEARCH_GATEWAY_URL', '')
+
+
+def _configured_tool_name() -> str:
+    return os.environ.get('WEB_SEARCH_TOOL_NAME', 'web-search-tool___WebSearch')
+
+
+def _region_from_gateway_url(url: str) -> str:
+    """The gateway lives in its own region (web-search is us-east-1-only),
+    which may differ from the Lambda's region — sign for the gateway's."""
+    host = urlparse(url).hostname or ''
+    match = re.search(r'\.gateway\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$', host)
+    if match:
+        return match.group(1)
+    return os.environ.get('AWS_REGION', 'us-east-1')
+
+
+def _signed_post(url: str, payload: dict) -> dict:
+    """POST a JSON-RPC payload to the gateway MCP endpoint with SigV4."""
+    body = json.dumps(payload)
+    session = boto3.session.Session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise WebSearchError('No AWS credentials available to sign the gateway request')
+
+    request = AWSRequest(
+        method='POST',
+        url=url,
+        data=body,
+        headers={
+            'Content-Type': 'application/json',
+            # Streamable-HTTP MCP servers may answer either plain JSON or SSE.
+            'Accept': 'application/json, text/event-stream',
+        },
+    )
+    SigV4Auth(credentials, 'bedrock-agentcore', _region_from_gateway_url(url)).add_auth(request)
+
+    http_request = urllib.request.Request(  # noqa: S310 — https gateway URL from CDK config
+        url,
+        data=body.encode('utf-8'),
+        headers=dict(request.headers),
+        method='POST',
+    )
+    try:
+        with urllib.request.urlopen(http_request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:  # noqa: S310
+            content_type = response.headers.get('Content-Type', '')
+            raw = response.read().decode('utf-8')
+    except Exception as e:
+        raise WebSearchError(f'Gateway request failed: {e}') from e
+
+    return _parse_jsonrpc_response(raw, content_type)
+
+
+def _parse_jsonrpc_response(raw: str, content_type: str) -> dict:
+    """Parse a JSON-RPC response that may arrive as plain JSON or as an SSE
+    frame (`data: {...}`), depending on how the gateway answers."""
+    text = raw.strip()
+    if 'text/event-stream' in content_type or text.startswith(('event:', 'data:')):
+        for line in text.splitlines():
+            if line.startswith('data:'):
+                text = line[len('data:'):].strip()
+                break
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise WebSearchError(f'Gateway returned non-JSON response: {text[:200]}') from e
+    if not isinstance(parsed, dict):
+        raise WebSearchError('Gateway returned unexpected JSON-RPC shape')
+    return parsed
+
+
+def _rpc(method: str, params: dict) -> dict:
+    """Issue one JSON-RPC call and return its `result`, raising on `error`."""
+    response = _signed_post(_gateway_url(), {
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': method,
+        'params': params,
+    })
+    if 'error' in response:
+        error = response['error']
+        message = error.get('message', str(error)) if isinstance(error, dict) else str(error)
+        raise WebSearchError(f'Gateway {method} error: {message}')
+    result = response.get('result')
+    if not isinstance(result, dict):
+        raise WebSearchError(f'Gateway {method} returned no result')
+    return result
+
+
+def _discover_tool_name() -> str:
+    """Find the WebSearch tool via tools/list (name is target-prefixed,
+    e.g. `web-search-tool___WebSearch`)."""
+    result = _rpc('tools/list', {})
+    tools = result.get('tools', [])
+    for tool in tools:
+        name = tool.get('name', '') if isinstance(tool, dict) else ''
+        if name.endswith('WebSearch'):
+            return name
+    raise WebSearchError('No WebSearch tool exposed by the gateway')
+
+
+def _is_unknown_tool_error(error: WebSearchError) -> bool:
+    return 'tool' in str(error).lower() and (
+        'not found' in str(error).lower() or 'unknown' in str(error).lower()
+    )
+
+
+def _call_web_search_tool(query: str, max_results: int) -> dict:
+    """tools/call with the configured name; on an unknown-tool error,
+    discover the real name once per container and retry."""
+    tool_name = _resolved_tool_name['name'] or _configured_tool_name()
+    arguments = {'query': query, 'maxResults': max_results}
+    try:
+        result = _rpc('tools/call', {'name': tool_name, 'arguments': arguments})
+    except WebSearchError as e:
+        if _resolved_tool_name['name'] or not _is_unknown_tool_error(e):
+            raise
+        discovered = _discover_tool_name()
+        logger.info(f"Web search tool name resolved via tools/list: {discovered}")
+        _resolved_tool_name['name'] = discovered
+        result = _rpc('tools/call', {'name': discovered, 'arguments': arguments})
+    else:
+        _resolved_tool_name['name'] = tool_name
+    return result
+
+
+def _extract_results(tool_result: dict) -> list[dict]:
+    """Unwrap the MCP envelope: content[0].text is a serialized JSON document
+    with an `id` and a `results` array of observations."""
+    if tool_result.get('isError'):
+        content = tool_result.get('content', [])
+        detail = content[0].get('text', '') if content and isinstance(content[0], dict) else ''
+        raise WebSearchError(f'Web search tool error: {detail[:300]}')
+
+    content = tool_result.get('content', [])
+    if not content or not isinstance(content[0], dict):
+        raise WebSearchError('Web search returned an empty MCP content block')
+    try:
+        payload = json.loads(content[0].get('text', ''))
+    except json.JSONDecodeError as e:
+        raise WebSearchError('Web search returned non-JSON result text') from e
+
+    raw_results = payload.get('results', []) if isinstance(payload, dict) else []
+    results = []
+    for raw in raw_results:
+        if not isinstance(raw, dict):
+            continue
+        text = str(raw.get('text', '') or '')
+        if not text:
+            continue
+        results.append({
+            'title': str(raw.get('title') or ''),
+            'url': str(raw.get('url') or ''),
+            'text': text,
+            'published_date': str(raw.get('publishedDate') or ''),
+        })
+    return results
+
+
+@tracer.capture_method
+def search_web(query: str, max_results: int = DEFAULT_MAX_RESULTS) -> list[dict]:
+    """Run one web search and return normalized observations.
+
+    Returns a list of {title, url, text, published_date} dicts. Knowledge-graph
+    observations (structured facts) come back with empty title/url and are kept
+    — their text is high-confidence factual grounding.
+
+    Raises WebSearchError on any failure; callers must treat web results as
+    optional enrichment.
+    """
+    if not is_web_search_configured():
+        raise WebSearchError('Web search is not configured (WEB_SEARCH_GATEWAY_URL unset)')
+    trimmed = query.strip()[:MAX_QUERY_LENGTH]
+    if not trimmed:
+        raise WebSearchError('Web search query is empty')
+    clamped = max(1, min(int(max_results), MAX_RESULTS_CAP))
+
+    tool_result = _call_web_search_tool(trimmed, clamped)
+    results = _extract_results(tool_result)
+    logger.info(f"Web search returned {len(results)} results for query ({len(trimmed)} chars)")
+    return results
+
+
+def format_web_results_for_llm(results: list[dict]) -> str:
+    """Format results for prompt context, keeping URLs/titles so the model can
+    (and the acceptable-use policy says it must) cite sources."""
+    if not results:
+        return ''
+    lines = []
+    for i, result in enumerate(results, 1):
+        title = result.get('title') or 'Knowledge graph fact'
+        url = result.get('url') or ''
+        published = result.get('published_date') or ''
+        header = f"{i}. {title}"
+        if published:
+            header += f" ({published})"
+        if url:
+            header += f"\n   Source: {url}"
+        snippet = (result.get('text') or '')[:1200]
+        lines.append(f"{header}\n   {snippet}")
+    return '\n\n'.join(lines)

--- a/voc-datalake/lambda/shared/web_search.py
+++ b/voc-datalake/lambda/shared/web_search.py
@@ -38,8 +38,19 @@ _REQUEST_TIMEOUT_SECONDS = 20
 
 # Resolved lazily and cached: the configured name is used as-is, but if the
 # gateway reports it unknown (target renamed, prefix convention change), we
-# fall back to one tools/list discovery per container.
+# fall back to tools/list discovery — at most once per call.
 _resolved_tool_name: dict = {'name': None}
+
+# Module-level credential cache (repo pattern: module-level boto3 state for
+# connection/credential reuse). botocore credentials self-refresh, so caching
+# the resolved provider is safe across invocations.
+_credentials_cache: dict = {'credentials': None}
+
+
+def _get_credentials():
+    if _credentials_cache['credentials'] is None:
+        _credentials_cache['credentials'] = boto3.session.Session().get_credentials()
+    return _credentials_cache['credentials']
 
 
 class WebSearchError(Exception):
@@ -74,8 +85,7 @@ def _region_from_gateway_url(url: str) -> str:
 def _signed_post(url: str, payload: dict) -> dict:
     """POST a JSON-RPC payload to the gateway MCP endpoint with SigV4."""
     body = json.dumps(payload)
-    session = boto3.session.Session()
-    credentials = session.get_credentials()
+    credentials = _get_credentials()
     if credentials is None:
         raise WebSearchError('No AWS credentials available to sign the gateway request')
 
@@ -145,7 +155,11 @@ def _rpc(method: str, params: dict) -> dict:
 
 def _discover_tool_name() -> str:
     """Find the WebSearch tool via tools/list (name is target-prefixed,
-    e.g. `web-search-tool___WebSearch`)."""
+    e.g. `web-search-tool___WebSearch`).
+
+    Reads only the first page: MCP tools/list can paginate via nextCursor,
+    but this gateway exposes a single connector target with one tool.
+    """
     result = _rpc('tools/list', {})
     tools = result.get('tools', [])
     for tool in tools:
@@ -162,14 +176,15 @@ def _is_unknown_tool_error(error: WebSearchError) -> bool:
 
 
 def _call_web_search_tool(query: str, max_results: int) -> dict:
-    """tools/call with the configured name; on an unknown-tool error,
-    discover the real name once per container and retry."""
+    """tools/call with the configured (or previously discovered) name; on an
+    unknown-tool error — including a stale cached name after a target rename
+    — discover the real name via tools/list and retry once."""
     tool_name = _resolved_tool_name['name'] or _configured_tool_name()
     arguments = {'query': query, 'maxResults': max_results}
     try:
         result = _rpc('tools/call', {'name': tool_name, 'arguments': arguments})
     except WebSearchError as e:
-        if _resolved_tool_name['name'] or not _is_unknown_tool_error(e):
+        if not _is_unknown_tool_error(e):
             raise
         discovered = _discover_tool_name()
         logger.info(f"Web search tool name resolved via tools/list: {discovered}")

--- a/voc-datalake/lambda/stream/package-lock.json
+++ b/voc-datalake/lambda/stream/package-lock.json
@@ -10,7 +10,11 @@
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.750.0",
         "@aws-sdk/client-dynamodb": "^3.750.0",
+        "@aws-sdk/credential-provider-node": "^3.750.0",
         "@aws-sdk/lib-dynamodb": "^3.750.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/signature-v4": "^5.3.0",
+        "@smithy/types": "^4.13.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {

--- a/voc-datalake/lambda/stream/package.json
+++ b/voc-datalake/lambda/stream/package.json
@@ -14,7 +14,11 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.750.0",
     "@aws-sdk/client-dynamodb": "^3.750.0",
+    "@aws-sdk/credential-provider-node": "^3.750.0",
     "@aws-sdk/lib-dynamodb": "^3.750.0",
+    "@smithy/protocol-http": "^5.3.0",
+    "@smithy/signature-v4": "^5.3.0",
+    "@smithy/types": "^4.13.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/voc-datalake/lambda/stream/src/handler.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.test.ts
@@ -17,6 +17,7 @@ const {
   mockSendErrorAndClose,
   mockStreamifyResponse,
   mockWrapStreamWithHeaders,
+  mockIsWebSearchConfigured,
 } = vi.hoisted(() => ({
   mockBuildVocChatContext: vi.fn(),
   mockBuildProjectChatContext: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockSendErrorAndClose: vi.fn(),
   mockStreamifyResponse: vi.fn(),
   mockWrapStreamWithHeaders: vi.fn(),
+  mockIsWebSearchConfigured: vi.fn(),
 }));
 
 vi.mock('./context/voc-context.js', () => ({
@@ -55,6 +57,11 @@ vi.mock('./tools/index.js', () => ({
   getUpdateDocumentTool: vi.fn().mockReturnValue({ toolSpec: { name: 'update_document' } }),
   getCreateDocumentTool: vi.fn().mockReturnValue({ toolSpec: { name: 'create_document' } }),
   getCreateProjectTool: vi.fn().mockReturnValue({ toolSpec: { name: 'create_project' } }),
+  getWebSearchTool: vi.fn().mockReturnValue({ toolSpec: { name: 'web_search' } }),
+}));
+
+vi.mock('./tools/web-search.js', () => ({
+  isWebSearchConfigured: mockIsWebSearchConfigured,
 }));
 
 vi.mock('./tools/executor.js', () => ({
@@ -119,6 +126,48 @@ describe('handler', () => {
       selectedDocumentIds: [],
       documents: [],
     });
+
+    // Default: web search gateway not deployed (mirrors the env default).
+    mockIsWebSearchConfigured.mockReturnValue(false);
+  });
+
+  // ── Web search tool registration ──
+
+  function toolNamesPassedToConverse(): string[] {
+    const call = mockConverseStream.mock.calls[0]?.[0] as { tools?: Array<{ toolSpec?: { name?: string } }> } | undefined;
+    return (call?.tools ?? []).map((tool) => tool.toolSpec?.name ?? '');
+  }
+
+  it('registers web_search in VoC chat when opted in and configured', async () => {
+    mockIsWebSearchConfigured.mockReturnValue(true);
+
+    await (handler as Function)(makeEvent({ message: 'hello', use_web_search: true }), mockStream());
+
+    expect(toolNamesPassedToConverse()).toContain('web_search');
+  });
+
+  it('omits web_search without the opt-in flag even when configured', async () => {
+    mockIsWebSearchConfigured.mockReturnValue(true);
+
+    await (handler as Function)(makeEvent({ message: 'hello' }), mockStream());
+
+    expect(toolNamesPassedToConverse()).not.toContain('web_search');
+  });
+
+  it('omits web_search when opted in but the gateway is not deployed', async () => {
+    mockIsWebSearchConfigured.mockReturnValue(false);
+
+    await (handler as Function)(makeEvent({ message: 'hello', use_web_search: true }), mockStream());
+
+    expect(toolNamesPassedToConverse()).not.toContain('web_search');
+  });
+
+  it('registers web_search in project chat when opted in and configured', async () => {
+    mockIsWebSearchConfigured.mockReturnValue(true);
+
+    await (handler as Function)(makeEvent({ message: 'hello', project_id: 'proj-1', use_web_search: true }), mockStream());
+
+    expect(toolNamesPassedToConverse()).toContain('web_search');
   });
 
   it('routes to VoC chat when no project_id', async () => {

--- a/voc-datalake/lambda/stream/src/handler.ts
+++ b/voc-datalake/lambda/stream/src/handler.ts
@@ -19,7 +19,9 @@ import { z } from 'zod';
 import { converseStream } from './bedrock/converse-stream.js';
 import { processStreamEvent, createStreamState, type ToolUseBlock } from './bedrock/stream-processor.js';
 import { executeTool } from './tools/executor.js';
-import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool, getCreateProjectTool } from './tools/index.js';
+import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool, getCreateProjectTool, getWebSearchTool } from './tools/index.js';
+import { isWebSearchConfigured } from './tools/web-search.js';
+import type { WebSource } from './tools/web-search.js';
 import type { DocumentChange } from './tools/update-document.js';
 import type { ProjectChange } from './tools/create-project.js';
 import { buildVocChatContext } from './context/voc-context.js';
@@ -95,6 +97,18 @@ function extractProjectId(path: string): string | null {
 
 // ── Tool execution helpers ──
 
+/** Artifacts accumulated across all tool rounds of one conversation. */
+interface CollectedArtifacts {
+  sources: Record<string, unknown>[];
+  documentChanges: DocumentChange[];
+  projectChanges: ProjectChange[];
+  webSources: WebSource[];
+}
+
+function createCollectedArtifacts(): CollectedArtifacts {
+  return { sources: [], documentChanges: [], projectChanges: [], webSources: [] };
+}
+
 function buildAssistantContent(state: { textContent: string; toolUseBlocks: ToolUseBlock[] }): ContentBlock[] {
   const content: ContentBlock[] = [];
   if (state.textContent) {
@@ -109,9 +123,7 @@ function buildAssistantContent(state: { textContent: string; toolUseBlocks: Tool
 async function executeToolsAndBuildResults(
   toolUseBlocks: ToolUseBlock[],
   contextFilters: ContextFilters,
-  collectedSources: Record<string, unknown>[],
-  collectedDocumentChanges: DocumentChange[],
-  collectedProjectChanges: ProjectChange[],
+  collected: CollectedArtifacts,
   stream: NodeJS.WritableStream,
   projectsTable?: string,
   projectId?: string,
@@ -127,12 +139,15 @@ async function executeToolsAndBuildResults(
       projectsTable,
       projectId,
     );
-    collectedSources.push(...result.sources);
+    collected.sources.push(...result.sources);
     if (result.documentChange) {
-      collectedDocumentChanges.push(result.documentChange);
+      collected.documentChanges.push(result.documentChange);
     }
     if (result.projectChange) {
-      collectedProjectChanges.push(result.projectChange);
+      collected.projectChanges.push(result.projectChange);
+    }
+    if (result.webSources) {
+      collected.webSources.push(...result.webSources);
     }
     // Notify the frontend that the tool has completed
     sendSSE(stream, { type: 'tool_result', toolName: tb.name });
@@ -150,9 +165,7 @@ async function runConversationLoop(
   stream: NodeJS.WritableStream,
   systemPrompt: string,
   contextFilters: ContextFilters,
-  collectedSources: Record<string, unknown>[],
-  collectedDocumentChanges: DocumentChange[],
-  collectedProjectChanges: ProjectChange[],
+  collected: CollectedArtifacts,
   loopCount: number,
   projectsTable?: string,
   projectId?: string,
@@ -194,14 +207,13 @@ async function runConversationLoop(
   messages.push({ role: 'assistant', content: buildAssistantContent(state) });
 
   const toolResults = await executeToolsAndBuildResults(
-    state.toolUseBlocks, contextFilters, collectedSources, collectedDocumentChanges,
-    collectedProjectChanges, stream, projectsTable, projectId,
+    state.toolUseBlocks, contextFilters, collected, stream, projectsTable, projectId,
   );
   messages.push({ role: 'user', content: toolResults });
 
   await runConversationLoop(
     messages, tools, stream, systemPrompt, contextFilters,
-    collectedSources, collectedDocumentChanges, collectedProjectChanges, loopCount + 1,
+    collected, loopCount + 1,
     projectsTable, projectId,
   );
 }
@@ -238,19 +250,26 @@ async function handleVocChat(body: ChatRequest, stream: NodeJS.WritableStream): 
   // projectId here (VoC chat is project-agnostic), but create_project only
   // needs the table, so PROJECTS_TABLE is passed as the projectsTable arg.
   const tools: Tool[] = [getSearchFeedbackTool(), getCreateProjectTool()];
-  const sources: Record<string, unknown>[] = [];
-  const documentChanges: DocumentChange[] = [];
-  const projectChanges: ProjectChange[] = [];
+  // Public web search is opt-in per request AND requires the AgentCore
+  // gateway to be deployed; otherwise the model never sees the tool.
+  if (body.use_web_search === true && isWebSearchConfigured()) {
+    tools.push(getWebSearchTool());
+  }
+  const collected = createCollectedArtifacts();
 
   await runConversationLoop(
     messages, tools, stream, ctx.systemPrompt, ctx.metadata.filters,
-    sources, documentChanges, projectChanges, 0,
+    collected, 0,
     PROJECTS_TABLE,
   );
 
   sendSSE(stream, {
     type: 'done',
-    metadata: { sources: deduplicateSources(sources), project_changes: projectChanges },
+    metadata: {
+      sources: deduplicateSources(collected.sources),
+      project_changes: collected.projectChanges,
+      web_sources: deduplicateWebSources(collected.webSources),
+    },
   });
   stream.end();
 }
@@ -386,18 +405,20 @@ async function handleProjectChat(
   // Always provide document tools in project chat so the AI can edit/create
   // documents even when they aren't explicitly #-mentioned
   const tools: Tool[] = [getSearchFeedbackTool(), getUpdateDocumentTool(), getCreateDocumentTool()];
+  if (body.use_web_search === true && isWebSearchConfigured()) {
+    tools.push(getWebSearchTool());
+  }
   console.log('Project chat tools:', tools.map(t => t.toolSpec?.name));
   console.log('Project ID:', projectId, 'PROJECTS_TABLE:', PROJECTS_TABLE);
 
-  const documentChanges: DocumentChange[] = [];
-  const projectChanges: ProjectChange[] = [];
+  const collected = createCollectedArtifacts();
 
   await runConversationLoop(
     messages, tools, stream, ctx.systemPrompt,
     // Project chat has no context string, but the picker's window settings
     // still apply to the search tool (issue #150).
     { days: body.days, dateBasis: body.date_basis },
-    [], documentChanges, projectChanges, 0,
+    collected, 0,
     PROJECTS_TABLE, projectId,
   );
 
@@ -405,7 +426,8 @@ async function handleProjectChat(
     type: 'done',
     metadata: {
       ...ctx.metadata,
-      document_changes: documentChanges,
+      document_changes: collected.documentChanges,
+      web_sources: deduplicateWebSources(collected.webSources),
     },
   });
   stream.end();
@@ -419,6 +441,17 @@ function deduplicateSources(sources: Record<string, unknown>[]): Record<string, 
     const id = typeof s.feedback_id === 'string' ? s.feedback_id : '';
     if (!id || seen.has(id)) return false;
     seen.add(id);
+    return true;
+  });
+}
+
+/** Dedupe web results by URL across tool rounds; keep URL-less
+ * knowledge-graph facts out of the citation list (nothing to link). */
+function deduplicateWebSources(webSources: WebSource[]): WebSource[] {
+  const seen = new Set<string>();
+  return webSources.filter((s) => {
+    if (!s.url || seen.has(s.url)) return false;
+    seen.add(s.url);
     return true;
   });
 }

--- a/voc-datalake/lambda/stream/src/schema.test.ts
+++ b/voc-datalake/lambda/stream/src/schema.test.ts
@@ -156,6 +156,17 @@ describe('chatRequestSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts the use_web_search opt-in flag', () => {
+    const result = chatRequestSchema.safeParse({ message: 'hi', use_web_search: true });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.use_web_search).toBe(true);
+  });
+
+  it('rejects a non-boolean use_web_search', () => {
+    const result = chatRequestSchema.safeParse({ message: 'hi', use_web_search: 'yes' });
+    expect(result.success).toBe(false);
+  });
 });
 
 

--- a/voc-datalake/lambda/stream/src/schema.ts
+++ b/voc-datalake/lambda/stream/src/schema.ts
@@ -39,6 +39,9 @@ export const chatRequestSchema = z.object({
   selected_documents: z.array(z.string()).optional(),
   // Roundtable mode: each selected persona responds in turn
   roundtable: z.boolean().optional(),
+  // Opt-in public web search (only honored when the AgentCore web search
+  // gateway is deployed; silently ignored otherwise)
+  use_web_search: z.boolean().optional(),
   // Attachments (images, PDFs)
   attachments: z.array(attachmentSchema).max(5).optional(),
   // Conversation history for multi-turn context

--- a/voc-datalake/lambda/stream/src/tools/executor.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/executor.test.ts
@@ -14,10 +14,15 @@ const mockExecuteSearchFeedback = vi.fn();
 const mockExecuteUpdateDocument = vi.fn();
 const mockExecuteCreateDocument = vi.fn();
 const mockExecuteCreateProject = vi.fn();
+const mockExecuteWebSearch = vi.fn();
 const mockSendSSE = vi.fn();
 
 vi.mock('./search-feedback.js', () => ({
   executeSearchFeedback: (...args: unknown[]) => mockExecuteSearchFeedback(...args),
+}));
+
+vi.mock('./web-search.js', () => ({
+  executeWebSearch: (...args: unknown[]) => mockExecuteWebSearch(...args),
 }));
 
 vi.mock('./update-document.js', () => ({
@@ -374,6 +379,51 @@ describe('executeTool', () => {
       );
 
       expect(result.projectChange).toEqual(projectChange);
+    });
+  });
+
+  describe('web_search', () => {
+    const webSources = [
+      { title: 'A Title', url: 'https://a.example', text: 'Snippet', published_date: '2026-01-01' },
+    ];
+
+    it('routes to executeWebSearch and returns webSources without feedback sources', async () => {
+      mockExecuteWebSearch.mockResolvedValueOnce({ content: 'Found 1 web results...', webSources });
+
+      const result = await executeTool(
+        makeToolBlock({ name: 'web_search', input: { query: 'competitor news' } }),
+        docClient, feedbackTable, {}, stream,
+      );
+
+      expect(mockExecuteWebSearch).toHaveBeenCalledWith({ query: 'competitor news' });
+      expect(result.webSources).toEqual(webSources);
+      // Web results must NOT masquerade as feedback sources (the frontend
+      // renders sources as feedback cards, web sources as cited links).
+      expect(result.sources).toEqual([]);
+      expect(result.content).toBe('Found 1 web results...');
+    });
+
+    it('emits a web-result count in the tool_result SSE event', async () => {
+      mockExecuteWebSearch.mockResolvedValueOnce({ content: 'ok', webSources });
+
+      await executeTool(
+        makeToolBlock({ name: 'web_search', input: { query: 'q' } }),
+        docClient, feedbackTable, {}, stream,
+      );
+
+      const toolResultEvents = mockSendSSE.mock.calls
+        .map((call) => call[1] as { type: string; content?: string })
+        .filter((event) => event.type === 'tool_result');
+      expect(toolResultEvents[0].content).toBe('Found 1 web results');
+    });
+
+    it('propagates web search failures', async () => {
+      mockExecuteWebSearch.mockRejectedValueOnce(new Error('gateway down'));
+
+      await expect(executeTool(
+        makeToolBlock({ name: 'web_search', input: { query: 'q' } }),
+        docClient, feedbackTable, {}, stream,
+      )).rejects.toThrow('gateway down');
     });
   });
 });

--- a/voc-datalake/lambda/stream/src/tools/executor.ts
+++ b/voc-datalake/lambda/stream/src/tools/executor.ts
@@ -8,6 +8,8 @@ import { executeUpdateDocument, executeCreateDocument } from './update-document.
 import type { DocumentChange } from './update-document.js';
 import { executeCreateProject } from './create-project.js';
 import type { ProjectChange } from './create-project.js';
+import { executeWebSearch } from './web-search.js';
+import type { WebSource } from './web-search.js';
 import { sendSSE } from '../lib/streaming.js';
 import { ServiceError } from '../lib/errors.js';
 import type { ToolUseBlock } from '../bedrock/stream-processor.js';
@@ -27,10 +29,24 @@ interface ToolResult {
   sources: Record<string, unknown>[];
   documentChange?: DocumentChange;
   projectChange?: ProjectChange;
+  webSources?: WebSource[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** One-line summary for the tool_result SSE event. */
+function summarizeToolResult(result: {
+  sources: Record<string, unknown>[];
+  documentChange?: DocumentChange;
+  projectChange?: ProjectChange;
+  webSources?: WebSource[];
+}): string {
+  if (result.projectChange) return `${result.projectChange.action}: ${result.projectChange.name}`;
+  if (result.documentChange) return `${result.documentChange.action}: ${result.documentChange.title}`;
+  if (result.webSources) return `Found ${result.webSources.length} web results`;
+  return `Found ${result.sources.length} items`;
 }
 
 async function handleSearchFeedback(
@@ -44,13 +60,57 @@ async function handleSearchFeedback(
   return { content: result.formatted, sources: result.items.slice(0, 5) };
 }
 
-interface ExecuteToolOptions {
-  docClient: DynamoDBDocumentClient;
-  feedbackTable: string;
-  projectsTable?: string;
-  projectId?: string;
-  contextFilters: ContextFilters;
-  stream: NodeJS.WritableStream;
+interface DispatchedResult {
+  content: string;
+  sources: Record<string, unknown>[];
+  documentChange?: DocumentChange;
+  projectChange?: ProjectChange;
+  webSources?: WebSource[];
+}
+
+/** Route a tool call to its implementation. */
+async function dispatchTool(
+  tool: ToolUseBlock,
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  contextFilters: ContextFilters,
+  projectsTable?: string,
+  projectId?: string,
+): Promise<DispatchedResult> {
+  switch (tool.name) {
+    case 'search_feedback': {
+      return handleSearchFeedback(tool.input, docClient, feedbackTable, contextFilters);
+    }
+    case 'web_search': {
+      const webResult = await executeWebSearch(tool.input);
+      // Web results are NOT feedback sources — they flow through webSources
+      // so the frontend renders them as cited links, not feedback cards.
+      return { content: webResult.content, sources: [], webSources: webResult.webSources };
+    }
+    case 'create_project': {
+      if (!projectsTable) throw new ServiceError('Projects table not configured for create_project');
+      console.log('create_project called:', JSON.stringify(tool.input));
+      const projectResult = await executeCreateProject(docClient, projectsTable, tool.input);
+      console.log('create_project result:', projectResult.content);
+      return { content: projectResult.content, sources: [], projectChange: projectResult.projectChange };
+    }
+    case 'update_document': {
+      if (!projectsTable || !projectId) throw new ServiceError('Project context required for update_document');
+      console.log('update_document called:', JSON.stringify(tool.input));
+      const updateResult = await executeUpdateDocument(docClient, projectsTable, projectId, tool.input);
+      console.log('update_document result:', updateResult.content);
+      return { content: updateResult.content, sources: [], documentChange: updateResult.documentChange };
+    }
+    case 'create_document': {
+      if (!projectsTable || !projectId) throw new ServiceError('Project context required for create_document');
+      console.log('create_document called:', JSON.stringify(tool.input));
+      const createResult = await executeCreateDocument(docClient, projectsTable, projectId, tool.input);
+      console.log('create_document result:', createResult.content);
+      return { content: createResult.content, sources: [], documentChange: createResult.documentChange };
+    }
+    default:
+      throw new ServiceError(`Unknown tool '${tool.name}'`);
+  }
 }
 
 export async function executeTool(
@@ -64,57 +124,10 @@ export async function executeTool(
 ): Promise<ToolResult> {
   sendSSE(stream, { type: 'tool_use', toolName: tool.name, toolInput: tool.input });
 
-  let result: {
-    content: string;
-    sources: Record<string, unknown>[];
-    documentChange?: DocumentChange;
-    projectChange?: ProjectChange;
-  };
-
-  switch (tool.name) {
-    case 'search_feedback': {
-      const searchResult = await handleSearchFeedback(tool.input, docClient, feedbackTable, contextFilters);
-      result = searchResult;
-      break;
-    }
-    case 'create_project': {
-      if (!projectsTable) throw new ServiceError('Projects table not configured for create_project');
-      console.log('create_project called:', JSON.stringify(tool.input));
-      const projectResult = await executeCreateProject(docClient, projectsTable, tool.input);
-      console.log('create_project result:', projectResult.content);
-      result = { content: projectResult.content, sources: [], projectChange: projectResult.projectChange };
-      break;
-    }
-    case 'update_document': {
-      if (!projectsTable || !projectId) throw new ServiceError('Project context required for update_document');
-      console.log('update_document called:', JSON.stringify(tool.input));
-      const updateResult = await executeUpdateDocument(docClient, projectsTable, projectId, tool.input);
-      console.log('update_document result:', updateResult.content);
-      result = { content: updateResult.content, sources: [], documentChange: updateResult.documentChange };
-      break;
-    }
-    case 'create_document': {
-      if (!projectsTable || !projectId) throw new ServiceError('Project context required for create_document');
-      console.log('create_document called:', JSON.stringify(tool.input));
-      const createResult = await executeCreateDocument(docClient, projectsTable, projectId, tool.input);
-      console.log('create_document result:', createResult.content);
-      result = { content: createResult.content, sources: [], documentChange: createResult.documentChange };
-      break;
-    }
-    default:
-      throw new ServiceError(`Unknown tool '${tool.name}'`);
-  }
+  const result = await dispatchTool(tool, docClient, feedbackTable, contextFilters, projectsTable, projectId);
 
   // Send tool_result SSE event
-  let resultSummary: string;
-  if (result.projectChange) {
-    resultSummary = `${result.projectChange.action}: ${result.projectChange.name}`;
-  } else if (result.documentChange) {
-    resultSummary = `${result.documentChange.action}: ${result.documentChange.title}`;
-  } else {
-    resultSummary = `Found ${result.sources.length} items`;
-  }
-  sendSSE(stream, { type: 'tool_result', toolName: tool.name, content: resultSummary });
+  sendSSE(stream, { type: 'tool_result', toolName: tool.name, content: summarizeToolResult(result) });
 
   // Send document_changed SSE event if a document was modified
   if (result.documentChange) {
@@ -138,5 +151,6 @@ export async function executeTool(
     sources: result.sources,
     documentChange: result.documentChange,
     projectChange: result.projectChange,
+    webSources: result.webSources,
   };
 }

--- a/voc-datalake/lambda/stream/src/tools/index.ts
+++ b/voc-datalake/lambda/stream/src/tools/index.ts
@@ -171,3 +171,35 @@ export function getCreateProjectTool(): Tool {
     },
   };
 }
+
+
+export function getWebSearchTool(): Tool {
+  return {
+    toolSpec: {
+      name: 'web_search',
+      description:
+        'Search the public web for current, external information: competitor moves, industry ' +
+        'news, product releases, market context, or anything not present in the customer ' +
+        'feedback dataset. The user explicitly enabled web search for this conversation. ' +
+        'Use search_feedback (not this tool) for anything about the customers\u2019 own feedback. ' +
+        'Keep queries under 200 characters. ALWAYS cite the source URLs from the results ' +
+        'inline in your answer \u2014 uncited web claims are not acceptable.',
+      inputSchema: {
+        json: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Natural-language search query (200 characters max).',
+            },
+            max_results: {
+              type: 'number',
+              description: 'How many results to return (1-10, default 5).',
+            },
+          },
+          required: ['query'],
+        },
+      },
+    },
+  };
+}

--- a/voc-datalake/lambda/stream/src/tools/web-search.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/web-search.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the web_search tool (AgentCore Gateway MCP client).
+ *
+ * The gateway is an external HTTP boundary: fetch is stubbed and the tests
+ * pin the protocol around it — SigV4-signed JSON-RPC requests, SSE-vs-JSON
+ * response bodies, MCP result unwrapping, tool-name discovery fallback,
+ * input clamping, and the citation-bearing formatting contract.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@aws-sdk/credential-provider-node', () => ({
+  // Static credentials so the real SignatureV4 can sign offline.
+  defaultProvider: () => () =>
+    Promise.resolve({ accessKeyId: 'AKIATEST', secretAccessKey: 'test-secret' }),
+}));
+
+import {
+  executeWebSearch,
+  isWebSearchConfigured,
+  resetToolNameCacheForTesting,
+} from './web-search.js';
+
+const GATEWAY_URL = 'https://gw-abc123.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp';
+const TOOL_NAME = 'web-search-tool___WebSearch';
+
+const SAMPLE_RESULTS = [
+  {
+    title: 'Python 3.13 Release Highlights',
+    url: 'https://example.com/python/releases/3.13',
+    text: 'Python 3.13 was released on October 7, 2024...',
+    publishedDate: '2024-10-07',
+  },
+  // Knowledge-graph observation: null title/url, structured facts in text.
+  { title: null, url: null, text: 'Founded: 1994. Founder: Jeff Bezos.' },
+];
+
+function toolCallBody(results: unknown[]): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      isError: false,
+      content: [{ type: 'text', text: JSON.stringify({ id: 'abc', results }) }],
+    },
+  });
+}
+
+function jsonResponse(body: string, status = 200, contentType = 'application/json'): Response {
+  return new Response(body, { status, headers: { 'content-type': contentType } });
+}
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv('WEB_SEARCH_GATEWAY_URL', GATEWAY_URL);
+  vi.stubEnv('WEB_SEARCH_TOOL_NAME', TOOL_NAME);
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+  resetToolNameCacheForTesting();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+function sentBody(callIndex = 0): { method: string; params: { name?: string; arguments?: Record<string, unknown> } } {
+  const init = mockFetch.mock.calls[callIndex][1] as { body: string };
+  return JSON.parse(init.body) as { method: string; params: { name?: string; arguments?: Record<string, unknown> } };
+}
+
+describe('isWebSearchConfigured', () => {
+  it('is true when the gateway URL is set', () => {
+    expect(isWebSearchConfigured()).toBe(true);
+  });
+
+  it('is false without the gateway URL', () => {
+    vi.stubEnv('WEB_SEARCH_GATEWAY_URL', '');
+    expect(isWebSearchConfigured()).toBe(false);
+  });
+});
+
+describe('executeWebSearch', () => {
+  it('rejects when unconfigured', async () => {
+    vi.stubEnv('WEB_SEARCH_GATEWAY_URL', '');
+    await expect(executeWebSearch({ query: 'x' })).rejects.toThrow('not configured');
+  });
+
+  it('skips empty queries without a network call', async () => {
+    const result = await executeWebSearch({ query: '   ' });
+    expect(result.content).toContain('empty query');
+    expect(result.webSources).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends a SigV4-signed JSON-RPC tools/call and normalizes results', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(toolCallBody(SAMPLE_RESULTS)));
+
+    const result = await executeWebSearch({ query: 'python 3.13 release' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(url).toBe(GATEWAY_URL);
+    // Signed by the real SignatureV4 for the gateway's region/service.
+    expect(init.headers.authorization).toContain('AWS4-HMAC-SHA256');
+    expect(init.headers.authorization).toContain('us-east-1/bedrock-agentcore');
+
+    const body = sentBody();
+    expect(body.method).toBe('tools/call');
+    expect(body.params.name).toBe(TOOL_NAME);
+    expect(body.params.arguments).toEqual({ query: 'python 3.13 release', maxResults: 5 });
+
+    expect(result.webSources).toEqual([
+      {
+        title: 'Python 3.13 Release Highlights',
+        url: 'https://example.com/python/releases/3.13',
+        text: 'Python 3.13 was released on October 7, 2024...',
+        published_date: '2024-10-07',
+      },
+      // Knowledge-graph fact kept, with empty (not null) title/url.
+      { title: '', url: '', text: 'Founded: 1994. Founder: Jeff Bezos.', published_date: '' },
+    ]);
+    // Formatting keeps citations and instructs the model to use them.
+    expect(result.content).toContain('cite its source URL');
+    expect(result.content).toContain('[Python 3.13 Release Highlights](https://example.com/python/releases/3.13)');
+  });
+
+  it('clamps the query to 200 chars and max_results to 10', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(toolCallBody([])));
+
+    await executeWebSearch({ query: 'q'.repeat(500), max_results: 99 });
+
+    const args = sentBody().params.arguments ?? {};
+    expect(String(args.query)).toHaveLength(200);
+    expect(args.maxResults).toBe(10);
+  });
+
+  it('parses SSE-framed gateway responses', async () => {
+    const sse = `event: message\ndata: ${toolCallBody(SAMPLE_RESULTS)}\n\n`;
+    mockFetch.mockResolvedValueOnce(jsonResponse(sse, 200, 'text/event-stream'));
+
+    const result = await executeWebSearch({ query: 'query' });
+    expect(result.webSources).toHaveLength(2);
+  });
+
+  it('reports zero results without failing', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(toolCallBody([])));
+    const result = await executeWebSearch({ query: 'query' });
+    expect(result.webSources).toEqual([]);
+    expect(result.content).toContain('No web results');
+  });
+
+  it('surfaces JSON-RPC errors', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'throttled' } })));
+    await expect(executeWebSearch({ query: 'q' })).rejects.toThrow('throttled');
+  });
+
+  it('surfaces tool-level errors from the MCP envelope', async () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      result: { isError: true, content: [{ type: 'text', text: 'quota exceeded' }] },
+    });
+    mockFetch.mockResolvedValueOnce(jsonResponse(body));
+    await expect(executeWebSearch({ query: 'q' })).rejects.toThrow('quota exceeded');
+  });
+
+  it('surfaces HTTP failures with status', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse('forbidden', 403, 'text/plain'));
+    await expect(executeWebSearch({ query: 'q' })).rejects.toThrow('HTTP 403');
+  });
+
+  it('surfaces non-JSON bodies', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse('<html>502</html>', 200, 'text/html'));
+    await expect(executeWebSearch({ query: 'q' })).rejects.toThrow('non-JSON');
+  });
+});
+
+describe('tool name discovery fallback', () => {
+  it('resolves the real tool name via tools/list on unknown-tool errors, then caches it', async () => {
+    const discovered = 'renamed-target___WebSearch';
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: "tool 'web-search-tool___WebSearch' not found" } })))
+      .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: [{ name: 'other___Thing' }, { name: discovered }] } })))
+      .mockResolvedValueOnce(jsonResponse(toolCallBody(SAMPLE_RESULTS)));
+
+    const result = await executeWebSearch({ query: 'query' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(sentBody(0).method).toBe('tools/call');
+    expect(sentBody(1).method).toBe('tools/list');
+    expect(sentBody(2).params.name).toBe(discovered);
+    expect(result.webSources).toHaveLength(2);
+
+    // Subsequent calls go straight to the discovered name.
+    mockFetch.mockResolvedValueOnce(jsonResponse(toolCallBody([])));
+    await executeWebSearch({ query: 'second' });
+    expect(sentBody(3).params.name).toBe(discovered);
+  });
+
+  it('does not attempt discovery for non-name errors', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'access denied' } })));
+    await expect(executeWebSearch({ query: 'q' })).rejects.toThrow('access denied');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails clearly when the gateway exposes no WebSearch tool', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'unknown tool' } })))
+      .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: [{ name: 'other___Thing' }] } })));
+    await expect(executeWebSearch({ query: 'q' })).rejects.toThrow('No WebSearch tool');
+  });
+});

--- a/voc-datalake/lambda/stream/src/tools/web-search.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/web-search.test.ts
@@ -203,6 +203,26 @@ describe('tool name discovery fallback', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  it('re-discovers when a previously cached name goes stale (target renamed)', async () => {
+    const first = 'first-target___WebSearch';
+    const renamed = 'renamed-target___WebSearch';
+    // Populate the cache through a successful call.
+    vi.stubEnv('WEB_SEARCH_TOOL_NAME', first);
+    mockFetch.mockResolvedValueOnce(jsonResponse(toolCallBody([])));
+    await executeWebSearch({ query: 'warm up' });
+
+    // The cached name now fails; a fresh discovery must self-heal.
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: `tool '${first}' not found` } })))
+      .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: [{ name: renamed }] } })))
+      .mockResolvedValueOnce(jsonResponse(toolCallBody(SAMPLE_RESULTS)));
+
+    const result = await executeWebSearch({ query: 'query' });
+
+    expect(result.webSources).toHaveLength(2);
+    expect(sentBody(3).params.name).toBe(renamed);
+  });
+
   it('fails clearly when the gateway exposes no WebSearch tool', async () => {
     mockFetch
       .mockResolvedValueOnce(jsonResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'unknown tool' } })))

--- a/voc-datalake/lambda/stream/src/tools/web-search.ts
+++ b/voc-datalake/lambda/stream/src/tools/web-search.ts
@@ -175,12 +175,12 @@ async function rpc(method: string, params: Record<string, unknown>): Promise<unk
 
 // ── Tool name resolution ──
 
-// Resolved once per container: the configured name is used as-is, but if the
+// Resolved lazily and cached: the configured name is used as-is, but if the
 // gateway reports it unknown (target renamed, prefix convention change), we
-// fall back to one tools/list discovery.
+// fall back to tools/list discovery — at most once per call.
 const resolvedToolName: { name: string | null } = { name: null };
 
-/** Test hook: clears the per-container tool-name cache. */
+/** @internal Test hook: clears the per-container tool-name cache. */
 export function resetToolNameCacheForTesting(): void {
   resolvedToolName.name = null;
 }
@@ -189,6 +189,8 @@ const toolsListSchema = z.object({
   tools: z.array(z.object({ name: z.string() }).passthrough()).optional(),
 }).passthrough();
 
+/** Reads only the first page: MCP tools/list can paginate via nextCursor,
+ * but this gateway exposes a single connector target with one tool. */
 async function discoverToolName(): Promise<string> {
   const result = toolsListSchema.safeParse(await rpc('tools/list', {}));
   const tools = result.success ? result.data.tools ?? [] : [];
@@ -203,6 +205,9 @@ function isUnknownToolError(err: unknown): boolean {
   return message.includes('tool') && (message.includes('not found') || message.includes('unknown'));
 }
 
+/** tools/call with the configured (or previously discovered) name; on an
+ * unknown-tool error — including a stale cached name after a target rename
+ * — discover the real name via tools/list and retry once. */
 async function callWebSearchTool(query: string, maxResults: number): Promise<unknown> {
   const toolName = resolvedToolName.name ?? configuredToolName();
   const params = { name: toolName, arguments: { query, maxResults } };
@@ -211,7 +216,7 @@ async function callWebSearchTool(query: string, maxResults: number): Promise<unk
     resolvedToolName.name = toolName;
     return result;
   } catch (err) {
-    if (resolvedToolName.name !== null || !isUnknownToolError(err)) throw err;
+    if (!isUnknownToolError(err)) throw err;
     const discovered = await discoverToolName();
     console.log(`Web search tool name resolved via tools/list: ${discovered}`);
     resolvedToolName.name = discovered;

--- a/voc-datalake/lambda/stream/src/tools/web-search.ts
+++ b/voc-datalake/lambda/stream/src/tools/web-search.ts
@@ -1,0 +1,324 @@
+/**
+ * web_search tool implementation — Amazon Bedrock AgentCore Gateway.
+ *
+ * The gateway exposes the AWS-managed `web-search` connector as a standard
+ * MCP tool. We call it directly over the gateway's streamable-HTTP MCP
+ * endpoint with a SigV4-signed JSON-RPC `tools/call` — no MCP SDK and no
+ * third-party search API; queries are served entirely within AWS.
+ *
+ * Configured via env (set by CDK only when the gateway is deployed):
+ *   WEB_SEARCH_GATEWAY_URL  gateway MCP endpoint
+ *   WEB_SEARCH_TOOL_NAME    gateway-prefixed MCP tool name (target___tool)
+ *
+ * Acceptable use: source titles/URLs must reach the end user — the formatted
+ * tool result embeds markdown links and the handler forwards `webSources`
+ * so the UI can render citations even if the model omits them.
+ */
+import { createHash, createHmac } from 'node:crypto';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { HttpRequest } from '@smithy/protocol-http';
+import { SignatureV4 } from '@smithy/signature-v4';
+import type { SourceData } from '@smithy/types';
+import { z } from 'zod';
+import { ServiceError } from '../lib/errors.js';
+
+// The web-search connector caps queries at 200 characters.
+const MAX_QUERY_LENGTH = 200;
+// Connector allows up to 25 results; keep chat answers lean.
+const DEFAULT_MAX_RESULTS = 5;
+const MAX_RESULTS_CAP = 10;
+
+const REQUEST_TIMEOUT_MS = 20_000;
+
+// ── Configuration ──
+
+export function isWebSearchConfigured(): boolean {
+  return Boolean(process.env.WEB_SEARCH_GATEWAY_URL);
+}
+
+function gatewayUrl(): string {
+  return process.env.WEB_SEARCH_GATEWAY_URL ?? '';
+}
+
+function configuredToolName(): string {
+  return process.env.WEB_SEARCH_TOOL_NAME ?? 'web-search-tool___WebSearch';
+}
+
+/** The gateway lives in its own region (web-search is us-east-1-only), which
+ * may differ from the Lambda's — sign for the gateway's region. */
+function regionFromGatewayUrl(url: string): string {
+  const host = new URL(url).hostname;
+  const match = /\.gateway\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$/.exec(host);
+  return match?.[1] ?? process.env.AWS_REGION ?? 'us-east-1';
+}
+
+// ── SigV4 signing (node:crypto adapter keeps this dependency-free) ──
+
+/** Normalize the SDK's SourceData union into bytes for node:crypto
+ * (strings are encoded as UTF-8, matching node's default). */
+function toBinary(data: SourceData): Uint8Array {
+  if (typeof data === 'string') return new TextEncoder().encode(data);
+  if (data instanceof Uint8Array) return data;
+  if (ArrayBuffer.isView(data)) return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  return new Uint8Array(data);
+}
+
+class NodeSha256 {
+  private readonly parts: Uint8Array[] = [];
+  private readonly secret?: Uint8Array;
+
+  constructor(secret?: SourceData) {
+    this.secret = secret === undefined ? undefined : toBinary(secret);
+  }
+
+  update(chunk: SourceData): void {
+    this.parts.push(toBinary(chunk));
+  }
+
+  digest(): Promise<Uint8Array> {
+    const hasher = this.secret === undefined
+      ? createHash('sha256')
+      : createHmac('sha256', this.secret);
+    for (const part of this.parts) hasher.update(part);
+    return Promise.resolve(new Uint8Array(hasher.digest()));
+  }
+
+  reset(): void {
+    this.parts.length = 0;
+  }
+}
+
+async function signedFetch(url: string, body: string): Promise<Response> {
+  const parsed = new URL(url);
+  const signer = new SignatureV4({
+    service: 'bedrock-agentcore',
+    region: regionFromGatewayUrl(url),
+    credentials: defaultProvider(),
+    sha256: NodeSha256,
+  });
+
+  const request = new HttpRequest({
+    method: 'POST',
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    path: parsed.pathname,
+    headers: {
+      host: parsed.hostname,
+      'content-type': 'application/json',
+      // Streamable-HTTP MCP servers may answer either plain JSON or SSE.
+      accept: 'application/json, text/event-stream',
+    },
+    body,
+  });
+
+  const signed = await signer.sign(request);
+  return fetch(url, {
+    method: 'POST',
+    headers: signed.headers,
+    body,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}
+
+// ── JSON-RPC over streamable HTTP ──
+
+const jsonRpcResponseSchema = z.object({
+  result: z.unknown().optional(),
+  error: z.object({ message: z.string().optional() }).passthrough().optional(),
+}).passthrough();
+
+/** JSON-RPC responses may arrive as plain JSON or as an SSE frame
+ * (`data: {...}`) depending on how the gateway answers. */
+function extractJsonRpcText(raw: string, contentType: string): string {
+  const text = raw.trim();
+  if (contentType.includes('text/event-stream') || text.startsWith('event:') || text.startsWith('data:')) {
+    for (const line of text.split('\n')) {
+      if (line.startsWith('data:')) return line.slice('data:'.length).trim();
+    }
+  }
+  return text;
+}
+
+/** JSON.parse with a domain error instead of a SyntaxError. */
+function parseJsonOrThrow(text: string, what: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ServiceError(`${what}: ${text.slice(0, 200)}`);
+  }
+}
+
+async function rpc(method: string, params: Record<string, unknown>): Promise<unknown> {
+  const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+  const response = await signedFetch(gatewayUrl(), body).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ServiceError(`Web search gateway request failed: ${message}`);
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new ServiceError(`Web search gateway HTTP ${response.status}: ${raw.slice(0, 200)}`);
+  }
+
+  const parsed = parseJsonOrThrow(
+    extractJsonRpcText(raw, response.headers.get('content-type') ?? ''),
+    'Web search gateway returned non-JSON response',
+  );
+  const envelope = jsonRpcResponseSchema.safeParse(parsed);
+  if (!envelope.success) {
+    throw new ServiceError('Web search gateway returned an unexpected JSON-RPC shape');
+  }
+  if (envelope.data.error) {
+    throw new ServiceError(`Web search gateway ${method} error: ${envelope.data.error.message ?? 'unknown'}`);
+  }
+  return envelope.data.result;
+}
+
+// ── Tool name resolution ──
+
+// Resolved once per container: the configured name is used as-is, but if the
+// gateway reports it unknown (target renamed, prefix convention change), we
+// fall back to one tools/list discovery.
+const resolvedToolName: { name: string | null } = { name: null };
+
+/** Test hook: clears the per-container tool-name cache. */
+export function resetToolNameCacheForTesting(): void {
+  resolvedToolName.name = null;
+}
+
+const toolsListSchema = z.object({
+  tools: z.array(z.object({ name: z.string() }).passthrough()).optional(),
+}).passthrough();
+
+async function discoverToolName(): Promise<string> {
+  const result = toolsListSchema.safeParse(await rpc('tools/list', {}));
+  const tools = result.success ? result.data.tools ?? [] : [];
+  const webSearch = tools.find((tool) => tool.name.endsWith('WebSearch'));
+  if (!webSearch) throw new ServiceError('No WebSearch tool exposed by the gateway');
+  return webSearch.name;
+}
+
+function isUnknownToolError(err: unknown): boolean {
+  if (!(err instanceof ServiceError)) return false;
+  const message = err.message.toLowerCase();
+  return message.includes('tool') && (message.includes('not found') || message.includes('unknown'));
+}
+
+async function callWebSearchTool(query: string, maxResults: number): Promise<unknown> {
+  const toolName = resolvedToolName.name ?? configuredToolName();
+  const params = { name: toolName, arguments: { query, maxResults } };
+  try {
+    const result = await rpc('tools/call', params);
+    resolvedToolName.name = toolName;
+    return result;
+  } catch (err) {
+    if (resolvedToolName.name !== null || !isUnknownToolError(err)) throw err;
+    const discovered = await discoverToolName();
+    console.log(`Web search tool name resolved via tools/list: ${discovered}`);
+    resolvedToolName.name = discovered;
+    return rpc('tools/call', { ...params, name: discovered });
+  }
+}
+
+// ── Result parsing ──
+
+const toolCallResultSchema = z.object({
+  isError: z.boolean().optional(),
+  content: z.array(z.object({ type: z.string().optional(), text: z.string().optional() }).passthrough()).optional(),
+}).passthrough();
+
+const webResultSchema = z.object({
+  title: z.string().nullable().optional(),
+  url: z.string().nullable().optional(),
+  text: z.string(),
+  publishedDate: z.string().nullable().optional(),
+}).passthrough();
+
+const searchPayloadSchema = z.object({
+  results: z.array(z.unknown()).optional(),
+}).passthrough();
+
+export interface WebSource {
+  title: string;
+  url: string;
+  text: string;
+  published_date: string;
+}
+
+/** Unwrap the MCP envelope down to the serialized results document. */
+function extractResultsDocument(toolResult: unknown): string {
+  const envelope = toolCallResultSchema.safeParse(toolResult);
+  if (!envelope.success) throw new ServiceError('Web search returned an unexpected MCP result shape');
+  const { isError, content } = envelope.data;
+  const firstText = content?.[0]?.text ?? '';
+  if (isError) throw new ServiceError(`Web search tool error: ${firstText.slice(0, 300)}`);
+  if (!firstText) throw new ServiceError('Web search returned an empty MCP content block');
+  return firstText;
+}
+
+/** Normalize raw observations. Knowledge-graph observations (structured
+ * facts) have null title/url and are kept — their text is high-confidence
+ * grounding. */
+function normalizeResults(rawResults: unknown[]): WebSource[] {
+  const sources: WebSource[] = [];
+  for (const raw of rawResults) {
+    const result = webResultSchema.safeParse(raw);
+    if (!result.success || result.data.text === '') continue;
+    sources.push({
+      title: result.data.title ?? '',
+      url: result.data.url ?? '',
+      text: result.data.text,
+      published_date: result.data.publishedDate ?? '',
+    });
+  }
+  return sources;
+}
+
+/** content[0].text is a serialized JSON document with a `results` array. */
+function extractResults(toolResult: unknown): WebSource[] {
+  const document = extractResultsDocument(toolResult);
+  const payload = parseJsonOrThrow(document, 'Web search returned non-JSON result text');
+  const parsedPayload = searchPayloadSchema.safeParse(payload);
+  return normalizeResults(parsedPayload.success ? parsedPayload.data.results ?? [] : []);
+}
+
+// ── Formatting ──
+
+function formatSource(source: WebSource, index: number): string {
+  const title = source.title === '' ? 'Knowledge graph fact' : source.title;
+  const published = source.published_date === '' ? '' : ` (${source.published_date})`;
+  const link = source.url === '' ? title : `[${title}](${source.url})`;
+  return `${index + 1}. ${link}${published}\n   ${source.text.slice(0, 1200)}`;
+}
+
+function formatResults(sources: WebSource[]): string {
+  if (sources.length === 0) return 'No web results found for this query.';
+  const header = `Found ${sources.length} web results. When you use one in your answer, cite its source URL inline:\n\n`;
+  return header + sources.map((source, i) => formatSource(source, i)).join('\n\n');
+}
+
+// ── Main export ──
+
+const webSearchInputSchema = z.object({
+  query: z.string().optional(),
+  max_results: z.number().optional(),
+}).passthrough();
+
+export async function executeWebSearch(
+  toolInput: unknown,
+): Promise<{ content: string; webSources: WebSource[] }> {
+  if (!isWebSearchConfigured()) {
+    throw new ServiceError('Web search is not configured (WEB_SEARCH_GATEWAY_URL unset)');
+  }
+  const parsed = webSearchInputSchema.safeParse(toolInput);
+  const input = parsed.success ? parsed.data : {};
+  const query = (input.query ?? '').trim().slice(0, MAX_QUERY_LENGTH);
+  if (query === '') {
+    return { content: 'Web search skipped: empty query.', webSources: [] };
+  }
+  const maxResults = Math.max(1, Math.min(Math.trunc(input.max_results ?? DEFAULT_MAX_RESULTS), MAX_RESULTS_CAP));
+
+  const toolResult = await callWebSearchTool(query, maxResults);
+  const webSources = extractResults(toolResult);
+  console.log(`web_search: ${webSources.length} results for a ${query.length}-char query`);
+  return { content: formatResults(webSources), webSources };
+}

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -660,6 +660,11 @@ export class VocApiStack extends cdk.Stack {
     const chatStreamLambda = new NodejsFunction(this, 'ChatStreamApi', {
       functionName: uniqueName('voc-chat-stream'),
       entry: path.join(__dirname, '../../lambda/stream/src/handler.ts'),
+      // The nodeModules install step below pairs CDK's generated minimal
+      // package.json with a copied lockfile. Without this, CDK discovers the
+      // CDK app's root package-lock.json (which doesn't contain the stream
+      // Lambda's deps) and `npm ci` fails with EUSAGE at bundling time.
+      depsLockFilePath: path.join(__dirname, '../../lambda/stream/package-lock.json'),
       handler: 'handler',
       runtime: lambda.Runtime.NODEJS_22_X,
       architecture: lambda.Architecture.ARM_64,

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -680,6 +680,15 @@ export class VocApiStack extends cdk.Stack {
           '@aws-sdk/*',
           '@smithy/*',
         ],
+        // The web-search SigV4 client imports these directly; bundle them so
+        // it runs against the pinned versions from package.json instead of
+        // whatever the managed runtime's SDK happens to hoist (transitive
+        // availability is not a documented contract). They are tiny.
+        nodeModules: [
+          '@aws-sdk/credential-provider-node',
+          '@smithy/protocol-http',
+          '@smithy/signature-v4',
+        ],
       },
       logGroup: this.createLogGroup('ChatStreamLogs', uniqueName('voc-chat-stream')),
     });
@@ -716,14 +725,17 @@ export class VocApiStack extends cdk.Stack {
 
     // Web search tool (AgentCore Gateway) — optional, opt-in per request.
     // Without the gateway the env vars stay unset and the tool is never
-    // registered with the model.
-    const webSearchEnabled = Boolean(webSearchGatewayUrl && webSearchGatewayArn && webSearchToolName);
-    if (webSearchGatewayUrl && webSearchGatewayArn && webSearchToolName) {
-      chatStreamLambda.addEnvironment('WEB_SEARCH_GATEWAY_URL', webSearchGatewayUrl);
-      chatStreamLambda.addEnvironment('WEB_SEARCH_TOOL_NAME', webSearchToolName);
+    // registered with the model. Collapse the three optional props into one
+    // narrowed value so enablement is decided exactly once.
+    const webSearch = webSearchGatewayUrl && webSearchGatewayArn && webSearchToolName
+      ? { gatewayUrl: webSearchGatewayUrl, gatewayArn: webSearchGatewayArn, toolName: webSearchToolName }
+      : undefined;
+    if (webSearch) {
+      chatStreamLambda.addEnvironment('WEB_SEARCH_GATEWAY_URL', webSearch.gatewayUrl);
+      chatStreamLambda.addEnvironment('WEB_SEARCH_TOOL_NAME', webSearch.toolName);
       chatStreamLambda.addToRolePolicy(new iam.PolicyStatement({
         actions: ['bedrock-agentcore:InvokeGateway'],
-        resources: [webSearchGatewayArn],
+        resources: [webSearch.gatewayArn],
       }));
     }
 
@@ -1120,7 +1132,7 @@ exports.handler = async (event) => {
       // Capability flags so the same frontend build can show/hide features
       // per environment (web search only exists when the gateway deployed).
       features: {
-        webSearch: webSearchEnabled,
+        webSearch: webSearch !== undefined,
       },
     };
 
@@ -1151,7 +1163,7 @@ exports.handler = async (event) => {
     new cdk.CfnOutput(this, 'CognitoUserPoolId', { value: userPool.userPoolId, description: 'Cognito User Pool ID' });
     new cdk.CfnOutput(this, 'CognitoClientId', { value: userPoolClient.userPoolClientId, description: 'Cognito User Pool Client ID' });
     new cdk.CfnOutput(this, 'WebSearchAvailable', {
-      value: webSearchEnabled ? 'true' : 'false',
+      value: webSearch !== undefined ? 'true' : 'false',
       description: 'Whether the AgentCore web search gateway is deployed (drives the frontend feature flag)',
     });
   }

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -47,6 +47,11 @@ export interface VocApiStackProps extends cdk.StackProps {
 
   // Processing stack resources
   researchStateMachine: sfn.StateMachine;
+  // Web search (AgentCore Gateway) — absent when the feature isn't deployed
+  // (non-us-east-1 regions or enableWebSearch=false).
+  webSearchGatewayUrl?: string;
+  webSearchGatewayArn?: string;
+  webSearchToolName?: string;
 
   // Config
   brandName: string;
@@ -74,7 +79,8 @@ export class VocApiStack extends cdk.Stack {
       feedbackTable, aggregatesTable, projectsTable, jobsTable, conversationsTable,
       kmsKey, rawDataBucket, avatarsCdnUrl, prototypesCdnUrl, websiteBucket, frontendDistribution,
       frontendDomainName, userPool, userPoolClient, identityPool, processingQueueUrl, processingQueueArn,
-      secretsArn, s3ImportBucket, researchStateMachine, brandName
+      secretsArn, s3ImportBucket, researchStateMachine, brandName,
+      webSearchGatewayUrl, webSearchGatewayArn, webSearchToolName
     } = props;
 
     // Guard: fail fast (before any asset bundling) if frontend/dist is missing
@@ -708,6 +714,19 @@ export class VocApiStack extends cdk.Stack {
     }));
     kmsKey.grantDecrypt(chatStreamLambda);
 
+    // Web search tool (AgentCore Gateway) — optional, opt-in per request.
+    // Without the gateway the env vars stay unset and the tool is never
+    // registered with the model.
+    const webSearchEnabled = Boolean(webSearchGatewayUrl && webSearchGatewayArn && webSearchToolName);
+    if (webSearchGatewayUrl && webSearchGatewayArn && webSearchToolName) {
+      chatStreamLambda.addEnvironment('WEB_SEARCH_GATEWAY_URL', webSearchGatewayUrl);
+      chatStreamLambda.addEnvironment('WEB_SEARCH_TOOL_NAME', webSearchToolName);
+      chatStreamLambda.addToRolePolicy(new iam.PolicyStatement({
+        actions: ['bedrock-agentcore:InvokeGateway'],
+        resources: [webSearchGatewayArn],
+      }));
+    }
+
     NagSuppressions.addResourceSuppressions(chatStreamLambda, [
       { id: 'AwsSolutions-L1', reason: 'Node.js 22 is the target runtime for the streaming Lambda — latest stable LTS' },
     ], true);
@@ -1098,6 +1117,11 @@ exports.handler = async (event) => {
         region: this.region,
         identityPoolId: identityPool.attrId
       },
+      // Capability flags so the same frontend build can show/hide features
+      // per environment (web search only exists when the gateway deployed).
+      features: {
+        webSearch: webSearchEnabled,
+      },
     };
 
     const websiteDeployment = new s3deploy.BucketDeployment(this, 'DeployWebsite', {
@@ -1126,6 +1150,10 @@ exports.handler = async (event) => {
     new cdk.CfnOutput(this, 'WebhookPlugins', { value: webhookPlugins.map(p => p.id).join(',') });
     new cdk.CfnOutput(this, 'CognitoUserPoolId', { value: userPool.userPoolId, description: 'Cognito User Pool ID' });
     new cdk.CfnOutput(this, 'CognitoClientId', { value: userPoolClient.userPoolClientId, description: 'Cognito User Pool Client ID' });
+    new cdk.CfnOutput(this, 'WebSearchAvailable', {
+      value: webSearchEnabled ? 'true' : 'false',
+      description: 'Whether the AgentCore web search gateway is deployed (drives the frontend feature flag)',
+    });
   }
 
   // ============================================

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -21,6 +21,11 @@ export interface VocProcessingStackProps extends cdk.StackProps {
   idempotencyTable: dynamodb.Table;
   processingQueue: sqs.Queue;
   kmsKey: kms.Key;
+  // Web search (AgentCore Gateway, deployed in us-east-1 by VocWebSearchStack)
+  // — absent when the feature isn't enabled.
+  webSearchGatewayUrl?: string;
+  webSearchGatewayArn?: string;
+  webSearchToolName?: string;
   config: {
     brandName: string;
     brandHandles: string[];
@@ -260,6 +265,21 @@ export class VocProcessingStack extends cdk.Stack {
     NagSuppressions.addResourceSuppressions(this.researchStateMachine, pluginSystemSuppressions, true);
 
     // ============================================
+    // WEB SEARCH (AgentCore Gateway — see VocWebSearchStack)
+    // ============================================
+    // Opt-in per research request; without the gateway the env vars stay
+    // unset and step_initialize skips web grounding.
+    const { webSearchGatewayUrl, webSearchGatewayArn, webSearchToolName } = props;
+    if (webSearchGatewayUrl && webSearchGatewayArn && webSearchToolName) {
+      researchStepLambda.addEnvironment('WEB_SEARCH_GATEWAY_URL', webSearchGatewayUrl);
+      researchStepLambda.addEnvironment('WEB_SEARCH_TOOL_NAME', webSearchToolName);
+      researchStepLambda.addToRolePolicy(new iam.PolicyStatement({
+        actions: ['bedrock-agentcore:InvokeGateway'],
+        resources: [webSearchGatewayArn],
+      }));
+    }
+
+    // ============================================
     // OUTPUTS
     // ============================================
     new cdk.CfnOutput(this, 'ProcessorFunctionArn', { value: this.processingLambda.functionArn });
@@ -284,6 +304,9 @@ export class VocProcessingStack extends cdk.Stack {
         'feedback_stats.$': '$.Payload.feedback_stats',
         'feedback_count.$': '$.Payload.feedback_count',
         'personas_context.$': '$.Payload.personas_context',
+        // step_initialize ALWAYS returns web_context (empty string when web
+        // search is off) — an absent key here would fail the state outright.
+        'web_context.$': '$.Payload.web_context',
       },
     });
     initializeStep.addRetry({ errors: ['Lambda.ServiceException', 'Lambda.TooManyRequestsException', 'States.Timeout'], interval: cdk.Duration.seconds(2), maxAttempts: 3, backoffRate: 2 });
@@ -299,6 +322,7 @@ export class VocProcessingStack extends cdk.Stack {
         'feedback_context.$': '$.initialize_result.feedback_context',
         'feedback_stats.$': '$.initialize_result.feedback_stats',
         'personas_context.$': '$.initialize_result.personas_context',
+        'web_context.$': '$.initialize_result.web_context',
       }),
       resultPath: '$.analysis_result',
       resultSelector: { 'analysis.$': '$.Payload.analysis' },

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -1,0 +1,111 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as bedrockagentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+import { uniqueName } from '../utils/naming';
+
+/**
+ * VocWebSearchStack — AgentCore Gateway exposing the AWS-managed
+ * `web-search` connector as an MCP tool.
+ *
+ * Used by AI Chat and Projects research for opt-in public-web grounding.
+ * Queries are served entirely within AWS (no third-party search engine).
+ *
+ * This stack is ALWAYS deployed to us-east-1: the web-search connector is
+ * only available there. The rest of the app can live in any region — the
+ * chat-stream and research Lambdas call the gateway URL cross-region over
+ * HTTPS with SigV4, and the gateway URL/ARN flow to those stacks via CDK
+ * cross-region references (SSM-backed when regions differ).
+ *
+ * Opt-in via `"enableWebSearch": true` in cdk.context.json. When the app
+ * region is not us-east-1, the account must also be bootstrapped in
+ * us-east-1 (`cdk bootstrap aws://ACCOUNT/us-east-1`).
+ *
+ * Cost note: Web Search invocations are billed at $7 per 1,000 queries.
+ * The feature is opt-in per request in both UIs.
+ */
+export class VocWebSearchStack extends cdk.Stack {
+  public readonly gatewayUrl: string;
+  public readonly gatewayArn: string;
+  public readonly toolName: string;
+
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Service role the Gateway assumes to reach the AWS-owned connector.
+    // Trust is scoped to this account so another account's gateway cannot
+    // assume it (confused-deputy protection per the AgentCore docs).
+    const serviceRole = new iam.Role(this, 'WebSearchGatewayRole', {
+      assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com').withConditions({
+        StringEquals: { 'aws:SourceAccount': this.account },
+      }),
+      description: 'Service role for the VoC web search AgentCore Gateway',
+    });
+
+    const gateway = new bedrockagentcore.CfnGateway(this, 'WebSearchGateway', {
+      name: uniqueName('voc-web-search'),
+      protocolType: 'MCP',
+      // Inbound auth: callers (chat stream + research Lambdas) sign requests
+      // with SigV4 and are authorized via bedrock-agentcore:InvokeGateway.
+      authorizerType: 'AWS_IAM',
+      roleArn: serviceRole.roleArn,
+      description: 'VoC web search gateway (AWS-managed web-search connector)',
+    });
+
+    // Grant after gateway creation so the InvokeGateway statement can be
+    // scoped to the concrete gateway ARN instead of a gateway/* wildcard.
+    const servicePolicy = new iam.Policy(this, 'WebSearchGatewayRolePolicy', {
+      statements: [
+        new iam.PolicyStatement({
+          sid: 'InvokeGateway',
+          actions: ['bedrock-agentcore:InvokeGateway'],
+          resources: [gateway.attrGatewayArn],
+        }),
+        new iam.PolicyStatement({
+          sid: 'InvokeWebSearch',
+          actions: ['bedrock-agentcore:InvokeWebSearch'],
+          // Service-owned tool ARN (the account segment is literally "aws")
+          // — checked per invocation when the gateway calls the connector.
+          resources: [`arn:aws:bedrock-agentcore:${this.region}:aws:tool/web-search.v1`],
+        }),
+      ],
+    });
+    servicePolicy.attachToRole(serviceRole);
+
+    // The aws-cdk-lib L1 for GatewayTarget predates connector targets (its
+    // Mcp union only models lambda/apiGateway/openApiSchema/smithyModel/
+    // mcpServer), so declare the target as a raw CfnResource against the
+    // CloudFormation schema, which does support Mcp.Connector.
+    const targetName = 'web-search-tool';
+    const target = new cdk.CfnResource(this, 'WebSearchGatewayTarget', {
+      type: 'AWS::BedrockAgentCore::GatewayTarget',
+      properties: {
+        GatewayIdentifier: gateway.attrGatewayIdentifier,
+        Name: targetName,
+        TargetConfiguration: {
+          Mcp: {
+            Connector: {
+              Source: { ConnectorId: 'web-search' },
+              Configurations: [{ Name: 'WebSearch', ParameterValues: {} }],
+            },
+          },
+        },
+        CredentialProviderConfigurations: [
+          { CredentialProviderType: 'GATEWAY_IAM_ROLE' },
+        ],
+      },
+    });
+    // Target provisioning exercises the service role, so make sure the
+    // permissions exist before CloudFormation creates the target.
+    target.node.addDependency(servicePolicy);
+
+    this.gatewayUrl = gateway.attrGatewayUrl;
+    this.gatewayArn = gateway.attrGatewayArn;
+    // Gateways expose target tools MCP-prefixed as `${target}___${tool}`.
+    // The runtime clients fall back to tools/list discovery if this drifts.
+    this.toolName = `${targetName}___WebSearch`;
+
+    new cdk.CfnOutput(this, 'WebSearchGatewayUrl', { value: this.gatewayUrl });
+    new cdk.CfnOutput(this, 'WebSearchGatewayArn', { value: this.gatewayArn });
+  }
+}

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -66,7 +66,7 @@ export class VocWebSearchStack extends cdk.Stack {
           actions: ['bedrock-agentcore:InvokeWebSearch'],
           // Service-owned tool ARN (the account segment is literally "aws")
           // — checked per invocation when the gateway calls the connector.
-          resources: [`arn:aws:bedrock-agentcore:${this.region}:aws:tool/web-search.v1`],
+          resources: [`arn:${this.partition}:bedrock-agentcore:${this.region}:aws:tool/web-search.v1`],
         }),
       ],
     });


### PR DESCRIPTION
## Summary

Fixes #68 (close manually on merge) — re-scoped by the maintainer from a Tavily integration to the native **Web Search Tool on Amazon Bedrock AgentCore** (GA June 2026): a fully managed, MCP-compatible web search behind an AgentCore Gateway. No third-party API keys, queries are served entirely within AWS, and billing is pay-per-use at **$7 per 1,000 queries**.

Two user-facing entry points, both **opt-in per request**:

- **AI Chat** (`/chat`): a "Web search" toggle in the filter bar (per-conversation, persisted). When on, the model gets a `web_search` tool alongside `search_feedback` and uses it for current/external questions (competitors, market context, releases). Web results render as a **cited-links block** under the answer — separate from feedback sources — satisfying the connector's acceptable-use requirement that source citations reach the end user.
- **Projects research**: an "Include public web search" checkbox in the Run Research wizard. `step_initialize` fetches results for the research question, the analysis prompt carries explicit attribution rules (web findings must cite URLs and must not be attributed to customers), and the saved report header discloses that web search was used.

## Architecture

```
chat-stream Lambda (Node)  ──┐   SigV4-signed JSON-RPC (tools/call)
                             ├──────────►  AgentCore Gateway (MCP, AWS_IAM auth)
research-step Lambda (Py)  ──┘             └── connector target: web-search (AWS-managed)
```

- **`VocWebSearchStack`** (new): Gateway (MCP protocol, `AWS_IAM` inbound auth), a `web-search` connector target, and a service role scoped to the concrete gateway ARN plus `bedrock-agentcore:InvokeWebSearch` on the service-owned tool ARN — granted *after* gateway creation so no `gateway/*` wildcard is needed. The target is declared via a raw `CfnResource`: the aws-cdk-lib 2.244 L1 union predates connector targets, while the CloudFormation schema supports them (`AWS::BedrockAgentCore::GatewayTarget ConnectorTargetConfiguration`).
- **Region handling**: the connector exists only in **us-east-1**, so the stack always deploys there. Deployment is **explicitly opt-in** (`"enableWebSearch": true`) in every region until a real gateway round-trip has been validated post-release; non-us-east-1 apps additionally need a us-east-1 bootstrap (CDK cross-region references carry the gateway URL/ARN). Documented in `docs/deployment.md`.
- **Invocation**: direct JSON-RPC 2.0 `tools/call` against the gateway's streamable-HTTP MCP endpoint, SigV4-signed for `bedrock-agentcore` (no MCP SDK dependency). Node signs via `@smithy/signature-v4` + a `node:crypto` hash adapter (all `@smithy/*`/`@aws-sdk/*` imports stay bundling-external); Python signs via botocore's `SigV4Auth` + stdlib urllib (no new layer deps). Both clients parse plain-JSON *and* SSE-framed responses.
- **Tool naming**: gateways expose target tools as `${target}___${tool}` (`web-search-tool___WebSearch`), passed via env. If the gateway reports the name unknown, both clients fall back to one `tools/list` discovery per container and cache the result — self-healing if the prefix convention or target name ever drifts.
- **Least privilege**: callers get `bedrock-agentcore:InvokeGateway` on the one gateway ARN only. Without the gateway deployed, the env vars are absent, the tool is never registered, the UI hides the controls (via `features.webSearch` in `config.json` / the `WebSearchAvailable` stack output), and `use_web_search` in requests is ignored.

## Failure semantics

- Web search is **always an enrichment**: a research-time failure logs a warning and the job continues feedback-only (pinned by test). The `web_context` key is *always* present in `step_initialize` output because the Step Functions `resultSelector` references it unconditionally — an absent key would fail the state (also pinned by test).
- Query length (200 chars) and `maxResults` (1–10) are clamped client-side to the connector's input schema.

## Testing

- **Backend (771 passed)**: 22 new tests for `shared/web_search.py` (JSON-RPC envelopes, SSE-vs-JSON bodies, MCP unwrapping, discovery fallback + caching, clamping, knowledge-graph observations, formatting) and 8 for the research steps (always-present `web_context` contract, graceful failure, prompt attribution rules, report disclosure).
- **Stream (207 passed)**: 15 new tests for the web-search tool — including real `SignatureV4` signing against stubbed fetch (asserts the `AWS4-HMAC-SHA256` authorization header for `us-east-1/bedrock-agentcore`) — plus executor dispatch, schema, and handler tool-registration matrix (opt-in × configured).
- **Frontend (1,592 passed)**: runtime-config feature flag (including legacy config.json without a `features` block), ChatFilters toggle gating/behavior.
- Gates: `npm run check` exit 0 (lint, typecheck frontend+cdk+stream, all suites), `npm run i18n:validate` exit 0 (new strings in all 8 locales), stream ESLint clean on all touched files (baseline debt in untouched files left alone), `cdk synth` verified for all stacks **with and without** the flag: gateway+target+scoped-policy render correctly, both consumer Lambdas get env+IAM through cross-region exports, and without the flag the gateway/env/IAM surface is absent (the state-machine `web_context` plumbing is deliberately unconditional — step_initialize always returns the key).

## Not verified (requires deployment)

- End-to-end gateway invocation (the AgentCore docs describe the gateway as stateless MCP with direct `tools/call`; if it turns out to require an MCP `initialize` handshake, that's a small client addition — flagging for post-deploy validation).
- The exact exposed tool name (mitigated by the discovery fallback).

Post-deploy checklist: deploy with the flag, toggle web search in chat, ask a current-events question, confirm cited links render; run a research job with the checkbox and confirm the report's web section + disclosure line.

## Scope notes

- Roundtable chat deliberately has no tools (one clean turn per persona) — unchanged.
- The REST `/chat` endpoint (legacy, no tool loop) is unchanged; the chat UI uses the streaming endpoint.
- Backend accepts `use_web_search` for project chat too (schema is shared); only the VoC chat UI exposes a toggle for now, per the issue scope.


