### PR TITLE
fix(data-explorer): query the GSI that exists — gsi4-by-feedback-id (#140)

### DIFF
--- a/voc-datalake/lambda/api/data_explorer_handler.py
+++ b/voc-datalake/lambda/api/data_explorer_handler.py
@@ -29,6 +29,9 @@ sqs_client = get_sqs_client()
 
 RAW_DATA_BUCKET = os.environ.get("RAW_DATA_BUCKET", "")
 FEEDBACK_TABLE = os.environ.get("FEEDBACK_TABLE", "")
+# Feedback-id lookup GSI — must match core-stack.ts (gsi4-by-feedback-id).
+# Regression-tested in test_data_explorer_handler.py (#140).
+FEEDBACK_ID_INDEX = 'gsi4-by-feedback-id'
 PROCESSING_QUEUE_URL = os.environ.get("PROCESSING_QUEUE_URL", "")
 
 # Available buckets for browsing
@@ -349,7 +352,7 @@ def save_feedback():
         else:
             # Need to find the item first
             response = table.query(
-                IndexName='gsi4-by-feedback-id',
+                IndexName=FEEDBACK_ID_INDEX,
                 KeyConditionExpression='feedback_id = :fid',
                 ExpressionAttributeValues={':fid': feedback_id},
                 Limit=1
@@ -412,7 +415,7 @@ def delete_feedback():
         
         # Find the item first using GSI
         response = table.query(
-            IndexName='gsi4-by-feedback-id',
+            IndexName=FEEDBACK_ID_INDEX,
             KeyConditionExpression='feedback_id = :fid',
             ExpressionAttributeValues={':fid': feedback_id},
             Limit=1

--- a/voc-datalake/lambda/api/data_explorer_handler.py
+++ b/voc-datalake/lambda/api/data_explorer_handler.py
@@ -349,7 +349,7 @@ def save_feedback():
         else:
             # Need to find the item first
             response = table.query(
-                IndexName='feedback-id-index',
+                IndexName='gsi4-by-feedback-id',
                 KeyConditionExpression='feedback_id = :fid',
                 ExpressionAttributeValues={':fid': feedback_id},
                 Limit=1
@@ -412,7 +412,7 @@ def delete_feedback():
         
         # Find the item first using GSI
         response = table.query(
-            IndexName='feedback-id-index',
+            IndexName='gsi4-by-feedback-id',
             KeyConditionExpression='feedback_id = :fid',
             ExpressionAttributeValues={':fid': feedback_id},
             Limit=1

--- a/voc-datalake/lambda/api/test/test_data_explorer_handler.py
+++ b/voc-datalake/lambda/api/test/test_data_explorer_handler.py
@@ -329,6 +329,7 @@ class TestSaveFeedback:
 
         # Assert
         assert response['statusCode'] == 200
+        mock_table.query.assert_called_once()
         assert mock_table.query.call_args.kwargs['IndexName'] == 'gsi4-by-feedback-id'
 
     @patch('data_explorer_handler.dynamodb')
@@ -412,6 +413,7 @@ class TestDeleteFeedback:
 
         # Assert
         assert response['statusCode'] == 200
+        mock_table.query.assert_called_once()
         assert mock_table.query.call_args.kwargs['IndexName'] == 'gsi4-by-feedback-id'
 
     @patch('data_explorer_handler.dynamodb')

--- a/voc-datalake/lambda/api/test/test_data_explorer_handler.py
+++ b/voc-datalake/lambda/api/test/test_data_explorer_handler.py
@@ -300,6 +300,38 @@ class TestSaveFeedback:
         assert body['success'] is True
 
     @patch('data_explorer_handler.dynamodb')
+    def test_lookup_queries_the_real_gsi_name(
+        self, mock_dynamodb, api_gateway_event, lambda_context
+    ):
+        """Regression (#140): the feedback-id lookup must query the GSI that
+        actually exists on the table (gsi4-by-feedback-id, core-stack.ts) —
+        'feedback-id-index' does not exist and made every non-key edit 500."""
+        # Arrange — no pk/sk in data forces the GSI lookup path
+        mock_table = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_table.query.return_value = {
+            'Items': [{'pk': 'SOURCE#webscraper', 'sk': 'FEEDBACK#fb-123'}]
+        }
+        mock_table.update_item.return_value = {}
+
+        from data_explorer_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/data-explorer/feedback',
+            body={
+                'feedback_id': 'fb-123',
+                'data': {'original_text': 'Updated via GSI lookup'}
+            }
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+
+        # Assert
+        assert response['statusCode'] == 200
+        assert mock_table.query.call_args.kwargs['IndexName'] == 'gsi4-by-feedback-id'
+
+    @patch('data_explorer_handler.dynamodb')
     def test_returns_error_when_feedback_id_missing(
         self, mock_dynamodb, api_gateway_event, lambda_context
     ):
@@ -352,6 +384,35 @@ class TestDeleteFeedback:
         # Assert
         assert response['statusCode'] == 200
         assert body['success'] is True
+
+    @patch('data_explorer_handler.dynamodb')
+    def test_delete_queries_the_real_gsi_name(
+        self, mock_dynamodb, api_gateway_event, lambda_context
+    ):
+        """Regression (#140): delete's feedback-id lookup must use
+        gsi4-by-feedback-id — the nonexistent 'feedback-id-index' made every
+        Data Explorer record delete fail with a ValidationException."""
+        # Arrange
+        mock_table = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_table.query.return_value = {
+            'Items': [{'pk': 'SOURCE#webscraper', 'sk': 'FEEDBACK#fb-123'}]
+        }
+        mock_table.delete_item.return_value = {}
+
+        from data_explorer_handler import lambda_handler
+        event = api_gateway_event(
+            method='DELETE',
+            path='/data-explorer/feedback',
+            query_params={'feedback_id': 'fb-123'}
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+
+        # Assert
+        assert response['statusCode'] == 200
+        assert mock_table.query.call_args.kwargs['IndexName'] == 'gsi4-by-feedback-id'
 
     @patch('data_explorer_handler.dynamodb')
     def test_returns_error_when_feedback_not_found(


### PR DESCRIPTION
## Summary

Fixes #140. `save_feedback` (in its GSI-lookup branch, i.e. whenever the edit payload doesn't carry `pk`/`sk`) and `delete_feedback` in `lambda/api/data_explorer_handler.py` queried `IndexName='feedback-id-index'` — an index that has never existed on the feedback table. The real index is **`gsi4-by-feedback-id`** (`lib/stacks/core-stack.ts`, partition key `feedback_id`, projection ALL). Result: every Data Explorer record **delete** failed with a DynamoDB `ValidationException` (surfaced as a 500), as did edits without inline keys.

## Change

- `data_explorer_handler.py`: `IndexName='feedback-id-index'` → `IndexName='gsi4-by-feedback-id'` at both query sites. Nothing else — key condition (`feedback_id = :fid`) already matches the GSI's partition key.

## Tests

Existing tests mocked the table, so the bad index name never surfaced. Added two regression tests in `test_data_explorer_handler.py` that pin the `IndexName` kwarg on both paths (`test_lookup_queries_the_real_gsi_name`, `test_delete_queries_the_real_gsi_name`) — a future rename drift between the stack and the handler now fails the suite instead of the live API.

## Validation (local)

- 20/20 tests in `test_data_explorer_handler.py` (18 existing + 2 new), `ruff check` clean.
- Repo-wide sweep: no remaining `feedback-id-index` references outside the regression-test docstrings.

Deployment note: live validation cumulated into the next batch deploy per maintainer decision.
