### PR TITLE
fix: resolve active Bedrock model for persona calls

### DIFF
--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -564,7 +564,7 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
     # lookups (chain + metadata stamp) could drift if an admin repointed the
     # 'documents' surface mid-run; one resolution cannot.
     resolved_model_id = get_active_model_id(surface='documents')
-    logger.info(f"[PERSONA] Resolved persona model: {resolved_model_id}")
+    logger.info("[PERSONA] Resolved persona model", extra={'model_id': resolved_model_id})
 
     # Get feedback data
     try:
@@ -636,16 +636,6 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
                 response_language=filters.get('response_language'),
                 sample_chars=context_budget,
             )
-            model_overrides = [
-                step.get('step_name', f'persona_step_{idx}')
-                for idx, step in enumerate(chain_steps, 1)
-                if step.get('model_id') or step.get('model')
-            ]
-            if model_overrides:
-                raise ValueError(
-                    'Persona generation steps must not override model_id: '
-                    + ', '.join(model_overrides)
-                )
             logger.info(f"[PERSONA] Built {len(chain_steps)} chain steps")
         except Exception as e:
             logger.error(f"[PERSONA] Failed to build chain steps: {e}")
@@ -678,7 +668,6 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
             results = converse_chain(
                 chain_steps,
                 progress_callback=lambda p, s: update_progress(p, s),
-                surface='documents',
                 model_id=resolved_model_id,
             )
             logger.info(f"[PERSONA] LLM chain returned {len(results)} results")

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -668,6 +668,7 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
             results = converse_chain(
                 chain_steps,
                 progress_callback=lambda p, s: update_progress(p, s),
+                surface='documents',
                 model_id=resolved_model_id,
             )
             logger.info(f"[PERSONA] LLM chain returned {len(results)} results")

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 
 # Shared module imports
 from shared.logging import logger, tracer, metrics
-from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource, get_bedrock_client
 from shared.api import validate_days, MAX_PERSONAS_PER_GENERATION
 from shared.persona_context import personas_prompt_context
 from shared.converse import converse_chain
@@ -38,7 +38,7 @@ from shared.feedback import (
     get_feedback_statistics,
     truncate_feedback_context,
 )
-from shared.model_config import surface_context_window_tokens
+from shared.model_config import get_active_model_id, surface_context_window_tokens
 from shared.avatar import (
     generate_persona_avatar as _generate_persona_avatar,
     get_avatar_cdn_url,
@@ -558,6 +558,14 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
         f"[PERSONA] Context budget: {context_budget} chars, fetch limit: {fetch_limit} items"
     )
 
+    # Resolve the persona-synthesis model ONCE per invocation and pin it on
+    # the chain below (converse_chain forwards it to every step) so the
+    # stored llm_metadata records exactly what was invoked. Two independent
+    # lookups (chain + metadata stamp) could drift if an admin repointed the
+    # 'documents' surface mid-run; one resolution cannot.
+    resolved_model_id = get_active_model_id(surface='documents')
+    logger.info(f"[PERSONA] Resolved persona model: {resolved_model_id}")
+
     # Get feedback data
     try:
         feedback_items = get_feedback_context(filters, limit=fetch_limit)
@@ -628,6 +636,16 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
                 response_language=filters.get('response_language'),
                 sample_chars=context_budget,
             )
+            model_overrides = [
+                step.get('step_name', f'persona_step_{idx}')
+                for idx, step in enumerate(chain_steps, 1)
+                if step.get('model_id') or step.get('model')
+            ]
+            if model_overrides:
+                raise ValueError(
+                    'Persona generation steps must not override model_id: '
+                    + ', '.join(model_overrides)
+                )
             logger.info(f"[PERSONA] Built {len(chain_steps)} chain steps")
         except Exception as e:
             logger.error(f"[PERSONA] Failed to build chain steps: {e}")
@@ -657,7 +675,12 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
         update_progress(20, 'executing_llm_chain')
         
         try:
-            results = converse_chain(chain_steps, progress_callback=lambda p, s: update_progress(p, s), surface='documents')
+            results = converse_chain(
+                chain_steps,
+                progress_callback=lambda p, s: update_progress(p, s),
+                surface='documents',
+                model_id=resolved_model_id,
+            )
             logger.info(f"[PERSONA] LLM chain returned {len(results)} results")
         except Exception as e:
             logger.error(f"[PERSONA] LLM chain execution failed: {e}")
@@ -790,7 +813,7 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
                 'created_at': now,
                 'updated_at': now,
                 'llm_metadata': {
-                    'model': BEDROCK_MODEL_ID,
+                    'model': resolved_model_id,
                     'prompt_version': PERSONA_PROMPT_VERSION,
                     'generation_time_ms': llm_time
                 },

--- a/voc-datalake/lambda/api/test/test_projects.py
+++ b/voc-datalake/lambda/api/test/test_projects.py
@@ -289,6 +289,15 @@ class TestGenerateAvatarPromptWithLlm:
 class TestGeneratePersonasModelMetadata:
     """Tests for persona generation model metadata."""
 
+    @staticmethod
+    def _put_item_payload(table):
+        call = table.put_item.call_args
+        assert call is not None, 'expected put_item to be called'
+        if call.kwargs.get('Item') is not None:
+            return call.kwargs['Item']
+        assert call.args, 'expected put_item Item as kwargs or first positional arg'
+        return call.args[0]
+
     def test_stores_resolved_model_id(self):
         """Stamps the resolved model, not the global fallback constant."""
         import projects
@@ -307,24 +316,25 @@ class TestGeneratePersonasModelMetadata:
                 patch('projects.converse_chain', return_value=[
                     json.dumps([{'name': 'Ada'}]),
                 ]) as mock_chain, \
-                patch('projects.get_active_model_id', return_value='resolved-model') as mock_model_id:
+                patch(
+                    'projects.get_active_model_id',
+                    return_value='resolved-model',
+                ) as mock_model_id:
             projects.generate_personas(
                 'proj-1',
                 {'persona_count': 1, 'generate_avatars': False},
             )
 
-        assert table.put_item.called
-        stored = table.put_item.call_args.kwargs['Item']
+        stored = self._put_item_payload(table)
         assert stored['llm_metadata']['model'] == 'resolved-model'
         # One resolution per invocation, and the chain is PINNED to it: the
         # model converse() invokes is the one llm_metadata records.
         mock_model_id.assert_called_once_with(surface='documents')
         assert mock_chain.call_args.kwargs['model_id'] == 'resolved-model'
 
-    def test_rejects_persona_step_model_override(self):
-        """llm_metadata records one model, so persona steps must not override it."""
+    def test_persona_chain_pin_tolerates_step_model_override(self):
+        """The resolved chain pin keeps metadata aligned without failing the job."""
         import projects
-        from shared.exceptions import ServiceError
 
         table = MagicMock()
         table.query.return_value = {'Items': []}
@@ -340,12 +350,16 @@ class TestGeneratePersonasModelMetadata:
                         'model': 'other-model',
                     },
                 ]), \
-                patch('projects.converse_chain') as mock_chain, \
+                patch('projects.converse_chain', return_value=[
+                    json.dumps([{'name': 'Ada'}]),
+                ]) as mock_chain, \
                 patch('projects.get_active_model_id', return_value='resolved-model'):
-            with pytest.raises(ServiceError, match='Failed to generate personas'):
-                projects.generate_personas(
-                    'proj-1',
-                    {'persona_count': 1, 'generate_avatars': False},
-                )
+            projects.generate_personas(
+                'proj-1',
+                {'persona_count': 1, 'generate_avatars': False},
+            )
 
-        mock_chain.assert_not_called()
+        stored = self._put_item_payload(table)
+        assert stored['llm_metadata']['model'] == 'resolved-model'
+        assert mock_chain.call_args.kwargs['model_id'] == 'resolved-model'
+        assert 'surface' not in mock_chain.call_args.kwargs

--- a/voc-datalake/lambda/api/test/test_projects.py
+++ b/voc-datalake/lambda/api/test/test_projects.py
@@ -290,13 +290,16 @@ class TestGeneratePersonasModelMetadata:
     """Tests for persona generation model metadata."""
 
     @staticmethod
-    def _put_item_payload(table):
-        call = table.put_item.call_args
-        assert call is not None, 'expected put_item to be called'
-        if call.kwargs.get('Item') is not None:
-            return call.kwargs['Item']
-        assert call.args, 'expected put_item Item as kwargs or first positional arg'
-        return call.args[0]
+    def _put_item_payloads(table):
+        """Every put_item payload, not just the final one: a persona_count > 1
+        run writes one row per persona and asserting only the last call would
+        silently skip the earlier ones."""
+        calls = table.put_item.call_args_list
+        assert calls, 'expected put_item to be called'
+        return [
+            c.kwargs['Item'] if c.kwargs.get('Item') is not None else c.args[0]
+            for c in calls
+        ]
 
     def test_stores_resolved_model_id(self):
         """Stamps the resolved model, not the global fallback constant."""
@@ -325,8 +328,8 @@ class TestGeneratePersonasModelMetadata:
                 {'persona_count': 1, 'generate_avatars': False},
             )
 
-        stored = self._put_item_payload(table)
-        assert stored['llm_metadata']['model'] == 'resolved-model'
+        for stored in self._put_item_payloads(table):
+            assert stored['llm_metadata']['model'] == 'resolved-model'
         # One resolution per invocation, and the chain is PINNED to it: the
         # model converse() invokes is the one llm_metadata records.
         mock_model_id.assert_called_once_with(surface='documents')
@@ -359,7 +362,7 @@ class TestGeneratePersonasModelMetadata:
                 {'persona_count': 1, 'generate_avatars': False},
             )
 
-        stored = self._put_item_payload(table)
-        assert stored['llm_metadata']['model'] == 'resolved-model'
+        for stored in self._put_item_payloads(table):
+            assert stored['llm_metadata']['model'] == 'resolved-model'
         assert mock_chain.call_args.kwargs['model_id'] == 'resolved-model'
-        assert 'surface' not in mock_chain.call_args.kwargs
+        assert mock_chain.call_args.kwargs['surface'] == 'documents'

--- a/voc-datalake/lambda/api/test/test_projects.py
+++ b/voc-datalake/lambda/api/test/test_projects.py
@@ -290,12 +290,14 @@ class TestGeneratePersonasModelMetadata:
     """Tests for persona generation model metadata."""
 
     @staticmethod
-    def _put_item_payloads(table):
+    def _put_item_payloads(table, expected_count):
         """Every persona put_item payload, not just the final one: a
         persona_count > 1 run writes one row per persona and asserting only
         the last call would silently skip the earlier ones. Filtered on
         llm_metadata so a hypothetical future non-persona row fails as
-        'no persona rows' instead of a bare KeyError."""
+        'no persona rows' instead of a bare KeyError, and pinned to
+        expected_count so a change that stops stamping llm_metadata on a
+        persona row fails loudly instead of dropping it from the list."""
         calls = table.put_item.call_args_list
         assert calls, 'expected put_item to be called'
         payloads = [
@@ -303,7 +305,10 @@ class TestGeneratePersonasModelMetadata:
             for c in calls
         ]
         persona_rows = [p for p in payloads if p.get('llm_metadata')]
-        assert persona_rows, 'expected put_item to write at least one persona row'
+        assert len(persona_rows) == expected_count, (
+            f'expected {expected_count} persona rows, '
+            f'found {len(persona_rows)}'
+        )
         return persona_rows
 
     def test_stores_resolved_model_id(self):
@@ -333,7 +338,8 @@ class TestGeneratePersonasModelMetadata:
                 {'persona_count': 1, 'generate_avatars': False},
             )
 
-        for stored in self._put_item_payloads(table):
+        # persona_count is 1 in this run: exactly one persona row expected.
+        for stored in self._put_item_payloads(table, 1):
             assert stored['llm_metadata']['model'] == 'resolved-model'
         # One resolution per invocation, and the chain is PINNED to it: the
         # model converse() invokes is the one llm_metadata records.
@@ -367,7 +373,8 @@ class TestGeneratePersonasModelMetadata:
                 {'persona_count': 1, 'generate_avatars': False},
             )
 
-        for stored in self._put_item_payloads(table):
+        # persona_count is 1 in this run: exactly one persona row expected.
+        for stored in self._put_item_payloads(table, 1):
             assert stored['llm_metadata']['model'] == 'resolved-model'
         assert mock_chain.call_args.kwargs['model_id'] == 'resolved-model'
         assert mock_chain.call_args.kwargs['surface'] == 'documents'

--- a/voc-datalake/lambda/api/test/test_projects.py
+++ b/voc-datalake/lambda/api/test/test_projects.py
@@ -284,3 +284,68 @@ class TestGenerateAvatarPromptWithLlm:
         result = generate_avatar_prompt_with_llm(persona_data, mock_bedrock)
         
         assert 'Professional headshot' in result
+
+
+class TestGeneratePersonasModelMetadata:
+    """Tests for persona generation model metadata."""
+
+    def test_stores_resolved_model_id(self):
+        """Stamps the resolved model, not the global fallback constant."""
+        import projects
+
+        table = MagicMock()
+        table.query.return_value = {'Items': []}
+        feedback_items = [{'feedback_id': 'f1', 'source_platform': 'web'}]
+
+        with patch('projects.projects_table', table), \
+                patch('projects.get_feedback_context', return_value=feedback_items), \
+                patch('projects.format_feedback_for_llm', return_value='feedback'), \
+                patch('projects.get_feedback_statistics', return_value={'total': 1}), \
+                patch('projects.get_persona_generation_steps', return_value=[
+                    {'step_name': projects.PERSONA_SYNTHESIS_STEP},
+                ]), \
+                patch('projects.converse_chain', return_value=[
+                    json.dumps([{'name': 'Ada'}]),
+                ]) as mock_chain, \
+                patch('projects.get_active_model_id', return_value='resolved-model') as mock_model_id:
+            projects.generate_personas(
+                'proj-1',
+                {'persona_count': 1, 'generate_avatars': False},
+            )
+
+        assert table.put_item.called
+        stored = table.put_item.call_args.kwargs['Item']
+        assert stored['llm_metadata']['model'] == 'resolved-model'
+        # One resolution per invocation, and the chain is PINNED to it: the
+        # model converse() invokes is the one llm_metadata records.
+        mock_model_id.assert_called_once_with(surface='documents')
+        assert mock_chain.call_args.kwargs['model_id'] == 'resolved-model'
+
+    def test_rejects_persona_step_model_override(self):
+        """llm_metadata records one model, so persona steps must not override it."""
+        import projects
+        from shared.exceptions import ServiceError
+
+        table = MagicMock()
+        table.query.return_value = {'Items': []}
+        feedback_items = [{'feedback_id': 'f1', 'source_platform': 'web'}]
+
+        with patch('projects.projects_table', table), \
+                patch('projects.get_feedback_context', return_value=feedback_items), \
+                patch('projects.format_feedback_for_llm', return_value='feedback'), \
+                patch('projects.get_feedback_statistics', return_value={'total': 1}), \
+                patch('projects.get_persona_generation_steps', return_value=[
+                    {
+                        'step_name': projects.PERSONA_SYNTHESIS_STEP,
+                        'model': 'other-model',
+                    },
+                ]), \
+                patch('projects.converse_chain') as mock_chain, \
+                patch('projects.get_active_model_id', return_value='resolved-model'):
+            with pytest.raises(ServiceError, match='Failed to generate personas'):
+                projects.generate_personas(
+                    'proj-1',
+                    {'persona_count': 1, 'generate_avatars': False},
+                )
+
+        mock_chain.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_projects.py
+++ b/voc-datalake/lambda/api/test/test_projects.py
@@ -291,15 +291,20 @@ class TestGeneratePersonasModelMetadata:
 
     @staticmethod
     def _put_item_payloads(table):
-        """Every put_item payload, not just the final one: a persona_count > 1
-        run writes one row per persona and asserting only the last call would
-        silently skip the earlier ones."""
+        """Every persona put_item payload, not just the final one: a
+        persona_count > 1 run writes one row per persona and asserting only
+        the last call would silently skip the earlier ones. Filtered on
+        llm_metadata so a hypothetical future non-persona row fails as
+        'no persona rows' instead of a bare KeyError."""
         calls = table.put_item.call_args_list
         assert calls, 'expected put_item to be called'
-        return [
+        payloads = [
             c.kwargs['Item'] if c.kwargs.get('Item') is not None else c.args[0]
             for c in calls
         ]
+        persona_rows = [p for p in payloads if p.get('llm_metadata')]
+        assert persona_rows, 'expected put_item to write at least one persona row'
+        return persona_rows
 
     def test_stores_resolved_model_id(self):
         """Stamps the resolved model, not the global fallback constant."""

--- a/voc-datalake/lambda/api/test/test_projects.py
+++ b/voc-datalake/lambda/api/test/test_projects.py
@@ -294,10 +294,9 @@ class TestGeneratePersonasModelMetadata:
         """Every persona put_item payload, not just the final one: a
         persona_count > 1 run writes one row per persona and asserting only
         the last call would silently skip the earlier ones. Filtered on
-        llm_metadata so a hypothetical future non-persona row fails as
-        'no persona rows' instead of a bare KeyError, and pinned to
-        expected_count so a change that stops stamping llm_metadata on a
-        persona row fails loudly instead of dropping it from the list."""
+        llm_metadata so a hypothetical future non-persona row is ignored,
+        while expected_count makes any missing persona metadata stamp fail
+        loudly as a row-count mismatch."""
         calls = table.put_item.call_args_list
         assert calls, 'expected put_item to be called'
         payloads = [

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -12,7 +12,7 @@ from boto3.dynamodb.conditions import Key
 
 # Shared module imports
 from shared.logging import logger, tracer
-from shared.aws import get_dynamodb_resource, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource
 from shared.api import api_handler
 from shared.converse import converse, BedrockThrottlingError
 from shared.persona_context import personas_prompt_context
@@ -47,13 +47,15 @@ PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
 feedback_table = None
 projects_table = None
 
-MODEL_ID = BEDROCK_MODEL_ID
+
 def _get_feedback_table():
     """Get feedback table, initializing if needed."""
     global feedback_table
     if feedback_table is None:
         feedback_table = get_feedback_table()
     return feedback_table
+
+
 def _get_projects_table():
     """Get projects table, initializing if needed."""
     global projects_table

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -12,6 +12,8 @@ import boto3
 
 from shared.logging import logger, tracer
 from shared.prompts import get_avatar_prompt_config, format_prompt
+# Lightweight runtime picker; it lazy-loads DynamoDB only when called.
+from shared.model_config import get_active_model_id
 
 # `shared.cloudfront_signing` (and through it `cryptography`) is imported LAZILY
 # inside get_avatar_cdn_url — the only function here that signs. The rest of this
@@ -214,27 +216,27 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
         'soft studio lighting, neutral background, photorealistic'
     )
 
+    model_id = get_active_model_id(surface='utility')
+
+    # Load prompt config before the Bedrock fallback boundary, preserving the
+    # old behaviour: prompt file problems are configuration errors, while model
+    # invocation problems degrade to a deterministic static prompt.
+    config = get_avatar_prompt_config()
+    system_prompt = config.get('system_prompt', '')
+    user_template = config.get('user_prompt_template', '')
+    fallback_template = config.get('fallback_prompt_template', fallback_template)
+
+    user_msg = format_prompt(
+        user_template,
+        name=name,
+        tagline=tagline,
+        age_range=age_range,
+        occupation=occupation,
+        location=location,
+        bio=bio[:300] if bio else 'N/A'
+    )
+
     try:
-        from shared.model_config import get_active_model_id
-
-        model_id = get_active_model_id(surface='utility')
-
-        # Load prompt config from external file
-        config = get_avatar_prompt_config()
-        system_prompt = config.get('system_prompt', '')
-        user_template = config.get('user_prompt_template', '')
-        fallback_template = config.get('fallback_prompt_template', fallback_template)
-
-        user_msg = format_prompt(
-            user_template,
-            name=name,
-            tagline=tagline,
-            age_range=age_range,
-            occupation=occupation,
-            location=location,
-            bio=bio[:300] if bio else 'N/A'
-        )
-
         request_body = {
             'anthropic_version': 'bedrock-2023-05-31',
             'max_tokens': config.get('max_tokens', 200),

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -216,8 +216,6 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
         'soft studio lighting, neutral background, photorealistic'
     )
 
-    model_id = get_active_model_id(surface='utility')
-
     # Load prompt config before the Bedrock fallback boundary, preserving the
     # old behaviour: prompt file problems are configuration errors, while model
     # invocation problems degrade to a deterministic static prompt.
@@ -237,6 +235,11 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
     )
 
     try:
+        # Inside the boundary on purpose: before the per-surface picker this was
+        # a constant that could never fail, so a transient picker (DynamoDB)
+        # problem must degrade to the static fallback prompt exactly like an
+        # invocation failure instead of becoming a new hard-failure path.
+        model_id = get_active_model_id(surface='utility')
         request_body = {
             'anthropic_version': 'bedrock-2023-05-31',
             'max_tokens': config.get('max_tokens', 200),

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -202,8 +202,6 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
     Returns:
         Generated image prompt string
     """
-    from shared.aws import BEDROCK_MODEL_ID
-    
     name = persona_data.get('name', 'Unknown')
     tagline = persona_data.get('tagline', '')
     identity = persona_data.get('identity', {})
@@ -211,23 +209,32 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
     age_range = identity.get('age_range', '')
     occupation = identity.get('occupation', '')
     location = identity.get('location', '')
-    
-    # Load prompt config from external file
-    config = get_avatar_prompt_config()
-    system_prompt = config.get('system_prompt', '')
-    user_template = config.get('user_prompt_template', '')
-    
-    user_msg = format_prompt(
-        user_template,
-        name=name,
-        tagline=tagline,
-        age_range=age_range,
-        occupation=occupation,
-        location=location,
-        bio=bio[:300] if bio else 'N/A'
+    fallback_template = (
+        'Professional headshot of a {occupation}, friendly expression, '
+        'soft studio lighting, neutral background, photorealistic'
     )
 
     try:
+        from shared.model_config import get_active_model_id
+
+        model_id = get_active_model_id(surface='utility')
+
+        # Load prompt config from external file
+        config = get_avatar_prompt_config()
+        system_prompt = config.get('system_prompt', '')
+        user_template = config.get('user_prompt_template', '')
+        fallback_template = config.get('fallback_prompt_template', fallback_template)
+
+        user_msg = format_prompt(
+            user_template,
+            name=name,
+            tagline=tagline,
+            age_range=age_range,
+            occupation=occupation,
+            location=location,
+            bio=bio[:300] if bio else 'N/A'
+        )
+
         request_body = {
             'anthropic_version': 'bedrock-2023-05-31',
             'max_tokens': config.get('max_tokens', 200),
@@ -236,7 +243,7 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
         }
         
         response = bedrock_client.invoke_model(
-            modelId=BEDROCK_MODEL_ID,
+            modelId=model_id,
             contentType='application/json',
             accept='application/json',
             body=json.dumps(request_body)
@@ -250,8 +257,10 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
         
         return result['content'][0]['text'].strip()
     except Exception as e:
-        logger.warning(f"[PERSONA_AVATAR] LLM prompt generation failed: {e}, using fallback")
-        fallback_template = config.get('fallback_prompt_template', 'Professional headshot of a {occupation}, friendly expression, soft studio lighting, neutral background, photorealistic')
+        logger.warning(
+            "[PERSONA_AVATAR] LLM prompt generation failed "
+            f"({type(e).__name__}: {e}), using fallback"
+        )
         return format_prompt(fallback_template, occupation=occupation or 'professional')
 
 

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -263,8 +263,9 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
         return result['content'][0]['text'].strip()
     except Exception as e:
         logger.warning(
-            "[PERSONA_AVATAR] LLM prompt generation failed "
-            f"({type(e).__name__}: {e}), using fallback"
+            "[PERSONA_AVATAR] Avatar prompt generation failed in model "
+            f"resolution or Bedrock invocation ({type(e).__name__}: {e}), "
+            "using static fallback prompt"
         )
         return format_prompt(fallback_template, occupation=occupation or 'professional')
 

--- a/voc-datalake/lambda/shared/avatar.py
+++ b/voc-datalake/lambda/shared/avatar.py
@@ -12,8 +12,6 @@ import boto3
 
 from shared.logging import logger, tracer
 from shared.prompts import get_avatar_prompt_config, format_prompt
-# Lightweight runtime picker; it lazy-loads DynamoDB only when called.
-from shared.model_config import get_active_model_id
 
 # `shared.cloudfront_signing` (and through it `cryptography`) is imported LAZILY
 # inside get_avatar_cdn_url — the only function here that signs. The rest of this
@@ -238,7 +236,9 @@ def generate_avatar_prompt_with_llm(persona_data: dict, bedrock_client) -> str:
         # Inside the boundary on purpose: before the per-surface picker this was
         # a constant that could never fail, so a transient picker (DynamoDB)
         # problem must degrade to the static fallback prompt exactly like an
-        # invocation failure instead of becoming a new hard-failure path.
+        # invocation failure instead of becoming a new hard-failure path. Import
+        # here too, matching this module's deliberately narrow import graph.
+        from shared.model_config import get_active_model_id
         model_id = get_active_model_id(surface='utility')
         request_body = {
             'anthropic_version': 'bedrock-2023-05-31',

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -555,26 +555,36 @@ def converse_chain(
     progress_callback: Callable[[int, str], None] | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
     surface: str = DEFAULT_SURFACE,
+    model_id: str | None = None,
 ) -> list[str]:
     """
     Execute a chain of LLM calls, each building on the previous.
-    
+
     Each step can have:
         - system: System prompt
         - user: User message (use {previous} to inject previous result)
         - max_tokens: Max output tokens (default 4096)
         - thinking_budget: Extended thinking budget (default 0 = disabled)
         - step_name: Optional name for progress reporting
+        - model_id/model: Optional explicit model for this step. It wins over
+          the chain-level `model_id` because step-specific configs are more
+          precise.
         - surface: Optional per-step AI surface override (defaults to the
           chain-level `surface`)
-    
+
     Args:
         steps: List of step configurations
         progress_callback: Optional callback(progress: int, step: str) to report progress
         max_retries: Maximum retry attempts for throttling (default: 5)
         surface: AI surface whose configured model the steps resolve to when
             they don't set their own model (default: the neutral fallback).
-    
+        model_id: Explicit model ID pinned across every step (forwarded to
+            converse(), where it takes precedence over surface resolution).
+            Callers that stamp "which model ran" into stored metadata resolve
+            once and pin it here, so what was invoked and what was recorded
+            cannot drift. When None, each step resolves from ``surface`` as
+            before.
+
     Returns:
         List of results from each step
     """
@@ -603,6 +613,7 @@ def converse_chain(
         user = step.get('user', '').replace('{previous}', context)
         thinking_budget = step.get('thinking_budget', 0)
         max_tokens = step.get('max_tokens', 4096)
+        step_model_id = step.get('model_id') or step.get('model') or model_id
         
         logger.info(f"[CHAIN] Step '{step_name}' config: max_tokens={max_tokens}, thinking_budget={thinking_budget}")
         logger.info(f"[CHAIN] Step '{step_name}' system_prompt length: {len(system)} chars")
@@ -618,6 +629,7 @@ def converse_chain(
                 surface=step.get('surface', surface),
                 max_retries=max_retries,
                 step_name=step_name,
+                model_id=step_model_id,
             )
             step_elapsed = time.time() - step_start
             logger.info(f"[CHAIN] Step '{step_name}' completed in {step_elapsed:.2f}s, output length: {len(result)} chars")

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -619,22 +619,22 @@ def converse_chain(
         max_tokens = step.get('max_tokens', 4096)
         step_explicit_model_id = step.get('model_id') or step.get('model')
         step_model_id = model_id or step_explicit_model_id
+        # An explicit model beats surface resolution inside converse(),
+        # whether that model comes from the chain pin or from the step
+        # itself. Every way this step loses that argument collapses into ONE
+        # warning naming everything dropped, so an operator greps once
+        # instead of matching several near-duplicate lines.
+        inert_overrides = []
         if step_model_id is not None and step.get('surface'):
-            # An explicit model wins over surface resolution inside
-            # converse(), whether that model came from this step or from a
-            # pinned chain model_id. Say so instead of silently eating an
-            # inert per-step surface.
-            model_source = 'chain model_id' if model_id else 'step model_id/model'
-            logger.warning(
-                f"[CHAIN] Step '{step_name}' sets surface='{step['surface']}' "
-                f"but {model_source} is explicit: that model wins and this "
-                "surface override is ignored"
-            )
+            inert_overrides.append(f"surface='{step['surface']}'")
         if model_id is not None and step_explicit_model_id:
+            inert_overrides.append('model_id/model')
+        if inert_overrides:
+            winner = ('the chain-pinned model_id' if model_id is not None
+                      else 'the step model_id/model')
             logger.warning(
-                f"[CHAIN] Step '{step_name}' sets model_id/model but the "
-                "chain pins model_id: the chain model wins and the step "
-                "model override is ignored"
+                f"[CHAIN] Step '{step_name}' drops inert overrides "
+                f"({', '.join(inert_overrides)}): {winner} is explicit and wins"
             )
         
         logger.info(f"[CHAIN] Step '{step_name}' config: max_tokens={max_tokens}, thinking_budget={thinking_budget}")

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -566,11 +566,14 @@ def converse_chain(
         - max_tokens: Max output tokens (default 4096)
         - thinking_budget: Extended thinking budget (default 0 = disabled)
         - step_name: Optional name for progress reporting
-        - model_id/model: Optional explicit model for this step. It wins over
-          the chain-level `model_id` because step-specific configs are more
-          precise.
+        - model_id/model: Optional explicit model for this step. Used only
+          when the chain itself is not pinned with `model_id`.
         - surface: Optional per-step AI surface override (defaults to the
-          chain-level `surface`)
+          chain-level `surface`). Inert whenever the step's model ends up
+          explicit, because converse() gives an explicit model precedence
+          over surface resolution; that includes every step of a chain
+          called with a pinned `model_id`. Give a step a model or a
+          surface, never both.
 
     Args:
         steps: List of step configurations
@@ -579,7 +582,8 @@ def converse_chain(
         surface: AI surface whose configured model the steps resolve to when
             they don't set their own model (default: the neutral fallback).
         model_id: Explicit model ID pinned across every step (forwarded to
-            converse(), where it takes precedence over surface resolution).
+            converse(), where it takes precedence over step-level model and
+            surface resolution).
             Callers that stamp "which model ran" into stored metadata resolve
             once and pin it here, so what was invoked and what was recorded
             cannot drift. When None, each step resolves from ``surface`` as
@@ -613,7 +617,25 @@ def converse_chain(
         user = step.get('user', '').replace('{previous}', context)
         thinking_budget = step.get('thinking_budget', 0)
         max_tokens = step.get('max_tokens', 4096)
-        step_model_id = step.get('model_id') or step.get('model') or model_id
+        step_explicit_model_id = step.get('model_id') or step.get('model')
+        step_model_id = model_id or step_explicit_model_id
+        if step_model_id is not None and step.get('surface'):
+            # An explicit model wins over surface resolution inside
+            # converse(), whether that model came from this step or from a
+            # pinned chain model_id. Say so instead of silently eating an
+            # inert per-step surface.
+            model_source = 'chain model_id' if model_id else 'step model_id/model'
+            logger.warning(
+                f"[CHAIN] Step '{step_name}' sets surface='{step['surface']}' "
+                f"but {model_source} is explicit: that model wins and this "
+                "surface override is ignored"
+            )
+        if model_id is not None and step_explicit_model_id:
+            logger.warning(
+                f"[CHAIN] Step '{step_name}' sets model_id/model but the "
+                "chain pins model_id: the chain model wins and the step "
+                "model override is ignored"
+            )
         
         logger.info(f"[CHAIN] Step '{step_name}' config: max_tokens={max_tokens}, thinking_budget={thinking_budget}")
         logger.info(f"[CHAIN] Step '{step_name}' system_prompt length: {len(system)} chars")

--- a/voc-datalake/lambda/shared/model_config.py
+++ b/voc-datalake/lambda/shared/model_config.py
@@ -118,6 +118,10 @@ ALLOWED_MODELS = [
 ]
 ALLOWED_MODEL_IDS = {m["id"] for m in ALLOWED_MODELS}
 
+# The text-model picker is intentionally Anthropic-only while avatar.py builds
+# the raw Anthropic Messages invoke_model body for utility-surface prompt
+# generation. Add a provider-aware wrapper before adding a non-Anthropic ID.
+
 # Both capability sets derive from the rows above so a model can never be added
 # to one and forgotten in the other.
 _OMIT_TEMPERATURE_IDS = {m["id"] for m in ALLOWED_MODELS if m["omit_temperature"]}

--- a/voc-datalake/lambda/shared/test/test_avatar.py
+++ b/voc-datalake/lambda/shared/test/test_avatar.py
@@ -10,7 +10,7 @@ class TestGenerateAvatarPromptWithLlm:
     """Tests for generate_avatar_prompt_with_llm function."""
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    @patch('shared.avatar.get_active_model_id', return_value='test-model')
     def test_successful_prompt_generation(self, mock_model_id, mock_config):
         """Generates image prompt from persona data using Claude."""
         from shared.avatar import generate_avatar_prompt_with_llm
@@ -46,7 +46,7 @@ class TestGenerateAvatarPromptWithLlm:
         mock_model_id.assert_called_once_with(surface='utility')
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    @patch('shared.avatar.get_active_model_id', return_value='test-model')
     def test_handles_thinking_blocks_in_response(self, mock_model_id, mock_config):
         """Extracts text from response with thinking blocks."""
         from shared.avatar import generate_avatar_prompt_with_llm
@@ -71,7 +71,7 @@ class TestGenerateAvatarPromptWithLlm:
         assert result == 'A portrait of a teacher'
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    @patch('shared.avatar.get_active_model_id', return_value='test-model')
     def test_fallback_on_llm_error(self, mock_model_id, mock_config):
         """Uses fallback prompt when LLM call fails."""
         from shared.avatar import generate_avatar_prompt_with_llm
@@ -91,7 +91,7 @@ class TestGenerateAvatarPromptWithLlm:
         assert 'Designer' in result
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    @patch('shared.avatar.get_active_model_id', return_value='test-model')
     def test_fallback_with_empty_occupation(self, mock_model_id, mock_config):
         """Uses 'professional' as default occupation in fallback."""
         from shared.avatar import generate_avatar_prompt_with_llm

--- a/voc-datalake/lambda/shared/test/test_avatar.py
+++ b/voc-datalake/lambda/shared/test/test_avatar.py
@@ -10,7 +10,7 @@ class TestGenerateAvatarPromptWithLlm:
     """Tests for generate_avatar_prompt_with_llm function."""
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.avatar.get_active_model_id', return_value='test-model')
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
     def test_successful_prompt_generation(self, mock_model_id, mock_config):
         """Generates image prompt from persona data using Claude."""
         from shared.avatar import generate_avatar_prompt_with_llm
@@ -46,7 +46,7 @@ class TestGenerateAvatarPromptWithLlm:
         mock_model_id.assert_called_once_with(surface='utility')
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.avatar.get_active_model_id', return_value='test-model')
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
     def test_handles_thinking_blocks_in_response(self, mock_model_id, mock_config):
         """Extracts text from response with thinking blocks."""
         from shared.avatar import generate_avatar_prompt_with_llm
@@ -71,7 +71,7 @@ class TestGenerateAvatarPromptWithLlm:
         assert result == 'A portrait of a teacher'
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.avatar.get_active_model_id', return_value='test-model')
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
     def test_fallback_on_llm_error(self, mock_model_id, mock_config):
         """Uses fallback prompt when LLM call fails."""
         from shared.avatar import generate_avatar_prompt_with_llm
@@ -91,7 +91,7 @@ class TestGenerateAvatarPromptWithLlm:
         assert 'Designer' in result
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.avatar.get_active_model_id', return_value='test-model')
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
     def test_fallback_with_empty_occupation(self, mock_model_id, mock_config):
         """Uses 'professional' as default occupation in fallback."""
         from shared.avatar import generate_avatar_prompt_with_llm

--- a/voc-datalake/lambda/shared/test/test_avatar.py
+++ b/voc-datalake/lambda/shared/test/test_avatar.py
@@ -1,17 +1,17 @@
 """Tests for shared.avatar module - avatar generation utilities."""
 
+import base64
 import json
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import patch, MagicMock
-import base64
+from unittest.mock import MagicMock, patch
 
 
 class TestGenerateAvatarPromptWithLlm:
     """Tests for generate_avatar_prompt_with_llm function."""
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.aws.BEDROCK_MODEL_ID', 'test-model')
-    def test_successful_prompt_generation(self, mock_config):
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    def test_successful_prompt_generation(self, mock_model_id, mock_config):
         """Generates image prompt from persona data using Claude."""
         from shared.avatar import generate_avatar_prompt_with_llm
 
@@ -42,10 +42,12 @@ class TestGenerateAvatarPromptWithLlm:
         result = generate_avatar_prompt_with_llm(persona, mock_bedrock)
         assert result == 'Professional headshot of a software engineer'
         mock_bedrock.invoke_model.assert_called_once()
+        assert mock_bedrock.invoke_model.call_args.kwargs['modelId'] == 'test-model'
+        mock_model_id.assert_called_once_with(surface='utility')
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.aws.BEDROCK_MODEL_ID', 'test-model')
-    def test_handles_thinking_blocks_in_response(self, mock_config):
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    def test_handles_thinking_blocks_in_response(self, mock_model_id, mock_config):
         """Extracts text from response with thinking blocks."""
         from shared.avatar import generate_avatar_prompt_with_llm
 
@@ -69,8 +71,8 @@ class TestGenerateAvatarPromptWithLlm:
         assert result == 'A portrait of a teacher'
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.aws.BEDROCK_MODEL_ID', 'test-model')
-    def test_fallback_on_llm_error(self, mock_config):
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    def test_fallback_on_llm_error(self, mock_model_id, mock_config):
         """Uses fallback prompt when LLM call fails."""
         from shared.avatar import generate_avatar_prompt_with_llm
 
@@ -89,8 +91,8 @@ class TestGenerateAvatarPromptWithLlm:
         assert 'Designer' in result
 
     @patch('shared.avatar.get_avatar_prompt_config')
-    @patch('shared.aws.BEDROCK_MODEL_ID', 'test-model')
-    def test_fallback_with_empty_occupation(self, mock_config):
+    @patch('shared.model_config.get_active_model_id', return_value='test-model')
+    def test_fallback_with_empty_occupation(self, mock_model_id, mock_config):
         """Uses 'professional' as default occupation in fallback."""
         from shared.avatar import generate_avatar_prompt_with_llm
 

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -508,8 +508,8 @@ class TestConverseChain:
         ]
 
     @patch('shared.converse.converse')
-    def test_step_model_overrides_chain_model_id(self, mock_converse):
-        """Uses the step model when both chain and step models are set."""
+    def test_chain_model_id_overrides_step_model(self, mock_converse):
+        """A pinned chain model keeps every step on the recorded model."""
         mock_converse.side_effect = ['First output', 'Second output']
 
         from shared.converse import converse_chain
@@ -522,7 +522,7 @@ class TestConverseChain:
 
         assert [c.kwargs['model_id'] for c in mock_converse.call_args_list] == [
             'chain-model',
-            'step-model',
+            'chain-model',
         ]
 
 
@@ -1129,3 +1129,44 @@ class TestConverseSurfaceRouting:
         )
 
         mock_resolve.assert_called_once_with('prototype')
+
+    @patch('shared.converse.logger')
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_chain_step_surface_under_pinned_model_id_is_flagged(
+        self, mock_get_client, mock_resolve, mock_logger,
+    ):
+        """A pinned chain model_id beats a per-step surface (explicit model >
+        surface resolution); the inert override is logged, not eaten quietly."""
+        mock_get_client.return_value = self._client()
+
+        from shared.converse import converse_chain
+        result = converse_chain(
+            [{'system': '', 'user': 'a', 'surface': 'prototype'}],
+            surface='documents',
+            model_id='pinned-model',
+        )
+
+        assert result == ['R']
+        mock_resolve.assert_not_called()
+        flagged = [c for c in mock_logger.warning.call_args_list if 'model wins' in str(c)]
+        assert flagged, 'expected a warning naming the ignored surface override'
+
+    @patch('shared.converse.logger')
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_chain_step_surface_under_step_model_id_is_flagged(
+        self, mock_get_client, mock_resolve, mock_logger,
+    ):
+        """A step model also beats that step's surface, even with no chain pin."""
+        mock_get_client.return_value = self._client()
+
+        from shared.converse import converse_chain
+        converse_chain(
+            [{'system': '', 'user': 'a', 'surface': 'prototype', 'model': 'step-model'}],
+            surface='documents',
+        )
+
+        mock_resolve.assert_not_called()
+        flagged = [c for c in mock_logger.warning.call_args_list if 'model wins' in str(c)]
+        assert flagged, 'expected a warning naming the ignored surface override'

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -1149,7 +1149,7 @@ class TestConverseSurfaceRouting:
 
         assert result == ['R']
         mock_resolve.assert_not_called()
-        flagged = [c for c in mock_logger.warning.call_args_list if 'model wins' in str(c)]
+        flagged = [c for c in mock_logger.warning.call_args_list if 'drops inert overrides' in str(c)]
         assert flagged, 'expected a warning naming the ignored surface override'
 
     @patch('shared.converse.logger')
@@ -1168,5 +1168,28 @@ class TestConverseSurfaceRouting:
         )
 
         mock_resolve.assert_not_called()
-        flagged = [c for c in mock_logger.warning.call_args_list if 'model wins' in str(c)]
+        flagged = [c for c in mock_logger.warning.call_args_list if 'drops inert overrides' in str(c)]
         assert flagged, 'expected a warning naming the ignored surface override'
+
+    @patch('shared.converse.logger')
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_chain_step_overrides_under_pinned_model_emit_one_warning(
+        self, mock_get_client, mock_resolve, mock_logger,
+    ):
+        """A step carrying BOTH a model and a surface under a chain pin logs
+        one combined warning naming everything dropped, not one per key."""
+        mock_get_client.return_value = self._client()
+
+        from shared.converse import converse_chain
+        result = converse_chain(
+            [{'system': '', 'user': 'a', 'surface': 'prototype', 'model': 'step-model'}],
+            surface='documents',
+            model_id='pinned-model',
+        )
+
+        assert result == ['R']
+        combined = [c for c in mock_logger.warning.call_args_list if 'drops inert overrides' in str(c)]
+        assert len(combined) == 1, 'expected exactly one combined warning'
+        assert "surface='prototype'" in str(combined[0])
+        assert 'model_id/model' in str(combined[0])

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -29,6 +29,25 @@ class TestConverse:
         assert result == 'Hello, world!'
         mock_client.converse.assert_called_once()
 
+    @patch('shared.converse.get_active_model_id')
+    @patch('shared.converse.get_bedrock_client')
+    def test_explicit_model_id_takes_precedence_over_surface(
+        self, mock_get_client, mock_get_active_model_id
+    ):
+        """Does not resolve the surface when model_id is explicit."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'Done'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        result = converse('Say hello', surface='documents', model_id='explicit-model')
+
+        assert result == 'Done'
+        mock_get_active_model_id.assert_not_called()
+        assert mock_client.converse.call_args.kwargs['modelId'] == 'explicit-model'
+
     @patch('shared.converse.get_bedrock_client')
     def test_includes_system_prompt(self, mock_get_client):
         """Includes system prompt when provided."""
@@ -465,6 +484,46 @@ class TestConverseChain:
         
         call_args = mock_converse.call_args
         assert call_args.kwargs['thinking_budget'] == 3000
+
+    @patch('shared.converse.converse')
+    def test_pins_explicit_model_id(self, mock_converse):
+        """Forwards an explicit model_id to every step."""
+        mock_converse.side_effect = ['First output', 'Second output']
+
+        from shared.converse import converse_chain
+        steps = [
+            {'system': 'S1', 'user': 'U1'},
+            {'system': 'S2', 'user': 'U2'},
+        ]
+
+        converse_chain(steps, surface='documents', model_id='resolved-model')
+
+        assert [c.kwargs['model_id'] for c in mock_converse.call_args_list] == [
+            'resolved-model',
+            'resolved-model',
+        ]
+        assert [c.kwargs['surface'] for c in mock_converse.call_args_list] == [
+            'documents',
+            'documents',
+        ]
+
+    @patch('shared.converse.converse')
+    def test_step_model_overrides_chain_model_id(self, mock_converse):
+        """Uses the step model when both chain and step models are set."""
+        mock_converse.side_effect = ['First output', 'Second output']
+
+        from shared.converse import converse_chain
+        steps = [
+            {'system': 'S1', 'user': 'U1'},
+            {'system': 'S2', 'user': 'U2', 'model': 'step-model'},
+        ]
+
+        converse_chain(steps, surface='documents', model_id='chain-model')
+
+        assert [c.kwargs['model_id'] for c in mock_converse.call_args_list] == [
+            'chain-model',
+            'step-model',
+        ]
 
 
 class TestExtractText:

--- a/voc-datalake/lambda/shared/test/test_model_config.py
+++ b/voc-datalake/lambda/shared/test/test_model_config.py
@@ -46,8 +46,11 @@ class TestAllowlist:
         assert ALLOWED_MODEL_IDS == {SONNET5, SONNET46, OPUS5, OPUS48, HAIKU45}
 
     def test_allowlist_is_anthropic_only_for_raw_invoke_model_callers(self):
+        """Matches any regional prefix on purpose: the constraint the raw
+        Anthropic invoke_model body cares about is the vendor shape, not which
+        cross-region inference profile an id sits behind."""
         assert all(
-            model_id.startswith('global.anthropic.')
+            model_id.startswith('anthropic.') or '.anthropic.' in model_id
             for model_id in ALLOWED_MODEL_IDS
         )
 
@@ -121,6 +124,16 @@ class TestGetActiveModelId:
         assert get_active_model_id('prototype') == OPUS5
         assert get_active_model_id('enrichment') == HAIKU45
         assert get_active_model_id() == BEDROCK_MODEL_ID
+
+    def test_persona_and_avatar_surfaces_resolve_to_registered_defaults(self, monkeypatch):
+        """projects.py resolves surface='documents' and avatar.py resolves
+        surface='utility'. Both names only ever appear as mock kwargs in those
+        callers' own tests, so nothing else would catch a typo: an
+        unregistered name silently falls back to the legacy global here."""
+        monkeypatch.delenv('AGGREGATES_TABLE', raising=False)
+        for surface in ('documents', 'utility'):
+            assert surface in SURFACE_DEFAULTS, f'{surface} is not a registered default'
+            assert get_active_model_id(surface=surface) == SURFACE_DEFAULTS[surface]
 
     def test_returns_per_surface_override(self, monkeypatch):
         monkeypatch.setenv('AGGREGATES_TABLE', 'agg')

--- a/voc-datalake/lambda/shared/test/test_model_config.py
+++ b/voc-datalake/lambda/shared/test/test_model_config.py
@@ -45,6 +45,12 @@ class TestAllowlist:
     def test_allowlist_has_all_five_models(self):
         assert ALLOWED_MODEL_IDS == {SONNET5, SONNET46, OPUS5, OPUS48, HAIKU45}
 
+    def test_allowlist_is_anthropic_only_for_raw_invoke_model_callers(self):
+        assert all(
+            model_id.startswith('global.anthropic.')
+            for model_id in ALLOWED_MODEL_IDS
+        )
+
     def test_every_surface_default_is_allowlisted(self):
         """A surface whose Automatic default isn't invocable would break that
         surface out of the box."""

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -36,6 +36,7 @@ import { z } from 'zod';
 
 import { VocApiStack } from './api-stack';
 import { ManifestSchema } from '../plugin-loader';
+import { allowlistedModelArns } from '../utils/model-allowlist';
 
 /** The only routes that may be served without credentials.
  *
@@ -456,6 +457,50 @@ describe('skipFeedbackFormItemRoutes (transitional upgrade flag)', () => {
   it('is a no-op when absent — the default template keeps the item routes', () => {
     expect(unauthenticatedRoutes(apiTemplate())).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
     expect(apiMethods(apiTemplate()).map((m) => m.route)).toContain('PUT /feedback-forms/{form_id}');
+  });
+});
+
+
+describe('persona Bedrock IAM grants', () => {
+  const StatementSchema = z.object({
+    Action: z.union([z.string(), z.array(z.string())]),
+    Resource: z.unknown(),
+  });
+
+  function statementsForRole(roleName: string): { actions: string[]; resources: string[] }[] {
+    const policies = apiTemplate().findResources('AWS::IAM::Policy');
+    const policy = Object.entries(policies).find(([id]) => id.includes(roleName));
+    expect(policy, `no IAM policy found for ${roleName}`).toBeDefined();
+
+    return z
+      .object({
+        Properties: z.object({
+          PolicyDocument: z.object({ Statement: z.array(StatementSchema) }),
+        }),
+      })
+      .parse(policy?.[1]).Properties.PolicyDocument.Statement
+      .map((s) => {
+        const resources = Array.isArray(s.Resource) ? s.Resource : [s.Resource];
+        return {
+          actions: Array.isArray(s.Action) ? s.Action : [s.Action],
+          resources: resources.filter((r): r is string => typeof r === 'string'),
+        };
+      });
+  }
+
+  it('grants persona roles every allowlisted text model ARN', () => {
+    const expected = allowlistedModelArns('us-east-1', '111111111111');
+    const roles = ['ProjectsLambdaRole', 'PersonaGeneratorRole', 'PersonaImporterRole'];
+
+    for (const role of roles) {
+      const resources = statementsForRole(role)
+        .filter((s) => s.actions.includes('bedrock:InvokeModel'))
+        .flatMap((s) => s.resources);
+
+      for (const arn of expected) {
+        expect(resources, `${role} is missing ${arn}`).toContain(arn);
+      }
+    }
   });
 });
 

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -462,6 +462,22 @@ describe('skipFeedbackFormItemRoutes (transitional upgrade flag)', () => {
 
 
 describe('persona Bedrock IAM grants', () => {
+  // These three roles are the CLOSED set of Lambdas whose runtime code can
+  // reach shared/avatar.py, so each needs bedrock:InvokeModel on the whole
+  // allowlist: avatar prompt generation resolves the utility surface at
+  // runtime and persona synthesis the documents surface, and either can be
+  // repointed to any allowlisted id via the picker.
+  //   ProjectsLambdaRole    api/projects_handler.py -> api/projects.py -> shared/avatar.py
+  //   PersonaGeneratorRole
+  //     jobs/persona_generator/handler.py
+  //       -> api/projects.generate_personas -> shared/avatar.py
+  //   PersonaImporterRole
+  //     jobs/persona_importer/handler.py
+  //       -> api/projects.generate_persona_avatar -> shared/avatar.py
+  // document_merger and document_generator ship shared/ inside their bundles
+  // (createJobLambdaCode stages it for every job) but never import avatar.py:
+  // they call shared.converse directly. If a future job starts importing
+  // avatar.py transitively, its role belongs in `roles` below.
   const StatementSchema = z.object({
     Action: z.union([z.string(), z.array(z.string())]),
     Resource: z.unknown(),


### PR DESCRIPTION
Closes #273

## Summary

Stops using the `BEDROCK_MODEL_ID` fallback constant at two live persona call sites and resolves the active model through the documented precedence chain instead.

- `shared/avatar.py`: avatar prompt generation resolves the active model for the `utility` surface before invoking Bedrock. Resolution sits inside the existing fallback boundary: a transient picker (DynamoDB) problem degrades to the static fallback prompt exactly like an invocation failure, matching the pre-picker behavior where a constant could never fail. Prompt-config loading stays above the boundary so prompt-file problems remain configuration errors.
- `api/projects.py`: persona generation pins the resolved `documents` model via `converse_chain(model_id=...)` and records it in `llm_metadata.model`. The `surface='documents'` argument stays on the call so surface-derived logging keeps its dimension; the pin decides which model is invoked.
- `shared/converse.py`: adds the public `converse_chain(model_id=...)` parameter (scope note: this is the one shared-module API change). When set, it pins the model for every step; a step-level `model`/`model_id` applies only when the chain is not pinned. Step keys that lose to an explicit model emit a single combined warning naming everything dropped: no silent overrides, no job failures. No persona step sets a model or surface today, so current chains are unaffected.
- `research/research_step_handler.py`: removes the unused `MODEL_ID` alias so the dead fallback import is not copied into future handlers.

## IAM note

The persona roles (`ProjectsLambdaRole`, `PersonaGeneratorRole`, `PersonaImporterRole`) already grant `bedrock:InvokeModel` on the full allowlist, which is what the runtime picker can now return for these surfaces. The new CDK regression test pins that lockstep; no stack change was required.

## Tests

Updated avatar tests to assert the resolved model id and the `utility` surface lookup. Added persona tests for the resolved-model metadata stamp, the chain pin, and tolerance of inert step overrides. Added a chain test asserting that a step with both `model` and `surface` under a pin logs exactly one combined warning.

Python:

```bash
pytest lambda/shared/test/test_avatar.py lambda/shared/test/test_model_config.py \
  lambda/api/test/test_projects.py lambda/shared/test/test_converse.py \
  lambda/jobs/persona_generator/test/test_persona_chain.py -q --no-cov
```

Result: 174 passed, 0 failed.

CDK/vitest (`lib/utils/model-allowlist.ts` already exists on `development`; this suite compiles that import):

```bash
npm test -- lib/stacks/api-stack.test.ts
```

Result: 56 passed, 0 failed, including the `persona Bedrock IAM grants` assertions.

Signed off with DCO.
