### PR TITLE
fix(webscraper): clear secret cache on manual runs — Save-then-Run-now stale read (#141)

### DIFF
--- a/voc-datalake/plugins/webscraper/ingestor/handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/handler.py
@@ -425,7 +425,14 @@ def lambda_handler(event, context):
     """Lambda entry point."""
     execution_id = event.get('execution_id')
     scraper_id = event.get('scraper_id')
-    
+
+    # Clear secret cache on manual runs so a warm container picks up a config
+    # saved moments ago (Save-then-Run-now, issue #141). get_secret is
+    # lru_cached without TTL; same guard as the app-review ingestors.
+    if execution_id:
+        from shared.aws import clear_secret_cache
+        clear_secret_cache()
+
     ingestor = WebScraperIngestor(
         execution_id=execution_id,
         target_scraper_id=scraper_id

--- a/voc-datalake/plugins/webscraper/ingestor/test_handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/test_handler.py
@@ -148,6 +148,7 @@ class TestLambdaHandlerSecretCache:
         lambda_handler({}, lambda_context)
 
         mock_clear.assert_not_called()
+        MockIngestor.assert_called_once()
 
     @patch("shared.aws.clear_secret_cache")
     @patch("webscraper.ingestor.handler.WebScraperIngestor")
@@ -157,10 +158,16 @@ class TestLambdaHandlerSecretCache:
         """Order matters: clearing after the ingestor loads its config would
         be a no-op — the stale snapshot would already be in memory."""
         call_order = []
-        mock_clear.side_effect = lambda: call_order.append("clear")
-        MockIngestor.side_effect = lambda **kw: call_order.append("ingestor") or MagicMock(
-            run=MagicMock(return_value={"status": "success"})
-        )
+
+        def record_clear():
+            call_order.append("clear")
+
+        def record_ingestor(**_kwargs):
+            call_order.append("ingestor")
+            return MagicMock(run=MagicMock(return_value={"status": "success"}))
+
+        mock_clear.side_effect = record_clear
+        MockIngestor.side_effect = record_ingestor
 
         from webscraper.ingestor.handler import lambda_handler
         lambda_handler({"execution_id": "exec-1"}, lambda_context)

--- a/voc-datalake/plugins/webscraper/ingestor/test_handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/test_handler.py
@@ -4,7 +4,8 @@ Tests for the Web Scraper Ingestor handler.
 Focus: `_extract_rating` rating extraction, including the word-based star
 classes fix (issue #148, e.g. ``<p class="star-rating Three">``). Also
 characterizes the pre-existing digit-class, rating-attribute, and text
-fallbacks so a regression in any of them is caught.
+fallbacks so a regression in any of them is caught. Plus the manual-run
+secret-cache clear (issue #141).
 """
 
 import pytest
@@ -97,3 +98,71 @@ class TestExtractRatingExisting:
 
     def test_no_rating_signal_returns_none(self, ingestor):
         assert ingestor._extract_rating(_el('<p class="star-rating"></p>'), {}) is None
+
+
+# ---------------------------------------------------------------------------
+# Manual-run secret-cache clear (issue #141)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def lambda_context():
+    ctx = MagicMock()
+    ctx.function_name = "test-webscraper"
+    ctx.memory_limit_in_mb = 512
+    ctx.invoked_function_arn = "arn:aws:lambda:us-east-1:123456789:function:test"
+    ctx.aws_request_id = "test-request-id"
+    return ctx
+
+
+class TestLambdaHandlerSecretCache:
+    """Save-then-Run-now must not serve a pre-save secret snapshot (#141).
+
+    get_secret is lru_cached without TTL, so a warm container invoked right
+    after a config save would otherwise read the stale secret and fail with
+    'No scraper configuration found'. Manual runs (execution_id present)
+    must clear the cache first — the same guard the app-review ingestors use.
+    """
+
+    @patch("shared.aws.clear_secret_cache")
+    @patch("webscraper.ingestor.handler.WebScraperIngestor")
+    def test_manual_run_clears_secret_cache(
+        self, MockIngestor, mock_clear, lambda_context
+    ):
+        from webscraper.ingestor.handler import lambda_handler
+        MockIngestor.return_value.run.return_value = {"status": "success"}
+
+        lambda_handler(
+            {"execution_id": "exec-1", "scraper_id": "s1"}, lambda_context
+        )
+
+        mock_clear.assert_called_once()
+
+    @patch("shared.aws.clear_secret_cache")
+    @patch("webscraper.ingestor.handler.WebScraperIngestor")
+    def test_scheduled_run_keeps_warm_cache(
+        self, MockIngestor, mock_clear, lambda_context
+    ):
+        from webscraper.ingestor.handler import lambda_handler
+        MockIngestor.return_value.run.return_value = {"status": "success"}
+
+        lambda_handler({}, lambda_context)
+
+        mock_clear.assert_not_called()
+
+    @patch("shared.aws.clear_secret_cache")
+    @patch("webscraper.ingestor.handler.WebScraperIngestor")
+    def test_manual_run_constructs_ingestor_after_clearing(
+        self, MockIngestor, mock_clear, lambda_context
+    ):
+        """Order matters: clearing after the ingestor loads its config would
+        be a no-op — the stale snapshot would already be in memory."""
+        call_order = []
+        mock_clear.side_effect = lambda: call_order.append("clear")
+        MockIngestor.side_effect = lambda **kw: call_order.append("ingestor") or MagicMock(
+            run=MagicMock(return_value={"status": "success"})
+        )
+
+        from webscraper.ingestor.handler import lambda_handler
+        lambda_handler({"execution_id": "exec-1"}, lambda_context)
+
+        assert call_order == ["clear", "ingestor"]


### PR DESCRIPTION
## Summary

Fixes #141. Saving a new/edited web-scraper config and immediately clicking **Run now** failed with **"No scraper configuration found"** (Pages scraped: 0) even though the config saved correctly; a retry ~30s later succeeded.

Root cause: `get_secret` in `lambda/shared/aws.py` is `@lru_cache` with **no TTL**, so a **warm** webscraper container invoked right after the save serves the pre-save secret snapshot — a stale read, not a save failure. The iOS/Android app-review ingestors already guard against exactly this by calling `clear_secret_cache()` at the top of manual (`execution_id`) invocations; the webscraper was the only manual-run ingestor without the guard.

## Change

`plugins/webscraper/ingestor/handler.py` — in `lambda_handler`, when the event carries an `execution_id` (manual Run-now), call `clear_secret_cache()` **before** constructing the ingestor (which reads the secret at init). Identical pattern and comment style as `app_reviews_ios`/`app_reviews_android`. Scheduled runs are untouched and keep the warm-cache benefit.

## Tests

3 regression tests in `plugins/webscraper/ingestor/test_handler.py`:
- manual run clears the cache;
- scheduled run does **not** (warm cache preserved);
- ordering: the clear happens **before** ingestor construction — clearing after would be a no-op since the stale snapshot would already be loaded (this is the assertion that fails if someone "simplifies" the fix by moving the call).

## Validation (local)

19/19 tests in the file (16 existing + 3 new), `ruff check` clean.

Deployment note: cumulated into the next batch deploy per maintainer decision (needs `VocIngestionStack` for the webscraper Lambda; the batch already owes #210/#211/#212).
