### PR TITLE
fix(stream): resolve the configured chat model for roundtable turns

### DIFF
--- a/voc-datalake/lambda/stream/src/handler.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.test.ts
@@ -29,6 +29,12 @@ const {
   mockWrapStreamWithHeaders: vi.fn(),
   mockIsWebSearchConfigured: vi.fn(),
 }));
+const { mockResolveModelOverride } = vi.hoisted(() => ({
+  mockResolveModelOverride: vi.fn(),
+}));
+vi.mock('./bedrock/model-override.js', () => ({
+  resolveModelOverride: mockResolveModelOverride,
+}));
 
 /** The handler streams into a mock — invoke it with a test-friendly signature. */
 type StreamHandler = (event: unknown, stream: unknown) => Promise<void>;
@@ -316,6 +322,31 @@ describe('handler', () => {
     // 3 personas → exactly 3 turns (previously the multi-round loop produced ~8)
     expect(personaTurns).toHaveLength(3);
     expect(mockConverseStream.mock.calls).toHaveLength(3);
+  });
+
+  it('sends the admin-configured chat model on every roundtable persona turn', async () => {
+    // Regression: handleRoundtableChat used to omit `modelId`, so each persona
+    // turn silently fell back to the BEDROCK_MODEL_ID env default and ignored
+    // the Settings picker. Fails if that argument is dropped again.
+    mockResolveModelOverride.mockResolvedValue('global.anthropic.claude-sonnet-4-6');
+    mockConverseStream.mockImplementation(() => (async function* () {
+      yield { contentBlockDelta: { delta: { text: 'my own view' }, contentBlockIndex: 0 } };
+      yield { messageStop: { stopReason: 'end_turn' } };
+    })());
+
+    await (handler as StreamHandler)(makeEvent({
+      message: '@all what frustrates you most?',
+      project_id: 'proj-1',
+      roundtable: true,
+    }), mockStream());
+
+    expect(mockConverseStream.mock.calls).toHaveLength(3);
+    for (const [params] of mockConverseStream.mock.calls) {
+      expect((params as Record<string, unknown>).modelId)
+        .toBe('global.anthropic.claude-sonnet-4-6');
+    }
+    // Resolved once for the whole loop, not per persona.
+    expect(mockResolveModelOverride).toHaveBeenCalledTimes(1);
   });
 
   it('roundtable does not inject the prior transcript into persona prompts', async () => {

--- a/voc-datalake/lambda/stream/src/handler.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.test.ts
@@ -367,6 +367,9 @@ describe('handler', () => {
       roundtable: true,
     }), mockStream());
 
+    // Pin the call count first: a bare for-of over mock.calls passes vacuously
+    // if roundtable dispatch regresses and no persona turn is ever made.
+    expect(mockConverseStream.mock.calls).toHaveLength(3);
     for (const [params] of mockConverseStream.mock.calls) {
       expect((params as Record<string, unknown>).modelId).toBeUndefined();
     }

--- a/voc-datalake/lambda/stream/src/handler.test.ts
+++ b/voc-datalake/lambda/stream/src/handler.test.ts
@@ -103,6 +103,10 @@ function makeEvent(body: Record<string, unknown>, path = '/chat/stream') {
 describe('handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks() clears calls but KEEPS implementations, so a per-test
+    // mockResolvedValue would leak into later tests. Re-assert the default
+    // (no admin override configured) so model resolution is order-independent.
+    mockResolveModelOverride.mockResolvedValue(undefined);
 
     // Default: converseStream yields a simple text response then stops
     mockConverseStream.mockReturnValue(
@@ -347,6 +351,25 @@ describe('handler', () => {
     }
     // Resolved once for the whole loop, not per persona.
     expect(mockResolveModelOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes modelId undefined on roundtable turns when no override is configured', async () => {
+    // Guards against "fixing" the hoist with a non-null default: converseStream
+    // owns the env-default fallback, so the handler must pass undefined through.
+    mockResolveModelOverride.mockResolvedValue(undefined);
+    mockConverseStream.mockImplementation(() => (async function* () {
+      yield { messageStop: { stopReason: 'end_turn' } };
+    })());
+
+    await (handler as StreamHandler)(makeEvent({
+      message: '@all thoughts?',
+      project_id: 'proj-1',
+      roundtable: true,
+    }), mockStream());
+
+    for (const [params] of mockConverseStream.mock.calls) {
+      expect((params as Record<string, unknown>).modelId).toBeUndefined();
+    }
   });
 
   it('roundtable does not inject the prior transcript into persona prompts', async () => {

--- a/voc-datalake/lambda/stream/src/handler.ts
+++ b/voc-datalake/lambda/stream/src/handler.ts
@@ -313,6 +313,11 @@ async function handleRoundtableChat(
     ? attachmentsToContentBlocks(body.attachments)
     : [];
   const historyMessages = historyToBedrockMessages(body.history);
+  // Roundtable turns are the "chat" surface too — resolve the admin-configured
+  // model ONCE (loop-invariant, like the hoists above). Without this every
+  // persona turn silently falls back to the BEDROCK_MODEL_ID env default,
+  // ignoring the Settings picker entirely.
+  const modelId = await resolveModelOverride(docClient, AGGREGATES_TABLE, 'chat');
 
   const responses: string[] = [];
 
@@ -344,6 +349,7 @@ Share your own perspective on the user's message in your own voice. Be direct an
         systemPrompt,
         maxTokens: ROUNDTABLE_MAX_TOKENS,
         thinkingBudget: ROUNDTABLE_THINKING_BUDGET,
+        modelId,
       });
 
       for await (const event of events) {


### PR DESCRIPTION
## Summary

`handleRoundtableChat` called `converseStream` without `modelId`, so every `@all` persona turn fell
through to the hardcoded `BEDROCK_MODEL_ID` env default (`global.anthropic.claude-sonnet-5`) and
ignored the admin model picker.

Regular chat and project chat already resolve the override in `runConversationLoop`. The roundtable
was the only Bedrock path in this Lambda that skipped **both** configurable levels (per-surface
override and the legacy global `model_id` pin).

Two lines: hoist `resolveModelOverride(..., 'chat')` above the persona loop, matching the existing
loop-invariant hoists, and pass `modelId` into the call.

## Why it mattered

- **Any account:** the Settings model picker silently did not apply to roundtables, and the
  roundtable's `thinkingBudget` was kept or dropped based on the wrong model's capabilities.
- **Accounts where the env default is not enabled in Bedrock:** every persona bubble rendered
  `couldn't respond: ... is not available for this account`, while the Python document/persona jobs
  succeeded on the configured model. The per-persona `catch` turned this into visible-but-non-fatal
  output, which is why it went unnoticed.

Same defect class as #273, which covers two Python call sites; this is the TypeScript one.

## Testing

- Stream suite **258 passed** (was 257); `tsc --noEmit` clean.
- **Non-vacuity proven:** reverting the `modelId` argument fails exactly the new test
  (1 failed / 257 passed), then restoring it goes green.
- The test asserts all three persona turns carry the configured model **and** that resolution happens
  once per loop, so it also pins the hoist.
- Required mocking `./bedrock/model-override.js` in `handler.test.ts` (previously unmocked, so the real
  resolver ran against an unmocked DynamoDB client and returned `undefined`). Scoped to the single
  imported function.

No capability plumbing needed: `converse-stream.ts` already keys `usesAdaptiveThinking()` off the
resolved id, so a configured model that accepts an explicit thinking budget regains one.

## Not covered here

Runtime verification against a deployed stack (`VocApiStack`) has not been done yet.
