### PR TITLE
fix(dev): admin UI visible in mock-only local dev

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -219,6 +219,8 @@ const mockUsers = [
 
 // Apply a user-admin mutation (issue #177). Returns { status, payload };
 // keeps the dispatch block small and the mutations in one auditable place.
+// Error payloads use the `error` key, matching the real API's shape
+// ({'success': False, 'error': ...} from lambda/shared/api.py).
 function handleUserAction(method, user, action, body) {
   const touch = () => { user.last_modified = new Date().toISOString(); };
   if (method === 'PUT' && action === 'group') {
@@ -233,7 +235,8 @@ function handleUserAction(method, user, action, body) {
   if (method === 'PUT' && (action === 'enable' || action === 'disable')) {
     user.enabled = action === 'enable';
     touch();
-    return { status: 200, payload: { success: true, message: `User ${action}d` } };
+    const confirmation = { enable: 'User enabled', disable: 'User disabled' };
+    return { status: 200, payload: { success: true, message: confirmation[action] } };
   }
   if (method === 'PUT' && !action) {
     const given = typeof body?.given_name === 'string' ? body.given_name : user.given_name;
@@ -248,7 +251,7 @@ function handleUserAction(method, user, action, body) {
     mockUsers.splice(mockUsers.indexOf(user), 1);
     return { status: 200, payload: { success: true, message: 'User deleted' } };
   }
-  return { status: 405, payload: { success: false, message: 'Method not allowed' } };
+  return { status: 405, payload: { success: false, error: 'Method not allowed' } };
 }
 
 // Mock scrapers — real ScraperConfig shape (issue #169). scraper_2 is
@@ -671,7 +674,7 @@ const server = http.createServer((req, res) => {
       const user = mockUsers.find(u => u.username === username);
       if (!user) {
         res.writeHead(404);
-        res.end(JSON.stringify({ success: false, message: 'User not found' }));
+        res.end(JSON.stringify({ success: false, error: 'User not found' }));
         return;
       }
       let parsedBody = null;

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -194,6 +194,63 @@ const mockFormStats = {
   form_4: { total_submissions: 41, avg_rating: 4.6, rating_count: 38 },
 };
 
+// Mock Cognito users (issue #177) — stateful so create/enable/disable/delete
+// reflect in the UI during a dev session. Shape mirrors CognitoUser.
+const mockUsers = [
+  {
+    username: 'admin-demo', email: 'admin@example.com', name: 'Ada Admin',
+    given_name: 'Ada', family_name: 'Admin', status: 'CONFIRMED', enabled: true,
+    groups: ['admins'], created_at: new Date(Date.now() - 30 * 86400000).toISOString(),
+    last_modified: new Date().toISOString(),
+  },
+  {
+    username: 'viewer-demo', email: 'viewer@example.com', name: 'Vic Viewer',
+    given_name: 'Vic', family_name: 'Viewer', status: 'CONFIRMED', enabled: true,
+    groups: ['users'], created_at: new Date(Date.now() - 10 * 86400000).toISOString(),
+    last_modified: new Date().toISOString(),
+  },
+  {
+    username: 'disabled-demo', email: 'disabled@example.com', name: 'Dee Disabled',
+    given_name: 'Dee', family_name: 'Disabled', status: 'CONFIRMED', enabled: false,
+    groups: ['users'], created_at: new Date(Date.now() - 60 * 86400000).toISOString(),
+    last_modified: new Date().toISOString(),
+  },
+];
+
+// Apply a user-admin mutation (issue #177). Returns { status, payload };
+// keeps the dispatch block small and the mutations in one auditable place.
+function handleUserAction(method, user, action, body) {
+  const touch = () => { user.last_modified = new Date().toISOString(); };
+  if (method === 'PUT' && action === 'group') {
+    const group = body?.group === 'admins' ? 'admins' : 'users';
+    user.groups = [group];
+    touch();
+    return { status: 200, payload: { success: true, message: `Moved ${user.username} to ${group}` } };
+  }
+  if (method === 'POST' && action === 'reset-password') {
+    return { status: 200, payload: { success: true, message: 'Password reset initiated' } };
+  }
+  if (method === 'PUT' && (action === 'enable' || action === 'disable')) {
+    user.enabled = action === 'enable';
+    touch();
+    return { status: 200, payload: { success: true, message: `User ${action}d` } };
+  }
+  if (method === 'PUT' && !action) {
+    const given = typeof body?.given_name === 'string' ? body.given_name : user.given_name;
+    const family = typeof body?.family_name === 'string' ? body.family_name : user.family_name;
+    user.given_name = given;
+    user.family_name = family;
+    user.name = [given, family].filter(Boolean).join(' ') || user.username;
+    touch();
+    return { status: 200, payload: { success: true, message: 'User updated', given_name: given, family_name: family, name: user.name } };
+  }
+  if (method === 'DELETE' && !action) {
+    mockUsers.splice(mockUsers.indexOf(user), 1);
+    return { status: 200, payload: { success: true, message: 'User deleted' } };
+  }
+  return { status: 405, payload: { success: false, message: 'Method not allowed' } };
+}
+
 // Mock scrapers — real ScraperConfig shape (issue #169). scraper_2 is
 // deliberately sparse (identity fields only), mirroring records persisted
 // before newer fields existed, so local dev exercises the normalizeScrapers()
@@ -257,6 +314,31 @@ const handlers = {
 
   // Sources status
   'GET /sources/status': () => mockSourcesStatus,
+
+  // User administration (issue #177) — stateful list; mutations live in the
+  // parameterized /users/:username dispatch block.
+  'GET /users': () => ({ success: true, users: mockUsers }),
+  'POST /users': (body) => {
+    if (!body || typeof body.username !== 'string' || body.username.trim() === '') {
+      return { __status: 400, body: { success: false, error: 'username is required' } };
+    }
+    if (mockUsers.some(u => u.username === body.username)) {
+      return { __status: 409, body: { success: false, error: 'User already exists' } };
+    }
+    const given = typeof body.given_name === 'string' ? body.given_name : '';
+    const family = typeof body.family_name === 'string' ? body.family_name : '';
+    const user = {
+      username: body.username,
+      email: typeof body.email === 'string' ? body.email : '',
+      name: [given, family].filter(Boolean).join(' ') || body.username,
+      given_name: given, family_name: family,
+      status: 'FORCE_CHANGE_PASSWORD', enabled: true,
+      groups: [body.group === 'admins' ? 'admins' : 'users'],
+      created_at: new Date().toISOString(), last_modified: new Date().toISOString(),
+    };
+    mockUsers.push(user);
+    return { success: true, user };
+  },
 
   // Settings - Categories
   'GET /settings/categories': () => mockCategoriesConfig,
@@ -574,6 +656,38 @@ const server = http.createServer((req, res) => {
       res.writeHead(404);
       res.end(JSON.stringify({ success: false, message: 'Form not found' }));
     }
+    return;
+  }
+
+  // User admin by username (issue #177). Exact-key routes ('GET /users',
+  // 'POST /users') win; unknown usernames 404 like the real API.
+  const userMatch = url.pathname.match(/^\/users\/([^/]+)(?:\/(group|reset-password|enable|disable))?$/);
+  if (userMatch && !(key in handlers)) {
+    const username = decodeURIComponent(userMatch[1]);
+    const action = userMatch[2];
+    let rawBody = '';
+    req.on('data', chunk => rawBody += chunk);
+    req.on('end', () => {
+      const user = mockUsers.find(u => u.username === username);
+      if (!user) {
+        res.writeHead(404);
+        res.end(JSON.stringify({ success: false, message: 'User not found' }));
+        return;
+      }
+      let parsedBody = null;
+      if (rawBody) {
+        try {
+          parsedBody = JSON.parse(rawBody);
+        } catch {
+          res.writeHead(400);
+          res.end(JSON.stringify({ success: false, error: 'Invalid JSON body' }));
+          return;
+        }
+      }
+      const result = handleUserAction(req.method, user, action, parsedBody);
+      res.writeHead(result.status);
+      res.end(JSON.stringify(result.payload));
+    });
     return;
   }
 

--- a/voc-datalake/frontend/src/store/authStore.test.ts
+++ b/voc-datalake/frontend/src/store/authStore.test.ts
@@ -1,8 +1,31 @@
 /**
  * @fileoverview Tests for authStore Zustand store.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
-import { useAuthStore } from './authStore'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAuthStore, useIsAdmin } from './authStore'
+import { getRuntimeConfig, isConfigLoaded } from '../runtimeConfig'
+
+// useIsAdmin reads the runtime config directly (services/auth imports this
+// store, so importing authService here would be a cycle) — mock the module
+// so each test controls whether Cognito is "configured".
+vi.mock('../runtimeConfig', () => ({
+  getRuntimeConfig: vi.fn(),
+  isConfigLoaded: vi.fn(),
+}))
+
+const mockGetRuntimeConfig = vi.mocked(getRuntimeConfig)
+const mockIsConfigLoaded = vi.mocked(isConfigLoaded)
+
+function stubCognito(configured: boolean) {
+  mockIsConfigLoaded.mockReturnValue(true)
+  mockGetRuntimeConfig.mockReturnValue({
+    apiEndpoint: 'https://api.example.com',
+    cognito: configured
+      ? { userPoolId: 'us-east-1_abc', clientId: 'client-123', region: 'us-east-1', identityPoolId: 'pool-1' }
+      : { userPoolId: '', clientId: '', region: '', identityPoolId: '' },
+  })
+}
 
 describe('authStore', () => {
   beforeEach(() => {
@@ -127,6 +150,71 @@ describe('authStore', () => {
       setError(null)
 
       expect(useAuthStore.getState().error).toBeNull()
+    })
+  })
+})
+
+
+/**
+ * Regression tests for issue #177: useIsAdmin lacked the routes' documented
+ * no-Cognito dev bypass, so mock-only local dev opened /settings (the routes
+ * bypass) while hiding every isAdmin-driven surface. Vitest runs as a DEV
+ * build (import.meta.env.DEV === true), which is exactly the branch under
+ * test; the production side of the gate is compile-time eliminated by Vite
+ * and enforced server-side (require_admin + Cognito authorizer) regardless.
+ */
+describe('useIsAdmin', () => {
+  beforeEach(() => {
+    useAuthStore.getState().logout()
+    vi.clearAllMocks()
+  })
+
+  describe('dev bypass (Cognito not configured, issue #177)', () => {
+    it('reports admin with no user at all', () => {
+      stubCognito(false)
+
+      const { result } = renderHook(() => useIsAdmin())
+
+      expect(result.current).toBe(true)
+    })
+
+    it('treats an unloaded config as not configured (still bypasses)', () => {
+      mockIsConfigLoaded.mockReturnValue(false)
+
+      const { result } = renderHook(() => useIsAdmin())
+
+      expect(result.current).toBe(true)
+      // Pre-load short-circuit: the config must never be read while unloaded
+      // (getRuntimeConfig throws in that state).
+      expect(mockGetRuntimeConfig).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with Cognito configured (the bypass must be inert)', () => {
+    it('reports admin only for users in the admins group', () => {
+      stubCognito(true)
+      useAuthStore.getState().setUser({ username: 'ada', email: 'ada@example.com', groups: ['admins'] })
+
+      const { result } = renderHook(() => useIsAdmin())
+
+      expect(result.current).toBe(true)
+    })
+
+    it('denies users outside the admins group', () => {
+      stubCognito(true)
+      useAuthStore.getState().setUser({ username: 'vic', email: 'vic@example.com', groups: ['users'] })
+
+      const { result } = renderHook(() => useIsAdmin())
+
+      expect(result.current).toBe(false)
+    })
+
+    it('denies when no user is present', () => {
+      stubCognito(true)
+
+      const { result } = renderHook(() => useIsAdmin())
+
+      expect(result.current).toBe(false)
     })
   })
 })

--- a/voc-datalake/frontend/src/store/authStore.ts
+++ b/voc-datalake/frontend/src/store/authStore.ts
@@ -122,9 +122,16 @@ export const useAuthStore = create<AuthState>()(
 /**
  * Whether Cognito is configured in the runtime config. Mirrors
  * authService.isConfigured(), which cannot be imported here because
- * services/auth.ts imports this store (import cycle). The pre-load guard
- * treats "config not loaded yet" as "not configured"; App gates rendering
- * on config load, so hooks never actually run before it resolves.
+ * services/auth.ts imports this store (import cycle).
+ *
+ * Pre-load: "config not loaded yet" is treated as "not configured", which
+ * in a DEV build activates the bypass below. This is safe ONLY because
+ * App.tsx gates <RouterProvider> on loadRuntimeConfig() resolving
+ * (configReady state), so no component calls this hook pre-load. If that
+ * loading gate is ever refactored away, a DEV build pointed at real
+ * Cognito would briefly report admin during the load window — keep the
+ * gate, or make this reactive to config load. The unloaded short-circuit
+ * itself is pinned by a test (getRuntimeConfig must not be called).
  */
 function cognitoConfigured(): boolean {
   if (!isConfigLoaded()) return false

--- a/voc-datalake/frontend/src/store/authStore.ts
+++ b/voc-datalake/frontend/src/store/authStore.ts
@@ -15,6 +15,7 @@
 
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { getRuntimeConfig, isConfigLoaded } from '../runtimeConfig'
 
 /**
  * Authenticated user information extracted from Cognito ID token.
@@ -119,10 +120,34 @@ export const useAuthStore = create<AuthState>()(
 )
 
 /**
+ * Whether Cognito is configured in the runtime config. Mirrors
+ * authService.isConfigured(), which cannot be imported here because
+ * services/auth.ts imports this store (import cycle). The pre-load guard
+ * treats "config not loaded yet" as "not configured"; App gates rendering
+ * on config load, so hooks never actually run before it resolves.
+ */
+function cognitoConfigured(): boolean {
+  if (!isConfigLoaded()) return false
+  const cfg = getRuntimeConfig()
+  return cfg.cognito.userPoolId !== '' && cfg.cognito.clientId !== ''
+}
+
+/**
  * Helper hook to check if current user is an admin.
- * @returns true if user is in the 'admins' group
+ *
+ * Local-dev bypass (issue #177): when Cognito is NOT configured and this is
+ * a DEV build, report admin — mirroring the documented bypass in
+ * ProtectedRoute/AdminRoute. Without it the routes open but every
+ * isAdmin-driven surface (Settings sidebar link, Users tab, AI Models card)
+ * stays hidden in mock-only dev. A production build without Cognito still
+ * fails closed here, exactly like the routes.
+ *
+ * @returns true if user is in the 'admins' group (or in the dev bypass)
  */
 export const useIsAdmin = (): boolean => {
   const user = useAuthStore((state) => state.user)
+  if (import.meta.env.DEV && !cognitoConfigured()) {
+    return true
+  }
   return user?.groups.includes('admins') ?? false
 }


### PR DESCRIPTION
Fixes #177

## Problem

Mock-only local dev (no Cognito) showed no admin surface: the Settings sidebar link, the Users tab, and the AI Models card (#166) were all hidden. `ProtectedRoute`/`AdminRoute` have a documented no-Cognito dev bypass, but `useIsAdmin()` didn't — so /settings opened by URL while every isAdmin-driven surface inside it stayed invisible. An inconsistent half-bypass.

## Security analysis (the important part)

This changes **UI visibility only**; the authorization boundary is unchanged and stays server-side:

1. **Compile-time elimination**: `import.meta.env.DEV` is a Vite build-time constant — in production bundles the bypass branch is statically `false` and dead-code-eliminated. The code does not ship.
2. **Config-gated**: even in a dev build, the bypass is inert whenever Cognito IS configured — group membership governs, pinned by tests.
3. **Fail-closed in production**: a production build without Cognito reports non-admin here and redirects at the routes — identical posture to the existing `ProtectedRoute`/`AdminRoute` bypasses this mirrors.
4. **The real boundary is the backend**: API Gateway's Cognito authorizer rejects unauthenticated calls, and `require_admin` (admins group, verified server-side) gates `/users/*` and `PUT /settings/model`. Client state is attacker-controlled by definition — anyone can flip a boolean in devtools today — which is exactly why no capability is granted by this flag.

Cycle note: `services/auth.ts` imports this store, so the store reads `runtimeConfig` directly instead of `authService.isConfigured()`, with a pre-load short-circuit (config is never read while unloaded — `getRuntimeConfig` throws in that state; pinned by a test asserting it's not called).

## Mock server

Stateful `/users` fixtures (3 CognitoUser-shaped users) + the full user-admin surface: `GET/POST /users`, `PUT /users/{u}` (attributes), `PUT /users/{u}/group|enable|disable`, `POST /users/{u}/reset-password`, `DELETE /users/{u}` — honest 404s for unknown usernames, mutations reflected in the session (`handleUserAction` keeps the dispatch small).

## Regression tests (mutation-verified)

5 new tests in `authStore.test.ts` — bypass active with no user when unconfigured; unloaded config short-circuits without touching `getRuntimeConfig`; configured path stays inert (admins → true, users → false, anonymous → false). Reverting the bypass fails exactly the two bypass tests. Vitest runs as a DEV build, which is precisely the branch under test; the production branch is compile-time eliminated (untestable in jsdom, same documented limitation as the existing route tests).

## Verification

- `npm run check` exits 0 (frontend 1701, CDK 33, backend green) — no existing test flipped by the bypass
- Browser-verified against the restarted mock: Settings link in sidebar, Users tab renders all three fixtures with actions, AI Models card shows all five per-surface pickers with the allowlist