### PR TITLE
fix(stream): unblock cold npm install — eslint-plugin-promise 7.3.0

### DIFF
--- a/voc-datalake/lambda/stream/package-lock.json
+++ b/voc-datalake/lambda/stream/package-lock.json
@@ -3355,9 +3355,9 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
-      "integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3370,7 +3370,7 @@
         "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-security": {


### PR DESCRIPTION
## Problem (hit live on the deployment path)

A cold `npm install` in `voc-datalake/lambda/stream` fails with ERESOLVE: the lockfile resolves `eslint-plugin-promise@7.2.1`, whose peer range is `eslint ^7||^8||^9`, while the project pins `eslint ^10.1.0`. Anyone cloning fresh (contributor or CI) can't install the stream workspace.

## Fix

Lockfile-only refresh to `eslint-plugin-promise@7.3.0` — already within the declared `^7.2.1` range; 7.3.0 adds the `eslint ^10` peer. No package.json changes.

## Verification

- `npm install` clean from cold
- stream suite: 230/230
- CDK bundling of the stream Lambda unaffected (deployed to production this session)

Known-and-separate: `npm run lint` in stream surfaces 176 pre-existing vitest-plugin rule violations in test files (not run by the root gate) — that's rule-adoption drift unrelated to this lockfile fix, happy to file an issue if maintainers want it tracked.