### PR TITLE
fix(api): require Cognito on feedback-form item routes

### DIFF
--- a/.kiro/prompts/aws-audit.md
+++ b/.kiro/prompts/aws-audit.md
@@ -37,7 +37,7 @@ VoC Data Lake is a **fully serverless** AWS platform for ingesting, processing, 
 | `voc-projects-api` | `projects_handler.py` | `/projects/*` | DynamoDB, Step Functions, Bedrock |
 | `voc-chat-stream` | `chat_stream_handler.py` | Function URL (streaming) | DynamoDB read, Bedrock streaming |
 | `voc-data-explorer-api` | `data_explorer_handler.py` | `/data-explorer/*` | S3, DynamoDB (feedback) |
-| `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-form/*` | DynamoDB, SQS |
+| `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-forms/*` | DynamoDB, SQS |
 | `voc-users-api` | `users_handler.py` | `/users/*` | Cognito, DynamoDB |
 
 ### DynamoDB Tables
@@ -84,7 +84,7 @@ voc-datalake/
 │   │   ├── settings_handler.py   # /settings/*
 │   │   ├── projects_handler.py   # /projects/*
 │   │   ├── data_explorer_handler.py # /data-explorer/*
-│   │   ├── feedback_form_handler.py # /feedback-form/*
+│   │   ├── feedback_form_handler.py # /feedback-forms/*
 │   │   ├── users_handler.py      # /users/*
 │   │   └── projects.py           # Shared business logic
 │   └── layers/                   # Lambda layers

--- a/.kiro/prompts/aws-security-review.md
+++ b/.kiro/prompts/aws-security-review.md
@@ -244,7 +244,7 @@ VoC Data Lake is a **fully serverless** AWS platform for ingesting, processing, 
 | `voc-settings-api` | `settings_handler.py` | `/settings/*` | DynamoDB, Bedrock |
 | `voc-projects-api` | `projects_handler.py` | `/projects/*` | DynamoDB, Step Functions, Bedrock, S3 |
 | `voc-users-api` | `users_handler.py` | `/users/*` | Cognito admin |
-| `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-form/*`, `/feedback-forms/*` | DynamoDB, SQS |
+| `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-forms/*` | DynamoDB, SQS |
 | `voc-chat-stream` | `chat_stream_handler.py` | Function URL (streaming) | DynamoDB read, Bedrock streaming |
 | `voc-data-explorer-api` | `data_explorer_handler.py` | `/data-explorer/*` | S3, DynamoDB (feedback) |
 
@@ -264,7 +264,10 @@ VoC Data Lake is a **fully serverless** AWS platform for ingesting, processing, 
 - Lambda Powertools (Logger, Tracer, Metrics) on all functions
 
 #### ⚠️ Known Considerations (Document but assess carefully)
-- **Public Feedback Form Endpoints**: `/feedback-form/submit` is public (required for form submissions)
+- **Public Feedback Form Endpoints**: exactly three routes are unauthenticated by design —
+  `GET /feedback-forms/{id}/config`, `POST /feedback-forms/{id}/submit` and
+  `GET /feedback-forms/{id}/iframe` (the embeddable widget runs on the customer's own site).
+  Every other route under `/feedback-forms` requires Cognito; `api-stack.test.ts` enforces this.
   - Mitigated by: Rate limiting, input validation
 - **Bedrock Global Inference Profile**: Uses cross-region inference for availability
   - Ensure IAM scoped to specific inference profile ARN

--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -150,7 +150,7 @@ lambda/api/
 ├── settings_handler.py      # /settings/*
 ├── projects_handler.py      # /projects/*
 ├── users_handler.py         # /users/* (Cognito admin)
-├── feedback_form_handler.py # /feedback-form/*, /feedback-forms/*
+├── feedback_form_handler.py # /feedback-forms/*
 ├── data_explorer_handler.py # /data-explorer/* (S3 raw data & DynamoDB browser)
 └── projects.py              # Shared business logic for projects
 ```

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -258,6 +258,13 @@ embeddable widget calls from the customer's own site.
 > `api-stack.test.ts` asserts the handler and stack stay in step, and that only
 > the three public routes are unauthenticated.
 
+> ⚠️ **"Cognito" above means authenticated, NOT authorized.** These routes check
+> that the caller has a valid token; they do not check *which* forms the caller
+> owns. `feedback_form_handler.py` imports no auth helper, so **any authenticated
+> user can read, update or delete any form and read any form's submissions**.
+> That residual gap is tracked separately (same class as the missing per-user
+> scoping on projects) — do not read this table as "fully protected".
+
 ### Projects (projects_handler.py)
 | Method | Path | Description |
 |--------|------|-------------|

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -51,7 +51,7 @@ voice-of-customer-datalake/       # Root repository
     │   │   ├── settings_handler.py       # /settings/* (brand, categories config)
     │   │   ├── projects_handler.py       # /projects/* (research projects, personas)
     │   │   ├── users_handler.py          # /users/* (Cognito user administration)
-    │   │   ├── feedback_form_handler.py  # /feedback-form/*, /feedback-forms/* (embeddable forms)
+    │   │   ├── feedback_form_handler.py  # /feedback-forms/* (embeddable forms)
     │   │   ├── data_explorer_handler.py  # /data-explorer/* (S3 raw data & DynamoDB browser)
     │   │   ├── logs_handler.py           # /logs/* (system logs)
     │   │   ├── manual_import_handler.py  # /manual-import/* (manual data import)
@@ -233,17 +233,30 @@ voice-of-customer-datalake/       # Root repository
 | POST | `/users/{username}/reset-password` | Reset password |
 
 ### Feedback Forms (feedback_form_handler.py)
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/feedback-form/config` | Get form config (public) |
-| PUT | `/feedback-form/config` | Update form config |
-| POST | `/feedback-form/submit` | Submit feedback (public) |
-| GET | `/feedback-form/embed` | Get embed code |
-| GET | `/feedback-forms` | List all forms |
-| POST | `/feedback-forms` | Create form |
-| GET | `/feedback-forms/{id}` | Get form (public) |
-| PUT | `/feedback-forms/{id}` | Update form |
-| DELETE | `/feedback-forms/{id}` | Delete form |
+
+Every route requires Cognito **except** the three marked public, which the
+embeddable widget calls from the customer's own site.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/feedback-forms` | Cognito | List all forms |
+| POST | `/feedback-forms` | Cognito | Create form |
+| GET | `/feedback-forms/{id}` | Cognito | Get form |
+| PUT | `/feedback-forms/{id}` | Cognito | Update form |
+| DELETE | `/feedback-forms/{id}` | Cognito | Delete form |
+| GET | `/feedback-forms/{id}/submissions` | Cognito | Read submitted feedback |
+| GET | `/feedback-forms/{id}/stats` | Cognito | Submission count + average rating |
+| GET | `/feedback-forms/{id}/config` | **public** | Form config for the widget |
+| POST | `/feedback-forms/{id}/submit` | **public** | Submit feedback |
+| GET | `/feedback-forms/{id}/iframe` | **public** | Iframe embed variant |
+
+> There is no `/feedback-form/*` (singular) API. These routes are declared
+> **explicitly** in `api-stack.ts` rather than behind a `{proxy+}`, so adding a
+> route to the handler also requires wiring it there. That is deliberate: a
+> proxy without `defaultMethodOptions` defaults to `AuthorizationType: NONE`,
+> which is how form update/delete and submission reads were once public.
+> `api-stack.test.ts` asserts the handler and stack stay in step, and that only
+> the three public routes are unauthenticated.
 
 ### Projects (projects_handler.py)
 | Method | Path | Description |

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -58,7 +58,7 @@ AWS Lambda execution roles have a **20KB policy size limit**. To stay under this
 | `voc-settings-api` | `settings_handler.py` | `/settings/*` | DynamoDB (aggregates), Bedrock |
 | `voc-projects-api` | `projects_handler.py` | `/projects/*` | DynamoDB (projects, jobs, feedback), Step Functions, Bedrock, S3 |
 | `voc-users-api` | `users_handler.py` | `/users/*` | Cognito admin |
-| `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-form/*`, `/feedback-forms/*` | DynamoDB (aggregates), SQS |
+| `voc-feedback-form-api` | `feedback_form_handler.py` | `/feedback-forms/*` | DynamoDB (aggregates), SQS |
 | `voc-chat-stream` | `lambda/stream` (TypeScript, esbuild-bundled) | `/chat/stream` SSE via API Gateway | DynamoDB read, Bedrock streaming |
 | `voc-data-explorer-api` | `data_explorer_handler.py` | `/data-explorer/*` | S3, DynamoDB (feedback) |
 | `voc-logs-api` | `logs_handler.py` | `/logs/*` | CloudWatch Logs read |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -622,6 +622,39 @@ Add the flag to every subsequent deploy of that environment (or to a
 local, uncommitted context override). New deployments should NOT set it —
 fresh pools get case-insensitive sign-in by default.
 
+### VocApiStack fails: "A sibling ({proxy+}) of this resource already has a variable path part"
+
+Only affects environments deployed **before** the `/feedback-forms` item
+routes were made explicit. Those routes used to sit behind a `{proxy+}`
+catch-all; they are now declared individually, which means the deploy has to
+create `/feedback-forms/{form_id}` and delete `/feedback-forms/{proxy+}`.
+CloudFormation creates new resources before deleting old ones inside a single
+update, so both variable path parts exist momentarily and API Gateway rejects
+the pair. The stack rolls back cleanly and the API keeps serving.
+
+**Fresh deployments are unaffected** — there is no proxy to remove.
+
+Upgrade an existing environment in two deploys. First remove the old proxy on
+its own, by temporarily commenting out the `feedbackFormItem` block in
+`lib/stacks/api-stack.ts` (everything from `addResource('{form_id}')` through
+the `publicFeedbackFormMethods` loop):
+
+```bash
+cdk deploy VocApiStack --exclusively
+```
+
+Then restore the file and deploy again to create the explicit routes:
+
+```bash
+git checkout -- lib/stacks/api-stack.ts
+cdk deploy VocApiStack --exclusively
+```
+
+Between the two deploys the per-form routes are unavailable, so the
+embeddable widget stops working until the second deploy finishes. They fail
+closed (no data is served), and the window is one deploy long. Schedule it
+accordingly if forms are live.
+
 ### CloudFront Cache
 
 If changes don't appear after deployment:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -634,26 +634,35 @@ the pair. The stack rolls back cleanly and the API keeps serving.
 
 **Fresh deployments are unaffected** — there is no proxy to remove.
 
-Upgrade an existing environment in two deploys. First remove the old proxy on
-its own, by temporarily commenting out the `feedbackFormItem` block in
-`lib/stacks/api-stack.ts` (everything from `addResource('{form_id}')` through
-the `publicFeedbackFormMethods` loop):
+Upgrade an existing environment in two deploys, using the transitional flag —
+no source edits are involved:
 
 ```bash
+# 1. Retire the old {proxy+}. The per-form routes are not created yet.
+cdk deploy VocApiStack --exclusively -c skipFeedbackFormItemRoutes=true
+
+# 2. Create the explicit per-form routes.
 cdk deploy VocApiStack --exclusively
 ```
 
-Then restore the file and deploy again to create the explicit routes:
+`skipFeedbackFormItemRoutes` is a no-op when absent, so the second command is
+just a normal deploy and fresh deployments never need the flag. Step 1 prints a
+warning naming itself as the first of two deploys. **Never leave the flag set** —
+while it is on, `/feedback-forms/{form_id}/*` does not exist.
 
-```bash
-git checkout -- lib/stacks/api-stack.ts
-cdk deploy VocApiStack --exclusively
-```
+Between the two deploys the per-form routes are unavailable, so the embeddable
+widget stops working until the second deploy finishes. They fail closed (no data
+is served, and nothing is left unauthenticated), and the window is one deploy
+long. Schedule it accordingly if forms are live.
 
-Between the two deploys the per-form routes are unavailable, so the
-embeddable widget stops working until the second deploy finishes. They fail
-closed (no data is served), and the window is one deploy long. Schedule it
-accordingly if forms are live.
+### The embeddable widget served from the frontend bucket is stale
+
+`frontend/public/feedback-widget.js` is published to the CDN but is **not** the
+widget the application uses. The live one is `lambda/api/static/feedback-widget.js`,
+served by the feedback-form Lambda. The frontend copy still calls the retired
+`/feedback-form/*` (singular) routes, so it has been broken independently of the
+authorization change above — do not debug it as a symptom of that change. It has
+no callers in the codebase; it is pending deletion or a repoint.
 
 ### CloudFront Cache
 

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -88,30 +88,6 @@ function filterByDateBasis(items, searchParams) {
   });
 }
 
-// Mock feedback form config (in-memory)
-let feedbackFormConfig = {
-  enabled: true,
-  title: 'Share Your Feedback',
-  description: 'We value your opinion. Help us improve by sharing your experience.',
-  question: 'How was your experience?',
-  placeholder: 'Tell us what you liked or what we could do better...',
-  rating_enabled: true,
-  rating_type: 'emoji',
-  rating_max: 5,
-  submit_button_text: 'Submit',
-  success_message: 'Thank you for your feedback! 🎉',
-  theme: {
-    primary_color: '#3B82F6',
-    background_color: '#FFFFFF',
-    text_color: '#1F2937',
-    border_radius: '12px'
-  },
-  collect_email: false,
-  collect_name: false,
-  custom_fields: [],
-  brand_name: 'Demo Brand',
-};
-
 // Mock sources status
 const mockSourcesStatus = {
   sources: [
@@ -332,22 +308,6 @@ const mockS3Files = {
 };
 
 const handlers = {
-  // Feedback Form endpoints
-  'GET /feedback-form/config': () => ({ success: true, config: feedbackFormConfig }),
-  'PUT /feedback-form/config': (body) => {
-    feedbackFormConfig = { ...feedbackFormConfig, ...body };
-    return { success: true, message: 'Configuration saved' };
-  },
-  'POST /feedback-form/submit': (body) => {
-    console.log('📝 Feedback submitted:', body);
-    return { success: true, feedback_id: 'mock_' + Date.now(), message: feedbackFormConfig.success_message };
-  },
-  'GET /feedback-form/embed': () => ({
-    success: true,
-    script_embed: '<!-- Mock embed code -->',
-    iframe_embed: '<!-- Mock iframe code -->'
-  }),
-
   // Feedback Forms list
   'GET /feedback-forms': () => ({ forms: mockFeedbackForms }),
 

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -659,24 +659,6 @@ describe('API Client', () => {
     })
   })
 
-  describe('getFeedbackFormConfig', () => {
-    it('fetches feedback form configuration', async () => {
-      const mockConfig = { success: true, config: { enabled: true, title: 'Feedback' } }
-      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockConfig),
-      })
-
-      const result = await api.getFeedbackFormConfig()
-
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://api.example.com/feedback-form/config',
-        expect.any(Object)
-      )
-      expect(result).toEqual(mockConfig)
-    })
-  })
-
   describe('getS3ImportSources', () => {
     it('fetches S3 import sources', async () => {
       const mockResponse = { sources: [{ name: 'default', display_name: 'Default' }], bucket: 'test-bucket' }
@@ -980,46 +962,6 @@ describe('API Client', () => {
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ job_id: 'job-1', reviews }),
-        })
-      )
-    })
-  })
-
-  describe('saveFeedbackFormConfig', () => {
-    it('sends PUT request with form config', async () => {
-      const config = { enabled: true, title: 'Feedback', description: 'Share your thoughts' }
-      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ success: true, message: 'Saved' }),
-      })
-
-      await api.saveFeedbackFormConfig(config as any)
-
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://api.example.com/feedback-form/config',
-        expect.objectContaining({
-          method: 'PUT',
-          body: JSON.stringify(config),
-        })
-      )
-    })
-  })
-
-  describe('submitFeedbackForm', () => {
-    it('sends POST request with feedback data', async () => {
-      const data = { text: 'Great product!', rating: 5, email: 'test@example.com' }
-      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ success: true, feedback_id: 'fb-1' }),
-      })
-
-      await api.submitFeedbackForm(data)
-
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://api.example.com/feedback-form/submit',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify(data),
         })
       )
     })

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -18,7 +18,6 @@ import type {
   PrioritizationScore,
   S3ImportSource,
   S3ImportFile,
-  FeedbackFormConfig,
   FeedbackForm,
   CognitoUser,
   ValidationLogEntry,
@@ -570,24 +569,6 @@ export const api = {
     fetchApi<{ success: boolean; message?: string }>(`/data-explorer/feedback?feedback_id=${encodeURIComponent(feedbackId)}`, {
       method: 'DELETE'
     }),
-
-  // Feedback Form (Embeddable) - Legacy single form
-  getFeedbackFormConfig: () => fetchApi<{ success: boolean; config: FeedbackFormConfig }>('/feedback-form/config'),
-  
-  saveFeedbackFormConfig: (config: FeedbackFormConfig) =>
-    fetchApi<{ success: boolean; message: string }>('/feedback-form/config', {
-      method: 'PUT',
-      body: JSON.stringify(config)
-    }),
-  
-  submitFeedbackForm: (data: { text: string; rating?: number; email?: string; name?: string; page_url?: string; custom_fields?: Record<string, string> }) =>
-    fetchApi<{ success: boolean; feedback_id?: string; message: string }>('/feedback-form/submit', {
-      method: 'POST',
-      body: JSON.stringify(data)
-    }),
-  
-  getFeedbackFormEmbed: (apiEndpoint: string) =>
-    fetchApi<{ success: boolean; script_embed: string; iframe_embed: string }>(`/feedback-form/embed?api_endpoint=${encodeURIComponent(apiEndpoint)}`),
 
   // Feedback Forms (Multiple forms management)
   getFeedbackForms: () => fetchApi<{ success: boolean; forms: FeedbackForm[] }>('/feedback-forms'),

--- a/voc-datalake/lib/plugin-loader.ts
+++ b/voc-datalake/lib/plugin-loader.ts
@@ -113,7 +113,10 @@ const IntegritySchema = z.object({
 
 const SecretsSchema = z.record(ConfigKeySchema, z.string());
 
-const ManifestSchema = z.object({
+/** Exported so tests can assert against the canonical manifest contract instead
+ *  of re-declaring a partial shape. A local re-declaration would keep passing if
+ *  a field here were renamed or moved, which silently disables such a guard. */
+export const ManifestSchema = z.object({
   id: PluginIdSchema,
   name: SafeStringSchema,
   icon: IconSchema,

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -12,13 +12,10 @@
  * cdk-nag suppression applied to the whole proxy subtree made the entire
  * prefix look assessed. A test asserting "these four routes are protected"
  * would not have caught it either, because the routes did not exist as
- * distinct constructs. So the guard is an invariant over the whole template —
- * every non-OPTIONS method carries an authorizer, except an explicit
- * allowlist — plus a lockstep check that every route the Lambda registers is
- * actually wired.
+ * distinct constructs. So the guard is an invariant over the whole template.
  *
- * OPTIONS is excluded because API Gateway generates unauthenticated CORS
- * preflight methods from `defaultCorsPreflightOptions`, and cdk-nag's own
+ * OPTIONS is excluded throughout because API Gateway generates unauthenticated
+ * CORS preflight methods from `defaultCorsPreflightOptions`, and cdk-nag's own
  * APIG4 rule excludes them for the same reason.
  */
 import { readFileSync } from 'node:fs';
@@ -49,19 +46,27 @@ const INTENTIONALLY_PUBLIC_ROUTES = [
   'POST /feedback-forms/{form_id}/submit',
 ];
 
-/** Synthesizing this stack is the expensive part of the suite, and every test
- *  wants the same template, so build it once. */
-let cachedTemplate: Template | undefined;
-function apiTemplate(): Template {
-  cachedTemplate ??= synthApiTemplate();
-  return cachedTemplate;
-}
+/** `/mcp` uses a custom Lambda token authorizer because MCP clients cannot run
+ *  the Cognito flow. Authenticated, just not by Cognito. */
+const CUSTOM_AUTHORIZER_ROUTE_PREFIXES = ['/mcp'];
 
-function synthApiTemplate(): Template {
+/** Every plugin on disk. Used to synthesize the shape a real deployment has,
+ *  rather than only the empty one. */
+const ALL_PLUGIN_IDS = [
+  'app_reviews_android',
+  'app_reviews_ios',
+  's3_import',
+  'synthetic_reviews',
+  'webscraper',
+];
+
+function synthApiTemplate(context: Record<string, unknown> = {}, enabledSources: string[] = []): Template {
   // Skip asset bundling (Docker) and the frontend-freshness guard — template
   // assertions only need structure, and the check would make the suite depend
   // on whether frontend/dist happens to be newer than frontend/src.
-  const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true } });
+  const app = new cdk.App({
+    context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true, ...context },
+  });
   const env = { account: '111111111111', region: 'us-east-1' };
   const deps = new cdk.Stack(app, 'TestDeps', { env });
 
@@ -102,13 +107,27 @@ function synthApiTemplate(): Template {
       definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(deps, 'Noop')),
     }),
     brandName: 'TestBrand',
-    // No plugins ⇒ no webhook receivers. Webhook methods are deliberately
-    // unauthenticated, so enabling a plugin here would correctly fail the
-    // invariant below and force a considered allowlist entry.
-    enabledSources: [],
+    enabledSources,
   });
 
   return Template.fromStack(stack);
+}
+
+// Synthesizing is the expensive part of the suite and most tests want the same
+// template, so cache the two shapes that get reused.
+let cachedDefault: Template | undefined;
+let cachedAllPlugins: Template | undefined;
+
+/** No plugins enabled. */
+function apiTemplate(): Template {
+  cachedDefault ??= synthApiTemplate();
+  return cachedDefault;
+}
+
+/** Every plugin on disk enabled — the shape a real deployment has. */
+function apiTemplateAllPlugins(): Template {
+  cachedAllPlugins ??= synthApiTemplate({}, ALL_PLUGIN_IDS);
+  return cachedAllPlugins;
 }
 
 // Template values arrive as `unknown`; parse rather than assert (no `as`).
@@ -122,12 +141,14 @@ const MethodSchema = z.object({
   HttpMethod: z.string(),
   ResourceId: ResourceIdSchema,
   AuthorizationType: z.string().optional(),
+  AuthorizerId: z.unknown().optional(),
 });
 
 interface ApiMethod {
   httpMethod: string;
   path: string;
   authorizationType: string;
+  hasAuthorizerId: boolean;
   route: string;
 }
 
@@ -150,25 +171,95 @@ function apiMethods(template: Template): ApiMethod[] {
   };
 
   return Object.values(template.findResources('AWS::ApiGateway::Method')).map((method) => {
-    const { HttpMethod, ResourceId, AuthorizationType } = MethodSchema.parse(method.Properties);
-    const path = pathOf(ResourceId) || '/';
+    const parsed = MethodSchema.parse(method.Properties);
+    const path = pathOf(parsed.ResourceId) || '/';
     return {
-      httpMethod: HttpMethod,
+      httpMethod: parsed.HttpMethod,
       path,
-      authorizationType: AuthorizationType ?? 'NONE',
-      route: `${HttpMethod} ${path}`,
+      authorizationType: parsed.AuthorizationType ?? 'NONE',
+      hasAuthorizerId: parsed.AuthorizerId !== undefined,
+      route: `${parsed.HttpMethod} ${path}`,
     };
   });
 }
 
+const nonOptions = (template: Template) => apiMethods(template).filter((m) => m.httpMethod !== 'OPTIONS');
+const unauthenticatedRoutes = (template: Template) =>
+  nonOptions(template).filter((m) => m.authorizationType === 'NONE').map((m) => m.route).sort();
+
+/** Collapses a caller-side path to the shape the template declares: strips any
+ *  query string and normalizes the form-id segment, which appears variously as
+ *  `${formId}`, a literal example id, or `{form_id}`. */
+function normalizeFormsPath(raw: string): string {
+  const path = raw.split('?')[0].replace(/\/+$/, '');
+  return path.replace(/^\/feedback-forms\/[^/]+/, '/feedback-forms/{form_id}');
+}
+
+/** Every `/feedback-forms...` path mentioned in a source file. */
+function callerFormsPaths(source: string): string[] {
+  const matches = source.match(/\/feedback-forms(?:\/[^\s'"`?)]*)*/g) ?? [];
+  return [...new Set(matches.map(normalizeFormsPath))].sort();
+}
+
+const readRepoFile = (...segments: string[]) => readFileSync(join(__dirname, '..', '..', ...segments), 'utf-8');
+
 describe('VocApiStack authorization invariant', () => {
   it('leaves only the three embeddable-widget routes unauthenticated', () => {
-    const unauthenticated = apiMethods(apiTemplate())
-      .filter((m) => m.httpMethod !== 'OPTIONS' && m.authorizationType === 'NONE')
-      .map((m) => m.route)
+    expect(unauthenticatedRoutes(apiTemplate())).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
+  });
+
+  it('leaves only those three unauthenticated with every plugin enabled too', () => {
+    // The empty-plugin shape is not what anyone deploys. Plugin webhook
+    // receivers are deliberately unauthenticated, so if a plugin ever declares
+    // a webhook this fails and forces a considered allowlist entry rather than
+    // shipping a new anonymous route silently. No manifest declares one today.
+    expect(unauthenticatedRoutes(apiTemplateAllPlugins())).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
+  });
+
+  it('pins the fact that makes the allowlist complete: no plugin declares a webhook', () => {
+    // Webhook receivers are added with no method options, i.e. deliberately
+    // anonymous. Today no manifest declares one, which is why the allowlist
+    // above is exactly three routes. Reading the manifests directly makes that
+    // assumption fail loudly the day it stops holding — the previous test
+    // compares two identical shapes until then, so on its own it cannot.
+    const pluginsDir = join(__dirname, '..', '..', 'plugins');
+    const withWebhook = ALL_PLUGIN_IDS.filter((id) => {
+      const manifest: unknown = JSON.parse(readFileSync(join(pluginsDir, id, 'manifest.json'), 'utf-8'));
+      const parsed = z
+        .object({ infrastructure: z.object({ webhook: z.object({ enabled: z.boolean() }).optional() }).optional() })
+        .safeParse(manifest);
+      return parsed.success && parsed.data.infrastructure?.webhook?.enabled === true;
+    });
+
+    expect(
+      withWebhook,
+      'A plugin now declares a webhook. Webhook methods are unauthenticated by design, '
+      + 'so add them to an explicit allowlist in this file rather than widening the assertion.',
+    ).toEqual([]);
+  });
+
+  it('authenticates every other method with Cognito, not merely "something"', () => {
+    // Asserting `!== NONE` would accept a method that regressed to AWS_IAM or
+    // picked up a stray authorizer.
+    const offenders = nonOptions(apiTemplateAllPlugins())
+      .filter((m) => !INTENTIONALLY_PUBLIC_ROUTES.includes(m.route))
+      .filter((m) => !CUSTOM_AUTHORIZER_ROUTE_PREFIXES.some((prefix) => m.path.startsWith(prefix)))
+      .filter((m) => m.authorizationType !== 'COGNITO_USER_POOLS' || !m.hasAuthorizerId)
+      .map((m) => `${m.route} [${m.authorizationType}]`)
       .sort();
 
-    expect(unauthenticated).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
+    expect(offenders).toEqual([]);
+  });
+
+  it('authenticates the custom-authorizer routes with a real authorizer', () => {
+    const mcp = nonOptions(apiTemplateAllPlugins())
+      .filter((m) => CUSTOM_AUTHORIZER_ROUTE_PREFIXES.some((prefix) => m.path.startsWith(prefix)));
+
+    expect(mcp.length).toBeGreaterThan(0);
+    for (const method of mcp) {
+      expect(method.authorizationType, method.route).toBe('CUSTOM');
+      expect(method.hasAuthorizerId, method.route).toBe(true);
+    }
   });
 
   it.each([
@@ -180,15 +271,17 @@ describe('VocApiStack authorization invariant', () => {
     const method = apiMethods(apiTemplate()).find((m) => m.route === route);
 
     expect(method, `${route} is not wired at all`).toBeDefined();
-    expect(method?.authorizationType).not.toBe('NONE');
+    expect(method?.authorizationType).toBe('COGNITO_USER_POOLS');
   });
+});
 
+describe('stack and callers stay in step', () => {
   it('wires every route the feedback-form handler registers', () => {
     // Independent oracle: the handler source, not the template under test.
     // Without the old {proxy+} catch-all, a route the handler registers but
     // nobody wires returns 403 Missing Authentication Token instead of working.
-    const handler = readFileSync(join(__dirname, '../../lambda/api/feedback_form_handler.py'), 'utf-8');
-    const registered = [...handler.matchAll(/@app\.(get|post|put|delete)\("([^"]+)"\)/g)]
+    const handler = readRepoFile('lambda', 'api', 'feedback_form_handler.py');
+    const registered = [...handler.matchAll(/@app\.(get|post|put|delete|route)\(\s*['"]([^'"]+)['"]/g)]
       .map(([, verb, path]) => `${verb.toUpperCase()} ${path.replace(/<(\w+)>/g, '{$1}')}`)
       .sort();
 
@@ -198,15 +291,54 @@ describe('VocApiStack authorization invariant', () => {
     expect(registered.filter((route) => !wired.has(route))).toEqual([]);
   });
 
+  it.each([
+    ['the API client', join('frontend', 'src', 'api', 'client.ts')],
+    ['the embeddable widget', join('lambda', 'api', 'static', 'feedback-widget.js')],
+  ])('wires every /feedback-forms path %s calls', (_label, relativePath) => {
+    // Callers fail opaquely now: an unwired path returns 403 rather than the
+    // handler's 404, so a caller-side path with no method is a live bug.
+    const wiredPaths = new Set(apiMethods(apiTemplate()).map((m) => m.path));
+    const referenced = callerFormsPaths(readRepoFile(...relativePath.split('/')));
+
+    expect(referenced.length).toBeGreaterThan(0);
+    expect(referenced.filter((path) => !wiredPaths.has(path))).toEqual([]);
+  });
+
   it('has no proxy resource left without explicit method options', () => {
     // The original defect in source form: `addProxy` without
-    // `defaultMethodOptions` silently publishes everything beneath it.
-    const source = readFileSync(join(__dirname, 'api-stack.ts'), 'utf-8');
-    const proxiesWithoutOptions = source
-      .split('\n')
-      .map((line, index) => ({ line: line.trim(), lineNumber: index + 1 }))
-      .filter(({ line }) => line.includes('addProxy(') && !line.includes('defaultMethodOptions'));
+    // `defaultMethodOptions` silently publishes everything beneath it. Matched
+    // on the call expression rather than a single line, so reformatting an
+    // addProxy call across lines cannot fail this falsely.
+    const source = readRepoFile('lib', 'stacks', 'api-stack.ts');
+    const bareProxies = [...source.matchAll(/addProxy\(/g)]
+      .map((match) => source.slice(match.index ?? 0, (match.index ?? 0) + 400))
+      .filter((call) => !call.includes('defaultMethodOptions'));
 
-    expect(proxiesWithoutOptions).toEqual([]);
+    expect(bareProxies).toEqual([]);
+  });
+});
+
+describe('skipFeedbackFormItemRoutes (transitional upgrade flag)', () => {
+  const flagged = () => synthApiTemplate({ skipFeedbackFormItemRoutes: true });
+
+  it('omits the item routes so the old {proxy+} can be retired first', () => {
+    // {form_id} cannot be created while {proxy+} still exists, and CloudFormation
+    // creates before deleting, so the upgrade needs one deploy without these.
+    const routes = apiMethods(flagged()).map((m) => m.route);
+
+    expect(routes.filter((route) => route.includes('{form_id}'))).toEqual([]);
+    expect(routes).toContain('GET /feedback-forms');
+    expect(routes).toContain('POST /feedback-forms');
+  });
+
+  it('leaves nothing unauthenticated during that transitional deploy', () => {
+    // The window is fail-closed: the public widget routes live under {form_id},
+    // so they are absent too rather than exposed.
+    expect(unauthenticatedRoutes(flagged())).toEqual([]);
+  });
+
+  it('is a no-op when absent — the default template keeps the item routes', () => {
+    expect(unauthenticatedRoutes(apiTemplate())).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
+    expect(apiMethods(apiTemplate()).map((m) => m.route)).toContain('PUT /feedback-forms/{form_id}');
   });
 });

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Authorization invariant for every method on the VoC REST API.
+ *
+ * Regression guard for the Checkov CKV_AWS_59 finding on `/feedback-forms`.
+ * The item routes sat behind an `anyMethod` proxy that was created without
+ * `defaultMethodOptions`, so API Gateway defaulted them to
+ * AuthorizationType.NONE: form update, form delete and reads of submitted
+ * customer feedback were reachable with no credentials at all, while the
+ * collection directly above them was Cognito-protected.
+ *
+ * The defect was a MISSING ARGUMENT. Nothing threw, no test broke, and a
+ * cdk-nag suppression applied to the whole proxy subtree made the entire
+ * prefix look assessed. A test asserting "these four routes are protected"
+ * would not have caught it either, because the routes did not exist as
+ * distinct constructs. So the guard is an invariant over the whole template —
+ * every non-OPTIONS method carries an authorizer, except an explicit
+ * allowlist — plus a lockstep check that every route the Lambda registers is
+ * actually wired.
+ *
+ * OPTIONS is excluded because API Gateway generates unauthenticated CORS
+ * preflight methods from `defaultCorsPreflightOptions`, and cdk-nag's own
+ * APIG4 rule excludes them for the same reason.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import { z } from 'zod';
+
+import { VocApiStack } from './api-stack';
+
+/** The only routes that may be served without credentials: the embeddable
+ *  widget runs on the customer's own site. `config` and `submit` are fetched
+ *  by lambda/api/static/feedback-widget.js; `iframe` is navigated to directly
+ *  by the browser in the iframe embed variant. */
+const INTENTIONALLY_PUBLIC_ROUTES = [
+  'GET /feedback-forms/{form_id}/config',
+  'GET /feedback-forms/{form_id}/iframe',
+  'POST /feedback-forms/{form_id}/submit',
+];
+
+/** Synthesizing this stack is the expensive part of the suite, and every test
+ *  wants the same template, so build it once. */
+let cachedTemplate: Template | undefined;
+function apiTemplate(): Template {
+  cachedTemplate ??= synthApiTemplate();
+  return cachedTemplate;
+}
+
+function synthApiTemplate(): Template {
+  // Skip asset bundling (Docker) and the frontend-freshness guard — template
+  // assertions only need structure, and the check would make the suite depend
+  // on whether frontend/dist happens to be newer than frontend/src.
+  const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true } });
+  const env = { account: '111111111111', region: 'us-east-1' };
+  const deps = new cdk.Stack(app, 'TestDeps', { env });
+
+  const table = (id: string) => new dynamodb.Table(deps, id, {
+    partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+    sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+  });
+  const userPool = new cognito.UserPool(deps, 'UserPool');
+  const websiteBucket = new s3.Bucket(deps, 'Website');
+
+  const stack = new VocApiStack(app, 'TestApiStack', {
+    env,
+    feedbackTable: table('Feedback'),
+    aggregatesTable: table('Aggregates'),
+    projectsTable: table('Projects'),
+    jobsTable: table('Jobs'),
+    conversationsTable: table('Conversations'),
+    kmsKey: new kms.Key(deps, 'Key'),
+    rawDataBucket: new s3.Bucket(deps, 'RawData'),
+    avatarsCdnUrl: 'https://cdn.example.invalid/avatars',
+    prototypesCdnUrl: 'https://cdn.example.invalid/prototypes',
+    cdnSigningSecretArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:cdn-signing`,
+    cdnSigningKeyPairId: 'KEXAMPLE0000',
+    websiteBucket,
+    frontendDistribution: new cloudfront.Distribution(deps, 'Dist', {
+      defaultBehavior: { origin: origins.S3BucketOrigin.withOriginAccessControl(websiteBucket) },
+    }),
+    frontendDomainName: 'app.example.invalid',
+    userPool,
+    userPoolClient: userPool.addClient('Client'),
+    identityPool: new cognito.CfnIdentityPool(deps, 'IdentityPool', { allowUnauthenticatedIdentities: false }),
+    authenticatedRole: new iam.Role(deps, 'AuthRole', { assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com') }),
+    processingQueueUrl: `https://sqs.${env.region}.amazonaws.com/${env.account}/processing`,
+    processingQueueArn: `arn:aws:sqs:${env.region}:${env.account}:processing`,
+    secretsArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:voc`,
+    s3ImportBucket: new s3.Bucket(deps, 'S3Import'),
+    researchStateMachine: new sfn.StateMachine(deps, 'Research', {
+      definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(deps, 'Noop')),
+    }),
+    brandName: 'TestBrand',
+    // No plugins ⇒ no webhook receivers. Webhook methods are deliberately
+    // unauthenticated, so enabling a plugin here would correctly fail the
+    // invariant below and force a considered allowlist entry.
+    enabledSources: [],
+  });
+
+  return Template.fromStack(stack);
+}
+
+// Template values arrive as `unknown`; parse rather than assert (no `as`).
+const RefSchema = z.object({ Ref: z.string() });
+const GetAttSchema = z.object({ 'Fn::GetAtt': z.tuple([z.string(), z.string()]) });
+const ResourceIdSchema = z.union([RefSchema, GetAttSchema]);
+type ResourceId = z.infer<typeof ResourceIdSchema>;
+
+const ApiResourceSchema = z.object({ PathPart: z.string(), ParentId: ResourceIdSchema });
+const MethodSchema = z.object({
+  HttpMethod: z.string(),
+  ResourceId: ResourceIdSchema,
+  AuthorizationType: z.string().optional(),
+});
+
+interface ApiMethod {
+  httpMethod: string;
+  path: string;
+  authorizationType: string;
+  route: string;
+}
+
+/**
+ * Reconstructs each method's full path by walking `ParentId` up the
+ * AWS::ApiGateway::Resource chain. The root is an `Fn::GetAtt
+ * [<api>, RootResourceId]`, which terminates the walk.
+ */
+function apiMethods(template: Template): ApiMethod[] {
+  const parts = new Map<string, { pathPart: string; parentId: ResourceId }>();
+  for (const [logicalId, resource] of Object.entries(template.findResources('AWS::ApiGateway::Resource'))) {
+    const { PathPart, ParentId } = ApiResourceSchema.parse(resource.Properties);
+    parts.set(logicalId, { pathPart: PathPart, parentId: ParentId });
+  }
+
+  const pathOf = (id: ResourceId): string => {
+    if (!('Ref' in id)) return '';
+    const node = parts.get(id.Ref);
+    return node ? `${pathOf(node.parentId)}/${node.pathPart}` : '';
+  };
+
+  return Object.values(template.findResources('AWS::ApiGateway::Method')).map((method) => {
+    const { HttpMethod, ResourceId, AuthorizationType } = MethodSchema.parse(method.Properties);
+    const path = pathOf(ResourceId) || '/';
+    return {
+      httpMethod: HttpMethod,
+      path,
+      authorizationType: AuthorizationType ?? 'NONE',
+      route: `${HttpMethod} ${path}`,
+    };
+  });
+}
+
+describe('VocApiStack authorization invariant', () => {
+  it('leaves only the three embeddable-widget routes unauthenticated', () => {
+    const unauthenticated = apiMethods(apiTemplate())
+      .filter((m) => m.httpMethod !== 'OPTIONS' && m.authorizationType === 'NONE')
+      .map((m) => m.route)
+      .sort();
+
+    expect(unauthenticated).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
+  });
+
+  it.each([
+    'PUT /feedback-forms/{form_id}',
+    'DELETE /feedback-forms/{form_id}',
+    'GET /feedback-forms/{form_id}/submissions',
+    'GET /feedback-forms/{form_id}/stats',
+  ])('requires an authorizer on %s', (route) => {
+    const method = apiMethods(apiTemplate()).find((m) => m.route === route);
+
+    expect(method, `${route} is not wired at all`).toBeDefined();
+    expect(method?.authorizationType).not.toBe('NONE');
+  });
+
+  it('wires every route the feedback-form handler registers', () => {
+    // Independent oracle: the handler source, not the template under test.
+    // Without the old {proxy+} catch-all, a route the handler registers but
+    // nobody wires returns 403 Missing Authentication Token instead of working.
+    const handler = readFileSync(join(__dirname, '../../lambda/api/feedback_form_handler.py'), 'utf-8');
+    const registered = [...handler.matchAll(/@app\.(get|post|put|delete)\("([^"]+)"\)/g)]
+      .map(([, verb, path]) => `${verb.toUpperCase()} ${path.replace(/<(\w+)>/g, '{$1}')}`)
+      .sort();
+
+    expect(registered.length).toBeGreaterThan(0);
+
+    const wired = new Set(apiMethods(apiTemplate()).map((m) => m.route));
+    expect(registered.filter((route) => !wired.has(route))).toEqual([]);
+  });
+
+  it('has no proxy resource left without explicit method options', () => {
+    // The original defect in source form: `addProxy` without
+    // `defaultMethodOptions` silently publishes everything beneath it.
+    const source = readFileSync(join(__dirname, 'api-stack.ts'), 'utf-8');
+    const proxiesWithoutOptions = source
+      .split('\n')
+      .map((line, index) => ({ line: line.trim(), lineNumber: index + 1 }))
+      .filter(({ line }) => line.includes('addProxy(') && !line.includes('defaultMethodOptions'));
+
+    expect(proxiesWithoutOptions).toEqual([]);
+  });
+});

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -18,7 +18,7 @@
  * CORS preflight methods from `defaultCorsPreflightOptions`, and cdk-nag's own
  * APIG4 rule excludes them for the same reason.
  */
-import { readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, it, expect } from 'vitest';
@@ -35,6 +35,7 @@ import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import { z } from 'zod';
 
 import { VocApiStack } from './api-stack';
+import { ManifestSchema } from '../plugin-loader';
 
 /** The only routes that may be served without credentials: the embeddable
  *  widget runs on the customer's own site. `config` and `submit` are fetched
@@ -50,15 +51,24 @@ const INTENTIONALLY_PUBLIC_ROUTES = [
  *  the Cognito flow. Authenticated, just not by Cognito. */
 const CUSTOM_AUTHORIZER_ROUTE_PREFIXES = ['/mcp'];
 
-/** Every plugin on disk. Used to synthesize the shape a real deployment has,
- *  rather than only the empty one. */
-const ALL_PLUGIN_IDS = [
-  'app_reviews_android',
-  'app_reviews_ios',
-  's3_import',
-  'synthetic_reviews',
-  'webscraper',
-];
+const PLUGINS_DIR = join(__dirname, '..', '..', 'plugins');
+
+/**
+ * Every plugin on disk, enumerated rather than hardcoded — a hardcoded list would
+ * make a newly registered plugin invisible to both the all-plugins invariant and
+ * the webhook pin below, i.e. exactly the case they exist to catch.
+ *
+ * `plugins/` also holds Python test files, `__pycache__`, `_shared/` and
+ * `_template/` (which does have a manifest.json), so filter the way
+ * `loadPlugins` does: a directory with a manifest, not `_`-prefixed.
+ */
+function discoverPluginIds(): string[] {
+  return readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith('_'))
+    .filter((entry) => existsSync(join(PLUGINS_DIR, entry.name, 'manifest.json')))
+    .map((entry) => entry.name)
+    .sort();
+}
 
 function synthApiTemplate(context: Record<string, unknown> = {}, enabledSources: string[] = []): Template {
   // Skip asset bundling (Docker) and the frontend-freshness guard — template
@@ -126,8 +136,15 @@ function apiTemplate(): Template {
 
 /** Every plugin on disk enabled — the shape a real deployment has. */
 function apiTemplateAllPlugins(): Template {
-  cachedAllPlugins ??= synthApiTemplate({}, ALL_PLUGIN_IDS);
+  cachedAllPlugins ??= synthApiTemplate({}, discoverPluginIds());
   return cachedAllPlugins;
+}
+
+/** The transitional first-deploy shape. */
+let cachedFlagged: Template | undefined;
+function apiTemplateFlagged(): Template {
+  cachedFlagged ??= synthApiTemplate({ skipFeedbackFormItemRoutes: true });
+  return cachedFlagged;
 }
 
 // Template values arrive as `unknown`; parse rather than assert (no `as`).
@@ -189,7 +206,15 @@ const unauthenticatedRoutes = (template: Template) =>
 
 /** Collapses a caller-side path to the shape the template declares: strips any
  *  query string and normalizes the form-id segment, which appears variously as
- *  `${formId}`, a literal example id, or `{form_id}`. */
+ *  `${formId}`, a literal example id, or `{form_id}`.
+ *
+ *  Deliberately a smoke test, with two known limits: a path built by
+ *  concatenation (`'/feedback-forms/' + id + '/submit'`) collapses to
+ *  `/feedback-forms` and passes without being checked, and a genuine collection
+ *  subresource (say `/feedback-forms/templates`) would be normalized to
+ *  `{form_id}` and pass spuriously. It catches the case that actually bit us —
+ *  a whole route removed from the stack while a caller still names it — and a
+ *  full solution would mean parsing the TypeScript. */
 function normalizeFormsPath(raw: string): string {
   const path = raw.split('?')[0].replace(/\/+$/, '');
   return path.replace(/^\/feedback-forms\/[^/]+/, '/feedback-forms/{form_id}');
@@ -208,6 +233,18 @@ describe('VocApiStack authorization invariant', () => {
     expect(unauthenticatedRoutes(apiTemplate())).toEqual(INTENTIONALLY_PUBLIC_ROUTES);
   });
 
+  it('discovers the real plugins, excluding scaffolding', () => {
+    // Two guards below are only as good as this enumeration, so pin it: it must
+    // find plugins, and must not pick up `_template`/`_shared` (which are not
+    // deployable) or the Python test files sitting in the same directory.
+    const ids = discoverPluginIds();
+
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids.filter((id) => id.startsWith('_'))).toEqual([]);
+    expect(ids.filter((id) => id.endsWith('.py'))).toEqual([]);
+    expect(ids).toContain('webscraper');
+  });
+
   it('leaves only those three unauthenticated with every plugin enabled too', () => {
     // The empty-plugin shape is not what anyone deploys. Plugin webhook
     // receivers are deliberately unauthenticated, so if a plugin ever declares
@@ -222,13 +259,17 @@ describe('VocApiStack authorization invariant', () => {
     // above is exactly three routes. Reading the manifests directly makes that
     // assumption fail loudly the day it stops holding — the previous test
     // compares two identical shapes until then, so on its own it cannot.
-    const pluginsDir = join(__dirname, '..', '..', 'plugins');
-    const withWebhook = ALL_PLUGIN_IDS.filter((id) => {
-      const manifest: unknown = JSON.parse(readFileSync(join(pluginsDir, id, 'manifest.json'), 'utf-8'));
-      const parsed = z
-        .object({ infrastructure: z.object({ webhook: z.object({ enabled: z.boolean() }).optional() }).optional() })
-        .safeParse(manifest);
-      return parsed.success && parsed.data.infrastructure?.webhook?.enabled === true;
+    //
+    // Parsed with the canonical ManifestSchema and `.parse`, deliberately: a
+    // local partial schema plus `safeParse` would treat a renamed or moved
+    // `infrastructure.webhook.enabled` as "no webhook" and silently disable this
+    // guard. Shape drift must throw here, not pass.
+    const pluginIds = discoverPluginIds();
+    expect(pluginIds.length, 'no plugins discovered — the enumeration is broken').toBeGreaterThan(0);
+
+    const withWebhook = pluginIds.filter((id) => {
+      const raw: unknown = JSON.parse(readFileSync(join(PLUGINS_DIR, id, 'manifest.json'), 'utf-8'));
+      return ManifestSchema.parse(raw).infrastructure.webhook?.enabled === true;
     });
 
     expect(
@@ -306,12 +347,25 @@ describe('stack and callers stay in step', () => {
 
   it('has no proxy resource left without explicit method options', () => {
     // The original defect in source form: `addProxy` without
-    // `defaultMethodOptions` silently publishes everything beneath it. Matched
-    // on the call expression rather than a single line, so reformatting an
-    // addProxy call across lines cannot fail this falsely.
+    // `defaultMethodOptions` silently publishes everything beneath it.
+    //
+    // Each call's argument list is delimited by matching its parentheses, not by
+    // a fixed window: a fixed slice both false-fails when the option sits just
+    // past the cutoff and false-passes on an unrelated occurrence just inside it.
     const source = readRepoFile('lib', 'stacks', 'api-stack.ts');
     const bareProxies = [...source.matchAll(/addProxy\(/g)]
-      .map((match) => source.slice(match.index ?? 0, (match.index ?? 0) + 400))
+      .map((match) => {
+        const open = (match.index ?? 0) + match[0].length - 1;
+        let depth = 0;
+        for (let i = open; i < source.length; i += 1) {
+          if (source[i] === '(') depth += 1;
+          else if (source[i] === ')') {
+            depth -= 1;
+            if (depth === 0) return source.slice(open, i + 1);
+          }
+        }
+        return source.slice(open);
+      })
       .filter((call) => !call.includes('defaultMethodOptions'));
 
     expect(bareProxies).toEqual([]);
@@ -319,7 +373,7 @@ describe('stack and callers stay in step', () => {
 });
 
 describe('skipFeedbackFormItemRoutes (transitional upgrade flag)', () => {
-  const flagged = () => synthApiTemplate({ skipFeedbackFormItemRoutes: true });
+  const flagged = apiTemplateFlagged;
 
   it('omits the item routes so the old {proxy+} can be retired first', () => {
     // {form_id} cannot be created while {proxy+} still exists, and CloudFormation

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1033,17 +1033,41 @@ export class VocApiStack extends cdk.Stack {
     usersResource.addMethod('POST', usersIntegration, authMethodOptions);
     usersResource.addProxy({ defaultIntegration: usersIntegration, anyMethod: true, defaultMethodOptions: authMethodOptions });
 
-    // /feedback-form/* (legacy single form - public endpoints, proxy to feedback form Lambda)
-    const feedbackFormResource = this.api.root.addResource('feedback-form');
-    const feedbackFormProxy = feedbackFormResource.addProxy({ defaultIntegration: feedbackFormIntegration, anyMethod: true });
-    NagSuppressions.addResourceSuppressions(feedbackFormProxy, publicFeedbackEndpointSuppressions, true);
-
     // /feedback-forms/* (multiple forms)
+    //
+    // Item routes are declared EXPLICITLY instead of behind an `anyMethod` proxy.
+    // A proxy with no `defaultMethodOptions` defaults every method to
+    // AuthorizationType.NONE, which published form update, form delete and reads
+    // of submitted customer feedback with no credentials at all. Explicit routes
+    // fail closed: a new handler route is unreachable until it is wired here,
+    // rather than silently inheriting a catch-all's (absent) authorization.
+    //
+    // Only the three routes the embeddable widget needs stay public — verified
+    // against lambda/api/static/feedback-widget.js (config + submit) plus the
+    // /iframe embed variant, which a browser navigates to directly. Keep this
+    // list and lambda/api/feedback_form_handler.py in step: every route the
+    // handler registers needs a method here, and api-stack.test.ts asserts that
+    // only these three are unauthenticated.
     const feedbackFormsResource = this.api.root.addResource('feedback-forms');
     feedbackFormsResource.addMethod('GET', feedbackFormIntegration, authMethodOptions);
     feedbackFormsResource.addMethod('POST', feedbackFormIntegration, authMethodOptions);
-    const feedbackFormsProxy = feedbackFormsResource.addProxy({ defaultIntegration: feedbackFormIntegration, anyMethod: true });
-    NagSuppressions.addResourceSuppressions(feedbackFormsProxy, publicFeedbackEndpointSuppressions, true);
+
+    const feedbackFormItem = feedbackFormsResource.addResource('{form_id}');
+    feedbackFormItem.addMethod('GET', feedbackFormIntegration, authMethodOptions);
+    feedbackFormItem.addMethod('PUT', feedbackFormIntegration, authMethodOptions);
+    feedbackFormItem.addMethod('DELETE', feedbackFormIntegration, authMethodOptions);
+    feedbackFormItem.addResource('submissions').addMethod('GET', feedbackFormIntegration, authMethodOptions);
+    feedbackFormItem.addResource('stats').addMethod('GET', feedbackFormIntegration, authMethodOptions);
+
+    // Intentionally unauthenticated: the widget runs on the customer's own site.
+    const publicFeedbackFormMethods = [
+      feedbackFormItem.addResource('config').addMethod('GET', feedbackFormIntegration),
+      feedbackFormItem.addResource('submit').addMethod('POST', feedbackFormIntegration),
+      feedbackFormItem.addResource('iframe').addMethod('GET', feedbackFormIntegration),
+    ];
+    for (const publicMethod of publicFeedbackFormMethods) {
+      NagSuppressions.addResourceSuppressions(publicMethod, publicFeedbackEndpointSuppressions);
+    }
 
     // /projects/*
     const projectsResource = this.api.root.addResource('projects');

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1068,12 +1068,19 @@ export class VocApiStack extends cdk.Stack {
     // the synthesized template is identical either way. Never leave it set:
     // while it is on, the per-form routes do not exist and the embeddable widget
     // is down. See docs/deployment.md.
+    //
+    // TODO(cleanup): this flag exists only to migrate environments deployed
+    // before the item routes became explicit. Once every environment has run the
+    // two-deploy upgrade, delete the flag, this branch and its tests — a
+    // permanently available "skip the authorization-bearing routes" switch is a
+    // footgun once nothing needs it.
     const skipFeedbackFormItemRoutes =
       this.node.tryGetContext('skipFeedbackFormItemRoutes') === true
       || this.node.tryGetContext('skipFeedbackFormItemRoutes') === 'true';
 
     if (skipFeedbackFormItemRoutes) {
-      cdk.Annotations.of(this).addWarning(
+      cdk.Annotations.of(this).addWarningV2(
+        'voc:skipFeedbackFormItemRoutes',
         'skipFeedbackFormItemRoutes is set: /feedback-forms/{form_id}/* is NOT being deployed. '
         + 'This is the first of two upgrade deploys — re-deploy without the flag to restore the routes.',
       );

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1057,21 +1057,43 @@ export class VocApiStack extends cdk.Stack {
     feedbackFormsResource.addMethod('GET', feedbackFormIntegration, authMethodOptions);
     feedbackFormsResource.addMethod('POST', feedbackFormIntegration, authMethodOptions);
 
-    const feedbackFormItem = feedbackFormsResource.addResource('{form_id}');
-    feedbackFormItem.addMethod('GET', feedbackFormIntegration, authMethodOptions);
-    feedbackFormItem.addMethod('PUT', feedbackFormIntegration, authMethodOptions);
-    feedbackFormItem.addMethod('DELETE', feedbackFormIntegration, authMethodOptions);
-    feedbackFormItem.addResource('submissions').addMethod('GET', feedbackFormIntegration, authMethodOptions);
-    feedbackFormItem.addResource('stats').addMethod('GET', feedbackFormIntegration, authMethodOptions);
+    // One-shot flag for upgrading an environment that still has the old
+    // /feedback-forms/{proxy+}. CloudFormation creates new resources before
+    // deleting old ones inside a single update, so {form_id} and {proxy+} would
+    // exist together and API Gateway rejects two variable path parts at one
+    // level. Deploy once with -c skipFeedbackFormItemRoutes=true to retire the
+    // proxy, then deploy again without it to create these routes.
+    //
+    // Absent (the default, and always for fresh deployments) this is a no-op —
+    // the synthesized template is identical either way. Never leave it set:
+    // while it is on, the per-form routes do not exist and the embeddable widget
+    // is down. See docs/deployment.md.
+    const skipFeedbackFormItemRoutes =
+      this.node.tryGetContext('skipFeedbackFormItemRoutes') === true
+      || this.node.tryGetContext('skipFeedbackFormItemRoutes') === 'true';
 
-    // Intentionally unauthenticated: the widget runs on the customer's own site.
-    const publicFeedbackFormMethods = [
-      feedbackFormItem.addResource('config').addMethod('GET', feedbackFormIntegration),
-      feedbackFormItem.addResource('submit').addMethod('POST', feedbackFormIntegration),
-      feedbackFormItem.addResource('iframe').addMethod('GET', feedbackFormIntegration),
-    ];
-    for (const publicMethod of publicFeedbackFormMethods) {
-      NagSuppressions.addResourceSuppressions(publicMethod, publicFeedbackEndpointSuppressions);
+    if (skipFeedbackFormItemRoutes) {
+      cdk.Annotations.of(this).addWarning(
+        'skipFeedbackFormItemRoutes is set: /feedback-forms/{form_id}/* is NOT being deployed. '
+        + 'This is the first of two upgrade deploys — re-deploy without the flag to restore the routes.',
+      );
+    } else {
+      const feedbackFormItem = feedbackFormsResource.addResource('{form_id}');
+      feedbackFormItem.addMethod('GET', feedbackFormIntegration, authMethodOptions);
+      feedbackFormItem.addMethod('PUT', feedbackFormIntegration, authMethodOptions);
+      feedbackFormItem.addMethod('DELETE', feedbackFormIntegration, authMethodOptions);
+      feedbackFormItem.addResource('submissions').addMethod('GET', feedbackFormIntegration, authMethodOptions);
+      feedbackFormItem.addResource('stats').addMethod('GET', feedbackFormIntegration, authMethodOptions);
+
+      // Intentionally unauthenticated: the widget runs on the customer's own site.
+      const publicFeedbackFormMethods = [
+        feedbackFormItem.addResource('config').addMethod('GET', feedbackFormIntegration),
+        feedbackFormItem.addResource('submit').addMethod('POST', feedbackFormIntegration),
+        feedbackFormItem.addResource('iframe').addMethod('GET', feedbackFormIntegration),
+      ];
+      for (const publicMethod of publicFeedbackFormMethods) {
+        NagSuppressions.addResourceSuppressions(publicMethod, publicFeedbackEndpointSuppressions);
+      }
     }
 
     // /projects/*

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1048,6 +1048,11 @@ export class VocApiStack extends cdk.Stack {
     // list and lambda/api/feedback_form_handler.py in step: every route the
     // handler registers needs a method here, and api-stack.test.ts asserts that
     // only these three are unauthenticated.
+    //
+    // Do NOT reintroduce a {proxy+} here to avoid the two-step upgrade it costs
+    // on already-deployed environments: {form_id} and {proxy+} cannot coexist as
+    // sibling variable paths, which is what makes the upgrade two deploys. See
+    // docs/deployment.md, "A sibling ({proxy+}) of this resource...".
     const feedbackFormsResource = this.api.root.addResource('feedback-forms');
     feedbackFormsResource.addMethod('GET', feedbackFormIntegration, authMethodOptions);
     feedbackFormsResource.addMethod('POST', feedbackFormIntegration, authMethodOptions);


### PR DESCRIPTION
## Summary

Every route under `/feedback-forms/{proxy+}` was served with `AuthorizationType: NONE`, so form
update, form delete, and reads of submitted customer feedback were reachable **with no credentials
at all**. The `/feedback-forms` collection above them (`GET`, `POST`) *was* Cognito-protected, so
the collection was guarded and every item beneath it was not.

This closes that gap by declaring the item routes explicitly instead of behind a catch-all proxy,
and adds a template-level invariant so it cannot silently reopen.

There is no separate issue for this: **this PR is the record.** It was fixed and verified before
being published, and nothing here is a working request example.

## Root cause

`api-stack.ts` calls `addProxy` **14 times. 12 pass authorization options** (11 ×
`authMethodOptions`, 1 × `mcpMethodOptions` for `/mcp`). The only two that omitted
`defaultMethodOptions` entirely were the two feedback-form proxies, so their methods defaulted to
`AuthorizationType: NONE`. On the plural resource the two collection methods immediately above the
proxy *do* pass it — which is exactly why the collection was protected and the items were not.

So this was a **missing argument, not a missing design**. The handler did not compensate:
`lambda/api/feedback_form_handler.py` imports no auth helper at all, so nothing checked the caller
at either layer.

Two things kept it invisible:

- `nag-suppressions.ts` suppressed `AwsSolutions-APIG4` and `AwsSolutions-COG4` across the whole
  proxy subtree with the reason "intentionally public to allow anonymous customer feedback
  submission". That is true for the widget routes and false for the rest, and the suppression made
  the entire prefix look assessed. **An existing suppression is not evidence a finding was ever
  assessed.**
- Checkov's `CKV_AWS_59` surfaced it because it does not read cdk-nag suppressions.

## What changed

The `{proxy+}` is replaced by explicit resources for all ten routes the handler registers:

| Auth | Method | Route |
|---|---|---|
| Cognito | `GET`, `POST` | `/feedback-forms` |
| Cognito | `GET`, `PUT`, `DELETE` | `/feedback-forms/{form_id}` |
| Cognito | `GET` | `/feedback-forms/{form_id}/submissions` |
| Cognito | `GET` | `/feedback-forms/{form_id}/stats` |
| **public** | `GET` | `/feedback-forms/{form_id}/config` |
| **public** | `POST` | `/feedback-forms/{form_id}/submit` |
| **public** | `GET` | `/feedback-forms/{form_id}/iframe` |

The public set is exactly what the embeddable widget needs, read off
`lambda/api/static/feedback-widget.js` rather than guessed. The APIG4/COG4 suppressions are narrowed
from both proxy subtrees to those three methods, so a suppression can no longer cover a route nobody
intended to publish.

**No frontend change was required:** `fetchApi` → `buildHeaders` → `getAuthHeaders` already attaches
the bearer token to every admin-UI call.

### Why not keep the proxy and re-open three routes?

That was the obvious shape and it does not work. The three public routes live *under* `{form_id}`,
and API Gateway rejects `{form_id}` as a sibling of `{proxy+}` — only one variable path part is
allowed per level. Declaring them therefore requires the proxy to go.

Explicit routes are also better on the merits: they **fail closed**. A route added to the handler is
now unreachable until it is wired here, instead of inheriting a catch-all's absent authorization.
Cost is ~25 extra CloudFormation resources (354 total, limit 500).

### Also in this PR

- **Removed the legacy singular `/feedback-form/*` surface.** The handler implements no routes under
  that prefix, so the proxy could only 404 while still costing a Lambda invocation — and it is what
  made the same mistake on the plural proxy look idiomatic. Its four `client.ts` methods had no
  callers; their tests asserted call shape against a mocked `fetch`, which is why they stayed green
  against routes that no longer existed.
- **Corrected five tracked docs** that described a `/feedback-form/*` API. The steering route table
  listed four routes that do not exist, omitted five that do, and marked
  `GET /feedback-forms/{id}` public — the mental model that produced this defect. It is now an
  explicit auth allowlist.

## ⚠️ Upgrading an existing deployment takes two deploys

**Fresh deployments are unaffected.** Existing ones are not, and this is documented in
`docs/deployment.md` troubleshooting (second commit).

Deploying this in one update fails and rolls back:

```
CREATE_FAILED  AWS::ApiGateway::Resource  .../feedback-forms/{form_id}
A sibling ({proxy+}) of this resource already has a variable path part -- only one is allowed
```

CloudFormation creates new resources before deleting old ones within a single update, so
`{form_id}` and `{proxy+}` coexist momentarily and API Gateway refuses the pair. Found by deploying
it. The rollback was clean and the API kept serving throughout.

The upgrade is: deploy once with the `feedbackFormItem` block commented out (removes the proxy),
then restore and deploy again. Between the two deploys the per-form routes are unavailable, so the
embeddable widget stops working for that window. They fail closed, which is still an improvement on
being open.

## Regression guard

New `lib/stacks/api-stack.test.ts` — the first test to synthesize `VocApiStack`.

The defect was a missing argument on constructs that did not exist individually, so a test asserting
"these four routes are protected" could not have caught it. The guard is therefore an **invariant
over the whole template**: every non-`OPTIONS` method must carry an authorizer, except a named
three-route allowlist. (`OPTIONS` is excluded because `defaultCorsPreflightOptions` generates
unauthenticated CORS preflight methods, which cdk-nag's own APIG4 rule also excludes.)

It also holds the stack and handler in step by reading the handler's registered routes as an
independent oracle — now load-bearing, since without the catch-all an unwired route returns
`403 Missing Authentication Token`.

**Fail-on-revert proven:** all 7 tests fail against the previous `api-stack.ts`, and the failure
output names the two offending methods.

## Verification

- `cdk synth` clean, **zero cdk-nag findings** after narrowing the suppressions.
- Synthesized template: 102 methods, 55 CORS `OPTIONS`, **exactly 3 non-`OPTIONS` methods without an
  authorizer**, and zero singular `feedback-form` resources.
- **Deployed and verified live.** 16 probes against a real deployment, using a throwaway form that
  was deleted afterwards: the 6 previously-public routes return 401 unauthenticated; the 3 widget
  routes return 200 unauthenticated **with usable payloads** (correct config title, ~17KB of iframe
  HTML, `submit` returning a `feedback_id`) — status codes alone would have accepted a broken body;
  the 4 admin routes return 200 with a token; the legacy singular route is gone.
- **Full async path re-checked:** an unauthenticated submission still traverses SQS → processor →
  feedback store and is readable only with credentials. Note `GET .../submissions` immediately after
  `submit` returns 0 by design — `submit` is `sqs.send_message` and the processor writes the table.
- `scripts/test-api.sh` **32/32**.
- Gates: `test:cdk` 145, frontend 1801, stream 257, handler pytest 15, `tsc` and ESLint clean.

## Relationship to existing issues

- **#242** lists `feedback_form_handler.py` but argues severity from "the endpoints are
  Cognito-authenticated, so a caller must be a valid user". That premise did not hold for this
  handler — the methods required no credentials. #242 should be narrowed to the genuinely
  Cognito-authenticated handlers and point here for feedback forms. I will post that correction
  separately so the two do not contradict each other.
- **#222** hardens the public submit path (throttle, payload validation) and explicitly excludes
  auth from its scope. Complementary; neither supersedes the other.
- **#246** no WAF — the reason no edge control compensated. The only limit was the stage-wide
  throttle, shared with authenticated traffic.
- **#255** is the same rot pattern (a caller left behind after a route was removed).

## Follow-ups deliberately not in this PR

- `frontend/public/feedback-widget.js` is a ~15KB duplicate of the widget with **zero code
  references**, published to the CDN, still calling the singular routes. It was already broken; this
  change makes it permanently so. Delete or repoint — but not inside a security fix.
- Website-bucket S3 access logging, and CDK `BucketDeployment`'s `cloudfront:CreateInvalidation` on
  `"*"` (same family as #234) — both one-file, low value.
- Checkov suppressions for the genuinely-public routes, which must come **after** this lands or they
  re-hide the finding.
- `.kiro/prompts/aws-security-review.md` still asserts WAF protection exists and cites a stack file
  that no longer exists; folds into #246.

## Notes for the reviewer

- **`npm run check` is red on this branch, and it is red on `development` too** — `lint:python`
  (ruff over `lambda/`, `plugins/`) has pre-existing failures, tracked in #271. None of the files
  changed here are under `lambda/` or `plugins/`, so ruff's input is byte-identical to base. The
  individual gates listed above all pass.
- The working tree also carries an unrelated `.gitignore` modification; it is **deliberately not
  included** in either commit.
