### PR TITLE
feat(processor): persist ingestion_method provenance on feedback records (#145)

### DIFF
--- a/voc-datalake/frontend/src/api/feedbackSchema.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackSchema.test.ts
@@ -62,6 +62,18 @@ describe('normalizeFeedbackItem', () => {
     const item = normalizeFeedbackItem(rawItem({ sentiment_score: -0.75 }))
     expect(item.sentiment_score).toBe(-0.75)
   })
+
+  it('preserves ingestion_method through normalization (#145)', () => {
+    // Regression: the schema strips unknown keys, so a field missing from it
+    // would be silently dropped at the API boundary even if persisted.
+    const item = normalizeFeedbackItem(rawItem({ ingestion_method: 'csv_upload' }))
+    expect(item.ingestion_method).toBe('csv_upload')
+  })
+
+  it('leaves ingestion_method undefined when the record does not carry it', () => {
+    const item = normalizeFeedbackItem(rawItem())
+    expect(item.ingestion_method).toBeUndefined()
+  })
 })
 
 describe('normalizeFeedbackItems', () => {

--- a/voc-datalake/frontend/src/api/feedbackSchema.ts
+++ b/voc-datalake/frontend/src/api/feedbackSchema.ts
@@ -49,6 +49,7 @@ export const FeedbackItemSchema = z.object({
   source_id: lenientString,
   source_platform: lenientString,
   source_channel: lenientString,
+  ingestion_method: z.string().optional(),
   source_url: z.string().optional(),
   brand_name: lenientString,
   source_created_at: lenientString,

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -5,6 +5,8 @@ export interface FeedbackItem {
   source_id: string
   source_platform: string
   source_channel: string
+  /** Ingestion-path provenance, e.g. 'manual', 'csv_upload', 'json_upload'. Absent for sources that don't send it. */
+  ingestion_method?: string
   source_url?: string
   brand_name: string
   source_created_at: string

--- a/voc-datalake/lambda/processor/handler.py
+++ b/voc-datalake/lambda/processor/handler.py
@@ -528,6 +528,9 @@ def process_feedback(raw_record: dict, idempotency_key: str = None) -> dict:
         'source_id': raw_record.get('id', ''),
         'source_platform': source_platform,
         'source_channel': raw_record.get('source_channel', 'unknown'),
+        # Ingestion-path provenance (e.g. 'manual', 'csv_upload', 'json_upload').
+        # Optional: sources that don't send it omit the field via None-stripping.
+        'ingestion_method': raw_record.get('ingestion_method'),
         'source_url': raw_record.get('url'),
         'brand_name': source_display,
         'source_created_at': raw_record.get('created_at'),

--- a/voc-datalake/lambda/processor/test/test_handler.py
+++ b/voc-datalake/lambda/processor/test/test_handler.py
@@ -498,6 +498,55 @@ class TestProcessFeedback:
     @patch('processor.handler.translate_text')
     @patch('processor.handler.detect_language')
     @patch('processor.handler.check_duplicate')
+    def test_persists_ingestion_method_when_sent(
+        self, mock_check_dup, mock_detect, mock_translate, mock_sentiment, mock_llm,
+        sample_sqs_record, sample_llm_insights
+    ):
+        """Carries ingestion_method provenance to the persisted item (#145)."""
+        from processor.handler import process_feedback
+
+        mock_check_dup.return_value = False
+        mock_detect.return_value = 'en'
+        mock_translate.return_value = sample_sqs_record['text']
+        mock_sentiment.return_value = {'label': 'positive', 'score': 0.8}
+        mock_llm.return_value = {'insights': sample_llm_insights, 'metadata': {}}
+
+        sample_sqs_record['ingestion_method'] = 'csv_upload'
+
+        result = process_feedback(sample_sqs_record)
+
+        assert result['ingestion_method'] == 'csv_upload'
+
+    @patch('processor.handler.invoke_bedrock_llm')
+    @patch('processor.handler.get_comprehend_sentiment')
+    @patch('processor.handler.translate_text')
+    @patch('processor.handler.detect_language')
+    @patch('processor.handler.check_duplicate')
+    def test_omits_ingestion_method_when_not_sent(
+        self, mock_check_dup, mock_detect, mock_translate, mock_sentiment, mock_llm,
+        sample_sqs_record, sample_llm_insights
+    ):
+        """Sources that don't send ingestion_method must not gain a spurious
+        or empty field (None-stripping keeps the record shape unchanged)."""
+        from processor.handler import process_feedback
+
+        mock_check_dup.return_value = False
+        mock_detect.return_value = 'en'
+        mock_translate.return_value = sample_sqs_record['text']
+        mock_sentiment.return_value = {'label': 'positive', 'score': 0.8}
+        mock_llm.return_value = {'insights': sample_llm_insights, 'metadata': {}}
+
+        assert 'ingestion_method' not in sample_sqs_record
+
+        result = process_feedback(sample_sqs_record)
+
+        assert 'ingestion_method' not in result
+
+    @patch('processor.handler.invoke_bedrock_llm')
+    @patch('processor.handler.get_comprehend_sentiment')
+    @patch('processor.handler.translate_text')
+    @patch('processor.handler.detect_language')
+    @patch('processor.handler.check_duplicate')
     def test_uses_preset_category_when_provided(
         self, mock_check_dup, mock_detect, mock_translate, mock_sentiment, mock_llm, 
         sample_sqs_record, sample_llm_insights

--- a/voc-datalake/schemas/feedback-event.schema.json
+++ b/voc-datalake/schemas/feedback-event.schema.json
@@ -33,6 +33,10 @@
       "enum": ["review", "comment", "post", "message", "thread", "tweet", "mention", "reply", "other"],
       "description": "Type of content"
     },
+    "ingestion_method": {
+      "type": "string",
+      "description": "Optional ingestion-path provenance (e.g. manual, csv_upload, json_upload). Omitted by sources that do not send it."
+    },
     "source_url": {
       "type": ["string", "null"],
       "format": "uri",


### PR DESCRIPTION
## Summary

Fixes #145. Three senders in `manual_import_handler.py` already stamp their SQS messages with `ingestion_method` (`'manual'`, `'csv_upload'`, `'json_upload'`), but the processor's persisted-item whitelist never read the field — so it was silently discarded and paste/CSV/JSON imports were indistinguishable after ingest (`source_platform = 'manual_import'` for all).

## Change

- `lambda/processor/handler.py` — add `'ingestion_method': raw_record.get('ingestion_method')` to the persisted item dict, grouped with the other source/provenance fields. The existing None-stripping means sources that don't send it (scrapers, app reviews, forms) simply omit the field: **no migration, no spurious empty attributes**.
- `frontend/src/api/types.ts` — `FeedbackItem.ingestion_method?: string` (optional, doc-commented).
- `schemas/feedback-event.schema.json` — documents the optional field (not added to `required`).

Exactly Option A from the issue; Option B's paste-flow tagging is already on `development` (the `'manual'` sender).

## Tests

Two processor regression tests: `test_persists_ingestion_method_when_sent` (field carried through to the item) and `test_omits_ingestion_method_when_not_sent` (records without it don't gain a spurious/empty field) — the two acceptance criteria from the issue.

## Validation (local)

- 51/51 processor tests (49 existing + 2 new), `ruff check` clean.
- Frontend `tsc -b` clean; schema file validates as JSON.

Deployment note: processor change → `VocProcessingStack`; joins the pending batch deploy (#210/#211/#212/#214) per maintainer decision. No backfill — only newly ingested items carry the field.
