### PR TITLE
docs: refresh everything the session made stale

### DIFF
--- a/.kiro/steering/bedrock-ai.md
+++ b/.kiro/steering/bedrock-ai.md
@@ -32,7 +32,12 @@ write and read back as Automatic if tampered.
 | Feedback enrichment (processor) | Claude Haiku 4.5 |
 | Utilities (category suggestions, selector detection) | Claude Sonnet 5 |
 
-### Allowlist (verify ids against `model_config.py`, not memory)
+### Allowlist
+
+Copied verbatim from `lambda/shared/model_config.py` (`ALLOWED_MODELS`,
+lines ~56-86) — that file and `lib/utils/model-allowlist.ts` are the
+source of truth (a lockstep test pins them to each other). Three ids are
+genuinely unsuffixed; only Haiku carries a dated suffix:
 
 ```
 global.anthropic.claude-sonnet-5

--- a/.kiro/steering/bedrock-ai.md
+++ b/.kiro/steering/bedrock-ai.md
@@ -1,59 +1,84 @@
 ---
 inclusion: auto
 name: bedrock-ai
-description: Bedrock AI model standards, Claude Sonnet usage patterns, LLM inference, prompt design, and Anthropic model invocation.
+description: Bedrock AI model standards, Claude model resolution, LLM inference, prompt design, and Anthropic model invocation.
 ---
 
 # Bedrock AI Model Standards
 
-## Default Model
+## Model Resolution (per-surface picker, issue #96 / PR #166)
 
-Always use **Claude Sonnet 4.5** via the global cross-region inference profile for all AI/LLM operations:
+Model ids are NOT hardcoded at call sites. Every AI surface resolves its
+model through `lambda/shared/model_config.py` (TS mirror for the streaming
+Lambda: `lambda/stream/src/lib/model-override.ts`):
 
 ```
-global.anthropic.claude-sonnet-4-5-20250929-v1:0
+explicit arg > per-surface admin override > legacy global model_id
+    > surface default > BEDROCK_MODEL_ID env
 ```
+
+Admins pick models per surface in Settings → AI Models (`GET/PUT
+/settings/model`, stored in aggregates under `SETTINGS#model`, PUT is
+admin-gated server-side). Overrides are validated against the allowlist on
+write and read back as Automatic if tampered.
+
+### Surface defaults
+
+| Surface | Default |
+|---|---|
+| AI Chat / streaming / project chat | Claude Sonnet 5 |
+| Document generation (PRD, PR/FAQ, personas, research) | Claude Sonnet 5 |
+| Prototype builder | Claude Opus 4.8 |
+| Feedback enrichment (processor) | Claude Haiku 4.5 |
+| Utilities (category suggestions, selector detection) | Claude Sonnet 5 |
+
+### Allowlist (verify ids against `model_config.py`, not memory)
+
+```
+global.anthropic.claude-sonnet-5
+global.anthropic.claude-sonnet-4-6
+global.anthropic.claude-opus-4-8
+global.anthropic.claude-haiku-4-5-20251001-v1:0
+```
+
+## Capability-aware invocation
+
+`shared/converse.py` and the streaming client drop unsupported fields per
+resolved model automatically: Sonnet 5 and Opus 4.8 reject `temperature`,
+and Sonnet 5 rejects an explicit thinking budget (adaptive thinking is
+always-on). Never pass those fields unconditionally — resolve the model
+first, then let the shared helpers shape the request.
 
 ## Usage Pattern
 
+Prefer the shared helpers (`shared/converse.py`) over raw client calls.
+When a raw call is unavoidable, resolve the model first:
+
 ```python
-import boto3
-import json
+from shared.model_config import get_active_model_id
 
-bedrock = boto3.client('bedrock-runtime')
-
-response = bedrock.invoke_model(
-    modelId='global.anthropic.claude-sonnet-4-5-20250929-v1:0',
-    contentType='application/json',
-    accept='application/json',
-    body=json.dumps({
-        'anthropic_version': 'bedrock-2023-05-31',
-        'max_tokens': 2048,
-        'system': 'Your system prompt here',
-        'messages': [
-            {'role': 'user', 'content': 'User message'}
-        ]
-    })
-)
-
-result = json.loads(response['body'].read())
-text = result['content'][0]['text']
+model_id = get_active_model_id(surface='utilities')
+response = bedrock.converse(modelId=model_id, ...)
 ```
 
 ## IAM Permissions
 
-Lambdas using Bedrock need this IAM permission:
+Grants are built from the single source of truth
+`lib/utils/model-allowlist.ts` (`allowlistedModelArns()`), which must stay
+in lockstep with `model_config.py`'s allowlist (a Python test asserts
+this). A model that is selectable but not invocable AccessDenies its
+surface — never grant a single hardcoded model id:
 
 ```typescript
+import { allowlistedModelArns } from '../utils/model-allowlist';
+
 lambda.addToRolePolicy(new iam.PolicyStatement({
-  actions: ['bedrock:InvokeModel'],
-  resources: [
-    `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`,
-  ],
+  actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+  resources: allowlistedModelArns(this.region, this.account),
 }));
 ```
 
-## Why Global Inference Profile?
+## Why Global Inference Profiles?
 
 - Cross-region availability and failover
 - Consistent model version across all regions

--- a/.kiro/steering/cdk-patterns.md
+++ b/.kiro/steering/cdk-patterns.md
@@ -163,7 +163,7 @@ Use least-privilege with specific actions:
 ```typescript
 // ✅ Good - specific actions with global inference profiles
 role.addToPolicy(new iam.PolicyStatement({
-  actions: ['bedrock:InvokeModel'],
+  actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
   resources: allowlistedModelArns(cdk.Aws.REGION, cdk.Aws.ACCOUNT_ID), // lib/utils/model-allowlist.ts — lockstep with model_config.py
 }));
 

--- a/.kiro/steering/cdk-patterns.md
+++ b/.kiro/steering/cdk-patterns.md
@@ -164,7 +164,7 @@ Use least-privilege with specific actions:
 // ✅ Good - specific actions with global inference profiles
 role.addToPolicy(new iam.PolicyStatement({
   actions: ['bedrock:InvokeModel'],
-  resources: [`arn:aws:bedrock:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0`],
+  resources: allowlistedModelArns(cdk.Aws.REGION, cdk.Aws.ACCOUNT_ID), // lib/utils/model-allowlist.ts — lockstep with model_config.py
 }));
 
 // ❌ Bad - too permissive

--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -103,30 +103,26 @@ def lambda_handler(event: dict, context: Any) -> dict:
     return processor.response()
 ```
 
-### Bedrock Invocation with Retry
+### Bedrock Invocation
+
+Never hardcode model ids — resolution goes through
+`shared/model_config.py` (the admin model picker's per-surface overrides
+apply automatically), and `shared/converse.py` shapes requests per model
+capability (Sonnet 5 / Opus 4.8 reject `temperature`; Sonnet 5 rejects an
+explicit thinking budget). Pass a `surface` and let the helper resolve:
 
 ```python
-BEDROCK_MODEL_ID = 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'
+from shared.converse import converse
 
 @tracer.capture_method
-def invoke_bedrock_llm(prompt: str) -> dict:
-    request_body = {
-        "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": 800,
-        "temperature": 0.1,
-        "system": SYSTEM_PROMPT,
-        "messages": [{"role": "user", "content": prompt}]
-    }
-    
-    response = bedrock_runtime.invoke_model(
-        modelId=BEDROCK_MODEL_ID,
-        body=json.dumps(request_body),
-        contentType='application/json',
-        accept='application/json'
+def invoke_bedrock_llm(prompt: str) -> str:
+    return converse(
+        prompt=prompt,
+        system_prompt=SYSTEM_PROMPT,
+        max_tokens=800,
+        surface='utilities',  # resolved via shared/model_config.py
+        step_name='my_feature',
     )
-    
-    response_body = json.loads(response['body'].read())
-    return json.loads(response_body['content'][0]['text'])
 ```
 
 ### Lambda Domain Isolation Pattern (MANDATORY)
@@ -148,7 +144,7 @@ AWS Lambda execution roles have a **20KB policy size limit**. When a single Lamb
 lambda/api/
 ├── metrics_handler.py       # /feedback/*, /metrics/* (read-only)
 ├── chat_handler.py          # /chat/*
-├── chat_stream_handler.py   # Streaming chat (Lambda Function URL)
+├── (streaming chat: lambda/stream — TypeScript, SSE at /chat/stream)
 ├── integrations_handler.py  # /integrations/*, /sources/*
 ├── scrapers_handler.py      # /scrapers/*
 ├── settings_handler.py      # /settings/*
@@ -165,7 +161,7 @@ lambda/api/
 |--------|---------|-----------------|
 | Metrics | `metrics_handler.py` | DynamoDB read (feedback, aggregates) |
 | Chat | `chat_handler.py` | DynamoDB RW (conversations), Bedrock |
-| Chat Stream | `chat_stream_handler.py` | DynamoDB read, Bedrock streaming |
+| Chat Stream | `lambda/stream` (TypeScript) | DynamoDB read, Bedrock streaming |
 | Integrations | `integrations_handler.py` | Secrets Manager, EventBridge |
 | Scrapers | `scrapers_handler.py` | Secrets Manager, Lambda invoke, Bedrock |
 | Settings | `settings_handler.py` | DynamoDB (aggregates), Bedrock |
@@ -179,7 +175,7 @@ lambda/api/
 1. Identify which domain the endpoint belongs to
 2. Add the route to the appropriate existing handler
 3. If creating a new domain, create a new `{domain}_handler.py` file
-4. Update `analytics-stack.ts` to create the Lambda and wire API Gateway routes
+4. Update `api-stack.ts` to create the Lambda and wire API Gateway routes
 5. Grant only the minimum required permissions
 
 **Example - Adding a new endpoint to existing domain:**
@@ -278,7 +274,7 @@ export class MyStack extends cdk.Stack {
 
 AWS Lambda execution roles have a **20KB policy size limit**. The CDK stack must create separate Lambdas for each domain with isolated permissions.
 
-**Current Lambda Architecture in `analytics-stack.ts`:**
+**Current Lambda Architecture in `api-stack.ts`:**
 
 ```typescript
 // 1. Metrics Lambda - read-only feedback/metrics queries
@@ -597,7 +593,7 @@ GET  /metrics/personas            # Persona breakdown
 
 # Chat
 POST /chat                        # AI chat endpoint
-POST /chat/stream                 # Streaming chat (via Lambda Function URL)
+POST /chat/stream                 # Streaming chat (SSE via API Gateway)
 
 # Scrapers
 GET  /scrapers                    # List scraper configs
@@ -685,14 +681,16 @@ aws cognito-idp initiate-auth \
 
 ### Manual Streaming API Test
 
-The streaming chat API uses a Lambda Function URL to bypass API Gateway's 29-second timeout:
+Streaming chat is SSE through API Gateway at `POST {api}/chat/stream`
+(the old SigV4 Lambda Function URL / `ChatStreamUrl` output no longer
+exists):
 
 ```bash
 # Get endpoints from CloudFormation
 CLIENT_ID=$(aws cloudformation describe-stacks --stack-name VocCoreStack \
   --query 'Stacks[0].Outputs[?OutputKey==`UserPoolClientId`].OutputValue' --output text)
-STREAM_URL=$(aws cloudformation describe-stacks --stack-name VocApiStack \
-  --query 'Stacks[0].Outputs[?OutputKey==`ChatStreamUrl`].OutputValue' --output text)
+API_URL=$(aws cloudformation describe-stacks --stack-name VocApiStack \
+  --query 'Stacks[0].Outputs[?OutputKey==`ApiEndpoint`].OutputValue' --output text)
 
 # Get Cognito token (use single quotes for password with !)
 # Note: Create test user first with aws cognito-idp admin-create-user
@@ -703,9 +701,10 @@ TOKEN=$(aws cognito-idp initiate-auth \
   --query 'AuthenticationResult.IdToken' \
   --output text)
 
-# Test streaming API
-curl -X POST "$STREAM_URL/chat/stream" \
+# Test streaming API — expect SSE events (metadata, text..., done)
+curl -N -X POST "${API_URL}chat/stream" \
   -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"message":"hello"}'
 ```
@@ -714,6 +713,10 @@ curl -X POST "$STREAM_URL/chat/stream" \
 
 1. Build Lambda layers with Docker: `./scripts/build-layers.sh`
 2. Deploy stacks: `npx cdk deploy --all --context frontendDomain=<domain>`
+   — a clean synth/deploy prints **zero warnings**; treat new warnings as
+   regressions. Pre-#105 environments additionally need
+   `-c omitUserPoolUsernameConfiguration=true` (see docs/deployment.md
+   troubleshooting).
 3. Validate API endpoints: `./scripts/test-api.sh <api_url> "Bearer <token>"`
 4. Check Lambda logs if any endpoint fails: `aws logs tail /aws/lambda/<function-name> --since 5m`
 

--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -702,7 +702,7 @@ TOKEN=$(aws cognito-idp initiate-auth \
   --output text)
 
 # Test streaming API — expect SSE events (metadata, text..., done)
-curl -N -X POST "${API_URL}chat/stream" \
+curl -N -X POST "${API_URL%/}/chat/stream" \
   -H "Content-Type: application/json" \
   -H "Accept: text/event-stream" \
   -H "Authorization: Bearer $TOKEN" \

--- a/.kiro/steering/deployment.md
+++ b/.kiro/steering/deployment.md
@@ -72,9 +72,10 @@ The platform consists of 5 CDK stacks (consolidated architecture):
 |-------|-------------|--------------|
 | `VocCoreStack` | DynamoDB tables, KMS, S3 buckets, Cognito, CloudFront | None |
 | `VocIngestionStack` | Plugin Lambdas, EventBridge schedules, SQS, Secrets | Core |
-| `VocProcessingStackConsolidated` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
+| `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
-| `VocBedrockAccessStack` | Bedrock model access configuration | None |
+| `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case | None |
+| `VocWebSearchStack` (optional) | AgentCore web-search gateway — `-c enableWebSearch=true`, always us-east-1 | None |
 
 ### Deploy All Stacks
 
@@ -103,9 +104,9 @@ cdk deploy --all --require-approval never
 
 Due to dependencies, stacks should be deployed in this order:
 
-1. `VocCoreStack` + `VocBedrockAccessStack` (parallel, no dependencies)
+1. `VocCoreStack` (+ optional `BedrockAccessStack` / `VocWebSearchStack`, no dependencies)
 2. `VocIngestionStack`
-3. `VocProcessingStackConsolidated`
+3. `VocProcessingStack`
 4. `VocApiStack`
 
 The `cdk deploy --all` command handles this automatically.

--- a/.kiro/steering/deployment.md
+++ b/.kiro/steering/deployment.md
@@ -66,7 +66,7 @@ npm run check        # lint + typecheck + test
 
 ## CDK Stacks
 
-The platform consists of 5 CDK stacks (consolidated architecture):
+The platform consists of 4 core stacks plus 2 optional ones:
 
 | Stack | Description | Dependencies |
 |-------|-------------|--------------|

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -11,7 +11,9 @@ Voice of the Customer (VoC) Data Lake is a **fully serverless** AWS platform for
 - **Plugin architecture**: Modular data source connectors with manifest-based configuration and enable/disable via `cdk.context.json`
 - **Menu configuration**: Enable/disable dashboard menu items via `cdk.context.json`
 - **Webhook support**: Real-time ingestion via webhooks for plugins that support it
-- **LLM-powered analysis**: Amazon Bedrock (Claude Sonnet 4.5) for categorization, sentiment, persona inference, and root cause hypothesis
+- **LLM-powered analysis**: Amazon Bedrock (Claude; per-surface model picker, default Sonnet 5) for categorization, sentiment, persona inference, and root cause hypothesis
+- **Per-surface AI model picker**: admins choose the Claude model per AI surface in Settings (chat, documents, prototypes, enrichment, utilities) over a curated allowlist
+- **Opt-in public web search**: AgentCore Gateway connector for chat and research (deploy with `enableWebSearch: true`; UI hides the toggle when absent)
 - **Multi-language support**: Auto-detection via Comprehend, translation via Amazon Translate
 - **Real-time aggregation**: DynamoDB Streams trigger instant metric updates
 - **REST API**: Query feedback and analytics via API Gateway + Lambda

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -46,7 +46,7 @@ voice-of-customer-datalake/       # Root repository
     │   ├── api/                      # Split into domain-specific Lambdas (20KB IAM policy limit) - 15 handlers
     │   │   ├── metrics_handler.py        # /feedback/*, /metrics/* (read-only queries)
     │   │   ├── chat_handler.py           # /chat/* (conversations)
-    │   │   ├── chat_stream_handler.py    # Streaming chat (Lambda Function URL)
+    │   │   └── (streaming chat lives in lambda/stream — TypeScript, SSE at /chat/stream via API Gateway)
     │   │   ├── integrations_handler.py   # /integrations/*, /sources/* (credentials, schedules)
     │   │   ├── scrapers_handler.py       # /scrapers/* (web scraper management)
     │   │   ├── settings_handler.py       # /settings/* (brand, categories config)
@@ -303,11 +303,12 @@ VocCoreStack (DynamoDB tables, S3 raw data bucket, KMS, Cognito, CloudFront)
        │
        ├──▶ VocIngestionStack (Plugin Lambdas, EventBridge, SQS, Secrets)
        │           │
-       │           └──▶ VocProcessingStackConsolidated (Processor, Aggregator, Step Functions, Bedrock)
+       │           └──▶ VocProcessingStack (Processor, Aggregator, Step Functions, Bedrock)
        │
        ├──▶ VocApiStack (API Gateway, API Lambdas, Webhooks, WAF)
        │           │
        │           └── Depends on: processingQueue, secretsArn, researchStateMachine, userPool
        │
-       └──▶ VocBedrockAccessStack (Bedrock model access configuration)
+       ├──▶ BedrockAccessStack (optional: Bedrock model access / Anthropic use case)
+       └──▶ VocWebSearchStack (optional, us-east-1: AgentCore web-search gateway, -c enableWebSearch=true)
 ```

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -46,7 +46,6 @@ voice-of-customer-datalake/       # Root repository
     │   ├── api/                      # Split into domain-specific Lambdas (20KB IAM policy limit) - 15 handlers
     │   │   ├── metrics_handler.py        # /feedback/*, /metrics/* (read-only queries)
     │   │   ├── chat_handler.py           # /chat/* (conversations)
-    │   │   └── (streaming chat lives in lambda/stream — TypeScript, SSE at /chat/stream via API Gateway)
     │   │   ├── integrations_handler.py   # /integrations/*, /sources/* (credentials, schedules)
     │   │   ├── scrapers_handler.py       # /scrapers/* (web scraper management)
     │   │   ├── settings_handler.py       # /settings/* (brand, categories config)
@@ -65,6 +64,7 @@ voice-of-customer-datalake/       # Root repository
     │   │       ├── prd-generation.json
     │   │       ├── prfaq-generation.json
     │   │       └── research-analysis.json
+    │   ├── stream/                   # Streaming chat Lambda (TypeScript, esbuild) — SSE at /chat/stream via API Gateway
     │   └── layers/
     │       ├── ingestion-deps/       # Layer: requests, aws-lambda-powertools, beautifulsoup4
     │       └── processing-deps/      # Layer: aws-lambda-powertools
@@ -308,7 +308,8 @@ VocCoreStack (DynamoDB tables, S3 raw data bucket, KMS, Cognito, CloudFront)
        ├──▶ VocApiStack (API Gateway, API Lambdas, Webhooks, WAF)
        │           │
        │           └── Depends on: processingQueue, secretsArn, researchStateMachine, userPool
-       │
-       ├──▶ BedrockAccessStack (optional: Bedrock model access / Anthropic use case)
-       └──▶ VocWebSearchStack (optional, us-east-1: AgentCore web-search gateway, -c enableWebSearch=true)
+
+Optional stacks with NO dependency on the core chain:
+  BedrockAccessStack (Bedrock model access / Anthropic use case)
+  VocWebSearchStack (us-east-1: AgentCore web-search gateway, -c enableWebSearch=true)
 ```

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -3,7 +3,7 @@
 ## Infrastructure (AWS CDK)
 
 - **Language**: TypeScript
-- **CDK Version**: ^2.261.0 (CLI pinned as devDependency, assembly schema 54+)
+- **CDK Version**: ^2.261.0 per `voc-datalake/package.json` (CLI pinned as devDependency, assembly schema 54+)
 - **Runtime**: Node.js 18+
 - **Entry Point**: `bin/voc-datalake.ts`
 

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -3,7 +3,7 @@
 ## Infrastructure (AWS CDK)
 
 - **Language**: TypeScript
-- **CDK Version**: ^2.229.0
+- **CDK Version**: ^2.261.0 (CLI pinned as devDependency, assembly schema 54+)
 - **Runtime**: Node.js 18+
 - **Entry Point**: `bin/voc-datalake.ts`
 
@@ -21,7 +21,7 @@
 | **EventBridge** | Scheduled ingestion | Rate expressions (1-30 min) |
 | **Secrets Manager** | API credentials | Auto-rotation capable |
 | **KMS** | Encryption | Customer-managed key, key rotation |
-| **Bedrock** | LLM inference | Claude Sonnet 4.5 (global inference profile) |
+| **Bedrock** | LLM inference | Per-surface model picker (default Claude Sonnet 5; allowlist in `lib/utils/model-allowlist.ts`, resolution via `shared/model_config.py`) |
 | **Comprehend** | NLP | Sentiment, language detection, key phrases |
 | **Translate** | Multi-language | Auto language pair detection |
 | **Step Functions** | Long-running jobs | Research workflows, persona generation |
@@ -59,7 +59,7 @@ AWS Lambda execution roles have a **20KB policy size limit**. To stay under this
 | `voc-projects-api` | `projects_handler.py` | `/projects/*` | DynamoDB (projects, jobs, feedback), Step Functions, Bedrock, S3 |
 | `voc-users-api` | `users_handler.py` | `/users/*` | Cognito admin |
 | `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-form/*`, `/feedback-forms/*` | DynamoDB (aggregates), SQS |
-| `voc-chat-stream` | `chat_stream_handler.py` | Function URL (streaming) | DynamoDB read, Bedrock streaming |
+| `voc-chat-stream` | `lambda/stream` (TypeScript, esbuild-bundled) | `/chat/stream` SSE via API Gateway | DynamoDB read, Bedrock streaming |
 | `voc-data-explorer-api` | `data_explorer_handler.py` | `/data-explorer/*` | S3, DynamoDB (feedback) |
 | `voc-logs-api` | `logs_handler.py` | `/logs/*` | CloudWatch Logs read |
 | `voc-manual-import-api` | `manual_import_handler.py` | `/manual-import/*` | DynamoDB, SQS, S3 |
@@ -180,6 +180,24 @@ npm run generate:manifests  # Generate plugin manifests only
 npm run generate:menu       # Generate menu config only
 ```
 
+### Mock-only local dev notes
+
+- Without Cognito configured, DEV builds treat the session as an admin
+  (mirrors the ProtectedRoute/AdminRoute bypass; production fails closed) —
+  Settings, Users tab, and the AI Models card are all reachable locally.
+- The mock serves stateful fixtures for the full app surface, including
+  project detail (`/projects/proj_1`), the Product tab (context, interview,
+  docs upload, report jobs), user admin, scrapers, and feedback forms.
+  Several fixtures are deliberately sparse (legacy-shaped records) so the
+  Zod boundary normalizers stay exercised in dev — don't "fix" them to be
+  complete.
+- Wire-shape rule: components never trust runtime data to match declared
+  types. Every list/query boundary normalizes through a lenient Zod schema
+  (`formSchema.ts`, `scrapersSchema.ts`, `categoriesSchema.ts` are the
+  precedents), and crash-prone render sites carry belt-and-braces guards.
+  Route-level errors are contained by `RouteErrorBoundary` (one bad page
+  never blanks the app).
+
 ## Secrets Manager Structure
 
 ```json
@@ -198,4 +216,4 @@ npm run generate:menu       # Generate menu config only
 - **DynamoDB**: On-demand billing, TTL for old data
 - **S3**: Raw data archival, partitioned for cost-effective querying
 - **Lambda**: ARM64 (Graviton), right-size memory, reserved concurrency
-- **Bedrock**: Use Claude Sonnet 4.5, batch when possible
+- **Bedrock**: resolve models via `shared/model_config.py` (never hardcode ids); batch when possible

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -332,9 +332,9 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 
-from shared.model_config import get_active_model_id
 # Resolve INSIDE the code under test (module-level calls run at import time
 # and dodge test mocks/monkeypatching) — never hardcode ids:
+#   from shared.model_config import get_active_model_id
 #   model_id = get_active_model_id(surface='utilities')
 
 

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -332,7 +332,8 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 
-MODEL_ID = get_active_model_id(surface)  # shared/model_config.py — never hardcode ids
+from shared.model_config import get_active_model_id
+MODEL_ID = get_active_model_id(surface='utilities')  # never hardcode ids
 
 
 @pytest.fixture

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -333,7 +333,9 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from shared.model_config import get_active_model_id
-MODEL_ID = get_active_model_id(surface='utilities')  # never hardcode ids
+# Resolve INSIDE the code under test (module-level calls run at import time
+# and dodge test mocks/monkeypatching) — never hardcode ids:
+#   model_id = get_active_model_id(surface='utilities')
 
 
 @pytest.fixture

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -332,7 +332,7 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 
-BEDROCK_MODEL_ID = 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'
+MODEL_ID = get_active_model_id(surface)  # shared/model_config.py — never hardcode ids
 
 
 @pytest.fixture

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A fully serverless AWS platform for ingesting, processing, and analyzing custome
 
 - **Plugin-Based Architecture**: Extensible data source plugins, easily create your own
 - **AI-Powered Analysis**: Amazon Bedrock (Claude) for sentiment, categorization, and insights
+- **Per-Surface Model Picker**: admins choose the Claude model per AI feature (chat, documents, prototypes, enrichment) over a curated allowlist
+- **Opt-In Web Search**: AgentCore Gateway connector for chat and research (`enableWebSearch: true`)
 - **Real-Time Processing**: Event-driven with SQS and DynamoDB Streams
 - **Multi-Language Support**: Auto-detection and translation
 - **React Dashboard**: Metrics, charts, AI chat, and project management

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,7 +177,7 @@ The platform consists of 4 core stacks plus 2 optional ones:
 | `VocIngestionStack` | Plugin Lambdas, EventBridge schedules, SQS, Secrets | Core |
 | `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
-| `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case submission — created only when `anthropicUseCase` is set in `cdk.context.json` | None |
+| `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case submission — created only when `anthropicUseCase` is set in `cdk.context.json` (see the conditional in `bin/voc-datalake.ts`) | None |
 | `VocWebSearchStack` (optional) | AgentCore Gateway for public web search — opt-in via `enableWebSearch: true`; always deploys to us-east-1 (the connector only exists there) | None |
 
 ### Deploy All Stacks

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -169,15 +169,16 @@ Access is granted immediately after successful submission.
 
 ## CDK Stacks
 
-The platform consists of 5 CDK stacks:
+The platform consists of 4 core stacks plus 2 optional ones:
 
 | Stack | Description | Dependencies |
 |-------|-------------|--------------|
 | `VocCoreStack` | DynamoDB tables, KMS, S3 buckets, Cognito, CloudFront | None |
 | `VocIngestionStack` | Plugin Lambdas, EventBridge schedules, SQS, Secrets | Core |
-| `VocProcessingStackConsolidated` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
+| `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
-| `VocBedrockAccessStack` | Bedrock model access configuration | None |
+| `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case submission — created only when `anthropicUseCase` is set in `cdk.context.json` | None |
+| `VocWebSearchStack` (optional) | AgentCore Gateway for public web search — opt-in via `enableWebSearch: true`; always deploys to us-east-1 (the connector only exists there) | None |
 
 ### Deploy All Stacks
 
@@ -193,7 +194,7 @@ cd voc-datalake
 # Deploy specific stack
 cdk deploy VocCoreStack
 cdk deploy VocIngestionStack
-cdk deploy VocProcessingStackConsolidated
+cdk deploy VocProcessingStack
 cdk deploy VocApiStack
 
 # Deploy multiple stacks
@@ -203,16 +204,41 @@ cdk deploy VocCoreStack VocIngestionStack
 cdk deploy --all --require-approval never
 ```
 
+A clean `cdk synth`/`cdk deploy` prints **zero warnings** — treat any new
+warning as a regression to investigate rather than noise to ignore.
+
 ### Stack Deployment Order
 
 Due to dependencies, stacks should be deployed in this order:
 
-1. `VocCoreStack` + `VocBedrockAccessStack` (parallel, no dependencies)
+1. `VocCoreStack` (+ optional `BedrockAccessStack` / `VocWebSearchStack`, no dependencies)
 2. `VocIngestionStack`
-3. `VocProcessingStackConsolidated`
+3. `VocProcessingStack`
 4. `VocApiStack`
 
 The `cdk deploy --all` command handles this automatically.
+
+### Enabling Web Search (optional)
+
+Public web search in AI Chat and Research is opt-in and off by default —
+without it the UI hides the web-search toggle entirely (the deployment
+reports `WebSearchAvailable=false` and `config.json` ships
+`features.webSearch: false`).
+
+To enable it:
+
+```bash
+# One-time: the gateway only exists in us-east-1, so that region must be
+# bootstrapped even when the app lives elsewhere (cross-region references)
+cdk bootstrap aws://ACCOUNT_ID/us-east-1
+
+cdk deploy --all -c enableWebSearch=true
+npm run deploy:frontend   # regenerates config.json with webSearch: true
+```
+
+Cost model: the gateway has no standing cost; searches bill per query
+(see AgentCore pricing) and only run for requests where the user turned
+the toggle on.
 
 ## Frontend Deployment
 
@@ -238,6 +264,28 @@ This script:
 2. Builds the frontend (`npm run build`)
 3. Syncs to S3
 4. Invalidates CloudFront cache
+
+### Frontend Caching Model
+
+Learned the hard way (issues #188/#191 — returning browsers rendered raw
+i18n keys after a redeploy):
+
+- **Hashed assets** (`dist/assets/*`) upload with
+  `Cache-Control: public,max-age=31536000,immutable` — content-hashed
+  names change on every code change, so they can cache forever.
+- **Stable-name files** (`index.html`, `config.json`, `locales/**`,
+  manifests) upload with `Cache-Control: no-cache` — browsers revalidate
+  with ETags (cheap 304s) and can never serve a stale copy. Without this,
+  browsers apply *heuristic* caching (~10% of object age) and can serve
+  week-old locale JSONs for days, no matter how many CloudFront
+  invalidations run — the staleness lives in the browser.
+- **Locale URLs are version-stamped** (`/locales/en/common.json?v=<git-sha>`
+  via `import.meta.env.APP_VERSION`, injected at build): each new bundle
+  requests URLs no old cache entry can match, which also retroactively
+  bust caches created before the headers existed.
+- The assets sync deliberately does **not** `--delete`: visitors holding a
+  previously-cached `index.html` still reference the previous deploy's
+  chunks; deleting them would turn a stale-but-working page into 404s.
 
 ### Frontend Build Process
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -236,9 +236,9 @@ cdk deploy --all -c enableWebSearch=true
 npm run deploy:frontend   # regenerates config.json with webSearch: true
 ```
 
-Cost model: the gateway has no standing cost; searches bill per query
-(see AgentCore pricing) and only run for requests where the user turned
-the toggle on.
+Cost model (per `bin/voc-datalake.ts`): the gateway has no standing cost;
+searches bill per query ($7/1k at the time of writing — check AgentCore
+pricing) and only run for requests where the user turned the toggle on.
 
 ## Frontend Deployment
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -651,7 +651,7 @@ export class VocIngestionStack extends cdk.Stack {
 import { loadPlugins, getEnabledPlugins, getPluginsWithWebhook } from '../plugin-loader';
 
 export class VocApiStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props: VocAnalyticsStackProps) {
+  constructor(scope: Construct, id: string, props: VocApiStackProps) {
     super(scope, id, props);
     
     // Load plugins

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -11,7 +11,7 @@ This document describes the plugin-based architecture for VoC data source connec
 1. **Tight coupling**: Data sources are hardcoded across multiple files:
    - `sourceConfig.ts` (frontend UI configuration)
    - `ingestion-stack.ts` (CDK infrastructure)
-   - `analytics-stack.ts` (webhook routes)
+   - `api-stack.ts` (webhook routes)
    - `cdk.context.json` (enabled sources list)
 
 2. **Difficult to contribute**: Adding a new connector requires changes in 4+ files across frontend and backend.
@@ -88,7 +88,7 @@ voc-datalake/
 │   ├── plugin-loader.ts              # Discovers and validates plugins
 │   └── stacks/
 │       ├── ingestion-stack.ts        # Uses plugin loader
-│       └── analytics-stack.ts        # Uses plugin loader for webhooks
+│       └── api-stack.ts        # Uses plugin loader for webhooks
 │
 └── frontend/src/
     ├── plugins/
@@ -647,7 +647,7 @@ export class VocIngestionStack extends cdk.Stack {
 ### Analytics Stack Changes (Webhooks)
 
 ```typescript
-// lib/stacks/analytics-stack.ts (key changes)
+// lib/stacks/api-stack.ts (key changes)
 import { loadPlugins, getEnabledPlugins, getPluginsWithWebhook } from '../plugin-loader';
 
 export class VocAnalyticsStack extends cdk.Stack {
@@ -1337,7 +1337,7 @@ For each existing connector:
 
 1. Create `lib/plugin-loader.ts`
 2. Update `ingestion-stack.ts` to use plugin loader
-3. Update `analytics-stack.ts` for dynamic webhook routes
+3. Update `api-stack.ts` for dynamic webhook routes
 4. Remove hardcoded source configs
 
 ### Phase 4: Update Frontend
@@ -1378,7 +1378,7 @@ For each existing connector:
 | File | Changes |
 |------|---------|
 | `lib/stacks/ingestion-stack.ts` | Use plugin loader instead of hardcoded configs |
-| `lib/stacks/analytics-stack.ts` | Dynamic webhook routes from plugins |
+| `lib/stacks/api-stack.ts` | Dynamic webhook routes from plugins |
 | `frontend/src/pages/Settings/Settings.tsx` | Import from plugins instead of sourceConfig |
 | `frontend/src/pages/Settings/SourceCard.tsx` | Accept manifest prop instead of sourceInfo |
 | `package.json` | Add generate:manifests script |

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -88,7 +88,7 @@ voc-datalake/
 │   ├── plugin-loader.ts              # Discovers and validates plugins
 │   └── stacks/
 │       ├── ingestion-stack.ts        # Uses plugin loader
-│       └── api-stack.ts        # Uses plugin loader for webhooks
+│       └── api-stack.ts              # Uses plugin loader for webhooks
 │
 └── frontend/src/
     ├── plugins/
@@ -650,7 +650,7 @@ export class VocIngestionStack extends cdk.Stack {
 // lib/stacks/api-stack.ts (key changes)
 import { loadPlugins, getEnabledPlugins, getPluginsWithWebhook } from '../plugin-loader';
 
-export class VocAnalyticsStack extends cdk.Stack {
+export class VocApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VocAnalyticsStackProps) {
     super(scope, id, props);
     


### PR DESCRIPTION
Documentation-only sweep correcting every factual drift found while working the codebase and operating the live deployment. No code changes.

## Model doctrine (per-surface picker, #166)

- `bedrock-ai` steering rewritten around the real architecture: resolution order (explicit arg → per-surface admin override → legacy global → surface default → env), surface-defaults table, the allowlist, capability-aware invocation (Sonnet 5/Opus 4.8 reject `temperature`; Sonnet 5 has always-on adaptive thinking), `get_active_model_id` / `converse(surface=...)` usage, and the `allowlistedModelArns()` IAM pattern — **all function names and ids verified against the actual modules**, not memory (my first draft invented `resolve_model_id`; the real name is `get_active_model_id`).
- Every hardcoded `Claude Sonnet 4.5` / `sonnet-4-5` id replaced across tech / product / testing / cdk-patterns / coding-standards steering. Zero remain repo-docs-wide.

## Streaming architecture

- All Lambda Function URL / `ChatStreamUrl` references corrected: streaming is **SSE through API Gateway** at `POST /chat/stream`, implemented in `lambda/stream` (TypeScript). The manual-test snippet now targets the real endpoint with `Accept: text/event-stream` — the exact command validated against production during this session's deployment.

## Stack names

- `VocProcessingStackConsolidated` → `VocProcessingStack`, `VocBedrockAccessStack` → `BedrockAccessStack` (optional), plus the optional `VocWebSearchStack` (us-east-1 only, `-c enableWebSearch=true`) — in `docs/deployment.md` and the deployment/structure steering.
- `docs/plugin-architecture.md`: 5 references to the long-renamed `analytics-stack.ts` → `api-stack.ts`.

## Deployment learnings (#184–#192, from operating the live environment)

`docs/deployment.md` gains: a web-search enablement section (us-east-1 bootstrap, cost model, how the `config.json` flag flows to the UI), a frontend-caching-model section (immutable hashed assets vs no-cache stable names, version-stamped locale URLs, and why the assets sync never `--delete`s), and the zero-warning-synth expectation. The coding-standards deployment checklist points at the pre-#105 `omitUserPoolUsernameConfiguration` flag.

## Local dev & resilience patterns

- tech steering: mock-only dev notes — the DEV admin bypass, the stateful mock surface, and that several fixtures are **deliberately sparse** (don't 'fix' them; they keep the Zod boundary normalizers exercised) — plus the wire-shape rule (lenient Zod normalizers at query boundaries, belt-and-braces render guards, RouteErrorBoundary containment).
- README: feature lines for the per-surface model picker and opt-in web search.

## Verification

`npm run check` exit 0 (docs-only; gate proves nothing broke by association). Grep sweeps confirm zero residual `sonnet-4-5`, `ChatStreamUrl`, `Consolidated`, or `analytics-stack` references outside one deliberate historical note.