### PR TITLE
chore(workshop): publish VocWebSearchStack with the workshop artifacts

### DIFF
--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 npx cdk synth --all && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all && node scripts/convert-template.mjs VocCoreStack VocIngestionStack  VocProcessingStack VocApiStack BedrockAccessStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack  VocProcessingStack VocApiStack BedrockAccessStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack  VocProcessingStack VocApiStack BedrockAccessStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 npx cdk synth --all && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },


### PR DESCRIPTION
## Problem

Web search deploys by default since #206, so a plain `cdk synth --all` emits `VocProcessingStack` and `VocApiStack` templates containing `Fn::ImportValue` on the gateway's exports:

```
VocWebSearchStack:ExportsOutputFnGetAttWebSearchGatewayGatewayArnBA97E0DC
VocWebSearchStack:ExportsOutputFnGetAttWebSearchGatewayGatewayUrlE01706EF
```

But `generate:workshop-artifacts` only converted five stacks, so `VocWebSearchStack` was never published alongside them.

Deploying those templates into a Workshop Studio event fails at CREATE:

```
No export named VocWebSearchStack:ExportsOutputFnGetAttWebSearchGatewayGatewayArnBA97E0DC found
```

`VocProcessingStack` and `VocApiStack` both fail in about 30 seconds with **zero resources created**. Because `VocApiStack` owns the frontend `BucketDeployment`, the event is also left with no API Gateway and an empty frontend bucket, so nothing is reachable. The imports are consumed by `ResearchStepLambda` (processing) and `ChatStreamApi` (api) plus their IAM policies.

This was hit on a real workshop test event: 2 of 5 stacks came up, 3 failed.

## Change

One line: add `VocWebSearchStack` to the `convert-template.mjs` stack list in `generate:workshop-artifacts`, so the exporting stack is published with its consumers. Listed first to mirror the `--all` deploy order, where it is stack `[1/6]`.

## Why no special handling is needed

- `addAssetParameters()` runs unconditionally in `convert-template.mjs`, so the converted template declares the usual `AssetBucket`/`AssetPrefix` parameters even though this stack has no Lambda assets. Its workshop `contentspec.yaml` entry is therefore uniform with the other five.
- Export names are emitted from the **CDK stack id**, so they match the consumers' imports regardless of the deployed CloudFormation stack name (Workshop Studio lowercases stack names).
- Every other transform in the converter is guarded (`continue` / optional chaining / `if (policyKey)`), so an asset-less stack passes through cleanly.

## Verification

Synthesized and converted the stack (`AWS_REGION=us-east-1`):

- Resources: `AWS::IAM::Role`, `AWS::BedrockAgentCore::Gateway`, `AWS::IAM::Policy`, `AWS::BedrockAgentCore::GatewayTarget` — 4 total, no Lambda.
- `Parameters`: `[AssetBucket, AssetPrefix]`.
- Export names match `VocProcessingStack`'s imports byte for byte.
- No `Custom::CrossRegionExportWriter` and no SSM cross-region reader when the app region is us-east-1.

`package.json` remains valid JSON (23 scripts). No application code, IaC or IAM is touched, so runtime behaviour and every non-workshop `cdk deploy` are unchanged.

## Note for whoever publishes workshop artifacts

Pin the synth region to us-east-1. `VocWebSearchStack` is hard-pinned to us-east-1, so when the ambient region differs, CDK switches to cross-region references: the stack grows a `Custom::CrossRegionExportWriter` plus a Lambda, and the consumers read the gateway through SSM instead of `Fn::ImportValue` — a different wiring shape than the published templates expect.

Note that the CDK CLI **overwrites** `CDK_DEFAULT_REGION` for the app subprocess, so setting that variable has no effect. Use `AWS_REGION` / `AWS_DEFAULT_REGION` or `--profile`. This is easy to hit silently, since the region otherwise comes from the `[default]` profile in `~/.aws/config`, and `contentspec.yaml` lists us-west-2 as a deployable region.

Pinning the region inside the npm script was deliberately left out of this PR to keep it to the one-line fix; happy to add it if preferred.

## Out of scope

A workshop test event separately showed that the event account's private marketplace can refuse `CreateFoundationModelAgreement` for the newest models (Sonnet 5 and Opus 5 were denied; Sonnet 4.6 and Haiku 4.5 succeeded). That is an event-account entitlement issue, independent of this change, and is not addressed here.
