### PR TITLE
fix(scrapers): normalize sparse records + drifted run status (undefinedm)

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -143,11 +143,33 @@ const mockFeedbackForms = [
   { id: 'form_3', name: 'Support Feedback', enabled: false, submissions: 89, created_at: new Date().toISOString() },
 ];
 
-// Mock scrapers
+// Mock scrapers — real ScraperConfig shape (issue #169). scraper_2 is
+// deliberately sparse (identity fields only), mirroring records persisted
+// before newer fields existed, so local dev exercises the normalizeScrapers()
+// boundary: base_url '' renders Not configured, frequency 0 renders
+// 'Manual only' (never 'undefinedm').
 const mockScrapers = [
-  { id: 'scraper_1', name: 'Product Reviews', url: 'https://example.com/reviews', enabled: true, schedule: 'rate(30 minutes)', last_run: new Date().toISOString(), status: 'success' },
-  { id: 'scraper_2', name: 'Forum Posts', url: 'https://forum.example.com', enabled: false, schedule: 'rate(1 hour)', last_run: null, status: 'disabled' },
+  {
+    id: 'scraper_1', name: 'Product Reviews', enabled: true,
+    base_url: 'https://example.com/reviews', urls: ['https://example.com/reviews?sort=recent'],
+    frequency_minutes: 30, extraction_method: 'css',
+    container_selector: '.review', text_selector: '.review-text',
+    rating_selector: '.review-stars@data-rating', author_selector: '.review-author',
+    date_selector: '.review-date',
+    pagination: { enabled: true, param: 'page', max_pages: 3, start: 1 },
+    last_run: new Date().toISOString(), items_found: 42,
+  },
+  // Sparse legacy record: identity fields only.
+  { id: 'scraper_2', name: 'Forum Posts', enabled: false },
 ];
+const mockScraperRuns = {
+  scraper_1: {
+    scraper_id: 'scraper_1', status: 'completed',
+    started_at: new Date(Date.now() - 3600000).toISOString(),
+    completed_at: new Date(Date.now() - 3590000).toISOString(),
+    pages_scraped: 3, items_found: 42, errors: [],
+  },
+};
 
 // Mock S3 data explorer
 const mockBuckets = [
@@ -338,17 +360,14 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Handle scraper status by ID
+  // Handle scraper status by ID — real RunStatus shape (issue #169):
+  // pages_scraped/items_found/errors, 'never_run' for scrapers without runs.
   if (req.method === 'GET' && url.pathname.match(/^\/scrapers\/[^/]+\/status$/)) {
     const id = url.pathname.split('/')[2];
-    const scraper = mockScrapers.find(s => s.id === id);
+    const run = mockScraperRuns[id];
     res.writeHead(200);
-    res.end(JSON.stringify({
-      id,
-      status: scraper ? scraper.status : 'unknown',
-      last_run: scraper ? scraper.last_run : null,
-      items_scraped: Math.floor(Math.random() * 50) + 10,
-      errors: 0
+    res.end(JSON.stringify(run ?? {
+      scraper_id: id, status: 'never_run', pages_scraped: 0, items_found: 0, errors: [],
     }));
     return;
   }

--- a/voc-datalake/frontend/src/api/scrapersApi.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.test.ts
@@ -41,4 +41,32 @@ describe('scrapersApi.getScrapers base_url normalization', () => {
 
     expect(scrapers).toEqual([])
   })
+
+  it('defaults a missing frequency so the card can never render undefinedm (issue #169)', async () => {
+    mockFetchApi.mockResolvedValue({ scrapers: [{ id: 's-1', name: 'Sparse', enabled: false }] })
+
+    const { scrapers } = await scrapersApi.getScrapers()
+
+    expect(scrapers[0].frequency_minutes).toBe(0)
+    expect(scrapers[0].urls).toEqual([])
+    expect(scrapers[0].pagination.enabled).toBe(false)
+  })
+})
+
+describe('scrapersApi.getScraperStatus normalization (issue #169)', () => {
+  beforeEach(() => {
+    mockFetchApi.mockReset()
+  })
+
+  it('degrades the drifted status shape to safe counts instead of blanks', async () => {
+    // What the mock server historically returned: items_scraped (not
+    // items_found), no pages_scraped, errors as a number.
+    mockFetchApi.mockResolvedValue({ id: 's-1', status: 'success', items_scraped: 12, errors: 0 })
+
+    const status = await scrapersApi.getScraperStatus('s-1')
+
+    expect(status.pages_scraped).toBe(0)
+    expect(status.items_found).toBe(0)
+    expect(status.errors).toEqual([])
+  })
 })

--- a/voc-datalake/frontend/src/api/scrapersApi.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.ts
@@ -1,24 +1,18 @@
 // Scrapers & Manual Import API - extracted from client.ts for code splitting
 import { fetchApi } from './client'
+import { normalizeScrapers, normalizeScraperRunStatus } from './scrapersSchema'
+import type { ScraperRunStatus } from './scrapersSchema'
 import type {
   ScraperConfig, ScraperTemplate,
 } from './types'
 
-// What /scrapers actually returns: base_url is declared required on
-// ScraperConfig, but runtime payloads have delivered scrapers without it
-// (issue #167). Model that honestly here and normalize on entry so the
-// declared contract is true for every consumer.
-type RawScraperConfig = Omit<ScraperConfig, 'base_url'> & { base_url?: string }
-
 export const scrapersApi = {
+  // ScraperConfig declares its fields required, but runtime payloads have
+  // delivered sparse records (issues #167/#169). Normalize on entry so the
+  // declared contract is true for every consumer.
   getScrapers: async (): Promise<{ scrapers: ScraperConfig[] }> => {
-    const response = await fetchApi<{ scrapers: RawScraperConfig[] }>('/scrapers')
-    return {
-      scrapers: (response.scrapers ?? []).map((scraper) => ({
-        ...scraper,
-        base_url: typeof scraper.base_url === 'string' ? scraper.base_url : '',
-      })),
-    }
+    const response = await fetchApi<{ scrapers?: unknown[] }>('/scrapers')
+    return { scrapers: normalizeScrapers(response.scrapers ?? []) }
   },
 
   getScraperTemplates: () => fetchApi<{ templates: ScraperTemplate[] }>('/scrapers/templates'),
@@ -65,17 +59,13 @@ export const scrapersApi = {
       status: string
     }>(`/scrapers/${id}/run`, { method: 'POST' }),
 
-  getScraperStatus: (id: string) =>
-    fetchApi<{
-      scraper_id: string
-      execution_id?: string
-      status: string
-      started_at?: string
-      completed_at?: string
-      pages_scraped: number
-      items_found: number
-      errors: string[]
-    }>(`/scrapers/${id}/status`),
+  // The status endpoint's runtime shape has drifted from the declared one
+  // (issue #169: undefined counts rendered 'Last: pages, reviews' blank).
+  // Normalize on entry: counts degrade to 0, errors to [].
+  getScraperStatus: async (id: string): Promise<ScraperRunStatus> => {
+    const response = await fetchApi<unknown>(`/scrapers/${id}/status`)
+    return normalizeScraperRunStatus(response)
+  },
 
   getScraperRuns: (id: string) =>
     fetchApi<{

--- a/voc-datalake/frontend/src/api/scrapersSchema.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.test.ts
@@ -85,6 +85,19 @@ describe('normalizeScrapers (issue #169)', () => {
     expect(scrapers.map((s) => s.id)).toEqual(['scraper_2'])
     expect(warn).toHaveBeenCalledTimes(2)
   })
+
+  it('passes unknown backend fields through so edit round-trips lose nothing', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, created_at: '2026-01-01T00:00:00Z', future_field: { nested: true } },
+    ])
+
+    // A record read from getScrapers() and saved back by the editor must
+    // not silently shed fields this schema doesn't enumerate.
+    expect(scraper).toMatchObject({
+      created_at: '2026-01-01T00:00:00Z',
+      future_field: { nested: true },
+    })
+  })
 })
 
 describe('normalizeScraperRunStatus (issue #169)', () => {
@@ -110,6 +123,17 @@ describe('normalizeScraperRunStatus (issue #169)', () => {
 
   it('defaults a missing status to never_run (nothing-to-show for the card)', () => {
     expect(normalizeScraperRunStatus({}).status).toBe('never_run')
+  })
+
+  it('degrades even a non-object response to never_run instead of throwing', () => {
+    // Error bodies and empty responses must not throw out of the polling
+    // path — same degrade-don't-reject philosophy as the fields.
+    for (const garbage of [null, undefined, 'Internal Server Error', 42]) {
+      const status = normalizeScraperRunStatus(garbage)
+      expect(status.status).toBe('never_run')
+      expect(status.pages_scraped).toBe(0)
+      expect(status.errors).toEqual([])
+    }
   })
 
   it('keeps string errors and drops junk elements', () => {

--- a/voc-datalake/frontend/src/api/scrapersSchema.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for issue #169: sparse scraper records rendered
+ * 'undefinedm' for frequency, and the drifted status shape rendered the
+ * last-run summary with blank counts ('Last: pages, reviews'). The schemas
+ * make the declared contracts true at the API boundary.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  normalizeScrapers, normalizeScraperRunStatus,
+} from './scrapersSchema'
+
+const sparseScraper = { id: 'scraper_2', name: 'Forum Posts', enabled: false }
+
+describe('normalizeScrapers (issue #169)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fills every missing field on a sparse legacy record with conservative defaults', () => {
+    const [scraper] = normalizeScrapers([sparseScraper])
+
+    expect(scraper.base_url).toBe('')
+    expect(scraper.urls).toEqual([])
+    // 0 = 'Manual only': the truthful schedule for a record that has none.
+    // Anything nonzero would claim runs that never happen; undefined was
+    // the 'undefinedm' symptom.
+    expect(scraper.frequency_minutes).toBe(0)
+    expect(scraper.container_selector).toBe('')
+    expect(scraper.text_selector).toBe('')
+    expect(scraper.pagination).toEqual({ enabled: false, param: 'page', max_pages: 1, start: 1 })
+  })
+
+  it('passes a fully configured record through unchanged', () => {
+    const configured = {
+      id: 'scraper_1', name: 'Product Reviews', enabled: true,
+      base_url: 'https://example.com/reviews', urls: ['https://example.com/reviews?sort=recent'],
+      frequency_minutes: 30, extraction_method: 'css',
+      container_selector: '.review', text_selector: '.review-text',
+      pagination: { enabled: true, param: 'page', max_pages: 3, start: 1 },
+      last_run: '2026-07-15T00:00:00Z', items_found: 42,
+    }
+
+    const [scraper] = normalizeScrapers([configured])
+
+    expect(scraper).toMatchObject(configured)
+  })
+
+  it('treats explicit nulls like missing fields (DynamoDB emits both)', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, base_url: null, frequency_minutes: null, urls: null, pagination: null },
+    ])
+
+    expect(scraper.base_url).toBe('')
+    expect(scraper.frequency_minutes).toBe(0)
+    expect(scraper.urls).toEqual([])
+    expect(scraper.pagination).toEqual({ enabled: false, param: 'page', max_pages: 1, start: 1 })
+  })
+
+  it('coerces numeric-string round-trips and merges partial pagination', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, frequency_minutes: '30', pagination: { enabled: true, max_pages: '5' } },
+    ])
+
+    expect(scraper.frequency_minutes).toBe(30)
+    expect(scraper.pagination).toEqual({ enabled: true, param: 'page', max_pages: 5, start: 1 })
+  })
+
+  it('salvages string urls and drops junk elements instead of discarding the array', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, urls: ['https://a.example.com', 42, null, 'https://b.example.com'] },
+    ])
+
+    expect(scraper.urls).toEqual(['https://a.example.com', 'https://b.example.com'])
+  })
+
+  it('drops records without a usable id instead of inventing one', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const scrapers = normalizeScrapers([
+      sparseScraper,
+      { name: 'No Identity', enabled: true },
+      { id: '', name: 'Empty Identity', enabled: true },
+    ])
+
+    expect(scrapers.map((s) => s.id)).toEqual(['scraper_2'])
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('normalizeScraperRunStatus (issue #169)', () => {
+  it('degrades missing counts to 0 so the summary never renders blank counts', () => {
+    // The drifted mock shape: items_scraped instead of items_found, no
+    // pages_scraped, errors as a number — rendered 'Last: pages, reviews'.
+    const status = normalizeScraperRunStatus({ id: 'scraper_1', status: 'success', items_scraped: 12, errors: 0 })
+
+    expect(status.pages_scraped).toBe(0)
+    expect(status.items_found).toBe(0)
+    expect(status.errors).toEqual([])
+  })
+
+  it('passes a real run status through unchanged', () => {
+    const run = {
+      scraper_id: 'scraper_1', status: 'completed',
+      started_at: '2026-07-15T00:00:00Z', completed_at: '2026-07-15T00:01:00Z',
+      pages_scraped: 3, items_found: 42, errors: [],
+    }
+
+    expect(normalizeScraperRunStatus(run)).toMatchObject(run)
+  })
+
+  it('defaults a missing status to never_run (nothing-to-show for the card)', () => {
+    expect(normalizeScraperRunStatus({}).status).toBe('never_run')
+  })
+
+  it('keeps string errors and drops junk elements', () => {
+    const status = normalizeScraperRunStatus({ status: 'error', errors: ['timeout', 500, null] })
+
+    expect(status.errors).toEqual(['timeout'])
+  })
+
+  it('coerces numeric-string counts', () => {
+    const status = normalizeScraperRunStatus({ status: 'completed', pages_scraped: '3', items_found: '42' })
+
+    expect(status.pages_scraped).toBe(3)
+    expect(status.items_found).toBe(42)
+  })
+})

--- a/voc-datalake/frontend/src/api/scrapersSchema.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.ts
@@ -51,6 +51,9 @@ const optionalString = z.string().optional().catch(undefined)
 /**
  * Schema for a stored scraper config.
  *
+ * - Loose object: unknown backend fields (created_at, future additions)
+ *   pass through untouched, so a record read from getScrapers() and saved
+ *   back by the editor round-trips without silent data loss.
  * - id is the one field that CANNOT be invented: it feeds React list keys
  *   and the status-polling endpoint, so records without a usable id are
  *   dropped (with a warning) by normalizeScrapers.
@@ -59,13 +62,15 @@ const optionalString = z.string().optional().catch(undefined)
  *   never happen ('undefinedm' was the rendered symptom, issue #169).
  * - base_url defaults to '' (the card's not-configured state, issue #167).
  */
-export const ScraperConfigSchema = z.object({
+export const ScraperConfigSchema = z.looseObject({
   id: z.string().min(1),
   name: z.string().catch(''),
   enabled: z.boolean().catch(false),
   base_url: z.string().catch(''),
   urls: stringArraySchema,
   frequency_minutes: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  // Must grow in lockstep with the backend's supported methods: an unknown
+  // method degrades to undefined (renderable), not a dropped record.
   extraction_method: z.enum(['css', 'jsonld']).optional().catch(undefined),
   template: optionalString,
   container_selector: z.string().catch(''),
@@ -90,7 +95,9 @@ export function normalizeScrapers(rawScrapers: readonly unknown[]): ScraperConfi
   return rawScrapers.flatMap((raw) => {
     const parsed = ScraperConfigSchema.safeParse(raw)
     if (!parsed.success) {
-      console.warn('Dropping scraper record that failed schema validation:', parsed.error.issues, raw)
+      // Issues only — no raw payload, which may carry config the user
+      // considers internal (URLs, selectors).
+      console.warn('Dropping scraper record that failed schema validation:', parsed.error.issues)
       return []
     }
     return [parsed.data]
@@ -102,22 +109,36 @@ export function normalizeScrapers(rawScrapers: readonly unknown[]): ScraperConfi
  * future statuses render as a benign amber badge rather than being
  * misreported); a missing status means 'never_run', which the card treats
  * as nothing-to-show. Counts degrade to 0 so the last-run summary renders
- * '0 pages, 0 reviews' instead of 'pages, reviews' (issue #169).
+ * '0 pages, 0 reviews' instead of 'pages, reviews' (issue #169). The
+ * object-level catch makes even a non-object response (null, an error
+ * string body) degrade to never_run — same philosophy, never throw.
  */
-export const ScraperRunStatusSchema = z.object({
-  scraper_id: optionalString,
-  execution_id: optionalString,
-  status: z.string().catch('never_run'),
-  started_at: optionalString,
-  completed_at: optionalString,
-  pages_scraped: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
-  items_found: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
-  errors: stringArraySchema,
-})
+export const ScraperRunStatusSchema = z
+  .object({
+    scraper_id: optionalString,
+    execution_id: optionalString,
+    status: z.string().catch('never_run'),
+    started_at: optionalString,
+    completed_at: optionalString,
+    pages_scraped: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+    items_found: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+    errors: stringArraySchema,
+  })
+  .catch(() => ({
+    scraper_id: undefined,
+    execution_id: undefined,
+    status: 'never_run',
+    started_at: undefined,
+    completed_at: undefined,
+    pages_scraped: 0,
+    items_found: 0,
+    errors: [],
+  }))
 
 export type ScraperRunStatus = z.infer<typeof ScraperRunStatusSchema>
 
-/** Make the declared run-status contract true for one wire response. */
+/** Make the declared run-status contract true for one wire response.
+ * Total: even a non-object response degrades to never_run. */
 export function normalizeScraperRunStatus(raw: unknown): ScraperRunStatus {
   return ScraperRunStatusSchema.parse(raw)
 }

--- a/voc-datalake/frontend/src/api/scrapersSchema.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Runtime validation/normalization for scraper API responses.
+ *
+ * ScraperConfig declares every field required, but runtime payloads have
+ * delivered sparse records (issue #167: missing base_url crashed the route;
+ * issue #169: missing frequency_minutes rendered 'undefinedm', and the
+ * status endpoint's drifted shape rendered 'Last: pages, reviews' with the
+ * counts blank). Following the project convention (see api/feedbackSchema.ts,
+ * pages/FeedbackForms/formSchema.ts), lenient Zod schemas make the declared
+ * contracts true at this boundary: invalid or missing fields degrade to
+ * conservative defaults instead of rejecting the record.
+ *
+ * Wire defaults are deliberately NOT the editor's DEFAULT_SCRAPER values:
+ * the editor seeds ergonomic starting values for a scraper the user is about
+ * to create (daily schedule, enabled), while the normalizer must describe an
+ * existing record truthfully — a record with no schedule is 'Manual only'
+ * (0), not 'Daily', and a record that never said enabled stays disabled.
+ *
+ * @module api/scrapersSchema
+ */
+import { z } from 'zod'
+import type { ScraperConfig } from './types'
+
+/** Coerce DynamoDB string round-trips like "30" to numbers; null/'' become
+ * undefined so the field-level catch supplies the default instead of 0. */
+function toOptionalFiniteNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/** Keep string items, drop junk elements instead of discarding the array. */
+const stringArraySchema = z
+  .array(z.unknown())
+  .catch(() => [])
+  .transform((items) => items.filter((item): item is string => typeof item === 'string'))
+
+// Per-field catches survive a partial pagination object; the object-level
+// catch covers pagination: null/absent wholesale.
+const paginationSchema = z
+  .object({
+    enabled: z.boolean().catch(false),
+    param: z.string().catch('page'),
+    max_pages: z.preprocess(toOptionalFiniteNumber, z.number().catch(1)),
+    start: z.preprocess(toOptionalFiniteNumber, z.number().catch(1)),
+  })
+  .catch(() => ({ enabled: false, param: 'page', max_pages: 1, start: 1 }))
+
+const optionalString = z.string().optional().catch(undefined)
+
+/**
+ * Schema for a stored scraper config.
+ *
+ * - id is the one field that CANNOT be invented: it feeds React list keys
+ *   and the status-polling endpoint, so records without a usable id are
+ *   dropped (with a warning) by normalizeScrapers.
+ * - frequency_minutes defaults to 0 ('Manual only') — the truthful reading
+ *   of a record with no schedule; anything else would claim runs that
+ *   never happen ('undefinedm' was the rendered symptom, issue #169).
+ * - base_url defaults to '' (the card's not-configured state, issue #167).
+ */
+export const ScraperConfigSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().catch(''),
+  enabled: z.boolean().catch(false),
+  base_url: z.string().catch(''),
+  urls: stringArraySchema,
+  frequency_minutes: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  extraction_method: z.enum(['css', 'jsonld']).optional().catch(undefined),
+  template: optionalString,
+  container_selector: z.string().catch(''),
+  text_selector: z.string().catch(''),
+  title_selector: optionalString,
+  rating_selector: optionalString,
+  rating_attribute: optionalString,
+  date_selector: optionalString,
+  author_selector: optionalString,
+  link_selector: optionalString,
+  pagination: paginationSchema,
+  last_run: optionalString,
+  items_found: z.preprocess(toOptionalFiniteNumber, z.number().optional().catch(undefined)),
+})
+
+/**
+ * Normalize a wire list for rendering: records without a usable id are
+ * dropped with a warning instead of inventing identity — '' ids would
+ * collide React list keys and poll a nonsense status endpoint.
+ */
+export function normalizeScrapers(rawScrapers: readonly unknown[]): ScraperConfig[] {
+  return rawScrapers.flatMap((raw) => {
+    const parsed = ScraperConfigSchema.safeParse(raw)
+    if (!parsed.success) {
+      console.warn('Dropping scraper record that failed schema validation:', parsed.error.issues, raw)
+      return []
+    }
+    return [parsed.data]
+  })
+}
+
+/**
+ * Schema for a scraper run status. status stays a plain string (unknown
+ * future statuses render as a benign amber badge rather than being
+ * misreported); a missing status means 'never_run', which the card treats
+ * as nothing-to-show. Counts degrade to 0 so the last-run summary renders
+ * '0 pages, 0 reviews' instead of 'pages, reviews' (issue #169).
+ */
+export const ScraperRunStatusSchema = z.object({
+  scraper_id: optionalString,
+  execution_id: optionalString,
+  status: z.string().catch('never_run'),
+  started_at: optionalString,
+  completed_at: optionalString,
+  pages_scraped: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  items_found: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  errors: stringArraySchema,
+})
+
+export type ScraperRunStatus = z.infer<typeof ScraperRunStatusSchema>
+
+/** Make the declared run-status contract true for one wire response. */
+export function normalizeScraperRunStatus(raw: unknown): ScraperRunStatus {
+  return ScraperRunStatusSchema.parse(raw)
+}

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -96,7 +96,6 @@ describe('ScraperCard base_url resilience (issue #167)', () => {
   })
 })
 
-
 describe('ScraperCard frequency resilience (issue #169)', () => {
   it('renders a dash instead of "undefinedm" for a runtime record without frequency', () => {
     const scraper = makeScraper({ base_url: 'https://example.com' })

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -95,3 +95,30 @@ describe('ScraperCard base_url resilience (issue #167)', () => {
     expect(screen.getByTitle(i18n.t('card.runNow', { ns: 'scrapers' }))).not.toBeDisabled()
   })
 })
+
+
+describe('ScraperCard frequency resilience (issue #169)', () => {
+  it('renders a dash instead of "undefinedm" for a runtime record without frequency', () => {
+    const scraper = makeScraper({ base_url: 'https://example.com' })
+    // The wire can deliver records persisted before frequency_minutes
+    // existed; static types say it is required, runtime reality disagrees.
+    Reflect.deleteProperty(scraper, 'frequency_minutes')
+
+    renderCard(scraper)
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument()
+  })
+
+  it('renders the human label for a known frequency', () => {
+    renderCard(makeScraper({ frequency_minutes: 30 }))
+
+    expect(screen.getByText('Every 30 minutes')).toBeInTheDocument()
+  })
+
+  it('renders Manual only for the normalized no-schedule default (0)', () => {
+    renderCard(makeScraper({ frequency_minutes: 0 }))
+
+    expect(screen.getByText('Manual only')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -200,6 +200,10 @@ function calculateTotalUrls(scraper: ScraperConfig): number {
 }
 
 function getFrequencyLabel(minutes: number): string {
+  // Belt-and-braces for issue #169: the list normalizes at the API boundary,
+  // but the card must stay render-safe standalone — a runtime-sparse record
+  // used to render 'undefinedm' here.
+  if (!Number.isFinite(minutes)) return '—'
   return FREQUENCY_OPTIONS.find((f) => f.value === minutes)?.label ?? `${minutes}m`
 }
 


### PR DESCRIPTION
Fixes #169

> **Stacked on #168** (`fix/scraper-card-invalid-url`) because both PRs touch the same `getScrapers` boundary — this PR's base is #168's branch so the diff shows only the delta. **Merge #168 first**; GitHub will auto-retarget this PR to `development` when #168's branch is deleted on merge.

## Problem (user-visible on /scrapers)

- **Frequency: `undefinedm`** — `getFrequencyLabel(scraper.frequency_minutes)` interpolated `undefined` for records that omit the field
- **`Last: pages, reviews`** with blank counts + a stray ⚠ badge — the status endpoint's mock shape drifted (`items_scraped` vs `items_found`, no `pages_scraped`, `errors` as a number, status `success`)

Same class as #167/#171: `ScraperConfig` declares every field required; runtime records persisted before newer fields existed disagree.

## Fix (same architecture as #172: lenient Zod at the boundary + render-safe component)

- **`api/scrapersSchema.ts`**: `ScraperConfigSchema` + `ScraperRunStatusSchema` with per-field `.catch()` — absence, explicit nulls, and wrong types degrade to **conservative wire defaults**, deliberately not the editor's `DEFAULT_SCRAPER` values: a record with no schedule is `frequency_minutes: 0` (**'Manual only'** — truthful) rather than the editor's 'Daily'; `base_url: ''` is the not-configured state. Partial `pagination` deep-merges; `urls`/`errors` salvage per item; numeric strings coerce (`'30'` → 30). `id` is strict — id-less records are dropped with a warning (inventing `''` would collide React keys and poll a nonsense status endpoint), mirroring #172's identity decision.
- **`scrapersApi`**: `getScrapers`/`getScraperStatus` normalize on entry, superseding #168's base_url-only inline map (same semantics, now schema-enforced).
- **`ScraperCard`**: belt-and-braces — a runtime record without frequency renders `—`, never `undefinedm`.
- **mock-server**: fixtures carry the real `ScraperConfig` shape; `scraper_2` stays deliberately sparse (identity only) so local dev permanently exercises the normalizer (per #169's ask); status route serves the real RunStatus shape with a `never_run` fallback.

## Regression tests (mutation-verified)

| Layer | Test | Verified by reverting |
|---|---|---|
| Schema | `scrapersSchema.test.ts` (11: defaults, nulls, coercion, partial-pagination merge, urls/errors salvage, id-drop+warn, passthrough) | — (unit) |
| API wiring | `scrapersApi.test.ts` (+2: frequency default through `getScrapers`, drifted-status degradation through `getScraperStatus`) | bypassing each normalizer failed exactly its test |
| Component | `ScraperCard.test.tsx` (+3: runtime-sparse record renders `—` not `undefinedm`; known label; 'Manual only' for 0) | removing the card guard failed exactly the `undefinedm` test |

## Verification

- `npm run check` exits 0 (frontend 1647, CDK 33, backend 818)
- Browser-verified against the restarted mock: card 1 shows **Every 30 minutes / 4 URLs / Last: 3 pages, 42 reviews ✓**; sparse card 2 shows **Not configured / Manual only / Never**; `document.body.innerText.includes('undefined')` → false

## Heads-up

`mock-server.js` is also touched by #172 (feedback-forms fixtures) — whichever merges second may need a trivial conflict resolution in that file.