### PR TITLE
fix: chat filter changes no longer no-op without an active conversation

### DIFF
--- a/voc-datalake/frontend/src/pages/Chat/Chat.test.tsx
+++ b/voc-datalake/frontend/src/pages/Chat/Chat.test.tsx
@@ -71,6 +71,7 @@ const mockCreateConversation = vi.fn()
 const mockAddMessage = vi.fn()
 const mockGetActiveConversation = vi.fn()
 const mockUpdateConversationFilters = vi.fn()
+const mockSetDraftFilters = vi.fn()
 
 vi.mock('../../store/chatStore', () => ({
   useChatStore: () => ({
@@ -79,6 +80,8 @@ vi.mock('../../store/chatStore', () => ({
     addMessage: mockAddMessage,
     getActiveConversation: mockGetActiveConversation,
     updateConversationFilters: mockUpdateConversationFilters,
+    draftFilters: {},
+    setDraftFilters: mockSetDraftFilters,
   }),
   // Export types for the component
 }))
@@ -383,6 +386,21 @@ describe('Chat', () => {
       // sendMessage was called
       // eslint-disable-next-line vitest/prefer-called-with
       expect(mockSendMessage).toHaveBeenCalled()
+    })
+  })
+
+  describe('filter changes without an active conversation (issue #161)', () => {
+    it('buffers the change as a draft instead of silently dropping it', async () => {
+      // Regression: with no active conversation, filter changes (source/
+      // category/sentiment dropdowns and the web-search toggle) used to
+      // no-op — the control snapped back and the user got no feedback.
+      const user = userEvent.setup()
+      render(<Chat />, { wrapper: createWrapper() })
+
+      await user.click(screen.getByRole('button', { name: 'Set Source Filter' }))
+
+      expect(mockSetDraftFilters).toHaveBeenCalledWith({ source: 'webscraper' })
+      expect(mockUpdateConversationFilters).not.toHaveBeenCalled()
     })
   })
 })

--- a/voc-datalake/frontend/src/pages/Chat/Chat.tsx
+++ b/voc-datalake/frontend/src/pages/Chat/Chat.tsx
@@ -212,6 +212,9 @@ export default function Chat() {
   } = useChatStore()
 
   const activeConversation = getActiveConversation()
+  // Treat null/undefined and '' uniformly everywhere (an empty-string id
+  // buffering a draft that ?? would never consume was a reviewer catch).
+  const hasActiveConversation = activeConversationId != null && activeConversationId !== ''
   // Filters live on the conversation; before one exists they buffer in the
   // store's draft (issue #161: filter changes — including the web-search
   // toggle — used to silently no-op on a fresh page and snap back). The
@@ -291,7 +294,7 @@ export default function Chat() {
   }, [isStreaming])
 
   const handleFiltersChange = (newFilters: ChatFiltersType) => {
-    if (activeConversationId != null && activeConversationId !== '') {
+    if (hasActiveConversation) {
       updateConversationFilters(activeConversationId, newFilters)
     } else {
       setDraftFilters(newFilters)
@@ -309,9 +312,9 @@ export default function Chat() {
       content: m.content,
     }))
 
-    // The first message materializes the conversation, which consumes the
-    // draft filters the user set beforehand (issue #161).
-    const conversationId = activeConversationId ?? createConversation()
+    // The first message materializes the conversation, which consumes any
+    // draft filters the user set beforehand.
+    const conversationId = hasActiveConversation ? activeConversationId : createConversation()
     addMessage(conversationId, {
       role: 'user',
       content: input,

--- a/voc-datalake/frontend/src/pages/Chat/Chat.tsx
+++ b/voc-datalake/frontend/src/pages/Chat/Chat.tsx
@@ -207,10 +207,16 @@ export default function Chat() {
     addMessage,
     getActiveConversation,
     updateConversationFilters,
+    draftFilters,
+    setDraftFilters,
   } = useChatStore()
 
   const activeConversation = getActiveConversation()
-  const filters: ChatFiltersType = activeConversation?.filters ?? {}
+  // Filters live on the conversation; before one exists they buffer in the
+  // store's draft (issue #161: filter changes — including the web-search
+  // toggle — used to silently no-op on a fresh page and snap back). The
+  // next conversation to be created consumes the draft.
+  const filters: ChatFiltersType = activeConversation?.filters ?? draftFilters
 
   const {
     isStreaming,
@@ -287,6 +293,8 @@ export default function Chat() {
   const handleFiltersChange = (newFilters: ChatFiltersType) => {
     if (activeConversationId != null && activeConversationId !== '') {
       updateConversationFilters(activeConversationId, newFilters)
+    } else {
+      setDraftFilters(newFilters)
     }
   }
 
@@ -301,6 +309,8 @@ export default function Chat() {
       content: m.content,
     }))
 
+    // The first message materializes the conversation, which consumes the
+    // draft filters the user set beforehand (issue #161).
     const conversationId = activeConversationId ?? createConversation()
     addMessage(conversationId, {
       role: 'user',

--- a/voc-datalake/frontend/src/pages/Chat/Chat.tsx
+++ b/voc-datalake/frontend/src/pages/Chat/Chat.tsx
@@ -212,8 +212,8 @@ export default function Chat() {
   } = useChatStore()
 
   const activeConversation = getActiveConversation()
-  // Treat null/undefined and '' uniformly everywhere (an empty-string id
-  // buffering a draft that ?? would never consume was a reviewer catch).
+  // Treat null/undefined and '' uniformly everywhere: an empty-string id
+  // must not buffer a draft that ?? would then never consume.
   const hasActiveConversation = activeConversationId != null && activeConversationId !== ''
   // Filters live on the conversation; before one exists they buffer in the
   // store's draft (issue #161: filter changes — including the web-search

--- a/voc-datalake/frontend/src/store/chatStore.test.ts
+++ b/voc-datalake/frontend/src/store/chatStore.test.ts
@@ -249,6 +249,46 @@ describe('chatStore', () => {
       const conversation = useChatStore.getState().conversations.find(c => c.id === id)
       expect(conversation?.filters).toEqual({})
     })
+
+    it('consumes a lingering draft even after the active conversation was deleted', () => {
+      // Store-level lifecycle pin: however the app got into "draft set, no
+      // active conversation" (e.g. delete), the next creation consumes it.
+      const store = useChatStore.getState()
+      const firstId = store.createConversation()
+      store.setDraftFilters({ category: 'delivery' })
+      store.deleteConversation(firstId)
+
+      const secondId = useChatStore.getState().createConversation()
+
+      const conversation = useChatStore.getState().conversations.find(c => c.id === secondId)
+      expect(conversation?.filters).toEqual({ category: 'delivery' })
+      expect(useChatStore.getState().draftFilters).toEqual({})
+    })
+
+    it('hands the conversation its own copy of the draft, not a shared reference', () => {
+      useChatStore.getState().setDraftFilters({ source: 'webscraper' })
+      const draftBefore = useChatStore.getState().draftFilters
+
+      const id = useChatStore.getState().createConversation()
+
+      const conversation = useChatStore.getState().conversations.find(c => c.id === id)
+      expect(conversation?.filters).not.toBe(draftBefore)
+      expect(conversation?.filters).toEqual({ source: 'webscraper' })
+    })
+
+    it('is excluded from the persisted payload', () => {
+      // A stale draft applying to a conversation created in a LATER session
+      // would be the same surprising-filter-state bug in reverse — the
+      // draft is ephemeral by design.
+      useChatStore.getState().setDraftFilters({ useWebSearch: true })
+
+      const options = useChatStore.persist.getOptions()
+      const persisted = options.partialize?.(useChatStore.getState()) ?? useChatStore.getState()
+
+      expect(persisted).not.toHaveProperty('draftFilters')
+      expect(persisted).toHaveProperty('conversations')
+      expect(persisted).toHaveProperty('activeConversationId')
+    })
   })
 
   describe('updateConversationFilters', () => {

--- a/voc-datalake/frontend/src/store/chatStore.test.ts
+++ b/voc-datalake/frontend/src/store/chatStore.test.ts
@@ -10,6 +10,7 @@ describe('chatStore', () => {
     useChatStore.setState({
       conversations: [],
       activeConversationId: null,
+      draftFilters: {},
     })
   })
 
@@ -219,6 +220,34 @@ describe('chatStore', () => {
       const state = useChatStore.getState()
       const conv = state.conversations.find(c => c.id === convId)
       expect(conv?.title).toBe('Custom Title')
+    })
+  })
+
+  describe('draftFilters (issue #161)', () => {
+    it('buffers filters set before any conversation exists', () => {
+      useChatStore.getState().setDraftFilters({ source: 'webscraper', useWebSearch: true })
+
+      expect(useChatStore.getState().draftFilters).toEqual({ source: 'webscraper', useWebSearch: true })
+    })
+
+    it('is consumed by the next conversation, however it is created', () => {
+      // Covers both entry points: the first message on the Chat page and
+      // the sidebar's New Chat both go through createConversation.
+      useChatStore.getState().setDraftFilters({ sentiment: 'negative' })
+
+      const id = useChatStore.getState().createConversation()
+
+      const conversation = useChatStore.getState().conversations.find(c => c.id === id)
+      expect(conversation?.filters).toEqual({ sentiment: 'negative' })
+      // Draft is cleared so the NEXT fresh conversation starts clean.
+      expect(useChatStore.getState().draftFilters).toEqual({})
+    })
+
+    it('creates conversations with empty filters when no draft is set', () => {
+      const id = useChatStore.getState().createConversation()
+
+      const conversation = useChatStore.getState().conversations.find(c => c.id === id)
+      expect(conversation?.filters).toEqual({})
     })
   })
 

--- a/voc-datalake/frontend/src/store/chatStore.ts
+++ b/voc-datalake/frontend/src/store/chatStore.ts
@@ -66,10 +66,10 @@ export const useChatStore = create<ChatStore>()(
           title: 'New Conversation',
           messages: [],
           // The new conversation consumes any draft filters chosen before it
-          // existed (issue #161) instead of silently resetting them —
-          // regardless of whether it was created by the first message or
-          // the sidebar's New Chat.
-          filters: get().draftFilters,
+          // existed instead of silently resetting them — regardless of
+          // whether it was created by the first message or the sidebar's
+          // New Chat. Copied so no live reference is shared with the draft.
+          filters: { ...get().draftFilters },
           createdAt: new Date(),
           updatedAt: new Date(),
         }

--- a/voc-datalake/frontend/src/store/chatStore.ts
+++ b/voc-datalake/frontend/src/store/chatStore.ts
@@ -34,6 +34,11 @@ export interface Conversation {
 interface ChatStore {
   conversations: Conversation[]
   activeConversationId: string | null
+  /** Filters chosen while NO conversation is active (issue #161: they used
+   * to silently no-op). Ephemeral by design (not persisted): the next
+   * conversation to be created consumes them, however it is created (first
+   * message on the Chat page or the sidebar's New Chat). */
+  draftFilters: ChatFilters
   
   // Actions
   createConversation: () => string
@@ -42,6 +47,7 @@ interface ChatStore {
   addMessage: (conversationId: string, message: Omit<ChatMessage, 'id' | 'timestamp'>) => void
   updateConversationTitle: (id: string, title: string) => void
   updateConversationFilters: (id: string, filters: ChatFilters) => void
+  setDraftFilters: (filters: ChatFilters) => void
   getActiveConversation: () => Conversation | null
   clearAllConversations: () => void
 }
@@ -51,6 +57,7 @@ export const useChatStore = create<ChatStore>()(
     (set, get) => ({
       conversations: [],
       activeConversationId: null,
+      draftFilters: {},
 
       createConversation: () => {
         const id = `conv_${Date.now()}`
@@ -58,15 +65,24 @@ export const useChatStore = create<ChatStore>()(
           id,
           title: 'New Conversation',
           messages: [],
-          filters: {},
+          // The new conversation consumes any draft filters chosen before it
+          // existed (issue #161) instead of silently resetting them —
+          // regardless of whether it was created by the first message or
+          // the sidebar's New Chat.
+          filters: get().draftFilters,
           createdAt: new Date(),
           updatedAt: new Date(),
         }
         set((state) => ({
           conversations: [newConversation, ...state.conversations],
           activeConversationId: id,
+          draftFilters: {},
         }))
         return id
+      },
+
+      setDraftFilters: (filters) => {
+        set({ draftFilters: filters })
       },
 
       deleteConversation: (id) => {


### PR DESCRIPTION
## Summary

Fixes #161 (close manually on merge).

On a fresh Chat page (no active conversation), every filter interaction — the source/category/sentiment dropdowns and the web-search toggle from #156 — was silently dropped: `handleFiltersChange` only wrote to the active conversation, so the control snapped back with no feedback. With the web-search toggle this had a billing-adjacent twist: a user could believe web search was on when it wasn't (fail-safe direction, but misleading).

## Change — option 2 from the issue (buffer locally), implemented at the store level

Filter changes made while no conversation is active buffer in a new `draftFilters` field on `chatStore`; **the next conversation to be created consumes the draft** (and clears it). Putting the draft in the store rather than component state means BOTH creation paths inherit it:

- first message on the Chat page (`handleSubmit` → `createConversation`), and
- the sidebar's **New Chat** button — the exact repro in the report ("the toggle appeared broken until New Chat was clicked"), which a component-local draft would still have lost.

The draft is deliberately **not persisted** (excluded from partialize): it's ephemeral pre-conversation state, gone on reload like any half-configured UI. `createConversation`'s signature is unchanged, so `ChatSidebar` needed no edits.

## Tests

- Store: draft buffering, consumption + clearing on creation, and the empty-draft default.
- Chat page regression test: with no active conversation, a filter change lands in the draft (`setDraftFilters` called, `updateConversationFilters` not) instead of being discarded.
- Full root gate green (`npm run check` exit 0; 44 tests across the two touched suites).

## Note

Sibling PR #164 (issue #160) touches the same two files (`chatStore.ts`/test) on independent lines — whichever merges second may see a trivial conflict.