### PR TITLE
test(cdk): pin web_context in the sibling context selections guard

### DIFF
--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -96,7 +96,7 @@ describe('research state machine wiring (issue #157)', () => {
   it('keeps the sibling context selections intact', () => {
     // The same silent-drop failure mode applies to every initialize output
     // the analyze prompt consumes; pin the full set that must flow.
-    for (const key of ['feedback_context', 'feedback_stats', 'personas_context']) {
+    for (const key of ['feedback_context', 'feedback_stats', 'personas_context', 'web_context']) {
       expect(state.definition).toContain(`"${key}.$":"$.Payload.${key}"`);
       expect(state.definition).toContain(`"${key}.$":"$.initialize_result.${key}"`);
     }


### PR DESCRIPTION
## Summary
Follow-up to #158's final review round (its one legitimate open item): the "sibling context selections" guard in `processing-stack-consolidated.test.ts` pins every initialize output that must flow to the analyze prompt — except `web_context` (#156), whose selector lines had no test coverage at all. One-word change: add `'web_context'` to the loop, pinning it at both wiring sites (initialize `resultSelector` + analyze payload).

## Why it matters
If a future edit drops the `web_context` selector line, the failure is the worst variant of the #157 silent-severing class: searches still run and bill ($7/1k queries), the report still stamps "Web search: enabled" (the disclosure reads the config flag, not the context), and the grounding silently never reaches the analysis — no error anywhere. This exact selector block was in a merge conflict twice in the past day (the #156 rebase and the #158 rebase over it); it accretes a sibling line per context feature and will conflict again.

## Testing
- CDK suite 33/33, tsc clean.
- Fail-on-revert verified: temporarily removing the `web_context` Payload selector line from the stack makes exactly the sibling test fail (`× keeps the sibling context selections intact`), stack restored byte-identical afterwards.
