### PR TITLE
fix(deploy): stale-cache i18n keys + warning-free CDK synth/deploy

### DIFF
--- a/voc-datalake/cdk.json
+++ b/voc-datalake/cdk.json
@@ -17,6 +17,7 @@
   "context": {
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:defaultCrossStackReferences": "strong",
     "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
     "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
     "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,

--- a/voc-datalake/frontend/scripts/deploy.sh
+++ b/voc-datalake/frontend/scripts/deploy.sh
@@ -112,7 +112,7 @@ jq -n \
 
 echo "  ✓ config.json generated with CloudFormation values"
 
-# Step 4: Sync to S3
+# Step 5: Sync to S3
 #
 # Cache-Control is split by mutability (issue #188): Vite's /assets/* are
 # content-hashed, so they can cache forever — but everything with a STABLE
@@ -121,13 +121,25 @@ echo "  ✓ config.json generated with CloudFormation values"
 # JSONs across deploys and the new JS bundle renders raw i18n keys
 # (nav.home, home.title, ...) until a hard refresh. CloudFront invalidation
 # can't fix that: the staleness lives in the browser cache.
+#
+# Metadata note: sync only sets Cache-Control on objects it uploads. That
+# is sufficient because `npm run build` regenerates dist/ with fresh
+# mtimes, so every file uploads (and gets metadata) on each deploy —
+# including the first deploy after this change on buckets that predate it.
+# Don't add --size-only: it would skip unchanged-content files and leave
+# their old metadata in place.
 echo ""
 echo "Step 5: Syncing to S3..."
-# Hashed, immutable assets: cache for a year.
-aws s3 sync dist/assets/ "s3://${BUCKET_NAME}/assets" --delete \
+# Hashed, immutable assets: cache for a year. Deliberately NO --delete:
+# visitors whose browsers cached the previous index.html (which nothing
+# revalidates until they pick up this fix) still reference the previous
+# deploy's chunks — deleting them would turn a stale-but-working page into
+# 404s. Old hashed chunks are harmless and pennies to keep.
+aws s3 sync dist/assets/ "s3://${BUCKET_NAME}/assets" \
   --cache-control 'public,max-age=31536000,immutable'
 # Everything else (stable names): always revalidate. ETags make this cheap
 # (304s), and no visitor ever holds a stale config/locale/index again.
+# --exclude also shields assets/* from this pass's --delete.
 aws s3 sync dist/ "s3://${BUCKET_NAME}" --delete \
   --exclude 'assets/*' \
   --cache-control 'no-cache'

--- a/voc-datalake/frontend/scripts/deploy.sh
+++ b/voc-datalake/frontend/scripts/deploy.sh
@@ -78,12 +78,12 @@ echo "  Avatars CDN: $AVATARS_CDN_URL"
 
 # Step 2: Build the frontend
 echo ""
-echo "Step 3: Building frontend..."
+echo "Step 2: Building frontend..."
 npm run build
 
 # Step 3: Generate runtime config.json
 echo ""
-echo "Step 4: Generating runtime config.json..."
+echo "Step 3: Generating runtime config.json..."
 
 # Use jq to properly escape values and generate valid JSON
 jq -n \
@@ -112,7 +112,7 @@ jq -n \
 
 echo "  ✓ config.json generated with CloudFormation values"
 
-# Step 5: Sync to S3
+# Step 4: Sync to S3
 #
 # Cache-Control is split by mutability (issue #188): Vite's /assets/* are
 # content-hashed, so they can cache forever — but everything with a STABLE
@@ -129,7 +129,7 @@ echo "  ✓ config.json generated with CloudFormation values"
 # Don't add --size-only: it would skip unchanged-content files and leave
 # their old metadata in place.
 echo ""
-echo "Step 5: Syncing to S3..."
+echo "Step 4: Syncing to S3..."
 # Hashed, immutable assets: cache for a year. Deliberately NO --delete:
 # visitors whose browsers cached the previous index.html (which nothing
 # revalidates until they pick up this fix) still reference the previous
@@ -146,7 +146,7 @@ aws s3 sync dist/ "s3://${BUCKET_NAME}" --delete \
 
 # Step 5: Invalidate CloudFront cache
 echo ""
-echo "Step 6: Invalidating CloudFront cache..."
+echo "Step 5: Invalidating CloudFront cache..."
 aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths '/*' > /dev/null
 
 echo ""

--- a/voc-datalake/frontend/scripts/deploy.sh
+++ b/voc-datalake/frontend/scripts/deploy.sh
@@ -113,9 +113,24 @@ jq -n \
 echo "  ✓ config.json generated with CloudFormation values"
 
 # Step 4: Sync to S3
+#
+# Cache-Control is split by mutability (issue #188): Vite's /assets/* are
+# content-hashed, so they can cache forever — but everything with a STABLE
+# name (index.html, config.json, locales/**, manifests) must revalidate on
+# every load. Without this, browsers heuristically cache the old locale
+# JSONs across deploys and the new JS bundle renders raw i18n keys
+# (nav.home, home.title, ...) until a hard refresh. CloudFront invalidation
+# can't fix that: the staleness lives in the browser cache.
 echo ""
 echo "Step 5: Syncing to S3..."
-aws s3 sync dist/ "s3://${BUCKET_NAME}" --delete
+# Hashed, immutable assets: cache for a year.
+aws s3 sync dist/assets/ "s3://${BUCKET_NAME}/assets" --delete \
+  --cache-control 'public,max-age=31536000,immutable'
+# Everything else (stable names): always revalidate. ETags make this cheap
+# (304s), and no visitor ever holds a stale config/locale/index again.
+aws s3 sync dist/ "s3://${BUCKET_NAME}" --delete \
+  --exclude 'assets/*' \
+  --cache-control 'no-cache'
 
 # Step 5: Invalidate CloudFront cache
 echo ""

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
@@ -22,8 +22,9 @@ import type { Category, Subcategory } from './CategoriesManager'
 
 /** Slug of a name for derived ids: lowercase, non-alphanumerics collapsed
  * to underscores, trimmed — 'billing/refunds' → 'billing_refunds'.
- * split/filter/join strips leading/trailing separators without the
- * backtracking-prone /^_+|_+$/ anchors (sonarjs/slow-regex). */
+ * split/filter/join instead of trim anchors (/^_+|_+$/): that regex is
+ * actually linear-time, but sonarjs/slow-regex conservatively flags the
+ * alternation, and the imperative form is just as clear. */
 function slugify(name: string): string {
   return name
     .trim()

--- a/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
+++ b/voc-datalake/frontend/src/components/CategoriesManager/categoriesSchema.ts
@@ -21,9 +21,17 @@ import { z } from 'zod'
 import type { Category, Subcategory } from './CategoriesManager'
 
 /** Slug of a name for derived ids: lowercase, non-alphanumerics collapsed
- * to underscores, trimmed — 'billing/refunds' → 'billing_refunds'. */
+ * to underscores, trimmed — 'billing/refunds' → 'billing_refunds'.
+ * split/filter/join strips leading/trailing separators without the
+ * backtracking-prone /^_+|_+$/ anchors (sonarjs/slow-regex). */
 function slugify(name: string): string {
-  return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .split('_')
+    .filter(Boolean)
+    .join('_')
 }
 
 /**

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -218,16 +218,6 @@ export class VocCoreStack extends cdk.Stack {
     });
     this.prototypesCdnUrl = `https://${this.frontendDomainName}/prototypes`;
 
-    // Acknowledged wildcard-key-policy warning (issue #189): the synthesized
-    // KMS condition is already scoped to THIS ACCOUNT's distributions
-    // (arn:...:cloudfront::ACCOUNT:distribution/*); scoping to the concrete
-    // distribution id would create exactly the circular dependency the
-    // warning describes, and the CDK README documents the wildcard as the
-    // supported shape. The ack must come AFTER the last
-    // withOriginAccessControl() call — each origin re-emits the warning, and
-    // acknowledgeWarning only strips messages added before it runs.
-    cdk.Annotations.of(this).acknowledgeWarning('@aws-cdk/aws-cloudfront-origins:wildcardKeyPolicyForOac');
-
     // ============================================
     // DYNAMODB TABLES
     // ============================================
@@ -694,6 +684,17 @@ export class VocCoreStack extends cdk.Stack {
       value: initialAdminPassword, 
       description: 'Initial admin user password (username: admin)'
     });
+
+    // Acknowledged wildcard-key-policy warning (issue #189): the synthesized
+    // KMS condition is already scoped to THIS ACCOUNT's distributions
+    // (arn:...:cloudfront::ACCOUNT:distribution/*); scoping to the concrete
+    // distribution id would create exactly the circular dependency the
+    // warning describes, and the CDK README documents the wildcard as the
+    // supported shape. Kept as the LAST statement of the constructor:
+    // every withOriginAccessControl() call re-emits the warning, and
+    // acknowledgeWarning only strips messages added before it runs — an
+    // origin added below the ack would silently re-break warning-free synth.
+    cdk.Annotations.of(this).acknowledgeWarning('@aws-cdk/aws-cloudfront-origins:wildcardKeyPolicyForOac');
   }
 
   private getCustomMessageLambdaCode(signInUrl: string): string {

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -185,7 +185,6 @@ export class VocCoreStack extends cdk.Stack {
       compress: true,
       cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
     });
-    cdk.Annotations.of(this).acknowledgeWarning('@aws-cdk/aws-cloudfront-origins:wildcardKeyPolicyForOac');
     this.avatarsCdnUrl = `https://${this.frontendDomainName}/avatars`;
 
     // Prototypes served from the same distribution under /prototypes/* with their
@@ -218,6 +217,16 @@ export class VocCoreStack extends cdk.Stack {
       responseHeadersPolicy: prototypeHeadersPolicy,
     });
     this.prototypesCdnUrl = `https://${this.frontendDomainName}/prototypes`;
+
+    // Acknowledged wildcard-key-policy warning (issue #189): the synthesized
+    // KMS condition is already scoped to THIS ACCOUNT's distributions
+    // (arn:...:cloudfront::ACCOUNT:distribution/*); scoping to the concrete
+    // distribution id would create exactly the circular dependency the
+    // warning describes, and the CDK README documents the wildcard as the
+    // supported shape. The ack must come AFTER the last
+    // withOriginAccessControl() call — each origin re-emits the warning, and
+    // acknowledgeWarning only strips messages added before it runs.
+    cdk.Annotations.of(this).acknowledgeWarning('@aws-cdk/aws-cloudfront-origins:wildcardKeyPolicyForOac');
 
     // ============================================
     // DYNAMODB TABLES

--- a/voc-datalake/package-lock.json
+++ b/voc-datalake/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
-        "aws-cdk-lib": "^2.241.0",
+        "aws-cdk": "^2.1131.0",
+        "aws-cdk-lib": "^2.261.0",
         "cdk-nag": "^2.37.55",
         "constructs": "^10.4.3",
         "ts-node": "^10.9.2",
@@ -22,23 +23,23 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "54.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.11.0.tgz",
+      "integrity": "sha512-qpkGINVp8CIaXXkEX5sPmARPk8bbvCFXhMHm/Nmae3K3V+OzDVthntuFVwGxl/jzfdrKPIhbkE9Mrxk+f1mK3A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -46,15 +47,15 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -63,7 +64,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -680,10 +681,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/aws-cdk": {
+      "version": "2.1131.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1131.0.tgz",
+      "integrity": "sha512-02oAVG4IBFwPtPlDE95H8tDJFfDuxJLdvyrdav6rn72mup/LIZRCfp95IB9kfM+FL4vQ9gn/QCEI7y7aNDTpKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib": {
-      "version": "2.244.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.244.0.tgz",
-      "integrity": "sha512-j5FVeZv5W+v6j6OnW8RjoN04T+8pYvDJJV7yXhhj4IiGDKPgMH3fflQLQXJousd2QQk+nSAjghDVJcrZ4GFyGA==",
+      "version": "2.261.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.261.0.tgz",
+      "integrity": "sha512-e52e3Abjg0HkuRWlWwtSv5+ZiMW1rhCDdL9ff7lzWXInU8xdfLJpuoimfa0IJwjiNGyphppgg52Azx9M80OA0g==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -694,28 +708,26 @@
         "minimatch",
         "punycode",
         "semver",
-        "table",
         "yaml",
         "mime-types"
       ],
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
-        "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "semver": "^7.8.1",
+        "yaml": "1.10.3"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -725,44 +737,19 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.5",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -770,55 +757,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -830,7 +768,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -850,54 +788,8 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -925,23 +817,8 @@
         "node": ">= 4"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -960,12 +837,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -989,12 +860,12 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1012,17 +883,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1031,65 +893,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
@@ -1102,7 +905,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -45,7 +45,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.3",
-    "aws-cdk-lib": "^2.241.0",
+    "aws-cdk": "^2.1131.0",
+    "aws-cdk-lib": "^2.261.0",
     "cdk-nag": "^2.37.55",
     "constructs": "^10.4.3",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
Fixes #188, fixes #189

Two deployment-path fixes found while operating the live environment, one commit each.

## 1. Raw i18n keys after redeploys (#188) — the user-visible bug

After deploying six weeks of changes, returning browsers rendered raw keys (`nav.home`, `home.title`, `home.phase1Desc`, ...) on the new Home page. Root cause: `deploy.sh` ran `aws s3 sync` with **no Cache-Control**, so browsers heuristically cached the stable-name files. The hash-busted JS updates instantly, then requests NEW translation keys from a STALE cached locale JSON. CloudFront invalidation can't help — the staleness is in the browser.

Fix: split the sync by mutability —
- `dist/assets/*` (content-hashed): `public,max-age=31536000,immutable`
- everything else (index.html, config.json, locales/**, manifests): `no-cache` (ETag revalidation, cheap 304s, never stale)

The second sync `--exclude 'assets/*'` so the two passes compose safely with `--delete`. **Deployed and verified live**: `curl -I` shows `no-cache` on locale/config/index and `immutable` on hashed assets.

## 2. Warning-free synth/deploy (#189)

| Warning | Fix |
|---|---|
| `GrantOnPrincipalOptions#scope is deprecated` | Fired inside aws-cdk-lib 2.241 internals (no repo code passes `scope`). Upgraded to `^2.261` + CLI 2.1131 (assembly schema 54). Live diff was benign: CDK-managed helper Lambdas nodejs22→24, one internal policy rename. Deployed to all four stacks. |
| KMS wildcard key policy | The existing `acknowledgeWarning` didn't work: **each `withOriginAccessControl()` re-emits the warning, and the ack only strips messages added before it runs** — the `/prototypes/*` origin sat after the old ack line. Moved the ack after the last origin with a rationale comment (condition already account-scoped; a concrete distribution id recreates the circular dependency the warning describes). |
| `defaultCrossStackReferences` advisory (new in 2.261) | Pinned `'strong'` in cdk.json per the advisory's lock-in option — preserves current producer-protecting behavior for the existing cross-stack refs. |

Also: the refreshed sonarjs eslint plugin began flagging `categoriesSchema.ts`'s `/^_+|_+$/` trim regex (`slow-regex`), breaking the root lint gate — replaced with split/filter/join; behavior pinned unchanged by the existing 49 schema tests.

Note: the `#0 building with desktop-linux...` lines in deploy output are normal Docker BuildKit progress from asset bundling, not warnings; likewise pip's boto3/botocore notice comes from the layer build image, predates these changes, and doesn't affect the layer contents.

## Verification

- `cdk synth` of all four stacks: **zero warnings** (was three)
- All four stacks deployed `UPDATE_COMPLETE` on the live environment; site 200, authenticated API 200 post-deploy
- `npm run check` exits 0; CDK suite 36/36; CategoriesManager suite 49/49