### PR TITLE
fix(ui): adopt ModalShell in the wizards, fixing both known keyboard traps

### DIFF
--- a/voc-datalake/frontend/src/components/DataSourceWizard/DataSourceWizard.tsx
+++ b/voc-datalake/frontend/src/components/DataSourceWizard/DataSourceWizard.tsx
@@ -91,66 +91,64 @@ export default function DataSourceWizard({
       ariaLabel={title}
       panelClassName="max-w-2xl max-h-[90vh] overflow-hidden"
     >
-      <div>
-        <WizardHeader title={title} icon={icon} step={step} totalSteps={totalSteps} onClose={onClose} />
-        <ProgressBar step={step} totalSteps={totalSteps} bgClass={colors.bg} />
-        
-        <div className="p-4 sm:p-6 overflow-y-auto max-h-[60vh]">
-          {stepContent === 'dataSources' && (
-            <DataSourcesStep
-              contextConfig={contextConfig}
-              onContextChange={onContextChange}
-              showFeedback={showFeedback}
-              showPersonas={showPersonas}
-              showDocuments={showDocuments}
-              showResearch={showResearch}
-              combineDocuments={combineDocuments}
-              personasCount={personas.length}
-              documentsCount={documents.length}
-              otherDocsCount={otherDocs.length}
-              researchDocsCount={researchDocs.length}
-              extraDataSources={extraDataSources}
-            />
-          )}
+      <WizardHeader title={title} icon={icon} step={step} totalSteps={totalSteps} onClose={onClose} />
+      <ProgressBar step={step} totalSteps={totalSteps} bgClass={colors.bg} />
 
-          {stepContent === 'feedbackFilters' && (
-            <FeedbackFiltersStep
-              contextConfig={contextConfig}
-              onContextChange={onContextChange}
-              sources={sources}
-              categories={categories}
-              loadingCategories={loadingCategories}
-              colors={colors}
-            />
-          )}
+      <div className="p-4 sm:p-6 overflow-y-auto max-h-[60vh]">
+        {stepContent === 'dataSources' && (
+          <DataSourcesStep
+            contextConfig={contextConfig}
+            onContextChange={onContextChange}
+            showFeedback={showFeedback}
+            showPersonas={showPersonas}
+            showDocuments={showDocuments}
+            showResearch={showResearch}
+            combineDocuments={combineDocuments}
+            personasCount={personas.length}
+            documentsCount={documents.length}
+            otherDocsCount={otherDocs.length}
+            researchDocsCount={researchDocs.length}
+            extraDataSources={extraDataSources}
+          />
+        )}
 
-          {stepContent === 'itemSelection' && (
-            <ItemSelectionStep
-              contextConfig={contextConfig}
-              onContextChange={onContextChange}
-              personas={personas}
-              documents={documents}
-              otherDocs={otherDocs}
-              researchDocs={researchDocs}
-              combineDocuments={combineDocuments}
-            />
-          )}
+        {stepContent === 'feedbackFilters' && (
+          <FeedbackFiltersStep
+            contextConfig={contextConfig}
+            onContextChange={onContextChange}
+            sources={sources}
+            categories={categories}
+            loadingCategories={loadingCategories}
+            colors={colors}
+          />
+        )}
 
-          {stepContent === 'final' && renderFinalStep()}
-        </div>
+        {stepContent === 'itemSelection' && (
+          <ItemSelectionStep
+            contextConfig={contextConfig}
+            onContextChange={onContextChange}
+            personas={personas}
+            documents={documents}
+            otherDocs={otherDocs}
+            researchDocs={researchDocs}
+            combineDocuments={combineDocuments}
+          />
+        )}
 
-        <WizardFooter
-          step={step}
-          totalSteps={totalSteps}
-          colors={colors}
-          finalStepValid={finalStepValid}
-          isSubmitting={isSubmitting}
-          submitLabel={submitLabel}
-          onBack={handleBack}
-          onNext={handleNext}
-          onSubmit={onSubmit}
-        />
+        {stepContent === 'final' && renderFinalStep()}
       </div>
+
+      <WizardFooter
+        step={step}
+        totalSteps={totalSteps}
+        colors={colors}
+        finalStepValid={finalStepValid}
+        isSubmitting={isSubmitting}
+        submitLabel={submitLabel}
+        onBack={handleBack}
+        onNext={handleNext}
+        onSubmit={onSubmit}
+      />
     </ModalShell>
   )
 }

--- a/voc-datalake/frontend/src/components/DataSourceWizard/DataSourceWizard.tsx
+++ b/voc-datalake/frontend/src/components/DataSourceWizard/DataSourceWizard.tsx
@@ -10,6 +10,7 @@ import type { ContextConfig } from './types'
 import { DataSourcesStep, FeedbackFiltersStep, ItemSelectionStep } from './DataSourceSteps'
 import type { ExtraDataSource } from './DataSourceSteps'
 import { useWizardState } from './useWizardState'
+import ModalShell from '../ModalShell'
 
 type AccentColor = 'purple' | 'amber' | 'blue' | 'green'
 
@@ -84,8 +85,13 @@ export default function DataSourceWizard({
   const colors = colorClasses[accentColor]
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 sm:p-6">
-      <div className="bg-white rounded-xl w-full max-w-2xl max-h-[90vh] overflow-hidden">
+    <ModalShell
+      isOpen
+      onClose={onClose}
+      ariaLabel={title}
+      panelClassName="max-w-2xl max-h-[90vh] overflow-hidden"
+    >
+      <div>
         <WizardHeader title={title} icon={icon} step={step} totalSteps={totalSteps} onClose={onClose} />
         <ProgressBar step={step} totalSteps={totalSteps} bgClass={colors.bg} />
         
@@ -145,7 +151,7 @@ export default function DataSourceWizard({
           onSubmit={onSubmit}
         />
       </div>
-    </div>
+    </ModalShell>
   )
 }
 

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -14,7 +14,18 @@ import ModalShell from './ModalShell'
 
 const onClose = vi.fn()
 
-function renderShell(props: Partial<React.ComponentProps<typeof ModalShell>> = {}) {
+/**
+ * Overridable props exclude the accessible-name pair on purpose. The name is a
+ * union (exactly one of ariaLabel / ariaLabelledBy), and `Partial<>` of a union
+ * makes both optional — which would let a spread satisfy neither arm and defeat
+ * the very guarantee these tests pin. Tests needing a different naming strategy
+ * render ModalShell directly, as the ariaLabelledBy cases below do.
+ */
+type ShellOverrides = Partial<
+  Omit<React.ComponentProps<typeof ModalShell>, 'ariaLabel' | 'ariaLabelledBy'>
+>
+
+function renderShell(props: ShellOverrides = {}) {
   return render(
     <ModalShell isOpen onClose={onClose} ariaLabel="Test dialog" {...props}>
       <button>first</button>

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -40,7 +40,14 @@ interface ModalShellProps {
    * dialog whenever the title was a ReactNode. The VISIBLE heading stays in
    * `children`, where each modal already renders it.
    */
-  readonly ariaLabel: string
+  readonly ariaLabel?: string
+  /**
+   * Id of the visible heading, as an alternative to `ariaLabel`. Preferred when a
+   * heading already exists: the accessible name cannot drift from what is on
+   * screen, and no separate (translatable) string is introduced. Exactly one of
+   * `ariaLabel` / `ariaLabelledBy` must be supplied.
+   */
+  readonly ariaLabelledBy?: string
   readonly children: ReactNode
   /** Extra classes for the panel, e.g. a different max-width. */
   readonly panelClassName?: string
@@ -118,6 +125,7 @@ export default function ModalShell({
   isOpen,
   onClose,
   ariaLabel,
+  ariaLabelledBy,
   children,
   panelClassName,
   dismissable = true,
@@ -199,7 +207,8 @@ export default function ModalShell({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        aria-label={ariaLabel}
+        aria-label={ariaLabelledBy === undefined ? ariaLabel : undefined}
+        aria-labelledby={ariaLabelledBy}
         tabIndex={-1}
         className={clsx('relative bg-white rounded-xl shadow-xl w-full', panelClassName)}
       >

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -30,24 +30,9 @@
 import { useEffect, useRef, type ReactNode } from 'react'
 import clsx from 'clsx'
 
-interface ModalShellProps {
+interface ModalShellBaseProps {
   readonly isOpen: boolean
   readonly onClose: () => void
-  /**
-   * The dialog's accessible name. A plain string rather than a node, so the name
-   * can never resolve to empty — an earlier draft rendered the title into a
-   * hidden element and pointed aria-labelledby at it, which produced a nameless
-   * dialog whenever the title was a ReactNode. The VISIBLE heading stays in
-   * `children`, where each modal already renders it.
-   */
-  readonly ariaLabel?: string
-  /**
-   * Id of the visible heading, as an alternative to `ariaLabel`. Preferred when a
-   * heading already exists: the accessible name cannot drift from what is on
-   * screen, and no separate (translatable) string is introduced. Exactly one of
-   * `ariaLabel` / `ariaLabelledBy` must be supplied.
-   */
-  readonly ariaLabelledBy?: string
   readonly children: ReactNode
   /** Extra classes for the panel, e.g. a different max-width. */
   readonly panelClassName?: string
@@ -58,6 +43,27 @@ interface ModalShellProps {
    */
   readonly dismissable?: boolean
 }
+
+/**
+ * The dialog's accessible name, as a union so that supplying NEITHER is a type
+ * error rather than a documented rule. Two optional props would let a caller omit
+ * both and get an unnamed dialog — precisely the defect this shell exists to
+ * prevent, and the reason the name is required at all.
+ *
+ * - `ariaLabel` is a plain string, never a node, so the name cannot resolve to
+ *   empty. An earlier draft rendered the title into a hidden element and pointed
+ *   aria-labelledby at it, which produced a NAMELESS dialog whenever the title was
+ *   a ReactNode. The visible heading stays in `children`.
+ * - `ariaLabelledBy` is preferred when a heading already exists: the name cannot
+ *   drift from what is on screen, and no separate translatable string is added.
+ *
+ * `?: never` on the unused side keeps object literals from satisfying both arms.
+ */
+type ModalShellNameProps =
+  | { readonly ariaLabel: string; readonly ariaLabelledBy?: never }
+  | { readonly ariaLabelledBy: string; readonly ariaLabel?: never }
+
+type ModalShellProps = ModalShellBaseProps & ModalShellNameProps
 
 /**
  * Focusable descendants in DOM order, excluding anything not actually reachable.
@@ -203,11 +209,14 @@ export default function ModalShell({
         className="absolute inset-0 bg-black/50"
         onClick={dismissable ? onClose : undefined}
       />
+      {/* Exactly one of aria-label / aria-labelledby is defined (enforced by
+          ModalShellNameProps), so neither needs to defer to the other — the
+          unused one is undefined and renders as no attribute at all. */}
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        aria-label={ariaLabelledBy === undefined ? ariaLabel : undefined}
+        aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
         tabIndex={-1}
         className={clsx('relative bg-white rounded-xl shadow-xl w-full', panelClassName)}

--- a/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.test.tsx
@@ -69,14 +69,23 @@ describe('TemplateWizard dialog semantics (ModalShell adoption)', () => {
       </>,
     )
 
-    const [first, second] = screen.getAllByRole('dialog')
-    const firstId = first.getAttribute('aria-labelledby')
-    const secondId = second.getAttribute('aria-labelledby')
+    const dialogs = screen.getAllByRole('dialog')
+    // Asserted before destructuring so a regression to a single dialog fails here
+    // rather than as a TypeError on the second element.
+    expect(dialogs).toHaveLength(2)
+
+    const [first, second] = dialogs
+    // Coalesce at the read so the ids are `string`, not `string | null` — the
+    // truthiness assertions below are the real check, and `getElementById` then
+    // needs no inline fallback.
+    const labelId = (dialog: HTMLElement) => dialog.getAttribute('aria-labelledby') ?? ''
+    const firstId = labelId(first)
+    const secondId = labelId(second)
 
     expect(firstId).toBeTruthy()
     expect(secondId).toBeTruthy()
     expect(firstId).not.toBe(secondId)
-    expect(first.contains(document.getElementById(firstId ?? ''))).toBe(true)
-    expect(second.contains(document.getElementById(secondId ?? ''))).toBe(true)
+    expect(first.contains(document.getElementById(firstId))).toBe(true)
+    expect(second.contains(document.getElementById(secondId))).toBe(true)
   })
 })

--- a/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.test.tsx
@@ -52,4 +52,31 @@ describe('TemplateWizard dialog semantics (ModalShell adoption)', () => {
     await user.click(screen.getByTestId('modal-overlay'))
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
+
+  // The heading id was a module-level constant before review; two mounted
+  // instances then shared it, and getElementById resolves to the FIRST match, so
+  // the second dialog was named by the first dialog's heading.
+  //
+  // Asserting the accessible NAME cannot catch that — the title is a fixed string,
+  // so both dialogs read "Create New Form" either way and the test passes while
+  // broken. The observable defect is the cross-reference, so that is what is
+  // pinned: ids must differ, and each must resolve INSIDE its own dialog.
+  it('names each instance from its own heading when mounted twice', () => {
+    render(
+      <>
+        <TemplateWizard onSelect={onSelect} onCancel={onCancel} />
+        <TemplateWizard onSelect={onSelect} onCancel={onCancel} />
+      </>,
+    )
+
+    const [first, second] = screen.getAllByRole('dialog')
+    const firstId = first.getAttribute('aria-labelledby')
+    const secondId = second.getAttribute('aria-labelledby')
+
+    expect(firstId).toBeTruthy()
+    expect(secondId).toBeTruthy()
+    expect(firstId).not.toBe(secondId)
+    expect(first.contains(document.getElementById(firstId ?? ''))).toBe(true)
+    expect(second.contains(document.getElementById(secondId ?? ''))).toBe(true)
+  })
 })

--- a/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * #283 stage 2: TemplateWizard was one of the two keyboard traps — no
+ * role="dialog", a fused overlay, and Escape did nothing.
+ *
+ * Its dismiss prop is `onCancel`, not `onClose` like every other ModalShell
+ * adopter, which makes it the riskiest wiring in the migration. `tsc` proved the
+ * prop exists; only a test proves it is what dismissal actually calls.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TemplateWizard from './TemplateWizard'
+
+const onSelect = vi.fn()
+const onCancel = vi.fn()
+
+function renderWizard() {
+  return render(<TemplateWizard onSelect={onSelect} onCancel={onCancel} />)
+}
+
+describe('TemplateWizard dialog semantics (ModalShell adoption)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('is exposed as a modal dialog named by its visible heading', () => {
+    renderWizard()
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    // Named via aria-labelledby, so the accessible name cannot drift from the
+    // heading on screen.
+    expect(dialog).toHaveAccessibleName('Create New Form')
+  })
+
+  it('calls onCancel when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.keyboard('{Escape}')
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel on overlay click but not on panel click', async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.click(screen.getByRole('dialog'))
+    expect(onCancel).not.toHaveBeenCalled()
+
+    await user.click(screen.getByTestId('modal-overlay'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.tsx
@@ -43,13 +43,13 @@ export default function TemplateWizard({ onSelect, onCancel }: TemplateWizardPro
     <ModalShell
       isOpen
       onClose={onCancel}
-      ariaLabel="Create New Form"
+      ariaLabelledBy="template-wizard-title"
       panelClassName="max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
     >
-      <div className="flex flex-col overflow-hidden">
+      <>
         <div className="flex items-center justify-between p-3 sm:p-4 border-b">
           <div className="min-w-0 flex-1">
-            <h2 className="text-base sm:text-lg font-semibold">Create New Form</h2>
+            <h2 id="template-wizard-title" className="text-base sm:text-lg font-semibold">Create New Form</h2>
             <p className="text-xs sm:text-sm text-gray-500">Choose a template to get started</p>
           </div>
           <button onClick={onCancel} className="p-2 hover:bg-gray-100 rounded-lg flex-shrink-0 ml-2">
@@ -126,7 +126,7 @@ export default function TemplateWizard({ onSelect, onCancel }: TemplateWizardPro
             </button>
           </div>
         </div>
-      </div>
+      </>
     </ModalShell>
   )
 }

--- a/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.tsx
@@ -1,7 +1,7 @@
 /**
  * Template Wizard Component for creating new feedback forms
  */
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { X, ArrowRight, User } from 'lucide-react'
 import type { FeedbackForm } from '../../api/client'
 import clsx from 'clsx'
@@ -16,6 +16,10 @@ interface TemplateWizardProps {
 export default function TemplateWizard({ onSelect, onCancel }: TemplateWizardProps) {
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
   const [collectPII, setCollectPII] = useState<'none' | 'name' | 'email' | 'both'>('none')
+  // Generated rather than a module-level constant: a fixed id would collide if the
+  // wizard were ever mounted twice, which silently mis-points aria-labelledby at
+  // the first instance's heading.
+  const titleId = useId()
 
   const handleContinue = () => {
     const template = formTemplates.find(t => t.id === selectedTemplate)
@@ -43,90 +47,88 @@ export default function TemplateWizard({ onSelect, onCancel }: TemplateWizardPro
     <ModalShell
       isOpen
       onClose={onCancel}
-      ariaLabelledBy="template-wizard-title"
+      ariaLabelledBy={titleId}
       panelClassName="max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
     >
-      <>
-        <div className="flex items-center justify-between p-3 sm:p-4 border-b">
-          <div className="min-w-0 flex-1">
-            <h2 id="template-wizard-title" className="text-base sm:text-lg font-semibold">Create New Form</h2>
-            <p className="text-xs sm:text-sm text-gray-500">Choose a template to get started</p>
-          </div>
-          <button onClick={onCancel} className="p-2 hover:bg-gray-100 rounded-lg flex-shrink-0 ml-2">
-            <X size={20} />
-          </button>
+      <div className="flex items-center justify-between p-3 sm:p-4 border-b">
+        <div className="min-w-0 flex-1">
+          <h2 id={titleId} className="text-base sm:text-lg font-semibold">Create New Form</h2>
+          <p className="text-xs sm:text-sm text-gray-500">Choose a template to get started</p>
+        </div>
+        <button onClick={onCancel} className="p-2 hover:bg-gray-100 rounded-lg flex-shrink-0 ml-2">
+          <X size={20} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto p-3 sm:p-4">
+        <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3 mb-6">
+          {formTemplates.map((template) => {
+            const Icon = template.icon
+            const isSelected = selectedTemplate === template.id
+            return (
+              <button
+                key={template.id}
+                onClick={() => setSelectedTemplate(template.id)}
+                className={clsx(
+                  'p-3 sm:p-4 rounded-xl border-2 text-left transition-all hover:shadow-md',
+                  isSelected ? 'border-blue-500 bg-blue-50 shadow-md' : 'border-gray-200 hover:border-gray-300'
+                )}
+              >
+                <div className={clsx('w-8 h-8 sm:w-10 sm:h-10 rounded-lg flex items-center justify-center mb-2 sm:mb-3', template.color)}>
+                  <Icon size={18} className="text-white sm:hidden" />
+                  <Icon size={20} className="text-white hidden sm:block" />
+                </div>
+                <h3 className="font-medium text-gray-900 mb-1 text-sm sm:text-base">{template.name}</h3>
+                <p className="text-xs text-gray-500 line-clamp-2">{template.description}</p>
+              </button>
+            )
+          })}
         </div>
 
-        <div className="flex-1 overflow-auto p-3 sm:p-4">
-          <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3 mb-6">
-            {formTemplates.map((template) => {
-              const Icon = template.icon
-              const isSelected = selectedTemplate === template.id
-              return (
+        {selectedTemplate && (
+          <div className="bg-gray-50 rounded-xl p-3 sm:p-4 border border-gray-200">
+            <h4 className="font-medium text-gray-900 mb-2 sm:mb-3 flex items-center gap-2 text-sm sm:text-base">
+              <User size={16} />
+              Contact Information Collection
+            </h4>
+            <p className="text-xs sm:text-sm text-gray-600 mb-3 sm:mb-4">
+              Choose what personal information to collect from respondents.
+            </p>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+              {piiOptions.map((option) => (
                 <button
-                  key={template.id}
-                  onClick={() => setSelectedTemplate(template.id)}
+                  key={option.id}
+                  onClick={() => setCollectPII(option.id)}
                   className={clsx(
-                    'p-3 sm:p-4 rounded-xl border-2 text-left transition-all hover:shadow-md',
-                    isSelected ? 'border-blue-500 bg-blue-50 shadow-md' : 'border-gray-200 hover:border-gray-300'
+                    'p-2 sm:p-3 rounded-lg border-2 text-left transition-all',
+                    collectPII === option.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'
                   )}
                 >
-                  <div className={clsx('w-8 h-8 sm:w-10 sm:h-10 rounded-lg flex items-center justify-center mb-2 sm:mb-3', template.color)}>
-                    <Icon size={18} className="text-white sm:hidden" />
-                    <Icon size={20} className="text-white hidden sm:block" />
-                  </div>
-                  <h3 className="font-medium text-gray-900 mb-1 text-sm sm:text-base">{template.name}</h3>
-                  <p className="text-xs text-gray-500 line-clamp-2">{template.description}</p>
+                  <p className="font-medium text-xs sm:text-sm text-gray-900">{option.label}</p>
+                  <p className="text-xs text-gray-500 hidden sm:block">{option.desc}</p>
                 </button>
-              )
-            })}
-          </div>
-
-          {selectedTemplate && (
-            <div className="bg-gray-50 rounded-xl p-3 sm:p-4 border border-gray-200">
-              <h4 className="font-medium text-gray-900 mb-2 sm:mb-3 flex items-center gap-2 text-sm sm:text-base">
-                <User size={16} />
-                Contact Information Collection
-              </h4>
-              <p className="text-xs sm:text-sm text-gray-600 mb-3 sm:mb-4">
-                Choose what personal information to collect from respondents.
-              </p>
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
-                {piiOptions.map((option) => (
-                  <button
-                    key={option.id}
-                    onClick={() => setCollectPII(option.id)}
-                    className={clsx(
-                      'p-2 sm:p-3 rounded-lg border-2 text-left transition-all',
-                      collectPII === option.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'
-                    )}
-                  >
-                    <p className="font-medium text-xs sm:text-sm text-gray-900">{option.label}</p>
-                    <p className="text-xs text-gray-500 hidden sm:block">{option.desc}</p>
-                  </button>
-                ))}
-              </div>
+              ))}
             </div>
-          )}
-        </div>
-
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3 p-3 sm:p-4 border-t bg-gray-50">
-          <p className="text-xs sm:text-sm text-gray-500 text-center sm:text-left">
-            {selectedTemplate ? `Selected: ${formTemplates.find(t => t.id === selectedTemplate)?.name}` : 'Select a template to continue'}
-          </p>
-          <div className="flex gap-2 sm:gap-3">
-            <button onClick={onCancel} className="btn btn-secondary flex-1 sm:flex-none">Cancel</button>
-            <button
-              onClick={handleContinue}
-              disabled={!selectedTemplate}
-              className="btn btn-primary flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed flex-1 sm:flex-none"
-            >
-              Continue
-              <ArrowRight size={16} />
-            </button>
           </div>
+        )}
+      </div>
+
+      <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3 p-3 sm:p-4 border-t bg-gray-50">
+        <p className="text-xs sm:text-sm text-gray-500 text-center sm:text-left">
+          {selectedTemplate ? `Selected: ${formTemplates.find(t => t.id === selectedTemplate)?.name}` : 'Select a template to continue'}
+        </p>
+        <div className="flex gap-2 sm:gap-3">
+          <button onClick={onCancel} className="btn btn-secondary flex-1 sm:flex-none">Cancel</button>
+          <button
+            onClick={handleContinue}
+            disabled={!selectedTemplate}
+            className="btn btn-primary flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed flex-1 sm:flex-none"
+          >
+            Continue
+            <ArrowRight size={16} />
+          </button>
         </div>
-      </>
+      </div>
     </ModalShell>
   )
 }

--- a/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/TemplateWizard.tsx
@@ -6,6 +6,7 @@ import { X, ArrowRight, User } from 'lucide-react'
 import type { FeedbackForm } from '../../api/client'
 import clsx from 'clsx'
 import { formTemplates } from './formTemplates'
+import ModalShell from '../../components/ModalShell'
 
 interface TemplateWizardProps {
   readonly onSelect: (config: Omit<FeedbackForm, 'form_id' | 'created_at' | 'updated_at'>) => void
@@ -39,8 +40,13 @@ export default function TemplateWizard({ onSelect, onCancel }: TemplateWizardPro
   ] as const
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-2 sm:p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-3xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+    <ModalShell
+      isOpen
+      onClose={onCancel}
+      ariaLabel="Create New Form"
+      panelClassName="max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
+    >
+      <div className="flex flex-col overflow-hidden">
         <div className="flex items-center justify-between p-3 sm:p-4 border-b">
           <div className="min-w-0 flex-1">
             <h2 className="text-base sm:text-lg font-semibold">Create New Form</h2>
@@ -121,6 +127,6 @@ export default function TemplateWizard({ onSelect, onCancel }: TemplateWizardPro
           </div>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocWizard.test.tsx
@@ -80,6 +80,41 @@ describe('DocWizard', () => {
     mockGetCategoriesConfig.mockResolvedValue({ categories: [] })
   })
 
+  // #283 stage 2: this wizard was one of the two keyboard traps found by browser
+  // testing — no role="dialog", a fused overlay, and Escape did nothing. It now
+  // renders through ModalShell, so it inherits dialog semantics and dismissal.
+  describe('dialog semantics (ModalShell adoption)', () => {
+    it('is exposed as a modal dialog named by its title', () => {
+      render(<DocWizard {...makeProps()} />, { wrapper: createWrapper() })
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+      expect(dialog).toHaveAccessibleName()
+    })
+
+    it('closes on Escape', async () => {
+      const user = userEvent.setup()
+      const props = makeProps()
+      render(<DocWizard {...props} />, { wrapper: createWrapper() })
+
+      await user.keyboard('{Escape}')
+
+      expect(props.onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('closes on overlay click but not on panel click', async () => {
+      const user = userEvent.setup()
+      const props = makeProps()
+      render(<DocWizard {...props} />, { wrapper: createWrapper() })
+
+      await user.click(screen.getByRole('dialog'))
+      expect(props.onClose).not.toHaveBeenCalled()
+
+      await user.click(screen.getByTestId('modal-overlay'))
+      expect(props.onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('doc-type multi-select', () => {
     it('shows PR-FAQ title when only prfaq is selected', () => {
       render(<DocWizard {...makeProps()} />, { wrapper: createWrapper() })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocWizard.test.tsx
@@ -89,7 +89,21 @@ describe('DocWizard', () => {
 
       const dialog = screen.getByRole('dialog')
       expect(dialog).toHaveAttribute('aria-modal', 'true')
-      expect(dialog).toHaveAccessibleName()
+      // Asserted as an exact string, not a bare toHaveAccessibleName(): the latter
+      // passes on any non-empty name, so it would not have caught the name drifting
+      // away from the visible heading.
+      expect(dialog).toHaveAccessibleName('Generate PR-FAQ')
+    })
+
+    it('keeps the dialog name in step with the doc-type selection', () => {
+      // Pins the name to the same value the heading shows, which is what makes the
+      // exact assertion above meaningful rather than a hardcoded coincidence.
+      render(
+        <DocWizard {...makeProps({ docTypes: ['prfaq', 'prd'] })} />,
+        { wrapper: createWrapper() },
+      )
+
+      expect(screen.getByRole('dialog')).toHaveAccessibleName('Generate PRD + PR-FAQ')
     })
 
     it('closes on Escape', async () => {


### PR DESCRIPTION
## Summary

Stage 2 of #283: both keyboard traps found by browser-testing the deployed build now render through `ModalShell`.

Both had the same shape — no `role="dialog"`, a **fused overlay** acting as backdrop *and* container, and Escape doing nothing.

## `DataSourceWizard` was the higher-leverage target

Worth flagging, because the issue lists these as separate items: **`PersonaWizard`, `ResearchWizard`, `DocWizard` and `MergeWizard` all render through `DataSourceWizard`**, so migrating that one component fixes four wizard surfaces at once — including the Documents → "New Document" flow I measured as a trap.

`TemplateWizard` migrated the same way. Its close prop is `onCancel`, not `onClose`; `tsc` caught that immediately.

## What they inherit now

`role="dialog"`, `aria-modal`, an accessible name, Escape, overlay click with a non-swallowing panel, focus-in and focus-restore-to-trigger, and the Tab trap.

Layout is preserved by moving the panel-specific classes (`max-w-2xl`, `max-h-[90vh] overflow-hidden`, and `flex flex-col` for `TemplateWizard`) onto `panelClassName`, and turning the old fused outer div into a plain wrapper.

## Testing

- 3 tests on `DocWizard` covering what the adoption bought: dialog role + accessible name, Escape closes, and overlay click closes while a **panel click does not**.
- **Non-vacuity verified:** reverting `DataSourceWizard` to the fused overlay fails all three (3 failed / 10 passed).
- Full suite **1844 passed / 116 files** (was 1841); `tsc` and ESLint clean across `src`. Unchanged at every existing wizard call site — the suite passing untouched is the evidence, since these wizards are exercised by `ResearchWizard.test.tsx` and `DocWizard.test.tsx` already.

## Adoption count

After this stage: `ConfirmModal` + 5 wizard surfaces on the shell. Remaining for stages 3-4 — `UserProfileModal` (already correct from #281, worth migrating for consistency), `SubmissionsModal`, `PersonaEditModal`, `DocumentModal`, `ImportPersonaModal`, `DataExplorer/EditModal`, the three `Scrapers` modals, `TemplateSelector`, the two `UserAdmin` modals, and the inline overlays in `Layout`/`Chat`/`Projects`/`FeedbackForms`/`DocumentsTab`.

## Verification status

Test-verified. Deploying and browser-testing next — the trap measurements that motivated this were taken live, so the fix should be confirmed the same way.
