### PR TITLE
chore(workshop): make workshop artifacts deployable (5-template cap + model pin)

### DIFF
--- a/voc-datalake/lambda/custom_resources/model_pin.py
+++ b/voc-datalake/lambda/custom_resources/model_pin.py
@@ -1,0 +1,85 @@
+"""Deploy-time seed for the global model pin (``settings.model_id``).
+
+Why this exists
+--------------
+Some accounts cannot invoke the newest Claude models. Workshop Studio events in
+particular sit behind an AWS Private Marketplace that refuses
+``CreateFoundationModelAgreement`` for Sonnet 5 / Opus 5, while Sonnet 4.6 and
+Haiku 4.5 work. Those events are fully automated: nobody can open Settings and
+pick a model per participant account, so the choice has to be made at deploy
+time.
+
+How it works
+------------
+``shared/model_config.py`` resolves a surface's model as::
+
+    explicit argument
+    > per-surface override (settings.surfaces[S])
+    > legacy global override (settings.model_id)     <- what this writes
+    > built-in SURFACE_DEFAULTS[S]
+    > BEDROCK_MODEL_ID
+
+Writing the single ``model_id`` attribute therefore repoints **every** surface,
+using a path both resolvers already implement (the TypeScript streaming-chat
+lookup in ``lambda/stream/src/bedrock/model-override.ts`` honours the same
+precedence). No change to ``SURFACE_DEFAULTS`` is needed, so deployments that
+can use the newer models are unaffected.
+
+Create-once, like the sibling admin bootstrap: the write is conditional on
+``model_id`` being absent, so an admin who later picks a model in Settings is
+never overwritten by a redeploy. It is a floor, not a lock — per-surface
+overrides still outrank it.
+"""
+import logging
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+MODEL_SETTINGS_PK = 'SETTINGS#model'
+MODEL_SETTINGS_SK = 'config'
+
+PHYSICAL_ID = 'voc-model-pin'
+
+
+def handler(event, _context):
+    """Seed settings.model_id unless it is already set.
+
+    Raises on unexpected failures: a silent no-op would leave the deployment
+    green while every AI surface resolves to a model the account cannot
+    invoke, which is far harder to diagnose than a failed stack.
+    """
+    request_type = event.get('RequestType')
+    props = event.get('ResourceProperties', {})
+    model_id = props.get('ModelId', '')
+    # Both arrive as resource properties from core-stack.ts. Deliberately no
+    # AGGREGATES_TABLE env fallback: nothing sets that variable on this
+    # function, and the fallback would mask a missing property (it silently
+    # absorbed one in tests, where lambda/conftest.py defines it).
+    table_name = props.get('TableName', '')
+
+    if request_type == 'Delete':
+        # Leave the setting in place; deleting the stack should not silently
+        # repoint a still-running app, and the table goes with it anyway.
+        return {'PhysicalResourceId': PHYSICAL_ID, 'Data': {'outcome': 'skipped'}}
+
+    if not model_id or not table_name:
+        raise ValueError(f'ModelId and TableName are required (got {model_id!r}, {table_name!r})')
+
+    table = boto3.resource('dynamodb').Table(table_name)
+    try:
+        table.update_item(
+            Key={'pk': MODEL_SETTINGS_PK, 'sk': MODEL_SETTINGS_SK},
+            UpdateExpression='SET model_id = :m',
+            ConditionExpression='attribute_not_exists(model_id)',
+            ExpressionAttributeValues={':m': model_id},
+        )
+        logger.info(f'Pinned every AI surface to {model_id}')
+        outcome = 'pinned'
+    except table.meta.client.exceptions.ConditionalCheckFailedException:
+        # Already configured (a previous deploy, or an admin's own choice).
+        logger.info(f'model_id already set; leaving it untouched (wanted {model_id})')
+        outcome = 'kept'
+
+    return {'PhysicalResourceId': PHYSICAL_ID, 'Data': {'outcome': outcome, 'modelId': model_id}}

--- a/voc-datalake/lambda/custom_resources/test/test_model_pin.py
+++ b/voc-datalake/lambda/custom_resources/test/test_model_pin.py
@@ -1,0 +1,141 @@
+"""Tests for the deploy-time global model pin.
+
+Fail-on-revert intent:
+  - the write MUST be conditional, so a redeploy cannot clobber a model an
+    admin later picked in Settings (create-once, like admin_bootstrap);
+  - an unexpected failure MUST raise, because a silent no-op leaves the stack
+    green while every AI surface resolves to a model the account cannot invoke.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class _ConditionalCheckFailed(Exception):
+    pass
+
+
+class _FakeTable:
+    def __init__(self, *, raises=None):
+        self.raises = raises
+        self.calls = []
+
+        conditional = _ConditionalCheckFailed
+
+        class _Exceptions:
+            ConditionalCheckFailedException = conditional
+
+        class _Client:
+            exceptions = _Exceptions()
+
+        class _Meta:
+            client = _Client()
+
+        self.meta = _Meta()
+
+    def update_item(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises is not None:
+            raise self.raises
+        return {}
+
+
+def _load(table):
+    """Import model_pin with boto3 stubbed to hand back our fake table."""
+    fake_boto3 = types.ModuleType('boto3')
+    fake_boto3.resource = lambda *_a, **_k: types.SimpleNamespace(Table=lambda _n: table)
+
+    saved_boto3 = sys.modules.get('boto3')
+    saved_module = sys.modules.pop('model_pin', None)
+    sys.modules['boto3'] = fake_boto3
+    try:
+        import model_pin  # noqa: PLC0415 — deliberate re-import under the stub
+        return model_pin
+    finally:
+        if saved_boto3 is None:
+            sys.modules.pop('boto3', None)
+        else:
+            sys.modules['boto3'] = saved_boto3
+        if saved_module is not None:
+            sys.modules['model_pin'] = saved_module
+        else:
+            sys.modules.pop('model_pin', None)
+
+
+def _event(request_type='Create', **props):
+    base = {'TableName': 'voc-aggregates', 'ModelId': 'global.anthropic.claude-sonnet-4-6'}
+    base.update(props)
+    return {'RequestType': request_type, 'ResourceProperties': base}
+
+
+def test_pins_the_model_when_unset():
+    table = _FakeTable()
+    module = _load(table)
+
+    result = module.handler(_event(), None)
+
+    assert result['Data']['outcome'] == 'pinned'
+    assert result['Data']['modelId'] == 'global.anthropic.claude-sonnet-4-6'
+    call = table.calls[0]
+    assert call['Key'] == {'pk': 'SETTINGS#model', 'sk': 'config'}
+    assert call['ExpressionAttributeValues'] == {':m': 'global.anthropic.claude-sonnet-4-6'}
+
+
+def test_write_is_conditional_so_a_redeploy_cannot_clobber_an_admin_choice():
+    table = _FakeTable()
+    module = _load(table)
+
+    module.handler(_event(), None)
+
+    assert table.calls[0]['ConditionExpression'] == 'attribute_not_exists(model_id)'
+
+
+def test_existing_value_is_kept_not_overwritten():
+    table = _FakeTable(raises=_ConditionalCheckFailed('already set'))
+    module = _load(table)
+
+    result = module.handler(_event(), None)
+
+    assert result['Data']['outcome'] == 'kept'
+
+
+def test_unexpected_errors_raise_rather_than_silently_no_op():
+    table = _FakeTable(raises=RuntimeError('table on fire'))
+    module = _load(table)
+
+    with pytest.raises(RuntimeError):
+        module.handler(_event(), None)
+
+
+def test_delete_is_a_no_op_and_leaves_the_setting_alone():
+    table = _FakeTable()
+    module = _load(table)
+
+    result = module.handler(_event('Delete'), None)
+
+    assert result['Data']['outcome'] == 'skipped'
+    assert table.calls == []
+
+
+@pytest.mark.parametrize('missing', ['TableName', 'ModelId'])
+def test_missing_required_properties_raise(missing):
+    table = _FakeTable()
+    module = _load(table)
+
+    with pytest.raises(ValueError):
+        module.handler(_event(**{missing: ''}), None)
+
+
+def test_physical_id_is_stable_across_request_types():
+    """A changing PhysicalResourceId would make CloudFormation replace/delete the resource."""
+    table = _FakeTable()
+    module = _load(table)
+
+    created = module.handler(_event(), None)['PhysicalResourceId']
+    deleted = module.handler(_event('Delete'), None)['PhysicalResourceId']
+
+    assert created == deleted

--- a/voc-datalake/lambda/shared/test/test_model_agreement_handler.py
+++ b/voc-datalake/lambda/shared/test/test_model_agreement_handler.py
@@ -52,7 +52,9 @@ class _FakeConflict(Exception):
     pass
 
 
-def _load_handler(*, create_raises: Exception | None = None):
+def _load_handler(*, create_raises: Exception | None = None,
+                  availability_raises: Exception | None = None,
+                  offers_raises: Exception | None = None):
     """exec the extracted handler with boto3/botocore stubbed out."""
     calls: dict[str, int] = {'create': 0}
 
@@ -62,9 +64,13 @@ def _load_handler(*, create_raises: Exception | None = None):
             AccessDeniedException = _FakeClientError
 
         def get_foundation_model_availability(self, modelId):  # noqa: N803
+            if availability_raises is not None:
+                raise availability_raises
             return {'agreementAvailability': {'status': 'NOT_AVAILABLE'}}
 
         def list_foundation_model_agreement_offers(self, modelId):  # noqa: N803
+            if offers_raises is not None:
+                raise offers_raises
             return {'offers': [{'offerToken': 'tok'}]}
 
         def create_foundation_model_agreement(self, modelId, offerToken):  # noqa: N803
@@ -117,6 +123,36 @@ def test_access_denied_is_non_fatal_and_reported():
     assert result['Data']['status'] == 'UNAVAILABLE'
     assert result['Data']['modelId'] == 'anthropic.claude-sonnet-5'
     assert result['Data']['errorCode'] == 'AccessDeniedException'
+
+
+def test_access_denied_from_the_availability_call_STILL_RAISES():
+    """The absorption is scoped to create_foundation_model_agreement only.
+
+    An AccessDenied from get_foundation_model_availability means this stack's
+    own role lacks a permission — a real bug — so it must fail the deployment
+    instead of being reported as an unavailable model. (Caught in review of
+    PR #269: the first version wrapped the whole try block.)
+    """
+    handler, calls = _load_handler(
+        availability_raises=_FakeClientError('AccessDeniedException', 'no bedrock:GetFoundationModelAvailability')
+    )
+
+    with pytest.raises(_FakeClientError):
+        handler(_event(), None)
+
+    assert calls['create'] == 0, 'must fail before attempting the agreement'
+
+
+def test_access_denied_from_the_offers_call_STILL_RAISES():
+    """Same reasoning for list_foundation_model_agreement_offers."""
+    handler, calls = _load_handler(
+        offers_raises=_FakeClientError('AccessDeniedException', 'no bedrock:ListFoundationModelAgreementOffers')
+    )
+
+    with pytest.raises(_FakeClientError):
+        handler(_event(), None)
+
+    assert calls['create'] == 0
 
 
 def test_other_client_errors_still_fail_the_stack():

--- a/voc-datalake/lambda/shared/test/test_model_agreement_handler.py
+++ b/voc-datalake/lambda/shared/test/test_model_agreement_handler.py
@@ -1,0 +1,145 @@
+"""Behavioural tests for BedrockAccessStack's inline ModelAgreement handler.
+
+The handler lives as an inline Python string inside
+``lib/stacks/bedrock-access-stack.ts`` (``getModelAgreementLambdaCode``), so it
+has no import path of its own. These tests extract that string and ``exec`` it
+with a stubbed boto3, which is the only way to exercise its branches.
+
+Fail-on-revert intent: a Private-Marketplace ``AccessDeniedException`` on
+CreateFoundationModelAgreement must NOT fail the stack (the whole point of the
+non-fatal branch), while every other error must still raise. Reverting either
+half turns one of these red.
+
+Precedent for reading a TS file from a Python test:
+``test_avatar_image_model_lockstep.py``.
+"""
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    # …/voc-datalake/lambda/shared/test/this_file.py -> …/voc-datalake
+    return Path(__file__).resolve().parents[3]
+
+
+def _handler_source() -> str:
+    """Extract the inline handler body from the CDK stack."""
+    ts = (_repo_root() / 'lib' / 'stacks' / 'bedrock-access-stack.ts').read_text(encoding='utf-8')
+    match = re.search(
+        r'private getModelAgreementLambdaCode\(\): string \{\s*return `(.*?)`;\s*\}',
+        ts,
+        re.DOTALL,
+    )
+    assert match, 'getModelAgreementLambdaCode() template literal not found'
+    source = match.group(1)
+    # The TS template literal escapes ${...} so Python f-strings survive.
+    return source.replace('\\${', '${')
+
+
+class _FakeClientError(Exception):
+    """Stand-in for botocore ClientError (same .response shape)."""
+
+    def __init__(self, code: str, message: str = 'denied'):
+        super().__init__(message)
+        self.response = {'Error': {'Code': code, 'Message': message}}
+
+
+class _FakeConflict(Exception):
+    pass
+
+
+def _load_handler(*, create_raises: Exception | None = None):
+    """exec the extracted handler with boto3/botocore stubbed out."""
+    calls: dict[str, int] = {'create': 0}
+
+    class _Bedrock:
+        class exceptions:  # noqa: N801 — mirrors botocore's client.exceptions
+            ConflictException = _FakeConflict
+            AccessDeniedException = _FakeClientError
+
+        def get_foundation_model_availability(self, modelId):  # noqa: N803
+            return {'agreementAvailability': {'status': 'NOT_AVAILABLE'}}
+
+        def list_foundation_model_agreement_offers(self, modelId):  # noqa: N803
+            return {'offers': [{'offerToken': 'tok'}]}
+
+        def create_foundation_model_agreement(self, modelId, offerToken):  # noqa: N803
+            calls['create'] += 1
+            if create_raises is not None:
+                raise create_raises
+            return {}
+
+    fake_boto3 = types.ModuleType('boto3')
+    fake_boto3.client = lambda *a, **k: _Bedrock()
+
+    fake_botocore = types.ModuleType('botocore')
+    fake_exceptions = types.ModuleType('botocore.exceptions')
+    fake_exceptions.ClientError = _FakeClientError
+    fake_botocore.exceptions = fake_exceptions
+
+    saved = {k: sys.modules.get(k) for k in ('boto3', 'botocore', 'botocore.exceptions')}
+    sys.modules['boto3'] = fake_boto3
+    sys.modules['botocore'] = fake_botocore
+    sys.modules['botocore.exceptions'] = fake_exceptions
+    try:
+        namespace: dict = {}
+        exec(compile(_handler_source(), '<model-agreement-handler>', 'exec'), namespace)
+        return namespace['handler'], calls
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+def _event():
+    return {'RequestType': 'Create', 'ResourceProperties': {'modelId': 'anthropic.claude-sonnet-5',
+                                                            'region': 'us-east-1'}}
+
+
+def test_access_denied_is_non_fatal_and_reported():
+    """A Private-Marketplace refusal must return UNAVAILABLE, not raise."""
+    handler, calls = _load_handler(
+        create_raises=_FakeClientError(
+            'AccessDeniedException',
+            'Unauthorized to perform action due to private marketplace eligibility',
+        )
+    )
+
+    result = handler(_event(), None)
+
+    assert calls['create'] == 1, 'the agreement call should have been attempted'
+    assert result['Data']['status'] == 'UNAVAILABLE'
+    assert result['Data']['modelId'] == 'anthropic.claude-sonnet-5'
+    assert result['Data']['errorCode'] == 'AccessDeniedException'
+
+
+def test_other_client_errors_still_fail_the_stack():
+    """Absorbing everything would hide real breakage, so only the allowlisted code is caught."""
+    handler, _ = _load_handler(create_raises=_FakeClientError('ThrottlingException', 'slow down'))
+
+    with pytest.raises(_FakeClientError):
+        handler(_event(), None)
+
+
+def test_happy_path_still_reports_created():
+    handler, calls = _load_handler()
+
+    result = handler(_event(), None)
+
+    assert calls['create'] == 1
+    assert result['Data']['status'] == 'CREATED'
+
+
+def test_conflict_is_still_treated_as_already_existing():
+    """The ClientError branch must not shadow the ConflictException branch."""
+    handler, _ = _load_handler(create_raises=_FakeConflict('already there'))
+
+    result = handler(_event(), None)
+
+    assert result['Data']['status'] == 'ALREADY_EXISTS'

--- a/voc-datalake/lambda/shared/test/test_model_agreement_handler.py
+++ b/voc-datalake/lambda/shared/test/test_model_agreement_handler.py
@@ -48,8 +48,19 @@ class _FakeClientError(Exception):
         self.response = {'Error': {'Code': code, 'Message': message}}
 
 
-class _FakeConflict(Exception):
-    pass
+class _FakeConflict(_FakeClientError):
+    """Stand-in for bedrock's ConflictException.
+
+    MUST subclass _FakeClientError: botocore's ConflictException *is* a
+    ClientError subclass, so the handler's inner `except ClientError` sees it
+    first and re-raises it (code not in NON_FATAL_ERROR_CODES) to the outer
+    ConflictException handler. A sibling class would skip that inner branch
+    entirely and the "ClientError branch does not shadow ConflictException"
+    assertion below would prove nothing. (Review nit on PR #269.)
+    """
+
+    def __init__(self, message: str = 'already exists'):
+        super().__init__('ConflictException', message)
 
 
 def _load_handler(*, create_raises: Exception | None = None,

--- a/voc-datalake/lib/stacks/bedrock-access-stack.ts
+++ b/voc-datalake/lib/stacks/bedrock-access-stack.ts
@@ -391,12 +391,37 @@ def handler(event, context):
             raise Exception(f"Offer token not found for {model_id}")
         
         logger.info(f"Creating agreement for {model_id}")
-        
-        # Create the agreement (accepts EULA)
-        bedrock.create_foundation_model_agreement(
-            modelId=model_id,
-            offerToken=offer_token
-        )
+
+        # Create the agreement (accepts EULA).
+        # The non-fatal absorption below is scoped to THIS call only. An
+        # AccessDeniedException from get_foundation_model_availability or
+        # list_foundation_model_agreement_offers above means this stack's own
+        # role is missing a permission — a real bug — and must still fail the
+        # deployment rather than be reported as an unavailable model.
+        try:
+            bedrock.create_foundation_model_agreement(
+                modelId=model_id,
+                offerToken=offer_token
+            )
+        except ClientError as e:
+            code = e.response.get('Error', {}).get('Code', '')
+            if code not in NON_FATAL_ERROR_CODES:
+                # Includes ConflictException, which the outer handler below
+                # turns into ALREADY_EXISTS.
+                raise
+            # The account is not allowed to accept this model's agreement (e.g.
+            # a Private Marketplace restriction). Report it instead of failing:
+            # the models whose agreements DID succeed remain usable, and a
+            # model that is unavailable here would only surface as an
+            # AccessDenied at inference time anyway.
+            logger.warning(
+                f"Agreement unavailable for {model_id} ({code}): {str(e)}. "
+                "Continuing — this model will not be invocable in this account."
+            )
+            return {
+                'PhysicalResourceId': f'model-agreement-{model_id}',
+                'Data': {'status': 'UNAVAILABLE', 'modelId': model_id, 'errorCode': code}
+            }
         
         logger.info(f"Successfully created agreement for {model_id}")
         
@@ -411,29 +436,6 @@ def handler(event, context):
         return {
             'PhysicalResourceId': f'model-agreement-{model_id}',
             'Data': {'status': 'ALREADY_EXISTS', 'modelId': model_id}
-        }
-
-    except ClientError as e:
-        # MUST stay below the ConflictException handler: that exception is also
-        # a ClientError, so ordering it first would swallow the already-exists
-        # case. Only the codes in NON_FATAL_ERROR_CODES are absorbed; every
-        # other ClientError still raises and fails the stack.
-        code = e.response.get('Error', {}).get('Code', '')
-        if code not in NON_FATAL_ERROR_CODES:
-            logger.error(f"Error creating agreement for {model_id}: {str(e)}")
-            raise
-        # The account is not allowed to accept this model's agreement (e.g. a
-        # Private Marketplace restriction). Report it instead of failing: the
-        # models whose agreements DID succeed remain usable, and a model that
-        # is unavailable here would only surface as an AccessDenied at
-        # inference time anyway.
-        logger.warning(
-            f"Agreement unavailable for {model_id} ({code}): {str(e)}. "
-            "Continuing — this model will not be invocable in this account."
-        )
-        return {
-            'PhysicalResourceId': f'model-agreement-{model_id}',
-            'Data': {'status': 'UNAVAILABLE', 'modelId': model_id, 'errorCode': code}
         }
 
     except Exception as e:

--- a/voc-datalake/lib/stacks/bedrock-access-stack.ts
+++ b/voc-datalake/lib/stacks/bedrock-access-stack.ts
@@ -321,9 +321,18 @@ export class BedrockAccessStack extends cdk.Stack {
 import boto3
 import json
 import logging
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+# Agreement failures that are a property of the ACCOUNT, not a bug in this
+# stack, and must not fail the deployment. Workshop Studio accounts sit behind
+# an AWS Private Marketplace that refuses CreateFoundationModelAgreement for
+# the newest models, which would otherwise take the whole stack (and, when it
+# is not last in the deploy order, everything after it) down over a model the
+# deployment may not even use.
+NON_FATAL_ERROR_CODES = ('AccessDeniedException',)
 
 def handler(event, context):
     """
@@ -403,7 +412,30 @@ def handler(event, context):
             'PhysicalResourceId': f'model-agreement-{model_id}',
             'Data': {'status': 'ALREADY_EXISTS', 'modelId': model_id}
         }
-        
+
+    except ClientError as e:
+        # MUST stay below the ConflictException handler: that exception is also
+        # a ClientError, so ordering it first would swallow the already-exists
+        # case. Only the codes in NON_FATAL_ERROR_CODES are absorbed; every
+        # other ClientError still raises and fails the stack.
+        code = e.response.get('Error', {}).get('Code', '')
+        if code not in NON_FATAL_ERROR_CODES:
+            logger.error(f"Error creating agreement for {model_id}: {str(e)}")
+            raise
+        # The account is not allowed to accept this model's agreement (e.g. a
+        # Private Marketplace restriction). Report it instead of failing: the
+        # models whose agreements DID succeed remain usable, and a model that
+        # is unavailable here would only surface as an AccessDenied at
+        # inference time anyway.
+        logger.warning(
+            f"Agreement unavailable for {model_id} ({code}): {str(e)}. "
+            "Continuing — this model will not be invocable in this account."
+        )
+        return {
+            'PhysicalResourceId': f'model-agreement-{model_id}',
+            'Data': {'status': 'UNAVAILABLE', 'modelId': model_id, 'errorCode': code}
+        }
+
     except Exception as e:
         logger.error(f"Error creating agreement for {model_id}: {str(e)}")
         raise

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -14,8 +14,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Construct } from 'constructs';
 import { uniqueName } from '../utils/naming';
+import { ALLOWED_MODEL_IDS } from '../utils/model-allowlist';
 import { NagSuppressions } from 'cdk-nag';
-import { idempotencyTableSuppressions, websiteBucketSuppressions, cloudfrontDefaultCertSuppressions, cognitoSecuritySuppressions, cdkCustomResourceSuppressions, lambdaBasicExecutionRoleSuppressions, cdnSigningKeySuppressions } from '../utils/nag-suppressions';
+import { idempotencyTableSuppressions, websiteBucketSuppressions, cloudfrontDefaultCertSuppressions, cognitoSecuritySuppressions, cdkCustomResourceSuppressions, lambdaBasicExecutionRoleSuppressions, cdnSigningKeySuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions } from '../utils/nag-suppressions';
 
 export interface VocCoreStackProps extends cdk.StackProps {
   brandName: string;
@@ -759,6 +760,96 @@ export class VocCoreStack extends cdk.Stack {
       ],
       true
     );
+
+    // ============================================
+    // GLOBAL MODEL PIN (opt-in, for accounts that cannot use the newest models)
+    // ============================================
+    // `-c defaultModelId=<allowlisted id>` seeds settings.model_id, the legacy
+    // global override that outranks SURFACE_DEFAULTS in both resolvers
+    // (shared/model_config.py and lambda/stream/src/bedrock/model-override.ts).
+    // One attribute therefore repoints every AI surface without touching the
+    // built-in defaults, so deployments that CAN use the newer models are
+    // unaffected.
+    //
+    // Motivating case: Workshop Studio events sit behind a Private Marketplace
+    // that refuses the model agreements for Sonnet 5 / Opus 5, and they are
+    // fully automated — there is no human to pick a model per participant
+    // account. Without the flag nothing below is created at all.
+    const defaultModelIdRaw = this.node.tryGetContext('defaultModelId');
+    if (defaultModelIdRaw !== undefined && defaultModelIdRaw !== null && defaultModelIdRaw !== '') {
+      const defaultModelId = String(defaultModelIdRaw);
+      // Fail at synth rather than writing a value the app would ignore:
+      // _allowlisted() drops non-allowlisted ids at read time, which would
+      // silently fall back to the defaults this flag exists to avoid.
+      if (!ALLOWED_MODEL_IDS.includes(defaultModelId)) {
+        throw new Error(
+          `defaultModelId '${defaultModelId}' is not in the model allowlist. ` +
+          `Allowed: ${ALLOWED_MODEL_IDS.join(', ')}`,
+        );
+      }
+
+      const modelPinLambda = new lambda.Function(this, 'ModelPinLambda', {
+        functionName: uniqueName('voc-model-pin'),
+        runtime: lambda.Runtime.PYTHON_3_14,
+        architecture: lambda.Architecture.ARM_64,
+        handler: 'index.handler',
+        // Real, unit-tested file (lambda/custom_resources/test), inlined so a
+        // small handler needs no asset bundling — same pattern as
+        // AdminBootstrapLambda.
+        code: lambda.Code.fromInline(
+          fs.readFileSync(path.join(__dirname, '../../lambda/custom_resources/model_pin.py'), 'utf8'),
+        ),
+        timeout: cdk.Duration.minutes(1),
+        description: 'Seeds the global Bedrock model pin (create once, never reset)',
+        logGroup: new logs.LogGroup(this, 'ModelPinLambdaLogs', {
+          retention: logs.RetentionDays.TWO_WEEKS,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      });
+      this.aggregatesTable.grantWriteData(modelPinLambda);
+
+      const modelPinProvider = new cr.Provider(this, 'ModelPinProvider', {
+        onEventHandler: modelPinLambda,
+        logGroup: new logs.LogGroup(this, 'ModelPinProviderLogs', {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      });
+
+      new cdk.CustomResource(this, 'ModelPin', {
+        serviceToken: modelPinProvider.serviceToken,
+        resourceType: 'Custom::ModelPin',
+        properties: {
+          TableName: this.aggregatesTable.tableName,
+          ModelId: defaultModelId,
+        },
+      });
+
+      new cdk.CfnOutput(this, 'DefaultModelPin', { value: defaultModelId });
+
+      // grantWriteData() emits the standard GSI (<TableArn>/index/*) and KMS
+      // (GenerateDataKey*/ReEncrypt*) wildcards, so reuse the shared
+      // suppressions rather than restating the same evidence.
+      NagSuppressions.addResourceSuppressions(
+        modelPinLambda,
+        [...lambdaBasicExecutionRoleSuppressions, ...dynamoDbGsiSuppressions, ...kmsEncryptionSuppressions],
+        true,
+      );
+      NagSuppressions.addResourceSuppressionsByPath(
+        this,
+        `${this.stackName}/ModelPinProvider/framework-onEvent`,
+        [
+          ...cdkCustomResourceSuppressions,
+          ...lambdaBasicExecutionRoleSuppressions,
+          {
+            id: 'AwsSolutions-IAM5',
+            reason: 'The CDK Provider framework invokes its handler by qualified ARN, requiring a version/alias wildcard scoped to ModelPinLambda only (same pattern as AdminBootstrapLambda).',
+            appliesTo: [{ regex: '/Resource::<.*ModelPinLambda.*\\.Arn>:\\*/' }],
+          },
+        ],
+        true
+      );
+    }
 
     // ============================================
     // COGNITO IDENTITY POOL (for AWS IAM authentication)

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c enableWebSearch=false && node scripts/convert-template.mjs VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c enableWebSearch=false -c defaultModelId=global.anthropic.claude-sonnet-4-6 && node scripts/convert-template.mjs VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c enableWebSearch=false && node scripts/convert-template.mjs VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },


### PR DESCRIPTION
Makes the workshop artifacts deployable in a Workshop Studio event. Three commits, two independent problems.

## 1. Web search cannot be published (fixes what #268 attempted)

#268 added `VocWebSearchStack` to the converter's stack list so the exporting stack would ship alongside the `VocProcessingStack`/`VocApiStack` templates that `Fn::ImportValue` its gateway ARN and URL. That turns out to be unpublishable — Workshop Studio rejects a contentspec referencing more than **5** CloudFormation templates:

```
INFRASTRUCTURE_VALIDATION_ERROR
[Contentspec Error - cloudformationTemplates] total number of cloudformation
templates referenced as a part of this infrastructure configuration exceeded 5
```

The workshop already publishes 5 and none can give up the slot: `BedrockAccessStack` creates the Bedrock model agreements, without which the app cannot invoke any model.

So the workshop opts out instead: synth with `-c enableWebSearch=false`, which drops the stack from the app and removes the imports from its consumers, leaving exactly 5 templates and no dangling exports. The 5-step participant lab never exercised web search — verified four ways: zero mentions across all content files and guides; all three backend entry points are strict opt-in; the UI hides both the chat toggle and the research data-source card when the feature flag is false; and an explicit request degrades with a warning rather than failing.

**The flag and the stack list must change together.** With the flag set, the stack is never constructed, so `cdk.out` holds no template for it, `convert-template.mjs` logs `Failed to load template or assets` and exits 1 because `success < stackNames.length`.

## 2. The event account cannot use the default models

Those accounts sit behind an AWS Private Marketplace that refuses `CreateFoundationModelAgreement` for Sonnet 5 and Opus 5. Reproduced identically in **two separate event accounts**, so it is how they are provisioned rather than a one-off. Only Sonnet 4.6 and Haiku 4.5 are invocable.

That breaks two things, addressed separately:

**`BedrockAccessStack` failed the whole deployment.** An `AccessDeniedException` from `CreateFoundationModelAgreement` is now reported as `UNAVAILABLE` instead of raising, joining the handler's existing non-fatal outcomes. Every other `ClientError`, and every other exception, still raises. The new branch sits *below* the `ConflictException` handler deliberately — that exception is itself a `ClientError`, so ordering it first would swallow the already-exists case.

Rationale: the agreements that do succeed remain usable and survive the failed stack, and a model the account cannot subscribe to would only surface as an `AccessDenied` at inference time anyway. Failing the whole stack over one such model is disproportionate, and when it is not last in the deploy order it takes everything after it down too.

**The app defaulted to models it cannot invoke.** A new opt-in `-c defaultModelId=<allowlisted id>` seeds `settings.model_id` — the legacy global override — through a create-once custom resource. Both resolvers already rank it above the built-in defaults:

```
explicit argument
> per-surface override (settings.surfaces[S])
> legacy global override (settings.model_id)     <- what this writes
> built-in SURFACE_DEFAULTS[S]
> BEDROCK_MODEL_ID
```

So one attribute repoints chat, documents, prototype, enrichment and utility without touching `SURFACE_DEFAULTS`. Note `BEDROCK_MODEL_ID` is deliberately not used: it ranks *below* the surface defaults, so setting it changes nothing while a surface has a default.

The workshop synth passes `-c defaultModelId=global.anthropic.claude-sonnet-4-6`.

## Scope: `cdk deploy` is untouched

- Web search still deploys by default; app-in-any-region with the gateway pinned to us-east-1 still works via CDK cross-region references.
- With no `defaultModelId` flag, **none** of the pin resources are created — no Lambda, provider, log groups or IAM — and the newer models remain the defaults.

## Implementation notes

- The pin is validated against `ALLOWED_MODEL_IDS` at synth. A non-allowlisted value would be dropped by `_allowlisted()` at read time and silently fall back to the very defaults the flag exists to bypass, so failing fast is clearer.
- Create-once (`ConditionExpression: attribute_not_exists(model_id)`), matching `AdminBootstrap`'s "create once, never reset": an admin who later picks a model in Settings is never overwritten by a redeploy. A floor, not a lock — per-surface overrides still outrank it.
- Kept out of `admin_bootstrap.py` deliberately: that handler is single-purpose and its provider logging is pinned `FATAL` because the initial admin password flows through its response. A separate resource also allows creating nothing when the flag is absent.
- Unexpected DynamoDB failures raise rather than no-op: a green stack whose every AI surface resolves to an uninvocable model is much harder to diagnose than a failed one.
- `grantWriteData()`'s GSI and KMS wildcards reuse the shared `dynamoDbGsi` / `kmsEncryption` nag suppressions.

## Verification

12 new tests, all fail-on-revert. The agreement tests extract the inline handler from the CDK stack and `exec` it against a stubbed boto3 — the same read-the-TS-from-Python approach as `test_avatar_image_model_lockstep.py` — asserting `AccessDenied` is absorbed, other codes still raise, and the `ClientError` branch does not shadow `ConflictException`. The pin tests assert the write is conditional, an existing value is kept, unexpected errors raise, and the `PhysicalResourceId` is stable across request types.

`tsc` clean. Synthed with **both** flags together, the exact combination the workshop script now uses:

- 5 stacks synthed, no `VocWebSearchStack`
- zero `VocWebSearchStack` references in `VocProcessingStack`
- one `Custom::ModelPin` in `VocCoreStack` with `ModelId=global.anthropic.claude-sonnet-4-6`
- cdk-nag clean; a bogus `-c defaultModelId=gpt-4` fails synth with the allowlist in the message
- with no flag: zero `ModelPin` resources

Live evidence for part 1: after publishing the 5-template set, a fresh event brought `VocCoreStack`, `VocIngestionStack` and `VocProcessingStack` to `CREATE_COMPLETE`, where processing had previously failed on the missing export.

## Not covered here

The corresponding workshop-repo change (drop the 6th template, restore the 5-entry contentspec, publish the regenerated templates) is committed in the Workshop Studio content repo, which lives outside this repository. The pin has not yet run in a real event — the next rebuild is its first live exercise.
