### PR TITLE
fix: expire orphanable problem resolutions, per-key pending state

### DIFF
--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -288,7 +288,7 @@ export default function ProblemAnalysis() {
   // clears it from everyone's default view. All query/mutation wiring lives
   // in the hook (complexity budget + useSettingsSync convention).
   const {
-    resolvedMap, resolvedLoading, togglePending, toggleFailed,
+    resolvedMap, resolvedLoading, pendingKeys, toggleFailed,
     toggleResolved, dismissToggleError,
   } = useProblemResolution(!!config.apiEndpoint)
 
@@ -644,7 +644,7 @@ export default function ProblemAnalysis() {
                         expandedProblems={expandedProblems}
                         onToggleProblem={toggleProblem}
                         onToggleResolved={toggleResolved}
-                        resolvePending={togglePending}
+                        pendingKeys={pendingKeys}
                       />
                     )
                   })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.test.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { SubcategoryRow } from './SubcategoryRow'
+import { buildResolutionKey } from './problemResolution'
 
 const mockSubcategoryGroup = {
   subcategory: 'shipping_speed',
@@ -225,6 +226,27 @@ describe('SubcategoryRow', () => {
 
       // When problem is expanded, feedback items should be visible
       expect(screen.getByText('Delivery was slow')).toBeInTheDocument()
+    })
+  })
+
+  describe('per-key pending (issue #159)', () => {
+    it('disables only the resolve button whose key is pending', () => {
+      renderWithRouter(
+        <SubcategoryRow
+          categoryName="delivery"
+          subcategoryGroup={mockSubcategoryGroup}
+          isExpanded={true}
+          onToggle={vi.fn()}
+          expandedProblems={new Set()}
+          onToggleProblem={vi.fn()}
+          onToggleResolved={vi.fn()}
+          pendingKeys={new Set([buildResolutionKey('delivery', 'shipping_speed', 'Slow delivery times')])}
+        />
+      )
+
+      const [slowDeliveryButton, damagedButton] = screen.getAllByRole('button', { name: /resolved/i })
+      expect(slowDeliveryButton).toBeDisabled()
+      expect(damagedButton).not.toBeDisabled()
     })
   })
 })

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/SubcategoryRow.tsx
@@ -11,7 +11,9 @@ interface SubcategoryRowProps {
   readonly expandedProblems: Set<string>
   readonly onToggleProblem: (key: string) => void
   readonly onToggleResolved: (key: string, resolved: boolean) => void
-  readonly resolvePending?: boolean
+  /** Resolution keys with an in-flight toggle — disables only their own
+   * button (issue #159: no page-wide lock). */
+  readonly pendingKeys?: ReadonlySet<string>
 }
 
 export function SubcategoryRow({
@@ -22,7 +24,7 @@ export function SubcategoryRow({
   expandedProblems,
   onToggleProblem,
   onToggleResolved,
-  resolvePending,
+  pendingKeys,
 }: SubcategoryRowProps) {
   const subcategoryKey = `${categoryName}:${subcategoryGroup.subcategory}`
 
@@ -66,7 +68,7 @@ export function SubcategoryRow({
                 isExpanded={expandedProblems.has(problemKey)}
                 onToggle={() => onToggleProblem(problemKey)}
                 onToggleResolved={() => onToggleResolved(resolutionKey, !problemGroup.resolved)}
-                resolvePending={resolvePending}
+                resolvePending={pendingKeys?.has(resolutionKey) === true}
               />
             )
           })}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/problemResolution.ts
@@ -98,6 +98,14 @@ function fitToKeyCaps(key: string): string {
  * normalized out of the values themselves so a literal pipe in a category
  * name can't merge two different problems under one key. The result is
  * deterministically truncated to the server's 255-char/255-byte caps.
+ *
+ * Lifecycle caveat (issue #159): the problem component is the similarity
+ * group's REPRESENTATIVE text, which can shift as the similarity slider or
+ * the data window changes — a resolution whose group re-forms differently
+ * becomes unreachable from the UI. The server compensates by expiring
+ * entries after RESOLVED_PROBLEMS_TTL_DAYS (default 180): expired
+ * resolutions drop out of GET responses (the problem resurfaces for
+ * re-review) and are pruned from storage under entry-cap pressure.
  */
 export function buildResolutionKey(category: string, subcategory: string, problem: string): string {
   const normalize = (value: string) =>

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.test.tsx
@@ -31,11 +31,15 @@ function createWrapper() {
   }
 }
 
-/** A promise the test resolves manually, to hold a mutation in flight. */
+/** A promise the test resolves or rejects manually, to hold a mutation in flight. */
 function deferred<T>() {
-  const holder: { resolve: (value: T) => void } = { resolve: () => undefined }
-  const promise = new Promise<T>((resolve) => {
+  const holder: { resolve: (value: T) => void; reject: (reason: Error) => void } = {
+    resolve: () => undefined,
+    reject: () => undefined,
+  }
+  const promise = new Promise<T>((resolve, reject) => {
     holder.resolve = resolve
+    holder.reject = reject
   })
   return { promise, holder }
 }
@@ -109,5 +113,33 @@ describe('useProblemResolution per-key pending', () => {
     await waitFor(() => expect(result.current.toggleFailed).toBe(true))
     // The key must be re-toggleable after a failure, not stuck pending.
     expect(result.current.pendingKeys.has('cat|sub|a')).toBe(false)
+  })
+
+  it('surfaces an early failure even when a later toggle succeeds', async () => {
+    // Regression (review round 1): mutation.isError only reflects the LATEST
+    // mutate() call, so key A's failure was masked once key B succeeded.
+    const failing = deferred<{ success: boolean }>()
+    const succeeding = deferred<{ success: boolean }>()
+    mockSetProblemResolved
+      .mockReturnValueOnce(failing.promise)
+      .mockReturnValueOnce(succeeding.promise)
+
+    const { result } = renderHook(() => useProblemResolution(true), { wrapper: createWrapper() })
+
+    act(() => result.current.toggleResolved('cat|sub|a', true))
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|a')).toBe(true))
+    act(() => result.current.toggleResolved('cat|sub|b', true))
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|b')).toBe(true))
+
+    // B succeeds AFTER A fails — A's failure must still be visible.
+    act(() => failing.holder.reject(new Error('boom')))
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|a')).toBe(false))
+    act(() => succeeding.holder.resolve({ success: true }))
+    await waitFor(() => expect(result.current.pendingKeys.size).toBe(0))
+
+    expect(result.current.toggleFailed).toBe(true)
+
+    act(() => result.current.dismissToggleError())
+    expect(result.current.toggleFailed).toBe(false)
   })
 })

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @fileoverview Tests for useProblemResolution — per-key pending (issue #159).
+ *
+ * Pending state must be scoped to the key being toggled: resolving one
+ * problem must not lock every resolve button on the page, and rapid
+ * double-clicks on the SAME key must still be dropped (SET/REMOVE race
+ * protection).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useProblemResolution } from './useProblemResolution'
+
+const mockGetResolvedProblems = vi.fn()
+const mockSetProblemResolved = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getResolvedProblems: (...args: unknown[]) => mockGetResolvedProblems(...args),
+    setProblemResolved: (...args: unknown[]) => mockSetProblemResolved(...args),
+  },
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+/** A promise the test resolves manually, to hold a mutation in flight. */
+function deferred<T>() {
+  const holder: { resolve: (value: T) => void } = { resolve: () => undefined }
+  const promise = new Promise<T>((resolve) => {
+    holder.resolve = resolve
+  })
+  return { promise, holder }
+}
+
+describe('useProblemResolution per-key pending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetResolvedProblems.mockResolvedValue({ resolved: {} })
+  })
+
+  it('marks only the toggled key as pending', async () => {
+    const { promise, holder } = deferred<{ success: boolean }>()
+    mockSetProblemResolved.mockReturnValue(promise)
+
+    const { result } = renderHook(() => useProblemResolution(true), { wrapper: createWrapper() })
+
+    act(() => result.current.toggleResolved('cat|sub|a', true))
+
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|a')).toBe(true))
+    expect(result.current.pendingKeys.has('cat|sub|b')).toBe(false)
+
+    act(() => holder.resolve({ success: true }))
+    await waitFor(() => expect(result.current.pendingKeys.size).toBe(0))
+  })
+
+  it('drops a second toggle of the SAME key while it is in flight', async () => {
+    const { promise, holder } = deferred<{ success: boolean }>()
+    mockSetProblemResolved.mockReturnValue(promise)
+
+    const { result } = renderHook(() => useProblemResolution(true), { wrapper: createWrapper() })
+
+    act(() => result.current.toggleResolved('cat|sub|a', true))
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|a')).toBe(true))
+    act(() => result.current.toggleResolved('cat|sub|a', false))
+
+    expect(mockSetProblemResolved).toHaveBeenCalledTimes(1)
+    act(() => holder.resolve({ success: true }))
+    await waitFor(() => expect(result.current.pendingKeys.size).toBe(0))
+  })
+
+  it('allows toggling a DIFFERENT key while another is in flight', async () => {
+    const first = deferred<{ success: boolean }>()
+    const second = deferred<{ success: boolean }>()
+    mockSetProblemResolved
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const { result } = renderHook(() => useProblemResolution(true), { wrapper: createWrapper() })
+
+    act(() => result.current.toggleResolved('cat|sub|a', true))
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|a')).toBe(true))
+    act(() => result.current.toggleResolved('cat|sub|b', true))
+
+    await waitFor(() => expect(result.current.pendingKeys.has('cat|sub|b')).toBe(true))
+    expect(mockSetProblemResolved).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      first.holder.resolve({ success: true })
+      second.holder.resolve({ success: true })
+    })
+    await waitFor(() => expect(result.current.pendingKeys.size).toBe(0))
+  })
+
+  it('clears the key from pending when the mutation fails', async () => {
+    mockSetProblemResolved.mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useProblemResolution(true), { wrapper: createWrapper() })
+
+    act(() => result.current.toggleResolved('cat|sub|a', true))
+
+    await waitFor(() => expect(result.current.toggleFailed).toBe(true))
+    // The key must be re-toggleable after a failure, not stuck pending.
+    expect(result.current.pendingKeys.has('cat|sub|a')).toBe(false)
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.ts
@@ -30,6 +30,11 @@ interface ProblemResolutionState {
 export function useProblemResolution(enabled: boolean): ProblemResolutionState {
   const queryClient = useQueryClient()
   const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(new Set())
+  // Failure is tracked in state, NOT via mutation.isError: all toggles share
+  // one useMutation, whose isError reflects only the LATEST mutate() call —
+  // under concurrent toggles (this hook's whole point), an earlier key's
+  // failure would be silently masked by a later key's success.
+  const [toggleFailed, setToggleFailed] = useState(false)
 
   const { data, isLoading } = useQuery({
     queryKey: ['resolved-problems'],
@@ -55,15 +60,19 @@ export function useProblemResolution(enabled: boolean): ProblemResolutionState {
         return next
       })
     },
+    onError: () => {
+      setToggleFailed(true)
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['resolved-problems'] })
     },
   })
 
   const toggleResolved = (key: string, resolved: boolean) => {
-    // Per-key double defense with the disabled button: covers the render gap
-    // before the disabled state paints, so a rapid double-click can't race
-    // SET/REMOVE for the same key server-side. Other keys stay toggleable.
+    // Per-key best-effort guard alongside the disabled button; the real
+    // backstop for a same-key SET/REMOVE race is that each request is a
+    // single atomic DynamoDB write — this just avoids firing an obviously
+    // redundant request. Other keys stay toggleable (issue #159).
     if (pendingKeys.has(key)) return
     mutation.mutate({ key, resolved })
   }
@@ -72,8 +81,8 @@ export function useProblemResolution(enabled: boolean): ProblemResolutionState {
     resolvedMap: data?.resolved ?? {},
     resolvedLoading: isLoading,
     pendingKeys,
-    toggleFailed: mutation.isError,
+    toggleFailed,
     toggleResolved,
-    dismissToggleError: () => mutation.reset(),
+    dismissToggleError: () => setToggleFailed(false),
   }
 }

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemResolution.ts
@@ -7,6 +7,7 @@
  * Settings' useSettingsSync.
  * @module pages/ProblemAnalysis/useProblemResolution
  */
+import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '../../api/client'
 import { parseResolvedProblemsResponse } from './problemResolution'
@@ -17,7 +18,10 @@ interface ProblemResolutionState {
   /** True while the initial resolved-state fetch is in flight — gate the
    * tree on it so resolved problems don't flash as unresolved. */
   resolvedLoading: boolean
-  togglePending: boolean
+  /** Keys with a resolve/unresolve currently in flight. Pending is PER KEY
+   * (issue #159): resolving one problem must not lock every button on the
+   * page, only its own — rapid multi-resolve workflows stay responsive. */
+  pendingKeys: ReadonlySet<string>
   toggleFailed: boolean
   toggleResolved: (key: string, resolved: boolean) => void
   dismissToggleError: () => void
@@ -25,6 +29,7 @@ interface ProblemResolutionState {
 
 export function useProblemResolution(enabled: boolean): ProblemResolutionState {
   const queryClient = useQueryClient()
+  const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(new Set())
 
   const { data, isLoading } = useQuery({
     queryKey: ['resolved-problems'],
@@ -40,23 +45,33 @@ export function useProblemResolution(enabled: boolean): ProblemResolutionState {
   const mutation = useMutation({
     mutationFn: ({ key, resolved }: { key: string; resolved: boolean }) =>
       api.setProblemResolved(key, resolved),
+    onMutate: ({ key }) => {
+      setPendingKeys((prev) => new Set(prev).add(key))
+    },
+    onSettled: (_data, _error, { key }) => {
+      setPendingKeys((prev) => {
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['resolved-problems'] })
     },
   })
 
   const toggleResolved = (key: string, resolved: boolean) => {
-    // Double defense with the disabled buttons: covers the render gap before
-    // the disabled state paints, so a rapid double-click can't race
-    // SET/REMOVE for the same key server-side.
-    if (mutation.isPending) return
+    // Per-key double defense with the disabled button: covers the render gap
+    // before the disabled state paints, so a rapid double-click can't race
+    // SET/REMOVE for the same key server-side. Other keys stay toggleable.
+    if (pendingKeys.has(key)) return
     mutation.mutate({ key, resolved })
   }
 
   return {
     resolvedMap: data?.resolved ?? {},
     resolvedLoading: isLoading,
-    togglePending: mutation.isPending,
+    pendingKeys,
     toggleFailed: mutation.isError,
     toggleResolved,
     dismissToggleError: () => mutation.reset(),

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -48,7 +48,7 @@ MAX_RESOLVED_ENTRIES = 500
 # Entries therefore expire after this many days: GET filters them out (an
 # old resolution resurfaces for re-review) and hitting the entry cap prunes
 # them from storage. 0 disables expiry entirely.
-def _parse_ttl_days(raw: str) -> int:
+def _parse_ttl_days(raw: str | None) -> int:
     """Parse the TTL env var defensively: the Lambda environment is a system
     boundary, and a console typo ("180d") must degrade to the default with a
     warning — not crash the whole settings Lambda at import."""

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from botocore.exceptions import ClientError
@@ -42,7 +42,47 @@ MAX_PROBLEM_KEY_LEN = 255
 MAX_PROBLEM_KEY_BYTES = 255
 MAX_RESOLVED_ENTRIES = 500
 
+# Resolution keys are derived CLIENT-side from similarity groups, so a key
+# can be orphaned forever when its group re-forms differently (issue #159):
+# nothing would ever unresolve it and it would hold one of the 500 slots.
+# Entries therefore expire after this many days: GET filters them out (an
+# old resolution resurfaces for re-review) and hitting the entry cap prunes
+# them from storage. 0 disables expiry entirely.
+RESOLVED_PROBLEMS_TTL_DAYS = int(os.environ.get('RESOLVED_PROBLEMS_TTL_DAYS', '180'))
+# REMOVE-expression chunk size when pruning (bounded so the update
+# expression stays far below DynamoDB's 4KB expression limit).
+_PRUNE_CHUNK_SIZE = 20
+
 app = create_api_resolver()
+
+
+def _resolution_expiry_cutoff() -> str | None:
+    """ISO-8601 cutoff below which resolutions are expired, or None when
+    expiry is disabled. Stored timestamps are UTC isoformat, so plain
+    lexicographic comparison is correct."""
+    if RESOLVED_PROBLEMS_TTL_DAYS <= 0:
+        return None
+    return (datetime.now(timezone.utc) - timedelta(days=RESOLVED_PROBLEMS_TTL_DAYS)).isoformat()
+
+
+def _is_expired_entry(entry: Any, cutoff: str) -> bool:
+    """An entry is expired when its resolved_at predates the cutoff.
+    Malformed entries (missing/non-string resolved_at) count as expired:
+    they can't be compared, can't be displayed meaningfully, and would
+    otherwise hold a cap slot forever."""
+    if not isinstance(entry, dict):
+        return True
+    resolved_at = entry.get('resolved_at')
+    if not isinstance(resolved_at, str) or not resolved_at:
+        return True
+    return resolved_at < cutoff
+
+
+def _without_expired(resolved: dict) -> dict:
+    cutoff = _resolution_expiry_cutoff()
+    if cutoff is None:
+        return resolved
+    return {key: entry for key, entry in resolved.items() if not _is_expired_entry(entry, cutoff)}
 
 
 @app.get("/settings/resolved-problems")
@@ -52,7 +92,10 @@ def get_resolved_problems():
 
     Shape: {'resolved': {problem_key: {'resolved_at': iso8601}}}. Shared
     across all users by design (issue #66) — resolving a problem clears it
-    from everyone's working view.
+    from everyone's working view. Entries older than
+    RESOLVED_PROBLEMS_TTL_DAYS are filtered out (issue #159): the problem
+    resurfaces for re-review, and the stored entry is reclaimed the next
+    time the entry cap is under pressure.
     """
     if not aggregates_table:
         raise ConfigurationError('Aggregates table not configured')
@@ -60,7 +103,7 @@ def get_resolved_problems():
         response = aggregates_table.get_item(
             Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK}
         )
-        return {'resolved': response.get('Item', {}).get('resolved', {})}
+        return {'resolved': _without_expired(response.get('Item', {}).get('resolved', {}))}
     except Exception as e:
         logger.exception("Failed to get resolved problems")
         raise ServiceError('Failed to retrieve resolved problems') from e
@@ -138,6 +181,36 @@ def _ensure_resolved_map() -> None:
     )
 
 
+def _prune_expired_entries() -> int:
+    """Remove expired entries from storage; returns how many were removed.
+
+    Called only under cap pressure (a resolve hit the entry cap), keeping
+    the steady state at one write per request. Removals are chunked so the
+    UpdateExpression stays small; each chunk is one atomic REMOVE."""
+    cutoff = _resolution_expiry_cutoff()
+    if cutoff is None:
+        return 0
+    response = aggregates_table.get_item(
+        Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK}
+    )
+    resolved = response.get('Item', {}).get('resolved', {})
+    if not isinstance(resolved, dict):
+        # Malformed storage — nothing safely prunable.
+        return 0
+    stale = [key for key, entry in resolved.items() if _is_expired_entry(entry, cutoff)]
+    for start in range(0, len(stale), _PRUNE_CHUNK_SIZE):
+        chunk = stale[start:start + _PRUNE_CHUNK_SIZE]
+        names = {f'#k{i}': key for i, key in enumerate(chunk)}
+        aggregates_table.update_item(
+            Key={'pk': RESOLVED_PROBLEMS_PK, 'sk': RESOLVED_PROBLEMS_SK},
+            UpdateExpression='REMOVE ' + ', '.join(f'#r.{alias}' for alias in names),
+            ExpressionAttributeNames={'#r': 'resolved', **names},
+        )
+    if stale:
+        logger.info(f"Pruned {len(stale)} expired resolved-problem entries under cap pressure")
+    return len(stale)
+
+
 def _resolve_problem_key(key: str) -> None:
     """Conditionally set the entry, materializing the parent map on first use.
 
@@ -145,7 +218,9 @@ def _resolve_problem_key(key: str) -> None:
     ValidationException or as a failed condition (functions on missing
     attributes evaluate false), depending on evaluation order — so both
     first-attempt failures fall through to ensure-parent + one retry, and
-    only a retry failure means the cap was genuinely reached.
+    only a retry failure means the cap was genuinely reached. At that point
+    expired entries are pruned (issue #159) and the write retried once more;
+    the cap error only surfaces when the map is full of LIVE entries.
     """
     try:
         _set_resolved_entry(key)
@@ -157,13 +232,22 @@ def _resolve_problem_key(key: str) -> None:
     _ensure_resolved_map()
     try:
         _set_resolved_entry(key)
+        return
     except ClientError as e:
-        if e.response.get('Error', {}).get('Code', '') == 'ConditionalCheckFailedException':
-            raise ValidationError(
-                f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
-                'Unresolve entries you no longer need first.'
-            ) from e
-        raise
+        if e.response.get('Error', {}).get('Code', '') != 'ConditionalCheckFailedException':
+            raise
+    # Cap reached: reclaim slots held by expired (often orphaned) entries.
+    if _prune_expired_entries() > 0:
+        try:
+            _set_resolved_entry(key)
+            return
+        except ClientError as e:
+            if e.response.get('Error', {}).get('Code', '') != 'ConditionalCheckFailedException':
+                raise
+    raise ValidationError(
+        f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
+        'Unresolve entries you no longer need first.'
+    )
 
 
 def _unresolve_problem_key(key: str) -> None:

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -48,7 +48,21 @@ MAX_RESOLVED_ENTRIES = 500
 # Entries therefore expire after this many days: GET filters them out (an
 # old resolution resurfaces for re-review) and hitting the entry cap prunes
 # them from storage. 0 disables expiry entirely.
-RESOLVED_PROBLEMS_TTL_DAYS = int(os.environ.get('RESOLVED_PROBLEMS_TTL_DAYS', '180'))
+def _parse_ttl_days(raw: str) -> int:
+    """Parse the TTL env var defensively: the Lambda environment is a system
+    boundary, and a console typo ("180d") must degrade to the default with a
+    warning — not crash the whole settings Lambda at import."""
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid RESOLVED_PROBLEMS_TTL_DAYS; falling back to default",
+            extra={"raw_value": raw, "default_days": 180},
+        )
+        return 180
+
+
+RESOLVED_PROBLEMS_TTL_DAYS = _parse_ttl_days(os.environ.get('RESOLVED_PROBLEMS_TTL_DAYS', '180'))
 # REMOVE-expression chunk size when pruning (bounded so the update
 # expression stays far below DynamoDB's 4KB expression limit).
 _PRUNE_CHUNK_SIZE = 20
@@ -78,7 +92,11 @@ def _is_expired_entry(entry: Any, cutoff: str) -> bool:
     return resolved_at < cutoff
 
 
-def _without_expired(resolved: dict) -> dict:
+def _without_expired(resolved: Any) -> dict:
+    # Same malformed-storage guard as _prune_expired_entries (symmetry):
+    # a non-dict value degrades to "nothing resolved", not a 500.
+    if not isinstance(resolved, dict):
+        return {}
     cutoff = _resolution_expiry_cutoff()
     if cutoff is None:
         return resolved
@@ -181,12 +199,21 @@ def _ensure_resolved_map() -> None:
     )
 
 
+@tracer.capture_method
 def _prune_expired_entries() -> int:
     """Remove expired entries from storage; returns how many were removed.
 
     Called only under cap pressure (a resolve hit the entry cap), keeping
     the steady state at one write per request. Removals are chunked so the
-    UpdateExpression stays small; each chunk is one atomic REMOVE."""
+    UpdateExpression stays small; each chunk is one atomic REMOVE.
+
+    Known race, accepted: the stale list is a get_item snapshot, and GET
+    already filters expired entries — so a user could re-resolve one of
+    these keys (fresh resolved_at) between the snapshot and the REMOVE,
+    losing the fresh entry. The window is milliseconds wide, requires the
+    same key, and self-heals (resolving again just works); a per-key
+    conditional REMOVE would trade that for N extra conditional writes.
+    """
     cutoff = _resolution_expiry_cutoff()
     if cutoff is None:
         return 0
@@ -207,7 +234,10 @@ def _prune_expired_entries() -> int:
             ExpressionAttributeNames={'#r': 'resolved', **names},
         )
     if stale:
-        logger.info(f"Pruned {len(stale)} expired resolved-problem entries under cap pressure")
+        logger.info(
+            "Pruned expired resolved-problem entries under cap pressure",
+            extra={"count": len(stale)},
+        )
     return len(stale)
 
 
@@ -236,6 +266,7 @@ def _resolve_problem_key(key: str) -> None:
     except ClientError as e:
         if e.response.get('Error', {}).get('Code', '') != 'ConditionalCheckFailedException':
             raise
+        cap_error = e
     # Cap reached: reclaim slots held by expired (often orphaned) entries.
     if _prune_expired_entries() > 0:
         try:
@@ -244,10 +275,11 @@ def _resolve_problem_key(key: str) -> None:
         except ClientError as e:
             if e.response.get('Error', {}).get('Code', '') != 'ConditionalCheckFailedException':
                 raise
+            cap_error = e
     raise ValidationError(
         f'Resolved-problem limit reached ({MAX_RESOLVED_ENTRIES}). '
         'Unresolve entries you no longer need first.'
-    )
+    ) from cap_error
 
 
 def _unresolve_problem_key(key: str) -> None:

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -5,7 +5,7 @@ Manages brand configuration and categories.
 import json
 import pytest
 from unittest.mock import patch, MagicMock
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 
 class TestGetBrandSettings:
@@ -463,8 +463,10 @@ class TestResolvedProblemsCap:
         from settings_handler import lambda_handler
 
         # Both the first attempt and the post-ensure retry fail the condition:
-        # the map genuinely holds MAX_RESOLVED_ENTRIES other keys.
+        # the map genuinely holds MAX_RESOLVED_ENTRIES other keys — and none
+        # of them are expired, so pruning (issue #159) frees nothing.
         mock_table.update_item.side_effect = [self._cap_failure(), {}, self._cap_failure()]
+        mock_table.get_item.return_value = {'Item': {'resolved': {}}}
 
         event = api_gateway_event(
             method='PUT', path='/settings/resolved-problems',
@@ -516,8 +518,135 @@ class TestResolvedProblemsCap:
 
         # Missing parent map == nothing to remove == success.
         assert response['statusCode'] == 200
-        assert mock_table.update_item.call_args.kwargs['ConditionExpression'] == 'attribute_exists(#r)' 
+        assert mock_table.update_item.call_args.kwargs['ConditionExpression'] == 'attribute_exists(#r)'
 
+
+
+class TestResolvedProblemsExpiry:
+    """Entry expiry and cap-pressure pruning (issue #159).
+
+    Resolution keys are client-derived from similarity groups, so a key can
+    be orphaned forever when its group re-forms differently. Entries expire
+    after RESOLVED_PROBLEMS_TTL_DAYS: GET filters them from responses, and a
+    resolve that hits the entry cap prunes them from storage before the cap
+    error is surfaced.
+    """
+
+    @staticmethod
+    def _entry(days_old: int) -> dict:
+        return {'resolved_at': (datetime.now(timezone.utc) - timedelta(days=days_old)).isoformat()}
+
+    @staticmethod
+    def _cap_failure():
+        from botocore.exceptions import ClientError
+        return ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'cap'}},
+            'UpdateItem',
+        )
+
+    @patch('settings_handler.aggregates_table')
+    def test_get_filters_expired_entries(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import lambda_handler
+
+        mock_table.get_item.return_value = {
+            'Item': {'resolved': {
+                'cat|sub|fresh': self._entry(days_old=1),
+                'cat|sub|ancient': self._entry(days_old=181),
+            }}
+        }
+
+        event = api_gateway_event(method='GET', path='/settings/resolved-problems')
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert 'cat|sub|fresh' in body['resolved']
+        assert 'cat|sub|ancient' not in body['resolved']
+
+    @patch('settings_handler.RESOLVED_PROBLEMS_TTL_DAYS', 0)
+    @patch('settings_handler.aggregates_table')
+    def test_ttl_zero_disables_expiry(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import lambda_handler
+
+        mock_table.get_item.return_value = {
+            'Item': {'resolved': {'cat|sub|ancient': self._entry(days_old=5000)}}
+        }
+
+        event = api_gateway_event(method='GET', path='/settings/resolved-problems')
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert 'cat|sub|ancient' in body['resolved']
+
+    @patch('settings_handler.aggregates_table')
+    def test_malformed_entries_count_as_expired(self, mock_table, api_gateway_event, lambda_context):
+        """Entries without a comparable resolved_at can never be displayed or
+        aged out normally — they must not hold cap slots forever."""
+        from settings_handler import lambda_handler
+
+        mock_table.get_item.return_value = {
+            'Item': {'resolved': {
+                'cat|sub|no-date': {},
+                'cat|sub|wrong-type': {'resolved_at': 12345},
+                'cat|sub|fresh': self._entry(days_old=1),
+            }}
+        }
+
+        event = api_gateway_event(method='GET', path='/settings/resolved-problems')
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert list(body['resolved']) == ['cat|sub|fresh']
+
+    @patch('settings_handler.aggregates_table')
+    def test_cap_pressure_prunes_expired_then_succeeds(self, mock_table, api_gateway_event, lambda_context):
+        """At the cap, expired entries are reclaimed and the resolve retried —
+        the user only sees the cap error when every entry is live."""
+        from settings_handler import lambda_handler
+
+        mock_table.update_item.side_effect = [
+            self._cap_failure(),  # initial conditional SET
+            {},                   # ensure parent map
+            self._cap_failure(),  # post-ensure retry: genuinely at cap
+            {},                   # pruning REMOVE
+            {},                   # final SET succeeds in the freed slot
+        ]
+        mock_table.get_item.return_value = {
+            'Item': {'resolved': {
+                'cat|sub|orphaned': self._entry(days_old=200),
+                'cat|sub|live': self._entry(days_old=3),
+            }}
+        }
+
+        event = api_gateway_event(
+            method='PUT', path='/settings/resolved-problems',
+            body={'key': 'cat|sub|new problem', 'resolved': True},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        remove_call = mock_table.update_item.call_args_list[3]
+        assert remove_call.kwargs['UpdateExpression'].startswith('REMOVE ')
+        # Only the expired key is pruned; the live one keeps its slot.
+        assert 'cat|sub|orphaned' in remove_call.kwargs['ExpressionAttributeNames'].values()
+        assert 'cat|sub|live' not in remove_call.kwargs['ExpressionAttributeNames'].values()
+
+    @patch('settings_handler.aggregates_table')
+    def test_prune_chunks_large_removals(self, mock_table):
+        """REMOVE expressions are chunked so they stay far below DynamoDB's
+        4KB expression limit even with hundreds of stale keys."""
+        from settings_handler import _prune_expired_entries
+
+        stale = {f'cat|sub|old {i}': self._entry(days_old=300) for i in range(45)}
+        mock_table.get_item.return_value = {'Item': {'resolved': stale}}
+        mock_table.update_item.return_value = {}
+
+        pruned = _prune_expired_entries()
+
+        assert pruned == 45
+        assert mock_table.update_item.call_count == 3  # 20 + 20 + 5
+        for call in mock_table.update_item.call_args_list:
+            aliases = [k for k in call.kwargs['ExpressionAttributeNames'] if k != '#r']
+            assert len(aliases) <= 20
 
 
 class TestResolvedProblemsKeyEncoding:

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -631,6 +631,31 @@ class TestResolvedProblemsExpiry:
         assert 'cat|sub|live' not in remove_call.kwargs['ExpressionAttributeNames'].values()
 
     @patch('settings_handler.aggregates_table')
+    def test_get_tolerates_malformed_resolved_attribute(self, mock_table, api_gateway_event, lambda_context):
+        """Non-dict storage under 'resolved' degrades to an empty map, not a 500
+        (symmetry with the prune path's guard)."""
+        from settings_handler import lambda_handler
+
+        mock_table.get_item.return_value = {'Item': {'resolved': 'corrupted'}}
+
+        event = api_gateway_event(method='GET', path='/settings/resolved-problems')
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['resolved'] == {}
+
+    def test_ttl_env_parse_falls_back_on_garbage(self):
+        """A console typo in RESOLVED_PROBLEMS_TTL_DAYS must not crash the
+        whole settings Lambda at import — boundary validation."""
+        from settings_handler import _parse_ttl_days
+
+        assert _parse_ttl_days('180d') == 180
+        assert _parse_ttl_days('') == 180
+        assert _parse_ttl_days(None) == 180
+        assert _parse_ttl_days('30') == 30
+        assert _parse_ttl_days('0') == 0
+
+    @patch('settings_handler.aggregates_table')
     def test_prune_chunks_large_removals(self, mock_table):
         """REMOVE expressions are chunked so they stay far below DynamoDB's
         4KB expression limit even with hundreds of stale keys."""


### PR DESCRIPTION
## Summary

Fixes #159 (close manually on merge) — both findings from the #66 follow-up.

### 1. Orphaned resolution keys no longer consume the cap forever

Resolution keys are derived client-side from similarity-group representative text, which shifts with the similarity slider and the data window. When a group re-forms differently, its old key becomes unreachable from the UI — un-unresolvable, permanently holding one of the 500 `MAX_RESOLVED_ENTRIES` slots.

Entries now **expire after `RESOLVED_PROBLEMS_TTL_DAYS`** (default **180**, env-overridable on the settings Lambda, `0` disables):

- **GET** filters expired entries from responses — an old resolution resurfaces for re-review (deliberate product behavior: a problem resolved half a year ago that still appears in current data deserves another look).
- **Cap-pressure pruning**: a resolve that hits the entry cap prunes expired entries from storage and retries once; the cap error only surfaces when the map is full of *live* entries. Pruning is deliberately lazy — the endpoint's documented one-write-per-request steady state is preserved, and a scheduled sweeper (extra infra) stays unnecessary.
- **Malformed entries** (missing/non-string `resolved_at`) count as expired: they can never be displayed or aged out normally and must not hold slots.
- REMOVE expressions are **chunked** (20 keys/update) to stay far below DynamoDB's 4KB expression limit.
- The key-lifecycle caveat is documented on `buildResolutionKey` (the issue's "at minimum document this").

### 2. Per-key pending instead of a page-wide lock

`useProblemResolution` now tracks a `pendingKeys` set (via `onMutate`/`onSettled`): toggling one problem disables only its own button, so rapid multi-resolve workflows stay responsive. The same-key double-click race protection (SET/REMOVE ordering) is preserved — a second toggle of an in-flight key is still dropped. `SubcategoryRow` computes per-problem disabled state from the set; `ProblemRow` is unchanged.

## Tests

- **Backend (+5)**: GET expiry filtering, TTL=0 disable, malformed-as-expired, cap-pressure prune-then-succeed (asserts only the expired key is REMOVEd), chunking (45 stale → 3 updates, ≤20 aliases each). The existing at-cap rejection test now explicitly configures "nothing prunable" so the 400 contract stays pinned.
- **Frontend (+5)**: four hook tests (only the toggled key pending; same-key double-toggle dropped; different-key concurrent toggles both fire; failed mutation un-pends the key) and one row test (only the pending key's button disabled).
- Full root gate green: lint, typecheck (frontend/CDK/stream), frontend + CDK + backend suites (823 backend). No new user-visible strings, so no i18n changes.

## Notes

- `RESOLVED_PROBLEMS_TTL_DAYS` is read from the Lambda environment with an in-code default of 180; no CDK plumbing added until someone actually needs a different value per environment (console-level override works today).
- PR #154 (model picker) touches the same `settings_handler.py` — different functions, but adjacent regions; whichever merges second may see a trivial conflict.