### PR TITLE
fix(cdk): kill the eternal ingestor hash churn — dir/** excludes leak dot-children

### DIFF
--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -127,7 +127,8 @@ export class VocApiStack extends cdk.Stack {
     const createApiLambdaCode = (handlerFileName: string): lambda.Code => {
       return lambda.Code.fromAsset('lambda', {
         // Stages only api/ + shared/ — everything else is hash noise.
-        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'jobs', 'processor', 'research'],
+        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, '/aggregator/', '/jobs/', '/processor/', '/research/'],
+        ignoreMode: cdk.IgnoreMode.GIT,
         bundling: {
           image: lambda.Runtime.PYTHON_3_14.bundlingImage,
           command: [
@@ -465,7 +466,8 @@ export class VocApiStack extends cdk.Stack {
     const createJobLambdaCode = (jobFolder: string): lambda.Code => {
       return lambda.Code.fromAsset('lambda', {
         // Stages only jobs/ + api/ (projects.py, product_context.py, prompts) + shared/.
-        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'processor', 'research'],
+        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, '/aggregator/', '/processor/', '/research/'],
+        ignoreMode: cdk.IgnoreMode.GIT,
         bundling: {
           image: lambda.Runtime.PYTHON_3_14.bundlingImage,
           command: [

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -127,7 +127,7 @@ export class VocApiStack extends cdk.Stack {
     const createApiLambdaCode = (handlerFileName: string): lambda.Code => {
       return lambda.Code.fromAsset('lambda', {
         // Stages only api/ + shared/ — everything else is hash noise.
-        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator/**', 'jobs/**', 'processor/**', 'research/**'],
+        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'jobs', 'processor', 'research'],
         bundling: {
           image: lambda.Runtime.PYTHON_3_14.bundlingImage,
           command: [
@@ -465,7 +465,7 @@ export class VocApiStack extends cdk.Stack {
     const createJobLambdaCode = (jobFolder: string): lambda.Code => {
       return lambda.Code.fromAsset('lambda', {
         // Stages only jobs/ + api/ (projects.py, product_context.py, prompts) + shared/.
-        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator/**', 'processor/**', 'research/**'],
+        exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'processor', 'research'],
         bundling: {
           image: lambda.Runtime.PYTHON_3_14.bundlingImage,
           command: [

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -26,6 +26,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { apiSecretsSuppressions, bedrockModelSuppressions } from '../utils/nag-suppressions';
 import { allowlistedModelArns } from '../utils/model-allowlist';
 import { pythonLayerCode } from '../utils/python-layer-bundling';
+import { ROOT_PLUGIN_ASSET_EXCLUDES } from '../utils/lambda-asset-excludes';
 
 export interface VocIngestionStackProps extends cdk.StackProps {
   feedbackTable: dynamodb.Table;
@@ -399,20 +400,12 @@ export class VocIngestionStack extends cdk.Stack {
   }
 
   private bundlePluginCode(pluginId: string): lambda.Code {
-    // Root-based staging (this bundle spans plugins/ AND lambda/shared), so
-    // everything not excluded here feeds the asset hash and redeploys all
-    // ingestors on unrelated edits (issue #194 follow-up). Only
-    // plugins/<id>/ingestor, plugins/_shared and lambda/shared are copied.
+    // Root-based staging (this bundle spans plugins/ AND lambda/shared):
+    // everything not excluded feeds the asset hash. The exclude list lives
+    // in lambda-asset-excludes.ts — see its doc for the dot-child pattern
+    // semantics that caused issue #203 (cdk.out/.cache churned every hash).
     return lambda.Code.fromAsset('.', {
-      exclude: [
-        '**/__pycache__', '**/*.pyc', '**/.DS_Store', '**/test/**', '**/conftest.py', '**/test_*.py',
-        'plugins/_template/**', 'node_modules/**', 'cdk.out/**', 'frontend/**', '*.ts', '*.js', '*.json', '*.md',
-        'bin/**', 'lib/**', 'dist/**', '.venv/**', '.pytest_cache/**', '.ruff_cache/**', 'coverage_html/**',
-        '.coverage', 'pytest.ini', 'requirements-dev.txt', 'chrome-extension/**', 'scripts/**', 'schemas/**',
-        'Workshop/**',
-        'lambda/aggregator/**', 'lambda/api/**', 'lambda/custom_resources/**', 'lambda/jobs/**',
-        'lambda/layers/**', 'lambda/processor/**', 'lambda/research/**', 'lambda/stream/**',
-      ],
+      exclude: ROOT_PLUGIN_ASSET_EXCLUDES,
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: [

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -26,7 +26,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { apiSecretsSuppressions, bedrockModelSuppressions } from '../utils/nag-suppressions';
 import { allowlistedModelArns } from '../utils/model-allowlist';
 import { pythonLayerCode } from '../utils/python-layer-bundling';
-import { ROOT_PLUGIN_ASSET_EXCLUDES } from '../utils/lambda-asset-excludes';
+import { rootPluginAssetExcludes } from '../utils/lambda-asset-excludes';
 
 export interface VocIngestionStackProps extends cdk.StackProps {
   feedbackTable: dynamodb.Table;
@@ -98,7 +98,10 @@ export class VocIngestionStack extends cdk.Stack {
     // Lambda Layer for common dependencies
     const dependenciesLayer = this.createDependenciesLayer();
 
-    // Create Lambda functions for each enabled plugin with ingestor
+    // Create Lambda functions for each enabled plugin with ingestor.
+    // allPluginIds feeds the per-plugin sibling excludes: every plugin dir
+    // on disk (enabled or not) is hash-noise for the OTHER ingestors.
+    const allPluginIds = allPlugins.map((p) => p.id);
     const ingestorPlugins = getPluginsWithIngestor(enabledPlugins);
     for (const plugin of ingestorPlugins) {
       this.createIngestorLambda(
@@ -106,7 +109,8 @@ export class VocIngestionStack extends cdk.Stack {
         ingestionRole,
         commonEnv,
         dependenciesLayer,
-        aggregatesTable
+        aggregatesTable,
+        allPluginIds
       );
     }
 
@@ -345,6 +349,7 @@ export class VocIngestionStack extends cdk.Stack {
     commonEnv: Record<string, string>,
     dependenciesLayer: lambda.LayerVersion,
     aggregatesTable: dynamodb.Table,
+    allPluginIds: string[],
   ): void {
     const infra = plugin.infrastructure.ingestor;
     if (!infra?.enabled) return;
@@ -360,7 +365,7 @@ export class VocIngestionStack extends cdk.Stack {
     lambdaEnv.AGGREGATES_TABLE = aggregatesTable.tableName;
 
     // Bundle plugin code from plugins/ directory
-    const ingestorCode = this.bundlePluginCode(plugin.id);
+    const ingestorCode = this.bundlePluginCode(plugin.id, allPluginIds);
 
     // Parse schedule from manifest
     const schedule = this.parseSchedule(infra.schedule);
@@ -399,13 +404,16 @@ export class VocIngestionStack extends cdk.Stack {
     this.ingestionLambdas.set(plugin.id, fn);
   }
 
-  private bundlePluginCode(pluginId: string): lambda.Code {
+  private bundlePluginCode(pluginId: string, allPluginIds: string[]): lambda.Code {
     // Root-based staging (this bundle spans plugins/ AND lambda/shared):
     // everything not excluded feeds the asset hash. The exclude list lives
-    // in lambda-asset-excludes.ts — see its doc for the dot-child pattern
-    // semantics that caused issue #203 (cdk.out/.cache churned every hash).
+    // in lambda-asset-excludes.ts — see its doc for why GIT ignore mode
+    // (issue #203: GLOB's 'dir/**' leaked dot-children like cdk.out/.cache,
+    // churning every ingestor hash on every deploy) and why sibling plugins
+    // are excluded per-id (their edits must not redeploy THIS ingestor).
     return lambda.Code.fromAsset('.', {
-      exclude: ROOT_PLUGIN_ASSET_EXCLUDES,
+      exclude: rootPluginAssetExcludes(pluginId, allPluginIds),
+      ignoreMode: cdk.IgnoreMode.GIT,
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: [

--- a/voc-datalake/lib/stacks/ingestion-stack.ts
+++ b/voc-datalake/lib/stacks/ingestion-stack.ts
@@ -10,6 +10,7 @@ import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3n from 'aws-cdk-lib/aws-s3-notifications';
 import * as logs from 'aws-cdk-lib/aws-logs';
+import * as fs from 'fs';
 import * as path from 'path';
 import { Construct } from 'constructs';
 import {
@@ -99,9 +100,12 @@ export class VocIngestionStack extends cdk.Stack {
     const dependenciesLayer = this.createDependenciesLayer();
 
     // Create Lambda functions for each enabled plugin with ingestor.
-    // allPluginIds feeds the per-plugin sibling excludes: every plugin dir
-    // on disk (enabled or not) is hash-noise for the OTHER ingestors.
-    const allPluginIds = allPlugins.map((p) => p.id);
+    // Sibling excludes derive from DISK, not the loader: a plugin dir the
+    // loader skips (malformed manifest, fresh scaffold) must still be
+    // excluded from every other ingestor's hash or it churns them all.
+    const allPluginIds = fs.readdirSync(pluginsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('_'))
+      .map((entry) => entry.name);
     const ingestorPlugins = getPluginsWithIngestor(enabledPlugins);
     for (const plugin of ingestorPlugins) {
       this.createIngestorLambda(

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -110,7 +110,7 @@ export class VocProcessingStack extends cdk.Stack {
     // FEEDBACK PROCESSOR LAMBDA
     // ============================================
     const processorCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator/**', 'api/**', 'jobs/**', 'research/**'],
+      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'api', 'jobs', 'research'],
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/processor/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],
@@ -159,7 +159,7 @@ export class VocProcessingStack extends cdk.Stack {
     // AGGREGATION LAMBDA
     // ============================================
     const aggregatorCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'api/**', 'jobs/**', 'processor/**', 'research/**'],
+      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'api', 'jobs', 'processor', 'research'],
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/aggregator/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],
@@ -224,7 +224,7 @@ export class VocProcessingStack extends cdk.Stack {
     // hashed the entire CDK project (scripts/, schemas/, coverage output...)
     // into this asset, redeploying it on every unrelated edit.
     const researchCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator/**', 'api/**', 'jobs/**', 'processor/**'],
+      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'api', 'jobs', 'processor'],
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/research/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -110,7 +110,8 @@ export class VocProcessingStack extends cdk.Stack {
     // FEEDBACK PROCESSOR LAMBDA
     // ============================================
     const processorCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'api', 'jobs', 'research'],
+      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, '/aggregator/', '/api/', '/jobs/', '/research/'],
+      ignoreMode: cdk.IgnoreMode.GIT,
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/processor/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],
@@ -159,7 +160,8 @@ export class VocProcessingStack extends cdk.Stack {
     // AGGREGATION LAMBDA
     // ============================================
     const aggregatorCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'api', 'jobs', 'processor', 'research'],
+      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, '/api/', '/jobs/', '/processor/', '/research/'],
+      ignoreMode: cdk.IgnoreMode.GIT,
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/aggregator/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],
@@ -224,7 +226,8 @@ export class VocProcessingStack extends cdk.Stack {
     // hashed the entire CDK project (scripts/, schemas/, coverage output...)
     // into this asset, redeploying it on every unrelated edit.
     const researchCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, 'aggregator', 'api', 'jobs', 'processor'],
+      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, '/aggregator/', '/api/', '/jobs/', '/processor/'],
+      ignoreMode: cdk.IgnoreMode.GIT,
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
         command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/research/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],

--- a/voc-datalake/lib/utils/lambda-asset-excludes.test.ts
+++ b/voc-datalake/lib/utils/lambda-asset-excludes.test.ts
@@ -1,23 +1,29 @@
 /**
- * Guard for the Lambda asset-staging excludes (issue #194 follow-up).
+ * Guards for the Lambda asset-staging excludes (issues #194/#201/#203).
  *
- * Staged-but-never-copied files still feed CDK asset hashes: before these
- * excludes, local layer build output, lambda/stream/node_modules (141MB),
- * tests and caches were hashed into every Python function asset, so every
- * deploy rolled ~25 functions with byte-identical code. These tests fail if
- * a staging site stops excluding the noise.
+ * Two failure classes are covered:
+ * 1. A staging site stops excluding the noise (hash churn: staged-but-never-
+ *    copied files feed CDK asset hashes — before these excludes, every
+ *    deploy rolled ~25 functions with byte-identical code).
+ * 2. The patterns regress to forms that leak DOT-CHILDREN (issue #203):
+ *    CDK matches with minimatch { matchBase: true }, and `**` never crosses
+ *    a dot segment — 'cdk.out/**' left cdk.out/.cache/*.zip (CDK's own
+ *    publishing cache) in the fingerprint, so every deploy changed the next
+ *    synth's ingestor hashes forever. The behavior tests below run the
+ *    REAL aws-cdk-lib IgnoreStrategy against the exported lists.
  */
-import { describe, it, expect } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import { PY_LAMBDA_ASSET_EXCLUDES } from './lambda-asset-excludes';
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { IgnoreStrategy } from 'aws-cdk-lib'
+import { PY_LAMBDA_ASSET_EXCLUDES, ROOT_PLUGIN_ASSET_EXCLUDES } from './lambda-asset-excludes'
 
-const stacksDir = path.join(process.cwd(), 'lib', 'stacks');
+const stacksDir = path.join(process.cwd(), 'lib', 'stacks')
 
 function stackSources(): Array<{ file: string; source: string }> {
   return fs.readdirSync(stacksDir)
     .filter((file) => file.endsWith('.ts') && !file.endsWith('.test.ts'))
-    .map((file) => ({ file, source: fs.readFileSync(path.join(stacksDir, file), 'utf8') }));
+    .map((file) => ({ file, source: fs.readFileSync(path.join(stacksDir, file), 'utf8') }))
 }
 
 /**
@@ -30,50 +36,125 @@ function stackSources(): Array<{ file: string; source: string }> {
  * assertions loudly.
  */
 function optionsObject(source: string, callStart: number): string {
-  const open = source.indexOf('{', callStart);
-  if (open === -1) return '';
-  let depth = 0;
+  const open = source.indexOf('{', callStart)
+  if (open === -1) return ''
+  let depth = 0
   for (let i = open; i < source.length; i++) {
-    if (source[i] === '{') depth += 1;
+    if (source[i] === '{') depth += 1
     if (source[i] === '}') {
-      depth -= 1;
-      if (depth === 0) return source.slice(open, i + 1);
+      depth -= 1
+      if (depth === 0) return source.slice(open, i + 1)
     }
   }
-  return source.slice(open);
+  return source.slice(open)
 }
 
 function forEachCallSite(needle: string, visit: (file: string, options: string) => void): void {
   for (const { file, source } of stackSources()) {
-    let searchFrom = 0;
+    let searchFrom = 0
     for (;;) {
-      const at = source.indexOf(needle, searchFrom);
-      if (at === -1) break;
-      visit(file, optionsObject(source, at + needle.length));
-      searchFrom = at + 1;
+      const at = source.indexOf(needle, searchFrom)
+      if (at === -1) break
+      visit(file, optionsObject(source, at + needle.length))
+      searchFrom = at + 1
     }
   }
 }
 
-describe('PY_LAMBDA_ASSET_EXCLUDES', () => {
-  it('keeps the load-bearing noise patterns', () => {
-    for (const pattern of ['layers/**', 'stream/**', 'custom_resources/**', '**/test/**', '**/test_*.py', '**/conftest.py', '**/__pycache__']) {
-      expect(PY_LAMBDA_ASSET_EXCLUDES).toContain(pattern);
+/**
+ * Ignore predicate exactly as CDK's staging walk evaluates it
+ * (fingerprint.js/copyDirectory): each ancestor DIRECTORY is tested with
+ * completelyIgnores (pruning the whole subtree when it matches), and the
+ * file itself with ignores(). Testing only the file path would miss the
+ * directory pruning that makes bare-name dir patterns work.
+ */
+function ignoresWith(excludes: string[]): (relativePath: string) => boolean {
+  const root = '/asset-root'
+  const strategy = IgnoreStrategy.glob(root, excludes)
+  return (relativePath) => {
+    const segments = relativePath.split('/')
+    for (let i = 1; i < segments.length; i++) {
+      const ancestorDir = path.join(root, ...segments.slice(0, i))
+      if (strategy.completelyIgnores(ancestorDir)) return true
     }
-  });
-});
+    return strategy.ignores(path.join(root, relativePath))
+  }
+}
 
-describe('asset staging sites', () => {
-  it("every fromAsset('lambda') spreads the shared excludes", () => {
+describe('asset staging sites use the shared lists', () => {
+  it("every fromAsset('lambda') spreads PY_LAMBDA_ASSET_EXCLUDES", () => {
     forEachCallSite("fromAsset('lambda'", (file, options) => {
-      expect(options, `${file} stages lambda/ without PY_LAMBDA_ASSET_EXCLUDES`).toContain('...PY_LAMBDA_ASSET_EXCLUDES');
-    });
-  });
+      expect(options, `${file} stages lambda/ without PY_LAMBDA_ASSET_EXCLUDES`).toContain('...PY_LAMBDA_ASSET_EXCLUDES')
+    })
+  })
 
-  it("every root-based fromAsset('.') excludes the layer build output and the stream Lambda", () => {
+  it("every root-based fromAsset('.') uses ROOT_PLUGIN_ASSET_EXCLUDES", () => {
     forEachCallSite("fromAsset('.'", (file, options) => {
-      expect(options, `${file} stages the project root without excluding lambda/layers`).toContain('lambda/layers/**');
-      expect(options, `${file} stages the project root without excluding lambda/stream`).toContain('lambda/stream/**');
-    });
-  });
-});
+      expect(options, `${file} stages the project root without the shared exclude list`).toContain('ROOT_PLUGIN_ASSET_EXCLUDES')
+    })
+  })
+
+  it('no exclude entry uses the dot-child-leaking dir/** form', () => {
+    // '**'-suffixed directory patterns do not exclude the directory's
+    // dot-children (issue #203). Directories must be excluded by name.
+    for (const pattern of [...PY_LAMBDA_ASSET_EXCLUDES, ...ROOT_PLUGIN_ASSET_EXCLUDES]) {
+      expect(pattern, `'${pattern}' would leak dot-children`).not.toMatch(/\/\*\*$/)
+    }
+  })
+})
+
+describe('root staging behavior (aws-cdk-lib IgnoreStrategy)', () => {
+  const ignores = ignoresWith(ROOT_PLUGIN_ASSET_EXCLUDES)
+
+  it('prunes cdk.out INCLUDING its dot-children — the issue #203 churn loop', () => {
+    expect(ignores('cdk.out')).toBe(true)
+    // The exact file class that fed every deploy's hash back into the next
+    // synth: CDK's own asset-publishing cache.
+    expect(ignores('cdk.out/.cache/0ce2e32d12eb43f7.zip')).toBe(true)
+  })
+
+  it('prunes the other volatile dirs with their dot-children', () => {
+    expect(ignores('node_modules/.bin/tsc')).toBe(true)
+    expect(ignores('.venv/.gitignore')).toBe(true)
+    expect(ignores('.ruff_cache/.gitignore')).toBe(true)
+    expect(ignores('frontend/.env.local')).toBe(true)
+  })
+
+  it('keeps everything the plugin bundles actually copy', () => {
+    expect(ignores('plugins/webscraper/ingestor/handler.py')).toBe(false)
+    expect(ignores('plugins/_shared/base_ingestor.py')).toBe(false)
+    expect(ignores('lambda/shared/api.py')).toBe(false)
+    // Manifests are synth-time inputs (plugin-loader) — staged is fine.
+    expect(ignores('plugins/webscraper/manifest.json')).toBe(true)
+  })
+
+  it('still drops tests and caches anywhere in the staged trees', () => {
+    expect(ignores('plugins/_shared/test/test_base_ingestor.py')).toBe(true)
+    expect(ignores('lambda/shared/test/test_api.py')).toBe(true)
+    expect(ignores('plugins/webscraper/ingestor/__pycache__/handler.cpython-314.pyc')).toBe(true)
+  })
+})
+
+describe('lambda staging behavior (aws-cdk-lib IgnoreStrategy)', () => {
+  const ignores = ignoresWith(PY_LAMBDA_ASSET_EXCLUDES)
+
+  it('prunes layer build output and the stream package, dot-children included', () => {
+    expect(ignores('layers/processing-deps/python/pydantic/main.py')).toBe(true)
+    expect(ignores('stream/node_modules/.bin/vitest')).toBe(true)
+    expect(ignores('stream/.env')).toBe(true)
+  })
+
+  it('keeps handler payloads — including the prompt JSONs the bundles ship', () => {
+    expect(ignores('shared/api.py')).toBe(false)
+    expect(ignores('api/metrics_handler.py')).toBe(false)
+    // Regression guard: prompt files MUST stay in the hash, or edits to
+    // them would deploy stale bundles.
+    expect(ignores('api/prompts/prd-generation.json')).toBe(false)
+  })
+
+  it('drops tests at any depth', () => {
+    expect(ignores('shared/test/test_api.py')).toBe(true)
+    expect(ignores('jobs/document_generator/test/test_handler.py')).toBe(true)
+    expect(ignores('api/test/conftest.py')).toBe(true)
+  })
+})

--- a/voc-datalake/lib/utils/lambda-asset-excludes.test.ts
+++ b/voc-datalake/lib/utils/lambda-asset-excludes.test.ts
@@ -22,7 +22,12 @@ import { IgnoreStrategy } from 'aws-cdk-lib';
 import { PY_LAMBDA_ASSET_EXCLUDES, rootPluginAssetExcludes } from './lambda-asset-excludes';
 
 const stacksDir = path.join(process.cwd(), 'lib', 'stacks');
-const PLUGIN_IDS = ['app_reviews_android', 'app_reviews_ios', 's3_import', 'synthetic_reviews', 'webscraper'];
+// Derived from disk exactly as ingestion-stack derives its sibling excludes —
+// a hardcoded list would silently stop covering a sixth plugin.
+const PLUGIN_IDS = fs.readdirSync(path.join(process.cwd(), 'plugins'), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && !entry.name.startsWith('_'))
+  .map((entry) => entry.name)
+  .sort();
 
 function stackSources(): Array<{ file: string; source: string }> {
   return fs.readdirSync(stacksDir)
@@ -103,10 +108,25 @@ describe('asset staging sites use the shared lists in GIT ignore mode', () => {
 describe('root staging behavior (aws-cdk-lib IgnoreStrategy.git)', () => {
   const ignores = ignoresWith(rootPluginAssetExcludes('webscraper', PLUGIN_IDS));
 
+  it('derives the plugin id set from disk (anti-vacuous)', () => {
+    // The known plugins must be present; a sixth is covered automatically.
+    for (const id of ['app_reviews_android', 'app_reviews_ios', 's3_import', 'synthetic_reviews', 'webscraper']) {
+      expect(PLUGIN_IDS).toContain(id);
+    }
+  });
+
   it('prunes cdk.out INCLUDING its dot-children — the issue #203 churn loop', () => {
     // The exact file class that fed every deploy's hash back into the next
     // synth: CDK's own asset-publishing cache.
     expect(ignores('cdk.out/.cache/0ce2e32d12eb43f7.zip')).toBe(true);
+  });
+
+  it('never hashes nor ships dev secrets, at any depth', () => {
+    // Staging excludes also gate the bundling container's /asset-input, so
+    // this keeps a stray .env out of the DEPLOYED bundle, not just the hash.
+    expect(ignores('.env.local')).toBe(true);
+    expect(ignores('plugins/webscraper/.env')).toBe(true);
+    expect(ignores('lambda/shared/.env.production')).toBe(true);
   });
 
   it('prunes repo metadata and tool dirs with their dot-children', () => {
@@ -162,7 +182,7 @@ describe('lambda staging behavior (aws-cdk-lib IgnoreStrategy.git)', () => {
   it('prunes layer build output and the stream package, dot-children included', () => {
     expect(ignores('layers/processing-deps/python/pydantic/main.py')).toBe(true);
     expect(ignores('stream/node_modules/.bin/vitest')).toBe(true);
-    expect(ignores('stream/.env')).toBe(true);
+    expect(ignores('shared/.env')).toBe(true);
   });
 
   it('keeps handler payloads — including the prompt JSONs the bundles ship', () => {

--- a/voc-datalake/lib/utils/lambda-asset-excludes.test.ts
+++ b/voc-datalake/lib/utils/lambda-asset-excludes.test.ts
@@ -5,25 +5,29 @@
  * 1. A staging site stops excluding the noise (hash churn: staged-but-never-
  *    copied files feed CDK asset hashes — before these excludes, every
  *    deploy rolled ~25 functions with byte-identical code).
- * 2. The patterns regress to forms that leak DOT-CHILDREN (issue #203):
- *    CDK matches with minimatch { matchBase: true }, and `**` never crosses
- *    a dot segment — 'cdk.out/**' left cdk.out/.cache/*.zip (CDK's own
- *    publishing cache) in the fingerprint, so every deploy changed the next
- *    synth's ingestor hashes forever. The behavior tests below run the
- *    REAL aws-cdk-lib IgnoreStrategy against the exported lists.
+ * 2. The patterns regress to forms that leak volatile files. Issue #203:
+ *    GLOB mode's 'dir/**' does not exclude dot-children (minimatch's `**`
+ *    never crosses a dot segment), so cdk.out/.cache/*.zip — CDK's own
+ *    publishing cache — fed each deploy's output into the next synth's
+ *    ingestor fingerprints, forever. The lists are written for
+ *    IgnoreMode.GIT; the behavior tests below run the REAL aws-cdk-lib
+ *    IgnoreStrategy.git with the walk's ancestor-directory pruning, which
+ *    is the load-bearing defense (static pattern checks can't cover every
+ *    leaky form).
  */
-import { describe, it, expect } from 'vitest'
-import * as fs from 'fs'
-import * as path from 'path'
-import { IgnoreStrategy } from 'aws-cdk-lib'
-import { PY_LAMBDA_ASSET_EXCLUDES, ROOT_PLUGIN_ASSET_EXCLUDES } from './lambda-asset-excludes'
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { IgnoreStrategy } from 'aws-cdk-lib';
+import { PY_LAMBDA_ASSET_EXCLUDES, rootPluginAssetExcludes } from './lambda-asset-excludes';
 
-const stacksDir = path.join(process.cwd(), 'lib', 'stacks')
+const stacksDir = path.join(process.cwd(), 'lib', 'stacks');
+const PLUGIN_IDS = ['app_reviews_android', 'app_reviews_ios', 's3_import', 'synthetic_reviews', 'webscraper'];
 
 function stackSources(): Array<{ file: string; source: string }> {
   return fs.readdirSync(stacksDir)
     .filter((file) => file.endsWith('.ts') && !file.endsWith('.test.ts'))
-    .map((file) => ({ file, source: fs.readFileSync(path.join(stacksDir, file), 'utf8') }))
+    .map((file) => ({ file, source: fs.readFileSync(path.join(stacksDir, file), 'utf8') }));
 }
 
 /**
@@ -36,27 +40,27 @@ function stackSources(): Array<{ file: string; source: string }> {
  * assertions loudly.
  */
 function optionsObject(source: string, callStart: number): string {
-  const open = source.indexOf('{', callStart)
-  if (open === -1) return ''
-  let depth = 0
+  const open = source.indexOf('{', callStart);
+  if (open === -1) return '';
+  let depth = 0;
   for (let i = open; i < source.length; i++) {
-    if (source[i] === '{') depth += 1
+    if (source[i] === '{') depth += 1;
     if (source[i] === '}') {
-      depth -= 1
-      if (depth === 0) return source.slice(open, i + 1)
+      depth -= 1;
+      if (depth === 0) return source.slice(open, i + 1);
     }
   }
-  return source.slice(open)
+  return source.slice(open);
 }
 
 function forEachCallSite(needle: string, visit: (file: string, options: string) => void): void {
   for (const { file, source } of stackSources()) {
-    let searchFrom = 0
+    let searchFrom = 0;
     for (;;) {
-      const at = source.indexOf(needle, searchFrom)
-      if (at === -1) break
-      visit(file, optionsObject(source, at + needle.length))
-      searchFrom = at + 1
+      const at = source.indexOf(needle, searchFrom);
+      if (at === -1) break;
+      visit(file, optionsObject(source, at + needle.length));
+      searchFrom = at + 1;
     }
   }
 }
@@ -65,96 +69,113 @@ function forEachCallSite(needle: string, visit: (file: string, options: string) 
  * Ignore predicate exactly as CDK's staging walk evaluates it
  * (fingerprint.js/copyDirectory): each ancestor DIRECTORY is tested with
  * completelyIgnores (pruning the whole subtree when it matches), and the
- * file itself with ignores(). Testing only the file path would miss the
- * directory pruning that makes bare-name dir patterns work.
+ * file itself with ignores().
  */
 function ignoresWith(excludes: string[]): (relativePath: string) => boolean {
-  const root = '/asset-root'
-  const strategy = IgnoreStrategy.glob(root, excludes)
+  const root = '/asset-root';
+  const strategy = IgnoreStrategy.git(root, excludes);
   return (relativePath) => {
-    const segments = relativePath.split('/')
+    const segments = relativePath.split('/');
     for (let i = 1; i < segments.length; i++) {
-      const ancestorDir = path.join(root, ...segments.slice(0, i))
-      if (strategy.completelyIgnores(ancestorDir)) return true
+      const ancestorDir = path.join(root, ...segments.slice(0, i));
+      if (strategy.completelyIgnores(ancestorDir)) return true;
     }
-    return strategy.ignores(path.join(root, relativePath))
-  }
+    return strategy.ignores(path.join(root, relativePath));
+  };
 }
 
-describe('asset staging sites use the shared lists', () => {
-  it("every fromAsset('lambda') spreads PY_LAMBDA_ASSET_EXCLUDES", () => {
+describe('asset staging sites use the shared lists in GIT ignore mode', () => {
+  it("every fromAsset('lambda') spreads PY_LAMBDA_ASSET_EXCLUDES with IgnoreMode.GIT", () => {
     forEachCallSite("fromAsset('lambda'", (file, options) => {
-      expect(options, `${file} stages lambda/ without PY_LAMBDA_ASSET_EXCLUDES`).toContain('...PY_LAMBDA_ASSET_EXCLUDES')
-    })
-  })
+      expect(options, `${file} stages lambda/ without PY_LAMBDA_ASSET_EXCLUDES`).toContain('...PY_LAMBDA_ASSET_EXCLUDES');
+      expect(options, `${file} must pin IgnoreMode.GIT — the lists are written for gitignore semantics`).toContain('IgnoreMode.GIT');
+    });
+  });
 
-  it("every root-based fromAsset('.') uses ROOT_PLUGIN_ASSET_EXCLUDES", () => {
+  it("every root-based fromAsset('.') uses rootPluginAssetExcludes with IgnoreMode.GIT", () => {
     forEachCallSite("fromAsset('.'", (file, options) => {
-      expect(options, `${file} stages the project root without the shared exclude list`).toContain('ROOT_PLUGIN_ASSET_EXCLUDES')
-    })
-  })
+      expect(options, `${file} stages the project root without the shared exclude helper`).toContain('rootPluginAssetExcludes(');
+      expect(options, `${file} must pin IgnoreMode.GIT`).toContain('IgnoreMode.GIT');
+    });
+  });
+});
 
-  it('no exclude entry uses the dot-child-leaking dir/** form', () => {
-    // '**'-suffixed directory patterns do not exclude the directory's
-    // dot-children (issue #203). Directories must be excluded by name.
-    for (const pattern of [...PY_LAMBDA_ASSET_EXCLUDES, ...ROOT_PLUGIN_ASSET_EXCLUDES]) {
-      expect(pattern, `'${pattern}' would leak dot-children`).not.toMatch(/\/\*\*$/)
-    }
-  })
-})
-
-describe('root staging behavior (aws-cdk-lib IgnoreStrategy)', () => {
-  const ignores = ignoresWith(ROOT_PLUGIN_ASSET_EXCLUDES)
+describe('root staging behavior (aws-cdk-lib IgnoreStrategy.git)', () => {
+  const ignores = ignoresWith(rootPluginAssetExcludes('webscraper', PLUGIN_IDS));
 
   it('prunes cdk.out INCLUDING its dot-children — the issue #203 churn loop', () => {
-    expect(ignores('cdk.out')).toBe(true)
     // The exact file class that fed every deploy's hash back into the next
     // synth: CDK's own asset-publishing cache.
-    expect(ignores('cdk.out/.cache/0ce2e32d12eb43f7.zip')).toBe(true)
-  })
+    expect(ignores('cdk.out/.cache/0ce2e32d12eb43f7.zip')).toBe(true);
+  });
 
-  it('prunes the other volatile dirs with their dot-children', () => {
-    expect(ignores('node_modules/.bin/tsc')).toBe(true)
-    expect(ignores('.venv/.gitignore')).toBe(true)
-    expect(ignores('.ruff_cache/.gitignore')).toBe(true)
-    expect(ignores('frontend/.env.local')).toBe(true)
-  })
+  it('prunes repo metadata and tool dirs with their dot-children', () => {
+    // .git/index changes on every commit/checkout — without this the
+    // ingestor hashes churn across commits with zero payload changes.
+    expect(ignores('.git/index')).toBe(true);
+    expect(ignores('.git/refs/heads/development')).toBe(true);
+    expect(ignores('node_modules/.bin/tsc')).toBe(true);
+    expect(ignores('.venv/.gitignore')).toBe(true);
+    expect(ignores('.ruff_cache/.gitignore')).toBe(true);
+    expect(ignores('frontend/.env.local')).toBe(true);
+    expect(ignores('.env.local')).toBe(true);
+  });
 
-  it('keeps everything the plugin bundles actually copy', () => {
-    expect(ignores('plugins/webscraper/ingestor/handler.py')).toBe(false)
-    expect(ignores('plugins/_shared/base_ingestor.py')).toBe(false)
-    expect(ignores('lambda/shared/api.py')).toBe(false)
-    // Manifests are synth-time inputs (plugin-loader) — staged is fine.
-    expect(ignores('plugins/webscraper/manifest.json')).toBe(true)
-  })
+  it('keeps everything the plugin bundle actually copies', () => {
+    expect(ignores('plugins/webscraper/ingestor/handler.py')).toBe(false);
+    expect(ignores('plugins/_shared/base_ingestor.py')).toBe(false);
+    expect(ignores('lambda/shared/api.py')).toBe(false);
+  });
 
-  it('still drops tests and caches anywhere in the staged trees', () => {
-    expect(ignores('plugins/_shared/test/test_base_ingestor.py')).toBe(true)
-    expect(ignores('lambda/shared/test/test_api.py')).toBe(true)
-    expect(ignores('plugins/webscraper/ingestor/__pycache__/handler.cpython-314.pyc')).toBe(true)
-  })
-})
+  it('top-level tool-dir names do NOT swallow payload subtrees of the same name', () => {
+    // The anchored '/lib/', '/bin/', '/scripts/', '/dist/' entries must not
+    // exclude a plugin's own helper folders — a silent payload drop.
+    expect(ignores('plugins/webscraper/ingestor/lib/parser.py')).toBe(false);
+    expect(ignores('plugins/webscraper/ingestor/scripts/seed.py')).toBe(false);
+    expect(ignores('lambda/shared/bin/helper.py')).toBe(false);
+    // ...while the top-level dirs themselves stay excluded.
+    expect(ignores('lib/stacks/core-stack.ts')).toBe(true);
+    expect(ignores('scripts/build-layers.sh')).toBe(true);
+  });
 
-describe('lambda staging behavior (aws-cdk-lib IgnoreStrategy)', () => {
-  const ignores = ignoresWith(PY_LAMBDA_ASSET_EXCLUDES)
+  it("sibling plugins never churn this plugin's hash; its own tree counts", () => {
+    expect(ignores('plugins/s3_import/ingestor/handler.py')).toBe(true);
+    expect(ignores('plugins/synthetic_reviews/ingestor/handler.py')).toBe(true);
+    expect(ignores('plugins/webscraper/ingestor/scraper.py')).toBe(false);
+  });
+
+  it('still drops tests, caches, and non-payload file types anywhere', () => {
+    expect(ignores('plugins/_shared/test/test_base_ingestor.py')).toBe(true);
+    expect(ignores('lambda/shared/test/test_api.py')).toBe(true);
+    expect(ignores('plugins/webscraper/ingestor/__pycache__/handler.cpython-314.pyc')).toBe(true);
+    // NOT staged: manifest.json is a synth-time input which plugin-loader
+    // reads from the SOURCE tree; the bundle command never copies it, so
+    // keeping it out of the hash is correct (edits to manifests alone must
+    // not redeploy ingestor code).
+    expect(ignores('plugins/webscraper/manifest.json')).toBe(true);
+  });
+});
+
+describe('lambda staging behavior (aws-cdk-lib IgnoreStrategy.git)', () => {
+  const ignores = ignoresWith(PY_LAMBDA_ASSET_EXCLUDES);
 
   it('prunes layer build output and the stream package, dot-children included', () => {
-    expect(ignores('layers/processing-deps/python/pydantic/main.py')).toBe(true)
-    expect(ignores('stream/node_modules/.bin/vitest')).toBe(true)
-    expect(ignores('stream/.env')).toBe(true)
-  })
+    expect(ignores('layers/processing-deps/python/pydantic/main.py')).toBe(true);
+    expect(ignores('stream/node_modules/.bin/vitest')).toBe(true);
+    expect(ignores('stream/.env')).toBe(true);
+  });
 
   it('keeps handler payloads — including the prompt JSONs the bundles ship', () => {
-    expect(ignores('shared/api.py')).toBe(false)
-    expect(ignores('api/metrics_handler.py')).toBe(false)
+    expect(ignores('shared/api.py')).toBe(false);
+    expect(ignores('api/metrics_handler.py')).toBe(false);
     // Regression guard: prompt files MUST stay in the hash, or edits to
     // them would deploy stale bundles.
-    expect(ignores('api/prompts/prd-generation.json')).toBe(false)
-  })
+    expect(ignores('api/prompts/prd-generation.json')).toBe(false);
+  });
 
   it('drops tests at any depth', () => {
-    expect(ignores('shared/test/test_api.py')).toBe(true)
-    expect(ignores('jobs/document_generator/test/test_handler.py')).toBe(true)
-    expect(ignores('api/test/conftest.py')).toBe(true)
-  })
-})
+    expect(ignores('shared/test/test_api.py')).toBe(true);
+    expect(ignores('jobs/document_generator/test/test_handler.py')).toBe(true);
+    expect(ignores('api/test/conftest.py')).toBe(true);
+  });
+});

--- a/voc-datalake/lib/utils/lambda-asset-excludes.ts
+++ b/voc-datalake/lib/utils/lambda-asset-excludes.ts
@@ -8,91 +8,108 @@
  * and caches were hashed into every Python function asset, so unrelated
  * edits redeployed all ~25 functions with byte-identical code.
  *
- * PATTERN SEMANTICS (issue #203 — this bit us hard): CDK matches each
- * pattern with `minimatch(relativePath, pattern, { matchBase: true })`, and
- * `**` NEVER crosses a dot segment. Consequences:
- *   - `'dir/**'` excludes dir's plain children but NOT its dot-children —
- *     `'cdk.out/**'` left `cdk.out/.cache/*.zip` (CDK's own publishing
- *     cache!) in the fingerprint, so every deploy changed the next synth's
- *     ingestor asset hashes, forever.
- *   - Excluding the DIRECTORY ITSELF ('cdk.out', or path-qualified
- *     'lambda/layers') prunes the whole subtree via completelyIgnores —
- *     dot-children included. ALWAYS name directories; never append '/**'.
- *   - matchBase applies to slash-less patterns only: bare 'test' matches a
- *     dir named test at ANY depth; 'lambda/layers' matches exactly that
- *     path.
+ * WHY IgnoreMode.GIT (issue #203 — the default GLOB mode bit us hard):
+ * GLOB matches with `minimatch(relativePath, pattern, { matchBase: true })`
+ * where `**` never crosses a dot segment — so 'cdk.out/**' left
+ * cdk.out/.cache/*.zip (CDK's own publishing cache!) in the fingerprint,
+ * and every deploy changed the next synth's ingestor hashes, forever.
+ * GLOB also cannot express "top-level only" for a bare name (matchBase
+ * makes 'lib' match plugins/x/ingestor/lib too). Gitignore semantics give
+ * both properties at once:
+ *   - 'dir/' prunes the whole subtree, dot-children included;
+ *   - a leading '/' anchors to the staging root, so payload subtrees that
+ *     happen to share a name (a plugin's lib/ or scripts/) still stage.
  *
- * lib/utils/lambda-asset-excludes.test.ts enforces both the spread usage in
- * the stacks and the dot-child behavior with aws-cdk-lib's own
- * IgnoreStrategy.
+ * EVERY call site that uses these lists MUST pass
+ * `ignoreMode: IgnoreMode.GIT` — the patterns are written for it, and
+ * lib/utils/lambda-asset-excludes.test.ts enforces both the spread usage
+ * and the behavior with aws-cdk-lib's own IgnoreStrategy.git.
  */
 
 /**
  * For `Code.fromAsset('lambda', ...)` bundles (api, jobs, processor,
  * aggregator, research). Spread this into `exclude`, then add the sibling
- * handler dirs that particular bundle does not copy.
+ * handler dirs that particular bundle does not copy (anchored, e.g.
+ * '/aggregator/').
  */
 export const PY_LAMBDA_ASSET_EXCLUDES = [
-  '__pycache__',
+  '__pycache__/',
   '*.pyc',
   '.DS_Store',
   // pytest suites (api/test, shared/test, jobs/*/test) never ship
-  'test',
+  'test/',
   'test_*.py',
   'conftest.py',
   // inlined into stacks via readFileSync, never bundled
-  'custom_resources',
+  '/custom_resources/',
   // pip layer sources + local build output (see python-layer-bundling.ts)
-  'layers',
+  '/layers/',
   // Node.js streaming Lambda — bundled separately by NodejsFunction
-  'stream',
+  '/stream/',
 ];
 
 /**
- * For the plugin ingestor bundles, which must stage from the PROJECT ROOT
- * (they copy plugins/<id>/ingestor + plugins/_shared + lambda/shared). Only
- * those three trees may influence the asset hash — everything else here is
- * noise, and dot-children of excluded dirs must be pruned too (see module
- * doc). Bare names match at any depth by design (e.g. 'dist' also covers
- * lambda/stream/dist).
+ * Excludes for one plugin-ingestor bundle, which must stage from the
+ * PROJECT ROOT (it copies plugins/<id>/ingestor + plugins/_shared +
+ * lambda/shared). Only those three trees may influence the asset hash:
+ * sibling plugins are excluded per-id, so editing one plugin no longer
+ * redeploys all five ingestors.
  */
-export const ROOT_PLUGIN_ASSET_EXCLUDES = [
-  '__pycache__',
-  '*.pyc',
-  '.DS_Store',
-  'test',
-  'conftest.py',
-  'test_*.py',
-  'node_modules',
-  'cdk.out',
-  'frontend',
-  '*.ts',
-  '*.js',
-  '*.json',
-  '*.md',
-  'bin',
-  'lib',
-  'dist',
-  '.venv',
-  '.pytest_cache',
-  '.ruff_cache',
-  'coverage_html',
-  '.coverage',
-  '.coveragerc',
-  'ruff.toml',
-  'pytest.ini',
-  'requirements-dev.txt',
-  'chrome-extension',
-  'scripts',
-  'schemas',
-  'Workshop',
-  'plugins/_template',
-  'lambda/aggregator',
-  'lambda/api',
-  'lambda/custom_resources',
-  'lambda/jobs',
-  'lambda/layers',
-  'lambda/processor',
-  'lambda/research',
-  'lambda/stream',
-];
+export function rootPluginAssetExcludes(pluginId: string, allPluginIds: string[]): string[] {
+  return [
+    // Any-depth noise inside the staged trees.
+    '__pycache__/',
+    '*.pyc',
+    '.DS_Store',
+    'test/',
+    'conftest.py',
+    'test_*.py',
+    // Hash-noise files anywhere (nothing the bundles copy is ts/js/json/md;
+    // plugin manifest.json is a synth-time input read from the SOURCE tree,
+    // not from the staged asset).
+    '*.ts',
+    '*.js',
+    '*.json',
+    '*.md',
+    // Top-level-only (anchored): repo/tooling dirs that must never feed the
+    // hash — but whose NAMES a plugin payload may legitimately reuse.
+    '/.git/',
+    '/.vscode/',
+    '/.idea/',
+    '/.env*',
+    '/node_modules/',
+    '/cdk.out/',
+    '/frontend/',
+    '/bin/',
+    '/lib/',
+    '/dist/',
+    '/.venv/',
+    '/.pytest_cache/',
+    '/.ruff_cache/',
+    '/coverage_html/',
+    '/.coverage',
+    '/.coveragerc',
+    '/ruff.toml',
+    '/pytest.ini',
+    '/requirements-dev.txt',
+    '/chrome-extension/',
+    '/scripts/',
+    '/schemas/',
+    '/Workshop/',
+    '/plugins/_template/',
+    // lambda/: only shared/ ships in ingestor bundles.
+    '/lambda/aggregator/',
+    '/lambda/api/',
+    '/lambda/custom_resources/',
+    '/lambda/jobs/',
+    '/lambda/layers/',
+    '/lambda/processor/',
+    '/lambda/research/',
+    '/lambda/stream/',
+    // Sibling plugins: their edits must not churn THIS plugin's hash.
+    ...allPluginIds
+      .filter((id) => id !== pluginId)
+      .sort()
+      .map((id) => `/plugins/${id}/`),
+  ];
+}

--- a/voc-datalake/lib/utils/lambda-asset-excludes.ts
+++ b/voc-datalake/lib/utils/lambda-asset-excludes.ts
@@ -36,6 +36,9 @@ export const PY_LAMBDA_ASSET_EXCLUDES = [
   '__pycache__/',
   '*.pyc',
   '.DS_Store',
+  // Never hash NOR ship dev secrets, at any depth (staging excludes also
+  // gate what the bundling container sees as /asset-input).
+  '.env*',
   // pytest suites (api/test, shared/test, jobs/*/test) never ship
   'test/',
   'test_*.py',
@@ -61,6 +64,8 @@ export function rootPluginAssetExcludes(pluginId: string, allPluginIds: string[]
     '__pycache__/',
     '*.pyc',
     '.DS_Store',
+    // Never hash NOR ship dev secrets, at any depth.
+    '.env*',
     'test/',
     'conftest.py',
     'test_*.py',
@@ -76,7 +81,6 @@ export function rootPluginAssetExcludes(pluginId: string, allPluginIds: string[]
     '/.git/',
     '/.vscode/',
     '/.idea/',
-    '/.env*',
     '/node_modules/',
     '/cdk.out/',
     '/frontend/',

--- a/voc-datalake/lib/utils/lambda-asset-excludes.ts
+++ b/voc-datalake/lib/utils/lambda-asset-excludes.ts
@@ -1,26 +1,98 @@
 /**
- * Shared staging excludes for Python Lambda `Code.fromAsset('lambda', ...)`
- * bundles (issue #194 follow-up).
+ * Shared staging excludes for Lambda `Code.fromAsset(...)` bundles
+ * (issues #194/#201 follow-ups, #203).
  *
  * Everything staged feeds the CDK asset hash — even files the bundling
  * command never copies into /asset-output. Without these excludes, local
- * layer build output (lambda/layers/&#42;/python from scripts/build-layers.sh),
- * the Node streaming Lambda's 141MB node_modules, tests, and caches were
- * hashed into every Python function asset, so unrelated edits redeployed
- * all ~25 functions with byte-identical code on every `cdk deploy`.
+ * layer build output, the Node streaming Lambda's 141MB node_modules, tests
+ * and caches were hashed into every Python function asset, so unrelated
+ * edits redeployed all ~25 functions with byte-identical code.
  *
- * Spread this into the `exclude` of EVERY fromAsset('lambda') call, then add
- * the sibling handler dirs that particular bundle does not copy
- * (lib/utils/lambda-asset-excludes.test.ts enforces the spread).
+ * PATTERN SEMANTICS (issue #203 — this bit us hard): CDK matches each
+ * pattern with `minimatch(relativePath, pattern, { matchBase: true })`, and
+ * `**` NEVER crosses a dot segment. Consequences:
+ *   - `'dir/**'` excludes dir's plain children but NOT its dot-children —
+ *     `'cdk.out/**'` left `cdk.out/.cache/*.zip` (CDK's own publishing
+ *     cache!) in the fingerprint, so every deploy changed the next synth's
+ *     ingestor asset hashes, forever.
+ *   - Excluding the DIRECTORY ITSELF ('cdk.out', or path-qualified
+ *     'lambda/layers') prunes the whole subtree via completelyIgnores —
+ *     dot-children included. ALWAYS name directories; never append '/**'.
+ *   - matchBase applies to slash-less patterns only: bare 'test' matches a
+ *     dir named test at ANY depth; 'lambda/layers' matches exactly that
+ *     path.
+ *
+ * lib/utils/lambda-asset-excludes.test.ts enforces both the spread usage in
+ * the stacks and the dot-child behavior with aws-cdk-lib's own
+ * IgnoreStrategy.
+ */
+
+/**
+ * For `Code.fromAsset('lambda', ...)` bundles (api, jobs, processor,
+ * aggregator, research). Spread this into `exclude`, then add the sibling
+ * handler dirs that particular bundle does not copy.
  */
 export const PY_LAMBDA_ASSET_EXCLUDES = [
-  '**/__pycache__',
-  '**/*.pyc',
-  '**/.DS_Store',
-  '**/test/**',        // pytest suites (api/test, shared/test, jobs/*/test) never ship
-  '**/test_*.py',      // stray test modules outside test/ dirs
-  '**/conftest.py',
-  'custom_resources/**', // inlined into stacks via readFileSync, never bundled
-  'layers/**',         // pip layer sources + local build output (see python-layer-bundling.ts)
-  'stream/**',         // Node.js streaming Lambda — bundled separately by NodejsFunction
+  '__pycache__',
+  '*.pyc',
+  '.DS_Store',
+  // pytest suites (api/test, shared/test, jobs/*/test) never ship
+  'test',
+  'test_*.py',
+  'conftest.py',
+  // inlined into stacks via readFileSync, never bundled
+  'custom_resources',
+  // pip layer sources + local build output (see python-layer-bundling.ts)
+  'layers',
+  // Node.js streaming Lambda — bundled separately by NodejsFunction
+  'stream',
+];
+
+/**
+ * For the plugin ingestor bundles, which must stage from the PROJECT ROOT
+ * (they copy plugins/<id>/ingestor + plugins/_shared + lambda/shared). Only
+ * those three trees may influence the asset hash — everything else here is
+ * noise, and dot-children of excluded dirs must be pruned too (see module
+ * doc). Bare names match at any depth by design (e.g. 'dist' also covers
+ * lambda/stream/dist).
+ */
+export const ROOT_PLUGIN_ASSET_EXCLUDES = [
+  '__pycache__',
+  '*.pyc',
+  '.DS_Store',
+  'test',
+  'conftest.py',
+  'test_*.py',
+  'node_modules',
+  'cdk.out',
+  'frontend',
+  '*.ts',
+  '*.js',
+  '*.json',
+  '*.md',
+  'bin',
+  'lib',
+  'dist',
+  '.venv',
+  '.pytest_cache',
+  '.ruff_cache',
+  'coverage_html',
+  '.coverage',
+  '.coveragerc',
+  'ruff.toml',
+  'pytest.ini',
+  'requirements-dev.txt',
+  'chrome-extension',
+  'scripts',
+  'schemas',
+  'Workshop',
+  'plugins/_template',
+  'lambda/aggregator',
+  'lambda/api',
+  'lambda/custom_resources',
+  'lambda/jobs',
+  'lambda/layers',
+  'lambda/processor',
+  'lambda/research',
+  'lambda/stream',
 ];


### PR DESCRIPTION
Fixes #203

## The bug that survived four sessions of deploys

The five plugin-ingestor Lambdas redeployed byte-identical code on nearly every `cdk deploy --all`, and `cdk diff` systematically disagreed with `cdk deploy` about their asset hashes. Root cause, finally proven with aws-cdk-lib's own machinery:

**CDK matches asset excludes with `minimatch(relativePath, pattern, { matchBase: true })`, and `**` never crosses a dot segment.** So `'cdk.out/**'` does NOT exclude `cdk.out/.cache/*.zip` — CDK's own asset-publishing cache. The feedback loop: deploy publishes zips into `.cache` → the next synth stages the project root for the ingestor assets → the fingerprint includes the new zips → new hashes → deploy publishes again → forever. A probe using `FileSystem.copyDirectory`/`fingerprint` with the exact exclude list showed **95→99 cache zips staged across one no-op deploy**, root fingerprint flipping, zero first-party changes. `node_modules/.bin`, `.venv/.gitignore` were staged through the same hole (static today, one tool-run from churning).

## Fix

Exclude directories **by name** — bare (`'cdk.out'`; matchBase applies slash-less patterns to basenames at any depth) or path-qualified (`'lambda/layers'`) — which prunes the whole subtree via `completelyIgnores`, dot-children included. Never `'dir/**'`.

- `ROOT_PLUGIN_ASSET_EXCLUDES` centralizes the root-staging list next to `PY_LAMBDA_ASSET_EXCLUDES` (both converted); the module doc records the semantics
- All stack call sites converted (`'aggregator/**'` → `'aggregator'`, …)
- Guard tests rewritten at the **behavior level**: the real `IgnoreStrategy` (with the walk's ancestor-`completelyIgnores` semantics) runs against the exported lists — `cdk.out/.cache/x.zip` must be ignored; plugin/shared payloads and the API prompt JSONs must **not** be (matchBase makes `'*.json'` any-depth, so this guards against hash-blind prompt edits); plus a static check rejecting any future `dir/**` entry. Mutation-verified both ways.

## Live acceptance — the sequence that never converged before

1. deploy (one-time hash roll from the new lists): Ingestion/Processing/Api updated
2. **deploy again: all five stacks `(no changes)`**
3. **`cdk diff`: `Number of stacks with differences: 0`**
4. **deploy a third time: all no-op**

Deploy and diff agree for the first time in the project's history. Full gate exit 0 (1096 backend tests, all suites).