### PR TITLE
feat: per-surface AI model picker with latest Claude models (alternative to #154)

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -125,6 +125,23 @@ const mockSourcesStatus = {
 // Problem resolution state (issue #66) — mutable so the toggle round-trips.
 const mockResolvedProblems = {};
 
+// Per-surface AI model picker state (issue #96) — mutable so selects round-trip.
+// Mirrors lambda/shared/model_config.py (source of truth, lockstep-tested there).
+const mockModelSurfaces = {};
+const mockAvailableModels = [
+  { key: 'sonnet5', id: 'global.anthropic.claude-sonnet-5', label: 'Claude Sonnet 5', description: 'Latest, highest-quality Sonnet — best for analysis and generation' },
+  { key: 'sonnet46', id: 'global.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Previous-generation Sonnet — strong quality, accepts temperature tuning' },
+  { key: 'opus48', id: 'global.anthropic.claude-opus-4-8', label: 'Claude Opus 4.8', description: 'Deepest reasoning — best for prototypes and complex documents' },
+  { key: 'haiku45', id: 'global.anthropic.claude-haiku-4-5-20251001-v1:0', label: 'Claude Haiku 4.5', description: 'Fastest and cheapest — good for high-volume enrichment' },
+];
+const mockSurfaceDefaults = {
+  chat: 'global.anthropic.claude-sonnet-5',
+  documents: 'global.anthropic.claude-sonnet-5',
+  prototype: 'global.anthropic.claude-opus-4-8',
+  enrichment: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+  utility: 'global.anthropic.claude-sonnet-5',
+};
+
 const mockCategoriesConfig = {
   categories: [
     { name: 'delivery', display_name: 'Delivery', description: 'Shipping and delivery issues', color: '#EF4444' },
@@ -188,6 +205,34 @@ const handlers = {
   // Settings - Categories
   'GET /settings/categories': () => mockCategoriesConfig,
   'PUT /settings/categories': () => ({ success: true, message: 'Categories saved' }),
+
+  // Settings - Per-surface AI model picker (issue #96)
+  'GET /settings/model': () => ({
+    available_models: mockAvailableModels,
+    surfaces: Object.entries(mockSurfaceDefaults).map(([key, defaultId]) => ({
+      key,
+      default_id: defaultId,
+      selected: mockModelSurfaces[key] ?? null,
+    })),
+    model_id: null,
+  }),
+  'PUT /settings/model': (body) => {
+    const surface = body?.surface;
+    const modelId = body?.model_id ?? null;
+    if (!surface || !(surface in mockSurfaceDefaults)) {
+      return { __status: 400, body: { success: false, error: 'surface must be a known picker surface' } };
+    }
+    if (modelId !== null && !mockAvailableModels.some((m) => m.id === modelId)) {
+      return { __status: 400, body: { success: false, error: 'model_id must be null or allowlisted' } };
+    }
+    if (modelId === null) {
+      delete mockModelSurfaces[surface];
+    } else {
+      mockModelSurfaces[surface] = modelId;
+    }
+    return { success: true, surface, model_id: modelId };
+  },
+
   'GET /settings/resolved-problems': () => ({ resolved: mockResolvedProblems }),
   'PUT /settings/resolved-problems': (body) => {
     if (!body || typeof body.key !== 'string' || body.key.trim() === '' || typeof body.resolved !== 'boolean') {

--- a/voc-datalake/frontend/public/locales/de/settings.json
+++ b/voc-datalake/frontend/public/locales/de/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "Automatisch — {{model}}",
+    "intro": "Wählen Sie, welches Claude-Modell die einzelnen KI-Funktionen antreibt, oder behalten Sie „Automatisch“ bei, um die abgestimmte Voreinstellung jeder Funktion zu nutzen. Laufende Funktionen übernehmen Änderungen innerhalb einer Minute.",
+    "loadFailed": "Modelleinstellungen konnten nicht geladen werden.",
+    "loading": "Modelle werden geladen...",
+    "saveFailed": "Modellauswahl konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "saved": "Gespeichert",
+    "surfaces": {
+      "chat": {
+        "description": "Konversationelle Datenabfragen und Projekt-Chat",
+        "label": "KI-Chat"
+      },
+      "documents": {
+        "description": "PRDs, PR/FAQs, Personas und Forschungsberichte",
+        "label": "Dokumenterstellung"
+      },
+      "enrichment": {
+        "description": "Stimmung, Kategorien und Dringlichkeit für jedes erfasste Element",
+        "label": "Feedback-Anreicherung"
+      },
+      "prototype": {
+        "description": "Interaktive HTML-Prototypen",
+        "label": "Prototyp-Builder"
+      },
+      "utility": {
+        "description": "Kategorievorschläge und Scraper-Selektor-Erkennung",
+        "label": "Dienstprogramme"
+      }
+    },
+    "title": "KI-Modelle"
+  },
   "api": {
     "connected": "Verbunden",
     "endpointHint": "Der API-Gateway-Endpunkt Ihrer VoC-Bereitstellung",

--- a/voc-datalake/frontend/public/locales/en/settings.json
+++ b/voc-datalake/frontend/public/locales/en/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "Automatic — {{model}}",
+    "intro": "Choose which Claude model powers each AI feature, or keep Automatic to use each feature’s tuned default. Running functions pick up changes within a minute.",
+    "loadFailed": "Could not load model settings.",
+    "loading": "Loading models...",
+    "saveFailed": "Failed to save model selection. Try again.",
+    "saved": "Saved",
+    "surfaces": {
+      "chat": {
+        "description": "Conversational data queries and project chat",
+        "label": "AI Chat"
+      },
+      "documents": {
+        "description": "PRDs, PR/FAQs, personas, and research reports",
+        "label": "Document Generation"
+      },
+      "enrichment": {
+        "description": "Sentiment, categories, and urgency on every ingested item",
+        "label": "Feedback Enrichment"
+      },
+      "prototype": {
+        "description": "Interactive HTML prototypes",
+        "label": "Prototype Builder"
+      },
+      "utility": {
+        "description": "Category suggestions and scraper selector detection",
+        "label": "Utilities"
+      }
+    },
+    "title": "AI Models"
+  },
   "api": {
     "connected": "Connected",
     "endpointHint": "The API Gateway endpoint from your VoC deployment",

--- a/voc-datalake/frontend/public/locales/es/settings.json
+++ b/voc-datalake/frontend/public/locales/es/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "Automático — {{model}}",
+    "intro": "Elija qué modelo de Claude impulsa cada función de IA, o mantenga Automático para usar el valor predeterminado ajustado de cada función. Las funciones en ejecución aplican los cambios en un minuto.",
+    "loadFailed": "No se pudo cargar la configuración de modelos.",
+    "loading": "Cargando modelos...",
+    "saveFailed": "No se pudo guardar la selección de modelo. Inténtelo de nuevo.",
+    "saved": "Guardado",
+    "surfaces": {
+      "chat": {
+        "description": "Consultas de datos conversacionales y chat de proyecto",
+        "label": "Chat de IA"
+      },
+      "documents": {
+        "description": "PRD, PR/FAQ, personas e informes de investigación",
+        "label": "Generación de documentos"
+      },
+      "enrichment": {
+        "description": "Sentimiento, categorías y urgencia en cada elemento ingerido",
+        "label": "Enriquecimiento de comentarios"
+      },
+      "prototype": {
+        "description": "Prototipos HTML interactivos",
+        "label": "Generador de prototipos"
+      },
+      "utility": {
+        "description": "Sugerencias de categorías y detección de selectores del scraper",
+        "label": "Utilidades"
+      }
+    },
+    "title": "Modelos de IA"
+  },
   "api": {
     "connected": "Conectado",
     "endpointHint": "El endpoint de API Gateway de su despliegue VoC",

--- a/voc-datalake/frontend/public/locales/fr/settings.json
+++ b/voc-datalake/frontend/public/locales/fr/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "Automatique — {{model}}",
+    "intro": "Choisissez le modèle Claude qui alimente chaque fonctionnalité d’IA, ou conservez Automatique pour utiliser le réglage par défaut de chaque fonctionnalité. Les fonctions en cours prennent en compte les changements en moins d’une minute.",
+    "loadFailed": "Impossible de charger les paramètres de modèle.",
+    "loading": "Chargement des modèles...",
+    "saveFailed": "Échec de l’enregistrement de la sélection du modèle. Réessayez.",
+    "saved": "Enregistré",
+    "surfaces": {
+      "chat": {
+        "description": "Requêtes de données conversationnelles et chat de projet",
+        "label": "Chat IA"
+      },
+      "documents": {
+        "description": "PRD, PR/FAQ, personas et rapports de recherche",
+        "label": "Génération de documents"
+      },
+      "enrichment": {
+        "description": "Sentiment, catégories et urgence sur chaque élément ingéré",
+        "label": "Enrichissement des retours"
+      },
+      "prototype": {
+        "description": "Prototypes HTML interactifs",
+        "label": "Générateur de prototypes"
+      },
+      "utility": {
+        "description": "Suggestions de catégories et détection des sélecteurs du scraper",
+        "label": "Utilitaires"
+      }
+    },
+    "title": "Modèles d’IA"
+  },
   "api": {
     "connected": "Connecté",
     "endpointHint": "Le point de terminaison API Gateway de votre déploiement VoC",

--- a/voc-datalake/frontend/public/locales/ja/settings.json
+++ b/voc-datalake/frontend/public/locales/ja/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "自動 — {{model}}",
+    "intro": "各AI機能を動かすClaudeモデルを選択するか、「自動」のままにして各機能に最適化されたデフォルトを使用します。実行中の関数は1分以内に変更を反映します。",
+    "loadFailed": "モデル設定を読み込めませんでした。",
+    "loading": "モデルを読み込んでいます...",
+    "saveFailed": "モデル選択の保存に失敗しました。もう一度お試しください。",
+    "saved": "保存済み",
+    "surfaces": {
+      "chat": {
+        "description": "対話型データクエリとプロジェクトチャット",
+        "label": "AIチャット"
+      },
+      "documents": {
+        "description": "PRD、PR/FAQ、ペルソナ、調査レポート",
+        "label": "ドキュメント生成"
+      },
+      "enrichment": {
+        "description": "取り込んだ全項目のセンチメント・カテゴリ・緊急度",
+        "label": "フィードバック強化"
+      },
+      "prototype": {
+        "description": "インタラクティブなHTMLプロトタイプ",
+        "label": "プロトタイプビルダー"
+      },
+      "utility": {
+        "description": "カテゴリ提案とスクレイパーセレクター検出",
+        "label": "ユーティリティ"
+      }
+    },
+    "title": "AIモデル"
+  },
   "api": {
     "connected": "接続済み",
     "endpointHint": "VoCデプロイメントのAPI Gatewayエンドポイント",

--- a/voc-datalake/frontend/public/locales/ko/settings.json
+++ b/voc-datalake/frontend/public/locales/ko/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "자동 — {{model}}",
+    "intro": "각 AI 기능을 구동할 Claude 모델을 선택하거나, 자동으로 두어 각 기능에 맞게 조정된 기본값을 사용하세요. 실행 중인 함수는 1분 이내에 변경 사항을 반영합니다.",
+    "loadFailed": "모델 설정을 불러오지 못했습니다.",
+    "loading": "모델을 불러오는 중...",
+    "saveFailed": "모델 선택을 저장하지 못했습니다. 다시 시도하세요.",
+    "saved": "저장됨",
+    "surfaces": {
+      "chat": {
+        "description": "대화형 데이터 질의 및 프로젝트 채팅",
+        "label": "AI 채팅"
+      },
+      "documents": {
+        "description": "PRD, PR/FAQ, 페르소나, 리서치 보고서",
+        "label": "문서 생성"
+      },
+      "enrichment": {
+        "description": "수집된 모든 항목의 감성, 카테고리, 긴급도",
+        "label": "피드백 보강"
+      },
+      "prototype": {
+        "description": "인터랙티브 HTML 프로토타입",
+        "label": "프로토타입 빌더"
+      },
+      "utility": {
+        "description": "카테고리 제안 및 스크레이퍼 선택자 감지",
+        "label": "유틸리티"
+      }
+    },
+    "title": "AI 모델"
+  },
   "api": {
     "connected": "연결됨",
     "endpointHint": "VoC 배포의 API Gateway 엔드포인트",

--- a/voc-datalake/frontend/public/locales/pt/settings.json
+++ b/voc-datalake/frontend/public/locales/pt/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "Automático — {{model}}",
+    "intro": "Escolha qual modelo Claude alimenta cada recurso de IA, ou mantenha Automático para usar o padrão ajustado de cada recurso. Funções em execução aplicam as alterações em até um minuto.",
+    "loadFailed": "Não foi possível carregar as configurações de modelo.",
+    "loading": "Carregando modelos...",
+    "saveFailed": "Falha ao salvar a seleção do modelo. Tente novamente.",
+    "saved": "Salvo",
+    "surfaces": {
+      "chat": {
+        "description": "Consultas de dados conversacionais e chat do projeto",
+        "label": "Chat de IA"
+      },
+      "documents": {
+        "description": "PRDs, PR/FAQs, personas e relatórios de pesquisa",
+        "label": "Geração de documentos"
+      },
+      "enrichment": {
+        "description": "Sentimento, categorias e urgência em cada item ingerido",
+        "label": "Enriquecimento de feedback"
+      },
+      "prototype": {
+        "description": "Protótipos HTML interativos",
+        "label": "Construtor de protótipos"
+      },
+      "utility": {
+        "description": "Sugestões de categorias e detecção de seletores do scraper",
+        "label": "Utilitários"
+      }
+    },
+    "title": "Modelos de IA"
+  },
   "api": {
     "connected": "Conectado",
     "endpointHint": "O endpoint do API Gateway da sua implantação VoC",

--- a/voc-datalake/frontend/public/locales/zh/settings.json
+++ b/voc-datalake/frontend/public/locales/zh/settings.json
@@ -1,4 +1,35 @@
 {
+  "aiModel": {
+    "automaticOption": "自动 — {{model}}",
+    "intro": "选择为每项 AI 功能提供支持的 Claude 模型，或保持“自动”以使用每项功能的调优默认值。正在运行的函数会在一分钟内应用更改。",
+    "loadFailed": "无法加载模型设置。",
+    "loading": "正在加载模型...",
+    "saveFailed": "保存模型选择失败。请重试。",
+    "saved": "已保存",
+    "surfaces": {
+      "chat": {
+        "description": "对话式数据查询和项目聊天",
+        "label": "AI 聊天"
+      },
+      "documents": {
+        "description": "PRD、PR/FAQ、用户画像和研究报告",
+        "label": "文档生成"
+      },
+      "enrichment": {
+        "description": "对每条采集项进行情感、类别和紧急度分析",
+        "label": "反馈增强"
+      },
+      "prototype": {
+        "description": "交互式 HTML 原型",
+        "label": "原型构建器"
+      },
+      "utility": {
+        "description": "类别建议和抓取器选择器检测",
+        "label": "实用工具"
+      }
+    },
+    "title": "AI 模型"
+  },
   "api": {
     "connected": "已连接",
     "endpointHint": "您的VoC部署的API Gateway端点",

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -280,6 +280,24 @@ export const api = {
     body: JSON.stringify(settings)
   }),
 
+  // AI model selection — per-surface, curated allowlist, admin-only UI (issue #96).
+  // `surfaces` lists each pickable AI surface with its built-in default and the
+  // admin-selected override (null = Automatic). `model_id` is a legacy global
+  // override kept for backward compatibility.
+  getModelSettings: () => fetchApi<{
+    available_models: Array<{ key: string; id: string; label: string; description: string }>
+    surfaces: Array<{ key: string; default_id: string; selected: string | null }>
+    model_id: string | null
+  }>('/settings/model'),
+
+  // Set (modelId = allowlisted id) or clear (modelId = null) the model for one
+  // surface. Backend is admin-gated; the UI only shows this to admins.
+  saveModelSettings: (surface: string, modelId: string | null) =>
+    fetchApi<{ success: boolean; surface: string | null; model_id: string | null }>('/settings/model', {
+      method: 'PUT',
+      body: JSON.stringify({ surface, model_id: modelId }),
+    }),
+
   // Problem resolution (Problem Analysis page; shared across users)
   getResolvedProblems: () => fetchApi<{
     resolved: Record<string, { resolved_at: string }>

--- a/voc-datalake/frontend/src/pages/Settings/AiModelSection.test.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/AiModelSection.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Tests for the per-surface AI model picker (issue #96).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import AiModelSection from './AiModelSection'
+
+const mockGetModelSettings = vi.fn()
+const mockSaveModelSettings = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getModelSettings: () => mockGetModelSettings(),
+    saveModelSettings: (surface: string, modelId: string | null) =>
+      mockSaveModelSettings(surface, modelId),
+  },
+}))
+
+const SONNET5 = 'global.anthropic.claude-sonnet-5'
+const OPUS48 = 'global.anthropic.claude-opus-4-8'
+const HAIKU45 = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+
+const modelSettingsFixture = {
+  available_models: [
+    { key: 'sonnet5', id: SONNET5, label: 'Claude Sonnet 5', description: 'Latest Sonnet' },
+    { key: 'sonnet46', id: 'global.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Previous Sonnet' },
+    { key: 'opus48', id: OPUS48, label: 'Claude Opus 4.8', description: 'Deepest reasoning' },
+    { key: 'haiku45', id: HAIKU45, label: 'Claude Haiku 4.5', description: 'Fastest' },
+  ],
+  surfaces: [
+    { key: 'chat', default_id: SONNET5, selected: null },
+    { key: 'documents', default_id: SONNET5, selected: null },
+    { key: 'prototype', default_id: OPUS48, selected: null },
+    { key: 'enrichment', default_id: HAIKU45, selected: null },
+    { key: 'utility', default_id: SONNET5, selected: null },
+  ],
+  model_id: null,
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('AiModelSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetModelSettings.mockResolvedValue(modelSettingsFixture)
+    mockSaveModelSettings.mockResolvedValue({ success: true, surface: 'chat', model_id: HAIKU45 })
+  })
+
+  it('renders nothing without an API endpoint', () => {
+    const { container } = render(<AiModelSection apiEndpoint="" isAdmin />, { wrapper: createWrapper() })
+
+    expect(container).toBeEmptyDOMElement()
+    expect(mockGetModelSettings).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing (and never fetches) for non-admins', () => {
+    const { container } = render(
+      <AiModelSection apiEndpoint="https://api.example.com" isAdmin={false} />,
+      { wrapper: createWrapper() },
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    expect(mockGetModelSettings).not.toHaveBeenCalled()
+  })
+
+  it('renders one selector per surface, all on Automatic by default', async () => {
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toBeInTheDocument())
+    const surfaceLabels = ['AI Chat', 'Document Generation', 'Prototype Builder', 'Feedback Enrichment', 'Utilities']
+    for (const label of surfaceLabels) {
+      const select = screen.getByLabelText(label)
+      expect(select).toHaveValue('')
+    }
+  })
+
+  it('shows each surface default inside its Automatic option', async () => {
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('Prototype Builder')).toBeInTheDocument())
+    const prototypeSelect = screen.getByLabelText('Prototype Builder')
+    expect(within(prototypeSelect).getByText('Automatic — Claude Opus 4.8')).toBeInTheDocument()
+    const enrichmentSelect = screen.getByLabelText('Feedback Enrichment')
+    expect(within(enrichmentSelect).getByText('Automatic — Claude Haiku 4.5')).toBeInTheDocument()
+  })
+
+  it('saves a per-surface selection and shows the Saved badge', async () => {
+    const user = userEvent.setup()
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toBeInTheDocument())
+    await user.selectOptions(screen.getByLabelText('AI Chat'), HAIKU45)
+
+    expect(mockSaveModelSettings).toHaveBeenCalledWith('chat', HAIKU45)
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument())
+  })
+
+  it('clears a selection back to Automatic (null)', async () => {
+    mockGetModelSettings.mockResolvedValue({
+      ...modelSettingsFixture,
+      surfaces: modelSettingsFixture.surfaces.map((s) =>
+        s.key === 'chat' ? { ...s, selected: HAIKU45 } : s,
+      ),
+    })
+    mockSaveModelSettings.mockResolvedValue({ success: true, surface: 'chat', model_id: null })
+    const user = userEvent.setup()
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toHaveValue(HAIKU45))
+    await user.selectOptions(screen.getByLabelText('AI Chat'), '')
+
+    expect(mockSaveModelSettings).toHaveBeenCalledWith('chat', null)
+  })
+
+  it('shows an error state instead of an infinite spinner when the load fails', async () => {
+    mockGetModelSettings.mockRejectedValue(new Error('boom'))
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() =>
+      expect(screen.getByText('Could not load model settings.')).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('Loading models...')).not.toBeInTheDocument()
+  })
+
+  it('shows a save error message when the mutation fails', async () => {
+    mockSaveModelSettings.mockRejectedValue(new Error('403'))
+    const user = userEvent.setup()
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toBeInTheDocument())
+    await user.selectOptions(screen.getByLabelText('AI Chat'), HAIKU45)
+
+    await waitFor(() =>
+      expect(screen.getByText('Failed to save model selection. Try again.')).toBeInTheDocument(),
+    )
+  })
+})

--- a/voc-datalake/frontend/src/pages/Settings/AiModelSection.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/AiModelSection.tsx
@@ -1,0 +1,174 @@
+/**
+ * @fileoverview Per-surface AI model selection for Settings (issue #96).
+ *
+ * Admins pick which allowlisted Bedrock model powers each AI *surface* (chat,
+ * documents, prototypes, feedback enrichment, utilities), or leave a surface
+ * on Automatic to use its tuned default. This is the per-surface alternative
+ * to a single global model toggle: enrichment can stay on cheap Haiku while
+ * chat runs on Sonnet 5 and prototypes on Opus 4.8.
+ *
+ * Free-form model IDs are rejected server-side, and the PUT is admin-gated
+ * server-side too (not just hidden in the UI).
+ *
+ * Model NAMES are product names (identical in every language), so they render
+ * from the server-provided `label` and are intentionally NOT in locale files —
+ * the i18n gate rejects same-as-English values. Surface labels/descriptions and
+ * the surrounding chrome are translated under `aiModel.*`.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { Cpu, CheckCircle2, Loader2, AlertCircle } from 'lucide-react'
+import { api } from '../../api/client'
+
+interface AiModelSectionProps {
+  readonly apiEndpoint: string
+  /** Card renders only for admins — the backend gates the PUT server-side too. */
+  readonly isAdmin: boolean
+}
+
+type ModelSettings = Awaited<ReturnType<typeof api.getModelSettings>>
+
+export default function AiModelSection({ apiEndpoint, isAdmin }: AiModelSectionProps) {
+  const { t } = useTranslation('settings')
+  const queryClient = useQueryClient()
+  const [savedSurface, setSavedSurface] = useState<string | null>(null)
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const enabled = isAdmin && apiEndpoint.length > 0
+
+  // Clear the "Saved" badge timer on unmount so it can't set state afterwards.
+  useEffect(() => () => {
+    if (savedTimer.current) clearTimeout(savedTimer.current)
+  }, [])
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['model-settings'],
+    queryFn: () => api.getModelSettings(),
+    enabled,
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: ({ surface, modelId }: { surface: string; modelId: string | null }) =>
+      api.saveModelSettings(surface, modelId),
+    onSuccess: (_result, { surface }) => {
+      setSavedSurface(surface)
+      if (savedTimer.current) clearTimeout(savedTimer.current)
+      savedTimer.current = setTimeout(() => setSavedSurface(null), 2000)
+      void queryClient.invalidateQueries({ queryKey: ['model-settings'] })
+    },
+  })
+
+  if (!enabled) return null
+
+  return (
+    <div className="card">
+      <div className="flex items-center gap-2 mb-1">
+        <Cpu size={18} className="text-blue-600" />
+        <h2 className="text-lg font-semibold">{t('aiModel.title')}</h2>
+      </div>
+      <p className="text-xs text-gray-500 mb-4">{t('aiModel.intro')}</p>
+      <AiModelSectionBody
+        data={data}
+        isLoading={isLoading}
+        isError={isError}
+        isSaving={saveMutation.isPending}
+        savedSurface={savedSurface}
+        onSelect={(surface, modelId) => saveMutation.mutate({ surface, modelId })}
+      />
+      {saveMutation.isError && (
+        <p className="text-xs text-red-600 mt-2" role="alert">{t('aiModel.saveFailed')}</p>
+      )}
+    </div>
+  )
+}
+
+interface AiModelSectionBodyProps {
+  readonly data: ModelSettings | undefined
+  readonly isLoading: boolean
+  readonly isError: boolean
+  readonly isSaving: boolean
+  readonly savedSurface: string | null
+  readonly onSelect: (surface: string, modelId: string | null) => void
+}
+
+function AiModelSectionBody({ data, isLoading, isError, isSaving, savedSurface, onSelect }: AiModelSectionBodyProps) {
+  const { t } = useTranslation('settings')
+
+  if (isError) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-red-600" role="alert">
+        <AlertCircle size={16} /> {t('aiModel.loadFailed')}
+      </div>
+    )
+  }
+  if (isLoading || !data) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-gray-500">
+        <Loader2 size={16} className="animate-spin" /> {t('aiModel.loading')}
+      </div>
+    )
+  }
+
+  // Model id → display label (product name, served by the backend).
+  const labelForId = new Map(data.available_models.map((model) => [model.id, model.label]))
+
+  return (
+    <fieldset className="space-y-3" disabled={isSaving}>
+      <legend className="sr-only">{t('aiModel.title')}</legend>
+      {data.surfaces.map((surface) => (
+        <SurfaceRow
+          key={surface.key}
+          surfaceKey={surface.key}
+          selected={surface.selected}
+          defaultLabel={labelForId.get(surface.default_id) ?? surface.default_id}
+          models={data.available_models}
+          justSaved={savedSurface === surface.key}
+          onSelect={(modelId) => onSelect(surface.key, modelId)}
+        />
+      ))}
+    </fieldset>
+  )
+}
+
+interface SurfaceRowProps {
+  readonly surfaceKey: string
+  readonly selected: string | null
+  readonly defaultLabel: string
+  readonly models: ModelSettings['available_models']
+  readonly justSaved: boolean
+  readonly onSelect: (modelId: string | null) => void
+}
+
+function SurfaceRow({ surfaceKey, selected, defaultLabel, models, justSaved, onSelect }: SurfaceRowProps) {
+  const { t } = useTranslation('settings')
+  const selectId = `ai-model-${surfaceKey}`
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border-b border-gray-100 pb-3 last:border-0 last:pb-0">
+      <div className="min-w-0">
+        <label htmlFor={selectId} className="block text-sm font-medium text-gray-900">
+          {t(`aiModel.surfaces.${surfaceKey}.label`)}
+        </label>
+        <p className="text-xs text-gray-500">{t(`aiModel.surfaces.${surfaceKey}.description`)}</p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {justSaved && (
+          <span className="text-xs text-green-600 flex items-center gap-1">
+            <CheckCircle2 size={14} /> {t('aiModel.saved')}
+          </span>
+        )}
+        <select
+          id={selectId}
+          className="input py-1.5 text-sm w-full sm:w-64"
+          value={selected ?? ''}
+          onChange={(event) => onSelect(event.target.value === '' ? null : event.target.value)}
+        >
+          <option value="">{t('aiModel.automaticOption', { model: defaultLabel })}</option>
+          {models.map((model) => (
+            <option key={model.id} value={model.id}>{model.label}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Settings/Settings.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/Settings.tsx
@@ -25,6 +25,7 @@ import clsx from 'clsx'
 import ConfirmModal from '../../components/ConfirmModal'
 import SourceCard from './SourceCard'
 import LogsSection from './LogsSection'
+import AiModelSection from './AiModelSection'
 import { useApiEndpointField, useBrandForm } from './useSettingsSync'
 import { getEnabledPlugins } from '../../plugins'
 
@@ -181,6 +182,7 @@ export default function Settings() {
               onHashtagsChange={setHashtags}
               onUrlsToTrackChange={setUrlsToTrack}
             />
+            <AiModelSection apiEndpoint={apiEndpoint} isAdmin={isAdmin} />
             <DangerZoneSection
               showResetConfirm={showResetConfirm}
               onShowResetConfirm={setShowResetConfirm}

--- a/voc-datalake/lambda/api/chat_handler.py
+++ b/voc-datalake/lambda/api/chat_handler.py
@@ -158,6 +158,7 @@ Top Categories: {', '.join([f"{cat}: {count}" for cat, count in sorted(category_
             prompt=f"{data_context}\n\nQuestion: {message}",
             system_prompt=system_prompt,
             max_tokens=1500,
+            surface='chat',
         )
         
         return {

--- a/voc-datalake/lambda/api/manual_import_processor.py
+++ b/voc-datalake/lambda/api/manual_import_processor.py
@@ -130,6 +130,12 @@ def process_job(job_id: str) -> None:
         # it defaults to 1, which is also the only accepted value with thinking
         # enabled, while temperature-restricted models (Sonnet 5, Opus 4.8)
         # reject the parameter outright when sent explicitly.
+        #
+        # This raw invoke_model path bypasses converse() and has NO
+        # auto-continuation, so the strict-JSON doctrine (shared/converse.py)
+        # applies in its single-call form: max_tokens=16000 must fit the whole
+        # JSON answer in one call; a truncated response falls through
+        # parse_llm_response() into unparsed_sections rather than corrupting.
         model_id = get_active_model_id('utility')
         request_body = {
             "anthropic_version": "bedrock-2023-05-31",

--- a/voc-datalake/lambda/api/manual_import_processor.py
+++ b/voc-datalake/lambda/api/manual_import_processor.py
@@ -12,8 +12,9 @@ from typing import Any
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer, metrics
-from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource, get_bedrock_client
 from shared.exceptions import ValidationError
+from shared.model_config import get_active_model_id, uses_adaptive_thinking
 
 dynamodb = get_dynamodb_resource()
 bedrock = get_bedrock_client()
@@ -121,24 +122,31 @@ def process_job(job_id: str) -> None:
             raw_text=raw_text
         )
         
-        # Call Bedrock with extended thinking
-        # Note: temperature must be 1 when extended thinking is enabled
+        # Call Bedrock with extended thinking. Parsing pasted reviews is a
+        # utility workload, so it follows the utility-surface model pick.
+        #
+        # Capability-aware body: adaptive-thinking models (Sonnet 5) reject an
+        # explicit `thinking` budget, and temperature is omitted everywhere —
+        # it defaults to 1, which is also the only accepted value with thinking
+        # enabled, while temperature-restricted models (Sonnet 5, Opus 4.8)
+        # reject the parameter outright when sent explicitly.
+        model_id = get_active_model_id('utility')
         request_body = {
             "anthropic_version": "bedrock-2023-05-31",
             "max_tokens": 16000,
-            "temperature": 1,
-            "thinking": {
-                "type": "enabled",
-                "budget_tokens": 5000
-            },
             "system": PARSE_SYSTEM_PROMPT,
             "messages": [{"role": "user", "content": user_prompt}]
         }
+        if not uses_adaptive_thinking(model_id):
+            request_body["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": 5000
+            }
         
-        logger.info(f"Invoking Bedrock for job {job_id}")
+        logger.info(f"Invoking Bedrock for job {job_id} with model {model_id}")
         
         bedrock_response = bedrock.invoke_model(
-            modelId=BEDROCK_MODEL_ID,
+            modelId=model_id,
             body=json.dumps(request_body),
             contentType="application/json",
             accept="application/json"

--- a/voc-datalake/lambda/api/product_context.py
+++ b/voc-datalake/lambda/api/product_context.py
@@ -21,7 +21,8 @@ from typing import Any
 from boto3.dynamodb.conditions import Key
 
 from shared.logging import logger, tracer
-from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource, get_bedrock_client
+from shared.model_config import get_active_model_id, omits_temperature
 from shared.exceptions import (
     ConfigurationError, NotFoundError, ValidationError, ServiceError,
 )
@@ -341,12 +342,19 @@ def interview_turn(project_id: str, body: dict) -> dict:
     messages.append({'role': 'user', 'content': [{'text': message}]})
 
     client = get_bedrock_client()
+    # Product-interview chat surface. Raw client call (tool use isn't wrapped by
+    # the shared converse helper), so resolve the model and omit temperature for
+    # models that reject it (Sonnet 5 / Opus 4.8) exactly as converse() does.
+    model = get_active_model_id('chat')
+    inference_config: dict = {'maxTokens': 1024}
+    if not omits_temperature(model):
+        inference_config['temperature'] = 0.3
     try:
         resp = client.converse(
-            modelId=BEDROCK_MODEL_ID,
+            modelId=model,
             messages=messages,
             system=[{'text': system_prompt}],
-            inferenceConfig={'maxTokens': 1024, 'temperature': 0.3},
+            inferenceConfig=inference_config,
             toolConfig={'tools': [_build_interview_tool()]},
         )
     except Exception as e:
@@ -603,6 +611,7 @@ def generate_report(project_id: str, body: dict) -> dict:
             system_prompt=system_prompt,
             max_tokens=4000,
             temperature=0.2,
+            surface='documents',
             step_name='product_report',
         )
     except Exception as e:

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -654,10 +654,13 @@ def autofill_prfaq_questions(project_id: str, body: dict) -> dict:
         "5. What does the customer experience look like?"
     )
 
+    # JSON output must fit ONE call: adaptive-thinking models (Sonnet 5)
+    # spend output budget on thinking, and the continuation seam is
+    # unreliable mid-JSON (live-caught on categories generate).
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
-        max_tokens=2500,
+        max_tokens=4096,
         temperature=0.3,
         surface='documents',
         step_name='prfaq_autofill',
@@ -741,7 +744,7 @@ def suggest_document_brief(project_id: str, body: dict) -> dict:
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
-        max_tokens=1200,
+        max_tokens=2048,  # JSON headroom for adaptive-thinking models (see prfaq_autofill note)
         temperature=0.4,
         surface='documents',
         step_name='document_brief_suggest',
@@ -822,7 +825,7 @@ def suggest_research_questions(project_id: str, body: dict) -> dict:
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
-        max_tokens=1500,
+        max_tokens=2048,  # JSON headroom for adaptive-thinking models (see prfaq_autofill note)
         temperature=0.4,
         surface='documents',
         step_name='research_suggest',

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -654,9 +654,8 @@ def autofill_prfaq_questions(project_id: str, body: dict) -> dict:
         "5. What does the customer experience look like?"
     )
 
-    # JSON output must fit ONE call: adaptive-thinking models (Sonnet 5)
-    # spend output budget on thinking, and the continuation seam is
-    # unreliable mid-JSON (live-caught on categories generate).
+    # 4096: strict-JSON output must fit ONE call (see the strict-JSON
+    # doctrine in shared/converse.py).
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
@@ -744,7 +743,7 @@ def suggest_document_brief(project_id: str, body: dict) -> dict:
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
-        max_tokens=2048,  # JSON headroom for adaptive-thinking models (see prfaq_autofill note)
+        max_tokens=2048,  # strict JSON: fit ONE call (doctrine in shared/converse.py)
         temperature=0.4,
         surface='documents',
         step_name='document_brief_suggest',
@@ -825,7 +824,7 @@ def suggest_research_questions(project_id: str, body: dict) -> dict:
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
-        max_tokens=2048,  # JSON headroom for adaptive-thinking models (see prfaq_autofill note)
+        max_tokens=2048,  # strict JSON: fit ONE call (doctrine in shared/converse.py)
         temperature=0.4,
         surface='documents',
         step_name='research_suggest',

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -349,7 +349,7 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
         update_progress(20, 'executing_llm_chain')
         
         try:
-            results = converse_chain(chain_steps, progress_callback=lambda p, s: update_progress(p, s))
+            results = converse_chain(chain_steps, progress_callback=lambda p, s: update_progress(p, s), surface='documents')
             logger.info(f"[PERSONA] LLM chain returned {len(results)} results")
         except Exception as e:
             logger.error(f"[PERSONA] LLM chain execution failed: {e}")
@@ -545,7 +545,7 @@ def generate_prd(project_id: str, body: dict) -> dict:
     )
 
     try:
-        results = converse_chain(chain_steps)
+        results = converse_chain(chain_steps, surface='documents')
         
         # Save PRD
         now = datetime.now(timezone.utc).isoformat()
@@ -659,6 +659,7 @@ def autofill_prfaq_questions(project_id: str, body: dict) -> dict:
         system_prompt=system_prompt,
         max_tokens=2500,
         temperature=0.3,
+        surface='documents',
         step_name='prfaq_autofill',
     )
 
@@ -742,6 +743,7 @@ def suggest_document_brief(project_id: str, body: dict) -> dict:
         system_prompt=system_prompt,
         max_tokens=1200,
         temperature=0.4,
+        surface='documents',
         step_name='document_brief_suggest',
     )
 
@@ -822,6 +824,7 @@ def suggest_research_questions(project_id: str, body: dict) -> dict:
         system_prompt=system_prompt,
         max_tokens=1500,
         temperature=0.4,
+        surface='documents',
         step_name='research_suggest',
     )
 
@@ -892,7 +895,7 @@ Quote: "{p.get('quote', '')}"
     )
 
     try:
-        results = converse_chain(chain_steps)
+        results = converse_chain(chain_steps, surface='documents')
         
         # Combine into final document
         full_document = f"""# PR/FAQ: {feature_idea}
@@ -1411,7 +1414,7 @@ def run_research(project_id: str, body: dict) -> dict:
     )
 
     try:
-        results = converse_chain(chain_steps)
+        results = converse_chain(chain_steps, surface='documents')
         
         # Save research - combine all results into a comprehensive report
         now = datetime.now(timezone.utc).isoformat()

--- a/voc-datalake/lambda/api/scrapers_handler.py
+++ b/voc-datalake/lambda/api/scrapers_handler.py
@@ -287,7 +287,7 @@ def analyze_url():
         from shared.converse import converse
         prompt = f"""Analyze this HTML and identify CSS selectors for extracting reviews:\n\n```html\n{html_sample}\n```\n\nReturn JSON with: container_selector, text_selector, rating_selector, author_selector, date_selector, confidence (high/medium/low), detected_reviews_count"""
 
-        response_text = converse(prompt=prompt, max_tokens=1000)
+        response_text = converse(prompt=prompt, max_tokens=1000, surface='utility')
         
         json_match = re.search(r'\{[^{}]*\}', response_text, re.DOTALL)
         if not json_match:

--- a/voc-datalake/lambda/api/scrapers_handler.py
+++ b/voc-datalake/lambda/api/scrapers_handler.py
@@ -287,7 +287,11 @@ def analyze_url():
         from shared.converse import converse
         prompt = f"""Analyze this HTML and identify CSS selectors for extracting reviews:\n\n```html\n{html_sample}\n```\n\nReturn JSON with: container_selector, text_selector, rating_selector, author_selector, date_selector, confidence (high/medium/low), detected_reviews_count"""
 
-        response_text = converse(prompt=prompt, max_tokens=1000, surface='utility')
+        # 2048 (was 1000): adaptive-thinking models (Sonnet 5) spend output
+        # budget on thinking; strict-JSON outputs must fit in ONE call because
+        # the auto-continuation seam is unreliable mid-JSON (live-caught on
+        # the categories endpoint).
+        response_text = converse(prompt=prompt, max_tokens=2048, surface='utility')
         
         json_match = re.search(r'\{[^{}]*\}', response_text, re.DOTALL)
         if not json_match:

--- a/voc-datalake/lambda/api/scrapers_handler.py
+++ b/voc-datalake/lambda/api/scrapers_handler.py
@@ -287,10 +287,8 @@ def analyze_url():
         from shared.converse import converse
         prompt = f"""Analyze this HTML and identify CSS selectors for extracting reviews:\n\n```html\n{html_sample}\n```\n\nReturn JSON with: container_selector, text_selector, rating_selector, author_selector, date_selector, confidence (high/medium/low), detected_reviews_count"""
 
-        # 2048 (was 1000): adaptive-thinking models (Sonnet 5) spend output
-        # budget on thinking; strict-JSON outputs must fit in ONE call because
-        # the auto-continuation seam is unreliable mid-JSON (live-caught on
-        # the categories endpoint).
+        # 2048: strict-JSON output must fit ONE call (see the strict-JSON
+        # doctrine in shared/converse.py).
         response_text = converse(prompt=prompt, max_tokens=2048, surface='utility')
         
         json_match = re.search(r'\{[^{}]*\}', response_text, re.DOTALL)

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -427,10 +427,8 @@ Return ONLY valid JSON in this exact format (no markdown, no explanation):
   ]
 }}"""
 
-        # 4096 (was 2000): Sonnet 5's always-on adaptive thinking counts
-        # against maxTokens, and a truncated strict-JSON response can't be
-        # stitched reliably by auto-continuation (live-caught: the resume seam
-        # dropped a comma → JSONDecodeError). Headroom keeps it to one call.
+        # 4096: strict-JSON output must fit ONE call (see the strict-JSON
+        # doctrine in shared/converse.py).
         response_text = converse(prompt=prompt, max_tokens=4096, temperature=0.3, surface='utility')
 
         json_match = re.search(r"\{[\s\S]*\}", response_text)

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -16,9 +16,13 @@ from botocore.exceptions import ClientError
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer, metrics
-from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
-from shared.api import create_api_resolver, api_handler
+from shared.aws import get_dynamodb_resource
+from shared.api import create_api_resolver, api_handler, require_admin
 from shared.exceptions import ConfigurationError, ValidationError, ServiceError
+from shared.model_config import (
+    ALLOWED_MODELS, ALLOWED_MODEL_IDS, PICKER_SURFACES, SURFACE_DEFAULTS,
+    MODEL_SETTINGS_PK, MODEL_SETTINGS_SK, clear_model_cache,
+)
 
 dynamodb = get_dynamodb_resource()
 AGGREGATES_TABLE = os.environ.get("AGGREGATES_TABLE", "")
@@ -43,6 +47,139 @@ MAX_PROBLEM_KEY_BYTES = 255
 MAX_RESOLVED_ENTRIES = 500
 
 app = create_api_resolver()
+
+
+@app.get("/settings/model")
+@tracer.capture_method
+def get_model_settings():
+    """Get the per-surface model overrides and the curated allowlist (issue #96).
+
+    Returns the allowlist plus, for each pickable surface, its built-in
+    default and the admin-selected override (``selected`` is null when the
+    surface is on Automatic). ``model_id`` is a legacy global override kept
+    for backward compatibility with the earlier single-model picker; when
+    set it applies to any surface left on Automatic.
+    """
+    if not aggregates_table:
+        raise ConfigurationError('Aggregates table not configured')
+    try:
+        response = aggregates_table.get_item(
+            Key={'pk': MODEL_SETTINGS_PK, 'sk': MODEL_SETTINGS_SK}
+        )
+        item = response.get('Item') or {}
+        stored = item.get('surfaces')
+        stored = stored if isinstance(stored, dict) else {}
+        legacy_global = item.get('model_id')
+        surfaces = [
+            {
+                'key': key,
+                'default_id': SURFACE_DEFAULTS[key],
+                # Ignore any stored value that has since left the allowlist.
+                'selected': stored.get(key) if stored.get(key) in ALLOWED_MODEL_IDS else None,
+            }
+            for key in PICKER_SURFACES
+        ]
+        return {
+            'available_models': ALLOWED_MODELS,
+            'surfaces': surfaces,
+            'model_id': legacy_global if legacy_global in ALLOWED_MODEL_IDS else None,
+        }
+    except ConfigurationError:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to get model settings: {e}")
+        raise ServiceError('Failed to retrieve model settings')
+
+
+@app.put("/settings/model")
+@tracer.capture_method
+def save_model_settings():
+    """Set or clear a per-surface Bedrock model override (issue #96).
+
+    Body shapes:
+      - ``{'surface': <picker surface>, 'model_id': <allowlisted id>}`` — pin
+        that surface to a model.
+      - ``{'surface': <picker surface>, 'model_id': null}`` — clear the
+        surface (back to Automatic / its default).
+      - ``{'model_id': <allowlisted id>|null}`` (no ``surface``) — set/clear
+        the legacy global override that applies to every un-pinned surface.
+
+    Admin-only: this changes inference cost/quality for the whole org, so it
+    is gated on the ``admins`` Cognito group server-side (not just in the UI).
+    """
+    if not aggregates_table:
+        raise ConfigurationError('Aggregates table not configured')
+    require_admin(app.current_event.raw_event)
+    body = app.current_event.json_body or {}
+    if 'model_id' not in body:
+        raise ValidationError('model_id is required (an allowlisted id, or null to clear)')
+    model_id = body.get('model_id')
+    if model_id is not None and model_id not in ALLOWED_MODEL_IDS:
+        raise ValidationError(
+            f"model_id must be null or one of: {', '.join(sorted(ALLOWED_MODEL_IDS))}"
+        )
+    surface = body.get('surface')
+    if surface is not None and surface not in PICKER_SURFACES:
+        raise ValidationError(
+            f"surface must be null or one of: {', '.join(PICKER_SURFACES)}"
+        )
+    try:
+        if surface is None:
+            _save_global_model(model_id)
+        else:
+            _save_surface_model(surface, model_id)
+        # Refresh this Lambda's own cache; other containers pick it up within the TTL.
+        clear_model_cache()
+        return {'success': True, 'surface': surface, 'model_id': model_id}
+    except Exception as e:
+        logger.exception(f"Failed to save model settings: {e}")
+        raise ServiceError('Failed to save model settings')
+
+
+def _load_model_item() -> dict:
+    """Read the model-settings item as a dict with a guaranteed surfaces map.
+
+    Config writes are a rare admin action, so read-modify-write is simpler and
+    safer than nested-map update expressions (which ValidationException when
+    the parent map doesn't exist yet).
+    """
+    response = aggregates_table.get_item(
+        Key={'pk': MODEL_SETTINGS_PK, 'sk': MODEL_SETTINGS_SK}
+    )
+    item = response.get('Item') or {}
+    if not isinstance(item.get('surfaces'), dict):
+        item['surfaces'] = {}
+    return item
+
+
+def _put_model_item(item: dict) -> None:
+    item['pk'] = MODEL_SETTINGS_PK
+    item['sk'] = MODEL_SETTINGS_SK
+    item['updated_at'] = datetime.now(timezone.utc).isoformat()
+    # Keep the item tidy: drop an empty surfaces map and a null legacy global.
+    if not item.get('surfaces'):
+        item.pop('surfaces', None)
+    if item.get('model_id') is None:
+        item.pop('model_id', None)
+    aggregates_table.put_item(Item=item)
+
+
+def _save_surface_model(surface: str, model_id: str | None) -> None:
+    item = _load_model_item()
+    if model_id is None:
+        item['surfaces'].pop(surface, None)
+    else:
+        item['surfaces'][surface] = model_id
+    _put_model_item(item)
+
+
+def _save_global_model(model_id: str | None) -> None:
+    item = _load_model_item()
+    if model_id is None:
+        item.pop('model_id', None)
+    else:
+        item['model_id'] = model_id
+    _put_model_item(item)
 
 
 @app.get("/settings/resolved-problems")
@@ -290,7 +427,7 @@ Return ONLY valid JSON in this exact format (no markdown, no explanation):
   ]
 }}"""
 
-        response_text = converse(prompt=prompt, max_tokens=2000, temperature=0.3)
+        response_text = converse(prompt=prompt, max_tokens=2000, temperature=0.3, surface='utility')
 
         json_match = re.search(r"\{[\s\S]*\}", response_text)
         if json_match:

--- a/voc-datalake/lambda/api/settings_handler.py
+++ b/voc-datalake/lambda/api/settings_handler.py
@@ -427,7 +427,11 @@ Return ONLY valid JSON in this exact format (no markdown, no explanation):
   ]
 }}"""
 
-        response_text = converse(prompt=prompt, max_tokens=2000, temperature=0.3, surface='utility')
+        # 4096 (was 2000): Sonnet 5's always-on adaptive thinking counts
+        # against maxTokens, and a truncated strict-JSON response can't be
+        # stitched reliably by auto-continuation (live-caught: the resume seam
+        # dropped a comma → JSONDecodeError). Headroom keeps it to one call.
+        response_text = converse(prompt=prompt, max_tokens=4096, temperature=0.3, surface='utility')
 
         json_match = re.search(r"\{[\s\S]*\}", response_text)
         if json_match:

--- a/voc-datalake/lambda/api/test/test_manual_import_processor.py
+++ b/voc-datalake/lambda/api/test/test_manual_import_processor.py
@@ -145,6 +145,80 @@ class TestProcessJob:
         process_job('job-123')
 
 
+class TestCapabilityAwareBedrockBody:
+    """The raw invoke_model body must match the resolved model's capabilities.
+
+    Regression for the Sonnet 5 default bump: an explicit `temperature` or
+    `thinking` budget in the request body 400s on adaptive-thinking /
+    temperature-restricted models. These tests fail if either field is
+    reintroduced unconditionally or the model stops routing through the
+    utility-surface picker.
+    """
+
+    JOB_ITEM = {
+        'Item': {
+            'raw_text': 'Great product! 5 stars. - John',
+            'source_origin': 'g2',
+        }
+    }
+    BEDROCK_RESPONSE = {
+        'body': MagicMock(read=lambda: json.dumps({
+            'content': [{'type': 'text', 'text': '{"reviews": [], "unparsed_sections": []}'}]
+        }).encode())
+    }
+
+    def _invoke_and_capture_body(self, mock_table, mock_bedrock):
+        mock_table.get_item.return_value = self.JOB_ITEM
+        mock_bedrock.invoke_model.return_value = self.BEDROCK_RESPONSE
+
+        from manual_import_processor import process_job
+        process_job('job-123')
+
+        kwargs = mock_bedrock.invoke_model.call_args.kwargs
+        return kwargs, json.loads(kwargs['body'])
+
+    @patch('manual_import_processor.get_active_model_id')
+    @patch('manual_import_processor.bedrock')
+    @patch('manual_import_processor.aggregates_table')
+    def test_routes_model_through_utility_surface(self, mock_table, mock_bedrock, mock_resolve):
+        """Model ID comes from get_active_model_id('utility'), not a hardcoded env."""
+        mock_resolve.return_value = 'global.anthropic.claude-sonnet-5'
+
+        kwargs, _ = self._invoke_and_capture_body(mock_table, mock_bedrock)
+
+        mock_resolve.assert_called_once_with('utility')
+        assert kwargs['modelId'] == 'global.anthropic.claude-sonnet-5'
+
+    @patch('manual_import_processor.get_active_model_id')
+    @patch('manual_import_processor.bedrock')
+    @patch('manual_import_processor.aggregates_table')
+    def test_adaptive_thinking_model_omits_thinking_and_temperature(
+        self, mock_table, mock_bedrock, mock_resolve
+    ):
+        """Sonnet 5 (adaptive thinking always-on) rejects both params."""
+        mock_resolve.return_value = 'global.anthropic.claude-sonnet-5'
+
+        _, body = self._invoke_and_capture_body(mock_table, mock_bedrock)
+
+        assert 'thinking' not in body
+        assert 'temperature' not in body
+
+    @patch('manual_import_processor.get_active_model_id')
+    @patch('manual_import_processor.bedrock')
+    @patch('manual_import_processor.aggregates_table')
+    def test_budgeted_thinking_model_keeps_thinking_but_omits_temperature(
+        self, mock_table, mock_bedrock, mock_resolve
+    ):
+        """Haiku 4.5 accepts an explicit thinking budget; temperature stays
+        omitted everywhere (defaults to 1, the only value thinking accepts)."""
+        mock_resolve.return_value = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+
+        _, body = self._invoke_and_capture_body(mock_table, mock_bedrock)
+
+        assert body['thinking'] == {'type': 'enabled', 'budget_tokens': 5000}
+        assert 'temperature' not in body
+
+
 class TestLambdaHandler:
     """Tests for the main Lambda handler."""
 

--- a/voc-datalake/lambda/api/test/test_projects_ai_assists.py
+++ b/voc-datalake/lambda/api/test/test_projects_ai_assists.py
@@ -171,3 +171,30 @@ class TestAutofillPrfaqQuestions(_Assists):
             import projects
             with pytest.raises(ConfigurationError):
                 projects.autofill_prfaq_questions('proj-1', {})
+
+
+class TestStrictJsonTokenHeadroom(_Assists):
+    """Regression: strict-JSON assists must fit their output in ONE Bedrock call.
+
+    Live-caught on voc-deploy (PR #166): adaptive-thinking models (Sonnet 5)
+    spend output budget on thinking, so a tight max_tokens truncated the JSON
+    and the auto-continuation resume seam dropped a comma → JSONDecodeError →
+    500. These floors would fail if the headroom fix were reverted; raising
+    max_continuations instead is NOT a fix here — continuation is unreliable
+    mid-JSON by design.
+    """
+
+    RAW_SUGGESTIONS = json.dumps({'suggestions': [{'title': 't', 'question': 'q'}]})
+    RAW_ANSWERS = json.dumps({'answers': {'q1': 'a'}})
+
+    def test_research_suggest_requests_one_call_headroom(self):
+        _, mock_converse = self.run('suggest_research_questions', {}, self.RAW_SUGGESTIONS)
+        assert mock_converse.call_args.kwargs['max_tokens'] >= 2048
+
+    def test_document_brief_requests_one_call_headroom(self):
+        _, mock_converse = self.run('suggest_document_brief', {'doc_type': 'prd'}, self.RAW_SUGGESTIONS)
+        assert mock_converse.call_args.kwargs['max_tokens'] >= 2048
+
+    def test_prfaq_autofill_requests_one_call_headroom(self):
+        _, mock_converse = self.run('autofill_prfaq_questions', {'feature_idea': 'x'}, self.RAW_ANSWERS)
+        assert mock_converse.call_args.kwargs['max_tokens'] >= 4096

--- a/voc-datalake/lambda/api/test/test_scrapers_handler.py
+++ b/voc-datalake/lambda/api/test/test_scrapers_handler.py
@@ -497,6 +497,11 @@ class TestAnalyzeUrl:
         assert body['success'] is True
         assert 'selectors' in body
         assert body['selectors']['container_selector'] == '.review'
+        # Regression (live-caught on voc-deploy, PR #166): strict-JSON output
+        # must fit ONE Bedrock call — adaptive-thinking models spend output
+        # budget on thinking, and continuation is unreliable mid-JSON.
+        assert mock_converse.call_args.kwargs['max_tokens'] >= 2048
+        assert mock_converse.call_args.kwargs['surface'] == 'utility'
 
     @patch('scrapers_handler.socket.getaddrinfo')
     def test_rejects_invalid_url(

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -284,6 +284,12 @@ class TestGenerateCategories:
         assert body['success'] is True
         assert len(body['categories']) > 0
         mock_converse.assert_called_once()
+        # Regression (live-caught on voc-deploy, PR #166): the strict-JSON
+        # category list must fit ONE Bedrock call — adaptive-thinking models
+        # (Sonnet 5) spend output budget on thinking, and the auto-continuation
+        # resume seam is unreliable mid-JSON (dropped a comma → 500).
+        assert mock_converse.call_args.kwargs['max_tokens'] >= 4096
+        assert mock_converse.call_args.kwargs['surface'] == 'utility'
 
     @patch('settings_handler.aggregates_table')
     def test_returns_error_when_description_missing(

--- a/voc-datalake/lambda/api/test/test_settings_handler.py
+++ b/voc-datalake/lambda/api/test/test_settings_handler.py
@@ -596,3 +596,212 @@ class TestResolvedProblemsSurrogates:
         assert response['statusCode'] == 400
         assert 'surrogate' in body['error']
         mock_table.update_item.assert_not_called()
+
+
+class TestGetModelSettings:
+    """Tests for GET /settings/model (per-surface AI model picker, issue #96)."""
+
+    @patch('settings_handler.aggregates_table')
+    def test_returns_allowlist_and_surfaces_when_unset(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """With nothing configured every surface is Automatic (selected=null)
+        and carries its built-in default."""
+        mock_table.get_item.return_value = {}
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(method='GET', path='/settings/model')
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        model_ids = {m['id'] for m in body['available_models']}
+        assert model_ids == {
+            'global.anthropic.claude-sonnet-5',
+            'global.anthropic.claude-sonnet-4-6',
+            'global.anthropic.claude-opus-4-8',
+            'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+        }
+        surfaces = {s['key']: s for s in body['surfaces']}
+        assert set(surfaces) == {'chat', 'documents', 'prototype', 'enrichment', 'utility'}
+        assert all(s['selected'] is None for s in body['surfaces'])
+        assert surfaces['prototype']['default_id'] == 'global.anthropic.claude-opus-4-8'
+        assert surfaces['enrichment']['default_id'] == 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+        assert body['model_id'] is None
+
+    @patch('settings_handler.aggregates_table')
+    def test_returns_configured_surface_overrides(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        mock_table.get_item.return_value = {
+            'Item': {
+                'pk': 'SETTINGS#model', 'sk': 'config',
+                'surfaces': {'chat': 'global.anthropic.claude-haiku-4-5-20251001-v1:0'},
+            }
+        }
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(method='GET', path='/settings/model')
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        surfaces = {s['key']: s for s in body['surfaces']}
+        assert surfaces['chat']['selected'] == 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+        assert surfaces['documents']['selected'] is None
+
+    @patch('settings_handler.aggregates_table')
+    def test_hides_non_allowlisted_stored_values(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """A stale/tampered stored id (e.g. delisted Sonnet 4.5) reads back
+        as Automatic, never as a selectable value."""
+        mock_table.get_item.return_value = {
+            'Item': {
+                'pk': 'SETTINGS#model', 'sk': 'config',
+                'surfaces': {'chat': 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'},
+                'model_id': 'anthropic.evil-model-v9',
+            }
+        }
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(method='GET', path='/settings/model')
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        surfaces = {s['key']: s for s in body['surfaces']}
+        assert surfaces['chat']['selected'] is None
+        assert body['model_id'] is None
+
+    @patch('settings_handler.aggregates_table')
+    def test_non_admin_can_read_model_settings(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """GET stays open to all authenticated users (read-only)."""
+        mock_table.get_item.return_value = {}
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(method='GET', path='/settings/model')
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'users'
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+
+
+class TestSaveModelSettings:
+    """Tests for PUT /settings/model (admin-gated, per-surface)."""
+
+    HAIKU = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+
+    @patch('settings_handler.clear_model_cache')
+    @patch('settings_handler.aggregates_table')
+    def test_pins_a_surface_and_clears_cache(
+        self, mock_table, mock_clear, api_gateway_event, lambda_context
+    ):
+        mock_table.get_item.return_value = {}
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT', path='/settings/model',
+            body={'surface': 'chat', 'model_id': self.HAIKU},
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body == {'success': True, 'surface': 'chat', 'model_id': self.HAIKU}
+        item = mock_table.put_item.call_args.kwargs['Item']
+        assert item['surfaces'] == {'chat': self.HAIKU}
+        assert item['pk'] == 'SETTINGS#model'
+        assert 'updated_at' in item
+        mock_clear.assert_called_once()
+
+    @patch('settings_handler.aggregates_table')
+    def test_clearing_a_surface_preserves_other_surfaces(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """{'surface': X, 'model_id': null} returns X to Automatic without
+        touching other pinned surfaces."""
+        mock_table.get_item.return_value = {
+            'Item': {
+                'pk': 'SETTINGS#model', 'sk': 'config',
+                'surfaces': {
+                    'chat': self.HAIKU,
+                    'prototype': 'global.anthropic.claude-opus-4-8',
+                },
+            }
+        }
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT', path='/settings/model',
+            body={'surface': 'chat', 'model_id': None},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        item = mock_table.put_item.call_args.kwargs['Item']
+        assert item['surfaces'] == {'prototype': 'global.anthropic.claude-opus-4-8'}
+
+    @patch('settings_handler.aggregates_table')
+    def test_global_override_without_surface_is_legacy_path(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """Body without 'surface' sets the legacy global override."""
+        mock_table.get_item.return_value = {}
+
+        from settings_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT', path='/settings/model',
+            body={'model_id': self.HAIKU},
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['surface'] is None
+        item = mock_table.put_item.call_args.kwargs['Item']
+        assert item['model_id'] == self.HAIKU
+
+    @pytest.mark.parametrize('payload', [
+        {'surface': 'chat'},                                        # missing model_id
+        {'surface': 'chat', 'model_id': 'anthropic.evil-model'},    # not allowlisted
+        {'surface': 'chat', 'model_id': 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'},  # delisted
+        {'surface': 'bogus', 'model_id': None},                     # unknown surface
+        {'surface': 'default', 'model_id': None},                   # internal bucket, not pickable
+    ])
+    @patch('settings_handler.aggregates_table')
+    def test_rejects_invalid_payloads(
+        self, mock_table, payload, api_gateway_event, lambda_context
+    ):
+        from settings_handler import lambda_handler
+        event = api_gateway_event(method='PUT', path='/settings/model', body=payload)
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        mock_table.put_item.assert_not_called()
+
+    @patch('settings_handler.aggregates_table')
+    def test_non_admin_put_is_403(self, mock_table, api_gateway_event, lambda_context):
+        """The Cognito authorizer only proves authentication; changing the
+        org-wide model mix requires the admins group server-side."""
+        from settings_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT', path='/settings/model',
+            body={'surface': 'chat', 'model_id': self.HAIKU},
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'users'
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
+        mock_table.put_item.assert_not_called()
+
+    @patch('settings_handler.aggregates_table')
+    def test_missing_groups_put_is_403(self, mock_table, api_gateway_event, lambda_context):
+        from settings_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT', path='/settings/model',
+            body={'surface': 'chat', 'model_id': self.HAIKU},
+        )
+        del event['requestContext']['authorizer']['claims']['cognito:groups']
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
+        mock_table.put_item.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_users_handler.py
+++ b/voc-datalake/lambda/api/test/test_users_handler.py
@@ -7,72 +7,9 @@ from unittest.mock import patch
 from datetime import datetime, timezone
 
 
-class TestGetCallerGroups:
-    """Tests for get_caller_groups helper function."""
-
-    def test_extracts_groups_from_claims(self):
-        """Extracts user groups from Cognito authorizer claims."""
-        import sys
-        import os
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from users_handler import get_caller_groups
-        
-        event = {
-            'requestContext': {
-                'authorizer': {
-                    'claims': {'cognito:groups': 'admins viewers'}
-                }
-            }
-        }
-        
-        groups = get_caller_groups(event)
-        assert 'admins' in groups
-        assert 'viewers' in groups
-
-    def test_handles_comma_separated_groups(self):
-        """Handles comma-separated groups format."""
-        from users_handler import get_caller_groups
-        
-        event = {
-            'requestContext': {
-                'authorizer': {
-                    'claims': {'cognito:groups': 'admins, viewers'}
-                }
-            }
-        }
-        
-        groups = get_caller_groups(event)
-        assert 'admins' in groups
-
-    def test_returns_empty_list_when_no_groups(self):
-        """Returns empty list when no groups in claims."""
-        from users_handler import get_caller_groups
-        
-        event = {
-            'requestContext': {
-                'authorizer': {
-                    'claims': {}
-                }
-            }
-        }
-        
-        groups = get_caller_groups(event)
-        assert groups == []
-
-    def test_handles_single_group(self):
-        """Handles single group string."""
-        from users_handler import get_caller_groups
-        
-        event = {
-            'requestContext': {
-                'authorizer': {
-                    'claims': {'cognito:groups': 'admins'}
-                }
-            }
-        }
-        
-        groups = get_caller_groups(event)
-        assert groups == ['admins']
+# NOTE: group-parsing/require_admin unit tests live in
+# lambda/shared/test/test_api.py — users_handler now gates through the
+# shared implementation instead of a local copy.
 
 
 class TestListUsers:

--- a/voc-datalake/lambda/api/users_handler.py
+++ b/voc-datalake/lambda/api/users_handler.py
@@ -17,8 +17,8 @@ from typing import Any
 from botocore.exceptions import ClientError, BotoCoreError
 
 from shared.logging import logger, tracer
-from shared.api import create_api_resolver, api_handler
-from shared.exceptions import ValidationError, NotFoundError, ServiceError, ConflictError, AuthorizationError
+from shared.api import create_api_resolver, api_handler, require_admin
+from shared.exceptions import ValidationError, NotFoundError, ServiceError, ConflictError
 
 # AWS Clients
 cognito = boto3.client('cognito-idp')
@@ -29,39 +29,16 @@ USER_POOL_ID = os.environ.get('USER_POOL_ID', '')
 app = create_api_resolver()
 
 
-def get_caller_groups(event: dict) -> list[str]:
-    """Extract user groups from Cognito authorizer claims."""
-    try:
-        claims = event.get('requestContext', {}).get('authorizer', {}).get('claims', {})
-        groups_str = claims.get('cognito:groups', '')
-        logger.info(f"Claims: {claims}")
-        logger.info(f"Groups string: {groups_str}, type: {type(groups_str)}")
-        if not groups_str:
-            return []
-        # Groups come as space-separated string or already a list
-        if isinstance(groups_str, list):
-            return groups_str
-        # Handle comma-separated groups (API Gateway format)
-        if ',' in groups_str:
-            return [g.strip() for g in groups_str.split(',')]
-        return groups_str.split(' ') if ' ' in groups_str else [groups_str]
-    except Exception as e:
-        logger.error(f"Error parsing groups: {e}")
-        return []
-
-
-def require_admin(event: dict) -> None:
-    """Verify caller is in admins group."""
-    groups = get_caller_groups(event)
-    if 'admins' not in groups:
-        raise AuthorizationError('Admin access required')
+# Admin gating uses the shared require_admin/get_caller_groups (shared/api.py):
+# same semantics as the old local copy, plus handling for the REST-authorizer
+# bracket-wrapped groups claim ("[admins, users]") the local copy missed.
 
 
 @app.get('/users')
 @tracer.capture_method
 def list_users():
     """List all users in the Cognito User Pool."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     try:
         users = []
@@ -116,7 +93,7 @@ def list_users():
 @tracer.capture_method
 def create_user():
     """Create a new user in Cognito."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     body = app.current_event.json_body or {}
     email = body.get('email', '').strip()
@@ -189,7 +166,7 @@ def create_user():
 @tracer.capture_method
 def update_user(username: str):
     """Update user attributes (given_name, family_name)."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
 
     body = app.current_event.json_body or {}
 
@@ -256,7 +233,7 @@ def update_user(username: str):
 @tracer.capture_method
 def update_user_group(username: str):
     """Update user's group (admins/users)."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     body = app.current_event.json_body or {}
     new_group = body.get('group', '').strip()
@@ -306,7 +283,7 @@ def update_user_group(username: str):
 @tracer.capture_method
 def reset_user_password(username: str):
     """Reset user's password (sends new temporary password via email)."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     try:
         cognito.admin_reset_user_password(
@@ -331,7 +308,7 @@ def reset_user_password(username: str):
 @tracer.capture_method
 def enable_user(username: str):
     """Enable a disabled user."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     try:
         cognito.admin_enable_user(
@@ -356,7 +333,7 @@ def enable_user(username: str):
 @tracer.capture_method
 def disable_user(username: str):
     """Disable a user (prevents login)."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     try:
         cognito.admin_disable_user(
@@ -381,7 +358,7 @@ def disable_user(username: str):
 @tracer.capture_method
 def delete_user(username: str):
     """Delete a user from Cognito."""
-    require_admin(app.current_event._data)
+    require_admin(app.current_event.raw_event)
     
     try:
         cognito.admin_delete_user(

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -140,7 +140,7 @@ def _generate_prd(ctx: JobContext, feature_idea: str, feedback_context: str,
         mapped = 50 + int((progress - 15) / 60 * 35)
         ctx.update_progress(mapped, step)
 
-    results = converse_chain(chain_steps, progress_callback=progress_callback)
+    results = converse_chain(chain_steps, progress_callback=progress_callback, surface='documents')
 
     # results[0] = problem_analysis, results[1] = solution_design, results[2] = prd_document
     content = results[2] if len(results) >= 3 else results[-1]
@@ -171,7 +171,7 @@ def _generate_prfaq(ctx: JobContext, feature_idea: str, feedback_context: str,
         mapped = 50 + int((progress - 15) / 60 * 35)
         ctx.update_progress(mapped, step)
 
-    results = converse_chain(chain_steps, progress_callback=progress_callback)
+    results = converse_chain(chain_steps, progress_callback=progress_callback, surface='documents')
 
     # results[0] = customer_thinking, [1] = press_release, [2] = customer_faq, [3] = internal_faq
     full_document = f"""# PR/FAQ: {feature_idea}
@@ -459,14 +459,15 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
     ) + feedback_section
 
     ctx.update_progress(40, 'invoking_bedrock')
-    # Opus 4.8 for the prototype build — stronger frontend/design instincts than
-    # the default chat model. converse() accepts a per-call model override.
+    # The 'prototype' surface defaults to Opus 4.8 — stronger frontend/design
+    # instincts than the chat model — but admins can repoint it via the picker.
+    # converse() drops `temperature` automatically for models that reject it
+    # (Opus 4.8 / Sonnet 5), so we no longer hard-pin the model or temperature.
     raw = converse(
         prompt=user_prompt,
         system_prompt=system_prompt,
-        model_id='global.anthropic.claude-opus-4-8',
+        surface='prototype',
         max_tokens=32000,
-        temperature=None,  # Opus 4.8 deprecates the temperature inference param.
         step_name='build_prototype',
     )
 
@@ -746,6 +747,7 @@ def _run_one_step(project_id: str, job_id: str, index: int) -> None:
         system_prompt=step.get('system', ''),
         max_tokens=step.get('max_tokens', 4096),
         thinking_budget=step.get('thinking_budget', 0),
+        surface=step.get('surface', 'documents'),
         step_name=step_name,
     )
     logger.info(f"[DOCSTEP] step '{step_name}' produced {len(result)} chars")

--- a/voc-datalake/lambda/jobs/document_generator/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_handler.py
@@ -355,16 +355,23 @@ class TestBuildPrototype:
         assert put_kwargs['Body'] == self.HTML.encode('utf-8')
         assert put_kwargs['ContentType'] == 'text/html; charset=utf-8'
 
-    def test_build_prototype_uses_opus(
+    def test_build_prototype_uses_prototype_surface(
         self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context
     ):
+        """The prototype build resolves its model through the 'prototype'
+        surface of the AI-model picker (whose default is Opus 4.8) instead of
+        hard-pinning a model id — admins can repoint it (issue #96)."""
         self._wire_tables(mock_dynamodb)
         mock_converse.return_value = self.HTML
 
         from jobs.document_generator.handler import lambda_handler
+        from shared.model_config import surface_default
         lambda_handler(self._prototype_event(sample_job_event), lambda_context)
 
-        assert mock_converse.call_args.kwargs['model_id'] == 'global.anthropic.claude-opus-4-8'
+        assert mock_converse.call_args.kwargs['surface'] == 'prototype'
+        assert 'model_id' not in mock_converse.call_args.kwargs
+        # The surface's Automatic default remains Opus 4.8.
+        assert surface_default('prototype') == 'global.anthropic.claude-opus-4-8'
 
     def test_build_prototype_passes_brand_and_language(
         self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context

--- a/voc-datalake/lambda/jobs/document_merger/handler.py
+++ b/voc-datalake/lambda/jobs/document_merger/handler.py
@@ -113,7 +113,7 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict
     # Higher token limits to support CJK languages (Korean, Japanese, Chinese)
     # which use 2-3x more tokens than English for equivalent content.
     max_tokens = 16000 if output_type == 'prfaq' else 12000
-    content = converse(prompt=user_prompt, system_prompt=system_prompt, max_tokens=max_tokens)
+    content = converse(prompt=user_prompt, system_prompt=system_prompt, max_tokens=max_tokens, surface='documents')
     
     ctx.update_progress(90, 'saving_document')
     now = datetime.now(timezone.utc).isoformat()

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -15,7 +15,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from shared.logging import logger, tracer, metrics
 from shared.jobs import job_handler, JobContext
-from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource, get_bedrock_client
+from shared.model_config import get_active_model_id
 from api.projects import generate_persona_avatar, get_avatar_cdn_url
 
 # Environment
@@ -74,8 +75,12 @@ CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
     ctx.update_progress(30, 'calling_ai')
     
     bedrock = get_bedrock_client()
+    # Persona import is a document-generation surface. Raw client call (image
+    # input isn't supported by the text-only shared converse helper), so resolve
+    # the model through the picker directly. No temperature is sent, so there's
+    # nothing to omit for temperature-restricted models.
     response = bedrock.converse(
-        modelId=BEDROCK_MODEL_ID,
+        modelId=get_active_model_id('documents'),
         system=[{'text': system_prompt}],
         messages=[{'role': 'user', 'content': converse_content}],
         inferenceConfig={'maxTokens': 4096}

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -79,8 +79,10 @@ CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
     # input isn't supported by the text-only shared converse helper), so resolve
     # the model through the picker directly. No temperature is sent, so there's
     # nothing to omit for temperature-restricted models.
+    model_id = get_active_model_id('documents')
+    logger.info(f"[IMPORT_PERSONA_JOB] Invoking Bedrock with model {model_id}")
     response = bedrock.converse(
-        modelId=get_active_model_id('documents'),
+        modelId=model_id,
         system=[{'text': system_prompt}],
         messages=[{'role': 'user', 'content': converse_content}],
         inferenceConfig={'maxTokens': 4096}

--- a/voc-datalake/lambda/processor/handler.py
+++ b/voc-datalake/lambda/processor/handler.py
@@ -54,9 +54,8 @@ PRIMARY_LANGUAGE = os.environ.get('PRIMARY_LANGUAGE', 'en')
 # Enrichment runs on every ingested item, so its built-in default is the
 # cheap/fast Haiku. The model is resolved through the per-surface AI-model
 # picker ('enrichment' surface) so admins can override it; the default and
-# allowlist live in shared.model_config. Kept as a last-resort literal for the
-# rare path where the resolver is unavailable at import time.
-PROCESSOR_FALLBACK_MODEL_ID = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+# allowlist live in shared.model_config (get_active_model_id never raises and
+# always returns a usable ID, so no local fallback is needed here).
 PROMPT_VERSION = '1.0.0'
 
 # Logs configuration - max entries to keep per source
@@ -339,7 +338,7 @@ def invoke_bedrock_llm(raw_record: dict, raise_on_throttle: bool = True) -> dict
     
     # Resolve the enrichment model through the picker (defaults to Haiku).
     # Recorded on the record's metadata so downstream can see which model ran.
-    active_model = get_active_model_id('enrichment') or PROCESSOR_FALLBACK_MODEL_ID
+    active_model = get_active_model_id('enrichment')
     try:
         content = converse(
             prompt=user_prompt,

--- a/voc-datalake/lambda/processor/handler.py
+++ b/voc-datalake/lambda/processor/handler.py
@@ -24,6 +24,7 @@ sys.path.insert(0, plugins_dir)
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, get_bedrock_client
 from shared.converse import converse, BedrockThrottlingError
+from shared.model_config import get_active_model_id
 from shared.idempotency import (
     get_persistence_layer,
     get_idempotency_config,
@@ -50,8 +51,12 @@ FEEDBACK_TABLE = os.environ['FEEDBACK_TABLE']
 AGGREGATES_TABLE = os.environ['AGGREGATES_TABLE']
 IDEMPOTENCY_TABLE = os.environ.get('IDEMPOTENCY_TABLE', '')
 PRIMARY_LANGUAGE = os.environ.get('PRIMARY_LANGUAGE', 'en')
-# Processor uses Haiku for cost efficiency (processes many items)
-PROCESSOR_MODEL_ID = os.environ.get('BEDROCK_MODEL_ID', 'global.anthropic.claude-haiku-4-5-20251001-v1:0')
+# Enrichment runs on every ingested item, so its built-in default is the
+# cheap/fast Haiku. The model is resolved through the per-surface AI-model
+# picker ('enrichment' surface) so admins can override it; the default and
+# allowlist live in shared.model_config. Kept as a last-resort literal for the
+# rare path where the resolver is unavailable at import time.
+PROCESSOR_FALLBACK_MODEL_ID = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
 PROMPT_VERSION = '1.0.0'
 
 # Logs configuration - max entries to keep per source
@@ -332,13 +337,16 @@ def invoke_bedrock_llm(raw_record: dict, raise_on_throttle: bool = True) -> dict
         categories_instruction=categories_instruction
     )
     
+    # Resolve the enrichment model through the picker (defaults to Haiku).
+    # Recorded on the record's metadata so downstream can see which model ran.
+    active_model = get_active_model_id('enrichment') or PROCESSOR_FALLBACK_MODEL_ID
     try:
         content = converse(
             prompt=user_prompt,
             system_prompt=SYSTEM_PROMPT,
             max_tokens=800,
             temperature=0.1,
-            model_id=PROCESSOR_MODEL_ID,
+            model_id=active_model,
             max_retries=5,
             raise_on_throttle=raise_on_throttle,
         )
@@ -353,7 +361,7 @@ def invoke_bedrock_llm(raw_record: dict, raise_on_throttle: bool = True) -> dict
         return {
             'insights': llm_result,
             'metadata': {
-                'model_name': PROCESSOR_MODEL_ID,
+                'model_name': active_model,
                 'prompt_version': PROMPT_VERSION,
                 'latency_ms': latency_ms,
             }

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -61,6 +61,7 @@ def invoke_bedrock_with_retry(system_prompt: str, user_message: str, max_tokens:
         prompt=user_message,
         system_prompt=system_prompt,
         max_tokens=max_tokens,
+        surface='documents',
         max_retries=max_retries,
         raise_on_throttle=True,
     )

--- a/voc-datalake/lambda/shared/api.py
+++ b/voc-datalake/lambda/shared/api.py
@@ -80,6 +80,42 @@ def validate_int(
         return default
 
 
+def get_caller_groups(event: dict) -> list[str]:
+    """Extract Cognito group memberships from the API Gateway authorizer claims.
+
+    Handles every format API Gateway emits for the ``cognito:groups`` claim:
+    a real list, and strings that are comma- or space-separated — including
+    the REST-authorizer serialization of the array claim as a
+    bracket-wrapped string (``"[admins]"`` / ``"[admins, users]"``).
+    """
+    try:
+        claims = event.get('requestContext', {}).get('authorizer', {}).get('claims', {})
+        groups = claims.get('cognito:groups', '')
+        if not groups:
+            return []
+        if isinstance(groups, list):
+            return groups
+        # REST API Gateway serializes array claims like "[admins, users]".
+        cleaned = groups.strip().removeprefix('[').removesuffix(']').strip()
+        if not cleaned:
+            return []
+        if ',' in cleaned:
+            return [g.strip() for g in cleaned.split(',')]
+        return cleaned.split(' ') if ' ' in cleaned else [cleaned]
+    except Exception:
+        return []
+
+
+def require_admin(event: dict) -> None:
+    """Raise AuthorizationError (403) unless the caller is in the admins group.
+
+    The Cognito authorizer only proves authentication; org-wide mutations
+    (user administration, AI model selection) must also check the group.
+    """
+    if 'admins' not in get_caller_groups(event):
+        raise AuthorizationError('Admin access required')
+
+
 def create_cors_config(allowed_origin: str | None = None) -> CORSConfig:
     """
     Create standard CORS configuration for API Gateway.
@@ -237,6 +273,8 @@ __all__ = [
     'create_cors_config',
     'create_api_resolver',
     'api_handler',
+    'get_caller_groups',
+    'require_admin',
     'get_configured_categories',
     'DEFAULT_CATEGORIES',
     # Exceptions

--- a/voc-datalake/lambda/shared/aws.py
+++ b/voc-datalake/lambda/shared/aws.py
@@ -131,5 +131,9 @@ def clear_secret_cache():
     get_secret.cache_clear()
 
 
-# Bedrock model ID - Claude Sonnet 4.5 global cross-region inference profile
-BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+# Default Bedrock model — Claude Sonnet 5 global cross-region inference profile.
+# This is the ultimate fallback for text inference. The per-surface AI-model
+# picker (shared/model_config.py) resolves a model per surface and only falls
+# back to this constant when nothing is configured and the surface has no more
+# specific default. Bumped from Sonnet 4.5 → Sonnet 5 (latest).
+BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-5"

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -8,7 +8,10 @@ import time
 from typing import Callable
 from botocore.exceptions import ClientError
 from shared.logging import logger
-from shared.aws import get_bedrock_client, BEDROCK_MODEL_ID
+from shared.aws import get_bedrock_client
+from shared.model_config import (
+    get_active_model_id, omits_temperature, uses_adaptive_thinking, DEFAULT_SURFACE,
+)
 
 
 # Retry configuration
@@ -56,6 +59,7 @@ def converse(
     temperature: float | None = 0.1,
     thinking_budget: int = 0,
     model_id: str | None = None,
+    surface: str = DEFAULT_SURFACE,
     max_retries: int = DEFAULT_MAX_RETRIES,
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
@@ -72,7 +76,12 @@ def converse(
             entirely — required for models like Opus 4.8 that reject/deprecate
             the `temperature` inference parameter.
         thinking_budget: If > 0, enables extended thinking with this token budget
-        model_id: Optional model ID override
+        model_id: Explicit model ID override. When None, the model is resolved
+            from the per-surface AI-model picker via ``surface``.
+        surface: AI surface whose configured model to use when ``model_id`` is
+            None (e.g. "chat", "documents", "prototype", "enrichment",
+            "utility"). See shared.model_config for the resolution order and
+            defaults. Ignored when ``model_id`` is passed explicitly.
         max_retries: Maximum retry attempts for throttling (default: 5)
         raise_on_throttle: If True, raise BedrockThrottlingError after max retries
         step_name: Name of the current step for logging
@@ -89,8 +98,8 @@ def converse(
         BedrockThrottlingError: If throttled after max retries and raise_on_throttle=True
         ClientError: For non-retryable AWS errors
     """
-    used_model = model_id or BEDROCK_MODEL_ID
-    logger.info(f"[BEDROCK] Starting converse call for step '{step_name}' with model {used_model}")
+    used_model = model_id or get_active_model_id(surface)
+    logger.info(f"[BEDROCK] Starting converse call for step '{step_name}' with model {used_model} (surface={surface})")
     logger.info(f"[BEDROCK] Request params: max_tokens={max_tokens}, temperature={temperature}, thinking_budget={thinking_budget}")
     logger.info(f"[BEDROCK] Prompt length: {len(prompt)} chars, system_prompt length: {len(system_prompt)} chars")
     
@@ -105,9 +114,11 @@ def converse(
     system = [{'text': system_prompt}] if system_prompt else None
     
     inference_config = {'maxTokens': max_tokens}
-    # Some models (e.g. Opus 4.8) reject `temperature` as deprecated. Pass
-    # temperature=None to omit it; otherwise include it as before.
-    if temperature is not None:
+    # Some models reject `temperature` as deprecated (Opus 4.8) or run adaptive
+    # thinking always-on (Sonnet 5). Omit it for those automatically — so any
+    # surface can be pointed at them via the picker without a 400 — and also
+    # when the caller explicitly passes temperature=None.
+    if temperature is not None and not omits_temperature(used_model):
         inference_config['temperature'] = temperature
     kwargs = {
         'modelId': used_model,
@@ -117,8 +128,11 @@ def converse(
     if system:
         kwargs['system'] = system
     
-    # Add extended thinking if budget specified
-    if thinking_budget > 0:
+    # Add extended thinking if budget specified. Models with always-on adaptive
+    # thinking (Sonnet 5) reject an explicit budget, so skip the field for them
+    # — their thinking runs automatically.
+    explicit_thinking = thinking_budget > 0 and not uses_adaptive_thinking(used_model)
+    if explicit_thinking:
         kwargs['additionalModelRequestFields'] = {
             'thinking': {
                 'type': 'enabled',
@@ -129,10 +143,11 @@ def converse(
     logger.info(f"[BEDROCK] Invoking Bedrock converse API for step '{step_name}'...")
     start_time = time.time()
 
-    # Continuation is incompatible with extended thinking: resuming a truncated
-    # turn requires replaying the assistant message, and thinking blocks have
-    # signing/ordering rules we don't handle here. Disable it in that case.
-    allow_continuation = max_continuations > 0 and thinking_budget <= 0
+    # Continuation is incompatible with EXPLICIT extended thinking: resuming a
+    # truncated turn requires replaying the assistant message, and thinking
+    # blocks have signing/ordering rules we don't handle here. Models where we
+    # skip the explicit budget (always-on adaptive thinking) can still continue.
+    allow_continuation = max_continuations > 0 and not explicit_thinking
 
     try:
         result, stop_reason = _invoke_with_retry(
@@ -344,6 +359,7 @@ def converse_chain(
     steps: list[dict],
     progress_callback: Callable[[int, str], None] | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    surface: str = DEFAULT_SURFACE,
 ) -> list[str]:
     """
     Execute a chain of LLM calls, each building on the previous.
@@ -354,11 +370,15 @@ def converse_chain(
         - max_tokens: Max output tokens (default 4096)
         - thinking_budget: Extended thinking budget (default 0 = disabled)
         - step_name: Optional name for progress reporting
+        - surface: Optional per-step AI surface override (defaults to the
+          chain-level `surface`)
     
     Args:
         steps: List of step configurations
         progress_callback: Optional callback(progress: int, step: str) to report progress
         max_retries: Maximum retry attempts for throttling (default: 5)
+        surface: AI surface whose configured model the steps resolve to when
+            they don't set their own model (default: the neutral fallback).
     
     Returns:
         List of results from each step
@@ -400,6 +420,7 @@ def converse_chain(
                 system_prompt=system,
                 max_tokens=max_tokens,
                 thinking_budget=thinking_budget,
+                surface=step.get('surface', surface),
                 max_retries=max_retries,
                 step_name=step_name,
             )

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -29,6 +29,14 @@ DEFAULT_MAX_DELAY = 30.0  # seconds
 # output and can blow the Lambda timeout on its own; many small calls each finish
 # in ~1-2 min and resume cleanly. This ceiling must therefore be generous enough
 # to assemble a long document from those small chunks (8 × ~8K ≈ 64K tokens).
+#
+# STRICT-JSON DOCTRINE: auto-continuation is safe for prose but NOT for strict
+# JSON output — the resume seam is lossy at token boundaries (live-caught: a
+# dropped comma between continued chunks → JSONDecodeError). Callers that parse
+# the response as JSON must size max_tokens so the answer fits in ONE call,
+# with headroom for adaptive-thinking models (Sonnet 5), whose always-on
+# thinking counts against maxTokens. See TestStrictJsonTokenHeadroom for the
+# enforced per-site floors.
 DEFAULT_MAX_CONTINUATIONS = 8
 
 # Nudge sent as the user turn when resuming a truncated response. Kept terse and

--- a/voc-datalake/lambda/shared/model_config.py
+++ b/voc-datalake/lambda/shared/model_config.py
@@ -1,0 +1,211 @@
+"""
+Runtime Bedrock model selection, per AI surface (issue #96).
+
+Admins pick the active model for each AI *surface* (chat, document
+generation, prototype builder, feedback enrichment, misc utility) from a
+curated allowlist in Settings. Choices are stored in the aggregates table
+and resolved here with a short per-container cache.
+
+Resolution order for a surface ``S``::
+
+    explicit model_id argument
+    > per-surface override      (settings.surfaces[S])
+    > legacy global override    (settings.model_id — applies to every surface)
+    > built-in default for S    (SURFACE_DEFAULTS[S])
+    > BEDROCK_MODEL_ID
+
+The per-surface design replaces the single global toggle: an admin can, for
+example, keep enrichment on cheap Haiku while running chat on Sonnet 5 and
+prototypes on Opus 4.8. The legacy global ``model_id`` is still honoured as a
+fallback so a value written by the older single-model picker keeps working.
+
+The allowlist is deliberately narrow: prompt templates in this project are
+tuned for Claude, and every entry is covered by the model agreements the
+BedrockAccessStack creates. Free-form model IDs are rejected server-side.
+
+Lambdas without the AGGREGATES_TABLE environment variable, or without read
+access to the table, silently use the surface default — the lookup must
+never break an inference path.
+"""
+import os
+import time
+
+from shared.aws import get_dynamodb_resource, BEDROCK_MODEL_ID
+from shared.logging import logger
+
+MODEL_SETTINGS_PK = "SETTINGS#model"
+MODEL_SETTINGS_SK = "config"
+
+# --- Curated allowlist -------------------------------------------------------
+# MUST stay in lockstep with:
+#   - lambda/stream/src/bedrock/model-override.ts        (streaming-chat lookup)
+#   - lib/stacks/api-stack.ts::allowlistedModelArns       (IAM invoke grants)
+#   - lib/stacks/processing-stack-consolidated.ts         (processor/aggregator/research grants)
+# A model that is selectable but not invocable AccessDenies the whole surface,
+# so the Python lockstep tests read the TS mirror and the CDK helper and assert
+# all three agree (a model added to one place fails the build until all match).
+#
+# Field notes:
+#   key               — stable id the frontend translates labels under.
+#   id                — global cross-region inference profile ID (verified
+#                       against the Bedrock model cards).
+#   omit_temperature  — the model rejects the `temperature` inference param
+#                       (Sonnet 5 runs adaptive thinking always-on; Opus 4.8
+#                       deprecates temperature). converse() drops temperature
+#                       automatically for these so any surface can point at them.
+ALLOWED_MODELS = [
+    {
+        "key": "sonnet5",
+        "id": "global.anthropic.claude-sonnet-5",
+        "label": "Claude Sonnet 5",
+        "description": "Latest, highest-quality Sonnet — best for analysis and generation",
+        "omit_temperature": True,
+    },
+    {
+        "key": "sonnet46",
+        "id": "global.anthropic.claude-sonnet-4-6",
+        "label": "Claude Sonnet 4.6",
+        "description": "Previous-generation Sonnet — strong quality, accepts temperature tuning",
+        "omit_temperature": False,
+    },
+    {
+        "key": "opus48",
+        "id": "global.anthropic.claude-opus-4-8",
+        "label": "Claude Opus 4.8",
+        "description": "Deepest reasoning — best for prototypes and complex documents",
+        "omit_temperature": True,
+    },
+    {
+        "key": "haiku45",
+        "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "label": "Claude Haiku 4.5",
+        "description": "Fastest and cheapest — good for high-volume enrichment",
+        "omit_temperature": False,
+    },
+]
+ALLOWED_MODEL_IDS = {m["id"] for m in ALLOWED_MODELS}
+_OMIT_TEMPERATURE_IDS = {m["id"] for m in ALLOWED_MODELS if m["omit_temperature"]}
+
+# Short aliases for the surface-default table below.
+_SONNET5 = "global.anthropic.claude-sonnet-5"
+_OPUS48 = "global.anthropic.claude-opus-4-8"
+_HAIKU45 = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+# Models that run adaptive thinking always-on: they don't accept an explicit
+# extended-thinking budget (Sonnet 5). converse() and the streaming client skip
+# the `thinking` request field for these so pointing a surface at them can't 400.
+_ADAPTIVE_THINKING_IDS = {_SONNET5}
+
+# --- Surfaces ----------------------------------------------------------------
+# Every independently selectable AI surface with its built-in default (the
+# "Automatic" behaviour when the admin hasn't pinned a model). The default is
+# chosen for the surface's workload: cheap Haiku on the high-volume enrichment
+# path, deep Opus on the prototype builder, flagship Sonnet everywhere else.
+#
+# "default" is an internal fallback bucket for any converse() caller that
+# doesn't name a surface; it is NOT exposed in the picker.
+SURFACE_DEFAULTS = {
+    "default": _SONNET5,
+    "chat": _SONNET5,
+    "documents": _SONNET5,
+    "prototype": _OPUS48,
+    "enrichment": _HAIKU45,
+    "utility": _SONNET5,
+}
+DEFAULT_SURFACE = "default"
+
+# Surfaces exposed in the Settings picker, in display order. Each carries a
+# short description key the frontend translates under `aiModel.surfaces.<key>`.
+PICKER_SURFACES = ("chat", "documents", "prototype", "enrichment", "utility")
+
+
+def surface_default(surface: str) -> str:
+    """Built-in default model ID for a surface. Never raises."""
+    return SURFACE_DEFAULTS.get(surface, BEDROCK_MODEL_ID)
+
+
+def omits_temperature(model_id: str) -> bool:
+    """True when the model rejects the `temperature` inference parameter."""
+    return model_id in _OMIT_TEMPERATURE_IDS
+
+
+def uses_adaptive_thinking(model_id: str) -> bool:
+    """True when the model runs adaptive thinking always-on and rejects an
+    explicit extended-thinking budget (skip the `thinking` request field)."""
+    return model_id in _ADAPTIVE_THINKING_IDS
+
+
+# --- Per-container cache -----------------------------------------------------
+# Cache the whole settings item (surfaces map + legacy global) so hot Lambdas
+# don't read DynamoDB on every inference. Failures cache for a shorter window
+# so a throttling blip doesn't pin inference to defaults for the full minute.
+_CACHE_TTL_SECONDS = 60
+_ERROR_CACHE_TTL_SECONDS = 10
+_cache: dict = {"value": None, "expires": 0.0}
+
+
+def clear_model_cache() -> None:
+    """Reset the container cache (used by tests and after saving settings)."""
+    _cache["value"] = None
+    _cache["expires"] = 0.0
+
+
+def _load_settings() -> dict:
+    """Return the cached model-settings item, or {} when absent/unreadable.
+
+    Shape: ``{'surfaces': {surface: model_id}, 'model_id': <legacy global>}``.
+    Never raises — a missing table env, missing item, or read failure all
+    resolve to an empty dict so callers fall back to surface defaults.
+    """
+    table_name = os.environ.get("AGGREGATES_TABLE", "")
+    if not table_name:
+        return {}
+    now = time.time()
+    if _cache["value"] is not None and now < _cache["expires"]:
+        return _cache["value"]
+    value: dict = {}
+    ttl = _CACHE_TTL_SECONDS
+    try:
+        table = get_dynamodb_resource().Table(table_name)
+        item = table.get_item(
+            Key={"pk": MODEL_SETTINGS_PK, "sk": MODEL_SETTINGS_SK}
+        ).get("Item")
+        if isinstance(item, dict):
+            value = item
+    except Exception as e:  # noqa: BLE001 — model lookup must never break inference
+        logger.warning(f"Model settings lookup failed; using defaults: {e}")
+        ttl = _ERROR_CACHE_TTL_SECONDS
+    _cache["value"] = value
+    _cache["expires"] = now + ttl
+    return value
+
+
+def _allowlisted(model_id) -> str | None:
+    """Return model_id when it is a valid allowlisted string, else None.
+
+    A configured value outside the allowlist (tampered/stale DB row) is
+    logged and ignored so it can never reach Bedrock.
+    """
+    if isinstance(model_id, str) and model_id in ALLOWED_MODEL_IDS:
+        return model_id
+    if model_id:
+        logger.warning(f"Configured model '{str(model_id)[:80]}' not in allowlist; ignoring")
+    return None
+
+
+def get_active_model_id(surface: str = DEFAULT_SURFACE) -> str:
+    """Resolve the Bedrock model ID to use for a given AI surface.
+
+    Never raises. Precedence: per-surface override > legacy global override >
+    built-in surface default > BEDROCK_MODEL_ID.
+    """
+    settings = _load_settings()
+    surfaces = settings.get("surfaces")
+    if isinstance(surfaces, dict):
+        per_surface = _allowlisted(surfaces.get(surface))
+        if per_surface:
+            return per_surface
+    legacy_global = _allowlisted(settings.get("model_id"))
+    if legacy_global:
+        return legacy_global
+    return surface_default(surface)

--- a/voc-datalake/lambda/shared/test/test_api.py
+++ b/voc-datalake/lambda/shared/test/test_api.py
@@ -415,3 +415,68 @@ class TestApiHandlerDecorator:
         assert len(call_tracker) == 1
         assert call_tracker[0][0] == event
 
+
+
+class TestGetCallerGroups:
+    """Tests for get_caller_groups (moved from test_users_handler when the
+    local users_handler copy was consolidated into shared.api)."""
+
+    def _event(self, groups):
+        claims = {} if groups is None else {'cognito:groups': groups}
+        return {'requestContext': {'authorizer': {'claims': claims}}}
+
+    def test_extracts_space_separated_groups(self):
+        from shared.api import get_caller_groups
+        groups = get_caller_groups(self._event('admins viewers'))
+        assert 'admins' in groups
+        assert 'viewers' in groups
+
+    def test_handles_comma_separated_groups(self):
+        from shared.api import get_caller_groups
+        groups = get_caller_groups(self._event('admins, viewers'))
+        assert 'admins' in groups
+        assert 'viewers' in groups
+
+    def test_handles_list_claim(self):
+        from shared.api import get_caller_groups
+        assert get_caller_groups(self._event(['admins'])) == ['admins']
+
+    def test_handles_bracket_wrapped_rest_serialization(self):
+        """REST API Gateway serializes the array claim as '[admins, users]' —
+        the format the old users_handler local copy mishandled."""
+        from shared.api import get_caller_groups
+        groups = get_caller_groups(self._event('[admins, users]'))
+        assert groups == ['admins', 'users']
+
+    def test_returns_empty_list_when_no_groups(self):
+        from shared.api import get_caller_groups
+        assert get_caller_groups(self._event(None)) == []
+
+    def test_handles_single_group(self):
+        from shared.api import get_caller_groups
+        assert get_caller_groups(self._event('admins')) == ['admins']
+
+
+class TestRequireAdmin:
+    """Tests for require_admin (the single shared implementation — all
+    handlers, including users_handler, gate through this)."""
+
+    def _event(self, groups):
+        claims = {} if groups is None else {'cognito:groups': groups}
+        return {'requestContext': {'authorizer': {'claims': claims}}}
+
+    def test_passes_for_admin_caller(self):
+        from shared.api import require_admin
+        require_admin(self._event('admins'))  # must not raise
+
+    def test_raises_authorization_error_for_non_admin(self):
+        from shared.api import require_admin
+        from shared.exceptions import AuthorizationError
+        with pytest.raises(AuthorizationError):
+            require_admin(self._event('users'))
+
+    def test_raises_authorization_error_when_groups_missing(self):
+        from shared.api import require_admin
+        from shared.exceptions import AuthorizationError
+        with pytest.raises(AuthorizationError):
+            require_admin(self._event(None))

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -46,7 +46,7 @@ class TestConverse:
 
     @patch('shared.converse.get_bedrock_client')
     def test_extended_thinking_budget(self, mock_get_client):
-        """Includes extended thinking when budget > 0."""
+        """Includes extended thinking when budget > 0 (explicit-budget model)."""
         mock_client = MagicMock()
         mock_client.converse.return_value = {
             'output': {'message': {'content': [{'text': 'Thoughtful response'}]}}
@@ -54,13 +54,31 @@ class TestConverse:
         mock_get_client.return_value = mock_client
         
         from shared.converse import converse
-        converse('Complex question', thinking_budget=5000)
+        converse('Complex question', thinking_budget=5000,
+                 model_id='global.anthropic.claude-sonnet-4-6')
         
         call_args = mock_client.converse.call_args
         assert 'additionalModelRequestFields' in call_args.kwargs
         thinking = call_args.kwargs['additionalModelRequestFields']['thinking']
         assert thinking['type'] == 'enabled'
         assert thinking['budget_tokens'] == 5000
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_skips_explicit_thinking_for_adaptive_models(self, mock_get_client):
+        """Sonnet 5 runs adaptive thinking always-on and rejects an explicit
+        budget — the field must be omitted so the call can't 400."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'Thoughtful response'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        converse('Complex question', thinking_budget=5000,
+                 model_id='global.anthropic.claude-sonnet-5')
+
+        call_args = mock_client.converse.call_args
+        assert 'additionalModelRequestFields' not in call_args.kwargs
 
     @patch('shared.converse.get_bedrock_client')
     def test_no_thinking_when_budget_zero(self, mock_get_client):
@@ -79,7 +97,7 @@ class TestConverse:
 
     @patch('shared.converse.get_bedrock_client')
     def test_includes_temperature_by_default(self, mock_get_client):
-        """Temperature is sent in inferenceConfig when a float is given."""
+        """Temperature is sent in inferenceConfig when the model accepts it."""
         mock_client = MagicMock()
         mock_client.converse.return_value = {
             'output': {'message': {'content': [{'text': 'R'}]}}
@@ -87,10 +105,30 @@ class TestConverse:
         mock_get_client.return_value = mock_client
 
         from shared.converse import converse
-        converse('Hi', temperature=0.4)
+        converse('Hi', temperature=0.4,
+                 model_id='global.anthropic.claude-sonnet-4-6')
 
         cfg = mock_client.converse.call_args.kwargs['inferenceConfig']
         assert cfg['temperature'] == 0.4
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_auto_omits_temperature_for_restricted_models(self, mock_get_client):
+        """Sonnet 5 / Opus 4.8 reject `temperature` — converse() drops it
+        automatically so any surface can be pointed at them via the picker
+        without every caller special-casing the param."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'R'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        for model in ('global.anthropic.claude-sonnet-5',
+                      'global.anthropic.claude-opus-4-8'):
+            converse('Hi', temperature=0.4, model_id=model)
+            cfg = mock_client.converse.call_args.kwargs['inferenceConfig']
+            assert 'temperature' not in cfg, model
+            assert cfg['maxTokens']  # other config still present
 
     @patch('shared.converse.get_bedrock_client')
     def test_omits_temperature_when_none(self, mock_get_client):
@@ -438,7 +476,8 @@ class TestConverseEdgeCases:
         mock_get_client.return_value = mock_client
         
         from shared.converse import converse
-        converse('Hello', max_tokens=500, temperature=0.7)
+        converse('Hello', max_tokens=500, temperature=0.7,
+                 model_id='global.anthropic.claude-sonnet-4-6')
         
         call_args = mock_client.converse.call_args
         assert call_args.kwargs['inferenceConfig']['maxTokens'] == 500
@@ -591,16 +630,87 @@ class TestConverseAutoContinuation:
 
     @patch('shared.converse.get_bedrock_client')
     def test_continuation_disabled_with_thinking_budget(self, mock_get_client):
-        """Continuation is skipped when extended thinking is enabled."""
+        """Continuation is skipped when EXPLICIT extended thinking is sent
+        (thinking-block replay is unsupported). Uses a model that accepts an
+        explicit budget — adaptive-thinking models never send the field and
+        so keep continuation."""
         mock_client = MagicMock()
         mock_client.converse.return_value = self._resp('partial', stop_reason='max_tokens')
         mock_get_client.return_value = mock_client
 
         from shared.converse import converse
-        result = converse('Hello', step_name='test', thinking_budget=5000)
+        result = converse('Hello', step_name='test', thinking_budget=5000,
+                          model_id='global.anthropic.claude-sonnet-4-6')
 
         assert result == 'partial'
         mock_client.converse.assert_called_once()
 
 
 
+
+
+class TestConverseSurfaceRouting:
+    """converse() resolves its model through the per-surface picker (issue #96)."""
+
+    @staticmethod
+    def _client(text='R'):
+        client = MagicMock()
+        client.converse.return_value = {
+            'output': {'message': {'content': [{'text': text}]}}
+        }
+        return client
+
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_resolves_model_for_named_surface(self, mock_get_client, mock_resolve):
+        mock_get_client.return_value = self._client()
+        mock_resolve.return_value = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+
+        from shared.converse import converse
+        converse('Hi', surface='enrichment')
+
+        mock_resolve.assert_called_once_with('enrichment')
+        call = mock_get_client.return_value.converse.call_args
+        assert call.kwargs['modelId'] == 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_explicit_model_id_bypasses_surface_resolution(self, mock_get_client, mock_resolve):
+        """explicit arg > configured surface — the documented precedence."""
+        mock_get_client.return_value = self._client()
+
+        from shared.converse import converse
+        converse('Hi', surface='chat', model_id='global.anthropic.claude-opus-4-8')
+
+        mock_resolve.assert_not_called()
+        call = mock_get_client.return_value.converse.call_args
+        assert call.kwargs['modelId'] == 'global.anthropic.claude-opus-4-8'
+
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_chain_threads_surface_to_every_step(self, mock_get_client, mock_resolve):
+        mock_get_client.return_value = self._client()
+        mock_resolve.return_value = 'global.anthropic.claude-sonnet-5'
+
+        from shared.converse import converse_chain
+        converse_chain(
+            [{'system': '', 'user': 'a'}, {'system': '', 'user': 'b'}],
+            surface='documents',
+        )
+
+        assert mock_resolve.call_count == 2
+        assert all(c.args == ('documents',) for c in mock_resolve.call_args_list)
+
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_chain_step_surface_overrides_chain_surface(self, mock_get_client, mock_resolve):
+        mock_get_client.return_value = self._client()
+        mock_resolve.return_value = 'global.anthropic.claude-sonnet-5'
+
+        from shared.converse import converse_chain
+        converse_chain(
+            [{'system': '', 'user': 'a', 'surface': 'prototype'}],
+            surface='documents',
+        )
+
+        mock_resolve.assert_called_once_with('prototype')

--- a/voc-datalake/lambda/shared/test/test_model_config.py
+++ b/voc-datalake/lambda/shared/test/test_model_config.py
@@ -1,0 +1,235 @@
+"""
+Tests for shared/model_config.py — per-surface Bedrock model selection (issue #96).
+"""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from shared.model_config import (  # noqa: E402
+    ALLOWED_MODELS, ALLOWED_MODEL_IDS, PICKER_SURFACES, SURFACE_DEFAULTS,
+    clear_model_cache, get_active_model_id, omits_temperature,
+    uses_adaptive_thinking, surface_default,
+)
+from shared.aws import BEDROCK_MODEL_ID  # noqa: E402
+
+SONNET5 = "global.anthropic.claude-sonnet-5"
+SONNET46 = "global.anthropic.claude-sonnet-4-6"
+OPUS48 = "global.anthropic.claude-opus-4-8"
+HAIKU45 = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    clear_model_cache()
+    yield
+    clear_model_cache()
+
+
+def _table_returning(item):
+    table = MagicMock()
+    table.get_item.return_value = {'Item': item} if item else {}
+    resource = MagicMock()
+    resource.Table.return_value = table
+    return resource, table
+
+
+class TestAllowlist:
+    def test_default_model_is_allowlisted(self):
+        assert BEDROCK_MODEL_ID in ALLOWED_MODEL_IDS
+
+    def test_allowlist_has_all_four_models(self):
+        assert ALLOWED_MODEL_IDS == {SONNET5, SONNET46, OPUS48, HAIKU45}
+
+    def test_every_surface_default_is_allowlisted(self):
+        """A surface whose Automatic default isn't invocable would break that
+        surface out of the box."""
+        for surface, model_id in SURFACE_DEFAULTS.items():
+            assert model_id in ALLOWED_MODEL_IDS, surface
+
+    def test_every_picker_surface_has_a_default(self):
+        for surface in PICKER_SURFACES:
+            assert surface in SURFACE_DEFAULTS
+
+    def test_model_entries_carry_stable_keys(self):
+        keys = [m['key'] for m in ALLOWED_MODELS]
+        assert keys == ['sonnet5', 'sonnet46', 'opus48', 'haiku45']
+
+
+class TestCapabilityFlags:
+    def test_sonnet5_and_opus48_omit_temperature(self):
+        """Sonnet 5 (adaptive thinking always-on) and Opus 4.8 (deprecated
+        param) reject `temperature`; sending it would 400 every call."""
+        assert omits_temperature(SONNET5)
+        assert omits_temperature(OPUS48)
+
+    def test_sonnet46_and_haiku_accept_temperature(self):
+        assert not omits_temperature(SONNET46)
+        assert not omits_temperature(HAIKU45)
+
+    def test_only_sonnet5_uses_adaptive_thinking(self):
+        assert uses_adaptive_thinking(SONNET5)
+        for model_id in (SONNET46, OPUS48, HAIKU45):
+            assert not uses_adaptive_thinking(model_id)
+
+
+class TestSurfaceDefaults:
+    def test_prototype_defaults_to_opus(self):
+        assert surface_default('prototype') == OPUS48
+
+    def test_enrichment_defaults_to_haiku(self):
+        """The high-volume enrichment path must stay on the cheap model by
+        default — the picker must not silently upgrade its cost profile."""
+        assert surface_default('enrichment') == HAIKU45
+
+    def test_chat_documents_utility_default_to_sonnet5(self):
+        for surface in ('chat', 'documents', 'utility'):
+            assert surface_default(surface) == SONNET5
+
+    def test_unknown_surface_falls_back_to_global_default(self):
+        assert surface_default('nonexistent') == BEDROCK_MODEL_ID
+
+
+class TestGetActiveModelId:
+    def test_returns_surface_default_without_table_env(self, monkeypatch):
+        monkeypatch.delenv('AGGREGATES_TABLE', raising=False)
+        assert get_active_model_id('prototype') == OPUS48
+        assert get_active_model_id('enrichment') == HAIKU45
+        assert get_active_model_id() == BEDROCK_MODEL_ID
+
+    def test_returns_per_surface_override(self, monkeypatch):
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, _ = _table_returning({'surfaces': {'chat': HAIKU45}})
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == HAIKU45
+
+    def test_surfaces_are_independent(self, monkeypatch):
+        """Pinning one surface must not move any other surface."""
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, _ = _table_returning({'surfaces': {'chat': HAIKU45}})
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == HAIKU45
+            assert get_active_model_id('documents') == SONNET5
+            assert get_active_model_id('prototype') == OPUS48
+            assert get_active_model_id('enrichment') == HAIKU45
+
+    def test_legacy_global_override_applies_to_unpinned_surfaces(self, monkeypatch):
+        """A model_id written by the older single-model picker still works,
+        but a per-surface pin beats it."""
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, _ = _table_returning({
+            'model_id': SONNET46,
+            'surfaces': {'prototype': OPUS48},
+        })
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == SONNET46          # global fallback
+            assert get_active_model_id('enrichment') == SONNET46    # global fallback
+            assert get_active_model_id('prototype') == OPUS48       # per-surface wins
+
+    def test_rejects_surface_value_outside_allowlist(self, monkeypatch):
+        """A tampered or stale DB value must not reach Bedrock."""
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, _ = _table_returning({'surfaces': {'chat': 'anthropic.evil-model-v9'}})
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == SONNET5
+
+    def test_rejects_legacy_global_outside_allowlist(self, monkeypatch):
+        """A stale global from before a model was delisted falls back to the
+        surface default — e.g. an old Sonnet 4.5 pin after the bump."""
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, _ = _table_returning(
+            {'model_id': 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'}
+        )
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == SONNET5
+            assert get_active_model_id('enrichment') == HAIKU45
+
+    def test_falls_back_to_defaults_when_lookup_fails(self, monkeypatch):
+        """No read permission / throttling must never break inference."""
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource = MagicMock()
+        resource.Table.return_value.get_item.side_effect = Exception('AccessDenied')
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == SONNET5
+            assert get_active_model_id('prototype') == OPUS48
+
+    def test_caches_lookup_within_ttl(self, monkeypatch):
+        """One DynamoDB read serves every surface within the TTL."""
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, table = _table_returning({'surfaces': {'chat': HAIKU45}})
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            assert get_active_model_id('chat') == HAIKU45
+            assert get_active_model_id('documents') == SONNET5
+            assert get_active_model_id('chat') == HAIKU45
+        assert table.get_item.call_count == 1
+
+    def test_clear_cache_forces_refetch(self, monkeypatch):
+        monkeypatch.setenv('AGGREGATES_TABLE', 'agg')
+        resource, table = _table_returning({'surfaces': {'chat': HAIKU45}})
+        with patch('shared.model_config.get_dynamodb_resource', return_value=resource):
+            get_active_model_id('chat')
+            clear_model_cache()
+            get_active_model_id('chat')
+        assert table.get_item.call_count == 2
+
+
+class TestAllowlistLockstep:
+    """The allowlist exists in three places; drift AccessDenies at runtime.
+
+    Python (this module) drives REST-API/job inference, the TS mirror drives
+    streaming chat, and the shared CDK helper grants the IAM invoke
+    permissions AND the BedrockAccessStack agreements. These tests read the
+    other two sources so a model added to one place fails the build until
+    all three agree.
+    """
+
+    @staticmethod
+    def _repo_root():
+        from pathlib import Path
+        return Path(__file__).resolve().parents[3]
+
+    def test_ts_stream_allowlist_matches_python(self):
+        import re
+        ts_source = (
+            self._repo_root() / 'lambda' / 'stream' / 'src' / 'bedrock' / 'model-override.ts'
+        ).read_text()
+        # Only the ALLOWED_MODEL_IDS set constitutes the allowlist — the
+        # capability sets (OMIT_TEMPERATURE/ADAPTIVE_THINKING) are subsets.
+        allowlist_block = ts_source.split('ALLOWED_MODEL_IDS')[1].split(']);')[0]
+        ts_ids = set(re.findall(r"'(global\.anthropic\.[^']+)'", allowlist_block))
+        assert ts_ids == ALLOWED_MODEL_IDS
+
+    def test_ts_capability_sets_match_python(self):
+        import re
+        ts_source = (
+            self._repo_root() / 'lambda' / 'stream' / 'src' / 'bedrock' / 'model-override.ts'
+        ).read_text()
+        omit_block = ts_source.split('OMIT_TEMPERATURE_IDS')[1].split(']);')[0]
+        ts_omit = set(re.findall(r"'(global\.anthropic\.[^']+)'", omit_block))
+        py_omit = {m['id'] for m in ALLOWED_MODELS if m['omit_temperature']}
+        assert ts_omit == py_omit
+
+    def test_cdk_allowlist_matches_python(self):
+        import re
+        cdk_source = (
+            self._repo_root() / 'lib' / 'utils' / 'model-allowlist.ts'
+        ).read_text()
+        allowlist_block = cdk_source.split('ALLOWED_MODEL_IDS')[1].split('];')[0]
+        cdk_ids = set(re.findall(r"'(global\.anthropic\.[^']+)'", allowlist_block))
+        assert cdk_ids == ALLOWED_MODEL_IDS
+
+    def test_nag_suppressions_cover_every_foundation_model(self):
+        """cdk-nag suppressions enumerate the foundation-model ARNs by string;
+        a missing one fails synth with an unsuppressed IAM5 finding."""
+        import re
+        nag_source = (
+            self._repo_root() / 'lib' / 'utils' / 'nag-suppressions.ts'
+        ).read_text()
+        suppressed = set(re.findall(
+            r"foundation-model/(anthropic\.[^']+)'", nag_source
+        ))
+        expected = {m['id'].replace('global.', '') for m in ALLOWED_MODELS}
+        assert expected <= suppressed

--- a/voc-datalake/lambda/stream/src/bedrock/converse-stream.test.ts
+++ b/voc-datalake/lambda/stream/src/bedrock/converse-stream.test.ts
@@ -128,12 +128,13 @@ describe('converseStream', () => {
     );
   });
 
-  it('uses default maxTokens and thinkingBudget', async () => {
+  it('uses default maxTokens and thinkingBudget (explicit-budget model)', async () => {
     mockSend.mockResolvedValueOnce({ stream: (async function* () {})() });
 
     for await (const _ of converseStream({
       messages: [{ role: 'user', content: [{ text: 'hi' }] }],
       systemPrompt: 'test',
+      modelId: 'global.anthropic.claude-sonnet-4-6',
     })) {
       // no-op
     }
@@ -156,6 +157,7 @@ describe('converseStream', () => {
       systemPrompt: 'test',
       maxTokens: 4096,
       thinkingBudget: 2000,
+      modelId: 'global.anthropic.claude-sonnet-4-6',
     })) {
       // no-op
     }
@@ -166,6 +168,50 @@ describe('converseStream', () => {
         additionalModelRequestFields: {
           thinking: { type: 'enabled', budget_tokens: 2000 },
         },
+      }),
+    );
+  });
+
+  it('omits the explicit thinking budget for adaptive-thinking models (Sonnet 5)', async () => {
+    // Sonnet 5 runs adaptive thinking always-on and rejects an explicit
+    // budget — sending it would 400 every chat turn. It is also the default
+    // model, so the no-modelId path must omit the field too.
+    mockSend.mockResolvedValueOnce({ stream: (async function* () {})() });
+    mockSend.mockResolvedValueOnce({ stream: (async function* () {})() });
+
+    for await (const _ of converseStream({
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      systemPrompt: 'test',
+      modelId: 'global.anthropic.claude-sonnet-5',
+    })) {
+      // no-op
+    }
+    for await (const _ of converseStream({
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      systemPrompt: 'test',
+    })) {
+      // no-op (env default is Sonnet 5)
+    }
+
+    for (const call of mockConverseStreamCommandCtor.mock.calls) {
+      expect(call[0]).not.toHaveProperty('additionalModelRequestFields');
+    }
+  });
+
+  it('passes the resolved model override as modelId', async () => {
+    mockSend.mockResolvedValueOnce({ stream: (async function* () {})() });
+
+    for await (const _ of converseStream({
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      systemPrompt: 'test',
+      modelId: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+    })) {
+      // no-op
+    }
+
+    expect(mockConverseStreamCommandCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
       }),
     );
   });

--- a/voc-datalake/lambda/stream/src/bedrock/converse-stream.ts
+++ b/voc-datalake/lambda/stream/src/bedrock/converse-stream.ts
@@ -9,8 +9,11 @@ import {
   type Tool,
   type ConverseStreamOutput,
 } from '@aws-sdk/client-bedrock-runtime';
+import { usesAdaptiveThinking } from './model-override.js';
 
-const MODEL_ID = process.env.BEDROCK_MODEL_ID ?? 'global.anthropic.claude-sonnet-4-6';
+// Fallback when no per-surface override is configured and no env is set.
+// The 'chat' surface default is Sonnet 5 (kept in sync with model_config.py).
+const MODEL_ID = process.env.BEDROCK_MODEL_ID ?? 'global.anthropic.claude-sonnet-5';
 
 const clientHolder: { instance: BedrockRuntimeClient | null } = { instance: null };
 
@@ -31,6 +34,8 @@ interface ConverseStreamParams {
   tools?: Tool[];
   maxTokens?: number;
   thinkingBudget?: number;
+  /** Admin-configured model override (per-surface); falls back to the env default. */
+  modelId?: string;
 }
 
 export async function* converseStream(
@@ -42,19 +47,27 @@ export async function* converseStream(
     tools,
     maxTokens = 16000,
     thinkingBudget = 5000,
+    modelId,
   } = params;
 
+  const resolvedModel = modelId ?? MODEL_ID;
   const system: SystemContentBlock[] = [{ text: systemPrompt }];
 
   const command = new ConverseStreamCommand({
-    modelId: MODEL_ID,
+    modelId: resolvedModel,
     messages,
     system,
     toolConfig: tools && tools.length > 0 ? { tools } : undefined,
     inferenceConfig: { maxTokens },
-    additionalModelRequestFields: {
-      thinking: { type: 'enabled', budget_tokens: thinkingBudget },
-    },
+    // Models with always-on adaptive thinking (Sonnet 5) reject an explicit
+    // budget — omit the field and let their thinking run automatically.
+    ...(usesAdaptiveThinking(resolvedModel)
+      ? {}
+      : {
+          additionalModelRequestFields: {
+            thinking: { type: 'enabled', budget_tokens: thinkingBudget },
+          },
+        }),
   });
 
   const bedrockClient = getBedrockClient();

--- a/voc-datalake/lambda/stream/src/bedrock/model-override.test.ts
+++ b/voc-datalake/lambda/stream/src/bedrock/model-override.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the per-surface model override lookup (issue #96).
+ *
+ * The lookup must never throw (a chat turn must survive a broken table),
+ * must enforce the allowlist against tampered DB values, and must apply the
+ * per-surface > legacy-global precedence mirrored from model_config.py.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  resolveModelOverride,
+  clearModelOverrideCache,
+  omitsTemperature,
+  usesAdaptiveThinking,
+  ALLOWED_MODEL_IDS,
+} from './model-override.js';
+
+const SONNET5 = 'global.anthropic.claude-sonnet-5';
+const SONNET46 = 'global.anthropic.claude-sonnet-4-6';
+const OPUS48 = 'global.anthropic.claude-opus-4-8';
+const HAIKU45 = 'global.anthropic.claude-haiku-4-5-20251001-v1:0';
+
+interface DocClientLike {
+  send: ReturnType<typeof vi.fn>;
+}
+
+function isDocClient(client: DocClientLike): client is DocClientLike & DynamoDBDocumentClient {
+  return typeof client.send === 'function';
+}
+
+/** Build a doc-client test double without `as` type assertions. */
+function docClientReturning(item: Record<string, unknown> | undefined): DynamoDBDocumentClient & DocClientLike {
+  const double: DocClientLike = { send: vi.fn().mockResolvedValue({ Item: item }) };
+  if (!isDocClient(double)) throw new Error('test double is not send-able');
+  return double;
+}
+
+function docClientRejecting(): DynamoDBDocumentClient & DocClientLike {
+  const double: DocClientLike = { send: vi.fn().mockRejectedValue(new Error('AccessDenied')) };
+  if (!isDocClient(double)) throw new Error('test double is not send-able');
+  return double;
+}
+
+beforeEach(() => {
+  clearModelOverrideCache();
+});
+
+describe('resolveModelOverride', () => {
+  it('returns undefined when no table name is configured', async () => {
+    const client = docClientReturning({});
+    expect(await resolveModelOverride(client, '')).toBeUndefined();
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when nothing is configured', async () => {
+    const client = docClientReturning(undefined);
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBeUndefined();
+  });
+
+  it('returns the per-surface override for the chat surface', async () => {
+    const client = docClientReturning({ surfaces: { chat: HAIKU45 } });
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBe(HAIKU45);
+  });
+
+  it('ignores overrides pinned to other surfaces', async () => {
+    const client = docClientReturning({ surfaces: { documents: OPUS48 } });
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBeUndefined();
+  });
+
+  it('falls back to the legacy global override when the surface is unpinned', async () => {
+    const client = docClientReturning({ model_id: SONNET46 });
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBe(SONNET46);
+  });
+
+  it('prefers the per-surface override over the legacy global', async () => {
+    const client = docClientReturning({
+      model_id: SONNET46,
+      surfaces: { chat: HAIKU45 },
+    });
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBe(HAIKU45);
+  });
+
+  it('rejects tampered values outside the allowlist', async () => {
+    const client = docClientReturning({
+      model_id: 'anthropic.evil-model-v9',
+      surfaces: { chat: 'anthropic.evil-model-v9' },
+    });
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBeUndefined();
+  });
+
+  it('never throws when the lookup fails (falls back to default)', async () => {
+    const client = docClientRejecting();
+    expect(await resolveModelOverride(client, 'agg', 'chat')).toBeUndefined();
+  });
+
+  it('caches the settings item across calls within the TTL', async () => {
+    const client = docClientReturning({ surfaces: { chat: HAIKU45 } });
+    await resolveModelOverride(client, 'agg', 'chat');
+    await resolveModelOverride(client, 'agg', 'chat');
+    expect(client.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearModelOverrideCache forces a refetch', async () => {
+    const client = docClientReturning({ surfaces: { chat: HAIKU45 } });
+    await resolveModelOverride(client, 'agg', 'chat');
+    clearModelOverrideCache();
+    await resolveModelOverride(client, 'agg', 'chat');
+    expect(client.send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('capability sets', () => {
+  it('allowlist has exactly the four picker models', () => {
+    expect(ALLOWED_MODEL_IDS).toEqual(new Set([SONNET5, SONNET46, OPUS48, HAIKU45]));
+  });
+
+  it('Sonnet 5 and Opus 4.8 omit temperature', () => {
+    expect(omitsTemperature(SONNET5)).toBe(true);
+    expect(omitsTemperature(OPUS48)).toBe(true);
+    expect(omitsTemperature(SONNET46)).toBe(false);
+    expect(omitsTemperature(HAIKU45)).toBe(false);
+  });
+
+  it('only Sonnet 5 uses always-on adaptive thinking', () => {
+    expect(usesAdaptiveThinking(SONNET5)).toBe(true);
+    expect(usesAdaptiveThinking(SONNET46)).toBe(false);
+    expect(usesAdaptiveThinking(OPUS48)).toBe(false);
+    expect(usesAdaptiveThinking(HAIKU45)).toBe(false);
+  });
+});

--- a/voc-datalake/lambda/stream/src/bedrock/model-override.ts
+++ b/voc-datalake/lambda/stream/src/bedrock/model-override.ts
@@ -1,0 +1,125 @@
+/**
+ * Runtime per-surface model resolution for streaming chat (issue #96).
+ *
+ * Admins pick a Bedrock model per AI surface in Settings; the choices live in
+ * the aggregates table under SETTINGS#model. Streaming chat is the "chat"
+ * surface: this module resolves the chat override (per-surface first, then the
+ * legacy global override), returning `undefined` when nothing valid is
+ * configured so the caller falls back to its env default. The lookup must
+ * never break a chat turn.
+ *
+ * The allowlist and the temperature/adaptive-thinking capability sets MIRROR
+ * lambda/shared/model_config.py and are enforced here too, so a tampered DB
+ * value can't steer inference to an arbitrary model. The Python lockstep tests
+ * read this file and assert the allowlist matches.
+ */
+import { GetCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+const MODEL_SETTINGS_PK = 'SETTINGS#model';
+const MODEL_SETTINGS_SK = 'config';
+
+// Curated allowlist — MUST stay in lockstep with model_config.py::ALLOWED_MODELS
+// and lib/stacks/api-stack.ts::allowlistedModelArns.
+export const ALLOWED_MODEL_IDS = new Set<string>([
+  'global.anthropic.claude-sonnet-5',
+  'global.anthropic.claude-sonnet-4-6',
+  'global.anthropic.claude-opus-4-8',
+  'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+]);
+
+// Models that reject the `temperature` inference param (Sonnet 5 runs adaptive
+// thinking; Opus 4.8 deprecates temperature). Mirrors model_config.py.
+export const OMIT_TEMPERATURE_IDS = new Set<string>([
+  'global.anthropic.claude-sonnet-5',
+  'global.anthropic.claude-opus-4-8',
+]);
+
+// Models with always-on adaptive thinking that reject an explicit thinking
+// budget — skip the `thinking` request field for these. Mirrors model_config.py.
+export const ADAPTIVE_THINKING_IDS = new Set<string>([
+  'global.anthropic.claude-sonnet-5',
+]);
+
+/** True when the model rejects the `temperature` inference parameter. */
+export function omitsTemperature(modelId: string): boolean {
+  return OMIT_TEMPERATURE_IDS.has(modelId);
+}
+
+/** True when the model runs adaptive thinking always-on (no explicit budget). */
+export function usesAdaptiveThinking(modelId: string): boolean {
+  return ADAPTIVE_THINKING_IDS.has(modelId);
+}
+
+const CACHE_TTL_MS = 60_000;
+// Lookup failures cache for a shorter window so a throttling blip doesn't
+// silently pin streaming chat to the default for a full minute.
+const ERROR_CACHE_TTL_MS = 10_000;
+
+const cache: { item: Record<string, unknown> | null; expires: number } = { item: null, expires: 0 };
+
+/** Reset the container cache (tests). */
+export function clearModelOverrideCache(): void {
+  cache.item = null;
+  cache.expires = 0;
+}
+
+async function loadSettings(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+): Promise<Record<string, unknown>> {
+  const now = Date.now();
+  if (cache.item !== null && now < cache.expires) {
+    return cache.item;
+  }
+  let item: Record<string, unknown> = {};
+  let ttl = CACHE_TTL_MS;
+  try {
+    const result = await docClient.send(new GetCommand({
+      TableName: tableName,
+      Key: { pk: MODEL_SETTINGS_PK, sk: MODEL_SETTINGS_SK },
+    }));
+    if (result.Item && typeof result.Item === 'object') {
+      item = result.Item as Record<string, unknown>;
+    }
+  } catch (error) {
+    console.warn('Model override lookup failed; using default:', error);
+    ttl = ERROR_CACHE_TTL_MS;
+  }
+  cache.item = item;
+  cache.expires = now + ttl;
+  return item;
+}
+
+function allowlisted(value: unknown): string | undefined {
+  if (typeof value === 'string' && ALLOWED_MODEL_IDS.has(value)) {
+    return value;
+  }
+  if (value) {
+    console.warn(`Configured model '${String(value).slice(0, 80)}' not in allowlist; ignoring`);
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the admin-configured model override for a surface, if any.
+ *
+ * Precedence: per-surface override > legacy global override > undefined
+ * (caller falls back to its own env default). Returns an allowlisted model id
+ * or undefined; never throws.
+ */
+export async function resolveModelOverride(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+  surface = 'chat',
+): Promise<string | undefined> {
+  if (!tableName) return undefined;
+  const item = await loadSettings(docClient, tableName);
+  const surfaces = item.surfaces;
+  if (surfaces && typeof surfaces === 'object') {
+    const perSurface = allowlisted((surfaces as Record<string, unknown>)[surface]);
+    if (perSurface) return perSurface;
+  }
+  const legacyGlobal = allowlisted(item.model_id);
+  if (legacyGlobal) return legacyGlobal;
+  return undefined;
+}

--- a/voc-datalake/lambda/stream/src/handler.ts
+++ b/voc-datalake/lambda/stream/src/handler.ts
@@ -17,6 +17,7 @@ import { isApiError, ValidationError } from './lib/errors.js';
 import { chatRequestSchema, type ChatRequest, type HistoryMessage } from './schema.js';
 import { z } from 'zod';
 import { converseStream } from './bedrock/converse-stream.js';
+import { resolveModelOverride } from './bedrock/model-override.js';
 import { processStreamEvent, createStreamState, type ToolUseBlock } from './bedrock/stream-processor.js';
 import { executeTool } from './tools/executor.js';
 import { getSearchFeedbackTool, getUpdateDocumentTool, getCreateDocumentTool, getCreateProjectTool, getWebSearchTool } from './tools/index.js';
@@ -183,12 +184,17 @@ async function runConversationLoop(
 
   const state = createStreamState();
 
+  // Streaming chat is the "chat" AI surface — resolve the admin-configured
+  // model override (falls back to the env default inside converseStream).
+  const modelId = await resolveModelOverride(docClient, AGGREGATES_TABLE, 'chat');
+
   const events = converseStream({
     messages,
     systemPrompt,
     tools: tools.length > 0 ? tools : undefined,
     maxTokens: 16000,
     thinkingBudget: 5000,
+    modelId,
   });
 
   for await (const event of events) {

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -532,6 +532,8 @@ export class VocApiStack extends cdk.Stack {
     feedbackTable.grantReadData(documentGeneratorRole);
     projectsTable.grantReadWriteData(documentGeneratorRole);
     jobsTable.grantReadWriteData(documentGeneratorRole);
+    // Model picker: read per-surface overrides (documents/prototype) from aggregates.
+    aggregatesTable.grantReadData(documentGeneratorRole);
     kmsKey.grantEncryptDecrypt(documentGeneratorRole);
     documentGeneratorRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
@@ -558,6 +560,7 @@ export class VocApiStack extends cdk.Stack {
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
+        AGGREGATES_TABLE: aggregatesTable.tableName,
         JOBS_TABLE: jobsTable.tableName,
         RAW_DATA_BUCKET: rawDataBucket.bucketName,
         PROTOTYPES_CDN_URL: prototypesCdnUrl,
@@ -573,6 +576,8 @@ export class VocApiStack extends cdk.Stack {
     feedbackTable.grantReadData(documentMergerRole);
     projectsTable.grantReadWriteData(documentMergerRole);
     jobsTable.grantReadWriteData(documentMergerRole);
+    // Model picker: read the documents-surface override from aggregates.
+    aggregatesTable.grantReadData(documentMergerRole);
     kmsKey.grantEncryptDecrypt(documentMergerRole);
     documentMergerRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
@@ -591,6 +596,7 @@ export class VocApiStack extends cdk.Stack {
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
+        AGGREGATES_TABLE: aggregatesTable.tableName,
         JOBS_TABLE: jobsTable.tableName,
         POWERTOOLS_SERVICE_NAME: 'voc-job-document-merger',
         LOG_LEVEL: 'INFO',
@@ -603,6 +609,8 @@ export class VocApiStack extends cdk.Stack {
     const personaImporterRole = this.createLambdaRole('PersonaImporterRole');
     projectsTable.grantReadWriteData(personaImporterRole);
     jobsTable.grantReadWriteData(personaImporterRole);
+    // Model picker: read the documents-surface override from aggregates.
+    aggregatesTable.grantReadData(personaImporterRole);
     kmsKey.grantEncryptDecrypt(personaImporterRole);
     personaImporterRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
@@ -621,6 +629,7 @@ export class VocApiStack extends cdk.Stack {
       memorySize: 512,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
+        AGGREGATES_TABLE: aggregatesTable.tableName,
         JOBS_TABLE: jobsTable.tableName,
         RAW_DATA_BUCKET: rawDataBucket.bucketName,
         AVATARS_CDN_URL: avatarsCdnUrl,

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -19,6 +19,7 @@ import { loadPlugins, getEnabledPlugins, getPluginsWithWebhook, capitalize, type
 import { uniqueName } from '../utils/naming';
 import { assertFrontendBuildFresh } from '../utils/assert-frontend-build';
 import { cdkCustomResourceSuppressions, apiGatewayRequestValidationSuppressions, publicFeedbackEndpointSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, marketplaceSuppressions } from '../utils/nag-suppressions';
+import { allowlistedModelArns } from '../utils/model-allowlist';
 
 export interface VocApiStackProps extends cdk.StackProps {
   // Core stack resources
@@ -225,10 +226,7 @@ export class VocApiStack extends cdk.Stack {
     NagSuppressions.addResourceSuppressions(scrapersRole, pluginSystemSuppressions, true);
     scrapersRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-      ],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
     // AWS Marketplace permissions required for Bedrock model access
     scrapersRole.addToPolicy(new iam.PolicyStatement({
@@ -292,7 +290,7 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(manualImportProcessorRole);
     manualImportProcessorRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [`arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`, 'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0'],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
 
     new lambda.Function(this, 'ManualImportProcessor', {
@@ -315,7 +313,7 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(settingsRole);
     settingsRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [`arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`, 'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0'],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
 
     const settingsLambda = new lambda.Function(this, 'SettingsApi', {
@@ -401,7 +399,7 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(chatRole);
     chatRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [`arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`, 'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0'],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
 
     const chatLambda = new lambda.Function(this, 'ChatApi', {
@@ -430,8 +428,8 @@ export class VocApiStack extends cdk.Stack {
     projectsRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
       resources: [
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
+        ...allowlistedModelArns(this.region, this.account),
+        // Nova Canvas powers persona avatar image generation.
         'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0',
       ],
     }));
@@ -487,10 +485,10 @@ export class VocApiStack extends cdk.Stack {
       });
     };
 
-    const claudeModelResources = [
-      `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-      'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-    ];
+    // Every allowlisted model (issue #96) so any AI surface can be repointed
+    // via the picker. Single source of truth kept in lockstep with
+    // lambda/shared/model_config.py and lambda/stream/src/bedrock/model-override.ts.
+    const claudeModelResources = allowlistedModelArns(this.region, this.account);
     const novaCanvasResource = 'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0';
 
     // Persona Generator Job Lambda
@@ -537,12 +535,9 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(documentGeneratorRole);
     documentGeneratorRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [
-        ...claudeModelResources,
-        // Opus 4.8 powers the HTML prototype builder (_generate_prototype).
-        `arn:aws:bedrock:*:${this.account}:inference-profile/global.anthropic.claude-opus-4-8`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-8',
-      ],
+      // Opus 4.8 (the prototype-builder default) is now part of the allowlist,
+      // so claudeModelResources already covers it — no separate grant needed.
+      resources: claudeModelResources,
     }));
     // Product context: read extracted product-doc text when generating PRD/PR-FAQ.
     rawDataBucket.grantRead(documentGeneratorRole, 'projects/*/product_docs/extracted/*');
@@ -674,7 +669,10 @@ export class VocApiStack extends cdk.Stack {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
         AGGREGATES_TABLE: aggregatesTable.tableName,
-        BEDROCK_MODEL_ID: 'global.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        // Streaming-chat ('chat' surface) default when no override is set.
+        // Bumped Sonnet 4.5 → Sonnet 5 (latest). The per-surface picker can
+        // override this at runtime via model-override.ts.
+        BEDROCK_MODEL_ID: 'global.anthropic.claude-sonnet-5',
         AVATARS_CDN_URL: avatarsCdnUrl,
         ALLOWED_ORIGIN: allowedOrigin,
       },
@@ -698,13 +696,11 @@ export class VocApiStack extends cdk.Stack {
       logGroup: this.createLogGroup('ChatStreamLogs', uniqueName('voc-chat-stream')),
     });
 
-    // Bedrock permissions — InvokeModelWithResponseStream
+    // Bedrock permissions — InvokeModelWithResponseStream. Grant every
+    // allowlisted model so the 'chat' surface can be repointed via the picker.
     chatStreamLambda.addToRolePolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
-      resources: [
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-      ],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
     // AWS Marketplace permissions required for Bedrock model access
     chatStreamLambda.addToRolePolicy(new iam.PolicyStatement({

--- a/voc-datalake/lib/stacks/bedrock-access-stack.ts
+++ b/voc-datalake/lib/stacks/bedrock-access-stack.ts
@@ -5,6 +5,7 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { z } from 'zod';
+import { ALLOWED_FOUNDATION_MODEL_IDS } from '../utils/model-allowlist';
 import { NagSuppressions } from 'cdk-nag';
 import { cdkCustomResourceSuppressions, lambdaBasicExecutionRoleSuppressions, pluginSystemSuppressions, bedrockAgreementSuppressions, marketplaceSuppressions } from '../utils/nag-suppressions';
 
@@ -49,12 +50,12 @@ export const AnthropicUseCaseSchema = z.object({
 export type AnthropicUseCaseConfig = z.infer<typeof AnthropicUseCaseSchema>;
 
 /**
- * Models that require agreement acceptance for VoC platform.
+ * Models that require agreement acceptance for the VoC platform. Sourced from
+ * the shared allowlist so every model the per-surface picker can select
+ * (issue #96) has its agreement created — Sonnet 5, Sonnet 4.6, Opus 4.8,
+ * and Haiku 4.5. Kept in lockstep with lambda/shared/model_config.py.
  */
-const REQUIRED_MODELS = [
-  'anthropic.claude-sonnet-4-5-20250929-v1:0',  // Chat/API
-  'anthropic.claude-haiku-4-5-20251001-v1:0',   // Processor
-];
+const REQUIRED_MODELS = [...ALLOWED_FOUNDATION_MODEL_IDS];
 
 export interface BedrockAccessStackProps extends cdk.StackProps {
   /**

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -24,6 +24,7 @@ import {
 import { uniqueName } from '../utils/naming';
 import { NagSuppressions } from 'cdk-nag';
 import { apiSecretsSuppressions, bedrockModelSuppressions } from '../utils/nag-suppressions';
+import { allowlistedModelArns } from '../utils/model-allowlist';
 
 export interface VocIngestionStackProps extends cdk.StackProps {
   feedbackTable: dynamodb.Table;
@@ -276,12 +277,13 @@ export class VocIngestionStack extends cdk.Stack {
   /**
    * Build a dedicated role for a plugin that opts in via `infrastructure.ingestor.bedrock`.
    * It gets the same base ingestion permissions PLUS a scoped bedrock:InvokeModel grant
-   * (Claude Sonnet only). This keeps least-privilege intact: only opted-in plugins can
-   * reach Bedrock, rather than widening the shared role for the whole plugin fleet.
+   * for the curated model allowlist. This keeps least-privilege intact: only opted-in
+   * plugins can reach Bedrock, rather than widening the shared role for the whole plugin
+   * fleet.
    *
-   * The model ARNs must match the model shared/converse.py actually invokes
-   * (shared.aws.BEDROCK_MODEL_ID = global.anthropic.claude-sonnet-4-5-...); a `global.`
-   * inference profile requires BOTH the inference-profile and foundation-model ARNs.
+   * The grant covers every model the per-surface picker can resolve to (issue #96),
+   * since these plugins invoke via shared/converse.py — kept in lockstep with
+   * lambda/shared/model_config.py through lib/utils/model-allowlist.ts.
    */
   private createBedrockIngestorRole(pluginId: string): iam.Role {
     const role = new iam.Role(this, `IngestorRole${capitalize(pluginId)}`, {
@@ -295,10 +297,7 @@ export class VocIngestionStack extends cdk.Stack {
 
     role.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-      ],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
 
     // The stack-level suppressions in bin/ cover the base grants but not Bedrock,

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -12,6 +12,7 @@ import { Construct } from 'constructs';
 import { NagSuppressions } from 'cdk-nag';
 import { uniqueName } from '../utils/naming';
 import { pluginSystemSuppressions } from '../utils/nag-suppressions';
+import { allowlistedModelArns } from '../utils/model-allowlist';
 
 export interface VocProcessingStackProps extends cdk.StackProps {
   feedbackTable: dynamodb.Table;
@@ -84,15 +85,12 @@ export class VocProcessingStack extends cdk.Stack {
     });
 
     // Bedrock permissions
+    // Enrichment defaults to Haiku but admins can repoint the 'enrichment'
+    // surface via the picker, so grant every allowlisted model (issue #96).
     processingRole.addToPolicy(new iam.PolicyStatement({
       sid: 'BedrockInvoke',
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
-      resources: [
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-haiku-4-5-20251001-v1:0`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
-      ],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
 
     // Comprehend + Translate permissions
@@ -217,14 +215,14 @@ export class VocProcessingStack extends cdk.Stack {
     feedbackTable.grantReadData(researchRole);
     projectsTable.grantReadWriteData(researchRole);
     jobsTable.grantReadWriteData(researchRole);
+    aggregatesTable.grantReadData(researchRole);
     kmsKey.grantEncryptDecrypt(researchRole);
 
+    // Research is a 'documents' surface (defaults to Sonnet 5) and is
+    // repointable via the picker, so grant every allowlisted model (issue #96).
     researchRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [
-        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-        'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-      ],
+      resources: allowlistedModelArns(this.region, this.account),
     }));
 
     const researchCode = lambda.Code.fromAsset('.', {
@@ -249,6 +247,9 @@ export class VocProcessingStack extends cdk.Stack {
         FEEDBACK_TABLE: feedbackTable.tableName,
         PROJECTS_TABLE: projectsTable.tableName,
         JOBS_TABLE: jobsTable.tableName,
+        // Needed so the per-surface AI-model picker ('documents') can resolve
+        // an admin override for research generation (issue #96).
+        AGGREGATES_TABLE: aggregatesTable.tableName,
         POWERTOOLS_SERVICE_NAME: 'voc-research-step',
         LOG_LEVEL: 'INFO',
       },

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -140,7 +140,9 @@ export class VocProcessingStack extends cdk.Stack {
         PROJECTS_TABLE: projectsTable.tableName,
         IDEMPOTENCY_TABLE: idempotencyTable.tableName,
         PRIMARY_LANGUAGE: config.primaryLanguage,
-        BEDROCK_MODEL_ID: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+        // No BEDROCK_MODEL_ID env: the enrichment model resolves through the
+        // per-surface AI-model picker (lambda/shared/model_config.py — the
+        // 'enrichment' surface defaults to Haiku, admins can override it).
         POWERTOOLS_SERVICE_NAME: 'voc-processor',
         POWERTOOLS_IDEMPOTENCY_DISABLED: '0',
         LOG_LEVEL: 'INFO',

--- a/voc-datalake/lib/utils/model-allowlist.ts
+++ b/voc-datalake/lib/utils/model-allowlist.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for the Bedrock models the per-surface AI-model
+ * picker can route inference to (issue #96).
+ *
+ * MUST stay in lockstep with:
+ *   - lambda/shared/model_config.py            (ALLOWED_MODELS — REST/job inference)
+ *   - lambda/stream/src/bedrock/model-override.ts (streaming-chat lookup)
+ *
+ * A model that is selectable but not invocable AccessDenies the surface, so
+ * every bedrock:InvokeModel* grant across the stacks (api, processing,
+ * ingestion) is built from allowlistedModelArns(), the BedrockAccessStack
+ * agreements are built from ALLOWED_FOUNDATION_MODEL_IDS, and a Python
+ * lockstep test asserts this list equals the one in model_config.py.
+ */
+
+/**
+ * Global cross-region inference profile IDs — exactly what the application
+ * passes to Bedrock as `modelId`, and what the picker stores/validates.
+ */
+export const ALLOWED_MODEL_IDS: readonly string[] = [
+  'global.anthropic.claude-sonnet-5',
+  'global.anthropic.claude-sonnet-4-6',
+  'global.anthropic.claude-opus-4-8',
+  'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+];
+
+/**
+ * Foundation-model IDs (the inference-profile IDs without the `global.`
+ * prefix). Used for Bedrock model-access agreements in BedrockAccessStack.
+ */
+export const ALLOWED_FOUNDATION_MODEL_IDS: readonly string[] = ALLOWED_MODEL_IDS.map(
+  (id) => id.replace(/^global\./, ''),
+);
+
+/**
+ * IAM resource ARNs granting bedrock:InvokeModel* on every allowlisted model:
+ * the region/account-scoped global inference-profile ARN plus the
+ * cross-region foundation-model ARN each profile can route to.
+ *
+ * The foundation-model ARN keeps a region wildcard (models are cross-region
+ * resources) — see bedrockModelSuppressions in lib/utils/nag-suppressions.ts.
+ */
+export function allowlistedModelArns(region: string, account: string): string[] {
+  const arns: string[] = [];
+  for (const id of ALLOWED_MODEL_IDS) {
+    const foundationModel = id.replace(/^global\./, '');
+    arns.push(`arn:aws:bedrock:${region}:${account}:inference-profile/${id}`);
+    arns.push(`arn:aws:bedrock:*::foundation-model/${foundationModel}`);
+  }
+  return arns;
+}

--- a/voc-datalake/lib/utils/nag-suppressions.ts
+++ b/voc-datalake/lib/utils/nag-suppressions.ts
@@ -138,12 +138,15 @@ export const bedrockModelSuppressions: NagPackSuppression[] = [
   {
     id: 'AwsSolutions-IAM5',
     reason: 'Bedrock foundation model ARNs require region wildcard as models are cross-region resources',
+    // Every model in the per-surface AI-model picker allowlist (issue #96),
+    // kept in lockstep with lib/utils/model-allowlist.ts. Only the
+    // foundation-model ARNs carry a region wildcard; the inference-profile
+    // ARNs are region/account-scoped and need no suppression.
     appliesTo: [
-      'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0',
-      'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
-      // Opus 4.8 powers the HTML prototype builder (document-generator Lambda).
+      'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-5',
+      'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-6',
       'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-8',
-      { regex: '/Resource::arn:aws:bedrock:\\*:.*:inference-profile/global\\.anthropic\\.claude-opus-4-8/' },
+      'Resource::arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Addresses #96 (close manually on merge — base is `development`). **Alternative to #154** — offered for maintainer choice; #154 stays open.

Admins get an **AI Models** card in Settings (brand tab, admin-only) with one selector **per AI surface** instead of #154's single global toggle:

| Surface | What it covers | Automatic default |
|---|---|---|
| AI Chat | chat, streaming chat, project/product interview | **Claude Sonnet 5** |
| Document Generation | PRDs, PR/FAQs, personas, research, merger, product reports | **Claude Sonnet 5** |
| Prototype Builder | interactive HTML prototypes | **Claude Opus 4.8** |
| Feedback Enrichment | processor (sentiment/category/urgency on every item) | **Claude Haiku 4.5** |
| Utilities | category suggestions, scraper selector detection | **Claude Sonnet 5** |

### Why per-surface instead of one global switch

With a global toggle, choosing Haiku downgrades exactly the wrong things: the volume driver (enrichment) is already on Haiku and pinned there, so the toggle only moves the low-volume, quality-sensitive surfaces. Per-surface lets a cost-conscious admin put chat on Haiku while keeping PRDs on Sonnet — the trade an admin actually wants to make. It also turns the previously **hardcoded** Opus prototype model into a picker-controlled surface.

### Model bumps (all IDs verified against the Bedrock model cards)

- Default model **Sonnet 4.5 → Sonnet 5** (`global.anthropic.claude-sonnet-5`)
- Allowlist: **Sonnet 5, Sonnet 4.6, Opus 4.8, Haiku 4.5** (latest Haiku; there is no Haiku 5)
- Capability-aware invocation: Sonnet 5 and Opus 4.8 reject `temperature`, and Sonnet 5 rejects an explicit thinking budget (adaptive thinking is always-on) — `converse()` and the streaming client drop those fields automatically per resolved model, so **any** surface can point at **any** allowlisted model without a 400. The two raw `client.converse()` sites (persona import, product interview) get the same treatment.

### Resolution & storage

`shared/model_config.py`: *explicit arg > per-surface override > legacy global `model_id` (kept for backward compat with #154's shape) > surface default > `BEDROCK_MODEL_ID`*. 60s per-container cache; the lookup never raises. One item in aggregates: `SETTINGS#model` `{surfaces: {surface: id}, model_id?}`. TS mirror (`model-override.ts`) resolves the `chat` surface for streaming.

`GET/PUT /settings/model` on the existing settings Lambda — GET open to all authenticated users, **PUT requires the `admins` Cognito group server-side** (`require_admin` promoted to `shared/api.py`). Non-allowlisted values are 400 on write and read back as Automatic, so a tampered DynamoDB row can't steer inference.

### IAM lockstep (structural, not aspirational)

New `lib/utils/model-allowlist.ts` is the single source for **all** `bedrock:InvokeModel*` grants (api / processing / ingestion stacks), the **BedrockAccessStack agreements** (now 4 models, previously missing Opus), and the cdk-nag suppressions. The research Lambda gains `AGGREGATES_TABLE` env + read so the documents override reaches Step Functions research. Python lockstep tests read the TS mirror, the CDK helper, and the nag suppressions — adding a model to one place fails the build until all agree.

## Testing

- 25 resolver tests (per-surface precedence, legacy-global fallback, tamper rejection incl. a stale Sonnet 4.5 pin, never-raises, cache TTL, lockstep ×4)
- 8 converse surface/capability tests (surface routing, explicit-arg precedence, chain threading, auto-omit temperature/thinking)
- 12 settings-handler tests (per-surface set/clear preserving siblings, legacy path, 5-case rejection incl. the internal `default` bucket, non-admin 403, missing-groups 403, non-admin GET 200)
- 12 stream override tests + 4 converse-stream tests (never-throws, cache, precedence, adaptive-thinking omission on both the explicit and env-default paths)
- 8 UI tests (per-surface render, Automatic default labels, select/clear round-trip, error state, hidden for non-admins/no endpoint)
- Full suites green: backend **1068 passed / 1 pre-existing skip**, frontend **1629**, stream **230**, CDK **33**; `tsc` clean ×3; `eslint` clean; `i18n:validate` exit 0 (8 locales)

## Notes

- Override propagation is cache-bounded (~60s), same as #154.
- The processor's enrichment default stays Haiku — no cost regression; the surface is simply overridable now.
- A `model_id` written by #154's single-model picker keeps working as the global fallback for un-pinned surfaces.
- Found while validating (pre-existing, unrelated): `Code.fromAsset('lambda')` in the processing stack doesn't exclude `stream/node_modules`, so CDK tests time out on any branch once stream deps are installed — candidate for a follow-up exclude fix.


## Deployment notes

- The processor's `BEDROCK_MODEL_ID` environment variable is removed from `processing-stack-consolidated.ts`. It had become inert (the enrichment surface resolves through the picker; the default stays Haiku 4.5). If you had customized the enrichment model by editing that env literal in the stack source, set it via the Settings → AI Models picker (enrichment surface) instead.
