### PR TITLE
feat(web-search): deploy the gateway by default for all deployments

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,7 +178,7 @@ The platform consists of 4 core stacks plus 2 optional ones:
 | `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
 | `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case submission — created only when `anthropicUseCase` is set in `cdk.context.json` (see the conditional in `bin/voc-datalake.ts`) | None |
-| `VocWebSearchStack` | AgentCore Gateway for public web search — deployed by default, opt out via `enableWebSearch: false`; always deploys to us-east-1 (the connector only exists there) | None |
+| `VocWebSearchStack` (default-on, opt-out) | AgentCore Gateway for public web search — deployed by default, opt out via `enableWebSearch: false`; always deploys to us-east-1 (the connector only exists there). **Upgrade note:** existing non-us-east-1 deployments must bootstrap us-east-1 once (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`) or set the opt-out flag | None |
 
 ### Deploy All Stacks
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,7 +178,7 @@ The platform consists of 4 core stacks plus 2 optional ones:
 | `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
 | `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case submission — created only when `anthropicUseCase` is set in `cdk.context.json` (see the conditional in `bin/voc-datalake.ts`) | None |
-| `VocWebSearchStack` (optional) | AgentCore Gateway for public web search — opt-in via `enableWebSearch: true`; always deploys to us-east-1 (the connector only exists there) | None |
+| `VocWebSearchStack` | AgentCore Gateway for public web search — deployed by default, opt out via `enableWebSearch: false`; always deploys to us-east-1 (the connector only exists there) | None |
 
 ### Deploy All Stacks
 
@@ -218,23 +218,23 @@ Due to dependencies, stacks should be deployed in this order:
 
 The `cdk deploy --all` command handles this automatically.
 
-### Enabling Web Search (optional)
+### Web Search (on by default)
 
-Public web search in AI Chat and Research is opt-in and off by default —
-without it the UI hides the web-search toggle entirely (the deployment
-reports `WebSearchAvailable=false` and `config.json` ships
-`features.webSearch: false`).
+Public web search in AI Chat and Research deploys by default; individual
+searches stay opt-in per request (chat toggle, research wizard checkbox).
 
-To enable it:
+Requirement: the gateway only exists in us-east-1, so that region must be
+bootstrapped even when the app lives elsewhere (cross-region references):
 
 ```bash
-# One-time: the gateway only exists in us-east-1, so that region must be
-# bootstrapped even when the app lives elsewhere (cross-region references)
 cdk bootstrap aws://ACCOUNT_ID/us-east-1
-
-cdk deploy --all -c enableWebSearch=true
-npm run deploy:frontend   # regenerates config.json with webSearch: true
 ```
+
+To opt OUT (e.g. when a us-east-1 bootstrap isn't possible) set
+`"enableWebSearch": false` in `cdk.context.json` or deploy with
+`-c enableWebSearch=false` — the UI then hides the web-search surfaces
+entirely (the deployment reports `WebSearchAvailable=false` and
+`config.json` ships `features.webSearch: false`).
 
 Cost model (per `bin/voc-datalake.ts`): the gateway has no standing cost;
 searches bill per query ($7/1k at the time of writing — check AgentCore
@@ -370,11 +370,11 @@ entirely within AWS and are billed at $7 per 1,000 searches; the feature is
 opt-in per request in both UIs (chat toggle, research wizard checkbox).
 
 The connector only exists in **us-east-1**, so the stack always deploys
-there. Deployment is **explicitly opt-in** while the connector integration
-is new — enable it with `"enableWebSearch": true` in `cdk.context.json`:
+there. Deployment is **on by default** (opt out with
+`"enableWebSearch": false` in `cdk.context.json`):
 
-- App deployed to us-east-1: the flag is all that's needed.
-- App deployed to any other region: the flag plus a us-east-1 bootstrap
+- App deployed to us-east-1: nothing else needed.
+- App deployed to any other region: a us-east-1 bootstrap
   (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`); CDK cross-region references
   carry the gateway URL/ARN to the app region.
 

--- a/voc-datalake/bin/voc-datalake.ts
+++ b/voc-datalake/bin/voc-datalake.ts
@@ -45,12 +45,10 @@ const env = {
 // Stack 0a: VocWebSearchStack (default-on, opt-out)
 // AgentCore Gateway for the AWS-managed web-search connector.
 // ============================================
-// Deployed BY DEFAULT (issue #205): the gateway has no standing cost and
-// searches are opt-in per request in both UIs ($7/1k queries) — chat's
-// toggle and the research wizard's checkbox stay off until a user turns
-// them on. Opt out with `"enableWebSearch": false` in cdk.context.json (or
-// `-c enableWebSearch=false`) — needed e.g. when the us-east-1 bootstrap
-// required for cross-region references is unavailable.
+// Flag semantics live in lib/utils/web-search-default.ts (single source of
+// truth). Summary: deploys by default; `enableWebSearch: false` opts out;
+// unrecognized values throw. Per-request search stays opt-in in both UIs
+// ($7/1k queries; the gateway itself has no standing cost).
 //
 // The connector only exists in us-east-1, so the stack always deploys
 // there. When the app itself lives in another region this additionally
@@ -67,6 +65,16 @@ if (deployWebSearch) {
     description: 'VoC Data Lake - Web Search (AgentCore Gateway, web-search connector) (uksb-0q2jyqfvlm)(tag:VocWebSearchStack)',
   });
   tagStack(webSearchStack, 'WebSearch');
+  if (webSearchCrossRegion) {
+    // Upgrade hint (issue #205): web search now deploys by default, and a
+    // non-us-east-1 app needs a us-east-1 bootstrap for the cross-region
+    // references. Say so at synth, before `cdk bootstrap`'s error becomes
+    // the first (and cryptic) signal.
+    cdk.Annotations.of(webSearchStack).addInfo(
+      `Web search deploys by default and requires a us-east-1 bootstrap when the app region is ${env.region} ` +
+      '(cdk bootstrap aws://ACCOUNT/us-east-1). Opt out with -c enableWebSearch=false.',
+    );
+  }
 }
 
 // ============================================

--- a/voc-datalake/bin/voc-datalake.ts
+++ b/voc-datalake/bin/voc-datalake.ts
@@ -10,6 +10,7 @@ import { VocApiStack } from '../lib/stacks/api-stack';
 import { VocWebSearchStack } from '../lib/stacks/web-search-stack';
 import { BedrockAccessStack, AnthropicUseCaseSchema } from '../lib/stacks/bedrock-access-stack';
 import { lambdaBasicExecutionRoleSuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, comprehendSuppressions, translateSuppressions, apiGatewayPushToCloudwatchLogsRoleSuppressions } from '../lib/utils/nag-suppressions';
+import { shouldDeployWebSearch } from '../lib/utils/web-search-default';
 
 const app = new cdk.App();
 
@@ -41,21 +42,21 @@ const env = {
 };
 
 // ============================================
-// Stack 0a: VocWebSearchStack (Optional, opt-in)
+// Stack 0a: VocWebSearchStack (default-on, opt-out)
 // AgentCore Gateway for the AWS-managed web-search connector.
 // ============================================
-// Explicitly opt-in via `"enableWebSearch": true` in cdk.context.json (or
-// `-c enableWebSearch=true`). The gateway itself has no standing cost and
-// searches are opt-in per request ($7/1k queries), but the connector
-// integration is new — keep deployment a conscious choice until a real
-// gateway round-trip has been validated post-release, then consider
-// defaulting it on for us-east-1.
+// Deployed BY DEFAULT (issue #205): the gateway has no standing cost and
+// searches are opt-in per request in both UIs ($7/1k queries) — chat's
+// toggle and the research wizard's checkbox stay off until a user turns
+// them on. Opt out with `"enableWebSearch": false` in cdk.context.json (or
+// `-c enableWebSearch=false`) — needed e.g. when the us-east-1 bootstrap
+// required for cross-region references is unavailable.
 //
 // The connector only exists in us-east-1, so the stack always deploys
 // there. When the app itself lives in another region this additionally
 // requires a us-east-1 bootstrap and CDK cross-region references.
 const webSearchContextRaw = app.node.tryGetContext('enableWebSearch');
-const deployWebSearch = webSearchContextRaw === true || webSearchContextRaw === 'true';
+const deployWebSearch = shouldDeployWebSearch(webSearchContextRaw);
 const webSearchCrossRegion = deployWebSearch && env.region !== 'us-east-1';
 
 let webSearchStack: VocWebSearchStack | undefined;

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -17,9 +17,10 @@ import { uniqueName } from '../utils/naming';
  * HTTPS with SigV4, and the gateway URL/ARN flow to those stacks via CDK
  * cross-region references (SSM-backed when regions differ).
  *
- * Opt-in via `"enableWebSearch": true` in cdk.context.json. When the app
- * region is not us-east-1, the account must also be bootstrapped in
- * us-east-1 (`cdk bootstrap aws://ACCOUNT/us-east-1`).
+ * Deployed BY DEFAULT (issue #205); opt out with `"enableWebSearch": false`
+ * in cdk.context.json. When the app region is not us-east-1, the account
+ * must also be bootstrapped in us-east-1
+ * (`cdk bootstrap aws://ACCOUNT/us-east-1`).
  *
  * Cost note: Web Search invocations are billed at $7 per 1,000 queries.
  * The feature is opt-in per request in both UIs.

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -17,10 +17,10 @@ import { uniqueName } from '../utils/naming';
  * HTTPS with SigV4, and the gateway URL/ARN flow to those stacks via CDK
  * cross-region references (SSM-backed when regions differ).
  *
- * Deployed BY DEFAULT (issue #205); opt out with `"enableWebSearch": false`
- * in cdk.context.json. When the app region is not us-east-1, the account
- * must also be bootstrapped in us-east-1
- * (`cdk bootstrap aws://ACCOUNT/us-east-1`).
+ * Deployed BY DEFAULT; flag semantics live in
+ * lib/utils/web-search-default.ts (single source of truth). When the app
+ * region is not us-east-1, the account must also be bootstrapped in
+ * us-east-1 (`cdk bootstrap aws://ACCOUNT/us-east-1`).
  *
  * Cost note: Web Search invocations are billed at $7 per 1,000 queries.
  * The feature is opt-in per request in both UIs.

--- a/voc-datalake/lib/utils/web-search-default.test.ts
+++ b/voc-datalake/lib/utils/web-search-default.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression guard for issue #205: web search deploys BY DEFAULT — the /chat
+ * toggle and the research wizard's web-search source are gated on the
+ * deployment reporting the feature, so a silent flip back to opt-in would
+ * hide both surfaces in every fresh deployment.
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldDeployWebSearch } from './web-search-default';
+
+describe('shouldDeployWebSearch', () => {
+  it('deploys by default when no context is provided', () => {
+    expect(shouldDeployWebSearch(undefined)).toBe(true);
+  });
+
+  it('stays on for explicit enables (boolean and CLI string)', () => {
+    expect(shouldDeployWebSearch(true)).toBe(true);
+    expect(shouldDeployWebSearch('true')).toBe(true);
+  });
+
+  it('opts out only on explicit false (boolean and CLI string)', () => {
+    expect(shouldDeployWebSearch(false)).toBe(false);
+    expect(shouldDeployWebSearch('false')).toBe(false);
+  });
+});

--- a/voc-datalake/lib/utils/web-search-default.test.ts
+++ b/voc-datalake/lib/utils/web-search-default.test.ts
@@ -2,7 +2,9 @@
  * Regression guard for issue #205: web search deploys BY DEFAULT — the /chat
  * toggle and the research wizard's web-search source are gated on the
  * deployment reporting the feature, so a silent flip back to opt-in would
- * hide both surfaces in every fresh deployment.
+ * hide both surfaces in every fresh deployment. Unrecognized flag values
+ * fail loud: under default-on, a typo must not silently deploy (or skip)
+ * the stack.
  */
 import { describe, it, expect } from 'vitest';
 import { shouldDeployWebSearch } from './web-search-default';
@@ -10,15 +12,26 @@ import { shouldDeployWebSearch } from './web-search-default';
 describe('shouldDeployWebSearch', () => {
   it('deploys by default when no context is provided', () => {
     expect(shouldDeployWebSearch(undefined)).toBe(true);
+    expect(shouldDeployWebSearch(null)).toBe(true);
   });
 
-  it('stays on for explicit enables (boolean and CLI string)', () => {
+  it('stays on for explicit enables (boolean and CLI string, any case)', () => {
     expect(shouldDeployWebSearch(true)).toBe(true);
     expect(shouldDeployWebSearch('true')).toBe(true);
+    expect(shouldDeployWebSearch('TRUE')).toBe(true);
   });
 
-  it('opts out only on explicit false (boolean and CLI string)', () => {
+  it('opts out on explicit false (boolean and CLI string, any case)', () => {
     expect(shouldDeployWebSearch(false)).toBe(false);
     expect(shouldDeployWebSearch('false')).toBe(false);
+    expect(shouldDeployWebSearch('FALSE')).toBe(false);
+    expect(shouldDeployWebSearch(' false ')).toBe(false);
+  });
+
+  it('throws on unrecognized values instead of guessing', () => {
+    for (const bad of ['flase', 'no', '0', 'off', 1, 0, {}]) {
+      expect(() => shouldDeployWebSearch(bad), `value: ${JSON.stringify(bad)}`)
+        .toThrow(/Unrecognized enableWebSearch/);
+    }
   });
 });

--- a/voc-datalake/lib/utils/web-search-default.ts
+++ b/voc-datalake/lib/utils/web-search-default.ts
@@ -1,8 +1,25 @@
 /**
- * Web-search deployment default (issue #205): VocWebSearchStack deploys
- * UNLESS explicitly opted out. CLI context arrives as strings, so both the
- * boolean and its string form must opt out.
+ * Web-search deployment default (issue #205) — SINGLE SOURCE OF TRUTH for
+ * the `enableWebSearch` context flag's semantics (bin/voc-datalake.ts,
+ * web-search-stack.ts and docs/deployment.md defer here).
+ *
+ * VocWebSearchStack deploys UNLESS explicitly opted out. CLI context
+ * arrives as strings, so string forms are accepted case-insensitively.
+ * Anything unrecognized throws at synth: under a default-ON paradigm a
+ * typo like `-c enableWebSearch=flase` must not silently deploy a stack
+ * the operator tried to disable (nor silently skip one they tried to
+ * force) — fail loud, not open.
  */
 export function shouldDeployWebSearch(contextValue: unknown): boolean {
-  return !(contextValue === false || contextValue === 'false');
+  if (contextValue === undefined || contextValue === null) return true;
+  if (contextValue === true || contextValue === false) return contextValue;
+  if (typeof contextValue === 'string') {
+    const normalized = contextValue.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+  throw new Error(
+    `Unrecognized enableWebSearch context value: ${JSON.stringify(contextValue)}. ` +
+    "Use true/false (web search deploys by default; opt out with -c enableWebSearch=false).",
+  );
 }

--- a/voc-datalake/lib/utils/web-search-default.ts
+++ b/voc-datalake/lib/utils/web-search-default.ts
@@ -1,0 +1,8 @@
+/**
+ * Web-search deployment default (issue #205): VocWebSearchStack deploys
+ * UNLESS explicitly opted out. CLI context arrives as strings, so both the
+ * boolean and its string form must opt out.
+ */
+export function shouldDeployWebSearch(contextValue: unknown): boolean {
+  return !(contextValue === false || contextValue === 'false');
+}


### PR DESCRIPTION
Fixes #205

The /chat web-search toggle and the Run Research wizard's 'Include public web search' data source were both fully built but invisible in every deployment that didn't opt into `VocWebSearchStack` — which was all of them, including production. The bin comment's condition for flipping the default ('a conscious choice until a real gateway round-trip has been validated post-release') has been met, so:

## Changes
- **Default on**: `VocWebSearchStack` deploys unless `enableWebSearch: false` (escape hatch for accounts that can't bootstrap us-east-1, which cross-region references require). Decision extracted to `shouldDeployWebSearch()` with a mutation-verified regression test — a silent flip back to opt-in fails the no-context case.
- **Per-request behavior unchanged**: the chat toggle stays off per message and the wizard checkbox unchecked; only stack deployment defaults on. Gateway has no standing cost; searches bill $7/1k queries.
- Docs reframed to opt-out (deployment.md stack table + enable section + feature section, web-search-stack.ts doc).

## Live verification (us-west-2 app, cross-region gateway)
- Deployed with **no context flag** — the stack came up purely from the new default; `WebSearchAvailable=true`, live `config.json` ships `features.webSearch: true`
- **Chat**: `POST /chat/stream` with `use_web_search: true` executed 4 web-search tool rounds and returned cited `web_sources` in the done event
- **Research**: `voc-research-step` now carries `WEB_SEARCH_GATEWAY_URL`/`TOOL_NAME`; the wizard's checkbox flows `use_web_search` through `/projects/{id}/research` into the Step Functions job (searches during analysis, disclosure line in the report)

Gate exit 0 (1096 backend tests, all suites).