### PR TITLE
fix(scrapers): normalize sparse records + drifted run status (undefinedm)

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -143,11 +143,33 @@ const mockFeedbackForms = [
   { id: 'form_3', name: 'Support Feedback', enabled: false, submissions: 89, created_at: new Date().toISOString() },
 ];
 
-// Mock scrapers
+// Mock scrapers — real ScraperConfig shape (issue #169). scraper_2 is
+// deliberately sparse (identity fields only), mirroring records persisted
+// before newer fields existed, so local dev exercises the normalizeScrapers()
+// boundary: base_url '' renders Not configured, frequency 0 renders
+// 'Manual only' (never 'undefinedm').
 const mockScrapers = [
-  { id: 'scraper_1', name: 'Product Reviews', url: 'https://example.com/reviews', enabled: true, schedule: 'rate(30 minutes)', last_run: new Date().toISOString(), status: 'success' },
-  { id: 'scraper_2', name: 'Forum Posts', url: 'https://forum.example.com', enabled: false, schedule: 'rate(1 hour)', last_run: null, status: 'disabled' },
+  {
+    id: 'scraper_1', name: 'Product Reviews', enabled: true,
+    base_url: 'https://example.com/reviews', urls: ['https://example.com/reviews?sort=recent'],
+    frequency_minutes: 30, extraction_method: 'css',
+    container_selector: '.review', text_selector: '.review-text',
+    rating_selector: '.review-stars@data-rating', author_selector: '.review-author',
+    date_selector: '.review-date',
+    pagination: { enabled: true, param: 'page', max_pages: 3, start: 1 },
+    last_run: new Date().toISOString(), items_found: 42,
+  },
+  // Sparse legacy record: identity fields only.
+  { id: 'scraper_2', name: 'Forum Posts', enabled: false },
 ];
+const mockScraperRuns = {
+  scraper_1: {
+    scraper_id: 'scraper_1', status: 'completed',
+    started_at: new Date(Date.now() - 3600000).toISOString(),
+    completed_at: new Date(Date.now() - 3590000).toISOString(),
+    pages_scraped: 3, items_found: 42, errors: [],
+  },
+};
 
 // Mock S3 data explorer
 const mockBuckets = [
@@ -338,17 +360,14 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Handle scraper status by ID
+  // Handle scraper status by ID — real RunStatus shape (issue #169):
+  // pages_scraped/items_found/errors, 'never_run' for scrapers without runs.
   if (req.method === 'GET' && url.pathname.match(/^\/scrapers\/[^/]+\/status$/)) {
     const id = url.pathname.split('/')[2];
-    const scraper = mockScrapers.find(s => s.id === id);
+    const run = mockScraperRuns[id];
     res.writeHead(200);
-    res.end(JSON.stringify({
-      id,
-      status: scraper ? scraper.status : 'unknown',
-      last_run: scraper ? scraper.last_run : null,
-      items_scraped: Math.floor(Math.random() * 50) + 10,
-      errors: 0
+    res.end(JSON.stringify(run ?? {
+      scraper_id: id, status: 'never_run', pages_scraped: 0, items_found: 0, errors: [],
     }));
     return;
   }

--- a/voc-datalake/frontend/src/api/scrapersApi.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Tests for the scrapers API boundary (issue #167).
+ *
+ * ScraperConfig declares base_url as a required string, but runtime
+ * payloads have delivered scrapers without it. getScrapers normalizes on
+ * entry so the declared contract is true for every consumer.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetchApi = vi.fn()
+
+vi.mock('./client', () => ({
+  fetchApi: (...args: unknown[]) => mockFetchApi(...args),
+}))
+
+import { scrapersApi } from './scrapersApi'
+
+describe('scrapersApi.getScrapers base_url normalization', () => {
+  beforeEach(() => {
+    mockFetchApi.mockReset()
+  })
+
+  it('fills a missing base_url with an empty string', async () => {
+    mockFetchApi.mockResolvedValue({
+      scrapers: [
+        { id: 's-1', name: 'No URL yet' },
+        { id: 's-2', name: 'Configured', base_url: 'https://example.com/reviews' },
+      ],
+    })
+
+    const { scrapers } = await scrapersApi.getScrapers()
+
+    expect(scrapers[0].base_url).toBe('')
+    expect(scrapers[1].base_url).toBe('https://example.com/reviews')
+  })
+
+  it('tolerates a payload without a scrapers array', async () => {
+    mockFetchApi.mockResolvedValue({})
+
+    const { scrapers } = await scrapersApi.getScrapers()
+
+    expect(scrapers).toEqual([])
+  })
+})

--- a/voc-datalake/frontend/src/api/scrapersApi.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.test.ts
@@ -41,4 +41,32 @@ describe('scrapersApi.getScrapers base_url normalization', () => {
 
     expect(scrapers).toEqual([])
   })
+
+  it('defaults a missing frequency so the card can never render undefinedm (issue #169)', async () => {
+    mockFetchApi.mockResolvedValue({ scrapers: [{ id: 's-1', name: 'Sparse', enabled: false }] })
+
+    const { scrapers } = await scrapersApi.getScrapers()
+
+    expect(scrapers[0].frequency_minutes).toBe(0)
+    expect(scrapers[0].urls).toEqual([])
+    expect(scrapers[0].pagination.enabled).toBe(false)
+  })
+})
+
+describe('scrapersApi.getScraperStatus normalization (issue #169)', () => {
+  beforeEach(() => {
+    mockFetchApi.mockReset()
+  })
+
+  it('degrades the drifted status shape to safe counts instead of blanks', async () => {
+    // What the mock server historically returned: items_scraped (not
+    // items_found), no pages_scraped, errors as a number.
+    mockFetchApi.mockResolvedValue({ id: 's-1', status: 'success', items_scraped: 12, errors: 0 })
+
+    const status = await scrapersApi.getScraperStatus('s-1')
+
+    expect(status.pages_scraped).toBe(0)
+    expect(status.items_found).toBe(0)
+    expect(status.errors).toEqual([])
+  })
 })

--- a/voc-datalake/frontend/src/api/scrapersApi.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.ts
@@ -4,8 +4,22 @@ import type {
   ScraperConfig, ScraperTemplate,
 } from './types'
 
+// What /scrapers actually returns: base_url is declared required on
+// ScraperConfig, but runtime payloads have delivered scrapers without it
+// (issue #167). Model that honestly here and normalize on entry so the
+// declared contract is true for every consumer.
+type RawScraperConfig = Omit<ScraperConfig, 'base_url'> & { base_url?: string }
+
 export const scrapersApi = {
-  getScrapers: () => fetchApi<{ scrapers: ScraperConfig[] }>('/scrapers'),
+  getScrapers: async (): Promise<{ scrapers: ScraperConfig[] }> => {
+    const response = await fetchApi<{ scrapers: RawScraperConfig[] }>('/scrapers')
+    return {
+      scrapers: (response.scrapers ?? []).map((scraper) => ({
+        ...scraper,
+        base_url: typeof scraper.base_url === 'string' ? scraper.base_url : '',
+      })),
+    }
+  },
 
   getScraperTemplates: () => fetchApi<{ templates: ScraperTemplate[] }>('/scrapers/templates'),
 

--- a/voc-datalake/frontend/src/api/scrapersApi.ts
+++ b/voc-datalake/frontend/src/api/scrapersApi.ts
@@ -1,24 +1,18 @@
 // Scrapers & Manual Import API - extracted from client.ts for code splitting
 import { fetchApi } from './client'
+import { normalizeScrapers, normalizeScraperRunStatus } from './scrapersSchema'
+import type { ScraperRunStatus } from './scrapersSchema'
 import type {
   ScraperConfig, ScraperTemplate,
 } from './types'
 
-// What /scrapers actually returns: base_url is declared required on
-// ScraperConfig, but runtime payloads have delivered scrapers without it
-// (issue #167). Model that honestly here and normalize on entry so the
-// declared contract is true for every consumer.
-type RawScraperConfig = Omit<ScraperConfig, 'base_url'> & { base_url?: string }
-
 export const scrapersApi = {
+  // ScraperConfig declares its fields required, but runtime payloads have
+  // delivered sparse records (issues #167/#169). Normalize on entry so the
+  // declared contract is true for every consumer.
   getScrapers: async (): Promise<{ scrapers: ScraperConfig[] }> => {
-    const response = await fetchApi<{ scrapers: RawScraperConfig[] }>('/scrapers')
-    return {
-      scrapers: (response.scrapers ?? []).map((scraper) => ({
-        ...scraper,
-        base_url: typeof scraper.base_url === 'string' ? scraper.base_url : '',
-      })),
-    }
+    const response = await fetchApi<{ scrapers?: unknown[] }>('/scrapers')
+    return { scrapers: normalizeScrapers(response.scrapers ?? []) }
   },
 
   getScraperTemplates: () => fetchApi<{ templates: ScraperTemplate[] }>('/scrapers/templates'),
@@ -65,17 +59,13 @@ export const scrapersApi = {
       status: string
     }>(`/scrapers/${id}/run`, { method: 'POST' }),
 
-  getScraperStatus: (id: string) =>
-    fetchApi<{
-      scraper_id: string
-      execution_id?: string
-      status: string
-      started_at?: string
-      completed_at?: string
-      pages_scraped: number
-      items_found: number
-      errors: string[]
-    }>(`/scrapers/${id}/status`),
+  // The status endpoint's runtime shape has drifted from the declared one
+  // (issue #169: undefined counts rendered 'Last: pages, reviews' blank).
+  // Normalize on entry: counts degrade to 0, errors to [].
+  getScraperStatus: async (id: string): Promise<ScraperRunStatus> => {
+    const response = await fetchApi<unknown>(`/scrapers/${id}/status`)
+    return normalizeScraperRunStatus(response)
+  },
 
   getScraperRuns: (id: string) =>
     fetchApi<{

--- a/voc-datalake/frontend/src/api/scrapersSchema.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.test.ts
@@ -85,6 +85,19 @@ describe('normalizeScrapers (issue #169)', () => {
     expect(scrapers.map((s) => s.id)).toEqual(['scraper_2'])
     expect(warn).toHaveBeenCalledTimes(2)
   })
+
+  it('passes unknown backend fields through so edit round-trips lose nothing', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, created_at: '2026-01-01T00:00:00Z', future_field: { nested: true } },
+    ])
+
+    // A record read from getScrapers() and saved back by the editor must
+    // not silently shed fields this schema doesn't enumerate.
+    expect(scraper).toMatchObject({
+      created_at: '2026-01-01T00:00:00Z',
+      future_field: { nested: true },
+    })
+  })
 })
 
 describe('normalizeScraperRunStatus (issue #169)', () => {
@@ -110,6 +123,17 @@ describe('normalizeScraperRunStatus (issue #169)', () => {
 
   it('defaults a missing status to never_run (nothing-to-show for the card)', () => {
     expect(normalizeScraperRunStatus({}).status).toBe('never_run')
+  })
+
+  it('degrades even a non-object response to never_run instead of throwing', () => {
+    // Error bodies and empty responses must not throw out of the polling
+    // path — same degrade-don't-reject philosophy as the fields.
+    for (const garbage of [null, undefined, 'Internal Server Error', 42]) {
+      const status = normalizeScraperRunStatus(garbage)
+      expect(status.status).toBe('never_run')
+      expect(status.pages_scraped).toBe(0)
+      expect(status.errors).toEqual([])
+    }
   })
 
   it('keeps string errors and drops junk elements', () => {

--- a/voc-datalake/frontend/src/api/scrapersSchema.test.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for issue #169: sparse scraper records rendered
+ * 'undefinedm' for frequency, and the drifted status shape rendered the
+ * last-run summary with blank counts ('Last: pages, reviews'). The schemas
+ * make the declared contracts true at the API boundary.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  normalizeScrapers, normalizeScraperRunStatus,
+} from './scrapersSchema'
+
+const sparseScraper = { id: 'scraper_2', name: 'Forum Posts', enabled: false }
+
+describe('normalizeScrapers (issue #169)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fills every missing field on a sparse legacy record with conservative defaults', () => {
+    const [scraper] = normalizeScrapers([sparseScraper])
+
+    expect(scraper.base_url).toBe('')
+    expect(scraper.urls).toEqual([])
+    // 0 = 'Manual only': the truthful schedule for a record that has none.
+    // Anything nonzero would claim runs that never happen; undefined was
+    // the 'undefinedm' symptom.
+    expect(scraper.frequency_minutes).toBe(0)
+    expect(scraper.container_selector).toBe('')
+    expect(scraper.text_selector).toBe('')
+    expect(scraper.pagination).toEqual({ enabled: false, param: 'page', max_pages: 1, start: 1 })
+  })
+
+  it('passes a fully configured record through unchanged', () => {
+    const configured = {
+      id: 'scraper_1', name: 'Product Reviews', enabled: true,
+      base_url: 'https://example.com/reviews', urls: ['https://example.com/reviews?sort=recent'],
+      frequency_minutes: 30, extraction_method: 'css',
+      container_selector: '.review', text_selector: '.review-text',
+      pagination: { enabled: true, param: 'page', max_pages: 3, start: 1 },
+      last_run: '2026-07-15T00:00:00Z', items_found: 42,
+    }
+
+    const [scraper] = normalizeScrapers([configured])
+
+    expect(scraper).toMatchObject(configured)
+  })
+
+  it('treats explicit nulls like missing fields (DynamoDB emits both)', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, base_url: null, frequency_minutes: null, urls: null, pagination: null },
+    ])
+
+    expect(scraper.base_url).toBe('')
+    expect(scraper.frequency_minutes).toBe(0)
+    expect(scraper.urls).toEqual([])
+    expect(scraper.pagination).toEqual({ enabled: false, param: 'page', max_pages: 1, start: 1 })
+  })
+
+  it('coerces numeric-string round-trips and merges partial pagination', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, frequency_minutes: '30', pagination: { enabled: true, max_pages: '5' } },
+    ])
+
+    expect(scraper.frequency_minutes).toBe(30)
+    expect(scraper.pagination).toEqual({ enabled: true, param: 'page', max_pages: 5, start: 1 })
+  })
+
+  it('salvages string urls and drops junk elements instead of discarding the array', () => {
+    const [scraper] = normalizeScrapers([
+      { ...sparseScraper, urls: ['https://a.example.com', 42, null, 'https://b.example.com'] },
+    ])
+
+    expect(scraper.urls).toEqual(['https://a.example.com', 'https://b.example.com'])
+  })
+
+  it('drops records without a usable id instead of inventing one', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const scrapers = normalizeScrapers([
+      sparseScraper,
+      { name: 'No Identity', enabled: true },
+      { id: '', name: 'Empty Identity', enabled: true },
+    ])
+
+    expect(scrapers.map((s) => s.id)).toEqual(['scraper_2'])
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('normalizeScraperRunStatus (issue #169)', () => {
+  it('degrades missing counts to 0 so the summary never renders blank counts', () => {
+    // The drifted mock shape: items_scraped instead of items_found, no
+    // pages_scraped, errors as a number — rendered 'Last: pages, reviews'.
+    const status = normalizeScraperRunStatus({ id: 'scraper_1', status: 'success', items_scraped: 12, errors: 0 })
+
+    expect(status.pages_scraped).toBe(0)
+    expect(status.items_found).toBe(0)
+    expect(status.errors).toEqual([])
+  })
+
+  it('passes a real run status through unchanged', () => {
+    const run = {
+      scraper_id: 'scraper_1', status: 'completed',
+      started_at: '2026-07-15T00:00:00Z', completed_at: '2026-07-15T00:01:00Z',
+      pages_scraped: 3, items_found: 42, errors: [],
+    }
+
+    expect(normalizeScraperRunStatus(run)).toMatchObject(run)
+  })
+
+  it('defaults a missing status to never_run (nothing-to-show for the card)', () => {
+    expect(normalizeScraperRunStatus({}).status).toBe('never_run')
+  })
+
+  it('keeps string errors and drops junk elements', () => {
+    const status = normalizeScraperRunStatus({ status: 'error', errors: ['timeout', 500, null] })
+
+    expect(status.errors).toEqual(['timeout'])
+  })
+
+  it('coerces numeric-string counts', () => {
+    const status = normalizeScraperRunStatus({ status: 'completed', pages_scraped: '3', items_found: '42' })
+
+    expect(status.pages_scraped).toBe(3)
+    expect(status.items_found).toBe(42)
+  })
+})

--- a/voc-datalake/frontend/src/api/scrapersSchema.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.ts
@@ -51,6 +51,9 @@ const optionalString = z.string().optional().catch(undefined)
 /**
  * Schema for a stored scraper config.
  *
+ * - Loose object: unknown backend fields (created_at, future additions)
+ *   pass through untouched, so a record read from getScrapers() and saved
+ *   back by the editor round-trips without silent data loss.
  * - id is the one field that CANNOT be invented: it feeds React list keys
  *   and the status-polling endpoint, so records without a usable id are
  *   dropped (with a warning) by normalizeScrapers.
@@ -59,13 +62,15 @@ const optionalString = z.string().optional().catch(undefined)
  *   never happen ('undefinedm' was the rendered symptom, issue #169).
  * - base_url defaults to '' (the card's not-configured state, issue #167).
  */
-export const ScraperConfigSchema = z.object({
+export const ScraperConfigSchema = z.looseObject({
   id: z.string().min(1),
   name: z.string().catch(''),
   enabled: z.boolean().catch(false),
   base_url: z.string().catch(''),
   urls: stringArraySchema,
   frequency_minutes: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  // Must grow in lockstep with the backend's supported methods: an unknown
+  // method degrades to undefined (renderable), not a dropped record.
   extraction_method: z.enum(['css', 'jsonld']).optional().catch(undefined),
   template: optionalString,
   container_selector: z.string().catch(''),
@@ -90,7 +95,9 @@ export function normalizeScrapers(rawScrapers: readonly unknown[]): ScraperConfi
   return rawScrapers.flatMap((raw) => {
     const parsed = ScraperConfigSchema.safeParse(raw)
     if (!parsed.success) {
-      console.warn('Dropping scraper record that failed schema validation:', parsed.error.issues, raw)
+      // Issues only — no raw payload, which may carry config the user
+      // considers internal (URLs, selectors).
+      console.warn('Dropping scraper record that failed schema validation:', parsed.error.issues)
       return []
     }
     return [parsed.data]
@@ -102,22 +109,36 @@ export function normalizeScrapers(rawScrapers: readonly unknown[]): ScraperConfi
  * future statuses render as a benign amber badge rather than being
  * misreported); a missing status means 'never_run', which the card treats
  * as nothing-to-show. Counts degrade to 0 so the last-run summary renders
- * '0 pages, 0 reviews' instead of 'pages, reviews' (issue #169).
+ * '0 pages, 0 reviews' instead of 'pages, reviews' (issue #169). The
+ * object-level catch makes even a non-object response (null, an error
+ * string body) degrade to never_run — same philosophy, never throw.
  */
-export const ScraperRunStatusSchema = z.object({
-  scraper_id: optionalString,
-  execution_id: optionalString,
-  status: z.string().catch('never_run'),
-  started_at: optionalString,
-  completed_at: optionalString,
-  pages_scraped: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
-  items_found: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
-  errors: stringArraySchema,
-})
+export const ScraperRunStatusSchema = z
+  .object({
+    scraper_id: optionalString,
+    execution_id: optionalString,
+    status: z.string().catch('never_run'),
+    started_at: optionalString,
+    completed_at: optionalString,
+    pages_scraped: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+    items_found: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+    errors: stringArraySchema,
+  })
+  .catch(() => ({
+    scraper_id: undefined,
+    execution_id: undefined,
+    status: 'never_run',
+    started_at: undefined,
+    completed_at: undefined,
+    pages_scraped: 0,
+    items_found: 0,
+    errors: [],
+  }))
 
 export type ScraperRunStatus = z.infer<typeof ScraperRunStatusSchema>
 
-/** Make the declared run-status contract true for one wire response. */
+/** Make the declared run-status contract true for one wire response.
+ * Total: even a non-object response degrades to never_run. */
 export function normalizeScraperRunStatus(raw: unknown): ScraperRunStatus {
   return ScraperRunStatusSchema.parse(raw)
 }

--- a/voc-datalake/frontend/src/api/scrapersSchema.ts
+++ b/voc-datalake/frontend/src/api/scrapersSchema.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Runtime validation/normalization for scraper API responses.
+ *
+ * ScraperConfig declares every field required, but runtime payloads have
+ * delivered sparse records (issue #167: missing base_url crashed the route;
+ * issue #169: missing frequency_minutes rendered 'undefinedm', and the
+ * status endpoint's drifted shape rendered 'Last: pages, reviews' with the
+ * counts blank). Following the project convention (see api/feedbackSchema.ts,
+ * pages/FeedbackForms/formSchema.ts), lenient Zod schemas make the declared
+ * contracts true at this boundary: invalid or missing fields degrade to
+ * conservative defaults instead of rejecting the record.
+ *
+ * Wire defaults are deliberately NOT the editor's DEFAULT_SCRAPER values:
+ * the editor seeds ergonomic starting values for a scraper the user is about
+ * to create (daily schedule, enabled), while the normalizer must describe an
+ * existing record truthfully — a record with no schedule is 'Manual only'
+ * (0), not 'Daily', and a record that never said enabled stays disabled.
+ *
+ * @module api/scrapersSchema
+ */
+import { z } from 'zod'
+import type { ScraperConfig } from './types'
+
+/** Coerce DynamoDB string round-trips like "30" to numbers; null/'' become
+ * undefined so the field-level catch supplies the default instead of 0. */
+function toOptionalFiniteNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/** Keep string items, drop junk elements instead of discarding the array. */
+const stringArraySchema = z
+  .array(z.unknown())
+  .catch(() => [])
+  .transform((items) => items.filter((item): item is string => typeof item === 'string'))
+
+// Per-field catches survive a partial pagination object; the object-level
+// catch covers pagination: null/absent wholesale.
+const paginationSchema = z
+  .object({
+    enabled: z.boolean().catch(false),
+    param: z.string().catch('page'),
+    max_pages: z.preprocess(toOptionalFiniteNumber, z.number().catch(1)),
+    start: z.preprocess(toOptionalFiniteNumber, z.number().catch(1)),
+  })
+  .catch(() => ({ enabled: false, param: 'page', max_pages: 1, start: 1 }))
+
+const optionalString = z.string().optional().catch(undefined)
+
+/**
+ * Schema for a stored scraper config.
+ *
+ * - id is the one field that CANNOT be invented: it feeds React list keys
+ *   and the status-polling endpoint, so records without a usable id are
+ *   dropped (with a warning) by normalizeScrapers.
+ * - frequency_minutes defaults to 0 ('Manual only') — the truthful reading
+ *   of a record with no schedule; anything else would claim runs that
+ *   never happen ('undefinedm' was the rendered symptom, issue #169).
+ * - base_url defaults to '' (the card's not-configured state, issue #167).
+ */
+export const ScraperConfigSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().catch(''),
+  enabled: z.boolean().catch(false),
+  base_url: z.string().catch(''),
+  urls: stringArraySchema,
+  frequency_minutes: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  extraction_method: z.enum(['css', 'jsonld']).optional().catch(undefined),
+  template: optionalString,
+  container_selector: z.string().catch(''),
+  text_selector: z.string().catch(''),
+  title_selector: optionalString,
+  rating_selector: optionalString,
+  rating_attribute: optionalString,
+  date_selector: optionalString,
+  author_selector: optionalString,
+  link_selector: optionalString,
+  pagination: paginationSchema,
+  last_run: optionalString,
+  items_found: z.preprocess(toOptionalFiniteNumber, z.number().optional().catch(undefined)),
+})
+
+/**
+ * Normalize a wire list for rendering: records without a usable id are
+ * dropped with a warning instead of inventing identity — '' ids would
+ * collide React list keys and poll a nonsense status endpoint.
+ */
+export function normalizeScrapers(rawScrapers: readonly unknown[]): ScraperConfig[] {
+  return rawScrapers.flatMap((raw) => {
+    const parsed = ScraperConfigSchema.safeParse(raw)
+    if (!parsed.success) {
+      console.warn('Dropping scraper record that failed schema validation:', parsed.error.issues, raw)
+      return []
+    }
+    return [parsed.data]
+  })
+}
+
+/**
+ * Schema for a scraper run status. status stays a plain string (unknown
+ * future statuses render as a benign amber badge rather than being
+ * misreported); a missing status means 'never_run', which the card treats
+ * as nothing-to-show. Counts degrade to 0 so the last-run summary renders
+ * '0 pages, 0 reviews' instead of 'pages, reviews' (issue #169).
+ */
+export const ScraperRunStatusSchema = z.object({
+  scraper_id: optionalString,
+  execution_id: optionalString,
+  status: z.string().catch('never_run'),
+  started_at: optionalString,
+  completed_at: optionalString,
+  pages_scraped: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  items_found: z.preprocess(toOptionalFiniteNumber, z.number().catch(0)),
+  errors: stringArraySchema,
+})
+
+export type ScraperRunStatus = z.infer<typeof ScraperRunStatusSchema>
+
+/** Make the declared run-status contract true for one wire response. */
+export function normalizeScraperRunStatus(raw: unknown): ScraperRunStatus {
+  return ScraperRunStatusSchema.parse(raw)
+}

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -96,7 +96,6 @@ describe('ScraperCard base_url resilience (issue #167)', () => {
   })
 })
 
-
 describe('ScraperCard frequency resilience (issue #169)', () => {
   it('renders a dash instead of "undefinedm" for a runtime record without frequency', () => {
     const scraper = makeScraper({ base_url: 'https://example.com' })

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -41,6 +41,12 @@ function renderCard(scraper: ScraperConfig) {
 }
 
 describe('scraperDomainLabel', () => {
+  it('resolves the shipped not-configured string from the i18n test setup', () => {
+    // Guard against vacuous passes: if the key stopped resolving, t() would
+    // return the raw key and component + test would "agree" on it.
+    expect(NOT_CONFIGURED).not.toContain('card.notConfigured')
+  })
+
   it('resolves the hostname for a valid URL', () => {
     expect(scraperDomainLabel('https://shop.example.com/reviews?page=1', NOT_CONFIGURED))
       .toBe('shop.example.com')
@@ -55,6 +61,13 @@ describe('scraperDomainLabel', () => {
   it('falls back to the raw value for unparseable URLs instead of throwing', () => {
     expect(scraperDomainLabel('example.com', NOT_CONFIGURED)).toBe('example.com')
     expect(scraperDomainLabel('not a url at all', NOT_CONFIGURED)).toBe('not a url at all')
+  })
+
+  it('falls back to the raw value for parseable URLs with an empty hostname', () => {
+    // mailto:/file: URLs construct successfully but have hostname === '' —
+    // an empty label would look like broken rendering.
+    expect(scraperDomainLabel('mailto:x@example.com', NOT_CONFIGURED)).toBe('mailto:x@example.com')
+    expect(scraperDomainLabel('file:///tmp/reviews.html', NOT_CONFIGURED)).toBe('file:///tmp/reviews.html')
   })
 })
 

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Tests for ScraperCard — invalid base_url resilience (issue #167).
+ *
+ * A render-time `new URL(...)` TypeError on a missing or malformed base_url
+ * crashed the entire /scrapers route. The card must render for every value
+ * runtime data has been observed to carry: undefined (mock server, older
+ * configs), empty/whitespace, scheme-less, and garbage.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import i18n from 'i18next'
+import ScraperCard, { scraperDomainLabel } from './ScraperCard'
+import { DEFAULT_SCRAPER } from './constants'
+import type { ScraperConfig } from '../../api/types'
+
+vi.mock('../../api/scrapersApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/scrapersApi')>()
+  // Full-surface stub (same pattern as ScraperEditor.test.tsx): future API
+  // calls hit an assertable vi.fn(), not an opaque "not a function".
+  const stubs = Object.fromEntries(
+    Object.keys(actual.scrapersApi).map((name) => [name, vi.fn().mockResolvedValue({ status: 'never_run' })]),
+  )
+  return { scrapersApi: stubs }
+})
+
+const NOT_CONFIGURED = i18n.t('card.notConfigured', { ns: 'scrapers' })
+
+function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
+  return {
+    ...DEFAULT_SCRAPER,
+    id: 's-1',
+    name: 'Test scraper',
+    ...overrides,
+  }
+}
+
+function renderCard(scraper: ScraperConfig) {
+  return render(
+    <ScraperCard scraper={scraper} onEdit={vi.fn()} onDelete={vi.fn()} onRun={vi.fn()} />
+  )
+}
+
+describe('scraperDomainLabel', () => {
+  it('resolves the hostname for a valid URL', () => {
+    expect(scraperDomainLabel('https://shop.example.com/reviews?page=1', NOT_CONFIGURED))
+      .toBe('shop.example.com')
+  })
+
+  it('treats undefined, empty, and whitespace as not configured', () => {
+    expect(scraperDomainLabel(undefined, NOT_CONFIGURED)).toBe(NOT_CONFIGURED)
+    expect(scraperDomainLabel('', NOT_CONFIGURED)).toBe(NOT_CONFIGURED)
+    expect(scraperDomainLabel('   ', NOT_CONFIGURED)).toBe(NOT_CONFIGURED)
+  })
+
+  it('falls back to the raw value for unparseable URLs instead of throwing', () => {
+    expect(scraperDomainLabel('example.com', NOT_CONFIGURED)).toBe('example.com')
+    expect(scraperDomainLabel('not a url at all', NOT_CONFIGURED)).toBe('not a url at all')
+  })
+})
+
+describe('ScraperCard base_url resilience (issue #167)', () => {
+  it('renders a scheme-less base_url instead of crashing the route', () => {
+    // Type-legal value that previously threw `TypeError: Invalid URL`
+    // during render and killed the whole /scrapers page.
+    renderCard(makeScraper({ base_url: 'example.com' }))
+
+    expect(screen.getByText('Test scraper')).toBeInTheDocument()
+    expect(screen.getByText('example.com')).toBeInTheDocument()
+  })
+
+  it('shows not-configured and disables Run for an empty base_url', () => {
+    renderCard(makeScraper({ base_url: '' }))
+
+    expect(screen.getByText(NOT_CONFIGURED)).toBeInTheDocument()
+    expect(screen.getByTitle(i18n.t('card.runNow', { ns: 'scrapers' }))).toBeDisabled()
+  })
+
+  it('renders normally for a valid base_url', () => {
+    renderCard(makeScraper({ base_url: 'https://shop.example.com/reviews' }))
+
+    expect(screen.getByText('shop.example.com')).toBeInTheDocument()
+    expect(screen.getByTitle(i18n.t('card.runNow', { ns: 'scrapers' }))).not.toBeDisabled()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -95,3 +95,30 @@ describe('ScraperCard base_url resilience (issue #167)', () => {
     expect(screen.getByTitle(i18n.t('card.runNow', { ns: 'scrapers' }))).not.toBeDisabled()
   })
 })
+
+
+describe('ScraperCard frequency resilience (issue #169)', () => {
+  it('renders a dash instead of "undefinedm" for a runtime record without frequency', () => {
+    const scraper = makeScraper({ base_url: 'https://example.com' })
+    // The wire can deliver records persisted before frequency_minutes
+    // existed; static types say it is required, runtime reality disagrees.
+    Reflect.deleteProperty(scraper, 'frequency_minutes')
+
+    renderCard(scraper)
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument()
+  })
+
+  it('renders the human label for a known frequency', () => {
+    renderCard(makeScraper({ frequency_minutes: 30 }))
+
+    expect(screen.getByText('Every 30 minutes')).toBeInTheDocument()
+  })
+
+  it('renders Manual only for the normalized no-schedule default (0)', () => {
+    renderCard(makeScraper({ frequency_minutes: 0 }))
+
+    expect(screen.getByText('Manual only')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -131,17 +131,26 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
   )
 }
 
-/** Display label for a scraper's target site. Never throws: base_url is
- * typed as a string but runtime data can violate that (the mock server
- * omits it; older saved configs may hold scheme-less or garbage values),
- * and a render-time TypeError here took down the whole /scrapers route
- * (issue #167). Unparseable-but-present values fall back to the raw
- * string so the user can still see what is configured. */
+/** base_url as runtime data actually delivers it (absent on the mock
+ * server and possibly on older configs, despite the declared type),
+ * normalized to a trimmed string — '' meaning "not configured". Single
+ * owner of that check so the label and the Run-button gate can't drift. */
+export function normalizedBaseUrl(baseUrl: string | undefined): string {
+  return typeof baseUrl === 'string' ? baseUrl.trim() : ''
+}
+
+/** Display label for a scraper's target site. Never throws: a render-time
+ * TypeError here took down the whole /scrapers route (issue #167).
+ * Unparseable-but-present values fall back to the raw string so the user
+ * can still see what is configured. */
 export function scraperDomainLabel(baseUrl: string | undefined, notConfigured: string): string {
-  const raw = typeof baseUrl === 'string' ? baseUrl.trim() : ''
+  const raw = normalizedBaseUrl(baseUrl)
   if (raw === '') return notConfigured
   try {
-    return new URL(raw).hostname
+    // mailto:/file: URLs parse successfully with an EMPTY hostname —
+    // fall back to the raw value rather than rendering an empty label.
+    const host = new URL(raw).hostname
+    return host !== '' ? host : raw
   } catch {
     return raw
   }
@@ -158,7 +167,7 @@ function ScraperCardHeader({
 }) {
   const { t } = useTranslation('scrapers')
   const domain = scraperDomainLabel(scraper.base_url, t('card.notConfigured'))
-  const hasUrl = typeof scraper.base_url === 'string' && scraper.base_url.trim() !== ''
+  const hasUrl = normalizedBaseUrl(scraper.base_url) !== ''
   return (
     <div className="flex items-start justify-between mb-3">
       <div className="flex items-center gap-3">

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -131,6 +131,22 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
   )
 }
 
+/** Display label for a scraper's target site. Never throws: base_url is
+ * typed as a string but runtime data can violate that (the mock server
+ * omits it; older saved configs may hold scheme-less or garbage values),
+ * and a render-time TypeError here took down the whole /scrapers route
+ * (issue #167). Unparseable-but-present values fall back to the raw
+ * string so the user can still see what is configured. */
+export function scraperDomainLabel(baseUrl: string | undefined, notConfigured: string): string {
+  const raw = typeof baseUrl === 'string' ? baseUrl.trim() : ''
+  if (raw === '') return notConfigured
+  try {
+    return new URL(raw).hostname
+  } catch {
+    return raw
+  }
+}
+
 function ScraperCardHeader({
   scraper, isRunning, onRun, onEdit, onDelete,
 }: {
@@ -141,7 +157,8 @@ function ScraperCardHeader({
   readonly onDelete: () => void
 }) {
   const { t } = useTranslation('scrapers')
-  const domain = scraper.base_url === '' ? t('card.notConfigured') : new URL(scraper.base_url).hostname
+  const domain = scraperDomainLabel(scraper.base_url, t('card.notConfigured'))
+  const hasUrl = typeof scraper.base_url === 'string' && scraper.base_url.trim() !== ''
   return (
     <div className="flex items-start justify-between mb-3">
       <div className="flex items-center gap-3">
@@ -154,7 +171,7 @@ function ScraperCardHeader({
         </div>
       </div>
       <div className="flex items-center gap-1">
-        <button onClick={onRun} disabled={isRunning || scraper.base_url === ''} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title={t('card.runNow')}>
+        <button onClick={onRun} disabled={isRunning || !hasUrl} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title={t('card.runNow')}>
           {isRunning ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
         </button>
         <button onClick={onEdit} className="p-2 hover:bg-gray-100 rounded" title={t('card.edit')}><Settings size={16} /></button>

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -200,6 +200,10 @@ function calculateTotalUrls(scraper: ScraperConfig): number {
 }
 
 function getFrequencyLabel(minutes: number): string {
+  // Belt-and-braces for issue #169: the list normalizes at the API boundary,
+  // but the card must stay render-safe standalone — a runtime-sparse record
+  // used to render 'undefinedm' here.
+  if (!Number.isFinite(minutes)) return '—'
   return FREQUENCY_OPTIONS.find((f) => f.value === minutes)?.label ?? `${minutes}m`
 }
 

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -131,7 +131,7 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
   )
 }
 
-/** base_url as runtime data actually delivers it (absent on the mock
+/** Exported for tests (not public API). base_url as runtime data actually delivers it (absent on the mock
  * server and possibly on older configs, despite the declared type),
  * normalized to a trimmed string — '' meaning "not configured". Single
  * owner of that check so the label and the Run-button gate can't drift. */
@@ -139,7 +139,7 @@ export function normalizedBaseUrl(baseUrl: string | undefined): string {
   return typeof baseUrl === 'string' ? baseUrl.trim() : ''
 }
 
-/** Display label for a scraper's target site. Never throws: a render-time
+/** Exported for tests (not public API). Display label for a scraper's target site. Never throws: a render-time
  * TypeError here took down the whole /scrapers route (issue #167).
  * Unparseable-but-present values fall back to the raw string so the user
  * can still see what is configured. */


### PR DESCRIPTION
Fixes #169

Successor to #175, which GitHub auto-closed when its stacked base (#168's branch) was deleted on merge — same branch, now rebased onto development with #168's squash merged in (conflicts resolved by taking this branch's schema-based versions, which supersede #168's inline map with identical semantics).

**Full review already completed on #175** (2 rounds, converged at 'approve pending the stacked-base retarget'): lenient Zod schemas at the scrapers API boundary (frequency 0 = 'Manual only', base_url '' = not configured, per-item salvage, numeric coercion, id-less records dropped with warning, looseObject round-trip safety, total run-status normalization that never throws), ScraperCard belt-and-braces dash, real-shape mock fixtures with one deliberately sparse record, mutation-verified regression tests at schema/API/component layers.

Post-resolution verification: `tsc --noEmit` clean, 142 tests green across the scrapers surface (schema 13, api 4, card 11, page + editor + helpers).