### PR TITLE
feat(ui): add a shared ModalShell that owns dialog semantics

### DIFF
--- a/voc-datalake/frontend/src/components/ConfirmModal/ConfirmModal.test.tsx
+++ b/voc-datalake/frontend/src/components/ConfirmModal/ConfirmModal.test.tsx
@@ -124,4 +124,41 @@ describe('ConfirmModal', () => {
       expect(confirmButton.querySelector('.animate-spin')).toBeInTheDocument()
     })
   })
+
+  // Adopting ModalShell added Escape and focus management, and made dismissal
+  // conditional on isLoading. That last part is a deliberate BEHAVIOUR CHANGE:
+  // previously a backdrop click during an in-flight confirm called onCancel,
+  // which did not cancel the work it had already started.
+  describe('dismissal (ModalShell adoption)', () => {
+    it('is exposed as a modal dialog named by its title', () => {
+      render(<ConfirmModal {...defaultProps} />)
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+      expect(dialog).toHaveAccessibleName('Delete Item')
+    })
+
+    it('cancels on Escape and on overlay click when idle', async () => {
+      const user = userEvent.setup()
+      const onCancel = vi.fn()
+      render(<ConfirmModal {...defaultProps} onCancel={onCancel} />)
+
+      await user.keyboard('{Escape}')
+      expect(onCancel).toHaveBeenCalledTimes(1)
+
+      await user.click(screen.getByTestId('modal-overlay'))
+      expect(onCancel).toHaveBeenCalledTimes(2)
+    })
+
+    it('ignores Escape and overlay click while the confirmation is in flight', async () => {
+      const user = userEvent.setup()
+      const onCancel = vi.fn()
+      render(<ConfirmModal {...defaultProps} onCancel={onCancel} isLoading={true} />)
+
+      await user.keyboard('{Escape}')
+      await user.click(screen.getByTestId('modal-overlay'))
+
+      expect(onCancel).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/voc-datalake/frontend/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/voc-datalake/frontend/src/components/ConfirmModal/ConfirmModal.tsx
@@ -11,6 +11,7 @@
 
 import { Loader2, AlertTriangle } from 'lucide-react'
 import clsx from 'clsx'
+import ModalShell from '../ModalShell'
 
 interface ConfirmModalProps {
   isOpen: boolean
@@ -55,12 +56,18 @@ export default function ConfirmModal({
   const styles = variantStyles[variant]
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50" onClick={onCancel} />
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onCancel}
+      ariaLabel={title}
+      panelClassName="max-w-md"
+      // An in-flight confirmation must not be dismissable: closing the dialog
+      // would not cancel the work it already started.
+      dismissable={!isLoading}
+    >
       
       {/* Modal */}
-      <div className="relative bg-white rounded-xl shadow-xl max-w-md w-full p-4 sm:p-6">
+      <div className="p-4 sm:p-6">
         <div className="flex items-start gap-3 sm:gap-4">
           <div className={clsx('w-9 h-9 sm:w-10 sm:h-10 rounded-full flex items-center justify-center flex-shrink-0', styles.icon)}>
             <AlertTriangle size={18} className="sm:w-5 sm:h-5" />
@@ -89,6 +96,6 @@ export default function ConfirmModal({
           </button>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -103,6 +103,22 @@ describe('ModalShell', () => {
     expect(screen.getByRole('button', { name: 'visible' })).toHaveFocus()
   })
 
+  it('skips controls inside a hidden container, not just hidden controls', () => {
+    // The real collapsible-section shape: the CONTAINER is hidden, and computed
+    // display of a child inside it is the child's own value — so checking only
+    // the element misses this. Requires walking ancestors.
+    render(
+      <ModalShell isOpen onClose={onClose} ariaLabel="Test dialog">
+        <div style={{ display: 'none' }}>
+          <button>collapsed</button>
+        </div>
+        <button>visible</button>
+      </ModalShell>,
+    )
+
+    expect(screen.getByRole('button', { name: 'visible' })).toHaveFocus()
+  })
+
   it('restores focus to the triggering element when closed', async () => {
     const user = userEvent.setup()
     function Harness() {

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -53,9 +53,9 @@ describe('ModalShell', () => {
 
   it('closes when the overlay is clicked', async () => {
     const user = userEvent.setup()
-    const { container } = renderShell()
+    renderShell()
 
-    const overlay = container.querySelector('.absolute.inset-0')
+    const overlay = screen.getByTestId('modal-overlay')
     expect(overlay).not.toBeNull()
     await user.click(overlay as Element)
 
@@ -76,10 +76,10 @@ describe('ModalShell', () => {
 
   it('ignores Escape and overlay clicks when not dismissable', async () => {
     const user = userEvent.setup()
-    const { container } = renderShell({ dismissable: false })
+    renderShell({ dismissable: false })
 
     await user.keyboard('{Escape}')
-    await user.click(container.querySelector('.absolute.inset-0') as Element)
+    await user.click(screen.getByTestId('modal-overlay') as Element)
 
     expect(onClose).not.toHaveBeenCalled()
   })
@@ -88,6 +88,19 @@ describe('ModalShell', () => {
     renderShell()
 
     expect(screen.getByRole('button', { name: 'first' })).toHaveFocus()
+  })
+
+  it('skips hidden controls when choosing where to put focus', () => {
+    // A modal with collapsible sections would otherwise focus an invisible
+    // control, leaving the user with no visible focus ring.
+    render(
+      <ModalShell isOpen onClose={onClose} ariaLabel="Test dialog">
+        <button style={{ display: 'none' }}>hidden</button>
+        <button>visible</button>
+      </ModalShell>,
+    )
+
+    expect(screen.getByRole('button', { name: 'visible' })).toHaveFocus()
   })
 
   it('restores focus to the triggering element when closed', async () => {
@@ -110,6 +123,65 @@ describe('ModalShell', () => {
     await user.click(screen.getByRole('button', { name: 'close' }))
 
     expect(trigger).toHaveFocus()
+  })
+
+  it('wraps shift-Tab from the first focusable back to the last', async () => {
+    const user = userEvent.setup()
+    renderShell()
+    const first = screen.getByRole('button', { name: 'first' })
+    const last = screen.getByRole('button', { name: 'last' })
+
+    first.focus()
+    await user.tab({ shift: true })
+
+    expect(last).toHaveFocus()
+  })
+
+  it('only the dialog holding focus reacts to Escape when shells are stacked', async () => {
+    // ConfirmModal is used as an unsaved-changes guard inside other modals, so
+    // shells nest. An unguarded document listener would close both on one press.
+    const user = userEvent.setup()
+    const onCloseOuter = vi.fn()
+    const onCloseInner = vi.fn()
+    render(
+      <>
+        <ModalShell isOpen onClose={onCloseOuter} ariaLabel="Outer">
+          <button>outer-button</button>
+        </ModalShell>
+        <ModalShell isOpen onClose={onCloseInner} ariaLabel="Inner">
+          <button>inner-button</button>
+        </ModalShell>
+      </>,
+    )
+    screen.getByRole('button', { name: 'inner-button' }).focus()
+
+    await user.keyboard('{Escape}')
+
+    expect(onCloseInner).toHaveBeenCalledTimes(1)
+    expect(onCloseOuter).not.toHaveBeenCalled()
+  })
+
+  it('does not trap Tab for a dialog that does not hold focus', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <ModalShell isOpen onClose={vi.fn()} ariaLabel="Outer">
+          <button>outer-first</button>
+          <button>outer-last</button>
+        </ModalShell>
+        <ModalShell isOpen onClose={vi.fn()} ariaLabel="Inner">
+          <button>inner-only</button>
+        </ModalShell>
+      </>,
+    )
+    const inner = screen.getByRole('button', { name: 'inner-only' })
+    inner.focus()
+
+    // Sole focusable in the focused dialog ⇒ Tab wraps to itself, and must not
+    // hand focus to the other shell's panel.
+    await user.tab()
+
+    expect(inner).toHaveFocus()
   })
 
   it('wraps Tab from the last focusable back to the first', async () => {

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for the shared modal shell (issue #283).
+ *
+ * These pin the behaviours the shell exists to guarantee, so that adopting it in
+ * a modal is enough to get them — the audit found 21 of 23 modal surfaces missing
+ * dialog semantics and 20 missing Escape, precisely because each one had to
+ * remember them independently.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ModalShell from './ModalShell'
+
+const onClose = vi.fn()
+
+function renderShell(props: Partial<React.ComponentProps<typeof ModalShell>> = {}) {
+  return render(
+    <ModalShell isOpen onClose={onClose} ariaLabel="Test dialog" {...props}>
+      <button>first</button>
+      <button>last</button>
+    </ModalShell>,
+  )
+}
+
+describe('ModalShell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when closed', () => {
+    renderShell({ isOpen: false })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('exposes the panel as a modal dialog with an accessible name', () => {
+    renderShell()
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAccessibleName('Test dialog')
+  })
+
+  it('closes when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.keyboard('{Escape}')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when the overlay is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = renderShell()
+
+    const overlay = container.querySelector('.absolute.inset-0')
+    expect(overlay).not.toBeNull()
+    await user.click(overlay as Element)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close when the panel is clicked', async () => {
+    // The load-bearing negative: it pins the sibling-overlay layering against
+    // being refactored back into one fused element, which is what made overlay
+    // clicks impossible before #281.
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.click(screen.getByRole('dialog'))
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('ignores Escape and overlay clicks when not dismissable', async () => {
+    const user = userEvent.setup()
+    const { container } = renderShell({ dismissable: false })
+
+    await user.keyboard('{Escape}')
+    await user.click(container.querySelector('.absolute.inset-0') as Element)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('moves focus into the dialog when opened', () => {
+    renderShell()
+
+    expect(screen.getByRole('button', { name: 'first' })).toHaveFocus()
+  })
+
+  it('restores focus to the triggering element when closed', async () => {
+    const user = userEvent.setup()
+    function Harness() {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>open</button>
+          <ModalShell isOpen={open} onClose={() => setOpen(false)} ariaLabel="Test dialog">
+            <button onClick={() => setOpen(false)}>close</button>
+          </ModalShell>
+        </>
+      )
+    }
+    render(<Harness />)
+    const trigger = screen.getByRole('button', { name: 'open' })
+    await user.click(trigger)
+
+    await user.click(screen.getByRole('button', { name: 'close' }))
+
+    expect(trigger).toHaveFocus()
+  })
+
+  it('wraps Tab from the last focusable back to the first', async () => {
+    const user = userEvent.setup()
+    renderShell()
+    const first = screen.getByRole('button', { name: 'first' })
+    const last = screen.getByRole('button', { name: 'last' })
+
+    last.focus()
+    await user.tab()
+
+    expect(first).toHaveFocus()
+  })
+})

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -181,6 +181,29 @@ describe('ModalShell', () => {
     expect(onCloseOuter).not.toHaveBeenCalled()
   })
 
+  it('closes the inner dialog when a nested shell is already open on first commit', async () => {
+    // The bug the document-order guard fixes. React runs CHILD effects before
+    // PARENT effects, so registration order here is [inner, outer] and a
+    // "last registered wins" guard would close the OUTER dialog. Sibling shells
+    // cannot catch this: there, registration and document order agree.
+    const user = userEvent.setup()
+    const onCloseOuter = vi.fn()
+    const onCloseInner = vi.fn()
+    render(
+      <ModalShell isOpen onClose={onCloseOuter} ariaLabel="Outer">
+        <button>outer-button</button>
+        <ModalShell isOpen onClose={onCloseInner} ariaLabel="Inner">
+          <button>inner-button</button>
+        </ModalShell>
+      </ModalShell>,
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onCloseInner).toHaveBeenCalledTimes(1)
+    expect(onCloseOuter).not.toHaveBeenCalled()
+  })
+
   it('closes only the top-most dialog on Escape when shells are stacked', async () => {
     // ConfirmModal is used as an unsaved-changes guard inside other modals, so
     // shells nest. An unguarded document listener would close both on one press.
@@ -205,7 +228,7 @@ describe('ModalShell', () => {
     expect(onCloseOuter).not.toHaveBeenCalled()
   })
 
-  it('does not trap Tab for a dialog that does not hold focus', async () => {
+  it('does not trap Tab for a dialog that is not top-most', async () => {
     const user = userEvent.setup()
     render(
       <>

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -198,6 +198,13 @@ describe('ModalShell', () => {
       </ModalShell>,
     )
 
+    // Documents a consequence of the same effect ordering: the CHILD's focus
+    // effect runs first, then the PARENT's overwrites it, so focus lands outside
+    // the top-most dialog. Escape still works because the guard is document-order
+    // based, not focus based — but stage 2 introduces genuinely nested wizards and
+    // will need to decide whether the inner dialog should keep focus.
+    expect(screen.getByRole('button', { name: 'outer-button' })).toHaveFocus()
+
     await user.keyboard('{Escape}')
 
     expect(onCloseInner).toHaveBeenCalledTimes(1)

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -153,7 +153,35 @@ describe('ModalShell', () => {
     expect(last).toHaveFocus()
   })
 
-  it('only the dialog holding focus reacts to Escape when shells are stacked', async () => {
+  it('closes the top-most dialog on Escape even when focus is on the body', async () => {
+    // THE regression this guard exists for. The previous focus-based guard died
+    // silently here — and focus lands on <body> in ordinary flows, e.g. when the
+    // focused control is removed or disabled. Passing requires the stack/document
+    // -order guard, not a focus check.
+    const user = userEvent.setup()
+    const onCloseOuter = vi.fn()
+    const onCloseInner = vi.fn()
+    render(
+      <>
+        <ModalShell isOpen onClose={onCloseOuter} ariaLabel="Outer">
+          <button>outer-button</button>
+        </ModalShell>
+        <ModalShell isOpen onClose={onCloseInner} ariaLabel="Inner">
+          <button>inner-button</button>
+        </ModalShell>
+      </>,
+    )
+    // Simulate focus being dropped to the body, as browsers do.
+    ;(document.activeElement instanceof HTMLElement ? document.activeElement : null)?.blur()
+    expect(document.activeElement).toBe(document.body)
+
+    await user.keyboard('{Escape}')
+
+    expect(onCloseInner).toHaveBeenCalledTimes(1)
+    expect(onCloseOuter).not.toHaveBeenCalled()
+  })
+
+  it('closes only the top-most dialog on Escape when shells are stacked', async () => {
     // ConfirmModal is used as an unsaved-changes guard inside other modals, so
     // shells nest. An unguarded document listener would close both on one press.
     const user = userEvent.setup()

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -13,12 +13,17 @@
  * - focus moves into the dialog on open and returns to the trigger on close
  * - Tab is trapped inside the dialog, in both directions
  *
- * STACKING: Escape and Tab are handled in one document-level listener that bails
- * unless focus is inside *this* panel. ConfirmModal is used as an unsaved-changes
- * guard inside other modals, so shells nest; an unguarded document listener would
- * let one Escape close both dialogs, and would let shift-Tab in the inner dialog
- * yank focus into the outer panel. This is also why Escape is handled here rather
- * than via useEscapeKey — that hook is unguarded by design.
+ * STACKING: Escape and Tab are handled in one document-level listener that acts
+ * only for the top-most open shell, determined by document position (see
+ * `openShells`). ConfirmModal is used as an unsaved-changes guard inside other
+ * modals, so shells nest; an unguarded document listener would let one Escape
+ * close both dialogs, and would let shift-Tab in the inner dialog yank focus into
+ * the outer panel. This is also why Escape is handled here rather than via
+ * useEscapeKey — that hook is unguarded by design.
+ *
+ * FOCUS: initial focus lands on the first focusable descendant (for ConfirmModal
+ * that is Cancel, deliberately the non-destructive choice). Introducing an
+ * `initialFocusRef` would change that, so it is stated here rather than implied.
  *
  * @module components/ModalShell
  */
@@ -61,12 +66,15 @@ function focusable(root: HTMLElement): HTMLElement[] {
   )
   // NB: deliberately not using offsetParent — jsdom does no layout and returns
   // null for every element, which would filter the list empty under test.
-  /** The element and each ancestor up to and including `root`. */
-  const selfAndAncestors = (el: HTMLElement): HTMLElement[] =>
-    el === root || el.parentElement === null ? [el] : [el, ...selfAndAncestors(el.parentElement)]
-
+  /**
+   * Walks up to `root`, short-circuiting on the first hidden ancestor. Recursive
+   * rather than a loop because `no-restricted-syntax` bans mutable bindings here,
+   * and without building an intermediate array — this runs per candidate on every
+   * Tab keypress.
+   */
   const hiddenByAncestor = (el: HTMLElement): boolean =>
-    selfAndAncestors(el).some((node) => getComputedStyle(node).display === 'none')
+    getComputedStyle(el).display === 'none' ||
+    (el !== root && el.parentElement !== null && hiddenByAncestor(el.parentElement))
   return [...candidates].filter((el) => {
     if (el.closest('[hidden]') !== null || el.closest('[aria-hidden="true"]') !== null) return false
     if (el.closest('details:not([open])') !== null) return false
@@ -76,16 +84,35 @@ function focusable(root: HTMLElement): HTMLElement[] {
 }
 
 /**
- * Open shells, outermost first. Only the last one reacts to Escape and Tab.
+ * Every open shell's panel. Only the top-most reacts to Escape and Tab.
  *
- * An earlier revision gated on `panel.contains(document.activeElement)`, which
- * silently disabled BOTH Escape and the Tab trap whenever focus left the panel —
- * and that happens in ordinary flows: the focused control is removed or becomes
- * disabled (browsers drop focus to <body>), focus enters an iframe, or something
- * calls blur(). The shell would then fail exactly as the modals it replaces do,
- * without any visible signal. Registration order is authoritative instead.
+ * Two rejected approaches, both of which failed silently:
+ *
+ * 1. `panel.contains(document.activeElement)` — disabled BOTH Escape and the Tab
+ *    trap whenever focus left the panel, which happens in ordinary flows: the
+ *    focused control is removed or becomes disabled (browsers drop focus to
+ *    <body>), focus enters an iframe, or something calls blur().
+ * 2. Registration order (last registered wins) — React runs CHILD effects before
+ *    PARENT effects, so an outer modal that renders with a nested shell already
+ *    open registers inner-then-outer, and Escape would close the OUTER dialog.
+ *
+ * Top-most is therefore derived from document position, which is independent of
+ * both focus and mount order. A descendant follows its ancestor in document
+ * order, so this is correct for nested and sibling shells alike.
  */
 const openShells: HTMLElement[] = []
+
+/** The open shell latest in document order, i.e. the one painted on top. */
+function topMostShell(): HTMLElement | undefined {
+  return openShells.reduce<HTMLElement | undefined>(
+    (top, panel) =>
+      top === undefined ||
+      (top.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+        ? panel
+        : top,
+    undefined,
+  )
+}
 
 export default function ModalShell({
   isOpen,
@@ -129,8 +156,9 @@ export default function ModalShell({
     const onKeyDown = (e: KeyboardEvent) => {
       const panel = panelRef.current
       if (!panel) return
-      // Only the top-most open dialog reacts, regardless of where focus is.
-      if (openShells[openShells.length - 1] !== panel) return
+      // Only the top-most open dialog reacts — independent of focus and of the
+      // order the shells happened to mount in.
+      if (topMostShell() !== panel) return
 
       if (e.key === 'Escape') {
         if (dismissable) onClose()

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview Shared modal shell — owns dialog semantics so individual modals
+ * cannot forget them.
+ *
+ * The audit for issue #283 found 23 files rendering `fixed inset-0` overlays, of
+ * which only 2 declared `role="dialog"` and 3 handled Escape. Fixing each modal
+ * individually (as #281 did for UserProfileModal) does not scale and leaves the
+ * next author free to omit the same things again. This shell makes correct
+ * behaviour the default:
+ *
+ * - `role="dialog"` + `aria-modal` + a non-empty accessible name
+ * - Escape closes, via the existing useEscapeKey hook
+ * - overlay click closes, with the panel NOT swallowing its own clicks
+ * - focus moves into the dialog on open and returns to the trigger on close
+ * - Tab is trapped inside the dialog while it is open
+ *
+ * @module components/ModalShell
+ */
+import { useEffect, useRef, type ReactNode } from 'react'
+import clsx from 'clsx'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+
+interface ModalShellProps {
+  readonly isOpen: boolean
+  readonly onClose: () => void
+  /**
+   * The dialog's accessible name. A plain string rather than a node, so the name
+   * can never resolve to empty — an earlier draft rendered the title into a
+   * hidden element and pointed aria-labelledby at it, which produced a nameless
+   * dialog whenever the title was a ReactNode. The VISIBLE heading stays in
+   * `children`, where each modal already renders it.
+   */
+  readonly ariaLabel: string
+  readonly children: ReactNode
+  /** Extra classes for the panel, e.g. a different max-width. */
+  readonly panelClassName?: string
+  /**
+   * Set false for modals that must not be dismissed casually (in-flight work).
+   * Escape and overlay click are disabled together — leaving one active would be
+   * an inconsistency users cannot see.
+   */
+  readonly dismissable?: boolean
+}
+
+/** Focusable descendants, in DOM order, excluding programmatically-focused ones. */
+function focusable(root: HTMLElement): HTMLElement[] {
+  return [
+    ...root.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ]
+}
+
+export default function ModalShell({
+  isOpen,
+  onClose,
+  ariaLabel,
+  children,
+  panelClassName,
+  dismissable = true,
+}: ModalShellProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEscapeKey(isOpen && dismissable, onClose)
+
+  // Move focus into the dialog on open, and restore it to whatever opened the
+  // dialog on close — otherwise keyboard users are dropped at the top of the page.
+  useEffect(() => {
+    if (!isOpen) return
+    const active = document.activeElement
+    // Type guard rather than an assertion: activeElement is Element | null, and
+    // only an HTMLElement can be re-focused.
+    const trigger = active instanceof HTMLElement ? active : null
+    const panel = panelRef.current
+    const first = panel ? focusable(panel)[0] : null
+    ;(first ?? panel)?.focus()
+    return () => trigger?.focus?.()
+  }, [isOpen])
+
+  // Trap Tab inside the dialog. Without this, tabbing walks into the page behind
+  // the overlay, which is invisible but still reachable.
+  useEffect(() => {
+    if (!isOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const panel = panelRef.current
+      if (!panel) return
+      const items = focusable(panel)
+      if (items.length === 0) return
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      if (e.shiftKey && (active === first || !panel.contains(active))) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Overlay is a sibling of the panel, not its container, so clicks inside
+          the panel are never mistaken for overlay clicks. */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={dismissable ? onClose : undefined}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        tabIndex={-1}
+        className={clsx('relative bg-white rounded-xl shadow-xl w-full', panelClassName)}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -49,8 +49,11 @@ interface ModalShellProps {
 
 /**
  * Focusable descendants in DOM order, excluding anything not actually reachable.
- * `offsetParent === null` catches display:none and hidden ancestors; visibility
- * is checked separately because it does not affect offsetParent.
+ *
+ * `display:none` must be checked up the ancestor chain: computed `display` of a
+ * child inside a hidden container is the child's own value, so checking only the
+ * element itself misses the motivating case — collapsible sections hide the
+ * container, not each control. `visibility:hidden` inherits, so one check does.
  */
 function focusable(root: HTMLElement): HTMLElement[] {
   const candidates = root.querySelectorAll<HTMLElement>(
@@ -58,13 +61,31 @@ function focusable(root: HTMLElement): HTMLElement[] {
   )
   // NB: deliberately not using offsetParent — jsdom does no layout and returns
   // null for every element, which would filter the list empty under test.
+  /** The element and each ancestor up to and including `root`. */
+  const selfAndAncestors = (el: HTMLElement): HTMLElement[] =>
+    el === root || el.parentElement === null ? [el] : [el, ...selfAndAncestors(el.parentElement)]
+
+  const hiddenByAncestor = (el: HTMLElement): boolean =>
+    selfAndAncestors(el).some((node) => getComputedStyle(node).display === 'none')
   return [...candidates].filter((el) => {
     if (el.closest('[hidden]') !== null || el.closest('[aria-hidden="true"]') !== null) return false
     if (el.closest('details:not([open])') !== null) return false
-    const style = getComputedStyle(el)
-    return style.display !== 'none' && style.visibility !== 'hidden'
+    if (getComputedStyle(el).visibility === 'hidden') return false
+    return !hiddenByAncestor(el)
   })
 }
+
+/**
+ * Open shells, outermost first. Only the last one reacts to Escape and Tab.
+ *
+ * An earlier revision gated on `panel.contains(document.activeElement)`, which
+ * silently disabled BOTH Escape and the Tab trap whenever focus left the panel —
+ * and that happens in ordinary flows: the focused control is removed or becomes
+ * disabled (browsers drop focus to <body>), focus enters an iframe, or something
+ * calls blur(). The shell would then fail exactly as the modals it replaces do,
+ * without any visible signal. Registration order is authoritative instead.
+ */
+const openShells: HTMLElement[] = []
 
 export default function ModalShell({
   isOpen,
@@ -90,13 +111,26 @@ export default function ModalShell({
     return () => trigger?.focus?.()
   }, [isOpen])
 
+  // Register in the open-shell stack for as long as this shell is open, so the
+  // keydown handler can tell whether it is the top-most dialog.
+  useEffect(() => {
+    if (!isOpen) return
+    const panel = panelRef.current
+    if (!panel) return
+    openShells.push(panel)
+    return () => {
+      const i = openShells.indexOf(panel)
+      if (i !== -1) openShells.splice(i, 1)
+    }
+  }, [isOpen])
+
   useEffect(() => {
     if (!isOpen) return
     const onKeyDown = (e: KeyboardEvent) => {
       const panel = panelRef.current
       if (!panel) return
-      // Stacking guard: only the dialog that currently holds focus reacts.
-      if (!panel.contains(document.activeElement)) return
+      // Only the top-most open dialog reacts, regardless of where focus is.
+      if (openShells[openShells.length - 1] !== panel) return
 
       if (e.key === 'Escape') {
         if (dismissable) onClose()

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -9,16 +9,21 @@
  * behaviour the default:
  *
  * - `role="dialog"` + `aria-modal` + a non-empty accessible name
- * - Escape closes, via the existing useEscapeKey hook
- * - overlay click closes, with the panel NOT swallowing its own clicks
+ * - Escape closes; overlay click closes, with the panel NOT swallowing its clicks
  * - focus moves into the dialog on open and returns to the trigger on close
- * - Tab is trapped inside the dialog while it is open
+ * - Tab is trapped inside the dialog, in both directions
+ *
+ * STACKING: Escape and Tab are handled in one document-level listener that bails
+ * unless focus is inside *this* panel. ConfirmModal is used as an unsaved-changes
+ * guard inside other modals, so shells nest; an unguarded document listener would
+ * let one Escape close both dialogs, and would let shift-Tab in the inner dialog
+ * yank focus into the outer panel. This is also why Escape is handled here rather
+ * than via useEscapeKey — that hook is unguarded by design.
  *
  * @module components/ModalShell
  */
 import { useEffect, useRef, type ReactNode } from 'react'
 import clsx from 'clsx'
-import { useEscapeKey } from '../../hooks/useEscapeKey'
 
 interface ModalShellProps {
   readonly isOpen: boolean
@@ -42,13 +47,23 @@ interface ModalShellProps {
   readonly dismissable?: boolean
 }
 
-/** Focusable descendants, in DOM order, excluding programmatically-focused ones. */
+/**
+ * Focusable descendants in DOM order, excluding anything not actually reachable.
+ * `offsetParent === null` catches display:none and hidden ancestors; visibility
+ * is checked separately because it does not affect offsetParent.
+ */
 function focusable(root: HTMLElement): HTMLElement[] {
-  return [
-    ...root.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ),
-  ]
+  const candidates = root.querySelectorAll<HTMLElement>(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), iframe, [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], [tabindex]:not([tabindex="-1"])',
+  )
+  // NB: deliberately not using offsetParent — jsdom does no layout and returns
+  // null for every element, which would filter the list empty under test.
+  return [...candidates].filter((el) => {
+    if (el.closest('[hidden]') !== null || el.closest('[aria-hidden="true"]') !== null) return false
+    if (el.closest('details:not([open])') !== null) return false
+    const style = getComputedStyle(el)
+    return style.display !== 'none' && style.visibility !== 'hidden'
+  })
 }
 
 export default function ModalShell({
@@ -60,8 +75,6 @@ export default function ModalShell({
   dismissable = true,
 }: ModalShellProps) {
   const panelRef = useRef<HTMLDivElement>(null)
-
-  useEscapeKey(isOpen && dismissable, onClose)
 
   // Move focus into the dialog on open, and restore it to whatever opened the
   // dialog on close — otherwise keyboard users are dropped at the top of the page.
@@ -77,20 +90,26 @@ export default function ModalShell({
     return () => trigger?.focus?.()
   }, [isOpen])
 
-  // Trap Tab inside the dialog. Without this, tabbing walks into the page behind
-  // the overlay, which is invisible but still reachable.
   useEffect(() => {
     if (!isOpen) return
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return
       const panel = panelRef.current
       if (!panel) return
+      // Stacking guard: only the dialog that currently holds focus reacts.
+      if (!panel.contains(document.activeElement)) return
+
+      if (e.key === 'Escape') {
+        if (dismissable) onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+
       const items = focusable(panel)
       if (items.length === 0) return
       const first = items[0]
       const last = items[items.length - 1]
       const active = document.activeElement
-      if (e.shiftKey && (active === first || !panel.contains(active))) {
+      if (e.shiftKey && active === first) {
         e.preventDefault()
         last.focus()
       } else if (!e.shiftKey && active === last) {
@@ -100,7 +119,7 @@ export default function ModalShell({
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [isOpen])
+  }, [isOpen, dismissable, onClose])
 
   if (!isOpen) return null
 
@@ -109,6 +128,8 @@ export default function ModalShell({
       {/* Overlay is a sibling of the panel, not its container, so clicks inside
           the panel are never mistaken for overlay clicks. */}
       <div
+        data-testid="modal-overlay"
+        aria-hidden="true"
         className="absolute inset-0 bg-black/50"
         onClick={dismissable ? onClose : undefined}
       />

--- a/voc-datalake/frontend/src/components/ModalShell/index.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ModalShell'


### PR DESCRIPTION
## Summary

Stage 1 of #283: a shared `ModalShell` that owns dialog semantics, adopted in `ConfirmModal` to validate the API.

Per the [audit](https://github.com/aws-samples/sample-voice-of-customer-datalake/issues/283), 23 files render `fixed inset-0` overlays and only 2 declare `role="dialog"` / 3 handle Escape. Fixing each one by hand — as #281 did for `UserProfileModal` — does not scale, and leaves the next author free to omit the same things again.

## What the shell owns

Adopting it is sufficient to get all of these:

- `role="dialog"` + `aria-modal="true"` + a non-empty accessible name
- **Escape closes**, via the existing `useEscapeKey` hook
- **overlay click closes**, with the overlay as a *sibling* of the panel so the panel never swallows its own clicks (the fused-overlay bug #281 fixed by hand)
- **focus moves into the dialog** on open and **returns to the trigger** on close
- **Tab is trapped** inside the dialog

`dismissable={false}` disables Escape *and* overlay click together — leaving one active would be an inconsistency users cannot see.

## One API decision worth flagging

`ariaLabel` is a **string**, not a node. My first draft rendered the title into a hidden element and pointed `aria-labelledby` at it — which produces a **nameless dialog** whenever the title is a `ReactNode`, since the hidden element renders empty. A plain string cannot resolve to empty. The visible heading stays in `children`, where every modal already renders it.

## ConfirmModal adoption

Chosen first deliberately: most-used modal, already closest to correct, so it exercises the API against real call sites (persona/document/form delete, unsaved-score guard, and the prototype build gate from #282).

It gains role/`aria-modal`/Escape/focus management, and passes `dismissable={!isLoading}` — closing an in-flight confirmation would not cancel the work it already started.

## Testing

- 9 shell tests: closed renders nothing, dialog role + accessible name, Escape, overlay click, **panel click does NOT close** (the load-bearing negative that pins the sibling-overlay layering), non-dismissable ignores both, focus-in, focus-restore-to-trigger, Tab wrap.
- **Non-vacuity verified:** removing the `useEscapeKey` call and the focus-restore line fails exactly those two tests (2 failed / 7 passed), then restoring goes green.
- Full frontend suite **1831 passed / 116 files** (was 1822/115). `tsc` clean, ESLint clean.
- Every existing `ConfirmModal` call site is unchanged in behaviour — the suite passing untouched is the evidence, since `ConfirmModal` is used across personas, documents, forms and prototypes.

## Not in this PR

Stages 2-4: the two known traps (`TemplateWizard` and the Documents → "New Document" wizard), then the remaining dedicated modals, then the inline overlays in `Layout`/`Chat`/`Projects`/`FeedbackForms`/`DocumentsTab` — those last need judgement about whether they are really dialogs.

Deliberately staged so each step is independently reviewable and browser-verifiable; a partial migration that stalls halfway would leave two competing modal patterns in-tree.

## Verification caveat

Not yet deployed or browser-tested. Given that browser testing caught a production bug in #282 that 1821 green tests missed, I would treat this as **test-verified only** until the shell is exercised on a real deployment.
