### PR TITLE
fix: Scrapers page no longer crashes on missing or malformed base_url

### DIFF
--- a/voc-datalake/frontend/src/api/scrapersApi.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Tests for the scrapers API boundary (issue #167).
+ *
+ * ScraperConfig declares base_url as a required string, but runtime
+ * payloads have delivered scrapers without it. getScrapers normalizes on
+ * entry so the declared contract is true for every consumer.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetchApi = vi.fn()
+
+vi.mock('./client', () => ({
+  fetchApi: (...args: unknown[]) => mockFetchApi(...args),
+}))
+
+import { scrapersApi } from './scrapersApi'
+
+describe('scrapersApi.getScrapers base_url normalization', () => {
+  beforeEach(() => {
+    mockFetchApi.mockReset()
+  })
+
+  it('fills a missing base_url with an empty string', async () => {
+    mockFetchApi.mockResolvedValue({
+      scrapers: [
+        { id: 's-1', name: 'No URL yet' },
+        { id: 's-2', name: 'Configured', base_url: 'https://example.com/reviews' },
+      ],
+    })
+
+    const { scrapers } = await scrapersApi.getScrapers()
+
+    expect(scrapers[0].base_url).toBe('')
+    expect(scrapers[1].base_url).toBe('https://example.com/reviews')
+  })
+
+  it('tolerates a payload without a scrapers array', async () => {
+    mockFetchApi.mockResolvedValue({})
+
+    const { scrapers } = await scrapersApi.getScrapers()
+
+    expect(scrapers).toEqual([])
+  })
+})

--- a/voc-datalake/frontend/src/api/scrapersApi.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.ts
@@ -4,8 +4,22 @@ import type {
   ScraperConfig, ScraperTemplate,
 } from './types'
 
+// What /scrapers actually returns: base_url is declared required on
+// ScraperConfig, but runtime payloads have delivered scrapers without it
+// (issue #167). Model that honestly here and normalize on entry so the
+// declared contract is true for every consumer.
+type RawScraperConfig = Omit<ScraperConfig, 'base_url'> & { base_url?: string }
+
 export const scrapersApi = {
-  getScrapers: () => fetchApi<{ scrapers: ScraperConfig[] }>('/scrapers'),
+  getScrapers: async (): Promise<{ scrapers: ScraperConfig[] }> => {
+    const response = await fetchApi<{ scrapers: RawScraperConfig[] }>('/scrapers')
+    return {
+      scrapers: (response.scrapers ?? []).map((scraper) => ({
+        ...scraper,
+        base_url: typeof scraper.base_url === 'string' ? scraper.base_url : '',
+      })),
+    }
+  },
 
   getScraperTemplates: () => fetchApi<{ templates: ScraperTemplate[] }>('/scrapers/templates'),
 

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -41,6 +41,12 @@ function renderCard(scraper: ScraperConfig) {
 }
 
 describe('scraperDomainLabel', () => {
+  it('resolves the shipped not-configured string from the i18n test setup', () => {
+    // Guard against vacuous passes: if the key stopped resolving, t() would
+    // return the raw key and component + test would "agree" on it.
+    expect(NOT_CONFIGURED).not.toContain('card.notConfigured')
+  })
+
   it('resolves the hostname for a valid URL', () => {
     expect(scraperDomainLabel('https://shop.example.com/reviews?page=1', NOT_CONFIGURED))
       .toBe('shop.example.com')
@@ -55,6 +61,13 @@ describe('scraperDomainLabel', () => {
   it('falls back to the raw value for unparseable URLs instead of throwing', () => {
     expect(scraperDomainLabel('example.com', NOT_CONFIGURED)).toBe('example.com')
     expect(scraperDomainLabel('not a url at all', NOT_CONFIGURED)).toBe('not a url at all')
+  })
+
+  it('falls back to the raw value for parseable URLs with an empty hostname', () => {
+    // mailto:/file: URLs construct successfully but have hostname === '' —
+    // an empty label would look like broken rendering.
+    expect(scraperDomainLabel('mailto:x@example.com', NOT_CONFIGURED)).toBe('mailto:x@example.com')
+    expect(scraperDomainLabel('file:///tmp/reviews.html', NOT_CONFIGURED)).toBe('file:///tmp/reviews.html')
   })
 })
 

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Tests for ScraperCard — invalid base_url resilience (issue #167).
+ *
+ * A render-time `new URL(...)` TypeError on a missing or malformed base_url
+ * crashed the entire /scrapers route. The card must render for every value
+ * runtime data has been observed to carry: undefined (mock server, older
+ * configs), empty/whitespace, scheme-less, and garbage.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import i18n from 'i18next'
+import ScraperCard, { scraperDomainLabel } from './ScraperCard'
+import { DEFAULT_SCRAPER } from './constants'
+import type { ScraperConfig } from '../../api/types'
+
+vi.mock('../../api/scrapersApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/scrapersApi')>()
+  // Full-surface stub (same pattern as ScraperEditor.test.tsx): future API
+  // calls hit an assertable vi.fn(), not an opaque "not a function".
+  const stubs = Object.fromEntries(
+    Object.keys(actual.scrapersApi).map((name) => [name, vi.fn().mockResolvedValue({ status: 'never_run' })]),
+  )
+  return { scrapersApi: stubs }
+})
+
+const NOT_CONFIGURED = i18n.t('card.notConfigured', { ns: 'scrapers' })
+
+function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
+  return {
+    ...DEFAULT_SCRAPER,
+    id: 's-1',
+    name: 'Test scraper',
+    ...overrides,
+  }
+}
+
+function renderCard(scraper: ScraperConfig) {
+  return render(
+    <ScraperCard scraper={scraper} onEdit={vi.fn()} onDelete={vi.fn()} onRun={vi.fn()} />
+  )
+}
+
+describe('scraperDomainLabel', () => {
+  it('resolves the hostname for a valid URL', () => {
+    expect(scraperDomainLabel('https://shop.example.com/reviews?page=1', NOT_CONFIGURED))
+      .toBe('shop.example.com')
+  })
+
+  it('treats undefined, empty, and whitespace as not configured', () => {
+    expect(scraperDomainLabel(undefined, NOT_CONFIGURED)).toBe(NOT_CONFIGURED)
+    expect(scraperDomainLabel('', NOT_CONFIGURED)).toBe(NOT_CONFIGURED)
+    expect(scraperDomainLabel('   ', NOT_CONFIGURED)).toBe(NOT_CONFIGURED)
+  })
+
+  it('falls back to the raw value for unparseable URLs instead of throwing', () => {
+    expect(scraperDomainLabel('example.com', NOT_CONFIGURED)).toBe('example.com')
+    expect(scraperDomainLabel('not a url at all', NOT_CONFIGURED)).toBe('not a url at all')
+  })
+})
+
+describe('ScraperCard base_url resilience (issue #167)', () => {
+  it('renders a scheme-less base_url instead of crashing the route', () => {
+    // Type-legal value that previously threw `TypeError: Invalid URL`
+    // during render and killed the whole /scrapers page.
+    renderCard(makeScraper({ base_url: 'example.com' }))
+
+    expect(screen.getByText('Test scraper')).toBeInTheDocument()
+    expect(screen.getByText('example.com')).toBeInTheDocument()
+  })
+
+  it('shows not-configured and disables Run for an empty base_url', () => {
+    renderCard(makeScraper({ base_url: '' }))
+
+    expect(screen.getByText(NOT_CONFIGURED)).toBeInTheDocument()
+    expect(screen.getByTitle(i18n.t('card.runNow', { ns: 'scrapers' }))).toBeDisabled()
+  })
+
+  it('renders normally for a valid base_url', () => {
+    renderCard(makeScraper({ base_url: 'https://shop.example.com/reviews' }))
+
+    expect(screen.getByText('shop.example.com')).toBeInTheDocument()
+    expect(screen.getByTitle(i18n.t('card.runNow', { ns: 'scrapers' }))).not.toBeDisabled()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -131,17 +131,26 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
   )
 }
 
-/** Display label for a scraper's target site. Never throws: base_url is
- * typed as a string but runtime data can violate that (the mock server
- * omits it; older saved configs may hold scheme-less or garbage values),
- * and a render-time TypeError here took down the whole /scrapers route
- * (issue #167). Unparseable-but-present values fall back to the raw
- * string so the user can still see what is configured. */
+/** base_url as runtime data actually delivers it (absent on the mock
+ * server and possibly on older configs, despite the declared type),
+ * normalized to a trimmed string — '' meaning "not configured". Single
+ * owner of that check so the label and the Run-button gate can't drift. */
+export function normalizedBaseUrl(baseUrl: string | undefined): string {
+  return typeof baseUrl === 'string' ? baseUrl.trim() : ''
+}
+
+/** Display label for a scraper's target site. Never throws: a render-time
+ * TypeError here took down the whole /scrapers route (issue #167).
+ * Unparseable-but-present values fall back to the raw string so the user
+ * can still see what is configured. */
 export function scraperDomainLabel(baseUrl: string | undefined, notConfigured: string): string {
-  const raw = typeof baseUrl === 'string' ? baseUrl.trim() : ''
+  const raw = normalizedBaseUrl(baseUrl)
   if (raw === '') return notConfigured
   try {
-    return new URL(raw).hostname
+    // mailto:/file: URLs parse successfully with an EMPTY hostname —
+    // fall back to the raw value rather than rendering an empty label.
+    const host = new URL(raw).hostname
+    return host !== '' ? host : raw
   } catch {
     return raw
   }
@@ -158,7 +167,7 @@ function ScraperCardHeader({
 }) {
   const { t } = useTranslation('scrapers')
   const domain = scraperDomainLabel(scraper.base_url, t('card.notConfigured'))
-  const hasUrl = typeof scraper.base_url === 'string' && scraper.base_url.trim() !== ''
+  const hasUrl = normalizedBaseUrl(scraper.base_url) !== ''
   return (
     <div className="flex items-start justify-between mb-3">
       <div className="flex items-center gap-3">

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -131,6 +131,22 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
   )
 }
 
+/** Display label for a scraper's target site. Never throws: base_url is
+ * typed as a string but runtime data can violate that (the mock server
+ * omits it; older saved configs may hold scheme-less or garbage values),
+ * and a render-time TypeError here took down the whole /scrapers route
+ * (issue #167). Unparseable-but-present values fall back to the raw
+ * string so the user can still see what is configured. */
+export function scraperDomainLabel(baseUrl: string | undefined, notConfigured: string): string {
+  const raw = typeof baseUrl === 'string' ? baseUrl.trim() : ''
+  if (raw === '') return notConfigured
+  try {
+    return new URL(raw).hostname
+  } catch {
+    return raw
+  }
+}
+
 function ScraperCardHeader({
   scraper, isRunning, onRun, onEdit, onDelete,
 }: {
@@ -141,7 +157,8 @@ function ScraperCardHeader({
   readonly onDelete: () => void
 }) {
   const { t } = useTranslation('scrapers')
-  const domain = scraper.base_url === '' ? t('card.notConfigured') : new URL(scraper.base_url).hostname
+  const domain = scraperDomainLabel(scraper.base_url, t('card.notConfigured'))
+  const hasUrl = typeof scraper.base_url === 'string' && scraper.base_url.trim() !== ''
   return (
     <div className="flex items-start justify-between mb-3">
       <div className="flex items-center gap-3">
@@ -154,7 +171,7 @@ function ScraperCardHeader({
         </div>
       </div>
       <div className="flex items-center gap-1">
-        <button onClick={onRun} disabled={isRunning || scraper.base_url === ''} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title={t('card.runNow')}>
+        <button onClick={onRun} disabled={isRunning || !hasUrl} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title={t('card.runNow')}>
           {isRunning ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
         </button>
         <button onClick={onEdit} className="p-2 hover:bg-gray-100 rounded" title={t('card.edit')}><Settings size={16} /></button>

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -131,7 +131,7 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
   )
 }
 
-/** base_url as runtime data actually delivers it (absent on the mock
+/** Exported for tests (not public API). base_url as runtime data actually delivers it (absent on the mock
  * server and possibly on older configs, despite the declared type),
  * normalized to a trimmed string — '' meaning "not configured". Single
  * owner of that check so the label and the Run-button gate can't drift. */
@@ -139,7 +139,7 @@ export function normalizedBaseUrl(baseUrl: string | undefined): string {
   return typeof baseUrl === 'string' ? baseUrl.trim() : ''
 }
 
-/** Display label for a scraper's target site. Never throws: a render-time
+/** Exported for tests (not public API). Display label for a scraper's target site. Never throws: a render-time
  * TypeError here took down the whole /scrapers route (issue #167).
  * Unparseable-but-present values fall back to the raw string so the user
  * can still see what is configured. */


### PR DESCRIPTION
## Summary

Fixes #167 (close manually on merge).

`ScraperCardHeader` computed the display domain with `new URL(scraper.base_url).hostname` behind an empty-string-only guard. Any other unparseable value threw `TypeError: Invalid URL` **during render**, and with no route error boundary the entire /scrapers page died with 'Unexpected Application Error'. Reproduced live against the local mock, which serves scrapers without `base_url` at all (it uses a `url` field) — so `undefined` hit the constructor. Older saved configs and scheme-less values (`example.com`) hit the same path with type-legal strings.

## Change

New `scraperDomainLabel(baseUrl, notConfigured)` owns the boundary:

| runtime value | rendered |
|---|---|
| `undefined` / `''` / whitespace | *Not configured* |
| unparseable but present (`example.com`, garbage) | the raw value — the user still sees what's configured |
| valid URL | its hostname |

The Run button's enable check gets the same normalization (it previously stayed **enabled** for `undefined`).

## Verification

- Unit tests over the label function (all five value classes) + a render regression test using a **type-legal** scheme-less `base_url` that crashed before the fix — mutation-verified (reverting the header line fails exactly that test).
- Browser-verified on the live dev server against the mock that reproduced the crash: cards render 'Not configured', Run disabled, no error boundary.
- Full root gate green (`npm run check` exit 0; 120 Scrapers-suite tests).

## Out of scope (observed while verifying, mock-data drift, cosmetic)

The mock's scraper shape also drifts from `ScraperConfig` in other fields (`url` vs `base_url`, missing frequency → 'undefinedm' in the card footer). This PR makes the page resilient to the crash-class problem; the mock-fixture alignment is tracked as **#169** (which also covers normalizing the remaining single-scraper endpoints, per review round 2).
