### PR TITLE
fix: collision-proof chat conversation and message IDs

### DIFF
--- a/voc-datalake/frontend/src/store/chatStore.test.ts
+++ b/voc-datalake/frontend/src/store/chatStore.test.ts
@@ -25,6 +25,14 @@ describe('chatStore', () => {
       expect(state.conversations[0].id).toBe(id)
     })
 
+    it('generates unique IDs for back-to-back creations (issue #160)', () => {
+      // Date.now()-based IDs collided within the same millisecond — two
+      // conversations then shared an ID and store operations affected both.
+      const ids = Array.from({ length: 50 }, () => useChatStore.getState().createConversation())
+
+      expect(new Set(ids).size).toBe(50)
+    })
+
     it('sets new conversation as active', () => {
       const { createConversation } = useChatStore.getState()
       
@@ -77,17 +85,15 @@ describe('chatStore', () => {
       expect(state.activeConversationId).toBeNull()
     })
 
-    it('preserves activeConversationId when deleting different conversation', async () => {
+    it('preserves activeConversationId when deleting different conversation', () => {
       // Reset state completely first
       useChatStore.setState({ conversations: [], activeConversationId: null })
       
       // Create first conversation
       const firstId = useChatStore.getState().createConversation()
-      
-      // Wait a tick to ensure different timestamp for second ID
-      await new Promise(resolve => setTimeout(resolve, 1))
-      
-      // Create second conversation
+      // Back-to-back creation is safe: IDs are collision-proof (issue #160),
+      // so no timestamp-separation sleep is needed (the old 1ms wait still
+      // flaked under full-suite load).
       const secondId = useChatStore.getState().createConversation()
       
       // Verify we have two different conversations
@@ -145,6 +151,19 @@ describe('chatStore', () => {
       expect(conv?.messages).toHaveLength(1)
       expect(conv?.messages[0].content).toBe('Hello')
       expect(conv?.messages[0].role).toBe('user')
+    })
+
+    it('generates unique message IDs within the same tick (issue #160)', () => {
+      const { createConversation, addMessage } = useChatStore.getState()
+
+      const convId = createConversation()
+      for (let i = 0; i < 50; i++) {
+        addMessage(convId, { role: 'user', content: `m${i}` })
+      }
+
+      const conv = useChatStore.getState().conversations.find(c => c.id === convId)
+      const ids = (conv?.messages ?? []).map(m => m.id)
+      expect(new Set(ids).size).toBe(50)
     })
 
     it('auto-generates title from first user message', () => {

--- a/voc-datalake/frontend/src/store/chatStore.ts
+++ b/voc-datalake/frontend/src/store/chatStore.ts
@@ -56,6 +56,8 @@ export const useChatStore = create<ChatStore>()(
         // crypto.randomUUID over Date.now(): two calls in the same
         // millisecond produced identical IDs (issue #160) — a real store
         // corruption risk and an observed test flake under full-suite load.
+        // randomUUID requires a secure context (https/localhost); dev over a
+        // plain-http LAN IP is not a supported workflow.
         const id = `conv_${crypto.randomUUID()}`
         const newConversation: Conversation = {
           id,
@@ -86,7 +88,7 @@ export const useChatStore = create<ChatStore>()(
       addMessage: (conversationId, message) => {
         const newMessage: ChatMessage = {
           ...message,
-          // Collision-proof per issue #160 (same rationale as conversation IDs).
+          // Collision-proof (see createConversation).
           id: `msg_${crypto.randomUUID()}`,
           timestamp: new Date(),
         }

--- a/voc-datalake/frontend/src/store/chatStore.ts
+++ b/voc-datalake/frontend/src/store/chatStore.ts
@@ -53,7 +53,10 @@ export const useChatStore = create<ChatStore>()(
       activeConversationId: null,
 
       createConversation: () => {
-        const id = `conv_${Date.now()}`
+        // crypto.randomUUID over Date.now(): two calls in the same
+        // millisecond produced identical IDs (issue #160) — a real store
+        // corruption risk and an observed test flake under full-suite load.
+        const id = `conv_${crypto.randomUUID()}`
         const newConversation: Conversation = {
           id,
           title: 'New Conversation',
@@ -83,7 +86,8 @@ export const useChatStore = create<ChatStore>()(
       addMessage: (conversationId, message) => {
         const newMessage: ChatMessage = {
           ...message,
-          id: `msg_${Date.now()}`,
+          // Collision-proof per issue #160 (same rationale as conversation IDs).
+          id: `msg_${crypto.randomUUID()}`,
           timestamp: new Date(),
         }
         


### PR DESCRIPTION
## Summary

Fixes #160 (close manually on merge).

`chatStore` generated conversation and message IDs from `Date.now()`, so two creations within the same millisecond shared an ID — a real store-corruption path (operations keyed by ID affect both) and the source of the intermittent `deleteConversation` test failure observed during #156's gate runs.

## Change

- `conv_${Date.now()}` → `conv_${crypto.randomUUID()}` and `msg_${Date.now()}` → `msg_${crypto.randomUUID()}`. `crypto.randomUUID()` is available in all supported browsers (secure contexts — CloudFront https and localhost dev) and in the vitest runtime. Prefixes are kept for debuggability; IDs are opaque strings everywhere (verified: nothing parses them), so persisted conversations from before this change stay valid.
- Removed the test suite's 1ms `setTimeout` timestamp-separation workaround — the flake's band-aid — and made that test synchronous.

## Tests

Two regression pins that fail on the old scheme with near-certainty: 50 back-to-back `createConversation()` calls must yield 50 distinct IDs, and 50 same-tick `addMessage` calls must yield 50 distinct message IDs. Full store suite: 23 passed; frontend lint/typecheck clean.