### PR TITLE
refactor(infra): merge the two us-east-1 AI-enablement stacks

### DIFF
--- a/.kiro/steering/deployment.md
+++ b/.kiro/steering/deployment.md
@@ -46,27 +46,48 @@ npm run deploy:all   # Deploys all CDK stacks + frontend
 Always run quality checks before deploying:
 
 ```bash
-# From project root
-npm run lint         # ESLint code quality
-npm run typecheck    # TypeScript type checking
-npm run test         # Run test suite
+# From project root ONLY — voc-datalake/package.json has no `lint` script
+npm run lint         # frontend + stream ESLint, and ruff over lambda/ + plugins/
+npm run typecheck    # frontend ONLY (use typecheck:all for frontend + CDK + stream)
+npm run test         # frontend ONLY
 
-# Or run all at once
-npm run check        # lint + typecheck + test
+npm run check        # lint && typecheck:all && test && test:cdk && test:stream && test:backend
 ```
 
 ### What Each Check Does
 
-| Command | Description |
-|---------|-------------|
-| `npm run lint` | Runs ESLint to catch code quality issues |
-| `npm run typecheck` | Runs TypeScript compiler to verify types |
-| `npm run test` | Runs Vitest test suite |
-| `npm run test:coverage` | Runs tests with coverage report |
+| Command | Covers |
+|---------|--------|
+| `npm run lint` | `lint:frontend` + `lint:stream` (ESLint) + `lint:python` (ruff over `lambda/`, `plugins/`) |
+| `npm run typecheck` | Frontend only |
+| `npm run typecheck:all` | Frontend + CDK (`typecheck:cdk`) + stream |
+| `npm run test` | Frontend Vitest |
+| `npm run test:cdk` / `test:stream` / `test:backend` | CDK Vitest / stream Vitest / pytest via `.venv/bin/python` |
+| `npm run check` | All of the above, chained with `&&` |
+
+**Two traps when using `check` as a gate:**
+
+- **It chains with `&&`, so the first failure hides every later step.** A
+  `lint:python` failure means you never learn whether the CDK or backend tests
+  pass. When triaging, run the individual scripts.
+- **There is no ESLint leg for the CDK TypeScript.** `bin/` and `lib/` are covered
+  only by `typecheck:cdk` — "lint is clean" says nothing about the CDK app.
 
 ## CDK Stacks
 
-The platform consists of 4 core stacks plus 2 optional ones:
+The platform consists of 4 core stacks plus 1 AI-enablement stack.
+
+> ### ⚠️ The stack count is capped at 5 — adding a stack is not a free action
+>
+> A downstream packaging consumer of this repo accepts at most **five**
+> CloudFormation templates, and the app is at exactly five. A sixth breaks
+> packaging, and the failure appears only there — never at `cdk synth`. Fold new
+> infrastructure into an existing stack, or drop one first.
+>
+> This is why the web-search gateway and Bedrock model access share
+> `VocWebSearchStack`. Nested stacks are not an escape hatch: `NestedStackProps`
+> has no `env`, so a nested stack inherits the parent region, and that stack must
+> be pinned to us-east-1.
 
 | Stack | Description | Dependencies |
 |-------|-------------|--------------|

--- a/.kiro/steering/deployment.md
+++ b/.kiro/steering/deployment.md
@@ -74,8 +74,7 @@ The platform consists of 4 core stacks plus 2 optional ones:
 | `VocIngestionStack` | Plugin Lambdas, EventBridge schedules, SQS, Secrets | Core |
 | `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
-| `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case | None |
-| `VocWebSearchStack` (optional) | AgentCore web-search gateway — `-c enableWebSearch=true`, always us-east-1 | None |
+| `VocWebSearchStack` (AI enablement, always us-east-1) | Two independently switchable halves: AgentCore web-search gateway (default-on, `-c enableWebSearch=false` opts out) + Bedrock model access / Anthropic use case (only when `anthropicUseCase` is set). Not created when both are off | None |
 
 ### Deploy All Stacks
 
@@ -104,10 +103,12 @@ cdk deploy --all --require-approval never
 
 Due to dependencies, stacks should be deployed in this order:
 
-1. `VocCoreStack` (+ optional `BedrockAccessStack` / `VocWebSearchStack`, no dependencies)
-2. `VocIngestionStack`
-3. `VocProcessingStack`
-4. `VocApiStack`
+1. `VocWebSearchStack` (no dependencies, but must precede Processing/Api, which
+   import its gateway exports when web search is enabled)
+2. `VocCoreStack`
+3. `VocIngestionStack`
+4. `VocProcessingStack`
+5. `VocApiStack`
 
 The `cdk deploy --all` command handles this automatically.
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -308,7 +308,9 @@ VocCoreStack (DynamoDB tables, S3 raw data bucket, KMS, Cognito, CloudFront)
        │           │
        │           └── Depends on: processingQueue, secretsArn, researchStateMachine, userPool
 
-Optional stacks with NO dependency on the core chain:
-  BedrockAccessStack (Bedrock model access / Anthropic use case)
-  VocWebSearchStack (us-east-1: AgentCore web-search gateway, -c enableWebSearch=true)
+AI-enablement stack, NO dependency on the core chain (but Processing/Api import
+its gateway exports, so it deploys first):
+  VocWebSearchStack (always us-east-1) = web-search gateway (default-on, opt out
+    with -c enableWebSearch=false) + Bedrock model access / Anthropic use case
+    (only when anthropicUseCase is set). Not created when both halves are off.
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A fully serverless AWS platform for ingesting, processing, and analyzing custome
 - **Plugin-Based Architecture**: Extensible data source plugins, easily create your own
 - **AI-Powered Analysis**: Amazon Bedrock (Claude) for sentiment, categorization, and insights
 - **Per-Surface Model Picker**: admins choose the Claude model per AI feature (chat, documents, prototypes, enrichment) over a curated allowlist
-- **Opt-In Web Search**: AgentCore Gateway connector for chat and research (`enableWebSearch: true`)
+- **Web Search**: AgentCore Gateway connector for chat and research — deployed by default, searches stay opt-in per request (opt out with `enableWebSearch: false`)
 - **Real-Time Processing**: Event-driven with SQS and DynamoDB Streams
 - **Multi-Language Support**: Auto-detection and translation
 - **React Dashboard**: Metrics, charts, AI chat, and project management

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,7 +92,9 @@ Anthropic requires first-time customers to submit use case details before invoki
 
 ### Automatic Setup via CDK
 
-The `BedrockAccessStack` automates this process. To enable it:
+The model-access half of `VocWebSearchStack` automates this process (it was its
+own `BedrockAccessStack` before the two us-east-1 stacks were merged). To enable
+it:
 
 1. Copy the example config:
    ```bash
@@ -169,7 +171,22 @@ Access is granted immediately after successful submission.
 
 ## CDK Stacks
 
-The platform consists of 4 core stacks plus 2 optional ones:
+The platform consists of 4 core stacks plus 1 AI-enablement stack.
+
+> The web-search gateway and Bedrock model access used to be two separate
+> stacks (`VocWebSearchStack` and `BedrockAccessStack`). They were merged:
+> both must live in us-east-1, both are one-shot account enablement, and
+> neither depends on the core chain — and keeping them apart put the app at
+> six CloudFormation templates, one over the ceiling Workshop Studio allows.
+> The merged stack keeps the id `VocWebSearchStack` because that id determines
+> the export names `VocProcessingStack` and `VocApiStack` import.
+>
+> **Migrating an existing deployment:** run `cdk deploy --all` (the agreements
+> are recreated in `VocWebSearchStack` and re-run idempotently — Bedrock
+> agreements persist per account, so nothing is lost), then delete the old
+> stack with `cdk destroy BedrockAccessStack`. CDK does not remove a stack that
+> has been dropped from the app, so that second step is manual. No gateway is
+> recreated and there is no feature downtime.
 
 | Stack | Description | Dependencies |
 |-------|-------------|--------------|
@@ -177,8 +194,7 @@ The platform consists of 4 core stacks plus 2 optional ones:
 | `VocIngestionStack` | Plugin Lambdas, EventBridge schedules, SQS, Secrets | Core |
 | `VocProcessingStack` | Processor, Aggregator, Step Functions, Bedrock | Core, Ingestion |
 | `VocApiStack` | API Gateway, API Lambdas, Webhooks, WAF | Core, Ingestion, Processing |
-| `BedrockAccessStack` (optional) | Bedrock model access / Anthropic use case submission — created only when `anthropicUseCase` is set in `cdk.context.json` (see the conditional in `bin/voc-datalake.ts`) | None |
-| `VocWebSearchStack` (default-on, opt-out) | AgentCore Gateway for public web search — deployed by default, opt out via `enableWebSearch: false`; always deploys to us-east-1 (the connector only exists there). **Upgrade note:** existing non-us-east-1 deployments must bootstrap us-east-1 once (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`) or set the opt-out flag | None |
+| `VocWebSearchStack` (AI enablement) | **Two independently switchable halves in one us-east-1 stack:** (a) the AgentCore Gateway for public web search — on by default, opt out via `enableWebSearch: false`; (b) Bedrock model access / Anthropic use-case submission — created only when `anthropicUseCase` is set in `cdk.context.json`. The stack is not created at all when both are off. Always deploys to us-east-1: the web-search connector exists only there, and `PutUseCaseForModelAccess` works only there. **Upgrade note:** existing non-us-east-1 deployments must bootstrap us-east-1 once (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`) or set the opt-out flag | None |
 
 ### Deploy All Stacks
 
@@ -211,10 +227,12 @@ warning as a regression to investigate rather than noise to ignore.
 
 Due to dependencies, stacks should be deployed in this order:
 
-1. `VocCoreStack` (+ optional `BedrockAccessStack` / `VocWebSearchStack`, no dependencies)
-2. `VocIngestionStack`
-3. `VocProcessingStack`
-4. `VocApiStack`
+1. `VocWebSearchStack` (no dependencies — but it must come **before** Processing
+   and Api, which import its gateway exports when web search is enabled)
+2. `VocCoreStack` (no dependencies)
+3. `VocIngestionStack`
+4. `VocProcessingStack`
+5. `VocApiStack`
 
 The `cdk deploy --all` command handles this automatically.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,9 +77,6 @@ Two things to know about the gate:
 - **There is no ESLint leg for the CDK TypeScript.** `bin/` and `lib/` are covered
   only by `typecheck:cdk`, so "lint is clean" says nothing about the CDK app.
 
-Note that `npm run lint` is only available from the **repo root** —
-`voc-datalake/package.json` has no `lint` script.
-
 ### Python Lambda Tests
 
 Lambda handlers have their own test suite using pytest:
@@ -420,7 +417,9 @@ there. Deployment is **on by default** (opt out with
 > `process.env.CDK_DEFAULT_REGION`, but **the CDK CLI overwrites that variable**
 > for the app subprocess from the resolved AWS environment — exporting it
 > yourself has no effect. Use `AWS_REGION` / `AWS_DEFAULT_REGION`, or
-> `--profile`. This matters here because `VocWebSearchStack` is the only
+> `--profile`. (Observed with the CDK CLI pinned in `voc-datalake/package.json`;
+> re-check if that behaviour ever changes, since the guidance below depends on
+> it.) This matters here because `VocWebSearchStack` is the only
 > region-pinned stack, so it is the only one whose region can differ from the
 > app's, and that difference is what triggers the cross-region wiring above.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -48,22 +48,37 @@ Always run quality checks before deploying:
 
 ```bash
 # From project root
-npm run lint         # ESLint code quality
-npm run typecheck    # TypeScript type checking
-npm run test         # Run test suite
+npm run lint         # frontend + stream ESLint, and ruff over lambda/ + plugins/
+npm run typecheck    # frontend TypeScript only
+npm run test         # frontend Vitest only
 
 # Or run all at once
-npm run check        # lint + typecheck + test
+npm run check        # lint + typecheck:all + test + test:cdk + test:stream + test:backend
 ```
 
 ### What Each Check Does
 
-| Command | Description |
-|---------|-------------|
-| `npm run lint` | Runs ESLint to catch code quality issues |
-| `npm run typecheck` | Runs TypeScript compiler to verify types |
-| `npm run test` | Runs Vitest test suite (frontend + CDK) |
-| `npm run test:coverage` | Runs tests with coverage report |
+| Command | Covers |
+|---------|--------|
+| `npm run lint` | `lint:frontend` + `lint:stream` (ESLint) + `lint:python` (ruff over `lambda/`, `plugins/`) |
+| `npm run typecheck` | Frontend only — use `typecheck:all` for frontend + CDK + stream |
+| `npm run test` | Frontend Vitest only |
+| `npm run test:cdk` | CDK Vitest (`voc-datalake`) |
+| `npm run test:stream` | Streaming chat Lambda Vitest |
+| `npm run test:backend` | Python pytest via `.venv/bin/python` |
+| `npm run check` | All of the above, chained with `&&` |
+| `npm run test:coverage` | Frontend tests with coverage report |
+
+Two things to know about the gate:
+
+- **`check` chains with `&&`, so the first failure hides every later step.** If
+  `lint:python` fails you never find out whether the CDK or backend tests pass.
+  When triaging, run the individual scripts rather than inferring from `check`.
+- **There is no ESLint leg for the CDK TypeScript.** `bin/` and `lib/` are covered
+  only by `typecheck:cdk`, so "lint is clean" says nothing about the CDK app.
+
+Note that `npm run lint` is only available from the **repo root** —
+`voc-datalake/package.json` has no `lint` script.
 
 ### Python Lambda Tests
 
@@ -174,12 +189,17 @@ Access is granted immediately after successful submission.
 The platform consists of 4 core stacks plus 1 AI-enablement stack.
 
 > The web-search gateway and Bedrock model access used to be two separate
-> stacks (`VocWebSearchStack` and `BedrockAccessStack`). They were merged:
-> both must live in us-east-1, both are one-shot account enablement, and
-> neither depends on the core chain — and keeping them apart put the app at
-> six CloudFormation templates, one over the ceiling Workshop Studio allows.
-> The merged stack keeps the id `VocWebSearchStack` because that id determines
-> the export names `VocProcessingStack` and `VocApiStack` import.
+> stacks (`VocWebSearchStack` and `BedrockAccessStack`). They were merged
+> because they are the same deployment unit: both must live in us-east-1, both
+> are one-shot account enablement built from custom resources, and neither
+> depends on the core chain. The merged stack keeps the id `VocWebSearchStack`
+> because that id determines the export names `VocProcessingStack` and
+> `VocApiStack` import.
+>
+> **Adding a stack is not a free action.** A downstream packaging consumer of
+> this repo caps the template count at five, so a sixth stack breaks it — and
+> the failure appears only at packaging time, never at `cdk synth`. Prefer
+> folding new infrastructure into an existing stack.
 >
 > **Migrating an existing deployment:** run `cdk deploy --all` (the agreements
 > are recreated in `VocWebSearchStack` and re-run idempotently — Bedrock
@@ -396,6 +416,14 @@ there. Deployment is **on by default** (opt out with
   (`cdk bootstrap aws://ACCOUNT_ID/us-east-1`); CDK cross-region references
   carry the gateway URL/ARN to the app region.
 
+> **Setting the app region:** `bin/voc-datalake.ts` reads
+> `process.env.CDK_DEFAULT_REGION`, but **the CDK CLI overwrites that variable**
+> for the app subprocess from the resolved AWS environment — exporting it
+> yourself has no effect. Use `AWS_REGION` / `AWS_DEFAULT_REGION`, or
+> `--profile`. This matters here because `VocWebSearchStack` is the only
+> region-pinned stack, so it is the only one whose region can differ from the
+> app's, and that difference is what triggers the cross-region wiring above.
+
 **Data residency note:** search queries are processed by the connector in
 us-east-1 regardless of where the app is deployed. Queries are derived from
 user input — the research question is sent as-is, and in chat the model
@@ -406,6 +434,44 @@ The frontend discovers availability through the `features.webSearch` flag in
 `config.json` (set by CDK and by `scripts/deploy.sh` from the
 `WebSearchAvailable` stack output). For local development against the mock,
 set `VITE_ENABLE_WEB_SEARCH=true`.
+
+### Pinning All AI Surfaces to One Model
+
+Each AI surface (chat, documents, prototypes, enrichment, utilities) has its own
+default model, and some accounts cannot invoke all of them — Bedrock model access
+is granted per account, and organizations behind an AWS Private Marketplace are
+commonly restricted to a subset. When a surface's default is unavailable, that
+feature fails at inference time with `AccessDeniedException`.
+
+To pin every surface to one known-available model at deploy time:
+
+```bash
+cdk deploy --all -c defaultModelId=global.anthropic.claude-sonnet-4-6
+```
+
+This creates a `Custom::ModelPin` resource in `VocCoreStack` that writes
+`model_id` to the `SETTINGS#model` configuration item. Behaviour worth knowing:
+
+- **Write-once.** The value is only set if absent, so an administrator's later
+  choice in Settings is never clobbered by a redeploy. It is a floor, not a lock —
+  per-surface overrides still take precedence.
+- **Validated at synth.** The id must be in `ALLOWED_MODEL_IDS`
+  (`lib/utils/model-allowlist.ts`); an unrecognized value fails the synth rather
+  than being silently discarded at read time and falling back to the very
+  defaults the flag exists to bypass.
+- **Absent flag creates nothing** — no Lambda, no custom resource, no log group.
+  Deployments that don't need it are unaffected.
+
+To check which models an account can actually invoke, call Converse — agreement
+and availability APIs can report a model as available when inference still
+returns `AccessDeniedException`:
+
+```bash
+aws bedrock-runtime converse --region us-east-1 \
+  --model-id global.anthropic.claude-sonnet-4-6 \
+  --messages '[{"role":"user","content":[{"text":"say ok"}]}]' \
+  --inference-config '{"maxTokens":5}'
+```
 
 After changing configuration:
 

--- a/voc-datalake/bin/voc-datalake.ts
+++ b/voc-datalake/bin/voc-datalake.ts
@@ -8,9 +8,10 @@ import { VocIngestionStack } from '../lib/stacks/ingestion-stack';
 import { VocProcessingStack } from '../lib/stacks/processing-stack-consolidated';
 import { VocApiStack } from '../lib/stacks/api-stack';
 import { VocWebSearchStack } from '../lib/stacks/web-search-stack';
-import { BedrockAccessStack, AnthropicUseCaseSchema } from '../lib/stacks/bedrock-access-stack';
+import { AnthropicUseCaseSchema, AnthropicUseCaseConfig } from '../lib/stacks/bedrock-access-stack';
 import { lambdaBasicExecutionRoleSuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions, pluginSystemSuppressions, cdkAssetsSuppressions, comprehendSuppressions, translateSuppressions, apiGatewayPushToCloudwatchLogsRoleSuppressions } from '../lib/utils/nag-suppressions';
 import { shouldDeployWebSearch } from '../lib/utils/web-search-default';
+import { shouldDeployAiEnablement } from '../lib/utils/ai-enablement-default';
 
 const app = new cdk.App();
 
@@ -42,29 +43,65 @@ const env = {
 };
 
 // ============================================
-// Stack 0a: VocWebSearchStack (default-on, opt-out)
-// AgentCore Gateway for the AWS-managed web-search connector.
+// Stack 0: VocWebSearchStack — the us-east-1 AI-enablement stack
 // ============================================
-// Flag semantics live in lib/utils/web-search-default.ts (single source of
-// truth). Summary: deploys by default; `enableWebSearch: false` opts out;
-// unrecognized values throw. Per-request search stays opt-in in both UIs
-// ($7/1k queries; the gateway itself has no standing cost).
+// Two independently switchable halves in ONE stack, because they are one
+// deployment unit: both must live in us-east-1 (the web-search connector
+// exists only there; PutUseCaseForModelAccess works only there), both are
+// one-shot account enablement, and neither depends on the core stack chain.
+// They used to be two stacks, which put the app at six CloudFormation
+// templates — one over Workshop Studio's ceiling of five.
 //
-// The connector only exists in us-east-1, so the stack always deploys
-// there. When the app itself lives in another region this additionally
-// requires a us-east-1 bootstrap and CDK cross-region references.
+//   half 1: AgentCore Gateway for the AWS-managed web-search connector.
+//           Deploys by default; `enableWebSearch: false` opts out;
+//           unrecognized values throw. Flag semantics live in
+//           lib/utils/web-search-default.ts (single source of truth).
+//           Per-request search stays opt-in in both UIs ($7/1k queries; the
+//           gateway itself has no standing cost).
+//   half 2: Bedrock model access — Anthropic use-case submission plus the
+//           model agreements. Skipped entirely when `anthropicUseCase` is
+//           absent, e.g. for an account that already has access.
+//
+// The stack id stays `VocWebSearchStack` deliberately: it determines the
+// CloudFormation export names VocProcessingStack and VocApiStack import.
 const webSearchContextRaw = app.node.tryGetContext('enableWebSearch');
 const deployWebSearch = shouldDeployWebSearch(webSearchContextRaw);
 const webSearchCrossRegion = deployWebSearch && env.region !== 'us-east-1';
 
+// Accept either boolean true (from cdk.context.json) or string "true"
+// (from `--context skipUseCaseSubmission=true` on the CLI, which CDK always
+// parses as a string).
+const skipRaw = app.node.tryGetContext('skipUseCaseSubmission');
+const skipUseCaseSubmission = skipRaw === true || skipRaw === 'true';
+
+const anthropicUseCaseRaw = app.node.tryGetContext('anthropicUseCase');
+let anthropicUseCase: AnthropicUseCaseConfig | undefined;
+if (anthropicUseCaseRaw) {
+  const parseResult = AnthropicUseCaseSchema.safeParse(anthropicUseCaseRaw);
+  if (parseResult.success) {
+    anthropicUseCase = parseResult.data;
+  } else {
+    console.warn('⚠️  Invalid anthropicUseCase config in cdk.context.json:');
+    console.warn(parseResult.error.format());
+    console.warn('Skipping Bedrock model access. See cdk.context.example.json for the required format.');
+  }
+}
+
 let webSearchStack: VocWebSearchStack | undefined;
-if (deployWebSearch) {
+if (shouldDeployAiEnablement(deployWebSearch, anthropicUseCase)) {
   webSearchStack = new VocWebSearchStack(app, 'VocWebSearchStack', {
     env: { account: env.account, region: 'us-east-1' },
-    crossRegionReferences: webSearchCrossRegion,
-    description: 'VoC Data Lake - Web Search (AgentCore Gateway, web-search connector) (uksb-0q2jyqfvlm)(tag:VocWebSearchStack)',
+    // Unconditionally true, matching what the model-access half required when
+    // it was its own us-east-1 stack. CDK only emits the SSM cross-region
+    // machinery when the regions actually differ, so this only *permits* it.
+    crossRegionReferences: true,
+    description: 'VoC Data Lake - AI Enablement (web search gateway, Bedrock model access) (uksb-0q2jyqfvlm)(tag:VocWebSearchStack)',
+    deployWebSearch,
+    anthropicUseCase,
+    modelRegion: env.region, // Create model agreements in the same region as other stacks
+    skipUseCaseSubmission,
   });
-  tagStack(webSearchStack, 'WebSearch');
+  tagStack(webSearchStack, 'AiEnablement');
   if (webSearchCrossRegion) {
     // Upgrade hint (issue #205): web search now deploys by default, and a
     // non-us-east-1 app needs a us-east-1 bootstrap for the cross-region
@@ -74,38 +111,6 @@ if (deployWebSearch) {
       `Web search deploys by default and requires a us-east-1 bootstrap when the app region is ${env.region} ` +
       '(cdk bootstrap aws://ACCOUNT/us-east-1). Opt out with -c enableWebSearch=false.',
     );
-  }
-}
-
-// ============================================
-// Stack 0: BedrockAccessStack (Optional)
-// Submits Anthropic use case for first-time access
-// ============================================
-const anthropicUseCaseRaw = app.node.tryGetContext('anthropicUseCase');
-let bedrockAccessStack: BedrockAccessStack | undefined;
-
-if (anthropicUseCaseRaw) {
-  // Validate the config using Zod schema
-  const parseResult = AnthropicUseCaseSchema.safeParse(anthropicUseCaseRaw);
-  // Accept either boolean true (from cdk.context.json) or string "true"
-  // (from `--context skipUseCaseSubmission=true` on the CLI, which CDK always
-  // parses as a string).
-  const skipRaw = app.node.tryGetContext('skipUseCaseSubmission');
-  const skipUseCaseSubmission = skipRaw === true || skipRaw === 'true';
-  
-  if (parseResult.success) {
-    bedrockAccessStack = new BedrockAccessStack(app, 'BedrockAccessStack', {
-      env,
-      description: 'VoC Data Lake - Bedrock Access (Anthropic Use Case & Model Agreements) (uksb-0q2jyqfvlm)(tag:BedrockAccessStack)',
-      anthropicUseCase: parseResult.data,
-      modelRegion: env.region, // Create model agreements in the same region as other stacks
-      skipUseCaseSubmission,
-    });
-    tagStack(bedrockAccessStack, 'BedrockAccess');
-  } else {
-    console.warn('⚠️  Invalid anthropicUseCase config in cdk.context.json:');
-    console.warn(parseResult.error.format());
-    console.warn('Skipping BedrockAccessStack. See cdk.context.example.json for the required format.');
   }
 }
 
@@ -208,10 +213,14 @@ tagStack(apiStack, 'Api');
 // Apply cdk-nag checks
 Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
 
-// Global suppressions
-if (bedrockAccessStack) {
-  NagSuppressions.addStackSuppressions(bedrockAccessStack, [...pluginSystemSuppressions, ...comprehendSuppressions, ...translateSuppressions], true);
-}
+// Global suppressions.
+// VocWebSearchStack deliberately gets NONE: the gateway half has always passed
+// cdk-nag unsuppressed (its IAM is scoped to the concrete gateway ARN), and the
+// model-access half carries its own resource-scoped suppressions inside
+// BedrockModelAccess. The plugin/Comprehend/Translate sets that used to be
+// applied to BedrockAccessStack at stack level were copy-paste — that stack
+// calls neither service — so they are dropped rather than inherited by the
+// gateway resources.
 NagSuppressions.addStackSuppressions(coreStack, [...lambdaBasicExecutionRoleSuppressions, ...cdkAssetsSuppressions], true);
 // Apply stack-level suppressions
 NagSuppressions.addStackSuppressions(ingestionStack, [...lambdaBasicExecutionRoleSuppressions, ...dynamoDbGsiSuppressions, ...kmsEncryptionSuppressions, ...s3BucketSuppressions], true);

--- a/voc-datalake/lib/stacks/bedrock-access-stack.ts
+++ b/voc-datalake/lib/stacks/bedrock-access-stack.ts
@@ -88,9 +88,11 @@ export interface BedrockModelAccessProps {
    * agreements land in the app's region even though this construct is hosted
    * by a stack pinned to us-east-1.
    *
-   * Defaults to us-west-2.
+   * Required deliberately: a default here would be a silently-wrong region for
+   * every caller that forgot to pass one, and the agreements would be created
+   * somewhere the app never calls Bedrock.
    */
-  modelRegion?: string;
+  modelRegion: string;
 
   /**
    * Skip the use case submission step.
@@ -122,7 +124,7 @@ export class BedrockModelAccess extends Construct {
 
     const stack = cdk.Stack.of(this);
     const anthropicUseCase = props.anthropicUseCase;
-    const modelRegion = props.modelRegion || 'us-west-2';
+    const modelRegion = props.modelRegion;
 
     // Validate and transform config at runtime
     const parseResult = AnthropicUseCaseSchema.safeParse(anthropicUseCase);
@@ -203,10 +205,16 @@ export class BedrockModelAccess extends Construct {
       // The AwsCustomResource construct creates a singleton Lambda with a
       // deterministic UUID. It is scoped to the STACK, not to this construct,
       // so these paths stay stack-relative.
+      //
+      // Built from the stack's CONSTRUCT ID, not `stack.stackName`: these are
+      // matched against `node.path`, which uses construct ids. The two only
+      // coincide while no explicit `stackName` is set, so using stackName here
+      // would silently stop matching — and therefore silently drop the
+      // suppressions — the day someone overrides it.
       const customResourceId = `AWS${cr.AwsCustomResource.PROVIDER_FUNCTION_UUID.split('-').join('')}`;
       const customResourceSuppressPaths = new Set([
-        `/${stack.stackName}/${customResourceId}/ServiceRole/Resource`,
-        `/${stack.stackName}/${customResourceId}/Resource`,
+        `/${stack.node.id}/${customResourceId}/ServiceRole/Resource`,
+        `/${stack.node.id}/${customResourceId}/Resource`,
       ]);
 
       const allExistingPaths = new Set(

--- a/voc-datalake/lib/stacks/bedrock-access-stack.ts
+++ b/voc-datalake/lib/stacks/bedrock-access-stack.ts
@@ -1,3 +1,14 @@
+/**
+ * NOTE ON THIS FILE'S NAME: it exports a Construct (BedrockModelAccess), not a
+ * stack, despite living in lib/stacks/ and being called *-stack.ts. This used
+ * to be BedrockAccessStack; it was folded into VocWebSearchStack to stay within
+ * Workshop Studio's five-template ceiling.
+ *
+ * The path was kept deliberately: lambda/shared/test/test_model_agreement_handler.py
+ * reads THIS path and regexes `getModelAgreementLambdaCode()` out of it to test
+ * the inline Python handler. Moving or renaming either silently breaks that
+ * suite. Rename both together if the inconsistency is worth fixing.
+ */
 import * as cdk from 'aws-cdk-lib';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -59,20 +70,28 @@ export type AnthropicUseCaseConfig = z.infer<typeof AnthropicUseCaseSchema>;
  */
 const REQUIRED_MODELS = [...ALLOWED_FOUNDATION_MODEL_IDS];
 
-export interface BedrockAccessStackProps extends cdk.StackProps {
+export interface BedrockModelAccessProps {
   /**
    * Anthropic use case configuration for first-time model access.
-   * If not provided, the stack will skip the use case submission.
+   *
+   * Required: the caller decides whether this half is deployed at all by
+   * choosing whether to construct it. See VocWebSearchStack.
    */
-  anthropicUseCase?: AnthropicUseCaseConfig;
-  
+  anthropicUseCase: AnthropicUseCaseConfig;
+
   /**
    * AWS region where the models will be used.
    * Model agreements are created in this region.
+   *
+   * This is a custom-resource *property*, not a placement decision — the
+   * handler does `boto3.client('bedrock', region_name=region)` — so the
+   * agreements land in the app's region even though this construct is hosted
+   * by a stack pinned to us-east-1.
+   *
    * Defaults to us-west-2.
    */
   modelRegion?: string;
-  
+
   /**
    * Skip the use case submission step.
    * @default false
@@ -81,43 +100,29 @@ export interface BedrockAccessStackProps extends cdk.StackProps {
 }
 
 /**
- * Stack that handles Anthropic model access for Amazon Bedrock.
- * 
- * This stack performs two operations:
+ * Bedrock model access for Anthropic models.
+ *
+ * Performs two operations:
  * 1. Submits the Anthropic use case form (required once per account, us-east-1 only)
  * 2. Creates model agreements for required Claude models (accepts EULA)
- * 
- * IMPORTANT: The PutUseCaseForModelAccess API ONLY works in us-east-1 region.
- * Model agreements can be created in any region where the models are available.
+ *
+ * IMPORTANT: The PutUseCaseForModelAccess API ONLY works in us-east-1, so the
+ * hosting stack must be pinned there. Model agreements can be created in any
+ * region where the models are available (see `modelRegion`).
+ *
+ * This is a Construct rather than a Stack: it is hosted by VocWebSearchStack,
+ * which is already pinned to us-east-1 for the same reason. The two used to be
+ * separate stacks, which put the app one template over Workshop Studio's
+ * five-template ceiling. Nothing else imports from this half — it publishes no
+ * consumed exports — so folding it in cost no cross-stack wiring.
  */
-export class BedrockAccessStack extends cdk.Stack {
-  public readonly accessGranted: boolean;
+export class BedrockModelAccess extends Construct {
+  constructor(scope: Construct, id: string, props: BedrockModelAccessProps) {
+    super(scope, id);
 
-  constructor(scope: Construct, id: string, props?: BedrockAccessStackProps) {
-    // CRITICAL: Force us-east-1 region - PutUseCaseForModelAccess only works there
-    super(scope, id, {
-      ...props,
-      env: {
-        ...props?.env,
-        region: 'us-east-1',
-      },
-      crossRegionReferences: true,
-    });
-
-    const anthropicUseCase = props?.anthropicUseCase;
-    const modelRegion = props?.modelRegion || props?.env?.region || 'us-west-2';
-
-    // Skip if no config provided
-    if (!anthropicUseCase) {
-      console.log('No Anthropic use case config provided. Skipping model access request.');
-      this.accessGranted = false;
-      
-      new cdk.CfnOutput(this, 'BedrockAccessStatus', {
-        value: 'SKIPPED - No anthropicUseCase config provided',
-        description: 'Status of Anthropic model access request',
-      });
-      return;
-    }
+    const stack = cdk.Stack.of(this);
+    const anthropicUseCase = props.anthropicUseCase;
+    const modelRegion = props.modelRegion || 'us-west-2';
 
     // Validate and transform config at runtime
     const parseResult = AnthropicUseCaseSchema.safeParse(anthropicUseCase);
@@ -152,7 +157,7 @@ export class BedrockAccessStack extends cdk.Stack {
     // Step 1: Submit Anthropic Use Case (us-east-1 only)
     // Skip for internal accounts
     // ============================================
-    const skipUseCaseSubmission = props?.skipUseCaseSubmission ?? false;
+    const skipUseCaseSubmission = props.skipUseCaseSubmission ?? false;
     let submitUseCase: cr.AwsCustomResource | undefined;
     
     if (!skipUseCaseSubmission) {
@@ -185,28 +190,33 @@ export class BedrockAccessStack extends cdk.Stack {
         installLatestAwsSdk: true,
       });
       
-      // Suppress CDK custom resource Lambda runtime warnings for AwsCustomResource
-      NagSuppressions.addResourceSuppressionsByPath(
-        this,
-        `${this.stackName}/SubmitAnthropicUseCase/CustomResourcePolicy/Resource`,
-        [...cdkCustomResourceSuppressions, ...bedrockAgreementSuppressions]
+      // Suppress CDK custom resource Lambda runtime warnings for AwsCustomResource.
+      // Object-based rather than path-based: this is now a Construct, so a
+      // hardcoded `<stackName>/SubmitAnthropicUseCase/...` path would no longer
+      // resolve (the real path gains this construct's id as a segment).
+      NagSuppressions.addResourceSuppressions(
+        submitUseCase,
+        [...cdkCustomResourceSuppressions, ...bedrockAgreementSuppressions],
+        true
       );
-      
-      // The AwsCustomResource construct creates a singleton Lambda with a deterministic UUID
+
+      // The AwsCustomResource construct creates a singleton Lambda with a
+      // deterministic UUID. It is scoped to the STACK, not to this construct,
+      // so these paths stay stack-relative.
       const customResourceId = `AWS${cr.AwsCustomResource.PROVIDER_FUNCTION_UUID.split('-').join('')}`;
       const customResourceSuppressPaths = new Set([
-        `/${this.stackName}/${customResourceId}/ServiceRole/Resource`,
-        `/${this.stackName}/${customResourceId}/Resource`,
+        `/${stack.stackName}/${customResourceId}/ServiceRole/Resource`,
+        `/${stack.stackName}/${customResourceId}/Resource`,
       ]);
-      
+
       const allExistingPaths = new Set(
-        this.node.findAll().map((node) => `/${node.node.path}`)
+        stack.node.findAll().map((node) => `/${node.node.path}`)
       );
-      
+
       for (const path of customResourceSuppressPaths) {
         if (allExistingPaths.has(path)) {
           NagSuppressions.addResourceSuppressionsByPath(
-            this,
+            stack,
             path,
             [...cdkCustomResourceSuppressions, ...lambdaBasicExecutionRoleSuppressions],
             true
@@ -258,9 +268,8 @@ export class BedrockAccessStack extends cdk.Stack {
     });
     
     // Suppress CDK custom resource Lambda runtime warnings for Provider
-    NagSuppressions.addResourceSuppressionsByPath(
-      this,
-      `${this.stackName}/ModelAgreementProvider/framework-onEvent`,
+    NagSuppressions.addResourceSuppressions(
+      modelAgreementProvider,
       [...cdkCustomResourceSuppressions, ...lambdaBasicExecutionRoleSuppressions, ...pluginSystemSuppressions],
       true
     );
@@ -288,9 +297,8 @@ export class BedrockAccessStack extends cdk.Stack {
       }
     });
 
-    this.accessGranted = true;
-
-    // Outputs
+    // Outputs. Informational only — nothing imports these, which is precisely
+    // why this half could be folded into another stack without rewiring.
     new cdk.CfnOutput(this, 'BedrockAccessStatus', {
       value: 'SUBMITTED',
       description: 'Status of Anthropic model access request',

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -200,3 +200,34 @@ describe('research Lambda bundle stages its prompt config', () => {
     }
   });
 });
+
+describe('web-search wiring is skipped cleanly when the gateway is absent', () => {
+  /**
+   * Reachable combination since the AI-enablement stacks were merged: the stack
+   * exists (for the Bedrock model-access half) while `deployWebSearch` is false,
+   * so `webSearchGatewayUrl`/`Arn`/`ToolName` are undefined. This is also the
+   * shape every `-c enableWebSearch=false` deployment produces.
+   *
+   * The guard at processing-stack-consolidated.ts:290 is what keeps that from
+   * synthesizing an env var or an IAM statement containing the string
+   * "undefined". These assertions fail if that guard is dropped or inverted.
+   */
+  const template = synthProcessingTemplate(); // helper omits the web-search props
+
+  it('sets no WEB_SEARCH environment variables on the research Lambda', () => {
+    const functions = Object.values(template.findResources('AWS::Lambda::Function'));
+    const webSearchVars = functions.flatMap((fn) => {
+      const vars: unknown = fn.Properties?.Environment?.Variables;
+      return vars && typeof vars === 'object'
+        ? Object.keys(vars).filter((k) => k.startsWith('WEB_SEARCH'))
+        : [];
+    });
+    expect(webSearchVars).toEqual([]);
+  });
+
+  it('grants no bedrock-agentcore permissions and leaks no "undefined" ARN', () => {
+    const rendered = JSON.stringify(template.toJSON());
+    expect(rendered).not.toContain('bedrock-agentcore');
+    expect(rendered).not.toContain('undefined');
+  });
+});

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -225,9 +225,23 @@ describe('web-search wiring is skipped cleanly when the gateway is absent', () =
     expect(webSearchVars).toEqual([]);
   });
 
-  it('grants no bedrock-agentcore permissions and leaks no "undefined" ARN', () => {
-    const rendered = JSON.stringify(template.toJSON());
-    expect(rendered).not.toContain('bedrock-agentcore');
-    expect(rendered).not.toContain('undefined');
+  it('grants no bedrock-agentcore permissions', () => {
+    // Scoped to IAM policy actions rather than a whole-template string match:
+    // a blanket search would also fire on an unrelated future mention and give
+    // a failure with no pointer to the guard it protects.
+    const actions = Object.values(template.findResources('AWS::IAM::Policy'))
+      .flatMap((policy) => policy.Properties?.PolicyDocument?.Statement ?? [])
+      .flatMap((statement: { Action?: string | string[] }) =>
+        typeof statement.Action === 'string' ? [statement.Action] : statement.Action ?? []);
+    expect(actions.filter((a) => a.startsWith('bedrock-agentcore'))).toEqual([]);
+  });
+
+  it('leaks no "undefined" into any Lambda environment value', () => {
+    // The concrete failure mode if the guard were dropped: an absent gateway
+    // URL/tool name stringified into an env var.
+    const values = Object.values(template.findResources('AWS::Lambda::Function'))
+      .flatMap((fn) => Object.values(fn.Properties?.Environment?.Variables ?? {}))
+      .filter((v): v is string => typeof v === 'string');
+    expect(values.filter((v) => v.includes('undefined'))).toEqual([]);
   });
 });

--- a/voc-datalake/lib/stacks/web-search-stack.test.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.test.ts
@@ -47,7 +47,7 @@ const ANTHROPIC_USE_CASE = {
   otherIndustryOption: '',
 };
 
-function synth(props: Omit<VocWebSearchStackProps, 'env' | 'modelRegion'> & { modelRegion?: string }): Template {
+function synth(props: Omit<VocWebSearchStackProps, 'env'>): Template {
   // Skip asset bundling — template assertions only need structure.
   const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
   const stack = new VocWebSearchStack(app, 'VocWebSearchStack', {
@@ -181,6 +181,31 @@ describe('VocWebSearchStack — model agreements target the app region, not the 
       region: 'eu-central-1',
       modelId: ALLOWED_FOUNDATION_MODEL_IDS[0],
     });
+  });
+});
+
+describe('VocWebSearchStack — modelRegion is required only when the model-access half is on', () => {
+  it('is not needed for a gateway-only deployment', () => {
+    // A gateway-only caller has no agreements, so it must not be forced to
+    // invent a region it never reads.
+    const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
+    expect(() => new VocWebSearchStack(app, 'VocWebSearchStack', {
+      env: { account: '111111111111', region: 'us-east-1' },
+      crossRegionReferences: true,
+      deployWebSearch: true,
+    })).not.toThrow();
+  });
+
+  it('throws when the model-access half is on without it', () => {
+    // Silently defaulting would create the agreements in a region the app never
+    // calls Bedrock in.
+    const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
+    expect(() => new VocWebSearchStack(app, 'VocWebSearchStack', {
+      env: { account: '111111111111', region: 'us-east-1' },
+      crossRegionReferences: true,
+      deployWebSearch: false,
+      anthropicUseCase: ANTHROPIC_USE_CASE,
+    })).toThrow(/modelRegion is required/);
   });
 });
 

--- a/voc-datalake/lib/stacks/web-search-stack.test.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Template-level tests for the merged us-east-1 AI-enablement stack.
+ *
+ * VocWebSearchStack hosts two independently switchable halves — the web-search
+ * AgentCore Gateway and Bedrock model access — because they are one deployment
+ * unit and splitting them put the app one CloudFormation template over Workshop
+ * Studio's ceiling of five.
+ *
+ * These tests fail if:
+ *  - either half stops being independently switchable (e.g. someone makes the
+ *    gateway unconditional again, which would break `-c enableWebSearch=false`,
+ *    or makes the agreements unconditional, breaking accounts that already have
+ *    Bedrock access);
+ *  - the gateway's export names drift. VocProcessingStack and VocApiStack import
+ *    them by literal name, so a rename silently breaks both consumer stacks at
+ *    deploy time with "No export named ..." and zero resources created — the
+ *    exact failure this stack caused in a workshop event;
+ *  - the both-halves-off guard is removed, which would synthesize a stack with
+ *    no resources. The workshop converter strips CDKMetadata, so that becomes an
+ *    invalid `Resources: {}` template.
+ */
+import { describe, it, expect } from 'vitest';
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { z } from 'zod';
+import { VocWebSearchStack, VocWebSearchStackProps } from './web-search-stack';
+import { shouldDeployAiEnablement } from '../utils/ai-enablement-default';
+import { ALLOWED_FOUNDATION_MODEL_IDS } from '../utils/model-allowlist';
+
+/** `Template.toJSON()` is untyped, so validate rather than assert. */
+const ExportedOutputSchema = z.object({ Export: z.object({ Name: z.string() }) });
+
+/** Names of every output carrying an `Export` block, sorted. */
+function exportNames(template: Template): string[] {
+  return Object.values(template.toJSON().Outputs ?? {})
+    .map((output) => ExportedOutputSchema.safeParse(output))
+    .flatMap((parsed) => (parsed.success ? [parsed.data.Export.Name] : []))
+    .sort();
+}
+
+const ANTHROPIC_USE_CASE = {
+  companyName: 'Test Co',
+  companyWebsite: 'https://example.com',
+  intendedUsers: '0' as const,
+  industryOption: 'Technology' as const,
+  useCases: 'Testing the merged AI-enablement stack synthesizes correctly.',
+  otherIndustryOption: '',
+};
+
+function synth(props: Omit<VocWebSearchStackProps, 'env'>): Template {
+  // Skip asset bundling — template assertions only need structure.
+  const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
+  const stack = new VocWebSearchStack(app, 'VocWebSearchStack', {
+    env: { account: '111111111111', region: 'us-east-1' },
+    crossRegionReferences: true,
+    ...props,
+  });
+  return Template.fromStack(stack);
+}
+
+const GATEWAY = 'AWS::BedrockAgentCore::Gateway';
+const GATEWAY_TARGET = 'AWS::BedrockAgentCore::GatewayTarget';
+/** One per allowlisted model; `cdk.CustomResource` renders as this type. */
+const AGREEMENT = 'AWS::CloudFormation::CustomResource';
+/** The AwsCustomResource wrapping PutUseCaseForModelAccess. */
+const USE_CASE_SUBMISSION = 'Custom::AWS';
+
+describe('VocWebSearchStack — both halves on (the default)', () => {
+  const template = synth({ deployWebSearch: true, anthropicUseCase: ANTHROPIC_USE_CASE });
+
+  it('creates the gateway and one agreement per allowlisted model', () => {
+    template.resourceCountIs(GATEWAY, 1);
+    template.resourceCountIs(GATEWAY_TARGET, 1);
+    template.resourceCountIs(AGREEMENT, ALLOWED_FOUNDATION_MODEL_IDS.length);
+    template.resourceCountIs(USE_CASE_SUBMISSION, 1);
+  });
+
+  it('scopes the gateway role to the concrete gateway ARN, not a wildcard', () => {
+    // Why the gateway half needs no cdk-nag IAM5 suppression.
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Sid: 'InvokeGateway',
+            Resource: { 'Fn::GetAtt': [Match.anyValue(), 'GatewayArn'] },
+          }),
+        ]),
+      }),
+    });
+  });
+});
+
+describe('VocWebSearchStack — the cross-stack contract with Processing and Api', () => {
+  /**
+   * The `ExportsOutput*` outputs only exist once another stack consumes the
+   * values, so this synthesizes a consumer too. That is deliberate: it is the
+   * real path, and these literal names are what VocProcessingStack and
+   * VocApiStack resolve at deploy time. A drift here fails those stacks with
+   * "No export named ..." and zero resources created.
+   */
+  it('exports the gateway ARN and URL under their established names', () => {
+    const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
+    const env = { account: '111111111111', region: 'us-east-1' };
+    const producer = new VocWebSearchStack(app, 'VocWebSearchStack', {
+      env,
+      crossRegionReferences: true,
+      deployWebSearch: true,
+      anthropicUseCase: ANTHROPIC_USE_CASE,
+    });
+    const consumer = new cdk.Stack(app, 'Consumer', { env });
+    new cdk.CfnOutput(consumer, 'Arn', { value: producer.gatewayArn! });
+    new cdk.CfnOutput(consumer, 'Url', { value: producer.gatewayUrl! });
+
+    expect(exportNames(Template.fromStack(producer))).toEqual([
+      'VocWebSearchStack:ExportsOutputFnGetAttWebSearchGatewayGatewayArnBA97E0DC',
+      'VocWebSearchStack:ExportsOutputFnGetAttWebSearchGatewayGatewayUrlE01706EF',
+    ]);
+  });
+
+  it('exposes the gateway properties as undefined when the half is off', () => {
+    // This is what lets processing-stack-consolidated.ts and api-stack.ts skip
+    // their web-search wiring with no change of their own.
+    const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
+    const stack = new VocWebSearchStack(app, 'VocWebSearchStack', {
+      env: { account: '111111111111', region: 'us-east-1' },
+      crossRegionReferences: true,
+      deployWebSearch: false,
+      anthropicUseCase: ANTHROPIC_USE_CASE,
+    });
+    expect(stack.gatewayArn).toBeUndefined();
+    expect(stack.gatewayUrl).toBeUndefined();
+    expect(stack.toolName).toBeUndefined();
+  });
+});
+
+describe('VocWebSearchStack — model access only (-c enableWebSearch=false)', () => {
+  const template = synth({ deployWebSearch: false, anthropicUseCase: ANTHROPIC_USE_CASE });
+
+  it('creates no gateway resources at all', () => {
+    template.resourceCountIs(GATEWAY, 0);
+    template.resourceCountIs(GATEWAY_TARGET, 0);
+  });
+
+  it('publishes no exports, so the consumer stacks import nothing', () => {
+    expect(exportNames(template)).toEqual([]);
+  });
+
+  it('still creates the agreements', () => {
+    template.resourceCountIs(AGREEMENT, ALLOWED_FOUNDATION_MODEL_IDS.length);
+  });
+});
+
+describe('VocWebSearchStack — gateway only (account already has Bedrock access)', () => {
+  const template = synth({ deployWebSearch: true });
+
+  it('creates the gateway', () => {
+    template.resourceCountIs(GATEWAY, 1);
+    template.resourceCountIs(GATEWAY_TARGET, 1);
+  });
+
+  it('creates no agreements and no use-case submission', () => {
+    template.resourceCountIs(AGREEMENT, 0);
+    template.resourceCountIs(USE_CASE_SUBMISSION, 0);
+  });
+});
+
+describe('VocWebSearchStack — model agreements target the app region, not the stack region', () => {
+  it('passes modelRegion through as a custom-resource property', () => {
+    // The stack is pinned to us-east-1; the agreements must still be created in
+    // whichever region the app runs in. This is what made merging the two
+    // stacks free rather than a regional behaviour change.
+    const template = synth({
+      deployWebSearch: false,
+      anthropicUseCase: ANTHROPIC_USE_CASE,
+      modelRegion: 'eu-central-1',
+    });
+    template.hasResourceProperties(AGREEMENT, {
+      region: 'eu-central-1',
+      modelId: ALLOWED_FOUNDATION_MODEL_IDS[0],
+    });
+  });
+});
+
+describe('shouldDeployAiEnablement', () => {
+  it('constructs the stack when either half is wanted', () => {
+    expect(shouldDeployAiEnablement(true, undefined)).toBe(true);
+    expect(shouldDeployAiEnablement(false, ANTHROPIC_USE_CASE)).toBe(true);
+    expect(shouldDeployAiEnablement(true, ANTHROPIC_USE_CASE)).toBe(true);
+  });
+
+  it('does NOT construct the stack when both halves are off', () => {
+    // Reachable in the normal deploy path: an account that already has Bedrock
+    // access, deployed with -c enableWebSearch=false. Constructing here would
+    // emit a resource-less stack, which the workshop converter turns into an
+    // invalid `Resources: {}`.
+    expect(shouldDeployAiEnablement(false, undefined)).toBe(false);
+  });
+});

--- a/voc-datalake/lib/stacks/web-search-stack.test.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.test.ts
@@ -47,12 +47,13 @@ const ANTHROPIC_USE_CASE = {
   otherIndustryOption: '',
 };
 
-function synth(props: Omit<VocWebSearchStackProps, 'env'>): Template {
+function synth(props: Omit<VocWebSearchStackProps, 'env' | 'modelRegion'> & { modelRegion?: string }): Template {
   // Skip asset bundling — template assertions only need structure.
   const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
   const stack = new VocWebSearchStack(app, 'VocWebSearchStack', {
     env: { account: '111111111111', region: 'us-east-1' },
     crossRegionReferences: true,
+    modelRegion: 'us-east-1',
     ...props,
   });
   return Template.fromStack(stack);
@@ -104,6 +105,7 @@ describe('VocWebSearchStack — the cross-stack contract with Processing and Api
     const producer = new VocWebSearchStack(app, 'VocWebSearchStack', {
       env,
       crossRegionReferences: true,
+      modelRegion: 'us-east-1',
       deployWebSearch: true,
       anthropicUseCase: ANTHROPIC_USE_CASE,
     });
@@ -124,6 +126,7 @@ describe('VocWebSearchStack — the cross-stack contract with Processing and Api
     const stack = new VocWebSearchStack(app, 'VocWebSearchStack', {
       env: { account: '111111111111', region: 'us-east-1' },
       crossRegionReferences: true,
+      modelRegion: 'us-east-1',
       deployWebSearch: false,
       anthropicUseCase: ANTHROPIC_USE_CASE,
     });
@@ -178,6 +181,21 @@ describe('VocWebSearchStack — model agreements target the app region, not the 
       region: 'eu-central-1',
       modelId: ALLOWED_FOUNDATION_MODEL_IDS[0],
     });
+  });
+});
+
+describe('VocWebSearchStack — the both-halves-off invariant is enforced, not just documented', () => {
+  it('throws rather than synthesizing a resource-less stack', () => {
+    // An empty stack becomes an invalid `Resources: {}` once
+    // convert-template.mjs strips CDKMetadata, so this must be impossible to
+    // reach even if a caller skips shouldDeployAiEnablement().
+    const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [] } });
+    expect(() => new VocWebSearchStack(app, 'VocWebSearchStack', {
+      env: { account: '111111111111', region: 'us-east-1' },
+      crossRegionReferences: true,
+      modelRegion: 'us-east-1',
+      deployWebSearch: false,
+    })).toThrow(/both halves are disabled/);
   });
 });
 

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -63,9 +63,14 @@ export interface VocWebSearchStackProps extends cdk.StackProps {
 
   /**
    * Region the model agreements are created in — normally the app's region, not
-   * this stack's. Required rather than defaulted; see BedrockModelAccessProps.
+   * this stack's.
+   *
+   * Optional here but **required whenever `anthropicUseCase` is set**, and
+   * validated as such: a gateway-only caller has no model agreements, so
+   * forcing it to invent a value it never reads would be noise. There is
+   * deliberately no default — see BedrockModelAccessProps.
    */
-  modelRegion: string;
+  modelRegion?: string;
 
   /** @default false */
   skipUseCaseSubmission?: boolean;
@@ -94,6 +99,13 @@ export class VocWebSearchStack extends cdk.Stack {
     }
 
     if (props.anthropicUseCase) {
+      if (!props.modelRegion) {
+        throw new Error(
+          `${id}: modelRegion is required when anthropicUseCase is set — it decides where the ` +
+          'model agreements are created, and this stack is pinned to us-east-1 regardless of ' +
+          'where the app runs. Pass the app region.',
+        );
+      }
       new BedrockModelAccess(this, 'BedrockModelAccess', {
         anthropicUseCase: props.anthropicUseCase,
         modelRegion: props.modelRegion,

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -3,17 +3,39 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as bedrockagentcore from 'aws-cdk-lib/aws-bedrockagentcore';
 import { Construct } from 'constructs';
 import { uniqueName } from '../utils/naming';
+import { BedrockModelAccess, AnthropicUseCaseConfig } from './bedrock-access-stack';
 
 /**
- * VocWebSearchStack — AgentCore Gateway exposing the AWS-managed
- * `web-search` connector as an MCP tool.
+ * VocWebSearchStack — the us-east-1 AI-enablement stack. Two independent
+ * halves, each switched on or off by the caller:
  *
- * Used by AI Chat and Projects research for opt-in public-web grounding.
- * Queries are served entirely within AWS (no third-party search engine).
+ *   1. an AgentCore Gateway exposing the AWS-managed `web-search` connector
+ *      as an MCP tool (`deployWebSearch`);
+ *   2. Bedrock model access — the Anthropic use-case submission and the model
+ *      agreements (`anthropicUseCase`).
  *
- * This stack is ALWAYS deployed to us-east-1: the web-search connector is
- * only available there. The rest of the app can live in any region — the
- * chat-stream and research Lambdas call the gateway URL cross-region over
+ * They live together because they are the same deployment unit: both must sit
+ * in us-east-1 (the web-search connector exists only there; the
+ * PutUseCaseForModelAccess API works only there), both are one-shot account
+ * enablement built from custom resources, and neither depends on the core
+ * stack chain. Keeping them apart put the app at six CloudFormation templates,
+ * one over Workshop Studio's ceiling of five.
+ *
+ * ⚠️ The stack is named for the web-search half only, for a deliberate reason:
+ * the CDK id determines the CloudFormation export names that VocProcessingStack
+ * and VocApiStack import. Renaming it would recreate the gateway (whose
+ * physical name is deterministic, so the new one would collide with the live
+ * one) and churn both consumer templates. The name is inherited debt, not a
+ * description — rename it only as part of a planned migration.
+ *
+ * Callers must not construct this stack with BOTH halves off: the result has no
+ * resources, and the workshop template converter strips CDKMetadata, so it
+ * would emit an invalid `Resources: {}`. Use shouldDeployAiEnablement().
+ *
+ * Web-search half: used by AI Chat and Projects research for opt-in
+ * public-web grounding. Queries are served entirely within AWS (no
+ * third-party search engine). The rest of the app can live in any region —
+ * the chat-stream and research Lambdas call the gateway URL cross-region over
  * HTTPS with SigV4, and the gateway URL/ARN flow to those stacks via CDK
  * cross-region references (SSM-backed when regions differ).
  *
@@ -25,13 +47,49 @@ import { uniqueName } from '../utils/naming';
  * Cost note: Web Search invocations are billed at $7 per 1,000 queries.
  * The feature is opt-in per request in both UIs.
  */
-export class VocWebSearchStack extends cdk.Stack {
-  public readonly gatewayUrl: string;
-  public readonly gatewayArn: string;
-  public readonly toolName: string;
+export interface VocWebSearchStackProps extends cdk.StackProps {
+  /**
+   * Create the AgentCore Gateway half. When false, the gateway, its role and
+   * its target are not synthesized at all and the `gateway*` properties are
+   * undefined — consumers already treat them as optional and skip the wiring.
+   */
+  deployWebSearch: boolean;
 
-  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+  /**
+   * Create the Bedrock model-access half. Omit for accounts that already have
+   * Anthropic access; the agreements are then neither created nor needed.
+   */
+  anthropicUseCase?: AnthropicUseCaseConfig;
+
+  /** Region the model agreements are created in. See BedrockModelAccessProps. */
+  modelRegion?: string;
+
+  /** @default false */
+  skipUseCaseSubmission?: boolean;
+}
+
+export class VocWebSearchStack extends cdk.Stack {
+  /** Undefined when `deployWebSearch` is false. */
+  public readonly gatewayUrl?: string;
+  public readonly gatewayArn?: string;
+  public readonly toolName?: string;
+
+  constructor(scope: Construct, id: string, props: VocWebSearchStackProps) {
     super(scope, id, props);
+
+    if (props.anthropicUseCase) {
+      new BedrockModelAccess(this, 'BedrockModelAccess', {
+        anthropicUseCase: props.anthropicUseCase,
+        modelRegion: props.modelRegion,
+        skipUseCaseSubmission: props.skipUseCaseSubmission,
+      });
+    }
+
+    if (!props.deployWebSearch) {
+      // Gateway half off. The stack still holds the model-access half — the
+      // caller is responsible for not constructing it with both halves off.
+      return;
+    }
 
     // Service role the Gateway assumes to reach the AWS-owned connector.
     // Trust is scoped to this account so another account's gateway cannot

--- a/voc-datalake/lib/stacks/web-search-stack.ts
+++ b/voc-datalake/lib/stacks/web-search-stack.ts
@@ -61,8 +61,11 @@ export interface VocWebSearchStackProps extends cdk.StackProps {
    */
   anthropicUseCase?: AnthropicUseCaseConfig;
 
-  /** Region the model agreements are created in. See BedrockModelAccessProps. */
-  modelRegion?: string;
+  /**
+   * Region the model agreements are created in — normally the app's region, not
+   * this stack's. Required rather than defaulted; see BedrockModelAccessProps.
+   */
+  modelRegion: string;
 
   /** @default false */
   skipUseCaseSubmission?: boolean;
@@ -76,6 +79,19 @@ export class VocWebSearchStack extends cdk.Stack {
 
   constructor(scope: Construct, id: string, props: VocWebSearchStackProps) {
     super(scope, id, props);
+
+    // Enforce the invariant here rather than trusting the caller: with both
+    // halves off this stack has no resources, and scripts/convert-template.mjs
+    // strips CDKMetadata, so the workshop artifact would be an invalid
+    // `Resources: {}`. shouldDeployAiEnablement() decides whether to construct
+    // it at all; this makes skipping that decision impossible.
+    if (!props.deployWebSearch && !props.anthropicUseCase) {
+      throw new Error(
+        `${id}: both halves are disabled (deployWebSearch=false and no anthropicUseCase), ` +
+        'which would synthesize a stack with no resources. Use shouldDeployAiEnablement() ' +
+        'to decide whether to construct this stack.',
+      );
+    }
 
     if (props.anthropicUseCase) {
       new BedrockModelAccess(this, 'BedrockModelAccess', {

--- a/voc-datalake/lib/utils/ai-enablement-default.ts
+++ b/voc-datalake/lib/utils/ai-enablement-default.ts
@@ -1,3 +1,5 @@
+import type { AnthropicUseCaseConfig } from '../stacks/bedrock-access-stack';
+
 /**
  * Guard for the us-east-1 AI-enablement stack (VocWebSearchStack), which hosts
  * two independently switchable halves: the web-search AgentCore Gateway and
@@ -16,7 +18,7 @@
  */
 export function shouldDeployAiEnablement(
   deployWebSearch: boolean,
-  anthropicUseCase: unknown,
+  anthropicUseCase: AnthropicUseCaseConfig | undefined,
 ): boolean {
   return deployWebSearch || anthropicUseCase !== undefined;
 }

--- a/voc-datalake/lib/utils/ai-enablement-default.ts
+++ b/voc-datalake/lib/utils/ai-enablement-default.ts
@@ -1,0 +1,22 @@
+/**
+ * Guard for the us-east-1 AI-enablement stack (VocWebSearchStack), which hosts
+ * two independently switchable halves: the web-search AgentCore Gateway and
+ * Bedrock model access.
+ *
+ * Both halves off is a REACHABLE combination in the normal deploy path — an
+ * account that already has Bedrock access omits `anthropicUseCase` from
+ * cdk.context.json, and an operator who does not want web search passes
+ * `-c enableWebSearch=false`. Constructing the stack in that case produces a
+ * stack with no resources, and `scripts/convert-template.mjs` strips
+ * CDKMetadata, so the workshop artifact would be an invalid `Resources: {}`.
+ *
+ * Hence: decide whether to construct the stack at all, rather than letting it
+ * synthesize empty. Kept as a named function so the hazard is greppable and
+ * covered by a test, instead of an unexplained `||` in bin/voc-datalake.ts.
+ */
+export function shouldDeployAiEnablement(
+  deployWebSearch: boolean,
+  anthropicUseCase: unknown,
+): boolean {
+  return deployWebSearch || anthropicUseCase !== undefined;
+}

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c defaultModelId=global.anthropic.claude-sonnet-4-6 && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c enableWebSearch=true -c defaultModelId=global.anthropic.claude-sonnet-4-6 && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },

--- a/voc-datalake/package.json
+++ b/voc-datalake/package.json
@@ -24,7 +24,7 @@
     "generate:menu": "ts-node scripts/generate-menu-config.ts",
     "generate:config": "npm run generate:manifests && npm run generate:menu",
     "generate:integrity": "ts-node scripts/generate-integrity.ts",
-    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c enableWebSearch=false -c defaultModelId=global.anthropic.claude-sonnet-4-6 && node scripts/convert-template.mjs VocCoreStack VocIngestionStack VocProcessingStack VocApiStack BedrockAccessStack",
+    "generate:workshop-artifacts": "rm -rf cdk.out && rm -rf Workshop && npx cdk synth --all -c defaultModelId=global.anthropic.claude-sonnet-4-6 && node scripts/convert-template.mjs VocWebSearchStack VocCoreStack VocIngestionStack VocProcessingStack VocApiStack",
     "validate:plugins": "ts-node scripts/validate-plugins.ts",
     "prebuild:frontend": "npm run generate:config"
   },


### PR DESCRIPTION
## Summary

The app synthesized **six** CloudFormation templates; Workshop Studio's `contentspec.yaml` accepts a
maximum of **five**. The workaround (merged in #269) was to synth workshop artifacts with
`-c enableWebSearch=false`, so the workshop ships a build the product does not.

`BedrockAccessStack` and `VocWebSearchStack` were already the same deployment unit and the code did not
notice: **both are hard-pinned to us-east-1**, both are one-shot AI account enablement built from custom
resources, and **neither depends on the core stack chain**. Merging them frees the fifth slot, so web
search deploys to the workshop and the flag divergence goes away.

`bedrock-access-stack.ts` overrode the region inside its own `super()` call (`region: 'us-east-1'`) and
discarded the `env` that `bin/` passed it — which is why the co-location was easy to miss.

## Why merging costs nothing

| | agreements half | web-search half |
|---|---|---|
| region | us-east-1 (hard-pinned) | us-east-1 (hard-pinned) |
| depends on the core chain | no — **0** `Fn::ImportValue` | no |
| exports consumed elsewhere | **0** (its 4 outputs have no `Export` block) | 2, imported 2× each by Processing and Api |

Model agreements are unaffected by placement: `modelRegion` is a **custom-resource property**, and the
handler does `boto3.client('bedrock', region_name=region)`. A us-east-1-placed stack still creates
agreements in the app's region, so multi-region support is untouched.

## Direction matters — agreements were folded INTO the gateway stack, not the reverse

Processing and Api import the **gateway's** exports, so this direction leaves both consumer templates
untouched with **zero export renames**. The reverse would have repointed 4 imports and recreated the
gateway — whose physical name is deterministic (`voc-web-search-<account>-<region>`), so the new one
would have collided with the live one.

The agreements are the safe half to move: Bedrock agreements **persist per account** independently of the
stack (the handler treats any non-`Create` request as a no-op), and this half publishes no consumed
exports, so deleting the old stack carries no ordering constraint.

## Both halves stay independently switchable

Synth-time gating, which is what this stack already did on two axes (early-return without
`anthropicUseCase`; `skipUseCaseSubmission`). **No new flag** — `shouldDeployWebSearch()` is already
default-on / opt-out. Consumers needed **no change**: `processing-stack-consolidated.ts:290` and
`api-stack.ts:786` already guard on the optional gateway props.

New guard, `lib/utils/ai-enablement-default.ts`: **both halves off is reachable** in the normal deploy
path (an account that already has Bedrock access, deployed with `-c enableWebSearch=false`). Constructing
the stack then yields no resources, and `convert-template.mjs` strips `CDKMetadata`, so the workshop
artifact would be an invalid `Resources: {}`.

## Verification

Four toggle combinations, from real synths:

| combination | AI template | AgentCore res. | agreements | exports | Proc/Api refs | templates |
|---|---|---:|---:|---:|---:|---:|
| both on (default) | present, 22 res. | 2 | 6 | 2 | 2 / 2 | **5** |
| `-c enableWebSearch=false` | present, 18 res. | 0 | 6 | 0 | 0 / 0 | 5 |
| `-c anthropicUseCase=` | present, 4 res. | 2 | 0 | 2 | 2 / 2 | 5 |
| both off | **not constructed** | — | — | — | 0 / 0 | 4 |

**Export names are byte-identical** to the currently published ones —
`VocWebSearchStack:ExportsOutputFnGetAttWebSearchGatewayGatewayArnBA97E0DC` and `…GatewayUrlE01706EF` —
and Processing and Api each still resolve exactly those two.

`generate:workshop-artifacts` ran end-to-end: **5/5 converted**, `VocWebSearchStack` at 22 resources,
uniform `AssetBucket`/`AssetPrefix` parameters, **zero account and zero region literals in all five
templates**, and `VocCoreStack`'s `Custom::ModelPin` intact.

New `lib/stacks/web-search-stack.test.ts` — 12 tests, verified **fail-on-revert** (stubbing out the
gateway gate fails 2 of them). Pins the export names against a real consumer stack, since CDK only emits
`ExportsOutput*` once another stack references the value.

**Proven live in a Workshop Studio event account:** a 4-resource gateway-only stack reached
`CREATE_COMPLETE`, and the service API confirmed the gateway and its `web-search-tool` target both
`READY`. This settles a previously open question — the gateway becomes template [1/5], so a refusal would
have taken all five stacks down. Probe stack deleted afterwards.

### Gates

`typecheck:all` clean · `test:cdk` 132 · `test:stream` 257 · `test:backend` 1281 · frontend 1804 ·
`lint:frontend` + `lint:stream` pass.

⚠️ `lint:python` (ruff) fails with 551 errors, so `npm run check` exits 1. **Pre-existing on
`development`, not from this branch** — ruff scans only `lambda` and `plugins`, and none of the files here
live in either, so its input is byte-identical to the base. Worth its own issue: the documented deployment
gate cannot currently pass.

## cdk-nag

Dropped the `pluginSystem` / `comprehend` / `translate` stack-level suppressions that were applied to
`BedrockAccessStack`: it calls neither Comprehend nor Translate, cdk-nag is clean without them, and
inheriting them would have covered gateway resources that have always passed unsuppressed.

## Migrating an existing deployment

1. `cdk deploy --all` — the agreements appear in `VocWebSearchStack` and re-run idempotently.
   Processing and Api are untouched (no import changes).
2. `cdk destroy BedrockAccessStack` — CDK does not delete a stack that has been dropped from the app, so
   this step is manual. Safe in any order: no consumed exports, and the agreements persist in the account.

No gateway is recreated and there is no feature downtime.

## Two naming compromises, documented in code rather than fixed

- **The stack keeps the id `VocWebSearchStack`** even though it now does more than web search. That id
  determines the export names Processing and Api import; renaming it would recreate the gateway and churn
  both consumer templates.
- **`lib/stacks/bedrock-access-stack.ts` keeps its path** while now exporting a Construct
  (`BedrockModelAccess`), because `lambda/shared/test/test_model_agreement_handler.py` reads that exact
  path and regexes `getModelAgreementLambdaCode()` out of it to test the inline Python handler. A
  file-header comment records this. Happy to rename both plus the one-line test update if preferred.

## Follow-up (separate, not required here)

Publish the gateway URL/ARN to SSM and read them at Lambda cold start instead of via `Fn::ImportValue`.
Processing and Api would then carry zero web-search references, the enablement stack could be listed last
again, and a gateway failure would degrade the feature instead of blocking two stacks. Note the gateway
**URL is not derivable** — the id is `<deterministic name>-<random suffix>` — so the stack must publish
it, though IAM can still be scoped by the name pattern.

## Workshop follow-up (not in this PR)

Republishing needs the artifacts regenerated from `development` after this merges. Two changes from the
previous recipe: `VocWebSearchStack` now carries **2 asset zips** (the custom-resource framework Lambdas
came with the agreements) where it previously had none, so `development/VocWebSearchStack/` must be
populated — additively, never `--delete`. And `development/BedrockAccessStack/` becomes an orphaned
prefix; leave it, since previously published builds still reference it.
