### PR TITLE
refactor: single source of truth for DynamoDB GSI names (#213)

### DIFF
--- a/voc-datalake/lambda/api/chat_handler.py
+++ b/voc-datalake/lambda/api/chat_handler.py
@@ -19,6 +19,7 @@ from shared.api import (
 )
 from shared.feedback import basis_date, window_cutoff
 from shared.exceptions import ConfigurationError, NotFoundError as AppNotFoundError
+from shared.indexes import FEEDBACK_BY_DATE_INDEX
 
 from aws_lambda_powertools.event_handler.exceptions import NotFoundError
 from boto3.dynamodb.conditions import Key
@@ -104,7 +105,7 @@ def chat():
     for i in range(min(days, 7)):
         date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
         response = feedback_table.query(
-            IndexName='gsi1-by-date',
+            IndexName=FEEDBACK_BY_DATE_INDEX,
             KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
             Limit=10,
             ScanIndexForward=False

--- a/voc-datalake/lambda/api/data_explorer_handler.py
+++ b/voc-datalake/lambda/api/data_explorer_handler.py
@@ -22,6 +22,7 @@ from shared.logging import logger, tracer
 from shared.aws import get_s3_client, get_dynamodb_resource, get_sqs_client
 from shared.api import create_api_resolver, api_handler, DecimalEncoder
 from shared.exceptions import ConfigurationError, ValidationError, NotFoundError, ServiceError
+from shared.indexes import FEEDBACK_BY_ID_INDEX
 
 s3_client = get_s3_client()
 dynamodb = get_dynamodb_resource()
@@ -29,9 +30,6 @@ sqs_client = get_sqs_client()
 
 RAW_DATA_BUCKET = os.environ.get("RAW_DATA_BUCKET", "")
 FEEDBACK_TABLE = os.environ.get("FEEDBACK_TABLE", "")
-# Feedback-id lookup GSI — must match core-stack.ts (gsi4-by-feedback-id).
-# Regression-tested in test_data_explorer_handler.py (#140).
-FEEDBACK_ID_INDEX = 'gsi4-by-feedback-id'
 PROCESSING_QUEUE_URL = os.environ.get("PROCESSING_QUEUE_URL", "")
 
 # Available buckets for browsing
@@ -352,7 +350,7 @@ def save_feedback():
         else:
             # Need to find the item first
             response = table.query(
-                IndexName=FEEDBACK_ID_INDEX,
+                IndexName=FEEDBACK_BY_ID_INDEX,
                 KeyConditionExpression='feedback_id = :fid',
                 ExpressionAttributeValues={':fid': feedback_id},
                 Limit=1
@@ -415,7 +413,7 @@ def delete_feedback():
         
         # Find the item first using GSI
         response = table.query(
-            IndexName=FEEDBACK_ID_INDEX,
+            IndexName=FEEDBACK_BY_ID_INDEX,
             KeyConditionExpression='feedback_id = :fid',
             ExpressionAttributeValues={':fid': feedback_id},
             Limit=1

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -22,6 +22,7 @@ from shared.api import DecimalEncoder, validate_date_basis
 from shared.feedback import query_feedback_by_date
 from shared.tokens import hash_token
 from shared.tables import get_projects_table, get_feedback_table, get_aggregates_table
+from shared.indexes import FEEDBACK_BY_ID_INDEX
 from projects import autoseed_project
 
 logger = Logger()
@@ -442,7 +443,7 @@ def _tool_get_feedback_detail(args: dict, _token_info: dict) -> list[dict]:
         return [{"type": "text", "text": "Feedback table not configured"}]
 
     response = feedback_table.query(
-        IndexName='gsi4-by-feedback-id',
+        IndexName=FEEDBACK_BY_ID_INDEX,
         KeyConditionExpression=Key('feedback_id').eq(feedback_id),
         Limit=1,
     )

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -19,6 +19,7 @@ from shared.api import (
     get_configured_categories, api_handler, DEFAULT_CATEGORIES
 )
 from shared.feedback import basis_date, window_cutoff
+from shared.indexes import AGGREGATES_BY_METRIC_TYPE_INDEX, FEEDBACK_BY_CATEGORY_INDEX, FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX, FEEDBACK_BY_URGENCY_INDEX
 
 # Pagination bounds for /feedback. The candidate window is a function of
 # offset+limit, capped to prevent unbounded DynamoDB scans. The cap also defines
@@ -144,7 +145,7 @@ def _scan_recent_items(
         date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
         remaining = soft_cap - len(items)
         day_items, day_has_more = _query_partition(
-            'gsi1-by-date',
+            FEEDBACK_BY_DATE_INDEX,
             Key('gsi1pk').eq(f'DATE#{date}'),
             max_matched=min(per_day_limit, remaining) if per_day_limit else remaining,
             source=source,
@@ -245,7 +246,7 @@ def list_feedback():
         # Category is the partition key here, so no source push-down needed;
         # paging still matters because one query returns at most one page.
         candidates, window_truncated = _query_partition(
-            'gsi2-by-category',
+            FEEDBACK_BY_CATEGORY_INDEX,
             Key('gsi2pk').eq(f'CATEGORY#{category}'),
             max_matched=candidate_cap,
         )
@@ -256,7 +257,7 @@ def list_feedback():
             # a day dominated by another source would otherwise fill the whole
             # page and starve the in-memory filter (issue #99).
             day_items, day_has_more = _query_partition(
-                'gsi1-by-date',
+                FEEDBACK_BY_DATE_INDEX,
                 Key('gsi1pk').eq(f'DATE#{date}'),
                 max_matched=candidate_cap - len(candidates),
                 source=source,
@@ -321,7 +322,7 @@ def get_urgent_feedback():
     fetch_limit = limit * 5 if has_filters else limit
     
     response = feedback_table.query(
-        IndexName='gsi3-by-urgency',
+        IndexName=FEEDBACK_BY_URGENCY_INDEX,
         KeyConditionExpression=Key('gsi3pk').eq('URGENCY#high'),
         Limit=fetch_limit,
         ScanIndexForward=False
@@ -417,7 +418,7 @@ def get_entities():
     
     # Get sources from aggregates
     source_response = aggregates_table.query(
-        IndexName='gsi1-by-metric-type',
+        IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('source')
     )
     source_totals = {}
@@ -429,7 +430,7 @@ def get_entities():
     
     # Get personas from aggregates
     persona_response = aggregates_table.query(
-        IndexName='gsi1-by-metric-type',
+        IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('persona')
     )
     persona_counts = {}
@@ -453,7 +454,7 @@ def get_entities():
     for i in range(min(days, 7)):
         date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
         response = feedback_table.query(
-            IndexName='gsi1-by-date',
+            IndexName=FEEDBACK_BY_DATE_INDEX,
             KeyConditionExpression=Key('gsi1pk').eq(f'DATE#{date}'),
             Limit=50,
             ScanIndexForward=False
@@ -556,7 +557,7 @@ def search_feedback():
 def get_feedback(feedback_id: str):
     """Get a single feedback item by ID."""
     response = feedback_table.query(
-        IndexName='gsi4-by-feedback-id',
+        IndexName=FEEDBACK_BY_ID_INDEX,
         KeyConditionExpression=Key('feedback_id').eq(feedback_id),
         Limit=1
     )
@@ -574,7 +575,7 @@ def get_similar_feedback(feedback_id: str):
     limit = validate_limit(params.get('limit'), default=8, max_val=50)
     
     response = feedback_table.query(
-        IndexName='gsi4-by-feedback-id',
+        IndexName=FEEDBACK_BY_ID_INDEX,
         KeyConditionExpression=Key('feedback_id').eq(feedback_id),
         Limit=1
     )
@@ -586,7 +587,7 @@ def get_similar_feedback(feedback_id: str):
     category = source_item.get('category', 'other')
     
     response = feedback_table.query(
-        IndexName='gsi2-by-category',
+        IndexName=FEEDBACK_BY_CATEGORY_INDEX,
         KeyConditionExpression=Key('gsi2pk').eq(f'CATEGORY#{category}'),
         Limit=limit + 10,
         ScanIndexForward=False
@@ -817,7 +818,7 @@ def get_source_metrics():
         }
     
     response = aggregates_table.query(
-        IndexName='gsi1-by-metric-type',
+        IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('source')
     )
     
@@ -859,7 +860,7 @@ def get_persona_metrics():
         }
     
     response = aggregates_table.query(
-        IndexName='gsi1-by-metric-type',
+        IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('persona')
     )
     

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -19,7 +19,13 @@ from shared.api import (
     get_configured_categories, api_handler, DEFAULT_CATEGORIES
 )
 from shared.feedback import basis_date, window_cutoff
-from shared.indexes import AGGREGATES_BY_METRIC_TYPE_INDEX, FEEDBACK_BY_CATEGORY_INDEX, FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX, FEEDBACK_BY_URGENCY_INDEX
+from shared.indexes import (
+    AGGREGATES_BY_METRIC_TYPE_INDEX,
+    FEEDBACK_BY_CATEGORY_INDEX,
+    FEEDBACK_BY_DATE_INDEX,
+    FEEDBACK_BY_ID_INDEX,
+    FEEDBACK_BY_URGENCY_INDEX,
+)
 
 # Pagination bounds for /feedback. The candidate window is a function of
 # offset+limit, capped to prevent unbounded DynamoDB scans. The cap also defines

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -35,6 +35,7 @@ from shared.avatar import (
 )
 
 from shared.tables import get_projects_table, get_feedback_table
+from shared.indexes import PROJECTS_BY_TYPE_INDEX
 
 # AWS Clients (using shared module for connection reuse)
 dynamodb = get_dynamodb_resource()
@@ -79,7 +80,7 @@ def list_projects() -> dict:
         return {'projects': []}
     
     response = projects_table.query(
-        IndexName='gsi1-by-type',
+        IndexName=PROJECTS_BY_TYPE_INDEX,
         KeyConditionExpression=Key('gsi1pk').eq('TYPE#PROJECT'),
         ScanIndexForward=False
     )

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -6,9 +6,11 @@ and job Lambdas (document generator, document merger).
 
 import logging
 import re
-from shared.indexes import FEEDBACK_BY_CATEGORY_INDEX, FEEDBACK_BY_DATE_INDEX
 from datetime import datetime, timezone, timedelta
+
 from boto3.dynamodb.conditions import Key
+
+from shared.indexes import FEEDBACK_BY_CATEGORY_INDEX, FEEDBACK_BY_DATE_INDEX
 
 logger = logging.getLogger(__name__)
 

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -6,6 +6,7 @@ and job Lambdas (document generator, document merger).
 
 import logging
 import re
+from shared.indexes import FEEDBACK_BY_CATEGORY_INDEX, FEEDBACK_BY_DATE_INDEX
 from datetime import datetime, timezone, timedelta
 from boto3.dynamodb.conditions import Key
 
@@ -132,7 +133,7 @@ def _fetch_and_filter(
         for category in categories:
             items.extend(_query_all_pages(
                 feedback_table,
-                index_name='gsi2-by-category',
+                index_name=FEEDBACK_BY_CATEGORY_INDEX,
                 key_expr=Key('gsi2pk').eq(f'CATEGORY#{category}'),
                 max_items=page_cap,
             ))
@@ -143,7 +144,7 @@ def _fetch_and_filter(
             date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
             items.extend(_query_all_pages(
                 feedback_table,
-                index_name='gsi1-by-date',
+                index_name=FEEDBACK_BY_DATE_INDEX,
                 key_expr=Key('gsi1pk').eq(f'DATE#{date}'),
                 max_items=page_cap,
             ))

--- a/voc-datalake/lambda/shared/indexes.py
+++ b/voc-datalake/lambda/shared/indexes.py
@@ -1,0 +1,38 @@
+"""
+DynamoDB GSI names — Python single source of truth (issue #213).
+
+The indexes themselves are defined in lib/stacks/core-stack.ts; these
+constants mirror them so handlers never hardcode index-name literals. A
+guard test (lambda/shared/test/test_indexes.py) parses the CDK stack and
+asserts SET EQUALITY with the values below, so a rename or addition on
+either side fails CI instead of the live API — the failure mode behind
+issue #140, where a handler queried a never-existing 'feedback-id-index'.
+
+The streaming Lambda has its own TypeScript mirror
+(lambda/stream/src/indexes.ts) with the same guard.
+"""
+
+# voc-feedback table
+FEEDBACK_BY_DATE_INDEX = 'gsi1-by-date'
+FEEDBACK_BY_CATEGORY_INDEX = 'gsi2-by-category'
+FEEDBACK_BY_URGENCY_INDEX = 'gsi3-by-urgency'
+FEEDBACK_BY_ID_INDEX = 'gsi4-by-feedback-id'
+
+# voc-aggregates table
+AGGREGATES_BY_METRIC_TYPE_INDEX = 'gsi1-by-metric-type'
+
+# voc-projects table
+PROJECTS_BY_TYPE_INDEX = 'gsi1-by-type'
+
+# voc-jobs table (no Python/TS consumer today; listed for stack parity)
+JOBS_BY_STATUS_INDEX = 'gsi1-by-status'
+
+ALL_INDEX_NAMES = frozenset({
+    FEEDBACK_BY_DATE_INDEX,
+    FEEDBACK_BY_CATEGORY_INDEX,
+    FEEDBACK_BY_URGENCY_INDEX,
+    FEEDBACK_BY_ID_INDEX,
+    AGGREGATES_BY_METRIC_TYPE_INDEX,
+    PROJECTS_BY_TYPE_INDEX,
+    JOBS_BY_STATUS_INDEX,
+})

--- a/voc-datalake/lambda/shared/test/test_indexes.py
+++ b/voc-datalake/lambda/shared/test/test_indexes.py
@@ -21,6 +21,9 @@ def _repo_root() -> Path:
 
 
 def _stack_index_names() -> set[str]:
+    # Assumes every GSI lives in core-stack.ts (true today — all seven tables
+    # are defined there). If an index is ever added in another stack file,
+    # widen this to glob lib/stacks/*.ts.
     source = (_repo_root() / 'lib' / 'stacks' / 'core-stack.ts').read_text()
     return set(re.findall(r"indexName:\s*'([^']+)'", source))
 
@@ -47,9 +50,17 @@ class TestIndexMirror:
         missing = stream_names - _stack_index_names()
         assert not missing, f'stream declares indexes the stack does not define: {missing}'
 
+    # Two literal shapes to catch:
+    # 1. Names following the stack's gsiN-by-* convention, wherever they appear.
+    # 2. ANY string literal passed straight to an IndexName=/index_name= kwarg —
+    #    the actual #140 failure was IndexName='feedback-id-index', a name that
+    #    matches no convention at all, so a convention-only scan misses it.
+    _GSI_CONVENTION = re.compile(r"['\"](gsi\d+-by-[a-z-]+)['\"]")
+    _INDEX_KWARG_LITERAL = re.compile(r"(?:IndexName|index_name)\s*=\s*['\"]([^'\"]+)['\"]")
+
     def test_no_new_hardcoded_index_literals_in_python(self):
-        """Handlers must use shared.indexes — a fresh 'gsi*-by-*' string
-        literal outside indexes.py reintroduces the drift this issue killed."""
+        """Handlers must use shared.indexes — a fresh GSI-name string literal
+        outside indexes.py reintroduces the drift this issue killed."""
         lambda_dir = _repo_root() / 'lambda'
         offenders = []
         for py in lambda_dir.rglob('*.py'):
@@ -61,9 +72,11 @@ class TestIndexMirror:
                 continue
             if '__pycache__' in parts or 'layers' in parts:
                 continue
-            for m in re.finditer(r"['\"](gsi\d+-by-[a-z-]+)['\"]", py.read_text()):
-                line = py.read_text()[: m.start()].count('\n') + 1
-                offenders.append(f'{rel.as_posix()}:{line} ({m.group(1)})')
+            source = py.read_text()
+            for pattern in (self._GSI_CONVENTION, self._INDEX_KWARG_LITERAL):
+                for m in pattern.finditer(source):
+                    line = source[: m.start()].count('\n') + 1
+                    offenders.append(f'{rel.as_posix()}:{line} ({m.group(1)})')
         assert not offenders, (
             'Hardcoded GSI-name literal(s) found — import from shared.indexes '
             f'instead (#213): {offenders}'

--- a/voc-datalake/lambda/shared/test/test_indexes.py
+++ b/voc-datalake/lambda/shared/test/test_indexes.py
@@ -1,0 +1,70 @@
+"""
+Guard tests for the DynamoDB GSI-name single source of truth (issue #213).
+
+lib/stacks/core-stack.ts defines the indexes; lambda/shared/indexes.py (and
+the streaming Lambda's src/indexes.ts) mirror the names. These tests parse
+the CDK source and assert the mirrors match, so a rename or addition on
+either side fails CI instead of the live API — the #140 failure mode, where
+a handler queried a never-existing index name and every Data Explorer delete
+500'd. Same pattern as the model-allowlist TS↔Python mirror test.
+"""
+
+import re
+from pathlib import Path
+
+from shared.indexes import ALL_INDEX_NAMES
+
+
+def _repo_root() -> Path:
+    # lambda/shared/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _stack_index_names() -> set[str]:
+    source = (_repo_root() / 'lib' / 'stacks' / 'core-stack.ts').read_text()
+    return set(re.findall(r"indexName:\s*'([^']+)'", source))
+
+
+class TestIndexMirror:
+    def test_python_mirror_matches_the_stack_exactly(self):
+        """Set equality both ways: a stack rename breaks the constant, and a
+        new stack index without a constant keeps the mirror incomplete."""
+        stack = _stack_index_names()
+        assert stack, 'parsed no indexName entries from core-stack.ts — parser drift?'
+        assert stack == set(ALL_INDEX_NAMES), (
+            f'stack-only: {stack - set(ALL_INDEX_NAMES)}, '
+            f'python-only: {set(ALL_INDEX_NAMES) - stack}'
+        )
+
+    def test_stream_mirror_names_exist_in_the_stack(self):
+        """The streaming Lambda declares only the indexes it uses — every one
+        of them must exist in the stack (subset, not equality)."""
+        stream_source = (
+            _repo_root() / 'lambda' / 'stream' / 'src' / 'indexes.ts'
+        ).read_text()
+        stream_names = set(re.findall(r"=\s*'(gsi[^']+)'", stream_source))
+        assert stream_names, 'parsed no index constants from stream/src/indexes.ts'
+        missing = stream_names - _stack_index_names()
+        assert not missing, f'stream declares indexes the stack does not define: {missing}'
+
+    def test_no_new_hardcoded_index_literals_in_python(self):
+        """Handlers must use shared.indexes — a fresh 'gsi*-by-*' string
+        literal outside indexes.py reintroduces the drift this issue killed."""
+        lambda_dir = _repo_root() / 'lambda'
+        offenders = []
+        for py in lambda_dir.rglob('*.py'):
+            rel = py.relative_to(lambda_dir)
+            parts = rel.parts
+            if 'test' in parts or any(p.startswith('test_') for p in parts):
+                continue
+            if rel.as_posix() == 'shared/indexes.py':
+                continue
+            if '__pycache__' in parts or 'layers' in parts:
+                continue
+            for m in re.finditer(r"['\"](gsi\d+-by-[a-z-]+)['\"]", py.read_text()):
+                line = py.read_text()[: m.start()].count('\n') + 1
+                offenders.append(f'{rel.as_posix()}:{line} ({m.group(1)})')
+        assert not offenders, (
+            'Hardcoded GSI-name literal(s) found — import from shared.indexes '
+            f'instead (#213): {offenders}'
+        )

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -5,6 +5,7 @@
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { ConfigurationError, NotFoundError } from '../lib/errors.js';
+import { FEEDBACK_BY_DATE_INDEX } from '../indexes.js';
 import { buildSinglePersonaPrompt, getLanguageInstruction } from './persona-prompt.js';
 
 // ── Avatar URL helpers ──
@@ -224,7 +225,7 @@ async function fetchRecentFeedback(
     const resp = await docClient.send(
       new QueryCommand({
         TableName: feedbackTable,
-        IndexName: 'gsi1-by-date',
+        IndexName: FEEDBACK_BY_DATE_INDEX,
         KeyConditionExpression: 'gsi1pk = :pk',
         ExpressionAttributeValues: { ':pk': 'DATE' },
         ScanIndexForward: false,

--- a/voc-datalake/lambda/stream/src/indexes.test.ts
+++ b/voc-datalake/lambda/stream/src/indexes.test.ts
@@ -7,13 +7,14 @@
  * stricter full-set mirror test in lambda/shared/test/test_indexes.py.
  */
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX } from './indexes.js'
 
 function stackIndexNames(): Set<string> {
   // lambda/stream/src -> voc-datalake/lib/stacks/core-stack.ts
-  const stackPath = resolve(__dirname, '../../../lib/stacks/core-stack.ts')
+  // import.meta.url (not __dirname): this package is ESM/NodeNext.
+  const stackPath = fileURLToPath(new URL('../../../lib/stacks/core-stack.ts', import.meta.url))
   const source = readFileSync(stackPath, 'utf-8')
   return new Set([...source.matchAll(/indexName:\s*'([^']+)'/g)].map((m) => m[1]))
 }

--- a/voc-datalake/lambda/stream/src/indexes.test.ts
+++ b/voc-datalake/lambda/stream/src/indexes.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Guard test for the streaming Lambda's GSI-name mirror (issue #213).
+ *
+ * Parses lib/stacks/core-stack.ts (the single source of truth) and asserts
+ * every constant declared here exists there, so a stack rename fails this
+ * suite instead of the live API (#140 failure mode). The Python side has the
+ * stricter full-set mirror test in lambda/shared/test/test_indexes.py.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX } from './indexes.js'
+
+function stackIndexNames(): Set<string> {
+  // lambda/stream/src -> voc-datalake/lib/stacks/core-stack.ts
+  const stackPath = resolve(__dirname, '../../../lib/stacks/core-stack.ts')
+  const source = readFileSync(stackPath, 'utf-8')
+  return new Set([...source.matchAll(/indexName:\s*'([^']+)'/g)].map((m) => m[1]))
+}
+
+describe('GSI name mirror (#213)', () => {
+  it('parses index definitions out of core-stack.ts', () => {
+    expect(stackIndexNames().size).toBeGreaterThanOrEqual(7)
+  })
+
+  it.each([
+    ['FEEDBACK_BY_DATE_INDEX', FEEDBACK_BY_DATE_INDEX],
+    ['FEEDBACK_BY_ID_INDEX', FEEDBACK_BY_ID_INDEX],
+  ])('%s exists in the CDK stack', (_name, value) => {
+    expect(stackIndexNames()).toContain(value)
+  })
+})

--- a/voc-datalake/lambda/stream/src/indexes.ts
+++ b/voc-datalake/lambda/stream/src/indexes.ts
@@ -1,0 +1,13 @@
+/**
+ * DynamoDB GSI names used by the streaming Lambda — TypeScript mirror of the
+ * single source of truth (issue #213).
+ *
+ * The indexes are defined in lib/stacks/core-stack.ts; a guard test
+ * (src/indexes.test.ts) parses the CDK stack source and asserts these values
+ * exist there, so a rename fails CI instead of the live API. The Python
+ * handlers have their own mirror (lambda/shared/indexes.py) with a stricter
+ * full-set guard.
+ */
+
+export const FEEDBACK_BY_DATE_INDEX = 'gsi1-by-date'
+export const FEEDBACK_BY_ID_INDEX = 'gsi4-by-feedback-id'

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -5,6 +5,7 @@
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { ConfigurationError } from '../lib/errors.js';
+import { FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX } from '../indexes.js';
 
 const searchInputSchema = z.object({
   query: z.string().optional(),
@@ -138,7 +139,7 @@ async function lookupByFeedbackId(
     const resp = await docClient.send(
       new QueryCommand({
         TableName: feedbackTable,
-        IndexName: 'gsi4-by-feedback-id',
+        IndexName: FEEDBACK_BY_ID_INDEX,
         KeyConditionExpression: 'feedback_id = :fid',
         ExpressionAttributeValues: { ':fid': feedbackId.toLowerCase().trim() },
         Limit: 1,
@@ -180,7 +181,7 @@ async function fetchDayPages(
   const resp = await docClient.send(
     new QueryCommand({
       TableName: feedbackTable,
-      IndexName: 'gsi1-by-date',
+      IndexName: FEEDBACK_BY_DATE_INDEX,
       KeyConditionExpression: 'gsi1pk = :pk',
       ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
       ScanIndexForward: false,


### PR DESCRIPTION
## Summary

Closes #213.

DynamoDB GSI names were hardcoded as string literals at ~24 call sites across the Python API handlers and the TypeScript stream Lambda. Issue #212 demonstrated the failure mode: `data_explorer_handler.py` queried a `feedback-id-index` that does not exist in the stack (the real GSI is `gsi4-by-feedback-id`), and nothing caught it until runtime.

This PR centralizes every GSI name behind constants that are **guard-tested against the CDK stack definition**, so a rename or typo on either side fails CI instead of failing in production.

## What changed

### Python — `lambda/shared/indexes.py` (new)

Seven constants mirroring the seven GSIs defined in `lib/stacks/core-stack.ts`, plus an `ALL_INDEX_NAMES` frozenset:

| Constant | Literal | Table |
|---|---|---|
| `FEEDBACK_BY_DATE_INDEX` | `gsi1-by-date` | feedback |
| `FEEDBACK_BY_CATEGORY_INDEX` | `gsi2-by-category` | feedback |
| `FEEDBACK_BY_URGENCY_INDEX` | `gsi3-by-urgency` | feedback |
| `FEEDBACK_BY_ID_INDEX` | `gsi4-by-feedback-id` | feedback |
| `AGGREGATES_BY_METRIC_TYPE_INDEX` | `gsi1-by-metric-type` | aggregates |
| `PROJECTS_BY_TYPE_INDEX` | `gsi1-by-type` | projects |
| `JOBS_BY_STATUS_INDEX` | `gsi1-by-status` | jobs |

Literals replaced in: `metrics_handler.py` (12 sites), `chat_handler.py`, `mcp_handler.py`, `projects.py`, `shared/feedback.py`, and `data_explorer_handler.py` (the local `FEEDBACK_ID_INDEX` alias introduced by #212's fix is removed in favor of the shared constant).

### TypeScript — `lambda/stream/src/indexes.ts` (new)

`FEEDBACK_BY_DATE_INDEX` and `FEEDBACK_BY_ID_INDEX` for the stream Lambda's three query sites (`tools/search-feedback.ts` x2, `context/project-context.ts` x1). Kept deliberately minimal: only the names the stream Lambda actually uses.

### Drift guards (mirror-test precedent from the model allowlist)

- **`lambda/shared/test/test_indexes.py`** — three tests:
  1. Parses the `addGlobalSecondaryIndex` blocks in `core-stack.ts` and asserts **set equality** with `ALL_INDEX_NAMES` (a GSI added to the stack without a constant fails, and vice versa).
  2. Asserts the TS `indexes.ts` names are a subset of the stack's names.
  3. Scans `lambda/**/*.py` for reintroduced hardcoded `gsi*`/`*-index` string literals outside the constants module.
- **`lambda/stream/src/indexes.test.ts`** — asserts the TS constants match their expected literals and are a subset of the stack's GSI names (parsed from `core-stack.ts`).

## Behavior

Unchanged. Every constant resolves to the exact literal previously in place — this is a mechanical refactor plus guard tests. No API responses, queries, or stack resources change.

## Testing

- Backend: `pytest` full suite — **922/922 passed**
- Stream: `vitest` — **3/3 passed** (new `indexes.test.ts`)
- Stream: `tsc --noEmit` clean
- Lint: `ruff check` clean

## Deployment

No infrastructure change (no CDK diff — names are identical). Lambda code-only change, rides along with the pending batch deploy of the dev branch. Per the agreed workflow, deploy + live validation are cumulated into the batch before the next dev→main release.
