### PR TITLE
fix: config-driven AI budgets, avatar model EOL prep, ingestor sizing

### DIFF
--- a/voc-datalake/lambda/api/prompts/avatar-generation.json
+++ b/voc-datalake/lambda/api/prompts/avatar-generation.json
@@ -9,6 +9,6 @@
     "model_id": "stability.stable-image-core-v1:1",
     "region": "us-west-2",
     "aspect_ratio": "1:1",
-    "output_format": "png"
+    "output_format": "jpeg"
   }
 }

--- a/voc-datalake/lambda/api/prompts/avatar-generation.json
+++ b/voc-datalake/lambda/api/prompts/avatar-generation.json
@@ -6,9 +6,9 @@
   "fallback_prompt_template": "Professional headshot of a {occupation}, friendly expression, soft studio lighting, neutral background, photorealistic",
   "max_tokens": 200,
   "image_model": {
-    "model_id": "amazon.nova-canvas-v1:0",
-    "region": "us-east-1",
-    "width": 1024,
-    "height": 1024
+    "model_id": "stability.stable-image-core-v1:1",
+    "region": "us-west-2",
+    "aspect_ratio": "1:1",
+    "output_format": "png"
   }
 }

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -61,6 +61,7 @@ def invoke_bedrock_with_retry(
     max_tokens: int = 4096,
     max_retries: int = 3,
     thinking_budget: int = 0,
+    step_name: str = 'unknown',
 ) -> str:
     """Invoke Bedrock with retry support using shared converse module."""
     return converse(
@@ -71,6 +72,7 @@ def invoke_bedrock_with_retry(
         surface='documents',
         max_retries=max_retries,
         raise_on_throttle=True,
+        step_name=step_name,
     )
 
 
@@ -97,6 +99,9 @@ def _step_inference(step_name: str, config: dict) -> dict:
         'system_prompt': system_prompt,
         'max_tokens': step_config['max_tokens'],
         'thinking_budget': step_config['thinking_budget'],
+        # Carried through to converse() so [BEDROCK] log lines identify which
+        # research step they belong to; all three logged as 'unknown' before.
+        'step_name': step_name,
     }
 # Wrapper function to pass module-level table reference to shared function
 def get_feedback_context(filters: dict, limit: int = 100) -> list[dict]:
@@ -283,6 +288,7 @@ IMPORTANT: Base ALL findings on the actual feedback data provided. Do not make a
         user_prompt,
         max_tokens=inference['max_tokens'],
         thinking_budget=inference['thinking_budget'],
+        step_name=inference['step_name'],
     )
     
     update_job_status(project_id, job_id, 'running', 45, 'analysis_complete')
@@ -319,6 +325,7 @@ Provide:
         user_prompt,
         max_tokens=inference['max_tokens'],
         thinking_budget=inference['thinking_budget'],
+        step_name=inference['step_name'],
     )
     
     update_job_status(project_id, job_id, 'running', 70, 'synthesis_complete')
@@ -360,6 +367,7 @@ Provide a final validated research report."""
         user_prompt,
         max_tokens=inference['max_tokens'],
         thinking_budget=inference['thinking_budget'],
+        step_name=inference['step_name'],
     )
     
     update_job_status(project_id, job_id, 'running', 90, 'validation_complete')

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -15,6 +15,10 @@ from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource, BEDROCK_MODEL_ID
 from shared.api import api_handler
 from shared.converse import converse, BedrockThrottlingError
+from shared.prompts import (
+    get_research_step_config,
+    get_response_language_instruction,
+)
 from shared.feedback import (
     get_feedback_context as _get_feedback_context,
     format_feedback_for_llm,
@@ -51,16 +55,49 @@ def _get_projects_table():
     return projects_table
 # Alias for backward compatibility with Step Functions error handling
 BedrockThrottlingException = BedrockThrottlingError
-def invoke_bedrock_with_retry(system_prompt: str, user_message: str, max_tokens: int = 4096, max_retries: int = 3) -> str:
+def invoke_bedrock_with_retry(
+    system_prompt: str,
+    user_message: str,
+    max_tokens: int = 4096,
+    max_retries: int = 3,
+    thinking_budget: int = 0,
+) -> str:
     """Invoke Bedrock with retry support using shared converse module."""
     return converse(
         prompt=user_message,
         system_prompt=system_prompt,
         max_tokens=max_tokens,
+        thinking_budget=thinking_budget,
         surface='documents',
         max_retries=max_retries,
         raise_on_throttle=True,
     )
+
+
+def _step_inference(step_name: str, config: dict) -> dict:
+    """Resolve a research step's system prompt and token budgets.
+
+    Both research paths read the SAME config (lambda/api/prompts/
+    research-analysis.json): the sync path via build_chain_steps, this async
+    Step Functions path via here. Previously this module hardcoded its own
+    budgets and duplicated the system prompts, so edits to that JSON silently
+    had no effect on the async path — it looked authoritative but was never
+    read. Keep it that way: budgets belong in the JSON, not inline.
+
+    The user prompt stays inline per step, because this path adds context the
+    templated sync path has no placeholders for (personas, uploaded documents,
+    public web-search results).
+    """
+    step_config = get_research_step_config(step_name)
+    system_prompt = step_config['system_prompt']
+    lang_instruction = get_response_language_instruction(config.get('response_language'))
+    if lang_instruction:
+        system_prompt = f"{system_prompt}\n\n{lang_instruction}"
+    return {
+        'system_prompt': system_prompt,
+        'max_tokens': step_config['max_tokens'],
+        'thinking_budget': step_config['thinking_budget'],
+    }
 # Wrapper function to pass module-level table reference to shared function
 def get_feedback_context(filters: dict, limit: int = 100) -> list[dict]:
     """Get feedback items based on filters for LLM context."""
@@ -197,18 +234,8 @@ def step_analyze(event: dict) -> dict:
     logger.info(f"Starting analysis for job {job_id}")
     update_job_status(project_id, job_id, 'running', 25, 'preparing_analysis')
     
-    system_prompt = """You are a senior user researcher conducting rigorous analysis of REAL customer feedback data.
-Your analysis must be grounded in the actual feedback provided - cite specific reviews, quote customers directly, and identify patterns from the data.
-Be thorough, data-driven, and cite specific examples."""
+    inference = _step_inference('data_analysis', config)
 
-    # Inject language instruction if non-English
-    response_language = config.get('response_language')
-    if response_language:
-        from shared.prompts import get_response_language_instruction
-        lang_instruction = get_response_language_instruction(response_language)
-        if lang_instruction:
-            system_prompt += f"\n\n{lang_instruction}"
-    
     # Build additional context sections
     additional_context = ""
     if personas_context:
@@ -251,7 +278,12 @@ Based on the ACTUAL FEEDBACK DATA above{' and the provided context' if additiona
 IMPORTANT: Base ALL findings on the actual feedback data provided. Do not make assumptions beyond what the data shows."""
 
     update_job_status(project_id, job_id, 'running', 30, 'calling_ai')
-    analysis = invoke_bedrock_with_retry(system_prompt, user_prompt, max_tokens=4000)
+    analysis = invoke_bedrock_with_retry(
+        inference['system_prompt'],
+        user_prompt,
+        max_tokens=inference['max_tokens'],
+        thinking_budget=inference['thinking_budget'],
+    )
     
     update_job_status(project_id, job_id, 'running', 45, 'analysis_complete')
     
@@ -267,17 +299,8 @@ def step_synthesize(event: dict) -> dict:
     logger.info(f"Synthesizing findings for job {job_id}")
     update_job_status(project_id, job_id, 'running', 50, 'preparing_synthesis')
     
-    system_prompt = """You are synthesizing research findings into actionable insights.
-Focus on clarity, prioritization, and recommendations."""
+    inference = _step_inference('synthesis', config)
 
-    # Inject language instruction if non-English
-    response_language = config.get('response_language')
-    if response_language:
-        from shared.prompts import get_response_language_instruction
-        lang_instruction = get_response_language_instruction(response_language)
-        if lang_instruction:
-            system_prompt += f"\n\n{lang_instruction}"
-    
     user_prompt = f"""Synthesize the analysis into clear findings.
 
 Previous analysis:
@@ -291,7 +314,12 @@ Provide:
 5. **Areas for Further Research**"""
 
     update_job_status(project_id, job_id, 'running', 55, 'calling_ai')
-    synthesis = invoke_bedrock_with_retry(system_prompt, user_prompt, max_tokens=3000)
+    synthesis = invoke_bedrock_with_retry(
+        inference['system_prompt'],
+        user_prompt,
+        max_tokens=inference['max_tokens'],
+        thinking_budget=inference['thinking_budget'],
+    )
     
     update_job_status(project_id, job_id, 'running', 70, 'synthesis_complete')
     
@@ -308,17 +336,8 @@ def step_validate(event: dict) -> dict:
     logger.info(f"Validating research for job {job_id}")
     update_job_status(project_id, job_id, 'running', 75, 'preparing_validation')
     
-    system_prompt = """You are a critical reviewer ensuring research quality.
-Challenge assumptions and verify conclusions."""
+    inference = _step_inference('validation', config)
 
-    # Inject language instruction if non-English
-    response_language = config.get('response_language')
-    if response_language:
-        from shared.prompts import get_response_language_instruction
-        lang_instruction = get_response_language_instruction(response_language)
-        if lang_instruction:
-            system_prompt += f"\n\n{lang_instruction}"
-    
     user_prompt = f"""Review and validate the research findings.
 
 Analysis:
@@ -336,7 +355,12 @@ Check:
 Provide a final validated research report."""
 
     update_job_status(project_id, job_id, 'running', 80, 'calling_ai')
-    validation = invoke_bedrock_with_retry(system_prompt, user_prompt, max_tokens=3000)
+    validation = invoke_bedrock_with_retry(
+        inference['system_prompt'],
+        user_prompt,
+        max_tokens=inference['max_tokens'],
+        thinking_budget=inference['thinking_budget'],
+    )
     
     update_job_status(project_id, job_id, 'running', 90, 'validation_complete')
     

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -99,9 +99,9 @@ def _step_inference(step_name: str, config: dict) -> dict:
         'system_prompt': system_prompt,
         'max_tokens': step_config['max_tokens'],
         'thinking_budget': step_config['thinking_budget'],
-        # Carried through to converse() so [BEDROCK] log lines identify which
-        # research step they belong to; all three logged as 'unknown' before.
-        'step_name': step_name,
+        # Resolved by shared.prompts from the config's 'name', so [BEDROCK] log
+        # lines match between this path and the sync chain.
+        'step_name': step_config['step_name'],
     }
 # Wrapper function to pass module-level table reference to shared function
 def get_feedback_context(filters: dict, limit: int = 100) -> list[dict]:

--- a/voc-datalake/lambda/research/test/test_research_step_budgets.py
+++ b/voc-datalake/lambda/research/test/test_research_step_budgets.py
@@ -1,0 +1,179 @@
+"""The async research path must take its budgets and system prompts from the
+shared prompt config, not from inlined copies.
+
+Background: research-analysis.json declared max_tokens 9000 per step while this
+Lambda hardcoded 4000/3000/3000 and duplicated the system prompts, so editing
+the config had no effect on the async Step Functions path — it looked
+authoritative but was never read. These tests fail if that decoy returns.
+
+The expected values are read from the JSON with a plain json.load rather than
+through shared.prompts, so the config is an INDEPENDENT oracle: a bug in the
+loader can't make the handler and the expectation drift together.
+"""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# lambda/research/test/ -> lambda/
+LAMBDA_DIR = Path(__file__).resolve().parents[2]
+RESEARCH_PROMPTS = LAMBDA_DIR / 'api' / 'prompts' / 'research-analysis.json'
+
+# The budgets this Lambda used to hardcode. Kept as explicit literals (not read
+# from anywhere) so re-introducing them fails loudly, while still leaving the
+# config free to be re-tuned above them.
+PRE_FIX_ANALYSIS_BUDGET = 4000
+PRE_FIX_SYNTHESIS_BUDGET = 3000
+PRE_FIX_VALIDATION_BUDGET = 3000
+
+
+def _step(step_name: str) -> dict:
+    return json.loads(RESEARCH_PROMPTS.read_text(encoding='utf-8'))['steps'][step_name]
+
+
+@pytest.fixture
+def mock_tables():
+    mock_fb = MagicMock()
+    mock_proj = MagicMock()
+    with patch('research_step_handler._get_feedback_table', return_value=mock_fb), \
+         patch('research_step_handler._get_projects_table', return_value=mock_proj):
+        yield {'feedback': mock_fb, 'projects': mock_proj}
+
+
+@pytest.fixture
+def mock_job_status():
+    with patch('research_step_handler.update_job_status') as m:
+        yield m
+
+
+@pytest.fixture
+def mock_converse():
+    with patch('research_step_handler.converse', return_value='result') as m:
+        yield m
+
+
+def _analyze_event(**config):
+    return {
+        'project_id': 'p1', 'job_id': 'j1',
+        'research_config': {'question': 'Q?', **config},
+        'feedback_context': 'fb', 'feedback_stats': 's',
+    }
+
+
+def _synthesize_event(**config):
+    return {
+        'project_id': 'p1', 'job_id': 'j1',
+        'research_config': {'question': 'Q?', **config},
+        'analysis': 'prior analysis',
+    }
+
+
+def _validate_event(**config):
+    return {
+        'project_id': 'p1', 'job_id': 'j1',
+        'research_config': {'question': 'Q?', **config},
+        'analysis': 'prior analysis', 'synthesis': 'prior synthesis',
+    }
+
+
+class TestBudgetsComeFromConfig:
+    """Each step's max_tokens must equal what the shared config declares."""
+
+    def test_analysis_uses_the_configured_budget(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_analyze
+
+        step_analyze(_analyze_event())
+        assert mock_converse.call_args.kwargs['max_tokens'] == _step('data_analysis')['max_tokens']
+
+    def test_synthesis_uses_the_configured_budget(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_synthesize
+
+        step_synthesize(_synthesize_event())
+        assert mock_converse.call_args.kwargs['max_tokens'] == _step('synthesis')['max_tokens']
+
+    def test_validation_uses_the_configured_budget(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_validate
+
+        step_validate(_validate_event())
+        assert mock_converse.call_args.kwargs['max_tokens'] == _step('validation')['max_tokens']
+
+    def test_configured_thinking_budget_reaches_bedrock(self, mock_tables, mock_job_status, mock_converse):
+        """data_analysis declares a thinking budget; it must be forwarded.
+
+        converse() drops it for adaptive-thinking models on its own, so passing
+        it is safe — but silently discarding it here would make the config lie.
+        """
+        from research_step_handler import step_analyze
+
+        step_analyze(_analyze_event())
+        assert mock_converse.call_args.kwargs['thinking_budget'] == _step('data_analysis')['thinking_budget']
+
+
+class TestBudgetsDoNotRegressToTheOldHardcodes:
+    """Fail-on-revert: the point of the change was to stop running the research
+    chain on budgets small enough to force continuation loops and empty-text
+    retries. Asserted as a floor, so re-tuning the config stays possible."""
+
+    def test_analysis_budget_exceeds_the_old_hardcode(self):
+        assert _step('data_analysis')['max_tokens'] > PRE_FIX_ANALYSIS_BUDGET
+
+    def test_synthesis_budget_exceeds_the_old_hardcode(self):
+        assert _step('synthesis')['max_tokens'] > PRE_FIX_SYNTHESIS_BUDGET
+
+    def test_validation_budget_exceeds_the_old_hardcode(self):
+        assert _step('validation')['max_tokens'] > PRE_FIX_VALIDATION_BUDGET
+
+
+class TestSystemPromptsComeFromConfig:
+    """The system prompts were duplicated between this module and the config.
+    Pin them to the config so the two paths can't drift."""
+
+    def test_analysis_system_prompt_matches_config(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_analyze
+
+        step_analyze(_analyze_event())
+        assert mock_converse.call_args.kwargs['system_prompt'] == _step('data_analysis')['system_prompt']
+
+    def test_synthesis_system_prompt_matches_config(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_synthesize
+
+        step_synthesize(_synthesize_event())
+        assert mock_converse.call_args.kwargs['system_prompt'] == _step('synthesis')['system_prompt']
+
+    def test_validation_system_prompt_matches_config(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_validate
+
+        step_validate(_validate_event())
+        assert mock_converse.call_args.kwargs['system_prompt'] == _step('validation')['system_prompt']
+
+
+class TestLanguageInstructionStillApplies:
+    """Sourcing the prompt from config must not drop the per-request language
+    instruction, which is appended on top of it."""
+
+    def test_analysis_appends_language_instruction(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_analyze
+
+        step_analyze(_analyze_event(response_language='es'))
+        system_prompt = mock_converse.call_args.kwargs['system_prompt']
+        assert system_prompt.startswith(_step('data_analysis')['system_prompt'])
+        assert 'Spanish' in system_prompt
+
+    def test_synthesis_appends_language_instruction(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_synthesize
+
+        step_synthesize(_synthesize_event(response_language='ko'))
+        assert 'Korean' in mock_converse.call_args.kwargs['system_prompt']
+
+    def test_validation_appends_language_instruction(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_validate
+
+        step_validate(_validate_event(response_language='ja'))
+        assert 'Japanese' in mock_converse.call_args.kwargs['system_prompt']
+
+    def test_no_language_leaves_the_config_prompt_untouched(self, mock_tables, mock_job_status, mock_converse):
+        from research_step_handler import step_analyze
+
+        step_analyze(_analyze_event())
+        assert mock_converse.call_args.kwargs['system_prompt'] == _step('data_analysis')['system_prompt']

--- a/voc-datalake/lambda/research/test/test_research_step_budgets.py
+++ b/voc-datalake/lambda/research/test/test_research_step_budgets.py
@@ -98,6 +98,21 @@ class TestBudgetsComeFromConfig:
         step_validate(_validate_event())
         assert mock_converse.call_args.kwargs['max_tokens'] == _step('validation')['max_tokens']
 
+    def test_each_step_identifies_itself_in_bedrock_logs(self, mock_tables, mock_job_status, mock_converse):
+        """converse() logs step_name; all three research steps used to log
+        'unknown', so live logs could not tell which step made a call.
+        (Raised in review of PR #228.)"""
+        from research_step_handler import step_analyze, step_synthesize, step_validate
+
+        step_analyze(_analyze_event())
+        assert mock_converse.call_args.kwargs['step_name'] == 'data_analysis'
+
+        step_synthesize(_synthesize_event())
+        assert mock_converse.call_args.kwargs['step_name'] == 'synthesis'
+
+        step_validate(_validate_event())
+        assert mock_converse.call_args.kwargs['step_name'] == 'validation'
+
     def test_configured_thinking_budget_reaches_bedrock(self, mock_tables, mock_job_status, mock_converse):
         """data_analysis declares a thinking budget; it must be forwarded.
 

--- a/voc-datalake/lambda/research/test/test_research_step_budgets.py
+++ b/voc-datalake/lambda/research/test/test_research_step_budgets.py
@@ -113,6 +113,20 @@ class TestBudgetsComeFromConfig:
         step_validate(_validate_event())
         assert mock_converse.call_args.kwargs['step_name'] == 'validation'
 
+    def test_step_name_matches_the_sync_chain_for_the_same_step(self, mock_tables, mock_job_status, mock_converse):
+        """Both research paths must report the SAME step name to Bedrock.
+
+        The sync path resolves it from the config's 'name' field; this path used
+        the raw dict key, so a config where the two differ would emit different
+        labels for the same step and defeat the purpose. (Raised in review of
+        PR #228.)
+        """
+        from research_step_handler import step_analyze
+
+        step_analyze(_analyze_event())
+        emitted = mock_converse.call_args.kwargs['step_name']
+        assert emitted == _step('data_analysis').get('name', 'data_analysis')
+
     def test_configured_thinking_budget_reaches_bedrock(self, mock_tables, mock_job_status, mock_converse):
         """data_analysis declares a thinking budget; it must be forwarded.
 

--- a/voc-datalake/lambda/research/test/test_research_step_budgets.py
+++ b/voc-datalake/lambda/research/test/test_research_step_budgets.py
@@ -98,34 +98,27 @@ class TestBudgetsComeFromConfig:
         step_validate(_validate_event())
         assert mock_converse.call_args.kwargs['max_tokens'] == _step('validation')['max_tokens']
 
-    def test_each_step_identifies_itself_in_bedrock_logs(self, mock_tables, mock_job_status, mock_converse):
-        """converse() logs step_name; all three research steps used to log
-        'unknown', so live logs could not tell which step made a call.
-        (Raised in review of PR #228.)"""
+    def test_each_step_reports_the_name_the_config_declares(self, mock_tables, mock_job_status, mock_converse):
+        """converse() logs step_name; all three steps used to log 'unknown', so
+        live logs could not tell which step made a call.
+
+        Expectations are DERIVED from the config, matching how the sync path
+        resolves them (build_chain_steps uses the 'name' field, falling back to
+        the key). An earlier version of this test hardcoded the three keys, which
+        only passed because name == key in this config today — adding a
+        human-readable name would have made it contradict the parity it is
+        supposed to protect. (Raised in review of PR #228.)
+        """
         from research_step_handler import step_analyze, step_synthesize, step_validate
 
-        step_analyze(_analyze_event())
-        assert mock_converse.call_args.kwargs['step_name'] == 'data_analysis'
-
-        step_synthesize(_synthesize_event())
-        assert mock_converse.call_args.kwargs['step_name'] == 'synthesis'
-
-        step_validate(_validate_event())
-        assert mock_converse.call_args.kwargs['step_name'] == 'validation'
-
-    def test_step_name_matches_the_sync_chain_for_the_same_step(self, mock_tables, mock_job_status, mock_converse):
-        """Both research paths must report the SAME step name to Bedrock.
-
-        The sync path resolves it from the config's 'name' field; this path used
-        the raw dict key, so a config where the two differ would emit different
-        labels for the same step and defeat the purpose. (Raised in review of
-        PR #228.)
-        """
-        from research_step_handler import step_analyze
-
-        step_analyze(_analyze_event())
-        emitted = mock_converse.call_args.kwargs['step_name']
-        assert emitted == _step('data_analysis').get('name', 'data_analysis')
+        for step_fn, event, key in (
+            (step_analyze, _analyze_event(), 'data_analysis'),
+            (step_synthesize, _synthesize_event(), 'synthesis'),
+            (step_validate, _validate_event(), 'validation'),
+        ):
+            step_fn(event)
+            expected = _step(key).get('name', key)
+            assert mock_converse.call_args.kwargs['step_name'] == expected
 
     def test_configured_thinking_budget_reaches_bedrock(self, mock_tables, mock_job_status, mock_converse):
         """data_analysis declares a thinking budget; it must be forwarded.

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -4,6 +4,7 @@ Uses Claude to generate image prompts, then the Bedrock image model configured
 in avatar-generation.json ("image_model") to create the images.
 """
 
+import hashlib
 import json
 import os
 import boto3
@@ -17,14 +18,16 @@ from shared.prompts import get_avatar_prompt_config, format_prompt
 # lockstep with lib/utils/model-allowlist.ts (which builds the IAM grant) by
 # test_avatar_image_model_lockstep.py.
 #
-# ⚠️ amazon.nova-canvas-v1:0 is LEGACY since 2026-03-30 and reaches EOL on
-# 2026-09-30; a legacy model also drops access for accounts idle 15+ days,
-# surfacing as ResourceNotFoundException. Avatar failures degrade silently
-# (avatar_url stays null), so this expiring by surprise is easy to miss.
-# See model-allowlist.ts for the migration steps.
-DEFAULT_IMAGE_MODEL_REGION = 'us-east-1'
-DEFAULT_IMAGE_MODEL_ID = 'amazon.nova-canvas-v1:0'
-DEFAULT_IMAGE_SIZE = 1024
+# The region is deliberately NOT the platform's us-east-1: no active
+# text-to-image model is offered there (Nova Canvas was the only one and went
+# legacy), so this calls us-west-2 cross-region. See model-allowlist.ts.
+DEFAULT_IMAGE_MODEL_REGION = 'us-west-2'
+DEFAULT_IMAGE_MODEL_ID = 'stability.stable-image-core-v1:1'
+DEFAULT_ASPECT_RATIO = '1:1'
+DEFAULT_OUTPUT_FORMAT = 'png'
+
+# Stability's seed field is a 32-bit unsigned range.
+_MAX_SEED = 4294967294
 
 
 def get_image_model_config() -> dict:
@@ -39,9 +42,20 @@ def get_image_model_config() -> dict:
     return {
         'model_id': image_model.get('model_id', DEFAULT_IMAGE_MODEL_ID),
         'region': image_model.get('region', DEFAULT_IMAGE_MODEL_REGION),
-        'width': image_model.get('width', DEFAULT_IMAGE_SIZE),
-        'height': image_model.get('height', DEFAULT_IMAGE_SIZE),
+        'aspect_ratio': image_model.get('aspect_ratio', DEFAULT_ASPECT_RATIO),
+        'output_format': image_model.get('output_format', DEFAULT_OUTPUT_FORMAT),
     }
+
+
+def _stable_seed(persona_id: str) -> int:
+    """Deterministic seed so regenerating one persona reproduces its avatar.
+
+    Uses sha256 rather than hash(): Python randomises str hashing per process
+    unless PYTHONHASHSEED is fixed, so the previous hash(persona_id) gave a
+    DIFFERENT seed on every cold start despite the code claiming consistency.
+    """
+    digest = hashlib.sha256(persona_id.encode('utf-8')).hexdigest()
+    return int(digest[:8], 16) % _MAX_SEED
 
 
 def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
@@ -113,7 +127,7 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
     Generate an AI avatar image for a persona.
     
     Uses Claude to create an intelligent image prompt from persona data (name, bio, occupation),
-    then Nova Canvas to generate the actual image.
+    then the configured image model to generate the actual image.
     
     Args:
         persona_data: Dict with name, tagline, identity (bio, age_range, occupation, location), persona_id
@@ -154,19 +168,16 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
         logger.info(f"[PERSONA_AVATAR] Creating Bedrock client for {model_region} (image model region)")
         bedrock_runtime = boto3.client('bedrock-runtime', region_name=model_region)
         
-        # Nova Canvas request format.
-        # Do NOT include 'quality' or 'cfgScale' params - they cause ValidationException
+        # Stability text-to-image request format (shared by stable-image-core,
+        # stable-image-ultra and sd3-5-large). Note this is NOT interchangeable
+        # with the Nova Canvas taskType/textToImageParams body it replaced — a
+        # model from another vendor needs its own builder here.
         request_body = {
-            "taskType": "TEXT_IMAGE",
-            "textToImageParams": {
-                "text": avatar_prompt,
-            },
-            "imageGenerationConfig": {
-                "numberOfImages": 1,
-                "width": image_model['width'],
-                "height": image_model['height'],
-                "seed": hash(persona_id) % 2147483647  # Consistent seed per persona
-            }
+            "prompt": avatar_prompt,
+            "mode": "text-to-image",
+            "aspect_ratio": image_model['aspect_ratio'],
+            "output_format": image_model['output_format'],
+            "seed": _stable_seed(persona_id),
         }
         
         logger.info(f"[PERSONA_AVATAR] Invoking image model: {model_id}")
@@ -180,14 +191,21 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
         images = result.get('images', [])
         
         if not images:
-            logger.warning("[PERSONA_AVATAR] Nova Canvas returned empty images array")
+            # finish_reasons explains a content-filtered or failed generation,
+            # which returns 200 with no image rather than raising.
+            logger.warning(
+                f"[PERSONA_AVATAR] {model_id} returned no images "
+                f"(finish_reasons={result.get('finish_reasons')})"
+            )
             return {'avatar_url': None, 'avatar_prompt': avatar_prompt}
         
-        logger.info(f"[PERSONA_AVATAR] Nova Canvas generated {len(images)} image(s)")
+        logger.info(f"[PERSONA_AVATAR] {model_id} generated {len(images)} image(s)")
         
-        # Decode base64 image and upload to S3
+        # Decode base64 image and upload to S3. Extension and content type follow
+        # the configured output_format so they cannot disagree with the bytes.
         image_data = base64.b64decode(images[0])
-        s3_key = f"avatars/{persona_id}.png"
+        image_format = image_model['output_format']
+        s3_key = f"avatars/{persona_id}.{image_format}"
         
         logger.info(f"[PERSONA_AVATAR] Uploading avatar to S3: s3://{s3_bucket}/{s3_key}")
         
@@ -196,7 +214,7 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
             Bucket=s3_bucket,
             Key=s3_key,
             Body=image_data,
-            ContentType='image/png',
+            ContentType=f"image/{'jpeg' if image_format == 'jpg' else image_format}",
             CacheControl='public, max-age=31536000, immutable',
         )
         
@@ -224,9 +242,9 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
             )
         elif 'ValidationException' in error_type or 'ValidationException' in str(e):
             logger.error(
-                f"[PERSONA_AVATAR] VALIDATION ERROR - Check the request format for {model_id} "
-                "(Nova Canvas wants square dimensions and rejects quality/cfgScale; "
-                "a replacement model may need a different body shape entirely)",
+                f"[PERSONA_AVATAR] VALIDATION ERROR - Check the request format for {model_id}. "
+                "Stability models take prompt/mode/aspect_ratio/output_format; a model "
+                "from another vendor needs its own request body, not this one",
                 extra={"error": str(e)},
             )
         else:

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -32,8 +32,20 @@ DEFAULT_ASPECT_RATIO = '1:1'
 # by the model as an invalid output_format.)
 DEFAULT_OUTPUT_FORMAT = 'jpeg'
 
-# Stability's seed field is a 32-bit unsigned range.
+# Stability's seed field is a 32-bit unsigned range, and it treats 0 as "pick a
+# random seed" — so a derived seed must never land on 0 or that one hash bucket
+# silently loses determinism.
 _MAX_SEED = 4294967294
+
+# Formats the model accepts for output_format. 'webp' is rejected by Bedrock
+# ("not a valid"), so an unknown value is coerced to the default rather than
+# failing generation at invoke time.
+_SUPPORTED_OUTPUT_FORMATS = frozenset({'png', 'jpeg'})
+
+# Extensions a persona's avatar may have been written under previously. The key
+# embeds the format, so changing output_format would otherwise leave the old
+# object orphaned forever.
+_HISTORICAL_EXTENSIONS = ('png', 'jpeg', 'jpg', 'webp')
 
 
 def get_image_model_config() -> dict:
@@ -45,12 +57,43 @@ def get_image_model_config() -> dict:
     the research prompts had. Defaults above apply only to absent keys.
     """
     image_model = get_avatar_prompt_config().get('image_model', {})
+    output_format = image_model.get('output_format', DEFAULT_OUTPUT_FORMAT)
+    if output_format not in _SUPPORTED_OUTPUT_FORMATS:
+        # Validate here rather than discovering it as a Bedrock ValidationException
+        # mid-generation: the format also names the S3 object, so a bad value would
+        # produce a misleading key and ContentType before the call even failed.
+        logger.warning(
+            f"[PERSONA_AVATAR] Unsupported output_format {output_format!r}; "
+            f"falling back to {DEFAULT_OUTPUT_FORMAT!r} "
+            f"(supported: {sorted(_SUPPORTED_OUTPUT_FORMATS)})"
+        )
+        output_format = DEFAULT_OUTPUT_FORMAT
     return {
         'model_id': image_model.get('model_id', DEFAULT_IMAGE_MODEL_ID),
         'region': image_model.get('region', DEFAULT_IMAGE_MODEL_REGION),
         'aspect_ratio': image_model.get('aspect_ratio', DEFAULT_ASPECT_RATIO),
-        'output_format': image_model.get('output_format', DEFAULT_OUTPUT_FORMAT),
+        'output_format': output_format,
     }
+
+
+def _delete_superseded_avatars(s3_client, bucket: str, persona_id: str, keep: str) -> None:
+    """Remove this persona's avatar stored under a different extension.
+
+    The S3 key embeds the image format, so regenerating a persona after an
+    output_format change writes a NEW object (avatars/x.jpeg) and leaves the old
+    one (avatars/x.png) behind with nothing referencing it. Best-effort: a failure
+    here must never fail avatar generation, and deleting an absent key is a no-op
+    in S3, so this costs nothing when there is nothing to clean.
+    """
+    for extension in _HISTORICAL_EXTENSIONS:
+        if extension == keep:
+            continue
+        try:
+            s3_client.delete_object(Bucket=bucket, Key=f"avatars/{persona_id}.{extension}")
+        except Exception as e:  # noqa: BLE001 - cleanup must not break generation
+            logger.warning(
+                f"[PERSONA_AVATAR] Could not remove superseded avatars/{persona_id}.{extension}: {e}"
+            )
 
 
 def _stable_seed(persona_id: str) -> int:
@@ -61,7 +104,9 @@ def _stable_seed(persona_id: str) -> int:
     DIFFERENT seed on every cold start despite the code claiming consistency.
     """
     digest = hashlib.sha256(persona_id.encode('utf-8')).hexdigest()
-    return int(digest[:8], 16) % _MAX_SEED
+    # Offset by 1: seed 0 means "choose randomly" to Stability, so a digest that
+    # happened to land on 0 would silently lose determinism for that one bucket.
+    return 1 + int(digest[:8], 16) % (_MAX_SEED - 1)
 
 
 def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
@@ -220,9 +265,14 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
             Bucket=s3_bucket,
             Key=s3_key,
             Body=image_data,
-            ContentType=f"image/{'jpeg' if image_format == 'jpg' else image_format}",
+            # No jpg/jpeg special case needed: get_image_model_config() has already
+            # constrained the format to _SUPPORTED_OUTPUT_FORMATS.
+            ContentType=f"image/{image_format}",
             CacheControl='public, max-age=31536000, immutable',
         )
+        # The key embeds the format, so a format change would otherwise leave the
+        # persona's previous avatar orphaned in the bucket.
+        _delete_superseded_avatars(s3_client, s3_bucket, persona_id, image_format)
         
         avatar_url = f"s3://{s3_bucket}/{s3_key}"
         logger.info(f"[PERSONA_AVATAR] SUCCESS - Avatar generated for {persona_name}: {avatar_url}")
@@ -265,8 +315,10 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
 def get_avatar_cdn_url(s3_uri: str, cdn_url: str = None) -> str | None:
     """Convert S3 URI to CloudFront CDN URL for avatar images.
     
-    S3 URI format: s3://bucket/avatars/{persona_id}.png
-    CDN URL format: https://{cdn_domain}/{persona_id}.png
+    S3 URI format: s3://bucket/avatars/{persona_id}.{ext}
+    CDN URL format: https://{cdn_domain}/{persona_id}.{ext}
+    The extension follows the configured output_format; parsing below is
+    extension-agnostic (it takes the trailing path segment).
     
     Args:
         s3_uri: S3 URI of the avatar image
@@ -284,12 +336,12 @@ def get_avatar_cdn_url(s3_uri: str, cdn_url: str = None) -> str | None:
         return None
     
     try:
-        # Extract filename from s3://bucket/avatars/{persona_id}.png
+        # Extract filename from s3://bucket/avatars/{persona_id}.{ext}
         # The CloudFront distribution has originPath='/avatars' so we just need the filename
         parts = s3_uri.split('/')
         if len(parts) < 2:
             return None
-        filename = parts[-1]  # e.g., persona_20241128123456_0.png
+        filename = parts[-1]  # e.g., persona_20241128123456_0.jpeg
         
         return f"{avatars_cdn_url.rstrip('/')}/{filename}"
     except Exception as e:

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -1,6 +1,7 @@
 """
 Shared avatar generation utilities for persona avatars.
-Uses Claude to generate image prompts and Nova Canvas to create images.
+Uses Claude to generate image prompts, then the Bedrock image model configured
+in avatar-generation.json ("image_model") to create the images.
 """
 
 import json
@@ -11,9 +12,36 @@ from shared.logging import logger, tracer
 from shared.prompts import get_avatar_prompt_config, format_prompt
 
 
-# Nova Canvas is only available in us-east-1
-NOVA_CANVAS_REGION = 'us-east-1'
-NOVA_CANVAS_MODEL_ID = 'amazon.nova-canvas-v1:0'
+# Image-model defaults, used only if avatar-generation.json omits the field.
+# The authoritative values live in that config's "image_model" block, kept in
+# lockstep with lib/utils/model-allowlist.ts (which builds the IAM grant) by
+# test_avatar_image_model_lockstep.py.
+#
+# ⚠️ amazon.nova-canvas-v1:0 is LEGACY since 2026-03-30 and reaches EOL on
+# 2026-09-30; a legacy model also drops access for accounts idle 15+ days,
+# surfacing as ResourceNotFoundException. Avatar failures degrade silently
+# (avatar_url stays null), so this expiring by surprise is easy to miss.
+# See model-allowlist.ts for the migration steps.
+DEFAULT_IMAGE_MODEL_REGION = 'us-east-1'
+DEFAULT_IMAGE_MODEL_ID = 'amazon.nova-canvas-v1:0'
+DEFAULT_IMAGE_SIZE = 1024
+
+
+def get_image_model_config() -> dict:
+    """Resolve the avatar image model settings from the prompt config.
+
+    Reads the "image_model" block of avatar-generation.json. That block existed
+    for a long time while this module ignored it in favour of hardcoded
+    constants, so editing the config had no effect — the same decoy-config trap
+    the research prompts had. Defaults above apply only to absent keys.
+    """
+    image_model = get_avatar_prompt_config().get('image_model', {})
+    return {
+        'model_id': image_model.get('model_id', DEFAULT_IMAGE_MODEL_ID),
+        'region': image_model.get('region', DEFAULT_IMAGE_MODEL_REGION),
+        'width': image_model.get('width', DEFAULT_IMAGE_SIZE),
+        'height': image_model.get('height', DEFAULT_IMAGE_SIZE),
+    }
 
 
 def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
@@ -116,13 +144,17 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
     avatar_prompt = generate_avatar_prompt_with_llm(persona_data, bedrock_client)
     logger.info(f"[PERSONA_AVATAR] Generated prompt: {avatar_prompt}")
     
+    image_model = get_image_model_config()
+    model_id = image_model['model_id']
+    model_region = image_model['region']
+
     try:
-        # Nova Canvas is only available in us-east-1
-        # IAM policy must include: arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0
-        logger.info(f"[PERSONA_AVATAR] Creating Bedrock client for {NOVA_CANVAS_REGION} (Nova Canvas region)")
-        bedrock_runtime = boto3.client('bedrock-runtime', region_name=NOVA_CANVAS_REGION)
+        # The image model is region-pinned; the IAM grant is built from the same
+        # values via imageModelArn() in lib/utils/model-allowlist.ts.
+        logger.info(f"[PERSONA_AVATAR] Creating Bedrock client for {model_region} (image model region)")
+        bedrock_runtime = boto3.client('bedrock-runtime', region_name=model_region)
         
-        # Nova Canvas request format - must use 1024x1024 dimensions
+        # Nova Canvas request format.
         # Do NOT include 'quality' or 'cfgScale' params - they cause ValidationException
         request_body = {
             "taskType": "TEXT_IMAGE",
@@ -131,16 +163,16 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
             },
             "imageGenerationConfig": {
                 "numberOfImages": 1,
-                "width": 1024,
-                "height": 1024,
+                "width": image_model['width'],
+                "height": image_model['height'],
                 "seed": hash(persona_id) % 2147483647  # Consistent seed per persona
             }
         }
         
-        logger.info(f"[PERSONA_AVATAR] Invoking Nova Canvas model: {NOVA_CANVAS_MODEL_ID}")
+        logger.info(f"[PERSONA_AVATAR] Invoking image model: {model_id}")
         
         response = bedrock_runtime.invoke_model(
-            modelId=NOVA_CANVAS_MODEL_ID,
+            modelId=model_id,
             body=json.dumps(request_body)
         )
         
@@ -176,9 +208,27 @@ def generate_persona_avatar(persona_data: dict, bedrock_client, s3_bucket: str =
     except Exception as e:
         error_type = type(e).__name__
         if 'AccessDenied' in error_type or 'AccessDenied' in str(e):
-            logger.error(f"[PERSONA_AVATAR] ACCESS DENIED - Check IAM policy includes arn:aws:bedrock:{NOVA_CANVAS_REGION}::foundation-model/{NOVA_CANVAS_MODEL_ID}", extra={"error": str(e)})
+            logger.error(f"[PERSONA_AVATAR] ACCESS DENIED - Check IAM policy includes arn:aws:bedrock:{model_region}::foundation-model/{model_id}", extra={"error": str(e)})
+        elif 'ResourceNotFound' in error_type or 'ResourceNotFound' in str(e):
+            # A legacy model reports itself as "not found" once the account loses
+            # access (15+ days idle during the legacy window, or past EOL). Name
+            # the cause explicitly: the generic branch below made a past outage
+            # look like a transient error for far too long.
+            logger.error(
+                f"[PERSONA_AVATAR] MODEL NOT AVAILABLE - {model_id} was not found in "
+                f"{model_region}. A LEGACY model returns this once the account loses "
+                "access (idle 15+ days) or after its EOL date. Check its lifecycle "
+                "state and migrate: aws bedrock list-foundation-models "
+                "--by-output-modality IMAGE",
+                extra={"error": str(e), "model_id": model_id, "region": model_region},
+            )
         elif 'ValidationException' in error_type or 'ValidationException' in str(e):
-            logger.error("[PERSONA_AVATAR] VALIDATION ERROR - Check Nova Canvas request format (must use 1024x1024, no quality/cfgScale params)", extra={"error": str(e)})
+            logger.error(
+                f"[PERSONA_AVATAR] VALIDATION ERROR - Check the request format for {model_id} "
+                "(Nova Canvas wants square dimensions and rejects quality/cfgScale; "
+                "a replacement model may need a different body shape entirely)",
+                extra={"error": str(e)},
+            )
         else:
             logger.error(f"[PERSONA_AVATAR] FAILED - Avatar generation error: {error_type}: {e}", extra={
                 "persona_id": persona_id,

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -24,7 +24,13 @@ from shared.prompts import get_avatar_prompt_config, format_prompt
 DEFAULT_IMAGE_MODEL_REGION = 'us-west-2'
 DEFAULT_IMAGE_MODEL_ID = 'stability.stable-image-core-v1:1'
 DEFAULT_ASPECT_RATIO = '1:1'
-DEFAULT_OUTPUT_FORMAT = 'png'
+# JPEG, not PNG: the model emits 1536x1536 and these render at 32-128 CSS px
+# (w-8 in chat bubbles, up to max-w-[128px] for the large variant, 80px in the
+# PDF export). Measured on the same seed/prompt: PNG 2,677,833 bytes vs JPEG
+# 401,603 — 6.7x smaller for photographic content that is downscaled anyway.
+# Lossless compression of a photo is the wrong trade here. ('webp' is rejected
+# by the model as an invalid output_format.)
+DEFAULT_OUTPUT_FORMAT = 'jpeg'
 
 # Stability's seed field is a 32-bit unsigned range.
 _MAX_SEED = 4294967294

--- a/voc-datalake/lambda/shared/prompts.py
+++ b/voc-datalake/lambda/shared/prompts.py
@@ -106,16 +106,18 @@ def _get_step(filename: str, step_name: str) -> dict:
     return steps_config[step_name]
 
 
-def _inference_from_step(step: dict) -> dict:
+def _inference_from_step(step: dict, step_name: str) -> dict:
     """Pull the inference settings out of a raw step config block.
 
     Single home for the per-field defaults so the chain builder and the public
-    accessor below cannot drift apart.
+    accessor below cannot drift apart — including 'step_name', which both paths
+    report to Bedrock logging and which must therefore resolve identically.
     """
     return {
         'system_prompt': step.get('system_prompt', ''),
         'max_tokens': step.get('max_tokens', DEFAULT_STEP_MAX_TOKENS),
         'thinking_budget': step.get('thinking_budget', 0),
+        'step_name': step.get('name', step_name),
     }
 
 
@@ -138,7 +140,7 @@ def get_step_inference_config(filename: str, step_name: str) -> dict:
     Returns:
         Dict with 'system_prompt', 'max_tokens' and 'thinking_budget'
     """
-    return _inference_from_step(_get_step(filename, step_name))
+    return _inference_from_step(_get_step(filename, step_name), step_name)
 
 
 def build_chain_steps(filename: str, step_names: list[str], context: dict) -> list[dict]:
@@ -159,7 +161,7 @@ def build_chain_steps(filename: str, step_names: list[str], context: dict) -> li
     chain_steps = []
     for step_name in step_names:
         step = _get_step(filename, step_name)
-        inference = _inference_from_step(step)
+        inference = _inference_from_step(step, step_name)
         system = inference['system_prompt']
         if language_instruction:
             system = f"{system}\n\n{language_instruction}"
@@ -168,7 +170,7 @@ def build_chain_steps(filename: str, step_names: list[str], context: dict) -> li
             'user': format_prompt(step.get('user_prompt_template', ''), **context),
             'max_tokens': inference['max_tokens'],
             'thinking_budget': inference['thinking_budget'],
-            'step_name': step.get('name', step_name),
+            'step_name': inference['step_name'],
         })
     
     return chain_steps

--- a/voc-datalake/lambda/shared/prompts.py
+++ b/voc-datalake/lambda/shared/prompts.py
@@ -138,7 +138,8 @@ def get_step_inference_config(filename: str, step_name: str) -> dict:
         step_name: Step key within the file's "steps" object
 
     Returns:
-        Dict with 'system_prompt', 'max_tokens' and 'thinking_budget'
+        Dict with 'system_prompt', 'max_tokens', 'thinking_budget' and
+        'step_name' (the config's 'name', falling back to the step key)
     """
     return _inference_from_step(_get_step(filename, step_name), step_name)
 

--- a/voc-datalake/lambda/shared/prompts.py
+++ b/voc-datalake/lambda/shared/prompts.py
@@ -9,6 +9,20 @@ from functools import lru_cache
 
 from shared.logging import logger
 
+# Fallback token budget for a chain step whose config omits max_tokens. Kept as a
+# named constant because two readers apply it (the chain builder and the
+# inference-config accessor) and they must not drift.
+DEFAULT_STEP_MAX_TOKENS = 4096
+
+# Prompt config filenames. Named so a file referenced from more than one place
+# (research: the sync chain builder AND the async step accessor; avatar: the
+# prompt config AND the image-model block) can't drift by typo.
+PERSONA_GENERATION_PROMPTS = 'persona-generation.json'
+PRD_GENERATION_PROMPTS = 'prd-generation.json'
+PRFAQ_GENERATION_PROMPTS = 'prfaq-generation.json'
+RESEARCH_ANALYSIS_PROMPTS = 'research-analysis.json'
+AVATAR_GENERATION_PROMPTS = 'avatar-generation.json'
+
 
 def get_prompts_dir() -> Path:
     """Get the prompts directory path."""
@@ -84,6 +98,49 @@ def format_prompt(template: str, **kwargs) -> str:
         return result
 
 
+def _get_step(filename: str, step_name: str) -> dict:
+    """Fetch one step's raw config block, with a clear error if it's absent."""
+    steps_config = load_prompt_file(filename).get('steps', {})
+    if step_name not in steps_config:
+        raise KeyError(f"Step '{step_name}' not found in {filename}")
+    return steps_config[step_name]
+
+
+def _inference_from_step(step: dict) -> dict:
+    """Pull the inference settings out of a raw step config block.
+
+    Single home for the per-field defaults so the chain builder and the public
+    accessor below cannot drift apart.
+    """
+    return {
+        'system_prompt': step.get('system_prompt', ''),
+        'max_tokens': step.get('max_tokens', DEFAULT_STEP_MAX_TOKENS),
+        'thinking_budget': step.get('thinking_budget', 0),
+    }
+
+
+def get_step_inference_config(filename: str, step_name: str) -> dict:
+    """
+    System prompt and token budgets for one chain step, WITHOUT building the
+    user prompt.
+
+    For callers that assemble their own user prompt but must still share the
+    chain config — specifically the async Step Functions research path, whose
+    prompt carries extra context (personas, documents, web search) that the
+    templated sync path does not. Before this existed, that path hardcoded its
+    own budgets and duplicated the system prompts, so editing the JSON silently
+    did nothing for it (the config looked authoritative but was never read).
+
+    Args:
+        filename: Name of the prompt file
+        step_name: Step key within the file's "steps" object
+
+    Returns:
+        Dict with 'system_prompt', 'max_tokens' and 'thinking_budget'
+    """
+    return _inference_from_step(_get_step(filename, step_name))
+
+
 def build_chain_steps(filename: str, step_names: list[str], context: dict) -> list[dict]:
     """
     Build a list of LLM chain steps from a prompt file.
@@ -96,25 +153,21 @@ def build_chain_steps(filename: str, step_names: list[str], context: dict) -> li
     Returns:
         List of step dicts ready for invoke_bedrock_chain()
     """
-    config = load_prompt_file(filename)
-    steps_config = config.get('steps', {})
     response_language = context.pop('response_language', None)
     language_instruction = get_response_language_instruction(response_language)
     
     chain_steps = []
     for step_name in step_names:
-        if step_name not in steps_config:
-            raise KeyError(f"Step '{step_name}' not found in {filename}")
-        
-        step = steps_config[step_name]
-        system = step.get('system_prompt', '')
+        step = _get_step(filename, step_name)
+        inference = _inference_from_step(step)
+        system = inference['system_prompt']
         if language_instruction:
             system = f"{system}\n\n{language_instruction}"
         chain_steps.append({
             'system': system,
             'user': format_prompt(step.get('user_prompt_template', ''), **context),
-            'max_tokens': step.get('max_tokens', 4096),
-            'thinking_budget': step.get('thinking_budget', 0),
+            'max_tokens': inference['max_tokens'],
+            'thinking_budget': inference['thinking_budget'],
             'step_name': step.get('name', step_name),
         })
     
@@ -177,7 +230,7 @@ def get_persona_generation_steps(
     }
     
     return build_chain_steps(
-        'persona-generation.json',
+        PERSONA_GENERATION_PROMPTS,
         ['research_analysis', 'persona_synthesis', 'validation'],
         context
     )
@@ -201,7 +254,7 @@ def get_prd_generation_steps(
     }
     
     return build_chain_steps(
-        'prd-generation.json',
+        PRD_GENERATION_PROMPTS,
         ['problem_analysis', 'solution_design', 'prd_document'],
         context
     )
@@ -237,7 +290,7 @@ def get_prfaq_generation_steps(
     }
 
     return build_chain_steps(
-        'prfaq-generation.json',
+        PRFAQ_GENERATION_PROMPTS,
         ['customer_thinking', 'press_release', 'customer_faq', 'internal_faq'],
         context
     )
@@ -261,15 +314,26 @@ def get_research_analysis_steps(
     }
     
     return build_chain_steps(
-        'research-analysis.json',
+        RESEARCH_ANALYSIS_PROMPTS,
         ['data_analysis', 'synthesis', 'validation'],
         context
     )
 
 
+def get_research_step_config(step_name: str) -> dict:
+    """Inference config for one research step.
+
+    Used by the async Step Functions research handler so both research paths
+    share one set of system prompts and token budgets. See
+    get_step_inference_config for why the async path can't use the chain
+    builder directly.
+    """
+    return get_step_inference_config(RESEARCH_ANALYSIS_PROMPTS, step_name)
+
+
 def get_avatar_prompt_config() -> dict:
     """Get avatar generation prompt configuration."""
-    return load_prompt_file('avatar-generation.json')
+    return load_prompt_file(AVATAR_GENERATION_PROMPTS)
 
 
 

--- a/voc-datalake/lambda/shared/test/test_avatar.py
+++ b/voc-datalake/lambda/shared/test/test_avatar.py
@@ -140,12 +140,10 @@ class TestGeneratePersonaAvatar:
 
         result = generate_persona_avatar(persona, MagicMock(), s3_bucket='test-bucket')
 
-        # Extension derives from the configured output_format, so this asserts
-        # against the config rather than a literal that breaks on a format change.
-        from shared.avatar import get_image_model_config
-
-        extension = get_image_model_config()['output_format']
-        assert result['avatar_url'] == f's3://test-bucket/avatars/p123.{extension}'
+        # Deliberately a LITERAL. Deriving the extension from
+        # get_image_model_config() would take the expectation from the same
+        # production code under test, so a wrong extension could never fail this.
+        assert result['avatar_url'] == 's3://test-bucket/avatars/p123.jpeg'
         assert result['avatar_prompt'] == 'A portrait prompt'
 
     @patch('shared.avatar.generate_avatar_prompt_with_llm')

--- a/voc-datalake/lambda/shared/test/test_avatar.py
+++ b/voc-datalake/lambda/shared/test/test_avatar.py
@@ -140,7 +140,12 @@ class TestGeneratePersonaAvatar:
 
         result = generate_persona_avatar(persona, MagicMock(), s3_bucket='test-bucket')
 
-        assert result['avatar_url'] == 's3://test-bucket/avatars/p123.png'
+        # Extension derives from the configured output_format, so this asserts
+        # against the config rather than a literal that breaks on a format change.
+        from shared.avatar import get_image_model_config
+
+        extension = get_image_model_config()['output_format']
+        assert result['avatar_url'] == f's3://test-bucket/avatars/p123.{extension}'
         assert result['avatar_prompt'] == 'A portrait prompt'
 
     @patch('shared.avatar.generate_avatar_prompt_with_llm')

--- a/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
@@ -1,0 +1,206 @@
+"""The avatar image model must be single-sourced and actually honoured.
+
+Two problems motivated these tests:
+
+1. avatar-generation.json carried an "image_model" block that avatar.py never
+   read — it used its own module constants instead. The config looked
+   authoritative but editing it did nothing.
+2. The model id was ALSO pasted into lib/stacks/api-stack.ts as a literal IAM
+   ARN in three places. A model that is invoked but not granted AccessDenies;
+   one that is granted but not invoked wastes the grant.
+
+So the Python config and the CDK source must agree, and the runtime must use
+what the config says. amazon.nova-canvas-v1:0 reaches EOL on 2026-09-30, so the
+migration these tests protect is a matter of when, not if.
+"""
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _repo_root() -> Path:
+    # lambda/shared/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _cdk_source() -> str:
+    return (_repo_root() / 'lib' / 'utils' / 'model-allowlist.ts').read_text(encoding='utf-8')
+
+
+def _avatar_config() -> dict:
+    path = _repo_root() / 'lambda' / 'api' / 'prompts' / 'avatar-generation.json'
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def _ts_const(name: str) -> str:
+    """Read a single exported string constant out of the CDK source."""
+    match = re.search(rf"export const {name} = '([^']+)';", _cdk_source())
+    assert match, f'{name} not found in model-allowlist.ts'
+    return match.group(1)
+
+
+class TestImageModelLockstep:
+    """The runtime config and the IAM grant must name the same model."""
+
+    def test_config_model_id_matches_cdk_source(self):
+        assert _avatar_config()['image_model']['model_id'] == _ts_const('IMAGE_MODEL_ID')
+
+    def test_config_region_matches_cdk_source(self):
+        assert _avatar_config()['image_model']['region'] == _ts_const('IMAGE_MODEL_REGION')
+
+    def test_api_stack_derives_the_arn_instead_of_hardcoding_it(self):
+        """Three roles used to embed the ARN as a literal, so a model swap had to
+        be repeated in three places or it silently AccessDenied."""
+        api_stack = (_repo_root() / 'lib' / 'stacks' / 'api-stack.ts').read_text(encoding='utf-8')
+        assert 'imageModelArn()' in api_stack
+        assert 'foundation-model/amazon.nova-canvas' not in api_stack
+
+
+class TestImageModelConfigIsHonoured:
+    """What the config declares is what gets invoked."""
+
+    @staticmethod
+    def _run_with_config(image_model: dict | None):
+        """Generate an avatar with a stubbed image_model block.
+
+        Returns (bedrock_runtime_mock, boto3_mock) for assertions.
+        """
+        config = {
+            'system_prompt': 'S',
+            'user_prompt_template': '{name}',
+            'max_tokens': 200,
+            'fallback_prompt_template': 'Headshot of {occupation}',
+        }
+        if image_model is not None:
+            config['image_model'] = image_model
+
+        mock_bedrock_runtime = MagicMock()
+        mock_s3 = MagicMock()
+        import base64
+        image_data = base64.b64encode(b'png').decode()
+        mock_bedrock_runtime.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps({'images': [image_data]}).encode()))
+        }
+
+        def client_factory(service, **kwargs):
+            return mock_bedrock_runtime if service == 'bedrock-runtime' else mock_s3
+
+        with patch('shared.avatar.get_avatar_prompt_config', return_value=config), \
+             patch('shared.avatar.generate_avatar_prompt_with_llm', return_value='prompt'), \
+             patch('shared.avatar.boto3') as mock_boto3:
+            mock_boto3.client.side_effect = client_factory
+            from shared.avatar import generate_persona_avatar
+            result = generate_persona_avatar(
+                {'persona_id': 'p1', 'name': 'N', 'identity': {}},
+                MagicMock(),
+                s3_bucket='b',
+            )
+        return mock_bedrock_runtime, mock_boto3, result
+
+    def test_invokes_the_model_id_from_config(self):
+        bedrock, _, result = self._run_with_config({
+            'model_id': 'vendor.some-future-image-model-v9:0',
+            'region': 'us-east-1', 'width': 1024, 'height': 1024,
+        })
+        assert result['avatar_url'] == 's3://b/avatars/p1.png'
+        assert bedrock.invoke_model.call_args.kwargs['modelId'] == 'vendor.some-future-image-model-v9:0'
+
+    def test_creates_the_bedrock_client_in_the_configured_region(self):
+        _, boto3_mock, _ = self._run_with_config({
+            'model_id': 'm', 'region': 'eu-west-1', 'width': 1024, 'height': 1024,
+        })
+        bedrock_calls = [
+            c for c in boto3_mock.client.call_args_list if c.args and c.args[0] == 'bedrock-runtime'
+        ]
+        assert bedrock_calls, 'no bedrock-runtime client was created'
+        assert bedrock_calls[0].kwargs['region_name'] == 'eu-west-1'
+
+    def test_uses_the_configured_dimensions(self):
+        bedrock, _, _ = self._run_with_config({
+            'model_id': 'm', 'region': 'us-east-1', 'width': 512, 'height': 768,
+        })
+        body = json.loads(bedrock.invoke_model.call_args.kwargs['body'])
+        assert body['imageGenerationConfig']['width'] == 512
+        assert body['imageGenerationConfig']['height'] == 768
+
+    def test_falls_back_to_defaults_when_the_block_is_missing(self):
+        """Older/partial configs must still work rather than KeyError."""
+        from shared.avatar import (
+            DEFAULT_IMAGE_MODEL_ID,
+            DEFAULT_IMAGE_MODEL_REGION,
+            DEFAULT_IMAGE_SIZE,
+        )
+
+        bedrock, boto3_mock, _ = self._run_with_config(None)
+        assert bedrock.invoke_model.call_args.kwargs['modelId'] == DEFAULT_IMAGE_MODEL_ID
+        body = json.loads(bedrock.invoke_model.call_args.kwargs['body'])
+        assert body['imageGenerationConfig']['width'] == DEFAULT_IMAGE_SIZE
+        bedrock_calls = [
+            c for c in boto3_mock.client.call_args_list if c.args and c.args[0] == 'bedrock-runtime'
+        ]
+        assert bedrock_calls[0].kwargs['region_name'] == DEFAULT_IMAGE_MODEL_REGION
+
+
+class TestLifecycleFailuresAreDiagnosable:
+    """Avatar failures degrade silently by design (avatar_url stays None), so the
+    log line is the only signal. Each branch must reference in-scope names and
+    name the model, or the outage looks like a mystery — which is what happened
+    the last time this model lost access."""
+
+    @staticmethod
+    def _fail_with(exc: Exception):
+        config = {
+            'system_prompt': 'S', 'user_prompt_template': '{name}', 'max_tokens': 200,
+            'fallback_prompt_template': 'H',
+            'image_model': {'model_id': 'test.image-model', 'region': 'us-east-1',
+                            'width': 1024, 'height': 1024},
+        }
+        mock_bedrock_runtime = MagicMock()
+        mock_bedrock_runtime.invoke_model.side_effect = exc
+
+        def client_factory(service, **kwargs):
+            return mock_bedrock_runtime if service == 'bedrock-runtime' else MagicMock()
+
+        with patch('shared.avatar.get_avatar_prompt_config', return_value=config), \
+             patch('shared.avatar.generate_avatar_prompt_with_llm', return_value='p'), \
+             patch('shared.avatar.boto3') as mock_boto3, \
+             patch('shared.avatar.logger') as mock_logger:
+            mock_boto3.client.side_effect = client_factory
+            from shared.avatar import generate_persona_avatar
+            result = generate_persona_avatar(
+                {'persona_id': 'p1', 'name': 'N', 'identity': {}}, MagicMock(), s3_bucket='b'
+            )
+        errors = ' '.join(str(c) for c in mock_logger.error.call_args_list)
+        return result, errors
+
+    def test_model_not_found_explains_the_legacy_lifecycle(self):
+        class ResourceNotFoundException(Exception):
+            pass
+
+        result, errors = self._fail_with(ResourceNotFoundException('not found'))
+        assert result['avatar_url'] is None
+        assert 'test.image-model' in errors
+        assert 'LEGACY' in errors
+
+    def test_access_denied_reports_the_arn_it_needs(self):
+        class AccessDeniedException(Exception):
+            pass
+
+        result, errors = self._fail_with(AccessDeniedException('denied'))
+        assert result['avatar_url'] is None
+        assert 'test.image-model' in errors
+        assert 'us-east-1' in errors
+
+    def test_validation_error_names_the_model(self):
+        class ValidationException(Exception):
+            pass
+
+        result, errors = self._fail_with(ValidationException('bad body'))
+        assert result['avatar_url'] is None
+        assert 'test.image-model' in errors
+
+    def test_unexpected_error_still_degrades_gracefully(self):
+        result, errors = self._fail_with(RuntimeError('boom'))
+        assert result['avatar_url'] is None
+        assert 'boom' in errors

--- a/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
@@ -168,10 +168,22 @@ class TestAvatarsAreNotShippedAsPng:
     regression in page weight, hence an explicit guard."""
 
     def test_default_format_is_lossy(self):
-        from shared.avatar import DEFAULT_OUTPUT_FORMAT
+        """'jpeg' specifically — the model rejects 'jpg' and 'webp', so accepting
+        them here would green-light a value that fails Bedrock validation."""
+        from shared.avatar import DEFAULT_OUTPUT_FORMAT, _SUPPORTED_OUTPUT_FORMATS
 
-        assert DEFAULT_OUTPUT_FORMAT != 'png'
-        assert DEFAULT_OUTPUT_FORMAT in {'jpeg', 'jpg'}
+        assert DEFAULT_OUTPUT_FORMAT == 'jpeg'
+        assert _SUPPORTED_OUTPUT_FORMATS == {'png', 'jpeg'}
+
+    def test_unsupported_format_falls_back_instead_of_failing_at_invoke(self):
+        """An unusable format must not reach Bedrock: it also names the S3 object,
+        so a bad value would produce a misleading key and ContentType."""
+        cfg = {'image_model': {'model_id': 'm', 'region': 'us-west-2',
+                               'aspect_ratio': '1:1', 'output_format': 'webp'}}
+        with patch('shared.avatar.get_avatar_prompt_config', return_value=cfg):
+            from shared.avatar import DEFAULT_OUTPUT_FORMAT, get_image_model_config
+
+            assert get_image_model_config()['output_format'] == DEFAULT_OUTPUT_FORMAT
 
     def test_shipped_config_agrees_with_the_default(self):
         assert _avatar_config()['image_model']['output_format'] != 'png'
@@ -211,6 +223,86 @@ class TestAvatarsAreNotShippedAsPng:
         assert result['avatar_url'] == 's3://b/avatars/p1.jpeg'
 
 
+class TestFormatChangeDoesNotOrphanOldAvatars:
+    """The S3 key embeds the image format, so regenerating a persona after an
+    output_format change writes avatars/x.jpeg and would leave avatars/x.png behind
+    with nothing referencing it — and there is no other avatar cleanup path in the
+    codebase. Raised as a blocker in review of PR #228 once the configured value
+    stopped being 'png'."""
+
+    @staticmethod
+    def _generate(output_format: str):
+        cfg = {
+            'system_prompt': 'S', 'user_prompt_template': '{name}', 'max_tokens': 200,
+            'fallback_prompt_template': 'H',
+            'image_model': {'model_id': 'm', 'region': 'us-west-2',
+                            'aspect_ratio': '1:1', 'output_format': output_format},
+        }
+        import base64
+        mock_bedrock = MagicMock()
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps(
+                {'images': [base64.b64encode(b'bytes').decode()]}).encode()))
+        }
+        mock_s3 = MagicMock()
+
+        def client_factory(service, **kwargs):
+            return mock_bedrock if service == 'bedrock-runtime' else mock_s3
+
+        with patch('shared.avatar.get_avatar_prompt_config', return_value=cfg), \
+             patch('shared.avatar.generate_avatar_prompt_with_llm', return_value='p'), \
+             patch('shared.avatar.boto3') as mock_boto3:
+            mock_boto3.client.side_effect = client_factory
+            from shared.avatar import generate_persona_avatar
+            generate_persona_avatar(
+                {'persona_id': 'p1', 'name': 'N', 'identity': {}}, MagicMock(), s3_bucket='b'
+            )
+        return mock_s3
+
+    def test_deletes_the_previous_extension_after_writing(self):
+        s3 = self._generate('jpeg')
+        deleted = {c.kwargs['Key'] for c in s3.delete_object.call_args_list}
+        assert 'avatars/p1.png' in deleted
+
+    def test_does_not_delete_the_object_it_just_wrote(self):
+        s3 = self._generate('jpeg')
+        written = s3.put_object.call_args.kwargs['Key']
+        deleted = {c.kwargs['Key'] for c in s3.delete_object.call_args_list}
+        assert written == 'avatars/p1.jpeg'
+        assert written not in deleted
+
+    def test_cleanup_failure_does_not_fail_generation(self):
+        """Cleanup is best-effort; losing an orphan is better than losing the avatar."""
+        cfg = {
+            'system_prompt': 'S', 'user_prompt_template': '{name}', 'max_tokens': 200,
+            'fallback_prompt_template': 'H',
+            'image_model': {'model_id': 'm', 'region': 'us-west-2',
+                            'aspect_ratio': '1:1', 'output_format': 'jpeg'},
+        }
+        import base64
+        mock_bedrock = MagicMock()
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps(
+                {'images': [base64.b64encode(b'bytes').decode()]}).encode()))
+        }
+        mock_s3 = MagicMock()
+        mock_s3.delete_object.side_effect = RuntimeError('AccessDenied')
+
+        def client_factory(service, **kwargs):
+            return mock_bedrock if service == 'bedrock-runtime' else mock_s3
+
+        with patch('shared.avatar.get_avatar_prompt_config', return_value=cfg), \
+             patch('shared.avatar.generate_avatar_prompt_with_llm', return_value='p'), \
+             patch('shared.avatar.boto3') as mock_boto3:
+            mock_boto3.client.side_effect = client_factory
+            from shared.avatar import generate_persona_avatar
+            result = generate_persona_avatar(
+                {'persona_id': 'p1', 'name': 'N', 'identity': {}}, MagicMock(), s3_bucket='b'
+            )
+
+        assert result['avatar_url'] == 's3://b/avatars/p1.jpeg'
+
+
 class TestSeedIsActuallyDeterministic:
     """The code claims "consistent seed per persona" so regenerating a persona
     reproduces its avatar. It used hash(persona_id), and Python RANDOMISES str
@@ -227,10 +319,18 @@ class TestSeedIsActuallyDeterministic:
         PYTHONHASHSEED must reach the same value, which hash() cannot guarantee."""
         import hashlib
 
+        from shared.avatar import _MAX_SEED, _stable_seed
+
+        digest = int(hashlib.sha256(b'persona_abc').hexdigest()[:8], 16)
+        assert _stable_seed('persona_abc') == 1 + digest % (_MAX_SEED - 1)
+
+    def test_seed_is_never_zero(self):
+        """Stability reads seed 0 as "choose randomly", so a digest landing on 0
+        would silently lose determinism for that one bucket. (Raised in review of
+        PR #228.) Scanned over many ids rather than asserting the offset alone."""
         from shared.avatar import _stable_seed
 
-        expected = int(hashlib.sha256(b'persona_abc').hexdigest()[:8], 16) % 4294967294
-        assert _stable_seed('persona_abc') == expected
+        assert all(_stable_seed(f'persona_{i}') != 0 for i in range(2000))
 
     def test_different_personas_get_different_seeds(self):
         from shared.avatar import _stable_seed

--- a/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
@@ -49,6 +49,20 @@ class TestImageModelLockstep:
     def test_config_region_matches_cdk_source(self):
         assert _avatar_config()['image_model']['region'] == _ts_const('IMAGE_MODEL_REGION')
 
+    def test_runtime_fallback_defaults_match_cdk_source(self):
+        """The defaults are a third copy of the id, so pin them too.
+
+        avatar.py falls back to DEFAULT_IMAGE_MODEL_* when the config's
+        image_model block is absent. If those drift from the CDK constants, that
+        fallback invokes a model the IAM grant does not cover — an AccessDenied
+        on a path that already degrades silently to avatar_url=None, so nobody
+        would notice. (Raised in review of PR #228.)
+        """
+        from shared.avatar import DEFAULT_IMAGE_MODEL_ID, DEFAULT_IMAGE_MODEL_REGION
+
+        assert DEFAULT_IMAGE_MODEL_ID == _ts_const('IMAGE_MODEL_ID')
+        assert DEFAULT_IMAGE_MODEL_REGION == _ts_const('IMAGE_MODEL_REGION')
+
     def test_api_stack_derives_the_arn_instead_of_hardcoding_it(self):
         """Three roles used to embed the ARN as a literal, so a model swap had to
         be repeated in three places or it silently AccessDenied."""

--- a/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
@@ -161,6 +161,56 @@ class TestImageModelConfigIsHonoured:
         assert bedrock_calls[0].kwargs['region_name'] == DEFAULT_IMAGE_MODEL_REGION
 
 
+class TestAvatarsAreNotShippedAsPng:
+    """The model emits 1536x1536 while avatars render at 32-128 CSS px, so the
+    encoding choice dominates payload size. Measured on one seed/prompt: PNG
+    2,677,833 bytes vs JPEG 401,603 — 6.7x. A revert to PNG is a silent 6x
+    regression in page weight, hence an explicit guard."""
+
+    def test_default_format_is_lossy(self):
+        from shared.avatar import DEFAULT_OUTPUT_FORMAT
+
+        assert DEFAULT_OUTPUT_FORMAT != 'png'
+        assert DEFAULT_OUTPUT_FORMAT in {'jpeg', 'jpg'}
+
+    def test_shipped_config_agrees_with_the_default(self):
+        assert _avatar_config()['image_model']['output_format'] != 'png'
+
+    def test_content_type_matches_the_configured_format(self):
+        """The S3 ContentType is derived, so a format change must not leave it
+        claiming image/png for JPEG bytes."""
+        cfg = {
+            'system_prompt': 'S', 'user_prompt_template': '{name}', 'max_tokens': 200,
+            'fallback_prompt_template': 'H',
+            'image_model': {'model_id': 'm', 'region': 'us-west-2',
+                            'aspect_ratio': '1:1', 'output_format': 'jpeg'},
+        }
+        mock_bedrock = MagicMock()
+        mock_s3 = MagicMock()
+        import base64
+        mock_bedrock.invoke_model.return_value = {
+            'body': MagicMock(read=MagicMock(return_value=json.dumps(
+                {'images': [base64.b64encode(b'jpegbytes').decode()]}).encode()))
+        }
+
+        def client_factory(service, **kwargs):
+            return mock_bedrock if service == 'bedrock-runtime' else mock_s3
+
+        with patch('shared.avatar.get_avatar_prompt_config', return_value=cfg), \
+             patch('shared.avatar.generate_avatar_prompt_with_llm', return_value='p'), \
+             patch('shared.avatar.boto3') as mock_boto3:
+            mock_boto3.client.side_effect = client_factory
+            from shared.avatar import generate_persona_avatar
+            result = generate_persona_avatar(
+                {'persona_id': 'p1', 'name': 'N', 'identity': {}}, MagicMock(), s3_bucket='b'
+            )
+
+        put = mock_s3.put_object.call_args.kwargs
+        assert put['ContentType'] == 'image/jpeg'
+        assert put['Key'] == 'avatars/p1.jpeg'
+        assert result['avatar_url'] == 's3://b/avatars/p1.jpeg'
+
+
 class TestSeedIsActuallyDeterministic:
     """The code claims "consistent seed per persona" so regenerating a persona
     reproduces its avatar. It used hash(persona_id), and Python RANDOMISES str

--- a/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_avatar_image_model_lockstep.py
@@ -10,8 +10,9 @@ Two problems motivated these tests:
    one that is granted but not invoked wastes the grant.
 
 So the Python config and the CDK source must agree, and the runtime must use
-what the config says. amazon.nova-canvas-v1:0 reaches EOL on 2026-09-30, so the
-migration these tests protect is a matter of when, not if.
+what the config says. The model was migrated off amazon.nova-canvas-v1:0 (EOL
+2026-09-30) to an active Stability generator in a DIFFERENT region, so these
+tests also pin the region that the IAM grant is built from.
 """
 import json
 import re
@@ -69,6 +70,7 @@ class TestImageModelLockstep:
         api_stack = (_repo_root() / 'lib' / 'stacks' / 'api-stack.ts').read_text(encoding='utf-8')
         assert 'imageModelArn()' in api_stack
         assert 'foundation-model/amazon.nova-canvas' not in api_stack
+        assert 'foundation-model/stability' not in api_stack
 
 
 class TestImageModelConfigIsHonoured:
@@ -115,14 +117,15 @@ class TestImageModelConfigIsHonoured:
     def test_invokes_the_model_id_from_config(self):
         bedrock, _, result = self._run_with_config({
             'model_id': 'vendor.some-future-image-model-v9:0',
-            'region': 'us-east-1', 'width': 1024, 'height': 1024,
+            'region': 'us-west-2', 'aspect_ratio': '1:1', 'output_format': 'png',
         })
         assert result['avatar_url'] == 's3://b/avatars/p1.png'
         assert bedrock.invoke_model.call_args.kwargs['modelId'] == 'vendor.some-future-image-model-v9:0'
 
     def test_creates_the_bedrock_client_in_the_configured_region(self):
         _, boto3_mock, _ = self._run_with_config({
-            'model_id': 'm', 'region': 'eu-west-1', 'width': 1024, 'height': 1024,
+            'model_id': 'm', 'region': 'eu-west-1', 'aspect_ratio': '1:1',
+            'output_format': 'png',
         })
         bedrock_calls = [
             c for c in boto3_mock.client.call_args_list if c.args and c.args[0] == 'bedrock-runtime'
@@ -130,30 +133,67 @@ class TestImageModelConfigIsHonoured:
         assert bedrock_calls, 'no bedrock-runtime client was created'
         assert bedrock_calls[0].kwargs['region_name'] == 'eu-west-1'
 
-    def test_uses_the_configured_dimensions(self):
+    def test_uses_the_configured_aspect_ratio_and_format(self):
         bedrock, _, _ = self._run_with_config({
-            'model_id': 'm', 'region': 'us-east-1', 'width': 512, 'height': 768,
+            'model_id': 'm', 'region': 'us-west-2',
+            'aspect_ratio': '3:2', 'output_format': 'jpeg',
         })
         body = json.loads(bedrock.invoke_model.call_args.kwargs['body'])
-        assert body['imageGenerationConfig']['width'] == 512
-        assert body['imageGenerationConfig']['height'] == 768
+        assert body['aspect_ratio'] == '3:2'
+        assert body['output_format'] == 'jpeg'
+        assert body['mode'] == 'text-to-image'
 
     def test_falls_back_to_defaults_when_the_block_is_missing(self):
         """Older/partial configs must still work rather than KeyError."""
         from shared.avatar import (
+            DEFAULT_ASPECT_RATIO,
             DEFAULT_IMAGE_MODEL_ID,
             DEFAULT_IMAGE_MODEL_REGION,
-            DEFAULT_IMAGE_SIZE,
         )
 
         bedrock, boto3_mock, _ = self._run_with_config(None)
         assert bedrock.invoke_model.call_args.kwargs['modelId'] == DEFAULT_IMAGE_MODEL_ID
         body = json.loads(bedrock.invoke_model.call_args.kwargs['body'])
-        assert body['imageGenerationConfig']['width'] == DEFAULT_IMAGE_SIZE
+        assert body['aspect_ratio'] == DEFAULT_ASPECT_RATIO
         bedrock_calls = [
             c for c in boto3_mock.client.call_args_list if c.args and c.args[0] == 'bedrock-runtime'
         ]
         assert bedrock_calls[0].kwargs['region_name'] == DEFAULT_IMAGE_MODEL_REGION
+
+
+class TestSeedIsActuallyDeterministic:
+    """The code claims "consistent seed per persona" so regenerating a persona
+    reproduces its avatar. It used hash(persona_id), and Python RANDOMISES str
+    hashing per process, so the seed differed on every cold start — the comment
+    was aspirational. Now sha256-derived."""
+
+    def test_same_persona_always_yields_the_same_seed(self):
+        from shared.avatar import _stable_seed
+
+        assert _stable_seed('persona_abc') == _stable_seed('persona_abc')
+
+    def test_seed_derives_from_a_process_independent_digest(self):
+        """Recomputed independently here: a fresh interpreter with a different
+        PYTHONHASHSEED must reach the same value, which hash() cannot guarantee."""
+        import hashlib
+
+        from shared.avatar import _stable_seed
+
+        expected = int(hashlib.sha256(b'persona_abc').hexdigest()[:8], 16) % 4294967294
+        assert _stable_seed('persona_abc') == expected
+
+    def test_different_personas_get_different_seeds(self):
+        from shared.avatar import _stable_seed
+
+        assert _stable_seed('persona_a') != _stable_seed('persona_b')
+
+    def test_seed_stays_inside_the_accepted_range(self):
+        from shared.avatar import _stable_seed
+
+        for pid in ('a', 'persona_20260802_0', 'ünïcodé-persona', 'x' * 200):
+            seed = _stable_seed(pid)
+            assert 0 <= seed < 4294967294
+
 
 
 class TestLifecycleFailuresAreDiagnosable:
@@ -167,8 +207,8 @@ class TestLifecycleFailuresAreDiagnosable:
         config = {
             'system_prompt': 'S', 'user_prompt_template': '{name}', 'max_tokens': 200,
             'fallback_prompt_template': 'H',
-            'image_model': {'model_id': 'test.image-model', 'region': 'us-east-1',
-                            'width': 1024, 'height': 1024},
+            'image_model': {'model_id': 'test.image-model', 'region': 'us-west-2',
+                            'aspect_ratio': '1:1', 'output_format': 'png'},
         }
         mock_bedrock_runtime = MagicMock()
         mock_bedrock_runtime.invoke_model.side_effect = exc
@@ -204,7 +244,7 @@ class TestLifecycleFailuresAreDiagnosable:
         result, errors = self._fail_with(AccessDeniedException('denied'))
         assert result['avatar_url'] is None
         assert 'test.image-model' in errors
-        assert 'us-east-1' in errors
+        assert 'us-west-2' in errors
 
     def test_validation_error_names_the_model(self):
         class ValidationException(Exception):

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -12,7 +12,7 @@ import { buildSinglePersonaPrompt, getLanguageInstruction } from './persona-prom
 
 const AVATARS_CDN_URL = process.env.AVATARS_CDN_URL ?? '';
 
-/** Convert an S3 URI (s3://bucket/avatars/file.png) to a CloudFront CDN URL. */
+/** Convert an S3 URI (s3://bucket/avatars/file.<ext>) to a CloudFront CDN URL. */
 function stripTrailingSlashes(value: string): string {
   // Recursive instead of a trailing-slash regex: sonarjs flags /\/+$/ as
   // backtracking-prone, and the input is a short constant env URL.

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -19,7 +19,7 @@ import { loadPlugins, getEnabledPlugins, getPluginsWithWebhook, capitalize, type
 import { uniqueName } from '../utils/naming';
 import { assertFrontendBuildFresh } from '../utils/assert-frontend-build';
 import { cdkCustomResourceSuppressions, apiGatewayRequestValidationSuppressions, publicFeedbackEndpointSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, marketplaceSuppressions } from '../utils/nag-suppressions';
-import { allowlistedModelArns } from '../utils/model-allowlist';
+import { allowlistedModelArns, imageModelArn } from '../utils/model-allowlist';
 import { pythonLayerCode } from '../utils/python-layer-bundling';
 import { PY_LAMBDA_ASSET_EXCLUDES } from '../utils/lambda-asset-excludes';
 
@@ -428,8 +428,9 @@ export class VocApiStack extends cdk.Stack {
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
       resources: [
         ...allowlistedModelArns(this.region, this.account),
-        // Nova Canvas powers persona avatar image generation.
-        'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0',
+        // Persona avatar image generation. Single-sourced in model-allowlist.ts
+        // so the grant tracks the model through its EOL migration.
+        imageModelArn(),
       ],
     }));
 
@@ -493,7 +494,8 @@ export class VocApiStack extends cdk.Stack {
     // via the picker. Single source of truth kept in lockstep with
     // lambda/shared/model_config.py and lambda/stream/src/bedrock/model-override.ts.
     const claudeModelResources = allowlistedModelArns(this.region, this.account);
-    const novaCanvasResource = 'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-canvas-v1:0';
+    // Persona avatar image model — see model-allowlist.ts for its EOL deadline.
+    const avatarImageModelResource = imageModelArn();
 
     // Persona Generator Job Lambda
     const personaGeneratorRole = this.createLambdaRole('PersonaGeneratorRole');
@@ -504,7 +506,7 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(personaGeneratorRole);
     personaGeneratorRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
-      resources: [...claudeModelResources, novaCanvasResource],
+      resources: [...claudeModelResources, avatarImageModelResource],
     }));
     rawDataBucket.grantReadWrite(personaGeneratorRole, 'avatars/*');
 
@@ -618,7 +620,7 @@ export class VocApiStack extends cdk.Stack {
     kmsKey.grantEncryptDecrypt(personaImporterRole);
     personaImporterRole.addToPolicy(new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel'],
-      resources: [...claudeModelResources, novaCanvasResource],
+      resources: [...claudeModelResources, avatarImageModelResource],
     }));
     rawDataBucket.grantReadWrite(personaImporterRole, 'avatars/*');
 

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -8,6 +8,9 @@
  * the analysis prompt. These tests fail if either half of the wiring is
  * removed again (e.g. in a conflict resolution on the selector block).
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
@@ -107,5 +110,43 @@ describe('research state machine wiring (issue #157)', () => {
     // is off); step_save consumes it for the report's disclosure section.
     expect(state.definition).toContain('"web_search_queries.$":"$.Payload.web_search_queries"');
     expect(state.definition).toContain('"web_search_queries.$":"$.initialize_result.web_search_queries"');
+  });
+});
+
+/**
+ * The research Lambda gained a RUNTIME file dependency: research_step_handler
+ * resolves its system prompts and token budgets from
+ * api/prompts/research-analysis.json instead of hardcoding them. Staging is not
+ * something unit tests of the handler can see — locally the repo layout resolves
+ * the path either way, so a missing bundle entry only surfaces as a
+ * FileNotFoundError on a deployed research job. It did: the first deploy of that
+ * change shipped a bundle with no prompts/ at all.
+ *
+ * Asserted against the source because asset staging appears in neither the
+ * synthesized template nor the assets manifest.
+ */
+describe('research Lambda bundle stages its prompt config', () => {
+  const source = readFileSync(join(__dirname, 'processing-stack-consolidated.ts'), 'utf-8');
+  const researchAsset = source.split('const researchCode')[1]?.split('});')[0] ?? '';
+
+  it('re-includes api/prompts rather than pruning the whole api subtree', () => {
+    // '/api/' with a trailing slash prunes the subtree, and gitignore semantics
+    // cannot re-enter a pruned directory — so the exclude must be per-entry.
+    expect(researchAsset).toContain("'/api/*'");
+    expect(researchAsset).toContain("'!/api/prompts'");
+    expect(researchAsset).not.toContain("'/api/',");
+  });
+
+  it('copies the prompts to the bundle root where get_prompts_dir looks first', () => {
+    // shared/prompts.py::get_prompts_dir checks /var/task/prompts first.
+    expect(researchAsset).toContain('/asset-input/api/prompts /asset-output/prompts');
+  });
+
+  it('still excludes the sibling handler trees it does not ship', () => {
+    // Guards the asset-hash discipline: re-including prompts must not turn into
+    // "stage everything", which would redeploy this function on unrelated edits.
+    for (const excluded of ["'/aggregator/'", "'/jobs/'", "'/processor/'"]) {
+      expect(researchAsset).toContain(excluded);
+    }
   });
 });

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -113,42 +113,36 @@ describe('research state machine wiring (issue #157)', () => {
   });
 });
 
+/** Narrow a CloudFormation resource to its Properties without a bare cast. */
+function propsOf(resource: unknown): Record<string, unknown> {
+  if (typeof resource === 'object' && resource !== null && 'Properties' in resource) {
+    const props = (resource as { Properties: unknown }).Properties;
+    if (typeof props === 'object' && props !== null) {
+      return props as Record<string, unknown>;
+    }
+  }
+  return {};
+}
+
 /**
- * research_step_handler resolves its system prompts and token budgets from
- * api/prompts/research-analysis.json at RUNTIME, so that file must be copied into
- * the bundle AND be part of the asset fingerprint. The first deploy of that change
- * shipped a bundle with no prompts/ at all — a FileNotFoundError on every research
- * job that the whole unit suite missed, because get_prompts_dir() resolves the repo
- * layout locally whether or not the bundle stages anything.
- *
- * These are source assertions, which is a weak form: they cannot prove staging, and
- * they break on reformatting. Kept only because bundling inputs appear in neither
- * the synthesized template nor the assets manifest, so the alternative is a
- * finch-dependent synth in unit tests. The behavioural half of this guard lives in
- * lambda/research/test/test_research_step_budgets.py, which fails if a step stops
- * reading the config at all.
- */
-/**
- * Raised in review of PR #228: moving the research budgets to config (9000 +
- * a 5000 thinking budget, up from 4000/0) increases per-step generation time, and
- * a mid-generation timeout throws the step away — the same failure the ingestor
- * sizing change fixes.
- *
- * The function already runs at Lambda's 15-minute HARD MAXIMUM, so there is no
- * headroom left to add: the only thing worth guarding is that nobody lowers it
- * while budgets are config-driven and can be raised by editing a JSON file.
+ * Budgets are config-driven now, so they can be raised by editing a JSON file
+ * while a mid-generation timeout discards the step. The function already runs at
+ * Lambda's 15-minute hard maximum, so the only thing to guard is that nobody
+ * lowers it. Memory matters too: Lambda scales CPU with it.
  */
 describe('research Lambda keeps the maximum timeout its budgets assume', () => {
   const MAX_LAMBDA_TIMEOUT_SECONDS = 900;
   let researchFn: Record<string, unknown>;
 
   beforeAll(() => {
+    // Matched on the handler, not the construct id: a rename should not silently
+    // skip these assertions.
     const fns = synthProcessingTemplate().findResources('AWS::Lambda::Function');
-    const entry = Object.entries(fns).find(
-      ([id]) => id.startsWith('ResearchStepLambda'),
-    );
-    expect(entry, 'ResearchStepLambda not found in the template').toBeDefined();
-    researchFn = (entry![1] as { Properties: Record<string, unknown> }).Properties;
+    const found = Object.values(fns)
+      .map(propsOf)
+      .find((p) => typeof p.Handler === 'string' && p.Handler.includes('research_step_handler'));
+    expect(found, 'no Lambda with the research_step_handler handler').toBeDefined();
+    researchFn = found ?? {};
   });
 
   it('runs at the maximum Lambda timeout', () => {
@@ -162,6 +156,18 @@ describe('research Lambda keeps the maximum timeout its budgets assume', () => {
   });
 });
 
+/**
+ * research_step_handler reads its prompts and budgets from
+ * api/prompts/research-analysis.json at RUNTIME. The first deploy of that change
+ * shipped a bundle with no prompts/ at all — a FileNotFoundError the unit suite
+ * could not see, because get_prompts_dir() resolves the repo layout locally
+ * whether or not the bundle stages anything.
+ *
+ * Source assertions are a weak form (they break on reformatting and cannot prove
+ * staging), used because bundling inputs appear in neither the template nor the
+ * assets manifest. The behavioural half lives in
+ * lambda/research/test/test_research_step_budgets.py.
+ */
 describe('research Lambda bundle stages its prompt config', () => {
   const source = readFileSync(join(__dirname, 'processing-stack-consolidated.ts'), 'utf-8');
   const researchAsset = source.split('const researchCode')[1]?.split('});')[0] ?? '';

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -132,27 +132,32 @@ function propsOf(resource: unknown): Record<string, unknown> {
  */
 describe('research Lambda keeps the maximum timeout its budgets assume', () => {
   const MAX_LAMBDA_TIMEOUT_SECONDS = 900;
-  let researchFn: Record<string, unknown>;
+  let researchFns: Record<string, unknown>[];
 
   beforeAll(() => {
     // Matched on the handler, not the construct id: a rename should not silently
-    // skip these assertions.
+    // skip these assertions. EVERY match is checked, so a second research
+    // function cannot appear under the ceiling unnoticed.
     const fns = synthProcessingTemplate().findResources('AWS::Lambda::Function');
-    const found = Object.values(fns)
+    researchFns = Object.values(fns)
       .map(propsOf)
-      .find((p) => typeof p.Handler === 'string' && p.Handler.includes('research_step_handler'));
-    expect(found, 'no Lambda with the research_step_handler handler').toBeDefined();
-    researchFn = found ?? {};
+      .filter((p) => typeof p.Handler === 'string' && p.Handler.includes('research_step_handler'));
+    expect(researchFns.length, 'no Lambda with the research_step_handler handler')
+      .toBeGreaterThan(0);
   });
 
   it('runs at the maximum Lambda timeout', () => {
-    expect(researchFn.Timeout).toBe(MAX_LAMBDA_TIMEOUT_SECONDS);
+    for (const fn of researchFns) {
+      expect(fn.Timeout).toBe(MAX_LAMBDA_TIMEOUT_SECONDS);
+    }
   });
 
   it('has enough memory that generation is not CPU-starved', () => {
     // Lambda scales CPU with memory; a small function makes long generations
     // slower and therefore likelier to hit the ceiling above.
-    expect(researchFn.MemorySize as number).toBeGreaterThanOrEqual(1024);
+    for (const fn of researchFns) {
+      expect(fn.MemorySize).toBeGreaterThanOrEqual(1024);
+    }
   });
 });
 

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -114,37 +114,76 @@ describe('research state machine wiring (issue #157)', () => {
 });
 
 /**
- * The research Lambda gained a RUNTIME file dependency: research_step_handler
- * resolves its system prompts and token budgets from
- * api/prompts/research-analysis.json instead of hardcoding them. Staging is not
- * something unit tests of the handler can see — locally the repo layout resolves
- * the path either way, so a missing bundle entry only surfaces as a
- * FileNotFoundError on a deployed research job. It did: the first deploy of that
- * change shipped a bundle with no prompts/ at all.
+ * research_step_handler resolves its system prompts and token budgets from
+ * api/prompts/research-analysis.json at RUNTIME, so that file must be copied into
+ * the bundle AND be part of the asset fingerprint. The first deploy of that change
+ * shipped a bundle with no prompts/ at all — a FileNotFoundError on every research
+ * job that the whole unit suite missed, because get_prompts_dir() resolves the repo
+ * layout locally whether or not the bundle stages anything.
  *
- * Asserted against the source because asset staging appears in neither the
- * synthesized template nor the assets manifest.
+ * These are source assertions, which is a weak form: they cannot prove staging, and
+ * they break on reformatting. Kept only because bundling inputs appear in neither
+ * the synthesized template nor the assets manifest, so the alternative is a
+ * finch-dependent synth in unit tests. The behavioural half of this guard lives in
+ * lambda/research/test/test_research_step_budgets.py, which fails if a step stops
+ * reading the config at all.
  */
+/**
+ * Raised in review of PR #228: moving the research budgets to config (9000 +
+ * a 5000 thinking budget, up from 4000/0) increases per-step generation time, and
+ * a mid-generation timeout throws the step away — the same failure the ingestor
+ * sizing change fixes.
+ *
+ * The function already runs at Lambda's 15-minute HARD MAXIMUM, so there is no
+ * headroom left to add: the only thing worth guarding is that nobody lowers it
+ * while budgets are config-driven and can be raised by editing a JSON file.
+ */
+describe('research Lambda keeps the maximum timeout its budgets assume', () => {
+  const MAX_LAMBDA_TIMEOUT_SECONDS = 900;
+  let researchFn: Record<string, unknown>;
+
+  beforeAll(() => {
+    const fns = synthProcessingTemplate().findResources('AWS::Lambda::Function');
+    const entry = Object.entries(fns).find(
+      ([id]) => id.startsWith('ResearchStepLambda'),
+    );
+    expect(entry, 'ResearchStepLambda not found in the template').toBeDefined();
+    researchFn = (entry![1] as { Properties: Record<string, unknown> }).Properties;
+  });
+
+  it('runs at the maximum Lambda timeout', () => {
+    expect(researchFn.Timeout).toBe(MAX_LAMBDA_TIMEOUT_SECONDS);
+  });
+
+  it('has enough memory that generation is not CPU-starved', () => {
+    // Lambda scales CPU with memory; a small function makes long generations
+    // slower and therefore likelier to hit the ceiling above.
+    expect(researchFn.MemorySize as number).toBeGreaterThanOrEqual(1024);
+  });
+});
+
 describe('research Lambda bundle stages its prompt config', () => {
   const source = readFileSync(join(__dirname, 'processing-stack-consolidated.ts'), 'utf-8');
   const researchAsset = source.split('const researchCode')[1]?.split('});')[0] ?? '';
 
-  it('re-includes api/prompts rather than pruning the whole api subtree', () => {
-    // '/api/' with a trailing slash prunes the subtree, and gitignore semantics
-    // cannot re-enter a pruned directory — so the exclude must be per-entry.
-    expect(researchAsset).toContain("'/api/*'");
+  it('copies the prompts to the bundle root where get_prompts_dir looks first', () => {
+    // THIS is the assertion that maps to the actual bug: a bundled asset mounts
+    // the source dir as /asset-input, so the copy — not the exclude — is what puts
+    // the config in the bundle. Verified empirically by reverting each half.
+    expect(researchAsset).toContain('/asset-input/api/prompts /asset-output/prompts');
+  });
+
+  it('keeps api/prompts inside the asset fingerprint', () => {
+    // Excluding api/ wholesale still bundles the prompts (the copy handles that),
+    // but drops them from the hash — so editing research-analysis.json would not
+    // redeploy the function and it would keep running the old budgets.
     expect(researchAsset).toContain("'!/api/prompts'");
     expect(researchAsset).not.toContain("'/api/',");
   });
 
-  it('copies the prompts to the bundle root where get_prompts_dir looks first', () => {
-    // shared/prompts.py::get_prompts_dir checks /var/task/prompts first.
-    expect(researchAsset).toContain('/asset-input/api/prompts /asset-output/prompts');
-  });
-
   it('still excludes the sibling handler trees it does not ship', () => {
-    // Guards the asset-hash discipline: re-including prompts must not turn into
-    // "stage everything", which would redeploy this function on unrelated edits.
+    // Re-including prompts must not become "stage everything", which would
+    // redeploy this function on unrelated edits.
     for (const excluded of ["'/aggregator/'", "'/jobs/'", "'/processor/'"]) {
       expect(researchAsset).toContain(excluded);
     }

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -226,11 +226,17 @@ export class VocProcessingStack extends cdk.Stack {
     // hashed the entire CDK project (scripts/, schemas/, coverage output...)
     // into this asset, redeploying it on every unrelated edit.
     const researchCode = lambda.Code.fromAsset('lambda', {
-      // api/ is excluded per-entry rather than as a subtree so api/prompts can be
-      // re-included: research_step_handler resolves its system prompts and token
-      // budgets from api/prompts/research-analysis.json at RUNTIME. A pruned
-      // '/api/' subtree cannot be re-entered under gitignore semantics, and
-      // without the config the handler raises FileNotFoundError on every job.
+      // research_step_handler resolves its system prompts and token budgets from
+      // api/prompts/research-analysis.json at RUNTIME, so that file must both be
+      // COPIED into the bundle (see the command below — that is what fixes the
+      // FileNotFoundError) and be part of this asset's FINGERPRINT.
+      //
+      // The fingerprint is why api/ is excluded per-entry instead of as a pruned
+      // '/api/' subtree: a bundled asset mounts the source dir as /asset-input, so
+      // the copy works either way, but with api/ excluded from the fingerprint an
+      // edit to research-analysis.json would not change the asset hash and the
+      // Lambda would keep running the OLD prompts and budgets. Only prompts are
+      // re-included, so api/*.py edits still cannot churn this function's hash.
       exclude: [
         ...PY_LAMBDA_ASSET_EXCLUDES,
         '/aggregator/',

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -226,17 +226,11 @@ export class VocProcessingStack extends cdk.Stack {
     // hashed the entire CDK project (scripts/, schemas/, coverage output...)
     // into this asset, redeploying it on every unrelated edit.
     const researchCode = lambda.Code.fromAsset('lambda', {
-      // research_step_handler resolves its system prompts and token budgets from
-      // api/prompts/research-analysis.json at RUNTIME, so that file must both be
-      // COPIED into the bundle (see the command below — that is what fixes the
-      // FileNotFoundError) and be part of this asset's FINGERPRINT.
-      //
-      // The fingerprint is why api/ is excluded per-entry instead of as a pruned
-      // '/api/' subtree: a bundled asset mounts the source dir as /asset-input, so
-      // the copy works either way, but with api/ excluded from the fingerprint an
-      // edit to research-analysis.json would not change the asset hash and the
-      // Lambda would keep running the OLD prompts and budgets. Only prompts are
-      // re-included, so api/*.py edits still cannot churn this function's hash.
+      // research_step_handler reads api/prompts/research-analysis.json at RUNTIME,
+      // so the prompts must be BOTH copied into the bundle (the cp below) and kept
+      // in the asset FINGERPRINT (this per-entry exclude) — otherwise editing the
+      // config would not change the hash and the Lambda would keep the old budgets.
+      // Only prompts are re-included, so api/*.py edits can't churn this hash.
       exclude: [
         ...PY_LAMBDA_ASSET_EXCLUDES,
         '/aggregator/',

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -226,11 +226,26 @@ export class VocProcessingStack extends cdk.Stack {
     // hashed the entire CDK project (scripts/, schemas/, coverage output...)
     // into this asset, redeploying it on every unrelated edit.
     const researchCode = lambda.Code.fromAsset('lambda', {
-      exclude: [...PY_LAMBDA_ASSET_EXCLUDES, '/aggregator/', '/api/', '/jobs/', '/processor/'],
+      // api/ is excluded per-entry rather than as a subtree so api/prompts can be
+      // re-included: research_step_handler resolves its system prompts and token
+      // budgets from api/prompts/research-analysis.json at RUNTIME. A pruned
+      // '/api/' subtree cannot be re-entered under gitignore semantics, and
+      // without the config the handler raises FileNotFoundError on every job.
+      exclude: [
+        ...PY_LAMBDA_ASSET_EXCLUDES,
+        '/aggregator/',
+        '/api/*',
+        '!/api/prompts',
+        '/jobs/',
+        '/processor/',
+      ],
       ignoreMode: cdk.IgnoreMode.GIT,
       bundling: {
         image: lambda.Runtime.PYTHON_3_14.bundlingImage,
-        command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/research/* /asset-output/ && cp -r /asset-input/shared /asset-output/'],
+        // INVARIANT: prompts land at the bundle ROOT (/var/task/prompts) —
+        // shared/prompts.py::get_prompts_dir resolves that path first. Same
+        // staging contract as the api-stack bundles.
+        command: ['bash', '-c', 'mkdir -p /asset-output && cp -r /asset-input/research/* /asset-output/ && cp -r /asset-input/shared /asset-output/ && cp -r /asset-input/api/prompts /asset-output/prompts'],
         platform: 'linux/arm64',
       },
     });

--- a/voc-datalake/lib/utils/model-allowlist.test.ts
+++ b/voc-datalake/lib/utils/model-allowlist.test.ts
@@ -12,6 +12,9 @@ import {
   ALLOWED_MODEL_IDS,
   allowlistedModelArns,
   bedrockFoundationModelSuppressionTargets,
+  IMAGE_MODEL_ID,
+  IMAGE_MODEL_REGION,
+  imageModelArn,
 } from './model-allowlist';
 
 const OPUS5 = 'global.anthropic.claude-opus-5';
@@ -81,6 +84,32 @@ describe('allowlistedModelArns', () => {
     const arns = allowlistedModelArns(REGION, ACCOUNT);
     for (const arn of arns.filter((a) => a.includes('foundation-model/'))) {
       expect(arn).not.toContain('foundation-model/global.');
+    }
+  });
+});
+
+describe('avatar image model', () => {
+  it('stays out of the text picker allowlist', () => {
+    // ALLOWED_MODEL_IDS drives the per-surface picker. An image model in there
+    // would become selectable for chat/documents and fail on the first call.
+    expect(ALLOWED_MODEL_IDS).not.toContain(IMAGE_MODEL_ID);
+    expect(ALLOWED_FOUNDATION_MODEL_IDS).not.toContain(IMAGE_MODEL_ID);
+  });
+
+  it('pins the ARN to a single region rather than wildcarding it', () => {
+    // A region-pinned ARN needs no cdk-nag suppression, unlike the cross-region
+    // text-model ARNs.
+    expect(imageModelArn()).toBe(
+      `arn:aws:bedrock:${IMAGE_MODEL_REGION}::foundation-model/${IMAGE_MODEL_ID}`,
+    );
+    expect(imageModelArn()).not.toContain(':*:');
+  });
+
+  it('is excluded from the cdk-nag wildcard suppressions', () => {
+    // Those targets exist only for wildcard-region ARNs; adding the pinned
+    // image model would be a suppression with nothing to suppress.
+    for (const target of bedrockFoundationModelSuppressionTargets()) {
+      expect(target).not.toContain(IMAGE_MODEL_ID);
     }
   });
 });

--- a/voc-datalake/lib/utils/model-allowlist.ts
+++ b/voc-datalake/lib/utils/model-allowlist.ts
@@ -74,3 +74,44 @@ export function bedrockFoundationModelSuppressionTargets(): string[] {
     (id) => `Resource::arn:aws:bedrock:*::foundation-model/${id}`,
   );
 }
+
+/**
+ * ── Persona avatar image model ────────────────────────────────────────────────
+ *
+ * Deliberately NOT part of ALLOWED_MODEL_IDS: that list is the per-surface text
+ * picker, and anything added there becomes selectable for chat/documents/etc.
+ * This is a fixed image model with its own request shape, region and IAM grant.
+ * It lives here anyway so one file still answers "which Bedrock models can this
+ * platform reach", and so the ARN is derived rather than pasted into each role.
+ *
+ * ⚠️ LIFECYCLE — ACTION REQUIRED BEFORE 2026-09-30
+ * Per the AWS Bedrock model-lifecycle table, amazon.nova-canvas-v1:0 entered
+ * LEGACY on 2026-03-30 with EOL on 2026-09-30, after which requests fail in
+ * every region. During the legacy window an account that does not invoke the
+ * model for 15+ days can ALSO lose access early, surfacing as
+ * ResourceNotFoundException ("marked as Legacy… upgrade to an active model") —
+ * which is exactly the outage previously seen on this codebase, where avatars
+ * silently stopped generating while persona creation carried on.
+ *
+ * Migrating is a one-line change here plus the same value in
+ * lambda/api/prompts/avatar-generation.json (a Python lockstep test pins the
+ * two together). Confirm the replacement against the account before switching:
+ *   aws bedrock list-foundation-models --by-output-modality IMAGE \
+ *     --query 'modelSummaries[].[modelId,modelLifecycle.status]' --output table
+ * Note the successor may need a different request body than Nova Canvas's
+ * TEXT_IMAGE/textToImageParams shape in lambda/shared/avatar.py.
+ */
+export const IMAGE_MODEL_ID = 'amazon.nova-canvas-v1:0';
+
+/** Nova Canvas is not offered in every region; the avatar client pins this one. */
+export const IMAGE_MODEL_REGION = 'us-east-1';
+
+/**
+ * IAM resource ARN for the avatar image model. Region-pinned (unlike the
+ * cross-region text models) because the model is only invoked in
+ * IMAGE_MODEL_REGION, which keeps the grant narrow enough to need no cdk-nag
+ * suppression.
+ */
+export function imageModelArn(): string {
+  return `arn:aws:bedrock:${IMAGE_MODEL_REGION}::foundation-model/${IMAGE_MODEL_ID}`;
+}

--- a/voc-datalake/lib/utils/model-allowlist.ts
+++ b/voc-datalake/lib/utils/model-allowlist.ts
@@ -84,27 +84,34 @@ export function bedrockFoundationModelSuppressionTargets(): string[] {
  * It lives here anyway so one file still answers "which Bedrock models can this
  * platform reach", and so the ARN is derived rather than pasted into each role.
  *
- * ⚠️ LIFECYCLE — ACTION REQUIRED BEFORE 2026-09-30
- * Per the AWS Bedrock model-lifecycle table, amazon.nova-canvas-v1:0 entered
- * LEGACY on 2026-03-30 with EOL on 2026-09-30, after which requests fail in
- * every region. During the legacy window an account that does not invoke the
- * model for 15+ days can ALSO lose access early, surfacing as
- * ResourceNotFoundException ("marked as Legacy… upgrade to an active model") —
- * which is exactly the outage previously seen on this codebase, where avatars
- * silently stopped generating while persona creation carried on.
+ * WHY NOT amazon.nova-canvas-v1:0 (the previous model): it went LEGACY on
+ * 2026-03-30 with EOL 2026-09-30, and a legacy model also drops access for
+ * accounts idle 15+ days — which had already caused a silent avatar outage here
+ * (generation degrades to avatar_url=null, so nothing visibly breaks).
  *
- * Migrating is a one-line change here plus the same value in
- * lambda/api/prompts/avatar-generation.json (a Python lockstep test pins the
- * two together). Confirm the replacement against the account before switching:
- *   aws bedrock list-foundation-models --by-output-modality IMAGE \
+ * WHY us-west-2 rather than the platform's us-east-1: as of 2026-08-02 there is
+ * NO active text-to-image model in us-east-1 — Nova Canvas is the only generator
+ * offered there and it is legacy. Every other image model in us-east-1 is a
+ * Stability EDITING primitive (inpaint/upscale/remove-background) that requires
+ * an input image. us-west-2 carries the three active generators, verified
+ * invocable from this account. avatar.py builds its own regional client, so the
+ * cross-region call needs no extra plumbing.
+ *
+ * Alternatives if quality matters more than cost/latency:
+ * stability.stable-image-ultra-v1:1 (best quality) or stability.sd3-5-large-v1:0.
+ * All three share one request/response shape, so switching is just this constant.
+ *
+ * To re-check the landscape:
+ *   aws bedrock list-foundation-models --region us-west-2 \
+ *     --by-output-modality IMAGE \
  *     --query 'modelSummaries[].[modelId,modelLifecycle.status]' --output table
- * Note the successor may need a different request body than Nova Canvas's
- * TEXT_IMAGE/textToImageParams shape in lambda/shared/avatar.py.
+ * A model from a different VENDOR will need a new payload builder in
+ * lambda/shared/avatar.py — the body shapes are not interchangeable.
  */
-export const IMAGE_MODEL_ID = 'amazon.nova-canvas-v1:0';
+export const IMAGE_MODEL_ID = 'stability.stable-image-core-v1:1';
 
-/** Nova Canvas is not offered in every region; the avatar client pins this one. */
-export const IMAGE_MODEL_REGION = 'us-east-1';
+/** Image generators are region-limited; the avatar client pins this one. */
+export const IMAGE_MODEL_REGION = 'us-west-2';
 
 /**
  * IAM resource ARN for the avatar image model. Region-pinned (unlike the

--- a/voc-datalake/plugins/app_reviews_android/manifest.json
+++ b/voc-datalake/plugins/app_reviews_android/manifest.json
@@ -10,8 +10,8 @@
     "ingestor": {
       "enabled": true,
       "schedule": "rate(30 minutes)",
-      "timeout": 300,
-      "memory": 512
+      "timeout": 600,
+      "memory": 1024
     }
   },
 

--- a/voc-datalake/plugins/app_reviews_ios/manifest.json
+++ b/voc-datalake/plugins/app_reviews_ios/manifest.json
@@ -10,8 +10,8 @@
     "ingestor": {
       "enabled": true,
       "schedule": "rate(30 minutes)",
-      "timeout": 300,
-      "memory": 512
+      "timeout": 900,
+      "memory": 1024
     }
   },
 

--- a/voc-datalake/plugins/test_app_reviews_manifest_limits.py
+++ b/voc-datalake/plugins/test_app_reviews_manifest_limits.py
@@ -1,0 +1,93 @@
+"""App-review ingestors need a Lambda budget that scales with their storefront sweep.
+
+The iOS ingestor walks every storefront in IOS_COUNTRIES, paginating each one,
+and only returns after the whole loop finishes — so a timeout throws away
+everything collected so far instead of yielding partial progress. It ran on the
+300s default while the pagination work (continuation tokens, empty-page retries)
+increased how much it fetches per run, which is the combination that made runs
+die with nothing to show.
+
+These tests tie the manifest budgets to the actual driver (storefront count) and
+to the ceilings enforced in lib/plugin-loader.ts, so neither side can drift
+without failing.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+PLUGINS_DIR = Path(__file__).resolve().parent
+VOC_DIR = PLUGINS_DIR.parent
+
+# What the ingestors used to get, and what proved insufficient. Explicit literals
+# so a revert to them fails rather than silently passing.
+PREVIOUS_TIMEOUT = 300
+PREVIOUS_MEMORY = 512
+
+# Conservative floor for the per-storefront cost: each country is a paginated
+# HTTP walk with rate limiting, so well over a second each. Expressed per
+# storefront rather than as a flat number so that ADDING storefronts forces the
+# timeout to be revisited.
+MIN_SECONDS_PER_STOREFRONT = 10
+
+
+def _manifest(plugin_id: str) -> dict:
+    path = PLUGINS_DIR / plugin_id / 'manifest.json'
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def _ingestor(plugin_id: str) -> dict:
+    return _manifest(plugin_id)['infrastructure']['ingestor']
+
+
+def _loader_ceiling(field: str) -> int:
+    """Read the hard ceiling the CDK plugin loader enforces for a field."""
+    source = (VOC_DIR / 'lib' / 'plugin-loader.ts').read_text(encoding='utf-8')
+    match = re.search(rf'{field}: z\.number\(\)\.int\(\)\.min\(\d+\)\.max\((\d+)\)', source)
+    assert match, f'could not find the {field} ceiling in plugin-loader.ts'
+    return int(match.group(1))
+
+
+def _ios_storefront_count() -> int:
+    source = (PLUGINS_DIR / 'app_reviews_ios' / 'ingestor' / 'countries.py').read_text(encoding='utf-8')
+    block = source.split('IOS_COUNTRIES')[1]
+    return len(re.findall(r'"[a-z]{2}"', block.split(']')[0]))
+
+
+@pytest.mark.parametrize('plugin_id', ['app_reviews_ios', 'app_reviews_android'])
+class TestBudgetsWereRaised:
+    def test_timeout_exceeds_the_previous_default(self, plugin_id):
+        assert _ingestor(plugin_id)['timeout'] > PREVIOUS_TIMEOUT
+
+    def test_memory_exceeds_the_previous_default(self, plugin_id):
+        assert _ingestor(plugin_id)['memory'] > PREVIOUS_MEMORY
+
+
+@pytest.mark.parametrize('plugin_id', ['app_reviews_ios', 'app_reviews_android'])
+class TestBudgetsStayWithinLoaderLimits:
+    """lib/plugin-loader.ts rejects the whole synth if a manifest exceeds these,
+    so an over-eager bump breaks deployment rather than any test."""
+
+    def test_timeout_within_ceiling(self, plugin_id):
+        assert _ingestor(plugin_id)['timeout'] <= _loader_ceiling('timeout')
+
+    def test_memory_within_ceiling(self, plugin_id):
+        assert _ingestor(plugin_id)['memory'] <= _loader_ceiling('memory')
+
+
+class TestIosBudgetTracksItsStorefrontSweep:
+    def test_timeout_scales_with_storefront_count(self):
+        """Adding storefronts must force a timeout review, since nothing is
+        yielded until every one of them has been walked."""
+        required = _ios_storefront_count() * MIN_SECONDS_PER_STOREFRONT
+        assert _ingestor('app_reviews_ios')['timeout'] >= required
+
+    def test_ios_gets_at_least_as_long_as_android(self):
+        """iOS fans out across many storefronts; Android queries one locale."""
+        assert _ingestor('app_reviews_ios')['timeout'] >= _ingestor('app_reviews_android')['timeout']
+
+    def test_storefront_list_is_actually_large(self):
+        """Guards the premise: if the sweep were trimmed to a couple of
+        countries, the scaling test above would go slack without anyone noticing."""
+        assert _ios_storefront_count() >= 20


### PR DESCRIPTION
Four independent fixes from an audit of the prd-fix `LESSONS.en.md` backlog, plus two bugs that the audit work surfaced during deployment and review.

## 1. Research budgets came from a config nobody read

`lambda/api/prompts/research-analysis.json` declared `max_tokens: 9000` per step, but the async Step Functions research path hardcoded `4000/3000/3000` and kept its own copies of the system prompts. Only the sync `run_research` path ever read that JSON, so editing it silently did nothing for the async path and raised no error.

The JSON is live for the sync path, so deleting it was not an option. Instead both paths now read it:

- `shared/prompts.py` gains `get_step_inference_config()` / `get_research_step_config()`, returning a step's system prompt and budgets **without** building a user prompt. The async path needs that because its prompt injects personas, uploaded documents and web-search results, which the templated sync path has no placeholders for.
- `research_step_handler.py` resolves each step through one `_step_inference()` helper, replacing three inlined system prompts and three copies of the language-instruction block.

The three inline prompts were verified byte-identical to the JSON before removal, so **no prompt behaviour changes** — only budgets, and `thinking_budget` and `step_name` are now honoured rather than discarded.

## 2. Avatar image model was reaching EOL — now migrated

`amazon.nova-canvas-v1:0` entered LEGACY on 2026-03-30 with EOL on 2026-09-30. A legacy model also drops access for accounts idle 15+ days, which explains an earlier run of `ResourceNotFoundException`. Avatar generation degrades to `avatar_url=None` by design, so the model expiring produces **no user-visible error** — only a log line.

**Migrated to `stability.stable-image-core-v1:1` in us-west-2.** Enumerated against the account rather than guessed, which is what made this more than an id swap:

| region | active text-to-image generators |
|---|---|
| us-east-1 | **0** (only LEGACY Nova Canvas; every other image model there is a Stability *editing* primitive needing an input image) |
| us-west-2 | **3**: `stable-image-core-v1:1`, `stable-image-ultra-v1:1`, `sd3-5-large-v1:0` |
| eu-west-1 / ap-northeast-1 | 0 |

Scanned 16 regions; Titan Image Generator is no longer offered (`ResourceNotFoundException` on v1, v1:0 and v2:0 — only Titan *embedding* models remain), so there is no in-region alternative. All three candidates were probe-invoked from the account to confirm entitlement before choosing; Core is cheapest and fastest and is ample for a headshot.

Supporting work that made the region change cheap: the model id and region are single-sourced in `lib/utils/model-allowlist.ts`, three pasted IAM ARN literals in `api-stack.ts` now derive from `imageModelArn()`, and `avatar-generation.json`'s `image_model` block — which the code had never read — is now authoritative.

**Also `output_format: jpeg`.** The model emits 1536×1536 while avatars render at 32-128 CSS px (`w-8` in chat bubbles, `max-w-[128px]` for the large variant, 80 px in the PDF export). Measured on one seed: **png 2,677,833 bytes vs jpeg 401,603 — 6.7× smaller for identical pixels** (`webp` is rejected by the model). Resolution itself is not reducible here: these models expose `aspect_ratio` only, no width/height. Cutting pixels would need Pillow and a layer rebuild, deliberately left out.

## 3. App-review ingestors were sized for less work than they do

The iOS ingestor walks all 40 storefronts in `IOS_COUNTRIES`, paginating each, and only returns once the whole loop finishes — so a timeout discards everything collected. It ran on the 300s/512MB default while pagination work increased how much each run fetches.

- iOS: `timeout 300 → 900`, `memory 512 → 1024`
- Android: `timeout 300 → 600`, `memory 512 → 1024`

Both sit inside the ceilings `plugin-loader.ts` already enforces. Tests read those ceilings from the loader rather than restating them, and tie the iOS timeout to the storefront count so adding countries forces a review.

## 4. The research Lambda shipped without its prompt config

Found by inspecting the deployed bundle: the research Lambda had **no `prompts/` directory at all**, so `get_research_step_config()` would raise `FileNotFoundError` on every job. Reading budgets from JSON turned a build-time constant into a runtime file dependency, and the research asset excluded the whole `/api/` subtree.

Unit tests structurally could not catch this — locally `get_prompts_dir()` resolves the repo layout either way. The `cp` into the bundle is the actual fix; the `/api/*` + `!/api/prompts` exclude keeps the config in the asset fingerprint so editing it redeploys the function.

## Verification

Gates on the current head:

- backend pytest **1223 passed**
- CDK vitest **92 passed**, `tsc --noEmit` clean (re-confirmed after the latest test edits)
- zero new ruff findings (project baseline is pre-existing)
- fail-on-revert verified for change 1 (4 tests fail against the reverted code)

Deployed to a test account and verified live:

- ingestor config live: iOS `Timeout=900 MemorySize=1024`, Android `Timeout=600 MemorySize=1024`
- `scripts/test-api.sh` **32/32**
- deployed research bundle re-inspected: `prompts/` present with all six configs, and a **live invocation of the deployed research Lambda logged** `max_tokens=9000, thinking_budget=5000` with zero `FileNotFoundError`
- **avatar path against real Bedrock:** a live generation on `stability.stable-image-core-v1:1` in us-west-2 returned one image, 2,677,833 bytes as PNG and 401,603 as JPEG, valid magic bytes, `finish_reasons=[None]`, reproducible seed
- **deployed IAM for the new cross-region ARN:** `iam simulate-principal-policy` returns **allowed** for `ProjectsLambdaRole`, `PersonaGeneratorRole` and `PersonaImporterRole` — the half local invocation cannot prove, since CLI credentials are Admin while the Lambdas use narrow roles

### Known gaps in verification

- The avatar path has **not** been exercised through the persona-generation UI or the PDF export. The S3 key and `ContentType` derive from `output_format`, and an audit found the key is constructed in exactly one place (`avatar.py`) with `core-stack.ts`/`api-stack.ts` using `avatars/*` wildcards and `get_avatar_cdn_url` parsing the trailing segment generically — but that is static evidence, not a rendered avatar.
- The last commits are **not deployed**; their runtime effect is limited to log labels, the seed offset and orphan cleanup.

## Notes for reviewers

- Change 1 alters no prompts, only budgets.
- Because the S3 key embeds the image format, a format change would orphan a persona's previous avatar; generation now best-effort deletes the other-extension objects, since no other avatar cleanup path exists in the codebase.
- The Python↔TypeScript lockstep tests parse TS with regex, following the existing `test_model_config.py` precedent rather than introducing a second convention.
- Per-storefront progress persistence for the iOS sweep is the real fix for that ingestor and is intentionally left to its own PR.
