### PR TITLE
fix(i18n): version-stamped locale URLs bust pre-#188 browser caches

### DIFF
--- a/voc-datalake/frontend/src/i18n/config.ts
+++ b/voc-datalake/frontend/src/i18n/config.ts
@@ -11,6 +11,7 @@ import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
+import { LOCALE_LOAD_PATH } from './loadPath'
 
 export const supportedLanguages = ['en', 'es', 'fr', 'de', 'pt', 'ja', 'zh', 'ko'] as const
 export type SupportedLanguage = (typeof supportedLanguages)[number]
@@ -49,7 +50,9 @@ void i18n
     defaultNS,
     ns: [...namespaces],
 
-    backend: { loadPath: '/locales/{{lng}}/{{ns}}.json' },
+    // Version-stamped path — see i18n/loadPath.ts for the cache-busting
+    // rationale (issue #191).
+    backend: { loadPath: LOCALE_LOAD_PATH },
 
     detection: {
       // 'navigator' is intentionally omitted so a non-English browser doesn't

--- a/voc-datalake/frontend/src/i18n/loadPath.test.ts
+++ b/voc-datalake/frontend/src/i18n/loadPath.test.ts
@@ -14,8 +14,8 @@ describe('LOCALE_LOAD_PATH (issue #191)', () => {
   })
 
   it('is version-stamped so stale cache entries can never match', () => {
-    // vitest.config.ts defines __APP_VERSION__ as 'test'; production builds
-    // stamp a per-build id via vite.config.ts define.
-    expect(LOCALE_LOAD_PATH).toBe('/locales/{{lng}}/{{ns}}.json?v=test')
+    // Shape assertion survives a change of the injected test literal;
+    // vitest.config.ts currently defines APP_VERSION as 'test'.
+    expect(LOCALE_LOAD_PATH).toMatch(/\?v=.+$/)
   })
 })

--- a/voc-datalake/frontend/src/i18n/loadPath.test.ts
+++ b/voc-datalake/frontend/src/i18n/loadPath.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Regression tests for issue #191: pre-#188 browser caches hold locale
+ * JSONs with heuristic freshness and serve them for days without a network
+ * request, so new bundles rendered raw i18n keys for translations added
+ * since. The loadPath must be version-stamped so each build requests URLs
+ * no stale cache entry can match.
+ */
+import { describe, it, expect } from 'vitest'
+import { LOCALE_LOAD_PATH } from './loadPath'
+
+describe('LOCALE_LOAD_PATH (issue #191)', () => {
+  it('keeps the i18next language/namespace placeholders', () => {
+    expect(LOCALE_LOAD_PATH).toContain('/locales/{{lng}}/{{ns}}.json')
+  })
+
+  it('is version-stamped so stale cache entries can never match', () => {
+    // vitest.config.ts defines __APP_VERSION__ as 'test'; production builds
+    // stamp a per-build id via vite.config.ts define.
+    expect(LOCALE_LOAD_PATH).toBe('/locales/{{lng}}/{{ns}}.json?v=test')
+  })
+})

--- a/voc-datalake/frontend/src/i18n/loadPath.ts
+++ b/voc-datalake/frontend/src/i18n/loadPath.ts
@@ -15,12 +15,17 @@
  * @module i18n/loadPath
  */
 
-/** Build id injected by Vite `define` (vite.config.ts / vitest.config.ts).
- * Declared here rather than in a .d.ts because the root .gitignore
+/** Build id injected by Vite `define` (vite.config.ts / vitest.config.ts),
+ * namespaced under import.meta.env so the substitution can't collide with
+ * user identifiers. This `declare global` augmentation is project-wide by
+ * nature (any module reading import.meta.env.APP_VERSION gets the type);
+ * it lives here rather than in vite-env.d.ts because the root .gitignore
  * excludes all *.d.ts files (build-emitted declarations). */
 declare global {
-  const APP_VERSION: string
+  interface ImportMetaEnv {
+    readonly APP_VERSION: string
+  }
 }
 
 /** i18next-http-backend loadPath, cache-busted per build. */
-export const LOCALE_LOAD_PATH = `/locales/{{lng}}/{{ns}}.json?v=${APP_VERSION}`
+export const LOCALE_LOAD_PATH = `/locales/{{lng}}/{{ns}}.json?v=${import.meta.env.APP_VERSION}`

--- a/voc-datalake/frontend/src/i18n/loadPath.ts
+++ b/voc-datalake/frontend/src/i18n/loadPath.ts
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Version-stamped locale load path (issue #191).
+ *
+ * Browsers that cached the locale JSONs before #188 set Cache-Control hold
+ * copies with heuristic freshness (~10% of object age — days, for files
+ * last deployed weeks earlier) and serve them without any network request,
+ * so the hash-busted JS bundle renders raw i18n keys for translations
+ * added since. Stamping the URL with the build id means each new bundle
+ * requests URLs no stale cache entry can match. config.json doesn't need
+ * this: runtimeConfig fetches it with cache: 'no-store'.
+ *
+ * Kept in its own side-effect-free module so tests can pin the URL shape
+ * without importing config.ts (which initializes the i18next singleton).
+ *
+ * @module i18n/loadPath
+ */
+
+/** Build id injected by Vite `define` (vite.config.ts / vitest.config.ts).
+ * Declared here rather than in a .d.ts because the root .gitignore
+ * excludes all *.d.ts files (build-emitted declarations). */
+declare global {
+  const APP_VERSION: string
+}
+
+/** i18next-http-backend loadPath, cache-busted per build. */
+export const LOCALE_LOAD_PATH = `/locales/{{lng}}/{{ns}}.json?v=${APP_VERSION}`

--- a/voc-datalake/frontend/vite.config.ts
+++ b/voc-datalake/frontend/vite.config.ts
@@ -1,7 +1,7 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { dirname, isAbsolute, join } from 'node:path'
 import { defineConfig } from 'vite'
 
 /**
@@ -9,22 +9,57 @@ import { defineConfig } from 'vite'
  * Derived from the git HEAD commit so identical source produces identical
  * bundles — a content-neutral redeploy keeps clients cache-warm, and
  * post-#188 no-cache headers cover same-sha freshness regardless.
- * Read straight from .git (no child process: sonarjs/no-os-command-from-path
- * bans PATH-resolved commands, and fs is faster anyway). Falls back to a
- * timestamp when .git is absent (CI tarballs) or the ref is packed.
+ *
+ * Resolution order: CI-provided sha env vars, then .git (read via fs —
+ * sonarjs/no-os-command-from-path bans PATH-resolved commands, and fs is
+ * faster than spawning git), then a timestamp. Handles ref indirection,
+ * detached HEAD, packed refs (fresh clones pack refs, so CI would
+ * otherwise always hit the fallback), and worktree/submodule `.git`
+ * files (gitdir: indirection).
+ *
+ * Known trade-off: a dirty working tree stamps the clean HEAD sha
+ * (dirty detection needs `git status`, which the lint rule above bans).
+ * Deploys are expected to come from committed trees, and #188's
+ * no-cache headers keep same-sha fetches revalidating regardless.
  */
 function buildId(): string {
+  const ciSha = process.env.GITHUB_SHA ?? process.env.CODEBUILD_RESOLVED_SOURCE_VERSION
+  if (ciSha !== undefined && ciSha !== '') return ciSha.slice(0, 7)
   try {
-    const gitDir = findUp('.git')
+    const gitDir = resolveGitDir()
     if (gitDir === null) return `${Date.now()}`
     const head = readFileSync(join(gitDir, 'HEAD'), 'utf8').trim()
     if (!head.startsWith('ref: ')) return head.slice(0, 7) // detached HEAD
-    const refPath = join(gitDir, head.slice(5))
-    if (!existsSync(refPath)) return `${Date.now()}` // packed ref — punt
-    return readFileSync(refPath, 'utf8').trim().slice(0, 7)
+    const sha = resolveRef(gitDir, head.slice(5))
+    return sha !== null ? sha.slice(0, 7) : `${Date.now()}`
   } catch {
     return `${Date.now()}`
   }
+}
+
+/** Locate the actual git directory: find-up for `.git`, following the
+ * `gitdir: <path>` indirection used by worktrees and submodules. */
+function resolveGitDir(): string | null {
+  const found = findUp('.git')
+  if (found === null) return null
+  if (statSync(found).isDirectory()) return found
+  const content = readFileSync(found, 'utf8').trim()
+  if (!content.startsWith('gitdir: ')) return null
+  const target = content.slice(8)
+  return isAbsolute(target) ? target : join(dirname(found), target)
+}
+
+/** Resolve a symbolic ref to a sha: loose ref file first, then packed-refs
+ * (fresh clones pack their refs — lines are `<sha> <ref>`). */
+function resolveRef(gitDir: string, ref: string): string | null {
+  const loose = join(gitDir, ref)
+  if (existsSync(loose)) return readFileSync(loose, 'utf8').trim()
+  const packedPath = join(gitDir, 'packed-refs')
+  if (!existsSync(packedPath)) return null
+  const line = readFileSync(packedPath, 'utf8')
+    .split('\n')
+    .find((entry) => !entry.startsWith('#') && !entry.startsWith('^') && entry.endsWith(` ${ref}`))
+  return line !== undefined ? line.split(' ')[0] : null
 }
 
 /** Walk up from cwd looking for a directory entry (monorepo: .git lives two levels up). */

--- a/voc-datalake/frontend/vite.config.ts
+++ b/voc-datalake/frontend/vite.config.ts
@@ -1,24 +1,42 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { defineConfig } from 'vite'
 
 /**
  * Build id for cache-busting runtime-fetched locale JSONs (issue #191).
- * Derived from the git commit (plus a -dirty marker for uncommitted trees)
- * so identical source produces identical bundles — a content-neutral
- * redeploy keeps clients cache-warm. Post-#188 fetches revalidate via
- * no-cache headers regardless, so a same-sha deploy loses nothing.
- * Falls back to a timestamp where git isn't available (CI tarballs).
+ * Derived from the git HEAD commit so identical source produces identical
+ * bundles — a content-neutral redeploy keeps clients cache-warm, and
+ * post-#188 no-cache headers cover same-sha freshness regardless.
+ * Read straight from .git (no child process: sonarjs/no-os-command-from-path
+ * bans PATH-resolved commands, and fs is faster anyway). Falls back to a
+ * timestamp when .git is absent (CI tarballs) or the ref is packed.
  */
 function buildId(): string {
   try {
-    const sha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
-    const dirty = execSync('git status --porcelain', { encoding: 'utf8' }).trim() !== ''
-    return dirty ? `${sha}-dirty` : sha
+    const gitDir = findUp('.git')
+    if (gitDir === null) return `${Date.now()}`
+    const head = readFileSync(join(gitDir, 'HEAD'), 'utf8').trim()
+    if (!head.startsWith('ref: ')) return head.slice(0, 7) // detached HEAD
+    const refPath = join(gitDir, head.slice(5))
+    if (!existsSync(refPath)) return `${Date.now()}` // packed ref — punt
+    return readFileSync(refPath, 'utf8').trim().slice(0, 7)
   } catch {
     return `${Date.now()}`
   }
+}
+
+/** Walk up from cwd looking for a directory entry (monorepo: .git lives two levels up). */
+function findUp(name: string): string | null {
+  const step = (dir: string, depth: number): string | null => {
+    const candidate = join(dir, name)
+    if (existsSync(candidate)) return candidate
+    const parent = dirname(dir)
+    if (parent === dir || depth >= 6) return null
+    return step(parent, depth + 1)
+  }
+  return step(process.cwd(), 0)
 }
 
 export default defineConfig({

--- a/voc-datalake/frontend/vite.config.ts
+++ b/voc-datalake/frontend/vite.config.ts
@@ -1,16 +1,34 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
+import { execSync } from 'node:child_process'
 import { defineConfig } from 'vite'
+
+/**
+ * Build id for cache-busting runtime-fetched locale JSONs (issue #191).
+ * Derived from the git commit (plus a -dirty marker for uncommitted trees)
+ * so identical source produces identical bundles — a content-neutral
+ * redeploy keeps clients cache-warm. Post-#188 fetches revalidate via
+ * no-cache headers regardless, so a same-sha deploy loses nothing.
+ * Falls back to a timestamp where git isn't available (CI tarballs).
+ */
+function buildId(): string {
+  try {
+    const sha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
+    const dirty = execSync('git status --porcelain', { encoding: 'utf8' }).trim() !== ''
+    return dirty ? `${sha}-dirty` : sha
+  } catch {
+    return `${Date.now()}`
+  }
+}
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
     global: 'globalThis',
-    // Build id stamped into runtime-fetched URLs (/config.json, locale
-    // JSONs) so each new bundle requests URLs no stale browser-cache entry
-    // can match (issue #191). The JS bundle itself is hash-busted, so the
-    // stamp always travels with fresh code.
-    APP_VERSION: JSON.stringify(`${Date.now()}`),
+    // Namespaced under import.meta.env: a bare identifier define would be
+    // replaced ANYWHERE the identifier appears in source (Vite does
+    // identifier-level substitution), silently corrupting unrelated code.
+    'import.meta.env.APP_VERSION': JSON.stringify(buildId()),
   },
   build: {
     rollupOptions: {

--- a/voc-datalake/frontend/vite.config.ts
+++ b/voc-datalake/frontend/vite.config.ts
@@ -4,7 +4,14 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  define: { global: 'globalThis' },
+  define: {
+    global: 'globalThis',
+    // Build id stamped into runtime-fetched URLs (/config.json, locale
+    // JSONs) so each new bundle requests URLs no stale browser-cache entry
+    // can match (issue #191). The JS bundle itself is hash-busted, so the
+    // stamp always travels with fresh code.
+    APP_VERSION: JSON.stringify(`${Date.now()}`),
+  },
   build: {
     rollupOptions: {
       output: {

--- a/voc-datalake/frontend/vite.config.ts
+++ b/voc-datalake/frontend/vite.config.ts
@@ -50,16 +50,29 @@ function resolveGitDir(): string | null {
 }
 
 /** Resolve a symbolic ref to a sha: loose ref file first, then packed-refs
- * (fresh clones pack their refs — lines are `<sha> <ref>`). */
+ * (fresh clones pack their refs — lines are `<sha> <ref>`). Linked
+ * worktrees keep HEAD in their private gitdir but refs/packed-refs in the
+ * COMMON dir (the `commondir` file points there), so refs resolve against
+ * that base when present. */
 function resolveRef(gitDir: string, ref: string): string | null {
-  const loose = join(gitDir, ref)
+  const refsBase = refsBaseDir(gitDir)
+  const loose = join(refsBase, ref)
   if (existsSync(loose)) return readFileSync(loose, 'utf8').trim()
-  const packedPath = join(gitDir, 'packed-refs')
+  const packedPath = join(refsBase, 'packed-refs')
   if (!existsSync(packedPath)) return null
   const line = readFileSync(packedPath, 'utf8')
     .split('\n')
     .find((entry) => !entry.startsWith('#') && !entry.startsWith('^') && entry.endsWith(` ${ref}`))
   return line !== undefined ? line.split(' ')[0] : null
+}
+
+/** Base directory for refs: the worktree common dir when `commondir`
+ * exists, otherwise the gitdir itself. */
+function refsBaseDir(gitDir: string): string {
+  const commonDirFile = join(gitDir, 'commondir')
+  if (!existsSync(commonDirFile)) return gitDir
+  const target = readFileSync(commonDirFile, 'utf8').trim()
+  return isAbsolute(target) ? target : join(gitDir, target)
 }
 
 /** Walk up from cwd looking for a directory entry (monorepo: .git lives two levels up). */

--- a/voc-datalake/frontend/vite.config.ts
+++ b/voc-datalake/frontend/vite.config.ts
@@ -23,8 +23,9 @@ import { defineConfig } from 'vite'
  * no-cache headers keep same-sha fetches revalidating regardless.
  */
 function buildId(): string {
-  const ciSha = process.env.GITHUB_SHA ?? process.env.CODEBUILD_RESOLVED_SOURCE_VERSION
-  if (ciSha !== undefined && ciSha !== '') return ciSha.slice(0, 7)
+  const ciSha = [process.env.GITHUB_SHA, process.env.CODEBUILD_RESOLVED_SOURCE_VERSION]
+    .find((value) => value !== undefined && value !== '')
+  if (ciSha !== undefined) return ciSha.slice(0, 7)
   try {
     const gitDir = resolveGitDir()
     if (gitDir === null) return `${Date.now()}`

--- a/voc-datalake/frontend/vitest.config.ts
+++ b/voc-datalake/frontend/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   define: {
     // Mirror vite.config.ts's build-id stamp (issue #191) — a stable value
     // in tests so assertions on versioned URLs are deterministic.
-    APP_VERSION: JSON.stringify('test'),
+    'import.meta.env.APP_VERSION': JSON.stringify('test'),
   },
   test: {
     globals: true,

--- a/voc-datalake/frontend/vitest.config.ts
+++ b/voc-datalake/frontend/vitest.config.ts
@@ -4,6 +4,11 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    // Mirror vite.config.ts's build-id stamp (issue #191) — a stable value
+    // in tests so assertions on versioned URLs are deterministic.
+    APP_VERSION: JSON.stringify('test'),
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
Fixes #191

## Problem (observed live after #188)

Raw i18n keys (`home.phase3Title`, `home.phase3Desc`) still rendered on the deployment for returning sessions. #188's Cache-Control headers were correct at the CDN — verified: the deployed `dashboard.json` carried all 15 `home.*` keys — but a header only governs fetches that reach the server. Browsers that cached the JSONs **before** #188 hold copies with no Cache-Control and heuristic freshness of ~10% of object age (days, for files last deployed six weeks prior), served without any network request. The hash-busted JS updates instantly and asks a stale JSON for keys that didn't exist when it was cached.

## Fix

Version-stamp the locale URLs from the always-fresh bundle:

- `i18n/loadPath.ts` (new, side-effect-free so tests don't boot the i18next singleton): `LOCALE_LOAD_PATH = '/locales/{{lng}}/{{ns}}.json?v=' + APP_VERSION`
- `APP_VERSION` injected by Vite `define` (`Date.now()` at build); vitest defines `'test'` for deterministic assertions
- `declare global` lives in `loadPath.ts` itself — the conventional `vite-env.d.ts` is blocked by the root `.gitignore`'s blanket `*.d.ts` rule, and the dunder `__APP_VERSION__` name is rejected by the repo's naming-convention lint (both discovered the hard way)
- `config.json` needs nothing — `runtimeConfig.ts` already fetches it with `cache: 'no-store'`

Old cache entries keyed on the un-versioned URL can never match a versioned request, so this retroactively unbricks every pre-#188 browser — belt-and-braces with #188's headers going forward.

## Verification (live)

- Fresh session on d7afw1xf9irnt.cloudfront.net: every locale request carries `?v=<build-id>` (network log), Home renders translated text, zero raw keys in the DOM
- Production bundle grep confirms the stamped path is baked in
- `npm run check` exits 0; `loadPath.test.ts` pins the placeholder shape and the version stamp