### PR TITLE
feat(webscraper): parse word-based star-rating classes (#148)

### DIFF
--- a/voc-datalake/plugins/webscraper/ingestor/handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/handler.py
@@ -20,6 +20,7 @@ import requests
 # Word-based star-rating classes, e.g. <p class="star-rating Three">. Used by
 # books.toscrape.com and similar review widgets that encode the star count as a
 # number word in the element's CSS class rather than a digit or an attribute.
+# Keys MUST be lowercase — lookups normalize the class token via .lower().
 WORD_STAR_RATINGS = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5}
 
 
@@ -113,6 +114,9 @@ class WebScraperIngestor(BaseIngestor):
                 rating = int(match.group(1))
                 if 1 <= rating <= 5:
                     return rating
+            # Only consulted on the element the config's rating_selector
+            # resolves to, so a bare 'one'/'two' grid-column class elsewhere
+            # in the DOM can't leak in as a rating.
             word_rating = WORD_STAR_RATINGS.get(cls.lower())
             if word_rating is not None:
                 return word_rating

--- a/voc-datalake/plugins/webscraper/ingestor/handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/handler.py
@@ -17,6 +17,12 @@ from _shared.base_ingestor import BaseIngestor, logger, tracer, metrics, fetch_w
 import requests
 
 
+# Word-based star-rating classes, e.g. <p class="star-rating Three">. Used by
+# books.toscrape.com and similar review widgets that encode the star count as a
+# number word in the element's CSS class rather than a digit or an attribute.
+WORD_STAR_RATINGS = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5}
+
+
 class WebScraperIngestor(BaseIngestor):
     """Configurable web scraper for extracting feedback from websites."""
 
@@ -107,6 +113,9 @@ class WebScraperIngestor(BaseIngestor):
                 rating = int(match.group(1))
                 if 1 <= rating <= 5:
                     return rating
+            word_rating = WORD_STAR_RATINGS.get(cls.lower())
+            if word_rating is not None:
+                return word_rating
         
         text = element.get_text(strip=True)
         match = re.search(r'(\d+(?:\.\d+)?)\s*(?:/\s*5|stars?|★)', text, re.I)

--- a/voc-datalake/plugins/webscraper/ingestor/test_handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/test_handler.py
@@ -1,0 +1,99 @@
+"""
+Tests for the Web Scraper Ingestor handler.
+
+Focus: `_extract_rating` rating extraction, including the word-based star
+classes fix (issue #148, e.g. ``<p class="star-rating Three">``). Also
+characterizes the pre-existing digit-class, rating-attribute, and text
+fallbacks so a regression in any of them is caught.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from bs4 import BeautifulSoup
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _el(html: str):
+    """Return the first tag parsed from an HTML snippet."""
+    return BeautifulSoup(html, "html.parser").find()
+
+
+@pytest.fixture
+def ingestor():
+    """Create a WebScraperIngestor with mocked AWS dependencies."""
+    with (
+        patch("_shared.base_ingestor.get_dynamodb_resource") as mock_dynamo,
+        patch("_shared.base_ingestor.get_s3_client"),
+        patch("_shared.base_ingestor.get_sqs_client"),
+        patch("_shared.base_ingestor.get_secret", return_value={}),
+    ):
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+        from webscraper.ingestor.handler import WebScraperIngestor
+        return WebScraperIngestor()
+
+
+# ---------------------------------------------------------------------------
+# Word-based star classes (issue #148)
+# ---------------------------------------------------------------------------
+
+class TestExtractRatingWordClasses:
+    def test_star_rating_three_returns_3(self, ingestor):
+        # The books.toscrape.com pattern.
+        el = _el('<p class="star-rating Three"></p>')
+        assert ingestor._extract_rating(el, {}) == 3
+
+    @pytest.mark.parametrize("word,expected", [
+        ("One", 1), ("Two", 2), ("Three", 3), ("Four", 4), ("Five", 5),
+    ])
+    def test_all_word_ratings(self, ingestor, word, expected):
+        el = _el(f'<p class="star-rating {word}"></p>')
+        assert ingestor._extract_rating(el, {}) == expected
+
+    def test_word_class_is_case_insensitive(self, ingestor):
+        assert ingestor._extract_rating(_el('<p class="FIVE"></p>'), {}) == 5
+        assert ingestor._extract_rating(_el('<p class="four"></p>'), {}) == 4
+
+    def test_word_only_matches_whole_class_token(self, ingestor):
+        # 'foo-three' must NOT match 'three' (no substring matching), so it
+        # falls through to the text fallback and returns None here.
+        el = _el('<p class="foo-three"></p>')
+        assert ingestor._extract_rating(el, {}) is None
+
+    def test_out_of_range_digit_falls_through_to_word(self, ingestor):
+        # First token has a digit outside 1-5 (ignored); the loop must
+        # continue and resolve the word token.
+        el = _el('<p class="rating-9 Three"></p>')
+        assert ingestor._extract_rating(el, {}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing behavior (characterization / regression guards)
+# ---------------------------------------------------------------------------
+
+class TestExtractRatingExisting:
+    def test_digit_in_class_still_works(self, ingestor):
+        assert ingestor._extract_rating(_el('<span class="rating-4"></span>'), {}) == 4
+
+    def test_rating_attribute_takes_precedence(self, ingestor):
+        # data-rating is checked before class names.
+        el = _el('<div data-rating="5" class="Two"></div>')
+        assert ingestor._extract_rating(el, {}) == 5
+
+    def test_custom_rating_attribute(self, ingestor):
+        el = _el('<div data-stars="4"></div>')
+        assert ingestor._extract_rating(el, {"rating_attribute": "data-stars"}) == 4
+
+    def test_text_fallback_x_out_of_5(self, ingestor):
+        assert ingestor._extract_rating(_el('<span>4/5</span>'), {}) == 4
+
+    def test_text_fallback_stars(self, ingestor):
+        assert ingestor._extract_rating(_el('<span>3 stars</span>'), {}) == 3
+
+    def test_none_element_returns_none(self, ingestor):
+        assert ingestor._extract_rating(None, {}) is None
+
+    def test_no_rating_signal_returns_none(self, ingestor):
+        assert ingestor._extract_rating(_el('<p class="star-rating"></p>'), {}) is None


### PR DESCRIPTION
## Summary

Fixes #148. The webscraper's `_extract_rating` only looked for **digits** in an element's CSS class names, so review widgets that encode the star count as a **number word** — e.g. `<p class="star-rating Three">`, the pattern used by [books.toscrape.com](https://books.toscrape.com) and similar widgets — ingested with **no rating**.

## Change

`voc-datalake/plugins/webscraper/ingestor/handler.py`:

- Add a module-level `WORD_STAR_RATINGS = {'one': 1, ... 'five': 5}` map.
- In the existing class-name loop, after the digit check, look up `cls.lower()` in the map and return the mapped value.

Design notes:
- **Class-token scoped, exact match, case-insensitive.** It matches a whole class token (`Three`, `FIVE`), never a substring — `foo-three` does not match, so it can't misfire on unrelated class names.
- **No text-scope matching.** The word map is deliberately *not* applied to element text, to avoid false positives like "one of the best…". Scope matches the issue.
- `rating_attribute` (checked first) and the digit / `x/5` / `stars` / `★` text fallbacks are unchanged. An out-of-range digit token (e.g. `rating-9`) still falls through and a later word token is resolved.

## Tests

New `voc-datalake/plugins/webscraper/ingestor/test_handler.py` (16 tests):

- Word classes: `star-rating Three` → 3, all of one–five, case-insensitivity, whole-token-only (`foo-three` → None), out-of-range-digit-falls-through-to-word.
- Characterization guards for the pre-existing paths: digit-in-class, `rating_attribute` precedence, custom attribute, `4/5` and `3 stars` text, `None` element, no-signal → None.

## Validation (local)

- 16/16 new webscraper tests pass; 5/5 `plugins/test_plugin_imports.py` pass.
- `ruff check` clean; `py_compile` OK; no editor diagnostics.

Backend-only plugin change — no infra or frontend impact.
