### PR TITLE
fix(stream): query per-day date partitions for recent-feedback context (#220)

### DIFF
--- a/voc-datalake/lambda/stream/src/context/project-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.test.ts
@@ -254,3 +254,131 @@ describe('buildProjectChatContext', () => {
     expect(ctx.metadata.selected_personas).toStrictEqual(['No Avatar Persona']);
   });
 });
+
+describe('fetchRecentFeedback via buildProjectChatContext (regression #220)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const todayUtc = new Date().toISOString().slice(0, 10);
+
+  function makeFeedback(overrides: Record<string, unknown> = {}) {
+    return {
+      source_platform: 'webscraper',
+      sentiment_label: 'negative',
+      category: 'delivery',
+      original_text: 'Package arrived late',
+      ...overrides,
+    };
+  }
+
+  /** Extract the gsi1pk value from a recorded QueryCommand call. */
+  function pkOfCall(call: unknown[]): string {
+    const cmd = call[0] as { input: { ExpressionAttributeValues?: Record<string, unknown> } };
+    const pk = cmd.input.ExpressionAttributeValues?.[':pk'];
+    return typeof pk === 'string' ? pk : '';
+  }
+
+  it('queries per-day DATE#YYYY-MM-DD partitions, never the bare DATE literal', async () => {
+    const docClient = createMockDocClient([
+      [projectMeta],
+      [makeFeedback()],
+    ]);
+
+    await buildProjectChatContext(
+      docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
+    );
+
+    const sendMock = (docClient.send as ReturnType<typeof vi.fn>);
+    const feedbackCalls = sendMock.mock.calls.slice(1); // call 0 = project query
+    expect(feedbackCalls.length).toBeGreaterThan(0);
+    for (const call of feedbackCalls) {
+      const pk = pkOfCall(call);
+      expect(pk).toMatch(/^DATE#\d{4}-\d{2}-\d{2}$/);
+      expect(pk).not.toBe('DATE');
+    }
+    // The walk starts at today's UTC partition.
+    expect(pkOfCall(feedbackCalls[0])).toBe(`DATE#${todayUtc}`);
+  });
+
+  it('includes the recent-feedback section when a recent day has items', async () => {
+    const docClient = createMockDocClient([
+      [projectMeta],
+      [makeFeedback(), makeFeedback({ original_text: 'Love the new feature' })],
+    ]);
+
+    const ctx = await buildProjectChatContext(
+      docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
+    );
+
+    expect(ctx.systemPrompt).toContain('Recent Customer Feedback');
+    expect(ctx.systemPrompt).toContain('Package arrived late');
+    expect(ctx.metadata.context).toStrictEqual(
+      expect.objectContaining({ feedback_count: 2 }),
+    );
+  });
+
+  it('walks backward across days and stops once the target is collected', async () => {
+    const day0 = Array.from({ length: 20 }, (_, i) => makeFeedback({ original_text: `day0 item ${i}` }));
+    const day1 = Array.from({ length: 20 }, (_, i) => makeFeedback({ original_text: `day1 item ${i}` }));
+    const docClient = createMockDocClient([
+      [projectMeta],
+      day0,
+      day1,
+    ]);
+
+    const ctx = await buildProjectChatContext(
+      docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
+    );
+
+    // 20 from day 0 + 10 from day 1 = the 30-item target; the walk stops there
+    // (1 project call + 2 day calls, not the full 30-day lookback).
+    expect(ctx.metadata.context).toStrictEqual(
+      expect.objectContaining({ feedback_count: 30 }),
+    );
+    const sendMock = (docClient.send as ReturnType<typeof vi.fn>);
+    expect(sendMock.mock.calls).toHaveLength(3);
+    expect(pkOfCall(sendMock.mock.calls[1])).toBe(`DATE#${todayUtc}`);
+    expect(pkOfCall(sendMock.mock.calls[2])).toMatch(/^DATE#\d{4}-\d{2}-\d{2}$/);
+    expect(pkOfCall(sendMock.mock.calls[2])).not.toBe(pkOfCall(sendMock.mock.calls[1]));
+  });
+
+  it('continues to the previous day when one day query fails', async () => {
+    let callIndex = 0;
+    const docClient = {
+      send: vi.fn().mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return Promise.resolve({ Items: [projectMeta] });
+        if (callIndex === 2) return Promise.reject(new Error('throttled'));
+        if (callIndex === 3) return Promise.resolve({ Items: [makeFeedback()] });
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildProjectChatContext(
+      docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
+    );
+
+    expect(ctx.metadata.context).toStrictEqual(
+      expect.objectContaining({ feedback_count: 1 }),
+    );
+    expect(ctx.systemPrompt).toContain('Recent Customer Feedback');
+  });
+
+  it('skips a malformed row without discarding the rest of the day', async () => {
+    const docClient = createMockDocClient([
+      [projectMeta],
+      [
+        { ...makeFeedback(), original_text: 12345 }, // wrong type → safeParse fails
+        makeFeedback({ original_text: 'valid row survives' }),
+      ],
+    ]);
+
+    const ctx = await buildProjectChatContext(
+      docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
+    );
+
+    expect(ctx.metadata.context).toStrictEqual(
+      expect.objectContaining({ feedback_count: 1 }),
+    );
+    expect(ctx.systemPrompt).toContain('valid row survives');
+  });
+});

--- a/voc-datalake/lambda/stream/src/context/project-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.test.ts
@@ -282,7 +282,7 @@ describe('fetchRecentFeedback via buildProjectChatContext (regression #220)', ()
   });
 
   // One parallel batch of day queries (mirrors DAY_QUERY_BATCH_SIZE in
-  // project-context.ts); +1 for the initial project query.
+  // recent-feedback.ts); +1 for the initial project query.
   const BATCH = 7;
 
   function makeFeedback(overrides: Record<string, unknown> = {}) {

--- a/voc-datalake/lambda/stream/src/context/project-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.test.ts
@@ -1,15 +1,22 @@
 /**
  * Tests for Project Chat context builder.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { buildProjectChatContext } from './project-context.js';
 
-function createMockDocClient(responses: Record<string, unknown>[][] = []) {
+function createMockDocClient(
+  responses: Record<string, unknown>[][] = [],
+  rejectAt?: { index: number; error: Error },
+) {
   let callIndex = 0;
   return {
     send: vi.fn().mockImplementation(() => {
-      const items = callIndex < responses.length ? responses[callIndex] : [];
+      const current = callIndex;
       callIndex++;
+      if (rejectAt && current === rejectAt.index) {
+        return Promise.reject(rejectAt.error);
+      }
+      const items = current < responses.length ? responses[current] : [];
       return Promise.resolve({ Items: items });
     }),
   } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
@@ -256,9 +263,27 @@ describe('buildProjectChatContext', () => {
 });
 
 describe('fetchRecentFeedback via buildProjectChatContext (regression #220)', () => {
-  beforeEach(() => vi.clearAllMocks());
+  // Pin the clock so the DATE#YYYY-MM-DD assertions can't flake across a
+  // UTC-midnight boundary during a test run.
+  const FIXED_NOW = new Date('2026-07-17T12:00:00Z');
+  const todayUtc = '2026-07-17';
+  let warnSpy: ReturnType<typeof vi.spyOn>;
 
-  const todayUtc = new Date().toISOString().slice(0, 10);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  // One parallel batch of day queries (mirrors DAY_QUERY_BATCH_SIZE in
+  // project-context.ts); +1 for the initial project query.
+  const BATCH = 7;
 
   function makeFeedback(overrides: Record<string, unknown> = {}) {
     return {
@@ -316,7 +341,7 @@ describe('fetchRecentFeedback via buildProjectChatContext (regression #220)', ()
     );
   });
 
-  it('walks backward across days and stops once the target is collected', async () => {
+  it('collects across days newest-first and stops batching once the target is met', async () => {
     const day0 = Array.from({ length: 20 }, (_, i) => makeFeedback({ original_text: `day0 item ${i}` }));
     const day1 = Array.from({ length: 20 }, (_, i) => makeFeedback({ original_text: `day1 item ${i}` }));
     const docClient = createMockDocClient([
@@ -329,29 +354,26 @@ describe('fetchRecentFeedback via buildProjectChatContext (regression #220)', ()
       docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
     );
 
-    // 20 from day 0 + 10 from day 1 = the 30-item target; the walk stops there
-    // (1 project call + 2 day calls, not the full 30-day lookback).
+    // 20 from day 0 top up to the 30-item target from day 1; newest day's
+    // items keep priority in the prompt, and no second batch is issued.
     expect(ctx.metadata.context).toStrictEqual(
       expect.objectContaining({ feedback_count: 30 }),
     );
+    expect(ctx.systemPrompt).toContain('day0 item 0');
     const sendMock = (docClient.send as ReturnType<typeof vi.fn>);
-    expect(sendMock.mock.calls).toHaveLength(3);
+    expect(sendMock.mock.calls).toHaveLength(1 + BATCH);
     expect(pkOfCall(sendMock.mock.calls[1])).toBe(`DATE#${todayUtc}`);
-    expect(pkOfCall(sendMock.mock.calls[2])).toMatch(/^DATE#\d{4}-\d{2}-\d{2}$/);
-    expect(pkOfCall(sendMock.mock.calls[2])).not.toBe(pkOfCall(sendMock.mock.calls[1]));
+    expect(pkOfCall(sendMock.mock.calls[2])).toBe('DATE#2026-07-16');
   });
 
-  it('continues to the previous day when one day query fails', async () => {
-    let callIndex = 0;
-    const docClient = {
-      send: vi.fn().mockImplementation(() => {
-        callIndex++;
-        if (callIndex === 1) return Promise.resolve({ Items: [projectMeta] });
-        if (callIndex === 2) return Promise.reject(new Error('throttled'));
-        if (callIndex === 3) return Promise.resolve({ Items: [makeFeedback()] });
-        return Promise.resolve({ Items: [] });
-      }),
-    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+  it('keeps collecting when one day query fails transiently, and warns', async () => {
+    // Call 1 (today's partition) rejects; call 2 (yesterday) has an item.
+    const responses: Record<string, unknown>[][] = [[projectMeta]];
+    responses[2] = [makeFeedback()];
+    const docClient = createMockDocClient(responses, {
+      index: 1,
+      error: new Error('throttled'),
+    });
 
     const ctx = await buildProjectChatContext(
       docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
@@ -361,6 +383,30 @@ describe('fetchRecentFeedback via buildProjectChatContext (regression #220)', ()
       expect.objectContaining({ feedback_count: 1 }),
     );
     expect(ctx.systemPrompt).toContain('Recent Customer Feedback');
+    // The original bug's worst property was silence — failures must be logged.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`day query failed for ${todayUtc}`),
+    );
+  });
+
+  it('stops the lookback on a persistent error instead of repeating it for 30 days', async () => {
+    const denied = new Error('not authorized');
+    denied.name = 'AccessDeniedException';
+    const docClient = createMockDocClient([[projectMeta]], { index: 1, error: denied });
+
+    const ctx = await buildProjectChatContext(
+      docClient, 'projects-table', 'feedback-table', 'proj-1', 'hello',
+    );
+
+    expect(ctx.metadata.context).toStrictEqual(
+      expect.objectContaining({ feedback_count: 0 }),
+    );
+    const sendMock = (docClient.send as ReturnType<typeof vi.fn>);
+    // Only the first batch runs — no pointless retries across the window.
+    expect(sendMock.mock.calls).toHaveLength(1 + BATCH);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('AccessDeniedException'),
+    );
   });
 
   it('skips a malformed row without discarding the rest of the day', async () => {

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -5,7 +5,7 @@
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { ConfigurationError, NotFoundError } from '../lib/errors.js';
-import { FEEDBACK_BY_DATE_INDEX } from '../indexes.js';
+import { fetchRecentFeedback } from './recent-feedback.js';
 import { buildSinglePersonaPrompt, getLanguageInstruction } from './persona-prompt.js';
 
 // ── Avatar URL helpers ──
@@ -204,84 +204,8 @@ function buildDocumentsContext(
 }
 
 // ── Feedback fetching ──
-
-interface FeedbackSummary {
-  count: number;
-  promptSection: string;
-}
-
-const feedbackItemSchema = z.object({
-  source_platform: z.string().optional(),
-  sentiment_label: z.string().optional(),
-  category: z.string().optional(),
-  original_text: z.string().optional(),
-}).passthrough();
-
-type RecentFeedbackItem = z.infer<typeof feedbackItemSchema>;
-
-// How many items the recent-feedback prompt section collects, and how far
-// back to look for them. The processor writes per-day partitions
-// (gsi1pk = 'DATE#YYYY-MM-DD'), so "most recent" means walking backward day
-// by day until enough items are collected — the same pattern as
-// tools/search-feedback.ts. A bare 'DATE' equality query matches nothing
-// (issue #220), which silently emptied this prompt section.
-const RECENT_FEEDBACK_TARGET = 30;
-const RECENT_FEEDBACK_LOOKBACK_DAYS = 30;
-const RECENT_FEEDBACK_PROMPT_LINES = 15;
-
-/** Parse and append one page of rows, capped at the collection target.
- * Per-row safeParse: one malformed item must not discard the rest. */
-function collectFeedbackRows(
-  rawItems: Record<string, unknown>[] | undefined,
-  items: RecentFeedbackItem[],
-): void {
-  for (const raw of rawItems ?? []) {
-    if (items.length >= RECENT_FEEDBACK_TARGET) break;
-    const parsed = feedbackItemSchema.safeParse(raw);
-    if (parsed.success) items.push(parsed.data);
-  }
-}
-
-async function fetchRecentFeedback(
-  docClient: DynamoDBDocumentClient,
-  feedbackTable: string,
-): Promise<FeedbackSummary> {
-  const items: RecentFeedbackItem[] = [];
-  const now = new Date();
-
-  for (const dayOffset of Array.from({ length: RECENT_FEEDBACK_LOOKBACK_DAYS }, (_, idx) => idx)) {
-    if (items.length >= RECENT_FEEDBACK_TARGET) break;
-    const d = new Date(now);
-    d.setUTCDate(d.getUTCDate() - dayOffset);
-    const dateStr = d.toISOString().slice(0, 10);
-    try {
-      const resp = await docClient.send(
-        new QueryCommand({
-          TableName: feedbackTable,
-          IndexName: FEEDBACK_BY_DATE_INDEX,
-          KeyConditionExpression: 'gsi1pk = :pk',
-          ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
-          ScanIndexForward: false,
-          Limit: RECENT_FEEDBACK_TARGET - items.length,
-        }),
-      );
-      collectFeedbackRows(resp.Items, items);
-    } catch {
-      // Transient per-day failure: keep what we have, try the previous day.
-    }
-  }
-
-  if (items.length === 0) return { count: 0, promptSection: '' };
-
-  const lines = items.slice(0, RECENT_FEEDBACK_PROMPT_LINES).map((item) => {
-    const src = item.source_platform ?? 'unknown';
-    const sent = item.sentiment_label ?? 'unknown';
-    const cat = item.category ?? 'unknown';
-    const text = (item.original_text ?? '').slice(0, 300);
-    return `[${src}|${sent}|${cat}] ${text}`;
-  });
-  return { count: items.length, promptSection: `## Recent Customer Feedback\n${lines.join('\n\n')}\n\n` };
-}
+// Extracted to recent-feedback.ts (issue #220): the per-day partition walk,
+// batching, and failure-visibility logic live there with their own tests.
 
 // ── System prompt assembly ──
 

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -217,36 +217,70 @@ const feedbackItemSchema = z.object({
   original_text: z.string().optional(),
 }).passthrough();
 
+type RecentFeedbackItem = z.infer<typeof feedbackItemSchema>;
+
+// How many items the recent-feedback prompt section collects, and how far
+// back to look for them. The processor writes per-day partitions
+// (gsi1pk = 'DATE#YYYY-MM-DD'), so "most recent" means walking backward day
+// by day until enough items are collected — the same pattern as
+// tools/search-feedback.ts. A bare 'DATE' equality query matches nothing
+// (issue #220), which silently emptied this prompt section.
+const RECENT_FEEDBACK_TARGET = 30;
+const RECENT_FEEDBACK_LOOKBACK_DAYS = 30;
+const RECENT_FEEDBACK_PROMPT_LINES = 15;
+
+/** Parse and append one page of rows, capped at the collection target.
+ * Per-row safeParse: one malformed item must not discard the rest. */
+function collectFeedbackRows(
+  rawItems: Record<string, unknown>[] | undefined,
+  items: RecentFeedbackItem[],
+): void {
+  for (const raw of rawItems ?? []) {
+    if (items.length >= RECENT_FEEDBACK_TARGET) break;
+    const parsed = feedbackItemSchema.safeParse(raw);
+    if (parsed.success) items.push(parsed.data);
+  }
+}
+
 async function fetchRecentFeedback(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
 ): Promise<FeedbackSummary> {
-  try {
-    const resp = await docClient.send(
-      new QueryCommand({
-        TableName: feedbackTable,
-        IndexName: FEEDBACK_BY_DATE_INDEX,
-        KeyConditionExpression: 'gsi1pk = :pk',
-        ExpressionAttributeValues: { ':pk': 'DATE' },
-        ScanIndexForward: false,
-        Limit: 30,
-      }),
-    );
-    const rawItems = resp.Items ?? [];
-    if (rawItems.length === 0) return { count: 0, promptSection: '' };
+  const items: RecentFeedbackItem[] = [];
+  const now = new Date();
 
-    const lines = rawItems.slice(0, 15).map((raw) => {
-      const item = feedbackItemSchema.parse(raw);
-      const src = item.source_platform ?? 'unknown';
-      const sent = item.sentiment_label ?? 'unknown';
-      const cat = item.category ?? 'unknown';
-      const text = (item.original_text ?? '').slice(0, 300);
-      return `[${src}|${sent}|${cat}] ${text}`;
-    });
-    return { count: rawItems.length, promptSection: `## Recent Customer Feedback\n${lines.join('\n\n')}\n\n` };
-  } catch {
-    return { count: 0, promptSection: '' };
+  for (const dayOffset of Array.from({ length: RECENT_FEEDBACK_LOOKBACK_DAYS }, (_, idx) => idx)) {
+    if (items.length >= RECENT_FEEDBACK_TARGET) break;
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - dayOffset);
+    const dateStr = d.toISOString().slice(0, 10);
+    try {
+      const resp = await docClient.send(
+        new QueryCommand({
+          TableName: feedbackTable,
+          IndexName: FEEDBACK_BY_DATE_INDEX,
+          KeyConditionExpression: 'gsi1pk = :pk',
+          ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
+          ScanIndexForward: false,
+          Limit: RECENT_FEEDBACK_TARGET - items.length,
+        }),
+      );
+      collectFeedbackRows(resp.Items, items);
+    } catch {
+      // Transient per-day failure: keep what we have, try the previous day.
+    }
   }
+
+  if (items.length === 0) return { count: 0, promptSection: '' };
+
+  const lines = items.slice(0, RECENT_FEEDBACK_PROMPT_LINES).map((item) => {
+    const src = item.source_platform ?? 'unknown';
+    const sent = item.sentiment_label ?? 'unknown';
+    const cat = item.category ?? 'unknown';
+    const text = (item.original_text ?? '').slice(0, 300);
+    return `[${src}|${sent}|${cat}] ${text}`;
+  });
+  return { count: items.length, promptSection: `## Recent Customer Feedback\n${lines.join('\n\n')}\n\n` };
 }
 
 // ── System prompt assembly ──

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -205,7 +205,8 @@ function buildDocumentsContext(
 
 // ── Feedback fetching ──
 // Extracted to recent-feedback.ts (issue #220): the per-day partition walk,
-// batching, and failure-visibility logic live there with their own tests.
+// batching, and failure-visibility logic live there. Covered end-to-end via
+// buildProjectChatContext in project-context.test.ts.
 
 // ── System prompt assembly ──
 

--- a/voc-datalake/lambda/stream/src/context/recent-feedback.ts
+++ b/voc-datalake/lambda/stream/src/context/recent-feedback.ts
@@ -1,0 +1,143 @@
+/**
+ * Recent-feedback prompt section for project chat / roundtable context.
+ *
+ * The processor writes per-day partitions (gsi1pk = 'DATE#YYYY-MM-DD'), so
+ * "most recent" means walking backward day by day until enough items are
+ * collected — the same pattern as tools/search-feedback.ts. A bare 'DATE'
+ * equality query matches nothing (issue #220), which silently emptied this
+ * prompt section.
+ */
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { z } from 'zod';
+import { FEEDBACK_BY_DATE_INDEX } from '../indexes.js';
+
+export interface FeedbackSummary {
+  count: number;
+  promptSection: string;
+}
+
+const feedbackItemSchema = z.object({
+  source_platform: z.string().optional(),
+  sentiment_label: z.string().optional(),
+  category: z.string().optional(),
+  original_text: z.string().optional(),
+}).passthrough();
+
+type RecentFeedbackItem = z.infer<typeof feedbackItemSchema>;
+
+// How many items the prompt section collects, and how far back to look.
+const RECENT_FEEDBACK_TARGET = 30;
+const RECENT_FEEDBACK_LOOKBACK_DAYS = 30;
+const RECENT_FEEDBACK_PROMPT_LINES = 15;
+
+// This runs on every project chat/roundtable request (not just explicit tool
+// calls), so day queries are issued in parallel batches: a sparse or empty
+// table costs at most LOOKBACK/BATCH sequential rounds (~5), not 30 serial
+// round-trips, and the common case (today has data) stays a single round.
+const DAY_QUERY_BATCH_SIZE = 7;
+
+// Error names that will fail identically for every partition of the same
+// index — retrying the remaining days would just repeat the failure 30x
+// and silently reproduce the empty-section symptom this fix removes.
+const PERSISTENT_QUERY_ERRORS = new Set([
+  'AccessDeniedException',
+  'ResourceNotFoundException',
+  'ValidationException',
+]);
+
+/** Parse and append one page of rows, capped at the collection target.
+ * Per-row safeParse: one malformed item must not discard the rest. Note this
+ * is best-effort: a day whose first `Limit` rows include malformed items can
+ * under-fill the target even if more valid rows exist in that partition (we
+ * don't follow LastEvaluatedKey here — acceptable for a prompt section). */
+function collectFeedbackRows(
+  rawItems: Record<string, unknown>[] | undefined,
+  items: RecentFeedbackItem[],
+): void {
+  for (const raw of rawItems ?? []) {
+    if (items.length >= RECENT_FEEDBACK_TARGET) break;
+    const parsed = feedbackItemSchema.safeParse(raw);
+    if (parsed.success) items.push(parsed.data);
+  }
+}
+
+interface DayQueryResult {
+  dateStr: string;
+  rows: Record<string, unknown>[];
+  errorName?: string;
+}
+
+async function queryDayPartition(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  dayOffset: number,
+  now: Date,
+): Promise<DayQueryResult> {
+  const d = new Date(now);
+  d.setUTCDate(d.getUTCDate() - dayOffset);
+  const dateStr = d.toISOString().slice(0, 10);
+  try {
+    const resp = await docClient.send(
+      new QueryCommand({
+        TableName: feedbackTable,
+        IndexName: FEEDBACK_BY_DATE_INDEX,
+        KeyConditionExpression: 'gsi1pk = :pk',
+        ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
+        ScanIndexForward: false,
+        Limit: RECENT_FEEDBACK_TARGET,
+      }),
+    );
+    return { dateStr, rows: resp.Items ?? [] };
+  } catch (err) {
+    return { dateStr, rows: [], errorName: err instanceof Error ? err.name : 'UnknownError' };
+  }
+}
+
+function hasPersistentFailure(results: DayQueryResult[]): boolean {
+  return results.some(
+    (r) => r.errorName !== undefined && PERSISTENT_QUERY_ERRORS.has(r.errorName),
+  );
+}
+
+export async function fetchRecentFeedback(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+): Promise<FeedbackSummary> {
+  const items: RecentFeedbackItem[] = [];
+  const now = new Date();
+  const batchStarts = Array.from(
+    { length: Math.ceil(RECENT_FEEDBACK_LOOKBACK_DAYS / DAY_QUERY_BATCH_SIZE) },
+    (_, idx) => idx * DAY_QUERY_BATCH_SIZE,
+  );
+
+  for (const batchStart of batchStarts) {
+    if (items.length >= RECENT_FEEDBACK_TARGET) break;
+    const batchEnd = Math.min(batchStart + DAY_QUERY_BATCH_SIZE, RECENT_FEEDBACK_LOOKBACK_DAYS);
+    const offsets = Array.from({ length: batchEnd - batchStart }, (_, idx) => batchStart + idx);
+    const results = await Promise.all(
+      offsets.map((offset) => queryDayPartition(docClient, feedbackTable, offset, now)),
+    );
+
+    // Results are in day order (newest first), so recency priority is kept.
+    for (const result of results) {
+      if (result.errorName) {
+        // The original bug's worst property was silence — make failures visible.
+        console.warn(`fetchRecentFeedback: day query failed for ${result.dateStr}: ${result.errorName}`);
+      } else {
+        collectFeedbackRows(result.rows, items);
+      }
+    }
+    if (hasPersistentFailure(results)) break;
+  }
+
+  if (items.length === 0) return { count: 0, promptSection: '' };
+
+  const lines = items.slice(0, RECENT_FEEDBACK_PROMPT_LINES).map((item) => {
+    const src = item.source_platform ?? 'unknown';
+    const sent = item.sentiment_label ?? 'unknown';
+    const cat = item.category ?? 'unknown';
+    const text = (item.original_text ?? '').slice(0, 300);
+    return `[${src}|${sent}|${cat}] ${text}`;
+  });
+  return { count: items.length, promptSection: `## Recent Customer Feedback\n${lines.join('\n\n')}\n\n` };
+}

--- a/voc-datalake/lambda/stream/src/context/recent-feedback.ts
+++ b/voc-datalake/lambda/stream/src/context/recent-feedback.ts
@@ -33,7 +33,11 @@ const RECENT_FEEDBACK_PROMPT_LINES = 15;
 // This runs on every project chat/roundtable request (not just explicit tool
 // calls), so day queries are issued in parallel batches: a sparse or empty
 // table costs at most LOOKBACK/BATCH sequential rounds (~5), not 30 serial
-// round-trips, and the common case (today has data) stays a single round.
+// round-trips. Deliberate trade-off: even when today's partition alone could
+// fill the target, one batch still issues 7 parallel queries with
+// Limit: TARGET each (up to 7×30 items evaluated to keep 30) — we pay a
+// little read amplification to bound latency. Don't "optimize" this back to
+// sequential-with-early-exit without re-reading the round-trip math above.
 const DAY_QUERY_BATCH_SIZE = 7;
 
 // Error names that will fail identically for every partition of the same


### PR DESCRIPTION
## Summary

Closes #220.

`fetchRecentFeedback()` in the streaming Lambda's project-context builder queried the `gsi1-by-date` index with an exact-match condition on the bare literal `'DATE'`, while the processor writes per-day partition keys of the form `DATE#YYYY-MM-DD` (`processor/handler.py:515`). The query therefore **always returned zero items**, and because the empty-result path is handled gracefully, project chat and roundtable prompts silently never included the recent-feedback grounding they were designed to carry — no error, no log signal, just degraded answer quality.

Same failure shape as #98 (which was resolved by the Python module's removal); this was the surviving TypeScript occurrence, found during the #213/#219 GSI-constants refactor.

## What changed

`voc-datalake/lambda/stream/src/context/project-context.ts` — `fetchRecentFeedback()` now mirrors the established per-day pattern from `tools/search-feedback.ts`:

- Walks backward from today's UTC date, one `DATE#YYYY-MM-DD` partition per query, up to a 30-day lookback (`RECENT_FEEDBACK_LOOKBACK_DAYS`, matching search-feedback's day cap)
- Stops as soon as 30 items are collected (`RECENT_FEEDBACK_TARGET`, the same count the old single query intended); each day query passes `Limit: remaining` so it never over-fetches
- A failing day query keeps what's already collected and moves to the previous day (was: one try/catch around everything, any failure discarded all)
- Per-row `safeParse` skips a malformed item instead of throwing away the whole result (was: strict `.parse` inside the map — one bad row nuked the section; same rationale as the `fetchDayPages` comment in search-feedback.ts)
- Prompt rendering unchanged: first 15 items formatted into the `## Recent Customer Feedback` section, `feedback_count` = items collected

## Why not share code with search-feedback.ts

The two walkers have different semantics: search-feedback pages exhaustively through each day via `LastEvaluatedKey` (it needs the full candidate set for aggregate stats, `MAX_CANDIDATES` 10000), while the context builder needs at most 30 items and never pages. Forcing one helper over both would mean parameterizing paging behavior for two call sites — kept them separate deliberately.

## Regression tests

5 new tests in `project-context.test.ts` (through the public `buildProjectChatContext` entry point):

1. **Every feedback query uses a `DATE#YYYY-MM-DD` partition key, never bare `'DATE'`** — inspects the recorded `QueryCommand` inputs; fails if the fix is reverted
2. Includes the recent-feedback section (and correct `feedback_count`) when a recent day has items
3. Walks backward across days and stops at the 30-item target (asserts exactly project + 2 day queries, descending distinct dates)
4. Continues to the previous day when one day query rejects
5. Skips a malformed row (wrong field type) without discarding the day

## Testing

- Stream: `vitest` — **242/242 passed** (18 in project-context.test.ts: 13 existing + 5 new)
- `tsc --noEmit` clean
- `eslint` 0 errors (the one remaining warning is pre-existing on `development`)

## Deployment

Stream Lambda code only — no CDK/IAM change. Per the agreed workflow, deploy + live validation ride the next batch (the just-completed batch deploy took `development` to `ca0b342`; this lands after it).
