### PR TITLE
fix(ui): stop rendering a working app on a dead session

### DIFF
--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -26,6 +26,7 @@ vi.mock('../services/auth', () => ({
 
 import { api, getDaysFromRange, getDateRangeParams, ALL_TIME_DAYS } from './client'
 import { authService } from '../services/auth'
+import { SESSION_EXPIRED_PATH } from '../services/sessionExpiry'
 
 describe('API Client', () => {
   beforeEach(() => {
@@ -132,19 +133,23 @@ describe('API Client', () => {
       expect(global.fetch).toHaveBeenCalledTimes(2)
     })
 
-    it('signs out and redirects when refresh fails', async () => {
+    it('signs out and redirects with a reason when refresh fails', async () => {
       ;(global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({ ok: false, status: 401 })
         .mockResolvedValueOnce({ ok: false, status: 401 })
 
       const originalLocation = window.location
+      const replace = vi.fn()
       Object.defineProperty(window, 'location', {
-        value: { href: '' },
+        value: { href: '', replace },
         writable: true,
       })
 
       await expect(api.getFeedback({ days: 7 })).rejects.toThrow('Session expired')
       expect(authService.signOut).toHaveBeenCalled()
+      // The reason must travel with the redirect: without it /login cannot
+      // tell the user why the app they were using stopped working.
+      expect(replace).toHaveBeenCalledWith(SESSION_EXPIRED_PATH)
 
       window.location = originalLocation
     })

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -26,7 +26,7 @@ vi.mock('../services/auth', () => ({
 
 import { api, getDaysFromRange, getDateRangeParams, ALL_TIME_DAYS } from './client'
 import { authService } from '../services/auth'
-import { SESSION_EXPIRED_PATH } from '../services/sessionExpiry'
+import { SESSION_EXPIRED_PATH, resetSessionExpiryForTests } from '../services/sessionExpiry'
 
 describe('API Client', () => {
   beforeEach(() => {
@@ -144,6 +144,8 @@ describe('API Client', () => {
         value: { href: '', replace },
         writable: true,
       })
+      // The redirect is idempotent and only a real page load resets it.
+      resetSessionExpiryForTests()
 
       await expect(api.getFeedback({ days: 7 })).rejects.toThrow('Session expired')
       expect(authService.signOut).toHaveBeenCalled()

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { authService } from '../services/auth'
+import { endExpiredSession } from '../services/sessionExpiry'
 import { getBaseUrl, getAuthHeaders, getDaysFromRange, getDateBasisBodyParams, ALL_TIME_DAYS } from './baseUrl'
 import type {
   DateBasis,
@@ -130,8 +131,9 @@ export async function fetchApi<T>(endpoint: string, options?: RequestInit): Prom
     try {
       return await handleUnauthorized<T>(endpoint, options, headers, baseUrl)
     } catch {
-      authService.signOut()
-      window.location.href = '/login'
+      // Carries the reason to /login so the user is told the session ended,
+      // instead of meeting a bare login form after a working-looking app.
+      endExpiredSession()
       throw new Error('Session expired. Please login again.')
     }
   }

--- a/voc-datalake/frontend/src/api/streamClient.test.ts
+++ b/voc-datalake/frontend/src/api/streamClient.test.ts
@@ -81,8 +81,7 @@ describe('streamChat auth handling', () => {
     const events = await drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' }))
 
     expect(events).toEqual([{ type: 'done' }])
-    // eslint-disable-next-line vitest/prefer-called-with
-    expect(authService.refreshSession).toHaveBeenCalled()
+    expect(authService.refreshSession).toHaveBeenCalledWith()
     expect(endExpiredSession).not.toHaveBeenCalled()
 
     // The retry must carry the new token, not the one that just 401'd.
@@ -98,8 +97,7 @@ describe('streamChat auth handling', () => {
       drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' })),
     ).rejects.toThrow('Session expired')
 
-    // eslint-disable-next-line vitest/prefer-called-with
-    expect(endExpiredSession).toHaveBeenCalled()
+    expect(endExpiredSession).toHaveBeenCalledWith()
     expect(global.fetch).toHaveBeenCalledTimes(1)
   })
 
@@ -113,8 +111,7 @@ describe('streamChat auth handling', () => {
       drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' })),
     ).rejects.toThrow('Session expired')
 
-    // eslint-disable-next-line vitest/prefer-called-with
-    expect(endExpiredSession).toHaveBeenCalled()
+    expect(endExpiredSession).toHaveBeenCalledWith()
   })
 
   it('leaves non-401 failures alone', async () => {

--- a/voc-datalake/frontend/src/api/streamClient.test.ts
+++ b/voc-datalake/frontend/src/api/streamClient.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Tests for the SSE stream client's auth handling.
+ *
+ * The stream path used to be the one place a dead session produced a message
+ * and nothing else: no refresh attempt, no sign-out, so the app kept rendering
+ * as if signed in. These cases pin the corrected behaviour.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../store/configStore', () => ({
+  useConfigStore: {
+    getState: () => ({
+      config: { apiEndpoint: 'https://api.example.com' },
+      dateBasis: 'imported',
+    }),
+  },
+}))
+
+vi.mock('../services/auth', () => ({
+  authService: {
+    isConfigured: () => true,
+    getIdToken: vi.fn(() => 'stale-token'),
+    refreshSession: vi.fn(),
+  },
+}))
+
+vi.mock('../services/sessionExpiry', () => ({
+  endExpiredSession: vi.fn(),
+}))
+
+import { streamChat } from './streamClient'
+import { authService } from '../services/auth'
+import { endExpiredSession } from '../services/sessionExpiry'
+
+/** Drain the generator so the fetch and its error handling actually run. */
+async function drain(gen: AsyncGenerator<unknown>): Promise<unknown[]> {
+  const events: unknown[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+/** A response whose body yields one SSE `done` event. */
+function okStream() {
+  const encoder = new TextEncoder()
+  let sent = false
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: () => {
+          if (sent) return Promise.resolve({ done: true, value: undefined })
+          sent = true
+          return Promise.resolve({
+            done: false,
+            value: encoder.encode('data: {"type":"done"}\n'),
+          })
+        },
+        releaseLock: () => undefined,
+      }),
+    },
+  }
+}
+
+describe('streamChat auth handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(authService.getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('stale-token')
+    global.fetch = vi.fn()
+  })
+
+  it('refreshes once and retries when the first attempt is unauthorized', async () => {
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      ;(authService.getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('fresh-token')
+      return Promise.resolve(undefined)
+    })
+    ;(global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce(okStream())
+
+    const events = await drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' }))
+
+    expect(events).toEqual([{ type: 'done' }])
+    // eslint-disable-next-line vitest/prefer-called-with
+    expect(authService.refreshSession).toHaveBeenCalled()
+    expect(endExpiredSession).not.toHaveBeenCalled()
+
+    // The retry must carry the new token, not the one that just 401'd.
+    const [, retryInit] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    expect(retryInit.headers.Authorization).toBe('fresh-token')
+  })
+
+  it('ends the session when the refresh itself fails', async () => {
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no session'))
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 401 })
+
+    await expect(
+      drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' })),
+    ).rejects.toThrow('Session expired')
+
+    // eslint-disable-next-line vitest/prefer-called-with
+    expect(endExpiredSession).toHaveBeenCalled()
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('ends the session when the retry is still unauthorized', async () => {
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+    ;(global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+
+    await expect(
+      drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' })),
+    ).rejects.toThrow('Session expired')
+
+    // eslint-disable-next-line vitest/prefer-called-with
+    expect(endExpiredSession).toHaveBeenCalled()
+  })
+
+  it('leaves non-401 failures alone', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await expect(
+      drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' })),
+    ).rejects.toThrow('Stream error: 500')
+
+    expect(authService.refreshSession).not.toHaveBeenCalled()
+    expect(endExpiredSession).not.toHaveBeenCalled()
+  })
+
+  it('still reports 403 as an auth problem without ending the session', async () => {
+    // 403 is authorization, not an expired token — WAF and IAM produce it too,
+    // so signing the user out would be the wrong response.
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 403 })
+
+    await expect(
+      drain(streamChat('https://api.example.com/chat/stream', { message: 'hi' })),
+    ).rejects.toThrow('Access denied')
+
+    expect(endExpiredSession).not.toHaveBeenCalled()
+  })
+})

--- a/voc-datalake/frontend/src/api/streamClient.ts
+++ b/voc-datalake/frontend/src/api/streamClient.ts
@@ -7,6 +7,8 @@
 import {
   getBaseUrl, getAuthHeaders, getDateBasisBodyParams,
 } from './baseUrl'
+import { authService } from '../services/auth'
+import { endExpiredSession } from '../services/sessionExpiry'
 
 class StreamAuthError extends Error {
   constructor(message: string) {
@@ -109,6 +111,51 @@ async function* readSSEStream(reader: ReadableStreamDefaultReader<Uint8Array>): 
   }
 }
 
+/** POST the stream request, reading the auth header fresh on every attempt. */
+function postStream(
+  endpoint: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<Response> {
+  return fetch(endpoint, {
+    method: 'POST',
+    headers: getStreamHeaders(),
+    body: JSON.stringify(body),
+    signal,
+  })
+}
+
+/**
+ * A 401 here means what it means in `fetchApi`: try one silent refresh, and
+ * if that does not yield a working token, end the session visibly.
+ *
+ * Previously this path threw an inline "session expired" message and stopped
+ * there, so the app kept rendering as if signed in — the chat surface was the
+ * one place a dead session produced a message and no sign-out.
+ */
+async function retryAfterRefresh(
+  endpoint: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const expired = () => {
+    endExpiredSession()
+    return new StreamAuthError('Session expired - please sign in again')
+  }
+
+  try {
+    await authService.refreshSession()
+  } catch {
+    throw expired()
+  }
+
+  const retry = await postStream(endpoint, body, signal)
+  if (retry.status === 401) {
+    throw expired()
+  }
+  return retry
+}
+
 /**
  * Async generator that streams SSE events from the chat endpoint.
  * Yields parsed StreamEvent objects as they arrive.
@@ -118,17 +165,12 @@ export async function* streamChat(
   body: Record<string, unknown>,
   signal?: AbortSignal,
 ): AsyncGenerator<StreamEvent> {
-  const headers = getStreamHeaders()
-
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-    signal,
-  })
+  const first = await postStream(endpoint, body, signal)
+  const response = first.status === 401
+    ? await retryAfterRefresh(endpoint, body, signal)
+    : first
 
   if (!response.ok) {
-    if (response.status === 401) throw new StreamAuthError('Session expired - please sign in again')
     if (response.status === 403) throw new StreamAuthError('Access denied - please sign in again')
     throw new StreamResponseError(`Stream error: ${response.status}`, response.status)
   }

--- a/voc-datalake/frontend/src/api/streamClient.ts
+++ b/voc-datalake/frontend/src/api/streamClient.ts
@@ -138,7 +138,8 @@ async function retryAfterRefresh(
   body: Record<string, unknown>,
   signal?: AbortSignal,
 ): Promise<Response> {
-  const expired = () => {
+  /** Ends the session and hands back the error to throw at the call site. */
+  const endSessionWithError = () => {
     endExpiredSession()
     return new StreamAuthError('Session expired - please sign in again')
   }
@@ -146,12 +147,12 @@ async function retryAfterRefresh(
   try {
     await authService.refreshSession()
   } catch {
-    throw expired()
+    throw endSessionWithError()
   }
 
   const retry = await postStream(endpoint, body, signal)
   if (retry.status === 401) {
-    throw expired()
+    throw endSessionWithError()
   }
   return retry
 }

--- a/voc-datalake/frontend/src/components/Layout/Layout.test.tsx
+++ b/voc-datalake/frontend/src/components/Layout/Layout.test.tsx
@@ -78,10 +78,14 @@ vi.mock('../UserProfileModal', () => ({
 import Layout from './Layout'
 import { useIsAdmin } from '../../store/authStore'
 
-function createWrapper(initialEntries = ['/']) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  })
+/**
+ * @param initialEntries - router history to start from
+ * @param queryClient - pass one in to inspect the cache after interacting
+ */
+function createWrapper(
+  initialEntries = ['/'],
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+) {
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
       <TestRouter initialEntries={initialEntries}>
@@ -298,6 +302,24 @@ describe('Layout with authenticated user', () => {
     await waitFor(() => {
       expect(screen.getByTitle('Sign out')).toBeInTheDocument()
     })
+  })
+
+  /*
+   * Sign-out is an in-app navigation, so the QueryClient survives it. Without
+   * an explicit clear, the next person to sign in on this browser sees the
+   * previous session's cached feedback while their own loads.
+   */
+  it('leaves no cached data behind when signing out', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData(['feedback'], { count: 1, items: [{ feedback_id: 'private' }] })
+    const user = userEvent.setup()
+
+    render(<Layout />, { wrapper: createWrapper(['/'], queryClient) })
+    await user.click(await screen.findByTitle('Sign out'))
+
+    expect(queryClient.getQueryData(['feedback'])).toBeUndefined()
+    // eslint-disable-next-line vitest/prefer-called-with
+    expect(mockSignOut).toHaveBeenCalled()
   })
 })
 

--- a/voc-datalake/frontend/src/components/Layout/Layout.test.tsx
+++ b/voc-datalake/frontend/src/components/Layout/Layout.test.tsx
@@ -318,8 +318,7 @@ describe('Layout with authenticated user', () => {
     await user.click(await screen.findByTitle('Sign out'))
 
     expect(queryClient.getQueryData(['feedback'])).toBeUndefined()
-    // eslint-disable-next-line vitest/prefer-called-with
-    expect(mockSignOut).toHaveBeenCalled()
+    expect(mockSignOut).toHaveBeenCalledWith()
   })
 })
 

--- a/voc-datalake/frontend/src/components/Layout/Layout.tsx
+++ b/voc-datalake/frontend/src/components/Layout/Layout.tsx
@@ -29,6 +29,7 @@ import {
   Database,
   Menu,
 } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { getDateRangeParams } from '../../api/client'
 import { useSummaryQuery } from '../../hooks/useSummaryQuery'
 import { useConfigStore } from '../../store/configStore'
@@ -139,6 +140,7 @@ export default function Layout() {
   const { user, isAuthenticated } = useAuthStore()
   const isAdmin = useIsAdmin()
   const dateParams = getDateRangeParams(timeRange, customDays, dateBasis)
+  const queryClient = useQueryClient()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [showProfileModal, setShowProfileModal] = useState(false)
   const { mobileMenuOpen, openMenu, closeMenu } = useMobileMenu(location.pathname)
@@ -166,9 +168,15 @@ export default function Layout() {
   const { data: summaryData } = useSummaryQuery(dateParams, config.apiEndpoint)
 
   const handleLogout = useCallback(() => {
+    // Sign-out is an in-app navigation, so the QueryClient outlives it and
+    // every cached authenticated response — urgent counts, feedback, projects
+    // — would render for whoever signs in next while their own data loads.
+    // The expired-session path does a full document load and so drops the
+    // cache implicitly; this one has to be explicit.
+    queryClient.clear()
     authService.signOut()
     navigate('/login')
-  }, [navigate])
+  }, [navigate, queryClient])
 
   const toggleSidebar = useCallback(() => setSidebarCollapsed(prev => !prev), [])
   const showProfile = useCallback(() => setShowProfileModal(true), [])

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.storeIntegration.test.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.storeIntegration.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview ProtectedRoute against the REAL auth store.
+ *
+ * Why a second file: `ProtectedRoute.test.tsx` mocks the store, and a mocked
+ * store cannot reproduce the defect this file exists to pin. Changing a
+ * `vi.fn()`'s return value does not notify React, so no re-render happens, the
+ * effect is never torn down, and the broken and fixed implementations behave
+ * identically — a test written there passes either way.
+ *
+ * The defect: `refreshSession` clears auth state internally before it rejects.
+ * With the validation gate DERIVED from the store, that clearing flipped the
+ * gate, React re-ran the effect deps, the cleanup fired mid-flight, and both
+ * the retry and the `?expired=1` redirect were cancelled — dropping the user on
+ * the bare login form this component exists to avoid. Only a real store, which
+ * really notifies subscribers, exercises that sequence.
+ *
+ * @module components/ProtectedRoute
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ProtectedRoute from './ProtectedRoute'
+import { useAuthStore } from '../../store/authStore'
+import { authService } from '../../services/auth'
+import { endExpiredSession } from '../../services/sessionExpiry'
+
+vi.mock('../../services/auth', () => ({
+  authService: {
+    isConfigured: vi.fn(() => true),
+    refreshSession: vi.fn(),
+    signOut: vi.fn(),
+  },
+}))
+
+vi.mock('../../services/sessionExpiry', () => ({
+  endExpiredSession: vi.fn(),
+}))
+
+function renderProtected() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/protected']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/login" element={<div>Login Page</div>} />
+        <Route
+          path="/protected"
+          element={<ProtectedRoute><div>Protected Content</div></ProtectedRoute>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/**
+ * The state a page load produces: `isAuthenticated` came back from
+ * localStorage, `sessionReady` did not (it is excluded from `partialize`).
+ */
+function restoreUnvalidatedSession() {
+  useAuthStore.setState({
+    user: { username: 'u', email: 'u@example.com', groups: [] },
+    accessToken: 'restored-access',
+    idToken: 'restored-id',
+    refreshToken: null,
+    isAuthenticated: true,
+    sessionReady: false,
+  })
+}
+
+describe('ProtectedRoute against the real auth store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(authService.isConfigured as ReturnType<typeof vi.fn>).mockReturnValue(true)
+    useAuthStore.getState().logout()
+  })
+
+  it('ends the session with the reason even though the refresh clears auth state first', async () => {
+    restoreUnvalidatedSession()
+    // Exactly what the real refreshSession does on a rejected refresh.
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      useAuthStore.getState().logout()
+      return Promise.reject(new Error('Session refresh failed'))
+    })
+
+    renderProtected()
+
+    await waitFor(() => expect(endExpiredSession).toHaveBeenCalledWith(), { timeout: 3000 })
+    // No flash of the unexplained form while that redirect resolves.
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+
+  it('renders the app once a real refresh validates the restored session', async () => {
+    restoreUnvalidatedSession()
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      useAuthStore.getState().setTokens({
+        accessToken: 'fresh-access',
+        idToken: 'fresh-id',
+        refreshToken: 'fresh-refresh',
+      })
+      return Promise.resolve(undefined)
+    })
+
+    renderProtected()
+
+    expect(await screen.findByText('Protected Content')).toBeInTheDocument()
+    expect(endExpiredSession).not.toHaveBeenCalled()
+  })
+
+  it('does not revalidate a session that is already validated', () => {
+    restoreUnvalidatedSession()
+    useAuthStore.getState().setTokens({
+      accessToken: 'a', idToken: 'b', refreshToken: 'c',
+    })
+
+    renderProtected()
+
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+    expect(authService.refreshSession).not.toHaveBeenCalled()
+  })
+})

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import ProtectedRoute from './ProtectedRoute'
 import { useAuthStore } from '../../store/authStore'
 import { authService } from '../../services/auth'
+import { endExpiredSession } from '../../services/sessionExpiry'
 
 /*
  * The store mock is a hook *and* carries `getState`, because the component
@@ -25,6 +26,10 @@ vi.mock('../../services/auth', () => ({
     refreshSession: vi.fn(),
     signOut: vi.fn(),
   },
+}))
+
+vi.mock('../../services/sessionExpiry', () => ({
+  endExpiredSession: vi.fn(),
 }))
 
 // Helper to render with router
@@ -52,10 +57,17 @@ function renderWithRouter(
   )
 }
 
-/** Point the store at a given auth state, reactively and imperatively. */
+/**
+ * Point the store at a given auth state, reactively and imperatively.
+ *
+ * Both halves must agree: the component renders from the hook and checks the
+ * post-refresh outcome through `getState`, so a helper that set only one of
+ * them would let a case pass for the wrong reason.
+ */
 function setAuthState(state: { isAuthenticated: boolean; sessionReady?: boolean }) {
-  ;(useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue(state)
-  mockGetState.mockReturnValue({ isAuthenticated: state.isAuthenticated })
+  const resolved = { sessionReady: false, ...state }
+  ;(useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue(resolved)
+  mockGetState.mockReturnValue(resolved)
 }
 
 describe('ProtectedRoute', () => {
@@ -132,16 +144,20 @@ describe('ProtectedRoute', () => {
         </ProtectedRoute>
       )
 
-      // eslint-disable-next-line vitest/prefer-called-with
-      expect(authService.refreshSession).toHaveBeenCalled()
+      expect(authService.refreshSession).toHaveBeenCalledWith()
     })
 
-    it('signs out when the refresh fails without clearing auth state itself', async () => {
-      // A ConfigError rejection leaves the store authenticated; failing open
-      // here would strand the user on the loader forever.
-      ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error('Cognito not configured'),
-      )
+    it('retries once before giving up, so a connectivity blip is survivable', async () => {
+      // First attempt fails; the second validates. refreshSession signs the
+      // user out for a transport failure exactly as for a dead session, so
+      // without the retry a moment of bad network is a forced logout.
+      ;(authService.refreshSession as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('network'))
+        .mockImplementationOnce(() => {
+          // Stand in for setTokens releasing the gate on a real refresh.
+          mockGetState.mockReturnValue({ isAuthenticated: true, sessionReady: true })
+          return Promise.resolve(undefined)
+        })
 
       renderWithRouter(
         <ProtectedRoute>
@@ -149,15 +165,16 @@ describe('ProtectedRoute', () => {
         </ProtectedRoute>
       )
 
-      // eslint-disable-next-line vitest/prefer-called-with
-      await waitFor(() => expect(authService.signOut).toHaveBeenCalled())
+      await waitFor(() => expect(authService.refreshSession).toHaveBeenCalledTimes(2))
+      expect(endExpiredSession).not.toHaveBeenCalled()
     })
 
-    it('leaves the sign-out to refreshSession when it already cleared state', async () => {
+    it('ends the session WITH the reason when both attempts fail', async () => {
+      // The bare <Navigate to="/login"> below would drop the explanation —
+      // and this is the path an idle deployment actually takes.
       ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('Session refresh failed'),
       )
-      mockGetState.mockReturnValue({ isAuthenticated: false })
 
       renderWithRouter(
         <ProtectedRoute>
@@ -165,8 +182,22 @@ describe('ProtectedRoute', () => {
         </ProtectedRoute>
       )
 
-      await waitFor(() => expect(authService.refreshSession).toHaveBeenCalledWith())
-      expect(authService.signOut).not.toHaveBeenCalled()
+      await waitFor(() => expect(endExpiredSession).toHaveBeenCalledWith())
+    })
+
+    it('ends the session if a refresh resolves without producing tokens', async () => {
+      // Only setTokens releases the gate, so a resolve that left sessionReady
+      // false would otherwise hang on the loader forever.
+      ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+      mockGetState.mockReturnValue({ isAuthenticated: true, sessionReady: false })
+
+      renderWithRouter(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      )
+
+      await waitFor(() => expect(endExpiredSession).toHaveBeenCalledWith())
     })
   })
 

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -185,6 +185,16 @@ describe('ProtectedRoute', () => {
       await waitFor(() => expect(endExpiredSession).toHaveBeenCalledWith())
     })
 
+    /*
+     * The case where `refreshSession` clears auth state before rejecting — the
+     * real failure path — is NOT tested here on purpose. A mocked store cannot
+     * reproduce it: re-pointing a `vi.fn()` does not notify React, so nothing
+     * re-renders, the effect is never torn down, and the broken and fixed
+     * implementations behave identically. It lives in
+     * `ProtectedRoute.storeIntegration.test.tsx`, against the real store, where
+     * it actually fails if the gate goes back to being store-derived.
+     */
+
     it('ends the session if a refresh resolves without producing tokens', async () => {
       // Only setTokens releases the gate, so a resolve that left sessionReady
       // false would otherwise hang on the loader forever.
@@ -238,9 +248,10 @@ describe('ProtectedRoute', () => {
   describe('location state', () => {
     it('preserves return path in location state when redirecting', () => {
       ;(authService.isConfigured as ReturnType<typeof vi.fn>).mockReturnValue(true)
-      ;(useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-        isAuthenticated: false,
-      })
+      // Through the helper, so the hook and `getState` agree: the one-shot gate
+      // reads `getState`, and setting only the hook left this validating and
+      // rendering the loader instead of redirecting.
+      setAuthState({ isAuthenticated: false })
 
       // The Navigate component should include state with the original path
       // This is tested implicitly by the redirect behavior

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -2,21 +2,28 @@
  * @fileoverview Tests for ProtectedRoute component.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import ProtectedRoute from './ProtectedRoute'
 import { useAuthStore } from '../../store/authStore'
 import { authService } from '../../services/auth'
 
-// Mock the auth store
+/*
+ * The store mock is a hook *and* carries `getState`, because the component
+ * reads reactively for rendering and imperatively inside the validation
+ * effect (where a stale closure would decide whether to force a sign-out).
+ */
+const mockGetState = vi.fn(() => ({ isAuthenticated: true }))
 vi.mock('../../store/authStore', () => ({
-  useAuthStore: vi.fn(),
+  useAuthStore: Object.assign(vi.fn(), { getState: () => mockGetState() }),
 }))
 
 // Mock the auth service
 vi.mock('../../services/auth', () => ({
   authService: {
     isConfigured: vi.fn(),
+    refreshSession: vi.fn(),
+    signOut: vi.fn(),
   },
 }))
 
@@ -45,9 +52,20 @@ function renderWithRouter(
   )
 }
 
+/** Point the store at a given auth state, reactively and imperatively. */
+function setAuthState(state: { isAuthenticated: boolean; sessionReady?: boolean }) {
+  ;(useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue(state)
+  mockGetState.mockReturnValue({ isAuthenticated: state.isAuthenticated })
+}
+
 describe('ProtectedRoute', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // clearAllMocks keeps implementations, so both halves of the store mock
+    // are re-pointed explicitly — otherwise a case that sets one of them
+    // leaks its state into every case after it.
+    mockGetState.mockReturnValue({ isAuthenticated: true })
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
     // Reset import.meta.env.DEV mock
     vi.stubGlobal('import', { meta: { env: { DEV: false } } })
   })
@@ -57,10 +75,8 @@ describe('ProtectedRoute', () => {
       ;(authService.isConfigured as ReturnType<typeof vi.fn>).mockReturnValue(true)
     })
 
-    it('renders children when user is authenticated', () => {
-      ;(useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-        isAuthenticated: true,
-      })
+    it('renders children when the session is authenticated and validated', () => {
+      setAuthState({ isAuthenticated: true, sessionReady: true })
 
       renderWithRouter(
         <ProtectedRoute>
@@ -69,12 +85,11 @@ describe('ProtectedRoute', () => {
       )
 
       expect(screen.getByText('Protected Content')).toBeInTheDocument()
+      expect(authService.refreshSession).not.toHaveBeenCalled()
     })
 
     it('redirects to login when user is not authenticated', () => {
-      ;(useAuthStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-        isAuthenticated: false,
-      })
+      setAuthState({ isAuthenticated: false })
 
       renderWithRouter(
         <ProtectedRoute>
@@ -84,6 +99,74 @@ describe('ProtectedRoute', () => {
 
       expect(screen.getByText('Login Page')).toBeInTheDocument()
       expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+    })
+  })
+
+  /*
+   * `isAuthenticated` comes back from localStorage on every page load, so
+   * without these three cases an expired token renders the whole app and only
+   * fails later, one 401 at a time — the defect this validation gate exists
+   * to close.
+   */
+  describe('when a restored session has not been validated yet', () => {
+    beforeEach(() => {
+      ;(authService.isConfigured as ReturnType<typeof vi.fn>).mockReturnValue(true)
+      setAuthState({ isAuthenticated: true, sessionReady: false })
+    })
+
+    it('renders neither the app nor a redirect while validating', () => {
+      renderWithRouter(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      )
+
+      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+      expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+    })
+
+    it('attempts a silent refresh', () => {
+      renderWithRouter(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      )
+
+      // eslint-disable-next-line vitest/prefer-called-with
+      expect(authService.refreshSession).toHaveBeenCalled()
+    })
+
+    it('signs out when the refresh fails without clearing auth state itself', async () => {
+      // A ConfigError rejection leaves the store authenticated; failing open
+      // here would strand the user on the loader forever.
+      ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Cognito not configured'),
+      )
+
+      renderWithRouter(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      )
+
+      // eslint-disable-next-line vitest/prefer-called-with
+      await waitFor(() => expect(authService.signOut).toHaveBeenCalled())
+    })
+
+    it('leaves the sign-out to refreshSession when it already cleared state', async () => {
+      ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Session refresh failed'),
+      )
+      mockGetState.mockReturnValue({ isAuthenticated: false })
+
+      renderWithRouter(
+        <ProtectedRoute>
+          <div>Protected Content</div>
+        </ProtectedRoute>
+      )
+
+      await waitFor(() => expect(authService.refreshSession).toHaveBeenCalledWith())
+      expect(authService.signOut).not.toHaveBeenCalled()
     })
   })
 

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -10,7 +10,7 @@
  * @module components/ProtectedRoute
  */
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../../store/authStore'
 import { authService } from '../../services/auth'
@@ -44,7 +44,7 @@ interface ProtectedRouteProps {
  */
 export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProps>) {
   const location = useLocation()
-  const { isAuthenticated, sessionReady } = useAuthStore()
+  const { isAuthenticated } = useAuthStore()
 
   /*
    * `isAuthenticated` is restored from localStorage, so on a fresh page load
@@ -52,15 +52,25 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
    * Rendering on that alone is what made an expired session look like a
    * working application: the full shell appeared, then every request 401'd.
    *
-   * `sessionReady` is the difference between restored and *validated*. It is
-   * set only when tokens arrive from Cognito (see authStore.setTokens) and
-   * cleared on logout, so it is false exactly once per page load — one
-   * refresh, not one per navigation.
+   * `sessionReady` is the difference between restored and *validated*: set only
+   * when tokens arrive from Cognito (see authStore.setTokens) and cleared on
+   * logout, so it is false exactly once per page load.
+   *
+   * 🔑 This is deliberately a ONE-SHOT snapshot in local state, NOT a value
+   * derived from the store on every render. Deriving it looks tidier and is
+   * broken: a failing refresh clears auth state internally, which would flip
+   * the derived condition to false, tear down the effect below mid-flight, and
+   * cancel both the retry and the redirect that carries the reason — leaving
+   * the user on the bare login form this component is trying to avoid. The
+   * validation outcome must not be cancellable by the thing it is validating.
    */
-  const needsValidation = isAuthenticated && !sessionReady && authService.isConfigured()
+  const [validating, setValidating] = useState(() => {
+    const { isAuthenticated: restored, sessionReady } = useAuthStore.getState()
+    return restored && !sessionReady && authService.isConfigured()
+  })
 
   useEffect(() => {
-    if (!needsValidation) return
+    if (!validating) return
 
     /*
      * Stops OUR follow-up work after unmount — it cannot cancel the refresh
@@ -91,7 +101,10 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
     }
 
     const validate = async () => {
-      if (await attemptRefresh()) return
+      if (await attemptRefresh()) {
+        if (run.live) setValidating(false)
+        return
+      }
 
       /*
        * `refreshSession` rejects — and signs out — for a transport failure just
@@ -101,12 +114,20 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
        */
       await new Promise((resolve) => setTimeout(resolve, BOOT_REFRESH_RETRY_MS))
       if (!run.live) return
-      if (await attemptRefresh()) return
+
+      if (await attemptRefresh()) {
+        if (run.live) setValidating(false)
+        return
+      }
 
       /*
        * End it with the REASON, rather than falling through to the bare
        * `<Navigate to="/login">` below. This is the path an idle deployment
        * actually takes, so it is the one that most needs the explanation.
+       *
+       * No `setValidating(false)` here on purpose: this navigates the document,
+       * and staying on the loader until it does is what stops a flash of the
+       * unexplained login form.
        */
       if (run.live) endExpiredSession()
     }
@@ -114,7 +135,7 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
     void validate()
 
     return () => { run.live = false }
-  }, [needsValidation])
+  }, [validating])
 
   // If Cognito is not configured, only allow access in development mode
   if (!authService.isConfigured()) {
@@ -125,9 +146,14 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
     return <Navigate to="/login" state={{ from: location.pathname }} replace />
   }
 
-  // Hold the shell back until the restored session is confirmed. On failure
-  // the effect above clears auth state, which falls through to the redirect.
-  if (needsValidation) {
+  /*
+   * Hold the shell back until the restored session is confirmed. Gated on the
+   * local snapshot, not on auth state: a failing refresh clears auth state
+   * before this component decides anything, and rendering the redirect on that
+   * would show the unexplained login form a moment before the redirect that
+   * explains it.
+   */
+  if (validating) {
     return <PageLoader />
   }
 

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -5,13 +5,16 @@
  * - Production: Requires Cognito authentication; redirects to /login if not authenticated
  * - Development: Allows unauthenticated access when Cognito is not configured (for local dev)
  * - Fails closed in production - if Cognito isn't configured, access is denied
+ * - Revalidates a restored session before rendering anything behind it
  * 
  * @module components/ProtectedRoute
  */
 
+import { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../../store/authStore'
 import { authService } from '../../services/auth'
+import PageLoader from '../PageLoader'
 
 interface ProtectedRouteProps {
   /** Child components to render if authenticated */
@@ -33,7 +36,46 @@ interface ProtectedRouteProps {
  */
 export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProps>) {
   const location = useLocation()
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, sessionReady } = useAuthStore()
+
+  /*
+   * `isAuthenticated` is restored from localStorage, so on a fresh page load
+   * it says "signed in" whether or not the token behind it is still alive.
+   * Rendering on that alone is what made an expired session look like a
+   * working application: the full shell appeared, then every request 401'd.
+   *
+   * `sessionReady` is the difference between restored and *validated*. It is
+   * set only when tokens arrive from Cognito (see authStore.setTokens) and
+   * cleared on logout, so it is false exactly once per page load — one
+   * refresh, not one per navigation.
+   */
+  const needsValidation = isAuthenticated && !sessionReady && authService.isConfigured()
+
+  useEffect(() => {
+    if (!needsValidation) return
+
+    /*
+     * Guards a late rejection: if the user has already left for /login and
+     * started signing in, a refresh failure landing afterwards must not sign
+     * out the session they just created. (Object rather than `let` — the
+     * codebase's local-mutable idiom.)
+     */
+    const run = { live: true }
+
+    void authService.refreshSession().catch(() => {
+      /*
+       * refreshSession clears auth state itself for the failures it can
+       * attribute (no current user, refresh rejected). A ConfigError leaves
+       * it intact, which would strand this component on its loader forever —
+       * so fail closed here rather than trusting that.
+       */
+      if (run.live && useAuthStore.getState().isAuthenticated) {
+        authService.signOut()
+      }
+    })
+
+    return () => { run.live = false }
+  }, [needsValidation])
 
   // If Cognito is not configured, only allow access in development mode
   if (!authService.isConfigured()) {
@@ -42,6 +84,12 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
     }
     // In production, fail closed - require auth configuration
     return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  }
+
+  // Hold the shell back until the restored session is confirmed. On failure
+  // the effect above clears auth state, which falls through to the redirect.
+  if (needsValidation) {
+    return <PageLoader />
   }
 
   // If not authenticated, redirect to login

--- a/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/voc-datalake/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -14,7 +14,15 @@ import { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../../store/authStore'
 import { authService } from '../../services/auth'
+import { endExpiredSession } from '../../services/sessionExpiry'
 import PageLoader from '../PageLoader'
+
+/**
+ * Pause before the single boot-validation retry. Long enough for a brief
+ * connectivity gap to clear, short enough to stay inside the loading state a
+ * user already accepts.
+ */
+const BOOT_REFRESH_RETRY_MS = 300
 
 interface ProtectedRouteProps {
   /** Child components to render if authenticated */
@@ -55,24 +63,55 @@ export default function ProtectedRoute({ children }: Readonly<ProtectedRouteProp
     if (!needsValidation) return
 
     /*
-     * Guards a late rejection: if the user has already left for /login and
-     * started signing in, a refresh failure landing afterwards must not sign
-     * out the session they just created. (Object rather than `let` — the
-     * codebase's local-mutable idiom.)
+     * Stops OUR follow-up work after unmount — it cannot cancel the refresh
+     * itself, and `refreshSession` clears auth state internally for the
+     * failures it can attribute, so that part happens either way. What this
+     * prevents is a late failure redirecting a user who has already reached
+     * /login and signed in again.
+     *
+     * Object rather than `let` because `no-restricted-syntax` bans `let`.
      */
     const run = { live: true }
 
-    void authService.refreshSession().catch(() => {
-      /*
-       * refreshSession clears auth state itself for the failures it can
-       * attribute (no current user, refresh rejected). A ConfigError leaves
-       * it intact, which would strand this component on its loader forever —
-       * so fail closed here rather than trusting that.
-       */
-      if (run.live && useAuthStore.getState().isAuthenticated) {
-        authService.signOut()
+    /**
+     * @returns whether the session came back validated
+     */
+    const attemptRefresh = async (): Promise<boolean> => {
+      try {
+        await authService.refreshSession()
+      } catch {
+        return false
       }
-    })
+      /*
+       * A post-condition, not trust: only `setTokens` releases the gate, so a
+       * resolve that somehow produced no tokens would leave this component on
+       * its loader forever — the failure this gate exists to avoid.
+       */
+      return useAuthStore.getState().sessionReady
+    }
+
+    const validate = async () => {
+      if (await attemptRefresh()) return
+
+      /*
+       * `refreshSession` rejects — and signs out — for a transport failure just
+       * as it does for a genuinely dead session, and this now runs on every
+       * page load. One retry keeps a moment of bad connectivity from becoming
+       * a forced logout; a real expiry just costs one extra round-trip.
+       */
+      await new Promise((resolve) => setTimeout(resolve, BOOT_REFRESH_RETRY_MS))
+      if (!run.live) return
+      if (await attemptRefresh()) return
+
+      /*
+       * End it with the REASON, rather than falling through to the bare
+       * `<Navigate to="/login">` below. This is the path an idle deployment
+       * actually takes, so it is the one that most needs the explanation.
+       */
+      if (run.live) endExpiredSession()
+    }
+
+    void validate()
 
     return () => { run.live = false }
   }, [needsValidation])

--- a/voc-datalake/frontend/src/pages/Login/Login.test.tsx
+++ b/voc-datalake/frontend/src/pages/Login/Login.test.tsx
@@ -25,12 +25,17 @@ vi.mock('../../services/auth', () => ({
 
 // Mock react-router-dom
 const mockNavigate = vi.fn()
+// Mutable so a test can arrive here the way an expired session does.
+let mockLocation: { state?: unknown; search: string } = {
+  state: { from: '/dashboard' },
+  search: '',
+}
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-    useLocation: () => ({ state: { from: '/dashboard' } }),
+    useLocation: () => mockLocation,
   }
 })
 
@@ -52,6 +57,44 @@ function createWrapper() {
 describe('Login', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLocation = { state: { from: '/dashboard' }, search: '' }
+  })
+
+  /*
+   * Landing here because a session died is not the same as landing here to
+   * sign in. Without the notice, an app that was working a moment ago simply
+   * becomes a login form with no explanation.
+   */
+  describe('expired-session notice', () => {
+    it('explains itself when redirected by an expired session', () => {
+      mockLocation = { search: '?expired=1' }
+
+      render(<Login />, { wrapper: createWrapper() })
+
+      expect(screen.getByText(/session expired/i)).toBeInTheDocument()
+    })
+
+    it('says nothing on an ordinary visit', () => {
+      render(<Login />, { wrapper: createWrapper() })
+
+      expect(screen.queryByText(/session expired/i)).not.toBeInTheDocument()
+    })
+
+    it('yields to a real submit error', async () => {
+      mockLocation = { search: '?expired=1' }
+      mockSignIn.mockRejectedValue(new Error('Incorrect username or password'))
+      const user = userEvent.setup()
+
+      render(<Login />, { wrapper: createWrapper() })
+      await user.type(screen.getByPlaceholderText(/Enter your username/i), 'testuser')
+      await user.type(screen.getByPlaceholderText(/Enter your password/i), 'wrong')
+      await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/incorrect username or password/i)).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/session expired/i)).not.toBeInTheDocument()
+    })
   })
 
   describe('initial render', () => {

--- a/voc-datalake/frontend/src/pages/Login/Login.tsx
+++ b/voc-datalake/frontend/src/pages/Login/Login.tsx
@@ -20,6 +20,7 @@ import {
   useNavigate, useLocation,
 } from 'react-router-dom'
 import { authService } from '../../services/auth'
+import { isSessionExpiredRedirect } from '../../services/sessionExpiry'
 import {
   LoginForm,
   NewPasswordForm,
@@ -189,6 +190,17 @@ export default function Login() {
   const [message, setMessage] = useState<string | null>(null)
   const [cognitoUser, setCognitoUser] = useState<CognitoUser | null>(null)
 
+  /*
+   * Arriving here because a session died is not the same as arriving here to
+   * sign in, and the user is owed the difference — otherwise an app that was
+   * working a moment ago just becomes a login form. Derived per render rather
+   * than seeded into state so it survives translations loading late, and a
+   * real submit error (wrong password) takes precedence over it.
+   */
+  const expiredNotice = isSessionExpiredRedirect(location.search)
+    ? t('errors.sessionExpired')
+    : null
+
   const handleLogin = async (e: SyntheticEvent) => {
     e.preventDefault()
     setError(null)
@@ -321,7 +333,7 @@ export default function Login() {
             verificationCode={verificationCode}
             showPassword={showPassword}
             isLoading={isLoading}
-            error={error}
+            error={error ?? expiredNotice}
             message={message}
             onUsernameChange={setUsername}
             onPasswordChange={setPassword}

--- a/voc-datalake/frontend/src/pages/Login/LoginSharedComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Login/LoginSharedComponents.tsx
@@ -13,10 +13,16 @@ interface ErrorAlertProps { readonly message: string }
 
 export function ErrorAlert({ message }: Readonly<ErrorAlertProps>) {
   return (
-    // role="alert" so the message is announced when it appears. It carried no
-    // role at all, which meant a screen-reader user got a red box they were
-    // never told about — including the session-expired notice, which is
-    // present on first render.
+    /*
+     * This carried no role at all, so a screen-reader user got a red box they
+     * were never told about. `role="alert"` fixes that for errors that APPEAR
+     * — a failed sign-in, a password mismatch — which is nearly all of them.
+     *
+     * It does not help a message already present at mount (the session-expired
+     * notice): a live region has to exist before its content is inserted to be
+     * announced. Making that case announce needs focus management, which is a
+     * bigger change than this component.
+     */
     <div
       role="alert"
       className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-3 rounded-lg"

--- a/voc-datalake/frontend/src/pages/Login/LoginSharedComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Login/LoginSharedComponents.tsx
@@ -13,7 +13,14 @@ interface ErrorAlertProps { readonly message: string }
 
 export function ErrorAlert({ message }: Readonly<ErrorAlertProps>) {
   return (
-    <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-3 rounded-lg">
+    // role="alert" so the message is announced when it appears. It carried no
+    // role at all, which meant a screen-reader user got a red box they were
+    // never told about — including the session-expired notice, which is
+    // present on first render.
+    <div
+      role="alert"
+      className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-3 rounded-lg"
+    >
       <AlertCircle size={16} />
       {message}
     </div>

--- a/voc-datalake/frontend/src/services/auth.test.ts
+++ b/voc-datalake/frontend/src/services/auth.test.ts
@@ -48,7 +48,6 @@ vi.mock('../runtimeConfig', () => ({
 // Mock authStore
 const mockSetUser = vi.fn()
 const mockSetTokens = vi.fn()
-const mockSetSessionReady = vi.fn()
 const mockLogout = vi.fn()
 
 vi.mock('../store/authStore', () => ({
@@ -56,7 +55,6 @@ vi.mock('../store/authStore', () => ({
     getState: () => ({
       setUser: mockSetUser,
       setTokens: mockSetTokens,
-      setSessionReady: mockSetSessionReady,
       logout: mockLogout,
       refreshToken: 'mock-refresh-token',
     }),

--- a/voc-datalake/frontend/src/services/auth.ts
+++ b/voc-datalake/frontend/src/services/auth.ts
@@ -180,7 +180,6 @@ export const authService = {
             refreshToken,
           })
           useAuthStore.getState().setUser(user)
-          useAuthStore.getState().setSessionReady(true)
 
           // Sync session with Amplify for IAM signing
           void authService.syncAmplifySession()

--- a/voc-datalake/frontend/src/services/sessionExpiry.test.ts
+++ b/voc-datalake/frontend/src/services/sessionExpiry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Tests for the shared session-expiry seam.
+ *
+ * The point of these is the *reason*: signing out was never the missing
+ * behaviour, telling the user why was.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('./auth', () => ({
+  authService: { signOut: vi.fn() },
+}))
+
+import { authService } from './auth'
+import { endExpiredSession, isSessionExpiredRedirect, SESSION_EXPIRED_PATH } from './sessionExpiry'
+
+describe('sessionExpiry', () => {
+  const originalLocation = window.location
+  const replace = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'location', {
+      value: { replace },
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    })
+  })
+
+  describe('endExpiredSession', () => {
+    it('clears auth state before navigating', () => {
+      endExpiredSession()
+
+      // eslint-disable-next-line vitest/prefer-called-with
+      expect(authService.signOut).toHaveBeenCalled()
+      expect(replace).toHaveBeenCalledWith(SESSION_EXPIRED_PATH)
+    })
+
+  })
+
+  describe('isSessionExpiredRedirect', () => {
+    it('recognizes the path endExpiredSession navigates to', () => {
+      const search = SESSION_EXPIRED_PATH.slice(SESSION_EXPIRED_PATH.indexOf('?'))
+
+      expect(isSessionExpiredRedirect(search)).toBe(true)
+    })
+
+    it('is false for a plain visit to the login page', () => {
+      expect(isSessionExpiredRedirect('')).toBe(false)
+      expect(isSessionExpiredRedirect('?next=/dashboard')).toBe(false)
+    })
+
+    it('is false for a flag that is present but not set', () => {
+      expect(isSessionExpiredRedirect('?expired=0')).toBe(false)
+      expect(isSessionExpiredRedirect('?expired')).toBe(false)
+    })
+  })
+})

--- a/voc-datalake/frontend/src/services/sessionExpiry.test.ts
+++ b/voc-datalake/frontend/src/services/sessionExpiry.test.ts
@@ -11,7 +11,12 @@ vi.mock('./auth', () => ({
 }))
 
 import { authService } from './auth'
-import { endExpiredSession, isSessionExpiredRedirect, SESSION_EXPIRED_PATH } from './sessionExpiry'
+import {
+  endExpiredSession,
+  isSessionExpiredRedirect,
+  resetSessionExpiryForTests,
+  SESSION_EXPIRED_PATH,
+} from './sessionExpiry'
 
 describe('sessionExpiry', () => {
   const originalLocation = window.location
@@ -19,6 +24,10 @@ describe('sessionExpiry', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // The redirect is idempotent by design, and production resets it with a
+    // full document load. Without this reset here, the first case to end a
+    // session would silently disarm every later one.
+    resetSessionExpiryForTests()
     Object.defineProperty(window, 'location', {
       value: { replace },
       writable: true,
@@ -36,11 +45,20 @@ describe('sessionExpiry', () => {
     it('clears auth state before navigating', () => {
       endExpiredSession()
 
-      // eslint-disable-next-line vitest/prefer-called-with
-      expect(authService.signOut).toHaveBeenCalled()
+      expect(authService.signOut).toHaveBeenCalledWith()
       expect(replace).toHaveBeenCalledWith(SESSION_EXPIRED_PATH)
     })
 
+    it('navigates once however many callers discover the dead session', () => {
+      // Concurrent requests 401 together, and all three callers share this
+      // seam, so this is the normal case rather than an edge one.
+      endExpiredSession()
+      endExpiredSession()
+      endExpiredSession()
+
+      expect(replace).toHaveBeenCalledTimes(1)
+      expect(authService.signOut).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('isSessionExpiredRedirect', () => {

--- a/voc-datalake/frontend/src/services/sessionExpiry.ts
+++ b/voc-datalake/frontend/src/services/sessionExpiry.ts
@@ -52,8 +52,9 @@ export function endExpiredSession(): void {
 }
 
 /**
- * Test seam — forget that a redirect happened. `__`-prefixed so a call site in
- * production code is obviously wrong.
+ * Test seam — forget that a redirect happened. The `ForTests` suffix is the
+ * signal; a `__` prefix would read louder but is rejected by this repo's
+ * `@typescript-eslint/naming-convention`.
  *
  * Production never needs it: the redirect is a full document load, which resets
  * the module. A test environment has no such reset, so **any test that

--- a/voc-datalake/frontend/src/services/sessionExpiry.ts
+++ b/voc-datalake/frontend/src/services/sessionExpiry.ts
@@ -25,15 +25,41 @@ const EXPIRED_FLAG = 'expired'
 export const SESSION_EXPIRED_PATH = `/login?${EXPIRED_FLAG}=1`
 
 /**
+ * Whether a redirect is already under way.
+ *
+ * Concurrent requests 401 together, so all three callers can reach this within
+ * the same tick. `location.replace` does not stop JavaScript from running, so
+ * without this the second and third calls issue redundant navigations while
+ * the first is still resolving. Module-level rather than per-call because the
+ * callers are independent and never see each other.
+ */
+const ending = { inProgress: false }
+
+/**
  * Clear auth state and send the user to `/login` with an explanation.
  *
  * `replace` rather than `assign`: the page we are leaving can no longer load
  * its data, so leaving it in the back history invites the user straight back
  * into the state this function exists to end.
+ *
+ * Idempotent — safe to call from every path that discovers the dead session.
  */
 export function endExpiredSession(): void {
+  if (ending.inProgress) return
+  ending.inProgress = true
   authService.signOut()
   window.location.replace(SESSION_EXPIRED_PATH)
+}
+
+/**
+ * Test seam: forget that a redirect happened.
+ *
+ * Production never needs this — the redirect is a full document load, which
+ * resets the module. A test environment has no such reset, so without it the
+ * first case to end a session would silently disarm every later one.
+ */
+export function resetSessionExpiryForTests(): void {
+  ending.inProgress = false
 }
 
 /**

--- a/voc-datalake/frontend/src/services/sessionExpiry.ts
+++ b/voc-datalake/frontend/src/services/sessionExpiry.ts
@@ -52,11 +52,13 @@ export function endExpiredSession(): void {
 }
 
 /**
- * Test seam: forget that a redirect happened.
+ * Test seam — forget that a redirect happened. `__`-prefixed so a call site in
+ * production code is obviously wrong.
  *
- * Production never needs this — the redirect is a full document load, which
- * resets the module. A test environment has no such reset, so without it the
- * first case to end a session would silently disarm every later one.
+ * Production never needs it: the redirect is a full document load, which resets
+ * the module. A test environment has no such reset, so **any test that
+ * exercises an expiry path must call this first** — forgetting it does not fail
+ * loudly, it silently disarms the redirect the test is asserting.
  */
 export function resetSessionExpiryForTests(): void {
   ending.inProgress = false

--- a/voc-datalake/frontend/src/services/sessionExpiry.ts
+++ b/voc-datalake/frontend/src/services/sessionExpiry.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview What happens when a session ends unexpectedly, in one place.
+ *
+ * Before this module the three callers agreed on nothing: `fetchApi` signed
+ * out and hard-navigated to `/login` with no reason attached, `streamChat`
+ * threw an inline "session expired" string and left the app rendering as if
+ * signed in, and nothing revalidated a persisted session on boot. The
+ * user-visible result was an expired token rendering a working, logged-in
+ * application (round-2 UI review, U3).
+ *
+ * The reason rides in the URL rather than in storage deliberately. The
+ * redirect is a full document load — the only reliable way to drop every
+ * in-memory cache and in-flight request at once — so an in-memory signal
+ * would not survive it, and `sessionStorage` is unavailable in some privacy
+ * modes. A spoofed flag only shows a message, so it needs no integrity.
+ *
+ * @module services/sessionExpiry
+ */
+import { authService } from './auth'
+
+/** Query flag appended to `/login` when a session ended unexpectedly. */
+const EXPIRED_FLAG = 'expired'
+
+/** Where an expired session lands, reason included. */
+export const SESSION_EXPIRED_PATH = `/login?${EXPIRED_FLAG}=1`
+
+/**
+ * Clear auth state and send the user to `/login` with an explanation.
+ *
+ * `replace` rather than `assign`: the page we are leaving can no longer load
+ * its data, so leaving it in the back history invites the user straight back
+ * into the state this function exists to end.
+ */
+export function endExpiredSession(): void {
+  authService.signOut()
+  window.location.replace(SESSION_EXPIRED_PATH)
+}
+
+/**
+ * Whether this `/login` visit was caused by an expired session.
+ *
+ * Reads the flag without consuming it, so the notice survives re-renders
+ * (typing in the form) and disappears only on navigation away.
+ *
+ * @param search - `location.search`, including the leading `?`
+ */
+export function isSessionExpiredRedirect(search: string): boolean {
+  return new URLSearchParams(search).get(EXPIRED_FLAG) === '1'
+}

--- a/voc-datalake/frontend/src/store/authStore.test.ts
+++ b/voc-datalake/frontend/src/store/authStore.test.ts
@@ -3,8 +3,15 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
+import { z } from 'zod'
 import { useAuthStore, useIsAdmin } from './authStore'
 import { getRuntimeConfig, isConfigLoaded } from '../runtimeConfig'
+
+/** Validates the persisted envelope at the boundary instead of asserting a type. */
+const PersistedAuthSchema = z.object({
+  state: z.record(z.string(), z.unknown()),
+  version: z.number().optional(),
+})
 
 // useIsAdmin reads the runtime config directly (services/auth imports this
 // store, so importing authService here would be a cycle) — mock the module
@@ -141,6 +148,44 @@ describe('authStore', () => {
       logout()
 
       expect(useAuthStore.getState().sessionReady).toBe(false)
+    })
+  })
+
+  /*
+   * The boot-validation gate in ProtectedRoute depends on `sessionReady` being
+   * ABSENT from the persisted payload: it must come back false on every page
+   * load, while `isAuthenticated` comes back true. Persist it and the gate is
+   * inert — `needsValidation` would always be false, the app would render on a
+   * restored-but-unvalidated session again, and every other test here would
+   * still pass, because they run against a fresh in-memory store.
+   *
+   * Asserting the whole key set rather than just the one omission, so adding
+   * any future field to the store forces a decision about persisting it.
+   */
+  describe('persisted shape', () => {
+    it('persists identity but not the validated flag', () => {
+      const { setUser, setTokens } = useAuthStore.getState()
+      setUser({ username: 'test', email: 'test@example.com', groups: [] })
+      setTokens({ accessToken: 'access', idToken: 'id', refreshToken: 'refresh' })
+
+      /*
+       * The suite's localStorage is a spy that stores nothing (see
+       * test/setup.ts), so read what persist WROTE rather than trying to read
+       * it back — which also inspects the payload more directly.
+       */
+      const writes = vi.mocked(localStorage.setItem).mock.calls
+        .filter(([key]) => key === 'voc-auth')
+      expect(writes.length).toBeGreaterThan(0)
+      const raw = writes[writes.length - 1][1]
+      const persisted: unknown = JSON.parse(raw)
+      const shape = PersistedAuthSchema.parse(persisted)
+
+      expect(Object.keys(shape.state).toSorted()).toEqual([
+        'accessToken', 'idToken', 'isAuthenticated', 'user',
+      ])
+      // The refresh token is memory-only by design; see the store's docblock.
+      expect(shape.state).not.toHaveProperty('refreshToken')
+      expect(shape.state).not.toHaveProperty('sessionReady')
     })
   })
 

--- a/voc-datalake/frontend/src/store/authStore.test.ts
+++ b/voc-datalake/frontend/src/store/authStore.test.ts
@@ -77,6 +77,26 @@ describe('authStore', () => {
       expect(state.refreshToken).toBe('refresh-token-789')
       expect(state.isAuthenticated).toBe(true)
     })
+
+    /*
+     * Tokens only arrive from Cognito, so this is the one moment a session
+     * goes from "restored from localStorage" to "validated" — and the only
+     * thing that releases ProtectedRoute's validation gate. Drop it and a
+     * *successful* refresh leaves the app on its loader forever, which is a
+     * worse failure than the expired-session bug this replaced.
+     */
+    it('marks the session validated, releasing the boot-validation gate', () => {
+      const { setTokens } = useAuthStore.getState()
+      expect(useAuthStore.getState().sessionReady).toBe(false)
+
+      setTokens({
+        accessToken: 'access',
+        idToken: 'id',
+        refreshToken: 'refresh',
+      })
+
+      expect(useAuthStore.getState().sessionReady).toBe(true)
+    })
   })
 
   describe('logout', () => {
@@ -112,6 +132,15 @@ describe('authStore', () => {
       const state = useAuthStore.getState()
       expect(state.isAuthenticated).toBe(false)
       expect(state.error).toBeNull()
+    })
+
+    it('un-validates the session so the next page load revalidates', () => {
+      const { setTokens, logout } = useAuthStore.getState()
+
+      setTokens({ accessToken: 'access', idToken: 'id', refreshToken: 'refresh' })
+      logout()
+
+      expect(useAuthStore.getState().sessionReady).toBe(false)
     })
   })
 

--- a/voc-datalake/frontend/src/store/authStore.ts
+++ b/voc-datalake/frontend/src/store/authStore.ts
@@ -59,8 +59,6 @@ interface AuthState {
     idToken: string;
     refreshToken: string
   }) => void
-  /** Mark session as validated and ready for API calls */
-  setSessionReady: (ready: boolean) => void
   /** Set loading state */
   setLoading: (loading: boolean) => void
   /** Set error message */
@@ -89,8 +87,14 @@ export const useAuthStore = create<AuthState>()(
         idToken: tokens.idToken,
         refreshToken: tokens.refreshToken,
         isAuthenticated: true,
+        // Tokens only ever arrive from Cognito — sign-in, the new-password
+        // challenge, or a refresh — so this is the one moment a session
+        // becomes *validated*, as opposed to merely restored from
+        // localStorage. Setting it here rather than at each call site means a
+        // future fourth caller cannot forget it and strand ProtectedRoute on
+        // its loading state.
+        sessionReady: true,
       }),
-      setSessionReady: (sessionReady) => set({ sessionReady }),
       setLoading: (isLoading) => set({ isLoading }),
       setError: (error) => set({ error }),
       logout: () => set({


### PR DESCRIPTION
## Summary

When the Cognito token expires, the app keeps rendering as if the user were signed in: full sidebar,
user identity chip, populated urgent badge, partially-filled pages. Every request 401s silently. The
natural reading is "the product is broken", not "I need to sign in again" — which is the state any
deployment left idle over a break or between demo sessions puts the next visitor in.

This is **U3** from the round-2 UI review, and it completes that review's Tier 2 alongside U12
(#281, #282, #284, #285).

## Correcting the premise before the fix

The analysis note that motivated this said "there is no global 401 handler". **That is wrong, and was
wrong when it was written.** `fetchApi` in `src/api/client.ts` already did 401 → `refreshSession()` →
retry → on failure `signOut()` + redirect, covered by `client.test.ts`. The symptom is real; the cause
was four narrower gaps.

| # | Gap | Evidence before this PR |
|---|---|---|
| 1 | **Nothing revalidated a restored session** | `authStore`'s `partialize` persists `isAuthenticated` to localStorage and no code path checked the token behind it on load; `App.tsx` gates rendering on runtime-config load only. So the authenticated shell rendered first and discovered the dead session one 401 at a time. |
| 2 | **No reason reached `/login`** | `window.location.href = '/login'` is a full document load carrying no router state and no parameter, so the login page could not distinguish a session that just died from an ordinary visit. The user met a bare form. |
| 3 | **Cached authenticated data outlived sign-out** | `Layout`'s logout is an in-app navigation, so the `QueryClient` survives it — and `queryClient.clear()` / `removeQueries` had **zero call sites** in the repo. The next person to sign in on that browser saw the previous session's data while their own loaded. |
| 4 | **The stream path bypassed all of it** | `streamClient.ts` threw an inline `'Session expired - please sign in again'` on 401 with no refresh attempt and no sign-out — the one surface that produced a message *and* left the app rendering as if signed in. |

Gap 1 is the root cause of the reported symptom. "`ProtectedRoute` gates on presence, not validity" is
that same gap restated: it reads a persisted boolean.

## What changed

**One new seam, `src/services/sessionExpiry.ts`**, so the three callers can no longer disagree:

- `endExpiredSession()` — clears auth state, then `window.location.replace('/login?expired=1')`.
  `replace`, not `assign`: the page being left can no longer load its data, so leaving it in the back
  history invites the user straight back into the state this function exists to end.
- `isSessionExpiredRedirect(search)` — read by `Login`.

The reason rides in the **URL rather than storage**, deliberately. The redirect is a full document load
(the only reliable way to drop every in-memory cache and in-flight request at once), so an in-memory
signal would not survive it, and `sessionStorage` is unavailable in some privacy modes. A spoofed flag
only shows a message, so it needs no integrity.

**`setTokens` now owns `sessionReady`, and `setSessionReady` is deleted.** The store already declared
`sessionReady` ("whether the session has been validated/refreshed after page load") — but
`setSessionReady` had zero non-test callers and *nothing read the flag*. Tokens only ever arrive from
Cognito (sign-in, the new-password challenge, or a refresh), so that is the one moment a session becomes
*validated* as opposed to *restored*. Setting it there rather than at each call site means a future
fourth caller cannot forget it; deleting the setter removes the ability to mark a session validated
without validating it.

**`ProtectedRoute` holds the shell back for one refresh per page load** — it renders neither content nor
a redirect while validating. It **fails closed** if `refreshSession` rejects without clearing auth state
itself: that method clears state for the failures it can attribute (no current user, refresh rejected),
but a `ConfigError` leaves it intact, which would otherwise strand the component on its loader forever.
The catch also carries a liveness flag, so a late rejection landing after the user has reached `/login`
and signed in cannot wipe the session they just created.

**`Login` explains itself** using `login:errors.sessionExpired`, derived per render rather than seeded
into state so it survives translations loading late, and so a real submit error takes precedence over it.

**`Layout` clears the query cache on sign-out.** The expired path does a full document load and drops
the cache implicitly; the in-app path has to be explicit.

**The stream path gets the same treatment as `fetchApi`**: one silent refresh, one retry carrying the
new token, and `endExpiredSession()` if that does not produce a working session. `403` is deliberately
left alone — that is authorization, not an expired token, and WAF and IAM produce it too, so signing the
user out would be the wrong response.

## No new locale keys

`login:errors.sessionExpired` already existed, genuinely translated, in **all 8** catalogues (it was
used by the new-password flow). Verified by reading all eight, not just `en` — a `defaultValue` is not a
translation.

## Behaviour changes worth a reviewer's attention

- An authenticated-but-unvalidated state now renders a loader instead of the app. That is the point of
  the change, and it correctly broke the old `renders children when user is authenticated` test, which
  is updated to supply `sessionReady`.
- Boot adds one Cognito refresh round-trip before the shell appears. This extends the existing
  `PageLoader` window (`App` already blocks on runtime config) rather than introducing a new one.
- Mock-only local dev is unaffected: `authService.isConfigured()` is false there, so `needsValidation`
  is false and the documented DEV bypass still renders children.

## Verification

- `eslint src --max-warnings 0` — clean.
- `tsc --noEmit -p tsconfig.app.json` — clean.
- **1,868 frontend tests across 119 files** pass.
- New coverage: `services/sessionExpiry.test.ts`, and **`api/streamClient.test.ts` — the stream auth
  path had no test coverage at all before this**. Extended `ProtectedRoute.test.tsx`, `Login.test.tsx`,
  `Layout.test.tsx`, `client.test.ts`, `authStore.test.ts`.
- The `authStore` case is the load-bearing one: revert `setTokens`'s `sessionReady` line and a
  *successful* refresh leaves `ProtectedRoute` on its loader forever — a worse failure than the bug
  being fixed. That had no test before.
- `Layout`'s test asserts the outcome (seed the cache, sign out, the entry is gone) rather than that
  `clear()` was called.

**Not verified:** the expired-session path is reproduced from mocked 401s, not from a real lapsed
Cognito token. Deployment and live-browser results are posted as a comment on this PR.

Backend, CDK and stream-Lambda code are untouched; every changed file is under `voc-datalake/frontend/src`.
