### PR TITLE
fix: local-dev gaps — project detail mock, web-search flag on the mock-only path

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -309,6 +309,85 @@ const handlers = {
   }),
 };
 
+// Project detail fixtures for /projects/:id — shape mirrors ProjectDetail
+// ({ project, personas, documents }) so the Project Detail page works
+// against the mock in local dev.
+const mockProjectDetails = {
+  proj_1: {
+    project: { project_id: 'proj_1', name: 'Q1 Product Improvements', description: 'Customer-driven improvements', status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), persona_count: 2, document_count: 2 },
+    personas: [
+      {
+        persona_id: 'persona_1',
+        name: 'Deadline-Driven Dana',
+        tagline: 'Orders late, expects miracles',
+        created_at: new Date().toISOString(),
+        confidence: 'high',
+        feedback_count: 14,
+        goals: ['Get orders delivered before the promised date', 'Track packages without contacting support'],
+        frustrations: ['Late deliveries with no proactive updates', 'Support wait times'],
+        quote: 'If the app just told me the truth about delivery dates, I would stop refreshing it every hour.',
+      },
+      {
+        persona_id: 'persona_2',
+        name: 'Value-Hunter Victor',
+        tagline: 'Compares every price twice',
+        created_at: new Date().toISOString(),
+        confidence: 'medium',
+        feedback_count: 9,
+        goals: ['Find the best price without coupons breaking at checkout'],
+        frustrations: ['Prices changing between cart and checkout'],
+        quote: 'I do not mind paying, I mind being surprised.',
+      },
+    ],
+    documents: [
+      {
+        document_id: 'research_1',
+        document_type: 'research',
+        title: 'Delivery Pain Points Analysis',
+        question: 'What are the main delivery-related pain points?',
+        content: '# Research Report: Delivery Pain Points\n\n## Executive Summary\nCustomers consistently report late deliveries and poor tracking visibility as their top frustrations.\n\n## Key Findings\n1. **Late deliveries** dominate negative feedback (62% of delivery mentions).\n2. **Tracking opacity** amplifies frustration more than lateness itself.\n\n## Recommendations\n- Proactive delay notifications\n- Honest delivery estimates at checkout',
+        feedback_count: 23,
+        created_at: new Date().toISOString(),
+      },
+      {
+        document_id: 'prfaq_1',
+        document_type: 'prfaq',
+        title: 'Proactive Delivery Updates',
+        feature_idea: 'Proactive delivery delay notifications',
+        content: '# PR/FAQ: Proactive Delivery Updates\n\n## Press Release\nToday we announced proactive delivery updates: customers are notified the moment a delay is detected, with an honest new estimate.\n\n## Customer FAQ\n**Q: Will I be spammed with notifications?**\nA: No — you are only notified when the estimate actually changes.\n\n## Internal FAQ\n**Q: What is the hardest technical dependency?**\nA: Carrier webhook latency and estimate recalculation.',
+        created_at: new Date().toISOString(),
+      },
+    ],
+  },
+  proj_2: {
+    project: { project_id: 'proj_2', name: 'Mobile App Redesign', description: 'UX improvements based on feedback', status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), persona_count: 1, document_count: 1 },
+    personas: [
+      {
+        persona_id: 'persona_3',
+        name: 'On-the-Go Grace',
+        tagline: 'Thumb-first, patience-last',
+        created_at: new Date().toISOString(),
+        confidence: 'medium',
+        feedback_count: 7,
+        goals: ['Reorder in under 30 seconds'],
+        frustrations: ['App logs her out weekly', 'Checkout buttons below the fold'],
+        quote: 'Every extra tap is a reason to use the website of your competitor.',
+      },
+    ],
+    documents: [
+      {
+        document_id: 'research_2',
+        document_type: 'research',
+        title: 'Mobile Checkout Friction',
+        question: 'Where do mobile users abandon checkout?',
+        content: '# Research Report: Mobile Checkout Friction\n\n## Executive Summary\nSession-loss on login and below-the-fold CTAs drive most abandonment mentions.',
+        feedback_count: 11,
+        created_at: new Date().toISOString(),
+      },
+    ],
+  },
+};
+
 const server = http.createServer((req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
@@ -350,6 +429,28 @@ const server = http.createServer((req, res) => {
       items_scraped: Math.floor(Math.random() * 50) + 10,
       errors: 0
     }));
+    return;
+  }
+
+  // Handle project detail by ID ('prioritization' is an exact-key route,
+  // not a project id — let it fall through to the routes table).
+  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+$/) && url.pathname !== '/projects/prioritization') {
+    const id = url.pathname.split('/')[2];
+    const detail = mockProjectDetails[id];
+    if (detail) {
+      res.writeHead(200);
+      res.end(JSON.stringify(detail));
+    } else {
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: 'Project not found' }));
+    }
+    return;
+  }
+
+  // Project jobs polling (research/persona generation) — none running locally.
+  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+\/jobs$/)) {
+    res.writeHead(200);
+    res.end(JSON.stringify({ jobs: [] }));
     return;
   }
 

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -296,10 +296,9 @@ const handlers = {
     sources: mockFeedback.slice(0, 2),
   }),
   'GET /projects': () => ({
-    projects: [
-      { project_id: 'proj_1', name: 'Q1 Product Improvements', description: 'Customer-driven improvements', status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), persona_count: 3, document_count: 2 },
-      { project_id: 'proj_2', name: 'Mobile App Redesign', description: 'UX improvements based on feedback', status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), persona_count: 2, document_count: 1 },
-    ]
+    // Derived from the detail fixtures — one source of truth, so list and
+    // detail can't drift when someone edits a project.
+    projects: Object.values(mockProjectDetails).map((detail) => detail.project),
   }),
   'GET /projects/prioritization': () => ({
     scores: {}
@@ -436,9 +435,9 @@ const server = http.createServer((req, res) => {
   // Handle project detail by ID. Exact-key routes win: anything present in
   // the handlers table (e.g. 'GET /projects/prioritization', or any future
   // /projects/... exact route) must never be shadowed by the id pattern.
-  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+$/) && !(key in handlers)) {
-    const id = url.pathname.split('/')[2];
-    const detail = mockProjectDetails[id];
+  const projectDetailMatch = url.pathname.match(/^\/projects\/([^/]+)$/);
+  if (req.method === 'GET' && projectDetailMatch && !(key in handlers)) {
+    const detail = mockProjectDetails[projectDetailMatch[1]];
     if (detail) {
       res.writeHead(200);
       res.end(JSON.stringify(detail));
@@ -450,10 +449,18 @@ const server = http.createServer((req, res) => {
   }
 
   // Project jobs polling (research/persona generation) — none running
-  // locally. Same exact-key precedence rule as above.
-  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+\/jobs$/) && !(key in handlers)) {
-    res.writeHead(200);
-    res.end(JSON.stringify({ jobs: [] }));
+  // locally. Same exact-key precedence rule as above, and unknown project
+  // ids 404 like the real API instead of masking bad-id bugs with an
+  // empty list.
+  const projectJobsMatch = url.pathname.match(/^\/projects\/([^/]+)\/jobs$/);
+  if (req.method === 'GET' && projectJobsMatch && !(key in handlers)) {
+    if (mockProjectDetails[projectJobsMatch[1]]) {
+      res.writeHead(200);
+      res.end(JSON.stringify({ jobs: [] }));
+    } else {
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: 'Project not found' }));
+    }
     return;
   }
 

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -311,7 +311,8 @@ const handlers = {
 
 // Project detail fixtures for /projects/:id — shape mirrors ProjectDetail
 // ({ project, personas, documents }) so the Project Detail page works
-// against the mock in local dev.
+// against the mock in local dev. Timestamps are frozen at server start on
+// purpose: stable fixtures beat fake freshness for a mock.
 const mockProjectDetails = {
   proj_1: {
     project: { project_id: 'proj_1', name: 'Q1 Product Improvements', description: 'Customer-driven improvements', status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), persona_count: 2, document_count: 2 },
@@ -432,9 +433,10 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Handle project detail by ID ('prioritization' is an exact-key route,
-  // not a project id — let it fall through to the routes table).
-  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+$/) && url.pathname !== '/projects/prioritization') {
+  // Handle project detail by ID. Exact-key routes win: anything present in
+  // the handlers table (e.g. 'GET /projects/prioritization', or any future
+  // /projects/... exact route) must never be shadowed by the id pattern.
+  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+$/) && !(key in handlers)) {
     const id = url.pathname.split('/')[2];
     const detail = mockProjectDetails[id];
     if (detail) {
@@ -447,8 +449,9 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Project jobs polling (research/persona generation) — none running locally.
-  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+\/jobs$/)) {
+  // Project jobs polling (research/persona generation) — none running
+  // locally. Same exact-key precedence rule as above.
+  if (req.method === 'GET' && url.pathname.match(/^\/projects\/[^/]+\/jobs$/) && !(key in handlers)) {
     res.writeHead(200);
     res.end(JSON.stringify({ jobs: [] }));
     return;

--- a/voc-datalake/frontend/src/runtimeConfig.test.ts
+++ b/voc-datalake/frontend/src/runtimeConfig.test.ts
@@ -152,4 +152,18 @@ describe('isWebSearchAvailable', () => {
 
     expect(isWebSearchAvailable()).toBe(true)
   })
+
+  it('keeps the flag on the mock-only path (no Cognito vars at all)', async () => {
+    // Regression: the invalid-env fallback (the branch that ALWAYS runs in
+    // mock-only dev) rebuilt the config without the features block, so the
+    // escape hatch never worked in the very environment it exists for.
+    vi.stubEnv('VITE_ENABLE_WEB_SEARCH', 'true')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('config.json unavailable')))
+
+    const { loadRuntimeConfig, isWebSearchAvailable } = await import('./runtimeConfig')
+    const config = await loadRuntimeConfig()
+
+    expect(config.apiEndpoint).toBe('http://localhost:3001')
+    expect(isWebSearchAvailable()).toBe(true)
+  })
 })

--- a/voc-datalake/frontend/src/runtimeConfig.ts
+++ b/voc-datalake/frontend/src/runtimeConfig.ts
@@ -156,6 +156,10 @@ function getEnvConfig(): RuntimeConfig {
         region: 'us-east-1',
         identityPoolId: '',
       },
+      // Keep the feature flags: mock-only dev (no Cognito vars) is exactly
+      // when this branch runs, and it's also exactly when the
+      // VITE_ENABLE_WEB_SEARCH escape hatch is needed.
+      features: envConfig.features,
     }
   }
 

--- a/voc-datalake/frontend/src/runtimeConfig.ts
+++ b/voc-datalake/frontend/src/runtimeConfig.ts
@@ -122,6 +122,14 @@ function getEnvString(key: string, defaultValue = ''): string {
  * Used for local development or when config.json is unavailable.
  */
 function getEnvConfig(): RuntimeConfig {
+  // Constructed as a literal boolean (=== 'true'), so this object is
+  // schema-conformant BY CONSTRUCTION — which is what lets the invalid-env
+  // fallback below reuse it verbatim. Single construction site on purpose.
+  const features = {
+    // Local development: VITE_ENABLE_WEB_SEARCH=true surfaces the web search
+    // toggles without a deployed config.json.
+    webSearch: getEnvString('VITE_ENABLE_WEB_SEARCH') === 'true',
+  }
   const envConfig = {
     apiEndpoint: getEnvString('VITE_API_ENDPOINT'),
     cognito: {
@@ -130,11 +138,7 @@ function getEnvConfig(): RuntimeConfig {
       region: getEnvString('VITE_COGNITO_REGION', 'us-east-1'),
       identityPoolId: getEnvString('VITE_IDENTITY_POOL_ID'),
     },
-    // Local development: VITE_ENABLE_WEB_SEARCH=true surfaces the web search
-    // toggles without a deployed config.json.
-    features: {
-      webSearch: getEnvString('VITE_ENABLE_WEB_SEARCH') === 'true',
-    },
+    features,
   }
 
   // Validate env config
@@ -158,8 +162,9 @@ function getEnvConfig(): RuntimeConfig {
       },
       // Keep the feature flags: mock-only dev (no Cognito vars) is exactly
       // when this branch runs, and it's also exactly when the
-      // VITE_ENABLE_WEB_SEARCH escape hatch is needed.
-      features: envConfig.features,
+      // VITE_ENABLE_WEB_SEARCH escape hatch is needed. Safe to reuse: the
+      // shared `features` object above is boolean-by-construction.
+      features,
     }
   }
 


### PR DESCRIPTION
## Summary

Two gaps found while validating locally against the mock (both browser-verified on the live dev server):

### 1. `/projects/:id` did nothing locally

The mock served only the projects LIST; the detail page's `GET /projects/{id}` 404'd. The mock now serves `ProjectDetail`-shaped fixtures for `proj_1`/`proj_2` — personas with goals/frustrations/quotes, a research report and a PR/FAQ document — plus the `/projects/{id}/jobs` polling endpoint (empty). The `/projects/prioritization` exact-key route is explicitly excluded from the id pattern. Verified: the Project Detail page renders fully (tabs, Personas (2), Documents (2), all wizards).

### 2. `VITE_ENABLE_WEB_SEARCH` never worked where it was needed

The env escape hatch for the web-search feature flag (#156) was dead on arrival for its target environment: **mock-only dev has no Cognito vars**, so env-config validation fails and the invalid-env fallback branch rebuilt the config **without the `features` block** — silently hiding the chat toggle and research checkbox. The fallback now carries `features` through, pinned by a regression test that sets ONLY the flag (no Cognito vars) and asserts availability on the localhost:3001 fallback.

Verified in-browser: the 'Web search' toggle renders in the chat filter bar with its tooltip, and toggles once a conversation is active. (On a *fresh* page it still snaps back — that's issue #161, fixed in the pending PR #165.)

## Notes

- `.env.local` itself is gitignored and not part of this PR; devs opt in per machine.
- Related: #169 tracks the broader scraper-fixture drift; this PR only adds the missing project surface.
- Gates: root `npm run check` exit 0; 10 runtimeConfig tests including the new no-Cognito-vars pin; mock passes `node --check`.