### PR TITLE
feat(scrapers): persistent Data Sources card for synthetic generators (#146)

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -121,6 +121,21 @@ const mockSourcesStatus = {
   ]
 };
 
+// Per-source persisted last-run records (?run_status=<source> variant of
+// GET /sources/status — the aggregates-table SOURCE_RUN# shape). Used by the
+// Synthetic Data source card (#146) and GeneratorConfigModal polling.
+const mockSourceRunStatuses = {
+  synthetic_reviews: {
+    source: 'synthetic_reviews',
+    execution_id: 'mock-exec-1',
+    status: 'completed',
+    started_at: '2026-07-15T09:00:00Z',
+    completed_at: '2026-07-15T09:01:30Z',
+    items_found: 5,
+    errors: [],
+  },
+};
+
 // Mock categories config
 // Problem resolution state (issue #66) — mutable so the toggle round-trips.
 const mockResolvedProblems = {};
@@ -335,8 +350,16 @@ const handlers = {
   // Feedback Forms list
   'GET /feedback-forms': () => ({ forms: mockFeedbackForms }),
 
-  // Sources status
-  'GET /sources/status': () => mockSourcesStatus,
+  // Sources status. With ?run_status=<source> returns the persisted last-run
+  // record for that source (backend _get_source_run_status shape) — used by
+  // GeneratorConfigModal polling and SyntheticSourceCard (#146).
+  'GET /sources/status': (body, query) => {
+    const source = query instanceof URLSearchParams ? query.get('run_status') : null;
+    if (typeof source === 'string' && source !== '') {
+      return mockSourceRunStatuses[source] ?? { source, status: 'never_run' };
+    }
+    return mockSourcesStatus;
+  },
 
   // User administration (issue #177) — stateful list; mutations live in the
   // parameterized /users/:username dispatch block.

--- a/voc-datalake/frontend/public/locales/de/scrapers.json
+++ b/voc-datalake/frontend/public/locales/de/scrapers.json
@@ -189,6 +189,12 @@
     "running": "Läuft..."
   },
   "subtitle": "Konfigurieren Sie Web-Scraper und App-Review-Quellen zur Feedback-Erfassung",
+  "syntheticCard": {
+    "generate": "Generieren",
+    "lastSummary": "Letzter Lauf: {{items}} Elemente generiert am {{date}}",
+    "neverRun": "Noch nicht ausgeführt — klicken Sie auf Generieren, um synthetische Bewertungen zu erstellen.",
+    "sectionTitle": "Synthetische Daten"
+  },
   "templateSelector": {
     "appReviewSources": "App-Bewertungsquellen",
     "autoDiscovered": "Automatisch erkannt",

--- a/voc-datalake/frontend/public/locales/en/scrapers.json
+++ b/voc-datalake/frontend/public/locales/en/scrapers.json
@@ -189,6 +189,12 @@
     "running": "Running..."
   },
   "subtitle": "Configure web scrapers and app review sources to collect feedback",
+  "syntheticCard": {
+    "generate": "Generate",
+    "lastSummary": "Last run: {{items}} items generated on {{date}}",
+    "neverRun": "Not run yet — click Generate to create synthetic reviews.",
+    "sectionTitle": "Synthetic Data"
+  },
   "templateSelector": {
     "appReviewSources": "App Review Sources",
     "autoDiscovered": "Auto-discovered",

--- a/voc-datalake/frontend/public/locales/es/scrapers.json
+++ b/voc-datalake/frontend/public/locales/es/scrapers.json
@@ -201,6 +201,12 @@
     "running": "Ejecutando..."
   },
   "subtitle": "Configure web scrapers y fuentes de reseñas de apps para recopilar feedback",
+  "syntheticCard": {
+    "generate": "Generar",
+    "lastSummary": "Última ejecución: {{items}} elementos generados el {{date}}",
+    "neverRun": "Aún sin ejecutar — haz clic en Generar para crear reseñas sintéticas.",
+    "sectionTitle": "Datos Sintéticos"
+  },
   "templateSelector": {
     "appReviewSources": "Fuentes de reseñas de apps",
     "autoDiscovered": "Auto-descubierto",

--- a/voc-datalake/frontend/public/locales/fr/scrapers.json
+++ b/voc-datalake/frontend/public/locales/fr/scrapers.json
@@ -201,6 +201,12 @@
     "running": "En cours..."
   },
   "subtitle": "Configurez les web scrapers et les sources d'avis d'applications pour collecter les retours",
+  "syntheticCard": {
+    "generate": "Générer",
+    "lastSummary": "Dernière exécution : {{items}} éléments générés le {{date}}",
+    "neverRun": "Pas encore exécuté — cliquez sur Générer pour créer des avis synthétiques.",
+    "sectionTitle": "Données Synthétiques"
+  },
   "templateSelector": {
     "appReviewSources": "Sources d'avis d'applications",
     "autoDiscovered": "Auto-découvert",

--- a/voc-datalake/frontend/public/locales/ja/scrapers.json
+++ b/voc-datalake/frontend/public/locales/ja/scrapers.json
@@ -189,6 +189,12 @@
     "running": "実行中..."
   },
   "subtitle": "Webスクレイパーとアプリレビューソースを設定してフィードバックを収集",
+  "syntheticCard": {
+    "generate": "生成",
+    "lastSummary": "前回の実行: {{date}} に {{items}} 件生成",
+    "neverRun": "未実行 — 「生成」をクリックして合成レビューを作成します。",
+    "sectionTitle": "合成データ"
+  },
   "templateSelector": {
     "appReviewSources": "アプリレビューソース",
     "autoDiscovered": "自動検出",

--- a/voc-datalake/frontend/public/locales/ko/scrapers.json
+++ b/voc-datalake/frontend/public/locales/ko/scrapers.json
@@ -189,6 +189,12 @@
     "running": "실행 중..."
   },
   "subtitle": "웹 스크레이퍼와 앱 리뷰 소스를 구성하여 피드백 수집",
+  "syntheticCard": {
+    "generate": "생성",
+    "lastSummary": "마지막 실행: {{date}}에 {{items}}개 생성",
+    "neverRun": "아직 실행되지 않음 — 생성을 클릭하여 합성 리뷰를 만드세요.",
+    "sectionTitle": "합성 데이터"
+  },
   "templateSelector": {
     "appReviewSources": "앱 리뷰 소스",
     "autoDiscovered": "자동 발견",

--- a/voc-datalake/frontend/public/locales/pt/scrapers.json
+++ b/voc-datalake/frontend/public/locales/pt/scrapers.json
@@ -201,6 +201,12 @@
     "running": "Executando..."
   },
   "subtitle": "Configure web scrapers e fontes de avaliações de apps para coletar feedback",
+  "syntheticCard": {
+    "generate": "Gerar",
+    "lastSummary": "Última execução: {{items}} itens gerados em {{date}}",
+    "neverRun": "Ainda não executado — clique em Gerar para criar avaliações sintéticas.",
+    "sectionTitle": "Dados Sintéticos"
+  },
   "templateSelector": {
     "appReviewSources": "Fontes de avaliações de apps",
     "autoDiscovered": "Auto-descoberto",

--- a/voc-datalake/frontend/public/locales/zh/scrapers.json
+++ b/voc-datalake/frontend/public/locales/zh/scrapers.json
@@ -189,6 +189,12 @@
     "running": "运行中..."
   },
   "subtitle": "配置网页抓取器和应用评论源以收集反馈",
+  "syntheticCard": {
+    "generate": "生成",
+    "lastSummary": "上次运行：{{date}} 生成了 {{items}} 条",
+    "neverRun": "尚未运行 — 点击\"生成\"以创建合成评论。",
+    "sectionTitle": "合成数据"
+  },
   "templateSelector": {
     "appReviewSources": "应用评论源",
     "autoDiscovered": "自动发现",

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.test.tsx
@@ -11,12 +11,15 @@ const mockDeleteScraper = vi.fn()
 const mockRunScraper = vi.fn()
 const mockGetScraperStatus = vi.fn()
 const mockGetAppConfigs = vi.fn()
+const mockGetSourceRunStatus = vi.fn()
 
 vi.mock('../../api/client', () => ({
   api: {
     getAppConfigs: (source: string) => mockGetAppConfigs(source),
     deleteAppConfig: vi.fn().mockResolvedValue({ success: true }),
     runSource: vi.fn().mockResolvedValue({ success: true }),
+    getSourceRunStatus: (source: string) => mockGetSourceRunStatus(source),
+    getIntegrationCredentials: vi.fn().mockResolvedValue({}),
   },
 }))
 
@@ -48,8 +51,26 @@ const mockPluginManifests = [
   { id: 'app_reviews_android', name: 'Android App Reviews', icon: '🤖', config: [], hasIngestor: true, hasWebhook: false, hasS3Trigger: false, enabled: true },
 ]
 
+// Mutable per-test list of synthetic plugins; default empty so pre-existing
+// tests keep their behavior. Reset in beforeEach.
+const mockSyntheticPlugins: Array<Record<string, unknown>> = []
+
+const syntheticPlugin = {
+  id: 'synthetic_reviews',
+  name: 'Synthetic Data Review Generator',
+  icon: '🧪',
+  description: 'Generate realistic synthetic customer reviews with AI.',
+  category: 'synthetic',
+  config: [],
+  hasIngestor: true,
+  hasWebhook: false,
+  hasS3Trigger: false,
+  enabled: true,
+}
+
 vi.mock('../../plugins', () => ({
   getPluginManifests: () => mockPluginManifests,
+  getSyntheticPlugins: () => mockSyntheticPlugins,
 }))
 
 // Mock subcomponents
@@ -112,12 +133,14 @@ const mockScrapers = [
 describe('Scrapers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSyntheticPlugins.length = 0
     mockGetScrapers.mockResolvedValue({ scrapers: mockScrapers })
     mockGetScraperStatus.mockResolvedValue({ status: 'never_run' })
     mockSaveScraper.mockResolvedValue({ success: true })
     mockDeleteScraper.mockResolvedValue({ success: true })
     mockRunScraper.mockResolvedValue({ success: true })
     mockGetAppConfigs.mockResolvedValue({ apps: [] })
+    mockGetSourceRunStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
   })
 
   describe('rendering', () => {
@@ -183,6 +206,55 @@ describe('Scrapers', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /create scraper/i })).toBeInTheDocument()
       })
+    })
+
+    it('suppresses the empty state when a synthetic source exists (#146)', async () => {
+      mockGetScrapers.mockResolvedValue({ scrapers: [] })
+      mockSyntheticPlugins.push(syntheticPlugin)
+
+      render(<Scrapers />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('No scrapers configured')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('synthetic data section (#146)', () => {
+    it('renders a card per synthetic plugin with the section title', async () => {
+      mockSyntheticPlugins.push(syntheticPlugin)
+
+      render(<Scrapers />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Synthetic Data' })).toBeInTheDocument()
+        expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
+      })
+    })
+
+    it('opens the generator modal from the card Generate button', async () => {
+      mockSyntheticPlugins.push(syntheticPlugin)
+      const user = userEvent.setup()
+
+      render(<Scrapers />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: /generate/i }))
+
+      // GeneratorConfigModal renders the plugin name in its header too.
+      expect(screen.getAllByText('Synthetic Data Review Generator').length).toBeGreaterThan(1)
+    })
+
+    it('does not render the section when no synthetic plugins exist', async () => {
+      render(<Scrapers />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Scraper')).toBeInTheDocument()
+      })
+      expect(screen.queryByRole('heading', { name: 'Synthetic Data' })).not.toBeInTheDocument()
     })
   })
 

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.test.tsx
@@ -256,6 +256,33 @@ describe('Scrapers', () => {
       })
       expect(screen.queryByRole('heading', { name: 'Synthetic Data' })).not.toBeInTheDocument()
     })
+
+    it('refreshes the card when the generator modal closes (a just-finished run shows immediately)', async () => {
+      mockSyntheticPlugins.push(syntheticPlugin)
+      // Card mounts with no run history…
+      mockGetSourceRunStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
+      const user = userEvent.setup()
+
+      render(<Scrapers />, { wrapper: createWrapper() })
+
+      expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()
+      await user.click(screen.getByRole('button', { name: /generate/i }))
+
+      // …a run completes while the modal is open…
+      mockGetSourceRunStatus.mockResolvedValue({
+        source: 'synthetic_reviews',
+        status: 'completed',
+        completed_at: '2026-07-17T09:00:00Z',
+        items_found: 3,
+        errors: [],
+      })
+
+      // …and closing the modal invalidates ['source-run-status'] → refetch.
+      await user.click(screen.getByRole('button', { name: /^close$/i }))
+
+      expect(await screen.findByText(/3 items generated/i)).toBeInTheDocument()
+      expect(screen.queryByText(/not run yet/i)).not.toBeInTheDocument()
+    })
   })
 
   describe('template selector', () => {

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -218,13 +218,12 @@ function useScraperMutations() {
 }
 
 function ScrapersContent({
-  scrapers, isLoading, appConfigPlugins, syntheticPlugins, generatorRefreshToken, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
+  scrapers, isLoading, appConfigPlugins, syntheticPlugins, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
 }: {
   readonly scrapers: ScraperConfig[]
   readonly isLoading: boolean
   readonly appConfigPlugins: PluginManifest[]
   readonly syntheticPlugins: PluginManifest[]
-  readonly generatorRefreshToken: number
   readonly onRefresh: () => void
   readonly onShowTemplates: () => void
   readonly onEdit: (s: ScraperConfig) => void
@@ -266,7 +265,7 @@ function ScrapersContent({
               <h2 className="text-sm font-semibold text-gray-700 mb-2">{t('syntheticCard.sectionTitle')}</h2>
               <div className="grid gap-4">
                 {syntheticPlugins.map((plugin) => (
-                  <SyntheticSourceCard key={plugin.id} plugin={plugin} refreshToken={generatorRefreshToken} onGenerate={() => onGenerate(plugin)} />
+                  <SyntheticSourceCard key={plugin.id} plugin={plugin} onGenerate={() => onGenerate(plugin)} />
                 ))}
               </div>
             </section>
@@ -298,8 +297,6 @@ export default function Scrapers() {
 
   const appConfigPlugins = getAppConfigPlugins()
   const syntheticPlugins = getSyntheticPlugins()
-  // Bumped when the generator modal closes so synthetic cards re-fetch status.
-  const [generatorRefreshToken, setGeneratorRefreshToken] = useState(0)
 
   const {
     data, isLoading, refetch,
@@ -381,7 +378,6 @@ export default function Scrapers() {
         isLoading={isLoading}
         appConfigPlugins={appConfigPlugins}
         syntheticPlugins={syntheticPlugins}
-        generatorRefreshToken={generatorRefreshToken}
         onRefresh={() => void refetch()}
         onShowTemplates={() => setShowTemplates(true)}
         onEdit={setEditingScraper}
@@ -420,7 +416,7 @@ export default function Scrapers() {
         onClose={() => {
           setSelectedGenerator(null)
           // Refresh synthetic cards so a just-finished run shows immediately.
-          setGeneratorRefreshToken((n) => n + 1)
+          void queryClient.invalidateQueries({ queryKey: ['source-run-status'] })
         }}
       />}
 

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import { scrapersApi } from '../../api/scrapersApi'
 import ConfirmModal from '../../components/ConfirmModal'
-import { getPluginManifests } from '../../plugins'
+import { getPluginManifests, getSyntheticPlugins } from '../../plugins'
 import { useConfigStore } from '../../store/configStore'
 import { useManualImportStore } from '../../store/manualImportStore'
 import { AppConfigCard } from './AppConfigComponents'
@@ -28,6 +28,7 @@ import PluginConfigModal from './PluginConfigModal'
 import { getAppIdentifier } from './scraper-helpers'
 import ScraperCard from './ScraperCard'
 import ScraperEditor from './ScraperEditor'
+import SyntheticSourceCard from './SyntheticSourceCard'
 import TemplateSelector from './TemplateSelector'
 import type { RunStatusInfo } from './AppConfigComponents'
 import type {
@@ -217,11 +218,13 @@ function useScraperMutations() {
 }
 
 function ScrapersContent({
-  scrapers, isLoading, appConfigPlugins, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp,
+  scrapers, isLoading, appConfigPlugins, syntheticPlugins, generatorRefreshToken, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
 }: {
   readonly scrapers: ScraperConfig[]
   readonly isLoading: boolean
   readonly appConfigPlugins: PluginManifest[]
+  readonly syntheticPlugins: PluginManifest[]
+  readonly generatorRefreshToken: number
   readonly onRefresh: () => void
   readonly onShowTemplates: () => void
   readonly onEdit: (s: ScraperConfig) => void
@@ -230,6 +233,7 @@ function ScrapersContent({
   readonly onEditPlugin: (p: PluginManifest) => void
   readonly onDeleteApp: (pluginId: string, appId: string) => void
   readonly onRunApp: (pluginId: string, appIdentifier: string) => void
+  readonly onGenerate: (p: PluginManifest) => void
 }) {
   const { t } = useTranslation('scrapers')
 
@@ -257,9 +261,19 @@ function ScrapersContent({
           {scrapers.map((scraper) => (
             <ScraperCard key={scraper.id} scraper={scraper} onEdit={() => onEdit(scraper)} onDelete={() => onDelete(scraper.id)} onRun={() => onRun(scraper.id)} />
           ))}
+          {syntheticPlugins.length > 0 ? (
+            <section aria-label={t('syntheticCard.sectionTitle')}>
+              <h2 className="text-sm font-semibold text-gray-700 mb-2">{t('syntheticCard.sectionTitle')}</h2>
+              <div className="grid gap-4">
+                {syntheticPlugins.map((plugin) => (
+                  <SyntheticSourceCard key={plugin.id} plugin={plugin} refreshToken={generatorRefreshToken} onGenerate={() => onGenerate(plugin)} />
+                ))}
+              </div>
+            </section>
+          ) : null}
         </div>
       )}
-      {!isLoading && scrapers.length === 0 && <EmptyState onCreateClick={onShowTemplates} />}
+      {!isLoading && scrapers.length === 0 && syntheticPlugins.length === 0 && <EmptyState onCreateClick={onShowTemplates} />}
     </div>
   )
 }
@@ -283,6 +297,9 @@ export default function Scrapers() {
   } | null>(null)
 
   const appConfigPlugins = getAppConfigPlugins()
+  const syntheticPlugins = getSyntheticPlugins()
+  // Bumped when the generator modal closes so synthetic cards re-fetch status.
+  const [generatorRefreshToken, setGeneratorRefreshToken] = useState(0)
 
   const {
     data, isLoading, refetch,
@@ -363,6 +380,8 @@ export default function Scrapers() {
         scrapers={scrapers}
         isLoading={isLoading}
         appConfigPlugins={appConfigPlugins}
+        syntheticPlugins={syntheticPlugins}
+        generatorRefreshToken={generatorRefreshToken}
         onRefresh={() => void refetch()}
         onShowTemplates={() => setShowTemplates(true)}
         onEdit={setEditingScraper}
@@ -374,6 +393,7 @@ export default function Scrapers() {
           appId,
         })}
         onRunApp={(pluginId, appIdentifier) => void api.runSource(pluginId, appIdentifier)}
+        onGenerate={(plugin) => setSelectedGenerator(plugin)}
       />
 
       <ManualImportModal />
@@ -397,7 +417,11 @@ export default function Scrapers() {
 
       {selectedGenerator == null ? null : <GeneratorConfigModal
         plugin={selectedGenerator}
-        onClose={() => setSelectedGenerator(null)}
+        onClose={() => {
+          setSelectedGenerator(null)
+          // Refresh synthetic cards so a just-finished run shows immediately.
+          setGeneratorRefreshToken((n) => n + 1)
+        }}
       />}
 
       {(isCreating || editingScraper != null) ? <ScraperEditor scraper={editingScraper} template={selectedTemplate} onSave={handleSaveScraper} onClose={handleCloseEditor} /> : null}

--- a/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.test.tsx
@@ -4,7 +4,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import SyntheticSourceCard from './SyntheticSourceCard'
+import { parseRunRecord } from './sourceRunStatus'
 import { api } from '../../api/client'
 import type { PluginManifest } from '../../plugins/types'
 
@@ -14,18 +16,58 @@ vi.mock('../../api/client', () => ({
   },
 }))
 
-const mockGetStatus = api.getSourceRunStatus as ReturnType<typeof vi.fn>
+const mockGetStatus = vi.mocked(api.getSourceRunStatus)
 
-const plugin = {
+// Fully-typed fixture — satisfies PluginManifestSchema without assertions.
+const plugin: PluginManifest = {
   id: 'synthetic_reviews',
   name: 'Synthetic Data Review Generator',
   icon: '🧪',
   description: 'Generate realistic synthetic customer reviews with AI.',
   category: 'synthetic',
-  enabled: true,
-  hasIngestor: true,
   config: [],
-} as unknown as PluginManifest
+  hasIngestor: true,
+  hasWebhook: false,
+  hasS3Trigger: false,
+  enabled: true,
+}
+
+function renderCard(onGenerate: () => void = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SyntheticSourceCard plugin={plugin} onGenerate={onGenerate} />
+    </QueryClientProvider>
+  )
+}
+
+describe('parseRunRecord', () => {
+  it('returns null for the never_run sentinel', () => {
+    expect(parseRunRecord({ source: 'synthetic_reviews', status: 'never_run' })).toBeNull()
+  })
+
+  it('returns null for a payload that is not a run record (wrong wire shape)', () => {
+    // The list variant the mock server historically returned for this path.
+    expect(parseRunRecord({ sources: [{ source: 'webscraper' }] })).toBeNull()
+    expect(parseRunRecord(null)).toBeNull()
+    expect(parseRunRecord('completed')).toBeNull()
+  })
+
+  it('degrades malformed optional fields instead of rejecting the record', () => {
+    const record = parseRunRecord({
+      status: 'completed',
+      items_found: 'five',
+      errors: 'oops',
+      completed_at: 42,
+    })
+    expect(record).not.toBeNull()
+    expect(record?.items_found).toBeUndefined()
+    expect(record?.errors).toBeUndefined()
+    expect(record?.completed_at).toBeUndefined()
+  })
+})
 
 describe('SyntheticSourceCard', () => {
   beforeEach(() => {
@@ -34,7 +76,7 @@ describe('SyntheticSourceCard', () => {
 
   it('renders the plugin name and description', async () => {
     mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
-    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+    renderCard()
 
     expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
     expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()
@@ -42,7 +84,7 @@ describe('SyntheticSourceCard', () => {
 
   it('shows the never-run hint when there is no run history', async () => {
     mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
-    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+    renderCard()
 
     expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()
     expect(screen.queryByText(/last run:/i)).not.toBeInTheDocument()
@@ -57,7 +99,7 @@ describe('SyntheticSourceCard', () => {
       items_found: 5,
       errors: [],
     })
-    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+    renderCard()
 
     const expectedDate = new Date('2026-07-16T10:01:00Z').toLocaleDateString()
     expect(await screen.findByText(new RegExp(`5 items generated on ${expectedDate.replace(/[/\\]/g, '\\$&')}`)))
@@ -73,7 +115,7 @@ describe('SyntheticSourceCard', () => {
       items_found: 0,
       errors: ['Bedrock throttled'],
     })
-    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+    renderCard()
 
     expect(await screen.findByText('✗')).toBeInTheDocument()
     expect(screen.getByText('Bedrock throttled')).toBeInTheDocument()
@@ -83,36 +125,23 @@ describe('SyntheticSourceCard', () => {
     mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
     const onGenerate = vi.fn()
     const user = userEvent.setup()
-    render(<SyntheticSourceCard plugin={plugin} onGenerate={onGenerate} />)
+    renderCard(onGenerate)
 
     await user.click(screen.getByRole('button', { name: /generate/i }))
 
     expect(onGenerate).toHaveBeenCalledTimes(1)
   })
 
-  it('re-fetches status when refreshToken changes (modal close)', async () => {
+  it('fetches status through the query layer keyed by plugin id', async () => {
     mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
-    const { rerender } = render(
-      <SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} refreshToken={0} />
-    )
-    await waitFor(() => expect(mockGetStatus).toHaveBeenCalledTimes(1))
+    renderCard()
 
-    mockGetStatus.mockResolvedValue({
-      source: 'synthetic_reviews',
-      status: 'completed',
-      completed_at: '2026-07-17T09:00:00Z',
-      items_found: 3,
-      errors: [],
-    })
-    rerender(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} refreshToken={1} />)
-
-    await waitFor(() => expect(mockGetStatus).toHaveBeenCalledTimes(2))
-    expect(await screen.findByText(/3 items generated/i)).toBeInTheDocument()
+    await waitFor(() => expect(mockGetStatus).toHaveBeenCalledWith('synthetic_reviews'))
   })
 
   it('stays render-safe when the status call fails', async () => {
     mockGetStatus.mockRejectedValue(new Error('boom'))
-    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+    renderCard()
 
     expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
     expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()

--- a/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Tests for SyntheticSourceCard (issue #146).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SyntheticSourceCard from './SyntheticSourceCard'
+import { api } from '../../api/client'
+import type { PluginManifest } from '../../plugins/types'
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getSourceRunStatus: vi.fn(),
+  },
+}))
+
+const mockGetStatus = api.getSourceRunStatus as ReturnType<typeof vi.fn>
+
+const plugin = {
+  id: 'synthetic_reviews',
+  name: 'Synthetic Data Review Generator',
+  icon: '🧪',
+  description: 'Generate realistic synthetic customer reviews with AI.',
+  category: 'synthetic',
+  enabled: true,
+  hasIngestor: true,
+  config: [],
+} as unknown as PluginManifest
+
+describe('SyntheticSourceCard', () => {
+  beforeEach(() => {
+    mockGetStatus.mockReset()
+  })
+
+  it('renders the plugin name and description', async () => {
+    mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
+    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+
+    expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
+    expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()
+  })
+
+  it('shows the never-run hint when there is no run history', async () => {
+    mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
+    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+
+    expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/last run:/i)).not.toBeInTheDocument()
+  })
+
+  it('shows items generated, date, and a success badge for a completed run', async () => {
+    mockGetStatus.mockResolvedValue({
+      source: 'synthetic_reviews',
+      status: 'completed',
+      started_at: '2026-07-16T10:00:00Z',
+      completed_at: '2026-07-16T10:01:00Z',
+      items_found: 5,
+      errors: [],
+    })
+    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+
+    const expectedDate = new Date('2026-07-16T10:01:00Z').toLocaleDateString()
+    expect(await screen.findByText(new RegExp(`5 items generated on ${expectedDate.replace(/[/\\]/g, '\\$&')}`)))
+      .toBeInTheDocument()
+    expect(screen.getByText('✓')).toBeInTheDocument()
+  })
+
+  it('shows a failure badge and the first error for an errored run', async () => {
+    mockGetStatus.mockResolvedValue({
+      source: 'synthetic_reviews',
+      status: 'error',
+      started_at: '2026-07-16T10:00:00Z',
+      items_found: 0,
+      errors: ['Bedrock throttled'],
+    })
+    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+
+    expect(await screen.findByText('✗')).toBeInTheDocument()
+    expect(screen.getByText('Bedrock throttled')).toBeInTheDocument()
+  })
+
+  it('calls onGenerate when the Generate button is clicked', async () => {
+    mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
+    const onGenerate = vi.fn()
+    const user = userEvent.setup()
+    render(<SyntheticSourceCard plugin={plugin} onGenerate={onGenerate} />)
+
+    await user.click(screen.getByRole('button', { name: /generate/i }))
+
+    expect(onGenerate).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches status when refreshToken changes (modal close)', async () => {
+    mockGetStatus.mockResolvedValue({ source: 'synthetic_reviews', status: 'never_run' })
+    const { rerender } = render(
+      <SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} refreshToken={0} />
+    )
+    await waitFor(() => expect(mockGetStatus).toHaveBeenCalledTimes(1))
+
+    mockGetStatus.mockResolvedValue({
+      source: 'synthetic_reviews',
+      status: 'completed',
+      completed_at: '2026-07-17T09:00:00Z',
+      items_found: 3,
+      errors: [],
+    })
+    rerender(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} refreshToken={1} />)
+
+    await waitFor(() => expect(mockGetStatus).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText(/3 items generated/i)).toBeInTheDocument()
+  })
+
+  it('stays render-safe when the status call fails', async () => {
+    mockGetStatus.mockRejectedValue(new Error('boom'))
+    render(<SyntheticSourceCard plugin={plugin} onGenerate={vi.fn()} />)
+
+    expect(screen.getByText('Synthetic Data Review Generator')).toBeInTheDocument()
+    expect(await screen.findByText(/not run yet/i)).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Persistent Data Sources card for synthetic generator plugins
+ * (issue #146). Shows the persisted last run (status badge, items generated,
+ * date) via api.getSourceRunStatus and opens GeneratorConfigModal to run.
+ * @module pages/Scrapers/SyntheticSourceCard
+ */
+
+import clsx from 'clsx'
+import { Sparkles } from 'lucide-react'
+import {
+  useCallback, useEffect, useState,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import type { PluginManifest } from '../../plugins/types'
+
+export interface SourceRunStatus {
+  status: string
+  started_at?: string
+  completed_at?: string
+  items_found?: number
+  errors?: string[]
+}
+
+function getLastRunBadge(status: SourceRunStatus): {
+  className: string;
+  icon: string
+} {
+  if (status.status === 'completed' && (status.errors?.length ?? 0) === 0) return {
+    className: 'bg-green-100 text-green-700',
+    icon: '✓',
+  }
+  if (status.status === 'error' || status.status === 'failed') return {
+    className: 'bg-red-100 text-red-700',
+    icon: '✗',
+  }
+  return {
+    className: 'bg-amber-100 text-amber-700',
+    icon: '⚠',
+  }
+}
+
+function LastRunSummary({ lastRun }: { readonly lastRun: SourceRunStatus }) {
+  const { t } = useTranslation('scrapers')
+  const badge = getLastRunBadge(lastRun)
+  const when = lastRun.completed_at ?? lastRun.started_at
+  const whenLabel = when != null && when !== '' ? new Date(when).toLocaleDateString() : t('card.never')
+  return (
+    <div className="mt-3 pt-3 border-t border-indigo-100 text-xs text-gray-500">
+      <div className="flex items-center justify-between">
+        <span>
+          {t('syntheticCard.lastSummary', {
+            items: lastRun.items_found ?? 0,
+            date: whenLabel,
+          })}
+        </span>
+        <span className={clsx('px-2 py-0.5 rounded', badge.className)}>{badge.icon}</span>
+      </div>
+      {(lastRun.errors?.length ?? 0) > 0 ? <p className="text-red-500 truncate mt-1">{lastRun.errors?.[0]}</p> : null}
+    </div>
+  )
+}
+
+/**
+ * One card per synthetic generator plugin. The Generate button delegates to
+ * the page, which opens the existing GeneratorConfigModal (no duplicated run
+ * flow); `refreshToken` changes when that modal closes so the card re-fetches.
+ */
+export default function SyntheticSourceCard({
+  plugin, onGenerate, refreshToken = 0,
+}: {
+  readonly plugin: PluginManifest
+  readonly onGenerate: () => void
+  readonly refreshToken?: number
+}) {
+  const { t } = useTranslation('scrapers')
+  const [lastRun, setLastRun] = useState<SourceRunStatus | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const result = await api.getSourceRunStatus(plugin.id)
+      // Wire-shape guard: only trust a real run record (string status that
+      // isn't the never_run sentinel). Anything else renders the never-run
+      // hint instead of a junk "0 items on Never" summary.
+      if (typeof result.status === 'string' && result.status !== '' && result.status !== 'never_run') {
+        setLastRun(result)
+      }
+    } catch {
+      /* status is decorative — never break the card */
+    }
+  }, [plugin.id])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- data fetch on mount + modal close
+    void fetchStatus()
+  }, [fetchStatus, refreshToken])
+
+  return (
+    <div className="card border-2 border-indigo-200 bg-indigo-50/30 transition-all">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-indigo-100 text-indigo-600 flex items-center justify-center text-xl">
+            {plugin.icon.slice(0, 2)}
+          </div>
+          <div>
+            <h3 className="font-semibold">{plugin.name}</h3>
+            <p className="text-sm text-gray-500">{plugin.description}</p>
+          </div>
+        </div>
+        <button
+          onClick={onGenerate}
+          className="btn btn-primary flex items-center gap-2 text-sm flex-shrink-0"
+          title={t('syntheticCard.generate')}
+        >
+          <Sparkles size={16} /> {t('syntheticCard.generate')}
+        </button>
+      </div>
+      {lastRun == null
+        ? <p className="mt-3 pt-3 border-t border-indigo-100 text-xs text-gray-400">{t('syntheticCard.neverRun')}</p>
+        : <LastRunSummary lastRun={lastRun} />}
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/SyntheticSourceCard.tsx
@@ -2,25 +2,22 @@
  * @fileoverview Persistent Data Sources card for synthetic generator plugins
  * (issue #146). Shows the persisted last run (status badge, items generated,
  * date) via api.getSourceRunStatus and opens GeneratorConfigModal to run.
+ *
+ * Data flow follows the repo patterns: TanStack Query for fetching (the page
+ * invalidates ['source-run-status'] when the generator modal closes) and a
+ * lenient Zod schema at the wire boundary (./sourceRunStatus).
+ *
  * @module pages/Scrapers/SyntheticSourceCard
  */
 
+import { useQuery } from '@tanstack/react-query'
 import clsx from 'clsx'
 import { Sparkles } from 'lucide-react'
-import {
-  useCallback, useEffect, useState,
-} from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
+import { parseRunRecord } from './sourceRunStatus'
+import type { SourceRunStatus } from './sourceRunStatus'
 import type { PluginManifest } from '../../plugins/types'
-
-export interface SourceRunStatus {
-  status: string
-  started_at?: string
-  completed_at?: string
-  items_found?: number
-  errors?: string[]
-}
 
 function getLastRunBadge(status: SourceRunStatus): {
   className: string;
@@ -64,36 +61,21 @@ function LastRunSummary({ lastRun }: { readonly lastRun: SourceRunStatus }) {
 /**
  * One card per synthetic generator plugin. The Generate button delegates to
  * the page, which opens the existing GeneratorConfigModal (no duplicated run
- * flow); `refreshToken` changes when that modal closes so the card re-fetches.
+ * flow) and invalidates the ['source-run-status'] queries when it closes.
  */
 export default function SyntheticSourceCard({
-  plugin, onGenerate, refreshToken = 0,
+  plugin, onGenerate,
 }: {
   readonly plugin: PluginManifest
   readonly onGenerate: () => void
-  readonly refreshToken?: number
 }) {
   const { t } = useTranslation('scrapers')
-  const [lastRun, setLastRun] = useState<SourceRunStatus | null>(null)
 
-  const fetchStatus = useCallback(async () => {
-    try {
-      const result = await api.getSourceRunStatus(plugin.id)
-      // Wire-shape guard: only trust a real run record (string status that
-      // isn't the never_run sentinel). Anything else renders the never-run
-      // hint instead of a junk "0 items on Never" summary.
-      if (typeof result.status === 'string' && result.status !== '' && result.status !== 'never_run') {
-        setLastRun(result)
-      }
-    } catch {
-      /* status is decorative — never break the card */
-    }
-  }, [plugin.id])
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- data fetch on mount + modal close
-    void fetchStatus()
-  }, [fetchStatus, refreshToken])
+  const { data } = useQuery({
+    queryKey: ['source-run-status', plugin.id],
+    queryFn: () => api.getSourceRunStatus(plugin.id),
+  })
+  const lastRun = data === undefined ? null : parseRunRecord(data)
 
   return (
     <div className="card border-2 border-indigo-200 bg-indigo-50/30 transition-all">

--- a/voc-datalake/frontend/src/pages/Scrapers/TemplateSelector.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/TemplateSelector.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { scrapersApi } from '../../api/scrapersApi'
-import { getPluginManifests } from '../../plugins'
+import { getPluginManifests, getSyntheticPlugins } from '../../plugins'
 import { useConfigStore } from '../../store/configStore'
 import type { ScraperTemplate } from '../../api/types'
 import type { PluginManifest } from '../../plugins/types'
@@ -113,13 +113,7 @@ function getDiscoverablePlugins(): PluginManifest[] {
   )
 }
 
-/**
- * Get synthetic data generator plugins (category 'synthetic'). These are on-demand
- * generators configured via a dedicated modal rather than the multi-app plugin config.
- */
-function getSyntheticPlugins(): PluginManifest[] {
-  return getPluginManifests().filter((p) => p.category === 'synthetic')
-}
+
 
 /**
  * Merge API templates with built-in fallbacks.

--- a/voc-datalake/frontend/src/pages/Scrapers/TemplateSelector.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/TemplateSelector.tsx
@@ -113,8 +113,6 @@ function getDiscoverablePlugins(): PluginManifest[] {
   )
 }
 
-
-
 /**
  * Merge API templates with built-in fallbacks.
  * API templates take precedence (by id) over built-ins.

--- a/voc-datalake/frontend/src/pages/Scrapers/sourceRunStatus.ts
+++ b/voc-datalake/frontend/src/pages/Scrapers/sourceRunStatus.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Wire-boundary schema for the ?run_status variant of
+ * GET /sources/status (issue #146). Lenient by design — the mock server
+ * historically served a different shape for this endpoint, so nothing here
+ * trusts the response to match its declared type. Malformed optional fields
+ * degrade instead of rejecting the record.
+ * @module pages/Scrapers/sourceRunStatus
+ */
+
+import { z } from 'zod'
+
+const sourceRunStatusSchema = z.object({
+  status: z.string().min(1),
+  started_at: z.string().optional().catch(undefined),
+  completed_at: z.string().optional().catch(undefined),
+  items_found: z.number().optional().catch(undefined),
+  errors: z.array(z.string()).optional().catch(undefined),
+})
+
+export type SourceRunStatus = z.infer<typeof sourceRunStatusSchema>
+
+/**
+ * Parse the wire response into a run record, or null when the source has
+ * never run (sentinel) or the payload doesn't look like a run record at all.
+ */
+export function parseRunRecord(raw: unknown): SourceRunStatus | null {
+  const parsed = sourceRunStatusSchema.safeParse(raw)
+  if (!parsed.success || parsed.data.status === 'never_run') return null
+  return parsed.data
+}

--- a/voc-datalake/frontend/src/plugins/index.ts
+++ b/voc-datalake/frontend/src/plugins/index.ts
@@ -36,4 +36,13 @@ export function getEnabledPlugins(): PluginManifest[] {
   return manifests.filter((m) => m.enabled)
 }
 
+/**
+ * Get synthetic data generator plugins (category 'synthetic'). On-demand
+ * generators configured via GeneratorConfigModal rather than the multi-app
+ * plugin config. Shared by TemplateSelector and the Data Sources page.
+ */
+export function getSyntheticPlugins(): PluginManifest[] {
+  return manifests.filter((m) => m.category === 'synthetic')
+}
+
 // Types are available directly from './types'

--- a/voc-datalake/frontend/src/plugins/index.ts
+++ b/voc-datalake/frontend/src/plugins/index.ts
@@ -42,7 +42,9 @@ export function getEnabledPlugins(): PluginManifest[] {
  * plugin config. Shared by TemplateSelector and the Data Sources page.
  */
 export function getSyntheticPlugins(): PluginManifest[] {
-  return manifests.filter((m) => m.category === 'synthetic')
+  // enabled-only: a disabled generator has no deployed Lambda, so neither the
+  // New Source tile nor the Data Sources card should offer a broken Generate.
+  return manifests.filter((m) => m.enabled && m.category === 'synthetic')
 }
 
 // Types are available directly from './types'


### PR DESCRIPTION
## Summary

Fixes #146. The synthetic-reviews generator was fire-and-forget: it appeared only as a tile in the *New Source* dialog and left **no trace** on the Data Sources page after a run — `/scrapers` showed "No scrapers configured" even right after generating reviews. Web scrapers and app-review sources render persistent cards; the generator now does too.

Frontend-only, exactly as scoped in the issue: the backend already persists the last run (`GET /sources/status?run_status=<id>` reads `SOURCE_RUN#{source}` from the aggregates table), so the card just consumes it.

## Change

- **`SyntheticSourceCard.tsx` (new)** — indigo card matching the TemplateSelector's Synthetic section styling: plugin icon/name/description, persisted last-run summary (items generated + date + ✓/✗/⚠ badge, first error line when present), never-run hint otherwise, and a **Generate** button that opens the existing `GeneratorConfigModal` (reuse, no duplicated run flow). A `refreshToken` prop makes the card re-fetch when the modal closes, so a just-finished run shows immediately.
- **`Scrapers.tsx`** — renders a "Synthetic Data" section (one card per `category === 'synthetic'` plugin); the empty state now requires **both** the scraper list and the synthetic list to be empty.
- **`plugins/index.ts`** — `getSyntheticPlugins()` lifted out of `TemplateSelector` (shared by both call sites).
- **i18n** — `syntheticCard.*` (4 keys) in all 8 `scrapers.json` locales, formatting-stable insertion.
- **`mock-server.js`** — `GET /sources/status` now honors the `?run_status=<source>` variant with a persisted-run fixture. Found during mock-UI verification: the mock returned the *list* shape for both variants, which initially made the card render a junk "0 items on Never" row — fixed both the mock **and** hardened the card with a wire-shape guard (only a real string status ≠ `never_run` renders the summary), per the repo's normalize-at-boundary rule.

## Tests

- `SyntheticSourceCard.test.tsx` (7): renders name/description; never-run hint; completed run (items + localized date + ✓); errored run (✗ + first error); `onGenerate` fires; `refreshToken` re-fetches; render-safe when the status call rejects.
- `Scrapers.test.tsx` (+4): section renders a card; Generate opens the real generator modal; section absent when no synthetic plugins; **empty state suppressed** when a synthetic source exists (the issue's headline symptom).

## Validation (local)

- Full frontend suite **1800/1800** (114 files); Scrapers folder 136/136.
- `tsc -b` clean, eslint clean, `i18n:check` exit 0, `vite build` OK, `node --check mock-server.js` OK.
- **Mock-UI E2E (Chrome)**: `/scrapers` renders the Synthetic Data section + card with "Last run: 5 items generated on 7/15/2026 ✓" (persisted via the mock fixture), Generate opens the generator modal, empty state absent.

Deployment note: frontend-only; joins the pending batch deploy per maintainer decision.
