### PR TITLE
perf(api): read metric windows in one query instead of one get_item per day

### DIFF
--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -421,13 +421,11 @@ def get_entities():
     categories_list = get_configured_categories(aggregates_table)
     category_counts = {}
     for category in categories_list:
-        total = 0
-        for i in range(days):
-            date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-            response = aggregates_table.get_item(Key={'pk': f'METRIC#daily_category#{category}', 'sk': date})
-            item = response.get('Item')
-            if item:
-                total += int(item.get('count', 0))
+        total = sum(
+            int(item.get('count', 0))
+            for item in _query_metric_window(
+                f'METRIC#daily_category#{category}', days, current_date)
+        )
         if total > 0:
             category_counts[category] = total
     
@@ -455,13 +453,10 @@ def get_entities():
             persona_counts[persona_name] = persona_counts.get(persona_name, 0) + int(item.get('count', 0))
     
     # Get feedback count
-    feedback_count = 0
-    for i in range(days):
-        date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-        response = aggregates_table.get_item(Key={'pk': 'METRIC#daily_total', 'sk': date})
-        item = response.get('Item')
-        if item:
-            feedback_count += int(item.get('count', 0))
+    feedback_count = sum(
+        int(item.get('count', 0))
+        for item in _query_metric_window('METRIC#daily_total', days, current_date)
+    )
     
     # Extract issues from recent feedback
     issues = {}
@@ -676,6 +671,42 @@ def _summary_from_items(days: int) -> dict:
     }
 
 
+def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dict]:
+    """Read one metric partition's trailing `days` window in a SINGLE query.
+
+    The aggregates table is keyed `(pk, sk)` with `sk` = 'YYYY-MM-DD'. ISO dates
+    sort lexicographically, so a trailing window is a contiguous sort-key range
+    and `between()` expresses it server-side: **one** request regardless of
+    `days`, replacing the one `get_item` per day this helper was extracted to
+    remove (`/metrics/summary` alone issued 3 x days, ~270 at a 90-day window).
+
+    Items come back NEWEST FIRST (`ScanIndexForward=False`) because the loops
+    this replaces walked `i` from 0 (today) upward, and `daily_totals` /
+    `daily_sentiment` are handed to the client in that order to be charted.
+    A plain query would return them ascending and silently reverse the charts.
+
+    Deliberately NOT the `gsi1-by-metric-type` shape used by `/metrics/sources`
+    and `/metrics/personas`. That index only carries items the aggregator tags
+    with `metric_type`, and it tags *only* `METRIC#daily_source#` and
+    `METRIC#persona#` (`aggregator/handler.py:26-31`) — precisely the two
+    endpoints that use it. The partitions here carry no such attribute and need
+    none: their `pk` is known, so the base table's own key schema answers the
+    question directly, and the window is filtered server-side rather than
+    reading every date ever recorded and discarding most of it in memory.
+
+    One page suffices: `validate_days` caps `days` at 365 and these are
+    single-counter items (~150 bytes), so a full window is ~55 KB against
+    DynamoDB's 1 MB page limit.
+    """
+    oldest = (current_date - timedelta(days=days - 1)).strftime('%Y-%m-%d')
+    newest = current_date.strftime('%Y-%m-%d')
+    response = aggregates_table.query(
+        KeyConditionExpression=Key('pk').eq(pk) & Key('sk').between(oldest, newest),
+        ScanIndexForward=False,
+    )
+    return response.get('Items', [])
+
+
 @app.get("/metrics/summary")
 @tracer.capture_method
 def get_summary():
@@ -689,30 +720,21 @@ def get_summary():
     
     current_date = datetime.now(timezone.utc)
     
-    totals = []
-    for i in range(days):
-        date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-        response = aggregates_table.get_item(Key={'pk': 'METRIC#daily_total', 'sk': date})
-        item = response.get('Item')
-        if item:
-            totals.append({'date': date, 'count': item.get('count', 0)})
+    totals = [
+        {'date': item['sk'], 'count': item.get('count', 0)}
+        for item in _query_metric_window('METRIC#daily_total', days, current_date)
+    ]
     
     sentiment_data = []
-    for i in range(days):
-        date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-        response = aggregates_table.get_item(Key={'pk': 'METRIC#daily_sentiment_avg', 'sk': date})
-        item = response.get('Item')
-        if item and item.get('count', 0) > 0:
+    for item in _query_metric_window('METRIC#daily_sentiment_avg', days, current_date):
+        if item.get('count', 0) > 0:
             avg = float(item.get('sum', 0)) / float(item.get('count', 1))
-            sentiment_data.append({'date': date, 'avg_sentiment': round(avg, 3), 'count': item.get('count')})
+            sentiment_data.append({'date': item['sk'], 'avg_sentiment': round(avg, 3), 'count': item.get('count')})
     
-    urgent_count = 0
-    for i in range(days):
-        date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-        response = aggregates_table.get_item(Key={'pk': 'METRIC#urgent', 'sk': date})
-        item = response.get('Item')
-        if item:
-            urgent_count += item.get('count', 0)
+    urgent_count = sum(
+        item.get('count', 0)
+        for item in _query_metric_window('METRIC#urgent', days, current_date)
+    )
     
     total_feedback = sum(int(t.get('count', 0)) for t in totals)
     avg_sentiment = sum(float(s.get('avg_sentiment', 0)) * int(s.get('count', 0)) for s in sentiment_data) / max(total_feedback, 1)
@@ -750,14 +772,11 @@ def get_sentiment_metrics():
                 result[sentiment] += 1
     else:
         for sentiment in sentiments:
-            total = 0
-            for i in range(days):
-                date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-                response = aggregates_table.get_item(Key={'pk': f'METRIC#daily_sentiment#{sentiment}', 'sk': date})
-                item = response.get('Item')
-                if item:
-                    total += int(item.get('count', 0))
-            result[sentiment] = total
+            result[sentiment] = sum(
+                int(item.get('count', 0))
+                for item in _query_metric_window(
+                    f'METRIC#daily_sentiment#{sentiment}', days, current_date)
+            )
     
     total = sum(result.values())
     return {
@@ -794,13 +813,11 @@ def get_category_metrics():
             result[category] = result.get(category, 0) + 1
     else:
         for category in categories:
-            total = 0
-            for i in range(days):
-                date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-                response = aggregates_table.get_item(Key={'pk': f'METRIC#daily_category#{category}', 'sk': date})
-                item = response.get('Item')
-                if item:
-                    total += item.get('count', 0)
+            total = sum(
+                int(item.get('count', 0))
+                for item in _query_metric_window(
+                    f'METRIC#daily_category#{category}', days, current_date)
+            )
             if total > 0:
                 result[category] = total
     

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -225,7 +225,7 @@ def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dic
     # it rather than return a quietly short answer that reads as authoritative.
     logger.warning(
         'Metric window paging hit its bound; returning a partial window',
-        extra={'pk': pk, 'days': days, 'pages': days, 'items': len(items)},
+        extra={'pk': pk, 'days': days, 'items': len(items)},
     )
     return items
 

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -187,6 +187,45 @@ def _scan_window_items(
 # Feedback Endpoints
 # ============================================
 
+def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dict]:
+    """Read one metric partition's trailing `days` window, newest date first.
+
+    `sk` is 'YYYY-MM-DD' and ISO dates sort lexicographically, so a window is a
+    contiguous sort-key range that `between()` bounds server-side: a fixed
+    number of requests regardless of `days`, not one `get_item` per day.
+
+    `ScanIndexForward=False` is load-bearing. Callers hand these items straight
+    to the client as `daily_totals` / `daily_sentiment`, which are charted
+    newest-first; DynamoDB's default ascending order would reverse both series
+    while leaving every total correct.
+
+    Not the `gsi1-by-metric-type` index: it only holds items the aggregator tags
+    with `metric_type`, which is just the daily_source and persona partitions.
+    These `pk`s are known anyway, so the base table answers directly and bounds
+    the window server-side instead of reading all dates and filtering in memory.
+    """
+    oldest = (current_date - timedelta(days=days - 1)).strftime('%Y-%m-%d')
+    newest = current_date.strftime('%Y-%m-%d')
+    condition = Key('pk').eq(pk) & Key('sk').between(oldest, newest)
+    items: list[dict] = []
+    kwargs: dict = {'KeyConditionExpression': condition, 'ScanIndexForward': False}
+    # A 365-day window of counter items sits far inside one 1 MB page today, but
+    # that rests on item width the aggregator controls, and these endpoints have
+    # no is_partial signal with which to report a truncated window. So follow the
+    # cursor -- but bounded, never `while True`: one date yields at most one item
+    # and an unfiltered page yields at least one, so a window of `days` dates
+    # cannot span more than `days` pages. A bound also means a surprising
+    # response shape degrades to a short read instead of spinning.
+    for _ in range(days):
+        response = aggregates_table.query(**kwargs)
+        items.extend(response.get('Items', []))
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            break
+        kwargs['ExclusiveStartKey'] = last_key
+    return items
+
+
 @app.get("/feedback")
 @tracer.capture_method
 def list_feedback():
@@ -669,42 +708,6 @@ def _summary_from_items(days: int) -> dict:
         'daily_totals': totals,
         'daily_sentiment': sentiment_data,
     }
-
-
-def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dict]:
-    """Read one metric partition's trailing `days` window in a SINGLE query.
-
-    The aggregates table is keyed `(pk, sk)` with `sk` = 'YYYY-MM-DD'. ISO dates
-    sort lexicographically, so a trailing window is a contiguous sort-key range
-    and `between()` expresses it server-side: **one** request regardless of
-    `days`, replacing the one `get_item` per day this helper was extracted to
-    remove (`/metrics/summary` alone issued 3 x days, ~270 at a 90-day window).
-
-    Items come back NEWEST FIRST (`ScanIndexForward=False`) because the loops
-    this replaces walked `i` from 0 (today) upward, and `daily_totals` /
-    `daily_sentiment` are handed to the client in that order to be charted.
-    A plain query would return them ascending and silently reverse the charts.
-
-    Deliberately NOT the `gsi1-by-metric-type` shape used by `/metrics/sources`
-    and `/metrics/personas`. That index only carries items the aggregator tags
-    with `metric_type`, and it tags *only* `METRIC#daily_source#` and
-    `METRIC#persona#` (`aggregator/handler.py:26-31`) — precisely the two
-    endpoints that use it. The partitions here carry no such attribute and need
-    none: their `pk` is known, so the base table's own key schema answers the
-    question directly, and the window is filtered server-side rather than
-    reading every date ever recorded and discarding most of it in memory.
-
-    One page suffices: `validate_days` caps `days` at 365 and these are
-    single-counter items (~150 bytes), so a full window is ~55 KB against
-    DynamoDB's 1 MB page limit.
-    """
-    oldest = (current_date - timedelta(days=days - 1)).strftime('%Y-%m-%d')
-    newest = current_date.strftime('%Y-%m-%d')
-    response = aggregates_table.query(
-        KeyConditionExpression=Key('pk').eq(pk) & Key('sk').between(oldest, newest),
-        ScanIndexForward=False,
-    )
-    return response.get('Items', [])
 
 
 @app.get("/metrics/summary")

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 from aws_lambda_powertools.event_handler.exceptions import NotFoundError
 from boto3.dynamodb.conditions import Attr, Key
 
-from shared.logging import tracer
+from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource
 from shared.api import (
     create_api_resolver, validate_days, validate_limit, validate_int,
@@ -183,10 +183,6 @@ def _scan_window_items(
     return items, is_partial
 
 
-# ============================================
-# Feedback Endpoints
-# ============================================
-
 def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dict]:
     """Read one metric partition's trailing `days` window, newest date first.
 
@@ -221,9 +217,22 @@ def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dic
         items.extend(response.get('Items', []))
         last_key = response.get('LastEvaluatedKey')
         if not last_key:
-            break
+            return items
         kwargs['ExclusiveStartKey'] = last_key
+    # Exhausting the bound with a cursor still open means the invariant above no
+    # longer holds, so the window really is partial. Nothing in the response
+    # shape can express that -- these endpoints have no is_partial flag -- so log
+    # it rather than return a quietly short answer that reads as authoritative.
+    logger.warning(
+        'Metric window paging hit its bound; returning a partial window',
+        extra={'pk': pk, 'days': days, 'pages': days, 'items': len(items)},
+    )
     return items
+
+
+# ============================================
+# Feedback Endpoints
+# ============================================
 
 
 @app.get("/feedback")

--- a/voc-datalake/lambda/api/test/test_metrics_handler.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler.py
@@ -137,7 +137,6 @@ class TestGetSummaryEndpoint:
         self, mock_agg_table, api_gateway_event, lambda_context
     ):
         """Returns zero values when no aggregates exist."""
-        mock_agg_table.get_item.return_value = {}
         mock_agg_table.query.return_value = {'Items': []}
         
         import sys
@@ -188,7 +187,8 @@ class TestGetSentimentEndpoint:
             query_params={'days': '7'}
         )
         
-        with patch('metrics_handler._query_metric_window', side_effect=window_side_effect):
+        with patch('metrics_handler._query_metric_window',
+                   side_effect=window_side_effect) as mock_window:
             response = lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
         
@@ -197,6 +197,16 @@ class TestGetSentimentEndpoint:
         # mere key presence.
         assert body['breakdown'] == counts
         assert body['total'] == 100
+        # The FULL partition keys, not just the trailing label: the stub above
+        # derives its label with rsplit, so 'METRIC#sentiment#positive' would
+        # satisfy it just as well as the real 'METRIC#daily_sentiment#positive'.
+        # Without this, the endpoint-to-partition mapping is unasserted.
+        assert [c.args[0] for c in mock_window.call_args_list] == [
+            'METRIC#daily_sentiment#positive',
+            'METRIC#daily_sentiment#neutral',
+            'METRIC#daily_sentiment#negative',
+            'METRIC#daily_sentiment#mixed',
+        ]
 
 
 class TestGetUrgentFeedback:
@@ -508,8 +518,15 @@ class TestGetCategoryMetrics:
             query_params={'days': '7'}
         )
         
-        with patch('metrics_handler._query_metric_window', side_effect=window_side_effect):
-            response = lambda_handler(event, lambda_context)
+        try:
+            with patch('metrics_handler._query_metric_window',
+                       side_effect=window_side_effect) as mock_window:
+                response = lambda_handler(event, lambda_context)
+        finally:
+            # Clearing on the way in fixed the inbound leak; clearing on the way
+            # out stops this test from handing {product, delivery} to whatever
+            # runs next. Same bug class, other direction.
+            clear_categories_cache()
         body = json.loads(response['body'])
         
         assert response['statusCode'] == 200
@@ -517,6 +534,12 @@ class TestGetCategoryMetrics:
         # previous 'categories' in body assertion could not see.
         assert body['categories'] == {'product': 50, 'delivery': 30}
         assert list(body['categories']) == ['product', 'delivery']
+        # Full partition keys: the stub derives its category with rsplit, so a
+        # wrong prefix would otherwise pass.
+        assert [c.args[0] for c in mock_window.call_args_list] == [
+            'METRIC#daily_category#product',
+            'METRIC#daily_category#delivery',
+        ]
 
 
 class TestGetSourceMetrics:
@@ -632,6 +655,37 @@ class TestQueryMetricWindow:
 
         assert mock_table.query.call_args.kwargs['ScanIndexForward'] is False
 
+    def test_follows_last_evaluated_key_so_a_window_cannot_truncate(self):
+        """Paged windows are concatenated, in order, and the cursor is passed on.
+
+        A 365-day window of counter items fits one 1 MB page today, but that
+        rests on item width the aggregator controls. If a page boundary ever
+        appears these endpoints have no is_partial signal, so a dropped page
+        would be a silently wrong total.
+        """
+        from metrics_handler import _query_metric_window
+
+        pages = [
+            {'Items': [{'sk': '2026-03-10', 'count': 1}], 'LastEvaluatedKey': {'pk': 'p', 'sk': '2026-03-10'}},
+            {'Items': [{'sk': '2026-03-09', 'count': 2}]},
+        ]
+        with patch('metrics_handler.aggregates_table') as mock_table:
+            mock_table.query.side_effect = pages
+            items = _query_metric_window('METRIC#urgent', 7,
+                                         datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert mock_table.query.call_count == 2
+        assert items == [
+            {'sk': '2026-03-10', 'count': 1},
+            {'sk': '2026-03-09', 'count': 2},
+        ]
+        # Second call resumes from the first page's cursor.
+        assert mock_table.query.call_args_list[1].kwargs['ExclusiveStartKey'] == {
+            'pk': 'p', 'sk': '2026-03-10'
+        }
+        # ...and the first does not carry one.
+        assert 'ExclusiveStartKey' not in mock_table.query.call_args_list[0].kwargs
+
     def test_a_single_day_window_is_the_current_date_alone(self):
         """days=1 must not read a zero-width or off-by-one range."""
         from boto3.dynamodb.conditions import Key
@@ -672,9 +726,15 @@ class TestMetricsRequestCountIsIndependentOfWindow:
             response = lambda_handler(event, lambda_context)
             assert response['statusCode'] == 200
             counts.append(mock_agg_table.query.call_count)
-            # The fan-out read the aggregates table with get_item; nothing in
-            # this endpoint should do that any more.
-            assert mock_agg_table.get_item.call_count == 0, f'per-day get_item returned at days={days}'
+            # Scoped to METRIC# partitions rather than all get_item calls: the
+            # fan-out being guarded against was per-day METRIC# reads, and a
+            # legitimate single-shot settings read (SETTINGS#...) moving onto
+            # this table later should not fail this test.
+            metric_get_items = [
+                c for c in mock_agg_table.get_item.call_args_list
+                if str(c.kwargs.get('Key', {}).get('pk', '')).startswith('METRIC#')
+            ]
+            assert metric_get_items == [], f'per-day METRIC# get_item returned at days={days}'
 
         # daily_total + daily_sentiment_avg + urgent = 3, flat across windows.
         assert counts == [3, 3, 3, 3]

--- a/voc-datalake/lambda/api/test/test_metrics_handler.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler.py
@@ -104,8 +104,10 @@ class TestGetSummaryEndpoint:
         self, mock_agg_table, api_gateway_event, lambda_context
     ):
         """Returns aggregated metrics for specified period."""
-        mock_agg_table.get_item.return_value = {
-            'Item': {'count': 50, 'sum': 25.0}
+        # One query per metric partition (see _query_metric_window), not one
+        # get_item per day.
+        mock_agg_table.query.return_value = {
+            'Items': [{'sk': '2026-01-07', 'count': 50, 'sum': 25.0}]
         }
         
         import sys
@@ -123,9 +125,12 @@ class TestGetSummaryEndpoint:
         body = json.loads(response['body'])
         
         assert response['statusCode'] == 200
-        assert 'total_feedback' in body
-        assert 'period_days' in body
         assert body['period_days'] == 7
+        # Exact values, not just key presence: the single item the stubbed query
+        # returns carries count=50, so every derived figure is determined.
+        assert body['total_feedback'] == 50
+        assert body['urgent_count'] == 50
+        assert body['daily_totals'] == [{'date': '2026-01-07', 'count': 50}]
 
     @patch('metrics_handler.aggregates_table')
     def test_returns_zero_totals_when_no_data(
@@ -133,6 +138,7 @@ class TestGetSummaryEndpoint:
     ):
         """Returns zero values when no aggregates exist."""
         mock_agg_table.get_item.return_value = {}
+        mock_agg_table.query.return_value = {'Items': []}
         
         import sys
         import os
@@ -161,19 +167,15 @@ class TestGetSentimentEndpoint:
         self, mock_fb_table, mock_agg_table, api_gateway_event, lambda_context
     ):
         """Returns sentiment distribution."""
-        def get_item_side_effect(Key):
-            pk = Key.get('pk', '')
-            if 'positive' in pk:
-                return {'Item': {'count': 60}}
-            elif 'negative' in pk:
-                return {'Item': {'count': 20}}
-            elif 'neutral' in pk:
-                return {'Item': {'count': 15}}
-            elif 'mixed' in pk:
-                return {'Item': {'count': 5}}
-            return {}
+        # Stub at the window helper: it takes the pk as a plain string, whereas
+        # the pk inside a real query's KeyConditionExpression is buried in a
+        # boto3 Condition object. The query shape itself is covered by
+        # TestQueryMetricWindow.
+        counts = {'positive': 60, 'negative': 20, 'neutral': 15, 'mixed': 5}
         
-        mock_agg_table.get_item.side_effect = get_item_side_effect
+        def window_side_effect(pk, days, current_date):
+            label = pk.rsplit('#', 1)[-1]
+            return [{'sk': '2026-01-07', 'count': counts[label]}]
         
         import sys
         import os
@@ -186,13 +188,15 @@ class TestGetSentimentEndpoint:
             query_params={'days': '7'}
         )
         
-        response = lambda_handler(event, lambda_context)
+        with patch('metrics_handler._query_metric_window', side_effect=window_side_effect):
+            response = lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
         
         assert response['statusCode'] == 200
-        assert 'breakdown' in body
-        assert 'positive' in body['breakdown']
-        assert 'negative' in body['breakdown']
+        # Exact breakdown, so a mis-keyed window would fail rather than pass on
+        # mere key presence.
+        assert body['breakdown'] == counts
+        assert body['total'] == 100
 
 
 class TestGetUrgentFeedback:
@@ -472,17 +476,26 @@ class TestGetCategoryMetrics:
         self, mock_fb_table, mock_agg_table, api_gateway_event, lambda_context
     ):
         """Returns category distribution."""
+        # get_configured_categories memoizes in a module-level cache that other
+        # test modules populate, so the stub below is only authoritative once
+        # the cache is cleared. Same pattern as shared/test/test_api.py.
+        from shared.api import clear_categories_cache
+        clear_categories_cache()
+        
+        # The configured-category list is still a get_item; only the per-day
+        # count walk became a windowed query.
         def get_item_side_effect(Key):
-            pk = Key.get('pk', '')
-            if pk == 'SETTINGS#categories':
+            if Key.get('pk', '') == 'SETTINGS#categories':
                 return {'Item': {'categories': [{'name': 'product'}, {'name': 'delivery'}]}}
-            elif 'product' in pk:
-                return {'Item': {'count': 50}}
-            elif 'delivery' in pk:
-                return {'Item': {'count': 30}}
             return {}
         
         mock_agg_table.get_item.side_effect = get_item_side_effect
+        
+        counts = {'product': 50, 'delivery': 30}
+        
+        def window_side_effect(pk, days, current_date):
+            category = pk.rsplit('#', 1)[-1]
+            return [{'sk': '2026-01-07', 'count': counts[category]}]
         
         import sys
         import os
@@ -495,11 +508,15 @@ class TestGetCategoryMetrics:
             query_params={'days': '7'}
         )
         
-        response = lambda_handler(event, lambda_context)
+        with patch('metrics_handler._query_metric_window', side_effect=window_side_effect):
+            response = lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
         
         assert response['statusCode'] == 200
-        assert 'categories' in body
+        # Exact values and descending-by-count ordering, both of which the
+        # previous 'categories' in body assertion could not see.
+        assert body['categories'] == {'product': 50, 'delivery': 30}
+        assert list(body['categories']) == ['product', 'delivery']
 
 
 class TestGetSourceMetrics:
@@ -566,3 +583,162 @@ class TestGetPersonaMetrics:
         
         assert response['statusCode'] == 200
         assert 'personas' in body
+
+
+class TestQueryMetricWindow:
+    """Tests for _query_metric_window - the per-day fan-out replacement.
+
+    The aggregates table is (pk, sk) with sk = 'YYYY-MM-DD'. Because ISO dates
+    sort lexicographically a trailing window is one contiguous sort-key range,
+    so a whole window costs ONE request instead of one get_item per day.
+    """
+
+    def test_reads_a_whole_window_in_one_query_with_inclusive_iso_bounds(self):
+        """One query, exact pk, and bounds spanning exactly `days` dates."""
+        # conftest.py already puts lambda/ and lambda/api/ on sys.path (:13-16),
+        # so the per-test path insertion the older tests carry is redundant.
+        from boto3.dynamodb.conditions import Key
+        from metrics_handler import _query_metric_window
+
+        current = datetime(2026, 3, 10, 12, 0, tzinfo=timezone.utc)
+        with patch('metrics_handler.aggregates_table') as mock_table:
+            mock_table.query.return_value = {'Items': [{'sk': '2026-03-10', 'count': 2}]}
+            items = _query_metric_window('METRIC#urgent', 7, current)
+
+        assert mock_table.query.call_count == 1
+        assert mock_table.get_item.call_count == 0
+        kwargs = mock_table.query.call_args.kwargs
+        # 7 days ending 2026-03-10 is 03-04..03-10 inclusive, i.e. the same set
+        # the replaced `for i in range(days)` loop visited. Comparing whole
+        # Condition objects pins the pk, both bounds and the operators at once.
+        assert kwargs['KeyConditionExpression'] == (
+            Key('pk').eq('METRIC#urgent') & Key('sk').between('2026-03-04', '2026-03-10')
+        )
+        assert items == [{'sk': '2026-03-10', 'count': 2}]
+
+    def test_requests_newest_first_because_the_charts_read_that_order(self):
+        """ScanIndexForward=False: a default query would silently reverse charts.
+
+        The loops this replaced counted `i` up from 0 (today), so `daily_totals`
+        and `daily_sentiment` reach the client newest-first. DynamoDB's default
+        is ascending, which would invert both series without changing any total.
+        """
+        from metrics_handler import _query_metric_window
+
+        with patch('metrics_handler.aggregates_table') as mock_table:
+            mock_table.query.return_value = {'Items': []}
+            _query_metric_window('METRIC#daily_total', 30,
+                                 datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert mock_table.query.call_args.kwargs['ScanIndexForward'] is False
+
+    def test_a_single_day_window_is_the_current_date_alone(self):
+        """days=1 must not read a zero-width or off-by-one range."""
+        from boto3.dynamodb.conditions import Key
+        from metrics_handler import _query_metric_window
+
+        with patch('metrics_handler.aggregates_table') as mock_table:
+            mock_table.query.return_value = {'Items': []}
+            _query_metric_window('METRIC#urgent', 1,
+                                 datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert mock_table.query.call_args.kwargs['KeyConditionExpression'] == (
+            Key('pk').eq('METRIC#urgent') & Key('sk').between('2026-03-10', '2026-03-10')
+        )
+
+
+class TestMetricsRequestCountIsIndependentOfWindow:
+    """The point of the change: round-trips must not scale with `days`.
+
+    Before this, /metrics/summary issued 3 x days sequential get_item calls
+    (~270 at a 90-day window, measured at 2609ms on 6,234 items). These tests
+    fail if that shape comes back.
+    """
+
+    @patch('metrics_handler.aggregates_table')
+    def test_summary_issues_three_queries_whatever_the_window(
+        self, mock_agg_table, api_gateway_event, lambda_context
+    ):
+        """One query per metric partition, and zero per-day get_items."""
+        from metrics_handler import lambda_handler
+
+        counts = []
+        for days in ('1', '7', '90', '365'):
+            mock_agg_table.reset_mock()
+            mock_agg_table.query.return_value = {'Items': [{'sk': '2026-03-10', 'count': 3, 'sum': 1.5}]}
+            event = api_gateway_event(
+                method='GET', path='/metrics/summary', query_params={'days': days}
+            )
+            response = lambda_handler(event, lambda_context)
+            assert response['statusCode'] == 200
+            counts.append(mock_agg_table.query.call_count)
+            # The fan-out read the aggregates table with get_item; nothing in
+            # this endpoint should do that any more.
+            assert mock_agg_table.get_item.call_count == 0, f'per-day get_item returned at days={days}'
+
+        # daily_total + daily_sentiment_avg + urgent = 3, flat across windows.
+        assert counts == [3, 3, 3, 3]
+
+    @patch('metrics_handler.aggregates_table')
+    def test_sentiment_issues_one_query_per_label_whatever_the_window(
+        self, mock_agg_table, api_gateway_event, lambda_context
+    ):
+        """Was 4 labels x days (360 reads at 90d); now 4 regardless."""
+        from metrics_handler import lambda_handler
+
+        counts = []
+        for days in ('7', '90'):
+            mock_agg_table.reset_mock()
+            mock_agg_table.query.return_value = {'Items': [{'sk': '2026-03-10', 'count': 1}]}
+            event = api_gateway_event(
+                method='GET', path='/metrics/sentiment', query_params={'days': days}
+            )
+            response = lambda_handler(event, lambda_context)
+            assert response['statusCode'] == 200
+            counts.append(mock_agg_table.query.call_count)
+
+        assert counts == [4, 4]
+
+    @patch('metrics_handler.aggregates_table')
+    def test_summary_keeps_daily_series_newest_first(
+        self, mock_agg_table, api_gateway_event, lambda_context
+    ):
+        """The handler must not re-sort what the query already ordered."""
+        from metrics_handler import lambda_handler
+
+        mock_agg_table.query.return_value = {'Items': [
+            {'sk': '2026-03-10', 'count': 5, 'sum': 2.5},
+            {'sk': '2026-03-09', 'count': 3, 'sum': 1.5},
+        ]}
+        event = api_gateway_event(
+            method='GET', path='/metrics/summary', query_params={'days': '7'}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert [t['date'] for t in body['daily_totals']] == ['2026-03-10', '2026-03-09']
+        assert [s['date'] for s in body['daily_sentiment']] == ['2026-03-10', '2026-03-09']
+
+    @patch('metrics_handler.aggregates_table')
+    def test_urgent_count_sums_the_window_exactly(
+        self, mock_agg_table, api_gateway_event, lambda_context
+    ):
+        """urgent_count is the sidebar badge AND the Dashboard heading (#278).
+
+        Those two must stay equal, so this value is a published contract: it is
+        the sum of METRIC#urgent over the window, not a page length.
+        """
+        from metrics_handler import lambda_handler
+
+        mock_agg_table.query.return_value = {'Items': [
+            {'sk': '2026-03-10', 'count': 7},
+            {'sk': '2026-03-09', 'count': 4},
+            {'sk': '2026-03-08', 'count': 1},
+        ]}
+        event = api_gateway_event(
+            method='GET', path='/metrics/summary', query_params={'days': '30'}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert body['urgent_count'] == 12

--- a/voc-datalake/lambda/api/test/test_metrics_handler.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler.py
@@ -686,6 +686,43 @@ class TestQueryMetricWindow:
         # ...and the first does not carry one.
         assert 'ExclusiveStartKey' not in mock_table.query.call_args_list[0].kwargs
 
+    def test_warns_when_the_paging_bound_is_hit_with_a_cursor_still_open(self):
+        """A bounded loop must not turn truncation back into a silent short read.
+
+        By the bound's own invariant this is unreachable (a window of `days`
+        dates cannot span more than `days` pages), so if it ever happens an
+        assumption has broken and that needs to be visible — these endpoints
+        have no is_partial field to carry the fact.
+        """
+        from metrics_handler import _query_metric_window
+
+        # Every page reports another cursor, so the bound is what stops it.
+        with patch('metrics_handler.aggregates_table') as mock_table, \
+             patch('metrics_handler.logger') as mock_logger:
+            mock_table.query.return_value = {
+                'Items': [{'sk': '2026-03-10', 'count': 1}],
+                'LastEvaluatedKey': {'pk': 'p', 'sk': '2026-03-10'},
+            }
+            items = _query_metric_window('METRIC#urgent', 3,
+                                         datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert mock_table.query.call_count == 3, 'bound should cap pages at `days`'
+        assert len(items) == 3
+        assert mock_logger.warning.called, 'a partial window must not be silent'
+
+    def test_does_not_warn_when_the_window_completes(self):
+        """The warning must be specific to truncation, not fire on every read."""
+        from metrics_handler import _query_metric_window
+
+        with patch('metrics_handler.aggregates_table') as mock_table, \
+             patch('metrics_handler.logger') as mock_logger:
+            mock_table.query.return_value = {'Items': [{'sk': '2026-03-10', 'count': 1}]}
+            _query_metric_window('METRIC#urgent', 3,
+                                 datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert mock_table.query.call_count == 1
+        assert not mock_logger.warning.called
+
     def test_a_single_day_window_is_the_current_date_alone(self):
         """days=1 must not read a zero-width or off-by-one range."""
         from boto3.dynamodb.conditions import Key

--- a/voc-datalake/lambda/api/test/test_metrics_handler_date_basis.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler_date_basis.py
@@ -727,7 +727,10 @@ class TestReviewMetricsPartiality:
         self, mock_fb, mock_agg, api_gateway_event, lambda_context
     ):
         """The exact pre-computed aggregate branch is never partial."""
-        mock_agg.get_item.return_value = {'Item': {'count': 5}}
+        # Aggregate reads are windowed queries now, not per-day get_items. This
+        # test is about the is_partial flag, so it only needs the branch to
+        # resolve; an unstubbed query would return a MagicMock, not rows.
+        mock_agg.query.return_value = {'Items': [{'sk': _day(1), 'count': 5}]}
 
         from metrics_handler import lambda_handler
         event = api_gateway_event(

--- a/voc-datalake/lambda/api/test/test_metrics_handler_date_basis.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler_date_basis.py
@@ -282,22 +282,30 @@ class TestSummaryDateBasis:
         ]
         # All items carry sentiment_score 0.8
         assert body['avg_sentiment'] == 0.8
-        # Aggregates table is bypassed entirely under review basis
+        # Aggregates table is bypassed entirely under review basis. Both access
+        # shapes must be absent for "entirely" to hold, now that the windowed
+        # query has replaced the per-day get_item walk.
         mock_agg.get_item.assert_not_called()
+        mock_agg.query.assert_not_called()
 
     @patch('metrics_handler.aggregates_table')
     @patch('metrics_handler.feedback_table')
     def test_imported_basis_still_reads_aggregates(
         self, mock_fb, mock_agg, api_gateway_event, lambda_context
     ):
-        mock_agg.get_item.return_value = {'Item': {'count': 5, 'sum': Decimal('2.5')}}
+        # Imported basis reads the aggregates table. It now does so with one
+        # windowed query per metric partition rather than a get_item per day;
+        # the point of this test is the table it reads, not the call shape.
+        mock_agg.query.return_value = {
+            'Items': [{'sk': _day(1), 'count': 5, 'sum': Decimal('2.5')}]
+        }
 
         from metrics_handler import lambda_handler
         event = api_gateway_event(path='/metrics/summary', query_params={'days': '7'})
         body = json.loads(lambda_handler(event, lambda_context)['body'])
 
         assert body['period_days'] == 7
-        assert mock_agg.get_item.called
+        assert mock_agg.query.called
         mock_fb.query.assert_not_called()
 
 

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -409,6 +409,11 @@ describe('metrics Lambda IAM grants', () => {
     Resource: z.unknown(),
   });
 
+  // Resource matching is keyed on the logical-ID substring 'Aggregates' appearing
+  // in the serialized Ref/GetAtt/ImportValue, since a cross-stack table ARN has no
+  // stable literal to compare against. Renaming the table construct away from
+  // 'Aggregates' will fail this test rather than silently pass it — the safe
+  // direction, but worth knowing before you chase the failure into IAM.
   it('grants dynamodb:Query on the aggregates table itself, not only its indexes', () => {
     const policies = apiTemplate().findResources('AWS::IAM::Policy');
     const metricsPolicy = Object.entries(policies).find(([id]) => id.includes('MetricsLambdaRole'));

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -396,3 +396,43 @@ describe('skipFeedbackFormItemRoutes (transitional upgrade flag)', () => {
     expect(apiMethods(apiTemplate()).map((m) => m.route)).toContain('PUT /feedback-forms/{form_id}');
   });
 });
+
+
+describe('metrics Lambda IAM grants', () => {
+  // The /metrics/* and /feedback/entities handlers read a whole date window with
+  // a base-table Query on the aggregates table (see _query_metric_window). Every
+  // Python test for those endpoints mocks `aggregates_table`, so a narrowed grant
+  // would surface only as an AccessDenied 500 in a deployed environment. This
+  // pins the action that makes those reads possible.
+  const StatementSchema = z.object({
+    Action: z.union([z.string(), z.array(z.string())]),
+    Resource: z.unknown(),
+  });
+
+  it('grants dynamodb:Query on the aggregates table itself, not only its indexes', () => {
+    const policies = apiTemplate().findResources('AWS::IAM::Policy');
+    const metricsPolicy = Object.entries(policies).find(([id]) => id.includes('MetricsLambdaRole'));
+    expect(metricsPolicy, 'no IAM policy found for MetricsLambdaRole').toBeDefined();
+
+    const statements = z
+      .object({ Properties: z.object({ PolicyDocument: z.object({ Statement: z.array(StatementSchema) }) }) })
+      .parse(metricsPolicy?.[1]).Properties.PolicyDocument.Statement;
+
+    const aggregatesQueryStatements = statements.filter((s) => {
+      const actions = Array.isArray(s.Action) ? s.Action : [s.Action];
+      return actions.includes('dynamodb:Query') && JSON.stringify(s.Resource).includes('Aggregates');
+    });
+    expect(aggregatesQueryStatements.length).toBeGreaterThan(0);
+
+    // The bare table ARN must be present, not just the `/index/*` child: a
+    // grant covering only indexes would satisfy a laxer check while every
+    // windowed read still failed.
+    const resources = JSON.stringify(aggregatesQueryStatements.map((s) => s.Resource));
+    expect(resources).toContain('Aggregates');
+    const hasBareTableArn = aggregatesQueryStatements.some((s) => {
+      const list = Array.isArray(s.Resource) ? s.Resource : [s.Resource];
+      return list.some((r) => JSON.stringify(r).includes('Aggregates') && !JSON.stringify(r).includes('index/*'));
+    });
+    expect(hasBareTableArn, 'aggregates Query granted on indexes only').toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Removes every per-day sequential `get_item` walk over the **aggregates** table in `metrics_handler.py`, replacing each with a single windowed query.

| Endpoint | Before | After |
|---|---|---|
| `/metrics/summary` | 3 × `days` (~**270** at 90d) | **3** queries |
| `/metrics/sentiment` | 4 × `days` (~360 at 90d) | **4** queries |
| `/metrics/categories` | N × `days` | **N** queries |
| `/feedback/entities` | N × `days` + `days` | **N + 1** queries |

Round-trip count is now independent of the requested window. Measured baseline for `/metrics/summary` on **6,234 feedback items**: **7d 565 ms · 30d 1011 ms · 90d 2609 ms** — linear in `days`, which is the fan-out showing through.

## Why now

#278 moved the sidebar urgent badge onto `/metrics/summary` (`urgent_count`), because the endpoint it read before reported a clamped page length and could never express the true count — at 90d it showed `10` against a real `306`, and raising `limit` could not fix it (`validate_limit(max_val=100)`). That fix was right, and it put a caller on the heaviest fan-out in the file.

To be precise about the impact, since it's easy to overstate: `Layout` is the parent route element so it never unmounts, and the query sets no `refetchInterval` — navigation triggers **zero** refetches, and the client cost is one fetch per session per window under TanStack's `staleTime: 30000`. The real problem is that **there is no server-side cache at any layer** — no API Gateway cache cluster, no memoization in the handler, aggregates read fresh every call. So the client cache protects one tab and amortizes nothing across users: N concurrent users cost N× the fan-out. That's a workshop's exact load profile, and it's only fixable server-side.

## How

The aggregates table is keyed `(pk, sk)` with `sk` = `'YYYY-MM-DD'`. ISO dates sort lexicographically, so a trailing window is one **contiguous sort-key range** and `between()` expresses it server-side:

```python
KeyConditionExpression=Key('pk').eq(pk) & Key('sk').between(oldest, newest),
ScanIndexForward=False,
```

**This is deliberately not the `gsi1-by-metric-type` shape** that `/metrics/sources` and `/metrics/personas` use, and that difference is the main thing worth reviewing. I had assumed it would be a straight substitution of the existing pattern; it isn't. That GSI only carries items the aggregator tags with `metric_type`, and `get_metric_type()` tags **only** `METRIC#daily_source#` and `METRIC#persona#` ([`aggregator/handler.py:26-31`](../blob/development/voc-datalake/lambda/aggregator/handler.py)) — precisely the two endpoints that use it. The five partitions here carry no such attribute.

So the fan-out was never an oversight; it was a consequence of the index not covering these items. Extending the GSI would have meant an aggregator change plus a backfill, with existing items silently missing from results until backfilled. Querying the base table by known `pk` needs neither, and is tighter besides: it filters the window server-side, where the GSI shape reads every date ever recorded and discards most of it in memory.

### `ScanIndexForward=False` is load-bearing

The replaced loops counted `i` up from `0` (today), so `daily_totals` and `daily_sentiment` reach the client **newest-first** and are charted in that order. A default ascending query would have reversed both series while leaving every total correct — a silent regression with no failing assertion anywhere. There's a test naming exactly that.

## Verification

- **pytest 1043 → 1050.** `test:cdk` 155 unchanged. No new ruff findings in any of the three changed files (`metrics_handler.py` 4 → 4, `test_metrics_handler.py` 17 → 17, `..._date_basis.py` 1 → 1; the repo-wide ruff baseline is pre-existing and untouched).
- **Proved non-vacuous:** reverting the handler while keeping the tests fails all 7 new tests plus the 3 updated ones. Nothing here passes by accident.
- `urgent_count` is pinned to the exact window sum, because the sidebar badge and the Dashboard `Urgent Issues (N)` heading both read it and #278 exists to keep them equal.
- Window equivalence is pinned by comparing whole boto3 `Condition` objects, so the `pk`, both bounds and the operators are asserted at once — including the `days=1` edge, which must read exactly one date rather than a zero-width or off-by-one range.

## Out of scope, deliberately

Two per-day loops remain, both over the **feedback** table via the date GSI (`:150` `_scan_recent_items`, `:260` `/feedback`). They're a different class: they carry a `soft_cap`, per-partition paging and an `is_partial` signal, so collapsing them means a real design decision about source push-down and how partiality is preserved. That belongs in its own change. `:464` is capped at `min(days, 7)` and is bounded by construction, not this bug.

## Incidental

- Fixed a latent test-isolation bug my stricter assertions exposed: `get_configured_categories` memoizes in a module-level cache that other test modules populate, so the category test passed alone and failed in the full suite. It now calls `clear_categories_cache()`, matching the precedent in `shared/test/test_api.py`.
- Two existing assertions were updated rather than deleted. `test_imported_basis_still_reads_aggregates` asserted `get_item.called`, but its intent is *which table* is read, not the call shape, so it now asserts `query.called`. Its sibling claiming the aggregates table is "bypassed entirely" under review basis now asserts **both** access shapes are absent, which is what "entirely" requires.
- Three previously near-vacuous assertions were tightened while I was in there (`'total_feedback' in body` → exact values), since they could not have caught an equivalence regression.
- New tests skip the per-test `sys.path.insert` boilerplate the older ones carry — `conftest.py:13-16` already puts both directories on `sys.path`, so it's redundant. I left the 17 existing instances alone rather than churn this diff.
