### PR TITLE
feat(frontend): route-level error boundary so one bad page can't blank the app

### DIFF
--- a/voc-datalake/frontend/public/locales/de/components.json
+++ b/voc-datalake/frontend/public/locales/de/components.json
@@ -53,6 +53,12 @@
     "downloadTXT": "Als TXT herunterladen",
     "kiroPromptTip": "Tipp: Kiro-Eingabeaufforderung in Projekteinstellungen konfigurieren"
   },
+  "errorBoundary": {
+    "description": "Auf dieser Seite ist ein unerwarteter Fehler aufgetreten. Sie können sie neu laden oder zur Startseite zurückkehren — der Rest der Anwendung ist nicht betroffen.",
+    "goHome": "Zur Startseite",
+    "reload": "Seite neu laden",
+    "title": "Etwas ist schiefgelaufen"
+  },
   "feedbackCard": {
     "copyText": "Text kopieren",
     "details": "Einzelheiten",

--- a/voc-datalake/frontend/public/locales/en/components.json
+++ b/voc-datalake/frontend/public/locales/en/components.json
@@ -53,6 +53,12 @@
     "downloadTXT": "Download as TXT",
     "kiroPromptTip": "Tip: Configure Kiro prompt in project settings"
   },
+  "errorBoundary": {
+    "description": "This page hit an unexpected error. You can reload it or go back home — the rest of the app is unaffected.",
+    "goHome": "Go to home",
+    "reload": "Reload page",
+    "title": "Something went wrong"
+  },
   "feedbackCard": {
     "copyText": "Copy text",
     "details": "Details",

--- a/voc-datalake/frontend/public/locales/es/components.json
+++ b/voc-datalake/frontend/public/locales/es/components.json
@@ -57,6 +57,12 @@
     "downloadTXT": "Descargar como TXT",
     "kiroPromptTip": "Consejo: Configura el prompt de Kiro en la configuración del proyecto"
   },
+  "errorBoundary": {
+    "description": "Esta página encontró un error inesperado. Puedes recargarla o volver al inicio; el resto de la aplicación no se ve afectado.",
+    "goHome": "Ir al inicio",
+    "reload": "Recargar página",
+    "title": "Algo salió mal"
+  },
   "feedbackCard": {
     "copyText": "Copiar texto",
     "details": "Detalles",

--- a/voc-datalake/frontend/public/locales/fr/components.json
+++ b/voc-datalake/frontend/public/locales/fr/components.json
@@ -57,6 +57,12 @@
     "downloadTXT": "Télécharger en TXT",
     "kiroPromptTip": "Conseil : Configurez l'invite Kiro dans les paramètres du projet"
   },
+  "errorBoundary": {
+    "description": "Cette page a rencontré une erreur inattendue. Vous pouvez la recharger ou revenir à l'accueil — le reste de l'application n'est pas affecté.",
+    "goHome": "Retour à l'accueil",
+    "reload": "Recharger la page",
+    "title": "Une erreur est survenue"
+  },
   "feedbackCard": {
     "copyText": "Copier le texte",
     "details": "Détails",

--- a/voc-datalake/frontend/public/locales/ja/components.json
+++ b/voc-datalake/frontend/public/locales/ja/components.json
@@ -53,6 +53,12 @@
     "downloadTXT": "TXTでダウンロード",
     "kiroPromptTip": "ヒント：プロジェクト設定でKiroプロンプトを設定してください"
   },
+  "errorBoundary": {
+    "description": "このページで予期しないエラーが発生しました。再読み込みするか、ホームに戻ってください。アプリの他の部分には影響ありません。",
+    "goHome": "ホームへ戻る",
+    "reload": "ページを再読み込み",
+    "title": "問題が発生しました"
+  },
   "feedbackCard": {
     "copyText": "テキストをコピー",
     "details": "詳細",

--- a/voc-datalake/frontend/public/locales/ko/components.json
+++ b/voc-datalake/frontend/public/locales/ko/components.json
@@ -53,6 +53,12 @@
     "downloadTXT": "TXT로 다운로드",
     "kiroPromptTip": "팁: 프로젝트 설정에서 Kiro 프롬프트 구성"
   },
+  "errorBoundary": {
+    "description": "이 페이지에서 예기치 않은 오류가 발생했습니다. 페이지를 새로 고치거나 홈으로 돌아갈 수 있으며, 앱의 나머지 부분은 영향을 받지 않습니다.",
+    "goHome": "홈으로 이동",
+    "reload": "페이지 새로 고침",
+    "title": "문제가 발생했습니다"
+  },
   "feedbackCard": {
     "copyText": "텍스트 복사",
     "details": "세부정보",

--- a/voc-datalake/frontend/public/locales/pt/components.json
+++ b/voc-datalake/frontend/public/locales/pt/components.json
@@ -57,6 +57,12 @@
     "downloadTXT": "Baixar como TXT",
     "kiroPromptTip": "Dica: Configure o prompt do Kiro nas configurações do projeto"
   },
+  "errorBoundary": {
+    "description": "Esta página encontrou um erro inesperado. Você pode recarregá-la ou voltar ao início — o restante do aplicativo não é afetado.",
+    "goHome": "Ir para o início",
+    "reload": "Recarregar página",
+    "title": "Algo deu errado"
+  },
   "feedbackCard": {
     "copyText": "Copiar texto",
     "details": "Detalhes",

--- a/voc-datalake/frontend/public/locales/zh/components.json
+++ b/voc-datalake/frontend/public/locales/zh/components.json
@@ -53,6 +53,12 @@
     "downloadTXT": "下载为 TXT",
     "kiroPromptTip": "提示：在项目设置中配置 Kiro 提示词"
   },
+  "errorBoundary": {
+    "description": "此页面遇到意外错误。您可以重新加载或返回首页，应用的其他部分不受影响。",
+    "goHome": "返回首页",
+    "reload": "重新加载页面",
+    "title": "出现问题"
+  },
   "feedbackCard": {
     "copyText": "复制文本",
     "details": "详情",

--- a/voc-datalake/frontend/src/App.tsx
+++ b/voc-datalake/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from './components/Layout'
 import ProtectedRoute from './components/ProtectedRoute'
 import AdminRoute from './components/AdminRoute'
 import PageLoader from './components/PageLoader'
+import RouteErrorBoundary from './components/RouteErrorBoundary'
 import Login from './pages/Login'
 import { loadRuntimeConfig, isConfigLoaded } from './runtimeConfig'
 import { useConfigStore } from './store/configStore'
@@ -35,10 +36,19 @@ const queryClient = new QueryClient({
   },
 })
 
+// Lazy pages share the same suspense fallback and, per issue #173, a
+// route-scoped error boundary: a render error in one page replaces only
+// that page's content — the layout and sidebar stay mounted.
+const page = (element: React.ReactNode) => ({
+  element: <Suspense fallback={<PageLoader />}>{element}</Suspense>,
+  errorElement: <RouteErrorBoundary />,
+})
+
 const router = createBrowserRouter([
   {
     path: '/login',
     element: <Login />,
+    errorElement: <RouteErrorBoundary />,
   },
   {
     path: '/',
@@ -47,21 +57,24 @@ const router = createBrowserRouter([
         <Layout />
       </ProtectedRoute>
     ),
+    // Catches errors thrown by Layout/ProtectedRoute themselves; page-level
+    // errors are handled by each child's errorElement so the layout survives.
+    errorElement: <RouteErrorBoundary />,
     children: [
-      { index: true, element: <Suspense fallback={<PageLoader />}><Home /></Suspense> },
-      { path: 'dashboard', element: <Suspense fallback={<PageLoader />}><Dashboard /></Suspense> },
-      { path: 'feedback', element: <Suspense fallback={<PageLoader />}><Feedback /></Suspense> },
-      { path: 'feedback/:id', element: <Suspense fallback={<PageLoader />}><FeedbackDetail /></Suspense> },
-      { path: 'categories', element: <Suspense fallback={<PageLoader />}><Categories /></Suspense> },
-      { path: 'problems', element: <Suspense fallback={<PageLoader />}><ProblemAnalysis /></Suspense> },
-      { path: 'chat', element: <Suspense fallback={<PageLoader />}><Chat /></Suspense> },
-      { path: 'projects', element: <Suspense fallback={<PageLoader />}><Projects /></Suspense> },
-      { path: 'projects/:id', element: <Suspense fallback={<PageLoader />}><ProjectDetail /></Suspense> },
-      { path: 'prioritization', element: <Suspense fallback={<PageLoader />}><Prioritization /></Suspense> },
-      { path: 'data-explorer', element: <Suspense fallback={<PageLoader />}><DataExplorer /></Suspense> },
-      { path: 'scrapers', element: <Suspense fallback={<PageLoader />}><Scrapers /></Suspense> },
-      { path: 'feedback-forms', element: <Suspense fallback={<PageLoader />}><FeedbackForms /></Suspense> },
-      { path: 'settings', element: <Suspense fallback={<PageLoader />}><AdminRoute><Settings /></AdminRoute></Suspense> },
+      { index: true, ...page(<Home />) },
+      { path: 'dashboard', ...page(<Dashboard />) },
+      { path: 'feedback', ...page(<Feedback />) },
+      { path: 'feedback/:id', ...page(<FeedbackDetail />) },
+      { path: 'categories', ...page(<Categories />) },
+      { path: 'problems', ...page(<ProblemAnalysis />) },
+      { path: 'chat', ...page(<Chat />) },
+      { path: 'projects', ...page(<Projects />) },
+      { path: 'projects/:id', ...page(<ProjectDetail />) },
+      { path: 'prioritization', ...page(<Prioritization />) },
+      { path: 'data-explorer', ...page(<DataExplorer />) },
+      { path: 'scrapers', ...page(<Scrapers />) },
+      { path: 'feedback-forms', ...page(<FeedbackForms />) },
+      { path: 'settings', ...page(<AdminRoute><Settings /></AdminRoute>) },
     ],
   },
 ])

--- a/voc-datalake/frontend/src/App.tsx
+++ b/voc-datalake/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Layout from './components/Layout'
@@ -39,7 +40,7 @@ const queryClient = new QueryClient({
 // Lazy pages share the same suspense fallback and, per issue #173, a
 // route-scoped error boundary: a render error in one page replaces only
 // that page's content — the layout and sidebar stay mounted.
-const page = (element: React.ReactNode) => ({
+const page = (element: ReactNode) => ({
   element: <Suspense fallback={<PageLoader />}>{element}</Suspense>,
   errorElement: <RouteErrorBoundary />,
 })

--- a/voc-datalake/frontend/src/components/RouteErrorBoundary/RouteErrorBoundary.test.tsx
+++ b/voc-datalake/frontend/src/components/RouteErrorBoundary/RouteErrorBoundary.test.tsx
@@ -41,26 +41,43 @@ function renderRouterAt(initialPath: string) {
 }
 
 describe('RouteErrorBoundary (issue #173)', () => {
+  // Component under test console.errors deliberately (observability), and
+  // react-router/React report the caught error too; silence the noise while
+  // keeping the spy available for the reporting assertion.
   beforeEach(() => {
-    // react-router and React both report the caught render error; keep the
-    // test output clean without hiding unrelated failures from assertions.
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('replaces only the failing route content — the layout survives', () => {
     renderRouterAt('/broken')
 
-    // Fallback rendered with the actual error surfaced.
+    // Fallback rendered; error detail is shown too since vitest runs in DEV
+    // (production hides it and keeps it in the log path only).
     expect(screen.getByRole('alert')).toBeInTheDocument()
     expect(screen.getByText('Something went wrong')).toBeInTheDocument()
     expect(screen.getByText('boom from page render')).toBeInTheDocument()
 
     // The app did NOT unmount: layout content is still there.
     expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+  })
+
+  it('reports the full error object so caught crashes stay observable', () => {
+    renderRouterAt('/broken')
+
+    const reported = vi
+      .mocked(console.error)
+      .mock.calls.some(
+        (args) =>
+          args[0] === 'Route render error caught by RouteErrorBoundary:' &&
+          args[1] instanceof Error &&
+          args[1].message === 'boom from page render',
+      )
+    expect(reported).toBe(true)
   })
 
   it('offers a working path back home', async () => {
@@ -73,20 +90,34 @@ describe('RouteErrorBoundary (issue #173)', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
-  it('offers a reload action', () => {
+  it('reload action triggers window.location.reload', async () => {
+    const reload = vi.fn()
+    // jsdom's Location is non-configurable; stubGlobal swaps the whole
+    // object (cast-free) so the component's reload call lands on the spy.
+    vi.stubGlobal('location', { ...window.location, reload })
+
+    const user = userEvent.setup()
     renderRouterAt('/broken')
 
-    expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /reload page/i }))
+
+    expect(reload).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('describeRouteError', () => {
-  it('summarizes route error responses as status + statusText', () => {
+  it('summarizes route error responses as status + statusText + data detail', () => {
     // isRouteErrorResponse is shape-based; this mirrors what the router
     // delivers for thrown Responses (e.g. 404s from loaders).
     const routeError = { status: 404, statusText: 'Not Found', internal: false, data: 'No route matches' }
 
-    expect(describeRouteError(routeError)).toBe('404 Not Found')
+    expect(describeRouteError(routeError)).toBe('404 Not Found — No route matches')
+  })
+
+  it('omits the data suffix when data is not a useful string', () => {
+    const routeError = { status: 500, statusText: 'Server Error', internal: false, data: null }
+
+    expect(describeRouteError(routeError)).toBe('500 Server Error')
   })
 
   it('uses the message of thrown Errors', () => {

--- a/voc-datalake/frontend/src/components/RouteErrorBoundary/RouteErrorBoundary.test.tsx
+++ b/voc-datalake/frontend/src/components/RouteErrorBoundary/RouteErrorBoundary.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for issue #173: without a route-level errorElement, a
+ * render error in any single page unmounted the entire app (the amplifier
+ * behind the #159/#167/#171 crashes). These pin that a throwing route
+ * renders the fallback while the surrounding layout stays mounted.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, Outlet, RouterProvider } from 'react-router-dom'
+import RouteErrorBoundary, { describeRouteError } from './index'
+
+function TestLayout() {
+  return (
+    <div>
+      <nav data-testid="sidebar">sidebar stays alive</nav>
+      <Outlet />
+    </div>
+  )
+}
+
+function BrokenPage(): never {
+  throw new Error('boom from page render')
+}
+
+function renderRouterAt(initialPath: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <TestLayout />,
+        children: [
+          { index: true, element: <div data-testid="home-page">healthy home</div> },
+          { path: 'broken', element: <BrokenPage />, errorElement: <RouteErrorBoundary /> },
+        ],
+      },
+    ],
+    { initialEntries: [initialPath] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+describe('RouteErrorBoundary (issue #173)', () => {
+  beforeEach(() => {
+    // react-router and React both report the caught render error; keep the
+    // test output clean without hiding unrelated failures from assertions.
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('replaces only the failing route content — the layout survives', () => {
+    renderRouterAt('/broken')
+
+    // Fallback rendered with the actual error surfaced.
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('boom from page render')).toBeInTheDocument()
+
+    // The app did NOT unmount: layout content is still there.
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+  })
+
+  it('offers a working path back home', async () => {
+    const user = userEvent.setup()
+    renderRouterAt('/broken')
+
+    await user.click(screen.getByRole('link', { name: /go to home/i }))
+
+    expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('offers a reload action', () => {
+    renderRouterAt('/broken')
+
+    expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument()
+  })
+})
+
+describe('describeRouteError', () => {
+  it('summarizes route error responses as status + statusText', () => {
+    // isRouteErrorResponse is shape-based; this mirrors what the router
+    // delivers for thrown Responses (e.g. 404s from loaders).
+    const routeError = { status: 404, statusText: 'Not Found', internal: false, data: 'No route matches' }
+
+    expect(describeRouteError(routeError)).toBe('404 Not Found')
+  })
+
+  it('uses the message of thrown Errors', () => {
+    expect(describeRouteError(new Error('kaput'))).toBe('kaput')
+  })
+
+  it('stringifies anything else', () => {
+    expect(describeRouteError('plain string failure')).toBe('plain string failure')
+    expect(describeRouteError(42)).toBe('42')
+  })
+})

--- a/voc-datalake/frontend/src/components/RouteErrorBoundary/index.tsx
+++ b/voc-datalake/frontend/src/components/RouteErrorBoundary/index.tsx
@@ -7,6 +7,7 @@
  * each child route, this fallback replaces only the failing route content —
  * the layout and sidebar stay interactive.
  */
+import { useEffect } from 'react'
 import { AlertTriangle, Home, RotateCcw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom'
@@ -14,7 +15,9 @@ import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom'
 /** Human-readable summary of whatever useRouteError() delivered (unknown). */
 export function describeRouteError(error: unknown): string {
   if (isRouteErrorResponse(error)) {
-    return `${error.status} ${error.statusText}`.trim()
+    const base = `${error.status} ${error.statusText}`.trim()
+    // Loader-thrown Responses often carry the actionable message in data.
+    return typeof error.data === 'string' && error.data ? `${base} — ${error.data}` : base
   }
   if (error instanceof Error) {
     return error.message
@@ -26,6 +29,13 @@ export default function RouteErrorBoundary() {
   const error = useRouteError()
   const { t } = useTranslation('components')
 
+  // Graceful catching must not swallow observability: report the FULL error
+  // object (stack included) so production render crashes stay diagnosable —
+  // console.error feeds CloudWatch RUM / browser monitoring when configured.
+  useEffect(() => {
+    console.error('Route render error caught by RouteErrorBoundary:', error)
+  }, [error])
+
   return (
     <div className="flex items-center justify-center min-h-[60vh] p-6" role="alert">
       <div className="max-w-md w-full text-center">
@@ -34,9 +44,13 @@ export default function RouteErrorBoundary() {
         </div>
         <h1 className="text-xl font-semibold text-gray-900 mb-2">{t('errorBoundary.title')}</h1>
         <p className="text-gray-600 mb-4">{t('errorBoundary.description')}</p>
-        <p className="text-sm font-mono text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 mb-6 break-words">
-          {describeRouteError(error)}
-        </p>
+        {import.meta.env.DEV && (
+          // Technical detail is dev-only: raw messages leak implementation
+          // internals to end users; production keeps them in the log path.
+          <p className="text-sm font-mono text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 mb-6 break-words">
+            {describeRouteError(error)}
+          </p>
+        )}
         <div className="flex items-center justify-center gap-3">
           <button
             onClick={() => window.location.reload()}

--- a/voc-datalake/frontend/src/components/RouteErrorBoundary/index.tsx
+++ b/voc-datalake/frontend/src/components/RouteErrorBoundary/index.tsx
@@ -1,0 +1,59 @@
+/**
+ * Route-level error boundary (issue #173).
+ *
+ * Three crashes (#159 ProjectDetail, #167 Scrapers, #171 Feedback Forms)
+ * shared the same amplifier: with no errorElement on the routes, a render
+ * error in one card unmounted the whole app. Mounted as errorElement on
+ * each child route, this fallback replaces only the failing route content —
+ * the layout and sidebar stay interactive.
+ */
+import { AlertTriangle, Home, RotateCcw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom'
+
+/** Human-readable summary of whatever useRouteError() delivered (unknown). */
+export function describeRouteError(error: unknown): string {
+  if (isRouteErrorResponse(error)) {
+    return `${error.status} ${error.statusText}`.trim()
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+export default function RouteErrorBoundary() {
+  const error = useRouteError()
+  const { t } = useTranslation('components')
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh] p-6" role="alert">
+      <div className="max-w-md w-full text-center">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-red-100 mb-4">
+          <AlertTriangle size={24} className="text-red-600" />
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900 mb-2">{t('errorBoundary.title')}</h1>
+        <p className="text-gray-600 mb-4">{t('errorBoundary.description')}</p>
+        <p className="text-sm font-mono text-gray-500 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 mb-6 break-words">
+          {describeRouteError(error)}
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => window.location.reload()}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            <RotateCcw size={16} />
+            {t('errorBoundary.reload')}
+          </button>
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <Home size={16} />
+            {t('errorBoundary.goHome')}
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Fixes #173

## Problem

Three recent crashes (#159 ProjectDetail, #167 Scrapers, #171 Feedback Forms) shared the same amplifier: the router had no `errorElement`, so a render error in one card unmounted the **whole app** into react-router's default developer error screen. Each root cause got its own fix + regression tests; this adds the missing defense-in-depth so the next unguarded property read degrades gracefully instead.

## Change

- **`RouteErrorBoundary`** (`src/components/RouteErrorBoundary/`): branded fallback with the error summary, a reload button, and a go-home link. Error extraction from `useRouteError()` is type-guarded (`isRouteErrorResponse` → `instanceof Error` → `String()`), no assertions.
- **`App.tsx`**: a `page()` helper attaches the existing `Suspense` wrapper **and** `errorElement` uniformly to every child route. Errors bubble to the nearest `errorElement`, so page failures replace only the route outlet — **the layout and sidebar stay mounted and interactive**. The root `/` and `/login` routes carry the same boundary for failures in `Layout`/`ProtectedRoute` themselves.
- **i18n**: `errorBoundary.*` strings added to the `components` namespace in all 8 locales, inserted preserving key order.

## Regression tests

`RouteErrorBoundary.test.tsx` (6 tests):
- a throwing child route renders the fallback (role=`alert`, real error message) **while the layout sibling stays mounted** — the exact #173 failure mode inverted
- 'Go to home' recovers to a healthy route without a page reload
- reload action present
- `describeRouteError` unit coverage for route-response / Error / other branches

## Verification

- `npm run check` exits 0 (frontend 1627 tests, CDK 33, backend 818)
- `npm run i18n:validate` clean for the new keys (unrelated parser churn on `dashboard.json` discarded per repo convention)
- **Browser-verified against the real crash**: on a branch without the #172 data fix, `/feedback-forms` with a sparse record now shows the branded fallback inside the intact layout (sidebar/header/breadcrumbs all alive), error text `Cannot read properties of undefined (reading 'primary_color')` surfaced, and 'Go to home' navigates to a fully rendered Home without reload.

## Relationship to #172

Independent and complementary: #172 fixes the Feedback Forms root cause (normalize sparse records); this PR contains the blast radius of any future render error. No file overlap — both branch from current `development`.