### PR TITLE
fix(categories): survive legacy rows without id/subcategories

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -142,15 +142,35 @@ const mockSurfaceDefaults = {
   utility: 'global.anthropic.claude-sonnet-5',
 };
 
+// Categories config — real contract shape (id + subcategories, issue #181).
+// The last entry is a deliberately sparse legacy row ({name, display_name,
+// color} only — what old DynamoDB rows carry) so local dev permanently
+// exercises the normalizeCategories() boundary.
 const mockCategoriesConfig = {
   categories: [
-    { name: 'delivery', display_name: 'Delivery', description: 'Shipping and delivery issues', color: '#EF4444' },
-    { name: 'customer_support', display_name: 'Customer Support', description: 'Support interactions', color: '#3B82F6' },
-    { name: 'product_quality', display_name: 'Product Quality', description: 'Quality concerns', color: '#F59E0B' },
-    { name: 'pricing', display_name: 'Pricing', description: 'Price-related feedback', color: '#10B981' },
-    { name: 'website', display_name: 'Website', description: 'Website experience', color: '#8B5CF6' },
+    {
+      id: 'cat_delivery', name: 'delivery', description: 'Shipping and delivery issues',
+      subcategories: [
+        { id: 'sub_late_delivery', name: 'late_delivery', description: 'Late deliveries' },
+        { id: 'sub_tracking', name: 'tracking', description: 'Tracking visibility' },
+      ],
+    },
+    {
+      id: 'cat_customer_support', name: 'customer_support', description: 'Support interactions',
+      subcategories: [
+        { id: 'sub_response_time', name: 'response_time', description: 'Slow responses' },
+      ],
+    },
+    {
+      id: 'cat_product_quality', name: 'product_quality', description: 'Quality concerns',
+      subcategories: [],
+    },
+    { id: 'cat_pricing', name: 'pricing', description: 'Price-related feedback', subcategories: [] },
+    { id: 'cat_website', name: 'website', description: 'Website experience', subcategories: [] },
+    // Sparse legacy row: no id, no subcategories.
     { name: 'app', display_name: 'Mobile App', description: 'App experience', color: '#EC4899' },
-  ]
+  ],
+  updated_at: new Date().toISOString(),
 };
 
 // Mock feedback forms — real wire shape (form_id, full FeedbackFormFields).

--- a/voc-datalake/frontend/src/components/CategoriesManager/CategoriesManager.test.tsx
+++ b/voc-datalake/frontend/src/components/CategoriesManager/CategoriesManager.test.tsx
@@ -980,3 +980,41 @@ describe('CategoriesManager', () => {
     })
   })
 })
+
+
+describe('sparse legacy rows (issue #181)', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+    })
+    mockSaveCategoriesConfig.mockResolvedValue({ success: true })
+  })
+
+  function renderComponent() {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <CategoriesManager />
+      </QueryClientProvider>
+    )
+  }
+
+  it('renders a legacy row without id/subcategories instead of crashing the tab', async () => {
+    // Exactly what the wire delivered when Settings → Categories crashed:
+    // old DynamoDB rows carry {name, display_name, color} only.
+    mockGetCategoriesConfig.mockResolvedValue({
+      categories: [
+        { name: 'app', display_name: 'Mobile App', description: 'App experience', color: '#EC4899' },
+      ],
+    })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('App experience')).toBeInTheDocument()
+    })
+    expect(screen.getByText('0 sub')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/components/CategoriesManager/CategoriesManager.tsx
+++ b/voc-datalake/frontend/src/components/CategoriesManager/CategoriesManager.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import { api } from '../../api/client'
 import ConfirmModal from '../ConfirmModal'
+import { normalizeCategories } from './categoriesSchema'
 
 export interface Category {
   id: string
@@ -51,6 +52,10 @@ export default function CategoriesManager() {
   const { data: categoriesConfig, isLoading } = useQuery({
     queryKey: ['categories-config'],
     queryFn: () => api.getCategoriesConfig(),
+    // Normalize once at the query boundary so the declared Category contract
+    // is true for every consumer — legacy rows lack id/subcategories and
+    // crashed this tab (issue #181).
+    select: (data) => ({ ...data, categories: normalizeCategories(data.categories ?? []) }),
   })
 
   const saveMutation = useMutation({
@@ -64,7 +69,8 @@ export default function CategoriesManager() {
     mutationFn: (description: string) => api.generateCategories(description),
     onSuccess: (data) => {
       if (data.categories) {
-        saveMutation.mutate(data.categories)
+        // The LLM response is a wire boundary too — normalize before saving.
+        saveMutation.mutate(normalizeCategories(data.categories))
       }
       setIsGenerating(false)
     },
@@ -125,7 +131,7 @@ export default function CategoriesManager() {
     }
     saveMutation.mutate(
       categories.map(c => c.id === categoryId 
-        ? { ...c, subcategories: [...c.subcategories, newSub] }
+        ? { ...c, subcategories: [...(c.subcategories ?? []), newSub] }
         : c
       )
     )
@@ -137,7 +143,7 @@ export default function CategoriesManager() {
       if (c.id !== categoryId) return c
       return {
         ...c,
-        subcategories: c.subcategories.map(s => {
+        subcategories: (c.subcategories ?? []).map(s => {
           if (s.id !== subcategoryId) return s
           return {
             ...s,
@@ -154,7 +160,7 @@ export default function CategoriesManager() {
   const handleDeleteSubcategory = (categoryId: string, subcategoryId: string) => {
     saveMutation.mutate(
       categories.map(c => c.id === categoryId 
-        ? { ...c, subcategories: c.subcategories.filter(s => s.id !== subcategoryId) }
+        ? { ...c, subcategories: (c.subcategories ?? []).filter(s => s.id !== subcategoryId) }
         : c
       )
     )
@@ -283,7 +289,9 @@ export default function CategoriesManager() {
                     {category.name}
                   </span>
                   <span className="text-xs text-gray-400 flex-shrink-0">
-                    {category.subcategories.length} sub
+                    {/* Belt-and-braces for issue #181: the query boundary
+                        normalizes, but the render must stay safe standalone. */}
+                    {(category.subcategories ?? []).length} sub
                   </span>
                   <button
                     onClick={() => handleDeleteCategory(category.id)}
@@ -296,7 +304,7 @@ export default function CategoriesManager() {
                 {/* Subcategories */}
                 {expandedCategories.has(category.id) && (
                   <div className="p-2 sm:p-3 pl-4 sm:pl-10 space-y-2 bg-white">
-                    {category.subcategories.map((sub) => (
+                    {(category.subcategories ?? []).map((sub) => (
                       <div key={sub.id} className="flex items-center gap-2 text-sm">
                         <span className="w-2 h-2 bg-gray-300 rounded-full flex-shrink-0" />
                         {editingSubcategory === sub.id ? (

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.test.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.test.ts
@@ -90,6 +90,18 @@ describe('normalizeCategories (issue #181)', () => {
     expect(categories.map((c) => c.id)).toEqual(['cat_app', 'cat_app_2'])
   })
 
+  it('never rewrites a stored id, regardless of list order', () => {
+    // The save flow round-trips wholesale: if the derived row (listed FIRST)
+    // claimed cat_app, the stored identity would be silently rewritten and
+    // persisted on the next save.
+    const categories = normalizeCategories([
+      { name: 'app' },
+      { id: 'cat_app', name: 'application', subcategories: [] },
+    ])
+
+    expect(categories.map((c) => c.id)).toEqual(['cat_app_2', 'cat_app'])
+  })
+
   it('sanitizes non-alphanumerics in derived ids', () => {
     const [category] = normalizeCategories([{ name: 'billing/refunds & credits' }])
 

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.test.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for issue #181: legacy category rows ({name,
+ * display_name, color} — no id, no subcategories) crashed the Settings
+ * Categories tab with "Cannot read properties of undefined (reading
+ * 'length')". normalizeCategories makes the declared Category contract
+ * true at the query boundary WITHOUT dropping user config: ids are
+ * derived from names, because the save flow round-trips the whole list
+ * and a dropped row would be silently deleted on the next save.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { normalizeCategories } from './categoriesSchema'
+
+const legacyRow = { name: 'app', display_name: 'Mobile App', description: 'App experience', color: '#EC4899' }
+
+describe('normalizeCategories (issue #181)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('gives a legacy row a derived id and an empty subcategories array', () => {
+    const [category] = normalizeCategories([legacyRow])
+
+    expect(category.id).toBe('cat_app')
+    expect(category.subcategories).toEqual([])
+    expect(category.name).toBe('app')
+  })
+
+  it('passes legacy fields through so a save round-trip loses nothing', () => {
+    const [category] = normalizeCategories([legacyRow])
+
+    expect(category).toMatchObject({ display_name: 'Mobile App', color: '#EC4899' })
+  })
+
+  it('keeps a complete row unchanged', () => {
+    const complete = {
+      id: 'cat_delivery',
+      name: 'delivery',
+      description: 'Shipping issues',
+      subcategories: [{ id: 'sub_late', name: 'late_delivery', description: 'Late' }],
+    }
+
+    expect(normalizeCategories([complete])).toEqual([complete])
+  })
+
+  it('treats explicit null subcategories like missing (DynamoDB emits both)', () => {
+    const [category] = normalizeCategories([{ ...legacyRow, subcategories: null }])
+
+    expect(category.subcategories).toEqual([])
+  })
+
+  it('salvages valid subcategory items, deriving missing sub ids', () => {
+    const [category] = normalizeCategories([{
+      id: 'cat_x', name: 'x',
+      subcategories: [
+        { name: 'late delivery' },
+        'junk-string',
+        { id: 'sub_ok', name: 'ok' },
+      ],
+    }])
+
+    expect(category.subcategories).toEqual([
+      { id: 'sub_late_delivery', name: 'late delivery' },
+      { id: 'sub_ok', name: 'ok' },
+    ])
+  })
+
+  it('derives ids deterministically so repeated loads agree', () => {
+    const first = normalizeCategories([legacyRow])
+    const second = normalizeCategories([legacyRow])
+
+    expect(first[0].id).toBe(second[0].id)
+  })
+
+  it('drops a row only when both id and name are unusable', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const categories = normalizeCategories([
+      legacyRow,
+      { description: 'nothing to key on' },
+      { id: '', name: '' },
+    ])
+
+    expect(categories.map((c) => c.id)).toEqual(['cat_app'])
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.test.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.test.ts
@@ -71,6 +71,40 @@ describe('normalizeCategories (issue #181)', () => {
     expect(first[0].id).toBe(second[0].id)
   })
 
+  it('de-duplicates colliding derived ids so row actions cannot cross-target', () => {
+    const categories = normalizeCategories([
+      { name: 'App' },
+      { name: 'app' },
+      { name: 'app  ' },
+    ])
+
+    expect(categories.map((c) => c.id)).toEqual(['cat_app', 'cat_app_2', 'cat_app_3'])
+  })
+
+  it('de-duplicates a derived id against a stored one', () => {
+    const categories = normalizeCategories([
+      { id: 'cat_app', name: 'application', subcategories: [] },
+      { name: 'app' },
+    ])
+
+    expect(categories.map((c) => c.id)).toEqual(['cat_app', 'cat_app_2'])
+  })
+
+  it('sanitizes non-alphanumerics in derived ids', () => {
+    const [category] = normalizeCategories([{ name: 'billing/refunds & credits' }])
+
+    expect(category.id).toBe('cat_billing_refunds_credits')
+  })
+
+  it('treats whitespace-only and symbol-only names as unusable identity', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const categories = normalizeCategories([legacyRow, { name: '   ' }, { name: '///' }])
+
+    expect(categories.map((c) => c.id)).toEqual(['cat_app'])
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
   it('drops a row only when both id and name are unusable', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Runtime validation/normalization for the categories config.
+ *
+ * The real GET /settings/categories returns the DynamoDB item verbatim
+ * (settings_handler.py: `item.get('categories', [])`), so nothing enforces
+ * the declared Category shape at runtime — legacy or hand-written rows lack
+ * `id`/`subcategories`, and reading `subcategories.length` off such a row
+ * crashed the Settings Categories tab (issue #181). Same class as
+ * #167/#169/#171; same architecture as formSchema.ts / scrapersSchema.ts.
+ *
+ * Identity strategy deliberately differs from those two: categories are
+ * user-editable config that the save flow round-trips WHOLESALE, so
+ * dropping an id-less row would silently delete it on the next save.
+ * Instead a missing id is DERIVED from the name (stable slug). A row is
+ * dropped only when both id and name are unusable — nothing to render,
+ * key on, or save.
+ *
+ * @module components/CategoriesManager/categoriesSchema
+ */
+import { z } from 'zod'
+import type { Category, Subcategory } from './CategoriesManager'
+
+/** Stable id for legacy rows that never had one: slug of the name. */
+function deriveId(prefix: string, name: string): string {
+  return `${prefix}_${name.trim().toLowerCase().replace(/\s+/g, '_')}`
+}
+
+// Loose objects: legacy fields (display_name, color, ...) survive the edit
+// round-trip — the save flow PUTs the whole list back.
+const rawSubcategorySchema = z.looseObject({
+  id: z.string().optional().catch(undefined),
+  name: z.string().catch(''),
+  description: z.string().optional().catch(undefined),
+})
+
+const rawCategorySchema = z.looseObject({
+  id: z.string().optional().catch(undefined),
+  name: z.string().catch(''),
+  description: z.string().optional().catch(undefined),
+  subcategories: z.array(z.unknown()).catch(() => []),
+})
+
+function normalizeSubcategory(raw: unknown): Subcategory[] {
+  const parsed = rawSubcategorySchema.safeParse(raw)
+  if (!parsed.success) return []
+  const { id, name } = parsed.data
+  if ((id === undefined || id === '') && name === '') return []
+  return [{ ...parsed.data, id: id !== undefined && id !== '' ? id : deriveId('sub', name), name }]
+}
+
+/**
+ * Make the declared Category contract true for one wire row, or drop it
+ * (empty array) when there is no usable identity at all.
+ */
+function normalizeCategory(raw: unknown): Category[] {
+  const parsed = rawCategorySchema.safeParse(raw)
+  if (!parsed.success) {
+    console.warn('Dropping category record that failed schema validation:', parsed.error.issues)
+    return []
+  }
+  const { id, name, subcategories } = parsed.data
+  if ((id === undefined || id === '') && name === '') {
+    console.warn('Dropping category record without usable id or name:', parsed.data)
+    return []
+  }
+  return [{
+    ...parsed.data,
+    id: id !== undefined && id !== '' ? id : deriveId('cat', name),
+    name,
+    subcategories: subcategories.flatMap(normalizeSubcategory),
+  }]
+}
+
+/**
+ * Normalize the categories list at the query boundary: legacy rows get a
+ * derived id and an empty subcategories array instead of crashing the tab;
+ * unknown legacy fields pass through so saves lose nothing.
+ */
+export function normalizeCategories(rawCategories: readonly unknown[]): Category[] {
+  return rawCategories.flatMap(normalizeCategory)
+}

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
@@ -26,17 +26,43 @@ function slugify(name: string): string {
   return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
 }
 
-/** Reserve a unique id: first-come keeps the plain candidate, later
- * collisions get a numeric suffix (cat_app, cat_app_2, ...) so two legacy
- * rows named 'App' and 'app' can't share delete/expand/edit actions. */
-function uniqueId(candidate: string, used: Set<string>, attempt = 1): string {
-  const proposal = attempt === 1 ? candidate : `${candidate}_${attempt}`
-  if (!used.has(proposal)) {
-    used.add(proposal)
-    return proposal
+/**
+ * Two-pass id allocation: every usable STORED id is reserved up front, so a
+ * derived id can never claim — and therefore silently rewrite — a stored
+ * identity that appears later in the list (the save flow round-trips
+ * wholesale, so a rewrite would persist). Within that constraint ids are
+ * de-duplicated first-come with numeric suffixes (cat_app, cat_app_2, ...),
+ * covering same-named legacy rows and pathological duplicate stored ids.
+ */
+function createIdAllocator(reservedStoredIds: ReadonlySet<string>) {
+  const assigned = new Set<string>()
+  const nextFree = (candidate: string, attempt: number): string => {
+    const proposal = attempt === 1 ? candidate : `${candidate}_${attempt}`
+    if (!assigned.has(proposal) && !reservedStoredIds.has(proposal)) {
+      assigned.add(proposal)
+      return proposal
+    }
+    return nextFree(candidate, attempt + 1)
   }
-  return uniqueId(candidate, used, attempt + 1)
+  return {
+    /** A stored id keeps itself; only a duplicate stored id gets suffixed. */
+    stored(id: string): string {
+      if (!assigned.has(id)) {
+        assigned.add(id)
+        return id
+      }
+      return nextFree(id, 2)
+    },
+    /** A derived id must not collide with anything stored or assigned. */
+    derived(candidate: string): string {
+      return nextFree(candidate, 1)
+    },
+  }
 }
+
+type IdAllocator = ReturnType<typeof createIdAllocator>
+
+const usableStoredId = (id: string | undefined): id is string => id !== undefined && id.trim() !== ''
 
 // Loose objects: legacy fields (display_name, color, ...) survive the edit
 // round-trip — the save flow PUTs the whole list back.
@@ -53,54 +79,63 @@ const rawCategorySchema = z.looseObject({
   subcategories: z.array(z.unknown()).catch(() => []),
 })
 
-/** A usable identity source: a non-empty stored id, or a name that slugs
- * to something non-empty (whitespace-only and symbol-only names don't). */
-function identityFor(prefix: string, id: string | undefined, name: string): string | null {
-  if (id !== undefined && id.trim() !== '') return id
+type RawCategory = z.infer<typeof rawCategorySchema>
+
+/** Allocate this row's id: stored ids keep themselves, missing ones are
+ * derived from the slugged name — or null when neither is usable. */
+function allocateIdentity(
+  prefix: string, id: string | undefined, name: string, allocator: IdAllocator,
+): string | null {
+  if (usableStoredId(id)) return allocator.stored(id)
   const slug = slugify(name)
-  return slug === '' ? null : `${prefix}_${slug}`
+  return slug === '' ? null : allocator.derived(`${prefix}_${slug}`)
 }
 
-function normalizeSubcategory(raw: unknown, usedIds: Set<string>): Subcategory[] {
-  const parsed = rawSubcategorySchema.safeParse(raw)
-  if (!parsed.success) return []
-  const identity = identityFor('sub', parsed.data.id, parsed.data.name)
-  if (identity === null) return []
-  return [{ ...parsed.data, id: uniqueId(identity, usedIds), name: parsed.data.name }]
+function normalizeSubcategories(rawSubs: readonly unknown[]): Subcategory[] {
+  const parsed = rawSubs
+    .map((raw) => rawSubcategorySchema.safeParse(raw))
+    .flatMap((result) => (result.success ? [result.data] : []))
+  const allocator = createIdAllocator(
+    new Set(parsed.map((sub) => sub.id).filter(usableStoredId)),
+  )
+  return parsed.flatMap((sub) => {
+    const identity = allocateIdentity('sub', sub.id, sub.name, allocator)
+    return identity === null ? [] : [{ ...sub, id: identity, name: sub.name }]
+  })
 }
 
-/**
- * Make the declared Category contract true for one wire row, or drop it
- * (empty array) when there is no usable identity at all.
- */
-function normalizeCategory(raw: unknown, usedIds: Set<string>): Category[] {
-  const parsed = rawCategorySchema.safeParse(raw)
-  if (!parsed.success) {
-    console.warn('Dropping category record that failed schema validation:', parsed.error.issues)
-    return []
-  }
-  const identity = identityFor('cat', parsed.data.id, parsed.data.name)
+function normalizeCategory(parsed: RawCategory, allocator: IdAllocator): Category[] {
+  const identity = allocateIdentity('cat', parsed.id, parsed.name, allocator)
   if (identity === null) {
-    console.warn('Dropping category record without usable id or name; keys present:', Object.keys(parsed.data))
+    console.warn('Dropping category record without usable id or name; keys present:', Object.keys(parsed))
     return []
   }
-  const usedSubIds = new Set<string>()
   return [{
-    ...parsed.data,
-    id: uniqueId(identity, usedIds),
-    name: parsed.data.name,
-    subcategories: parsed.data.subcategories.flatMap((sub) => normalizeSubcategory(sub, usedSubIds)),
+    ...parsed,
+    id: identity,
+    name: parsed.name,
+    subcategories: normalizeSubcategories(parsed.subcategories),
   }]
 }
 
 /**
  * Normalize the categories list at the query boundary: legacy rows get a
  * derived id and an empty subcategories array instead of crashing the tab;
- * unknown legacy fields pass through so saves lose nothing. Ids are
- * de-duplicated across the list (derived or stored) so row actions can
- * never cross-target.
+ * unknown legacy fields pass through so saves lose nothing. Stored ids are
+ * never rewritten (reserved before any derivation); all ids are unique
+ * across the list so row actions can never cross-target.
  */
 export function normalizeCategories(rawCategories: readonly unknown[]): Category[] {
-  const usedIds = new Set<string>()
-  return rawCategories.flatMap((raw) => normalizeCategory(raw, usedIds))
+  const parsedRows = rawCategories.flatMap((raw) => {
+    const result = rawCategorySchema.safeParse(raw)
+    if (!result.success) {
+      console.warn('Dropping category record that failed schema validation:', result.error.issues)
+      return []
+    }
+    return [result.data]
+  })
+  const allocator = createIdAllocator(
+    new Set(parsedRows.map((row) => row.id).filter(usableStoredId)),
+  )
+  return parsedRows.flatMap((row) => normalizeCategory(row, allocator))
 }

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
@@ -20,9 +20,22 @@
 import { z } from 'zod'
 import type { Category, Subcategory } from './CategoriesManager'
 
-/** Stable id for legacy rows that never had one: slug of the name. */
-function deriveId(prefix: string, name: string): string {
-  return `${prefix}_${name.trim().toLowerCase().replace(/\s+/g, '_')}`
+/** Slug of a name for derived ids: lowercase, non-alphanumerics collapsed
+ * to underscores, trimmed — 'billing/refunds' → 'billing_refunds'. */
+function slugify(name: string): string {
+  return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+}
+
+/** Reserve a unique id: first-come keeps the plain candidate, later
+ * collisions get a numeric suffix (cat_app, cat_app_2, ...) so two legacy
+ * rows named 'App' and 'app' can't share delete/expand/edit actions. */
+function uniqueId(candidate: string, used: Set<string>, attempt = 1): string {
+  const proposal = attempt === 1 ? candidate : `${candidate}_${attempt}`
+  if (!used.has(proposal)) {
+    used.add(proposal)
+    return proposal
+  }
+  return uniqueId(candidate, used, attempt + 1)
 }
 
 // Loose objects: legacy fields (display_name, color, ...) survive the edit
@@ -40,42 +53,54 @@ const rawCategorySchema = z.looseObject({
   subcategories: z.array(z.unknown()).catch(() => []),
 })
 
-function normalizeSubcategory(raw: unknown): Subcategory[] {
+/** A usable identity source: a non-empty stored id, or a name that slugs
+ * to something non-empty (whitespace-only and symbol-only names don't). */
+function identityFor(prefix: string, id: string | undefined, name: string): string | null {
+  if (id !== undefined && id.trim() !== '') return id
+  const slug = slugify(name)
+  return slug === '' ? null : `${prefix}_${slug}`
+}
+
+function normalizeSubcategory(raw: unknown, usedIds: Set<string>): Subcategory[] {
   const parsed = rawSubcategorySchema.safeParse(raw)
   if (!parsed.success) return []
-  const { id, name } = parsed.data
-  if ((id === undefined || id === '') && name === '') return []
-  return [{ ...parsed.data, id: id !== undefined && id !== '' ? id : deriveId('sub', name), name }]
+  const identity = identityFor('sub', parsed.data.id, parsed.data.name)
+  if (identity === null) return []
+  return [{ ...parsed.data, id: uniqueId(identity, usedIds), name: parsed.data.name }]
 }
 
 /**
  * Make the declared Category contract true for one wire row, or drop it
  * (empty array) when there is no usable identity at all.
  */
-function normalizeCategory(raw: unknown): Category[] {
+function normalizeCategory(raw: unknown, usedIds: Set<string>): Category[] {
   const parsed = rawCategorySchema.safeParse(raw)
   if (!parsed.success) {
     console.warn('Dropping category record that failed schema validation:', parsed.error.issues)
     return []
   }
-  const { id, name, subcategories } = parsed.data
-  if ((id === undefined || id === '') && name === '') {
-    console.warn('Dropping category record without usable id or name:', parsed.data)
+  const identity = identityFor('cat', parsed.data.id, parsed.data.name)
+  if (identity === null) {
+    console.warn('Dropping category record without usable id or name; keys present:', Object.keys(parsed.data))
     return []
   }
+  const usedSubIds = new Set<string>()
   return [{
     ...parsed.data,
-    id: id !== undefined && id !== '' ? id : deriveId('cat', name),
-    name,
-    subcategories: subcategories.flatMap(normalizeSubcategory),
+    id: uniqueId(identity, usedIds),
+    name: parsed.data.name,
+    subcategories: parsed.data.subcategories.flatMap((sub) => normalizeSubcategory(sub, usedSubIds)),
   }]
 }
 
 /**
  * Normalize the categories list at the query boundary: legacy rows get a
  * derived id and an empty subcategories array instead of crashing the tab;
- * unknown legacy fields pass through so saves lose nothing.
+ * unknown legacy fields pass through so saves lose nothing. Ids are
+ * de-duplicated across the list (derived or stored) so row actions can
+ * never cross-target.
  */
 export function normalizeCategories(rawCategories: readonly unknown[]): Category[] {
-  return rawCategories.flatMap(normalizeCategory)
+  const usedIds = new Set<string>()
+  return rawCategories.flatMap((raw) => normalizeCategory(raw, usedIds))
 }


### PR DESCRIPTION
Fixes #181

## Problem

Settings → Categories crashed with `Cannot read properties of undefined (reading 'length')` in `<CategoriesManager>` — contained by #174's route error boundary, but the tab itself was dead. The component reads `category.subcategories.length`/`.map` as required by the declared type, while the real `GET /settings/categories` returns the DynamoDB item **verbatim** (`item.get('categories', [])` in settings_handler.py) — so legacy rows shaped `{name, display_name, color}` have no `id` and no `subcategories`. The local mock served exactly that legacy shape, which is how it surfaced. Same class as #167/#169/#171.

## Fix (same architecture as #172/#176, one deliberate difference)

- **`categoriesSchema.ts`** — lenient Zod normalization at the query boundary. **Identity strategy differs from formSchema/scrapersSchema on purpose**: categories are user-editable config that the save flow round-trips wholesale, so dropping an id-less row would silently delete it on the next save. Missing ids are **derived** from names (stable slug — `cat_app`), deterministic across loads; a row is dropped only when both id and name are unusable. `looseObject` keeps legacy fields (`display_name`, `color`) intact through round-trips; subcategories salvage per item with derived sub ids.
- **`CategoriesManager`** — `select` at the query boundary; the **LLM generate response is normalized before saving too** (it's a wire boundary as much as the GET); belt-and-braces `?? []` at the render and mutation sites so the component stays render-safe standalone.
- **mock-server** — categories now carry the real contract shape (id + subcategories), keeping one deliberately sparse legacy row so local dev permanently exercises the normalizer.

## Regression tests (mutation-verified)

- `categoriesSchema.test.ts` (7): derived id + empty subcategories for the legacy shape, loose passthrough (`display_name`/`color` survive), complete-row passthrough, explicit-null subcategories, per-item salvage with derived sub ids, deterministic derivation, drop-only-when-both-unusable (with warn count)
- `CategoriesManager.test.tsx` pin: renders the exact crash shape to **'0 sub'** — reverting the boundary + guard fails exactly this test (verified)

## Verification

- Browser: Settings → Categories renders 6 categories including the legacy row ('App experience', 0 sub), no error boundary
- `npm run check` exits 0 (frontend 1709, CDK 33, backend green)