### PR TITLE
fix(ui): count Problem Analysis over the window, not its first page

### DIFF
--- a/voc-datalake/frontend/public/locales/de/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/de/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "Kategorien",
     "feedback": "Rückmeldungen",
-    "loadingWindow": "Feedback wird geladen… bisher {{loaded}} von {{total}}.",
-    "partialWindow": "Die Zahlen umfassen {{loaded}} von {{total}} Einträgen in diesem Zeitraum.",
+    "loadFailed": "Feedback für diesen Zeitraum konnte nicht geladen werden, daher werden keine Zahlen angezeigt. Erneut versuchen oder den Zeitraum eingrenzen.",
+    "loadingWindow": "Feedback wird geladen… bisher {{loaded, number}} von {{total, number}}.",
+    "partialWindow": "Die Zahlen umfassen {{loaded, number}} von {{total, number}} Einträgen in diesem Zeitraum.",
     "problems": "Probleme",
     "subcategories": "Unterkategorien",
     "urgent": "Dringend"

--- a/voc-datalake/frontend/public/locales/de/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/de/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "Feedback wird geladen… bisher {{loaded, number}} von {{total, number}}.",
     "partialWindow": "Die Zahlen umfassen {{loaded, number}} von {{total, number}} Einträgen in diesem Zeitraum.",
     "problems": "Probleme",
+    "retry": "Erneut versuchen",
     "subcategories": "Unterkategorien",
     "urgent": "Dringend"
   },

--- a/voc-datalake/frontend/public/locales/de/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/de/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "Kategorien",
     "feedback": "Rückmeldungen",
+    "loadingWindow": "Feedback wird geladen… bisher {{loaded}} von {{total}}.",
+    "partialWindow": "Die Zahlen umfassen {{loaded}} von {{total}} Einträgen in diesem Zeitraum.",
     "problems": "Probleme",
     "subcategories": "Unterkategorien",
     "urgent": "Dringend"

--- a/voc-datalake/frontend/public/locales/en/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/en/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "Categories",
     "feedback": "Feedback",
+    "loadingWindow": "Loading feedback… {{loaded}} of {{total}} so far.",
+    "partialWindow": "Counts cover {{loaded}} of {{total}} items in this window.",
     "problems": "Problems",
     "subcategories": "Subcategories",
     "urgent": "Urgent"

--- a/voc-datalake/frontend/public/locales/en/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/en/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "Categories",
     "feedback": "Feedback",
-    "loadingWindow": "Loading feedback… {{loaded}} of {{total}} so far.",
-    "partialWindow": "Counts cover {{loaded}} of {{total}} items in this window.",
+    "loadFailed": "Could not load feedback for this window, so no counts are shown. Retry, or narrow the time range.",
+    "loadingWindow": "Loading feedback… {{loaded, number}} of {{total, number}} so far.",
+    "partialWindow": "Counts cover {{loaded, number}} of {{total, number}} items in this window.",
     "problems": "Problems",
     "subcategories": "Subcategories",
     "urgent": "Urgent"

--- a/voc-datalake/frontend/public/locales/en/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/en/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "Loading feedback… {{loaded, number}} of {{total, number}} so far.",
     "partialWindow": "Counts cover {{loaded, number}} of {{total, number}} items in this window.",
     "problems": "Problems",
+    "retry": "Retry",
     "subcategories": "Subcategories",
     "urgent": "Urgent"
   },

--- a/voc-datalake/frontend/public/locales/es/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/es/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "Categorías",
     "feedback": "Comentarios",
+    "loadingWindow": "Cargando comentarios… {{loaded}} de {{total}} hasta ahora.",
+    "partialWindow": "Los recuentos abarcan {{loaded}} de {{total}} elementos de este periodo.",
     "problems": "Problemas",
     "subcategories": "Subcategorías",
     "urgent": "Urgente"

--- a/voc-datalake/frontend/public/locales/es/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/es/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "Cargando comentarios… {{loaded, number}} de {{total, number}} hasta ahora.",
     "partialWindow": "Los recuentos abarcan {{loaded, number}} de {{total, number}} elementos de este periodo.",
     "problems": "Problemas",
+    "retry": "Reintentar",
     "subcategories": "Subcategorías",
     "urgent": "Urgente"
   },

--- a/voc-datalake/frontend/public/locales/es/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/es/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "Categorías",
     "feedback": "Comentarios",
-    "loadingWindow": "Cargando comentarios… {{loaded}} de {{total}} hasta ahora.",
-    "partialWindow": "Los recuentos abarcan {{loaded}} de {{total}} elementos de este periodo.",
+    "loadFailed": "No se pudieron cargar los comentarios de este periodo, por lo que no se muestran recuentos. Vuelve a intentarlo o reduce el intervalo de tiempo.",
+    "loadingWindow": "Cargando comentarios… {{loaded, number}} de {{total, number}} hasta ahora.",
+    "partialWindow": "Los recuentos abarcan {{loaded, number}} de {{total, number}} elementos de este periodo.",
     "problems": "Problemas",
     "subcategories": "Subcategorías",
     "urgent": "Urgente"

--- a/voc-datalake/frontend/public/locales/fr/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/fr/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "Chargement des retours… {{loaded, number}} sur {{total, number}} pour l’instant.",
     "partialWindow": "Les décomptes couvrent {{loaded, number}} éléments sur {{total, number}} dans cette période.",
     "problems": "Problèmes",
+    "retry": "Réessayer",
     "subcategories": "Sous-catégories",
     "urgent": "Prioritaire"
   },

--- a/voc-datalake/frontend/public/locales/fr/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/fr/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "Catégories",
     "feedback": "Retours",
+    "loadingWindow": "Chargement des retours… {{loaded}} sur {{total}} pour l’instant.",
+    "partialWindow": "Les décomptes couvrent {{loaded}} éléments sur {{total}} dans cette période.",
     "problems": "Problèmes",
     "subcategories": "Sous-catégories",
     "urgent": "Prioritaire"

--- a/voc-datalake/frontend/public/locales/fr/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/fr/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "Catégories",
     "feedback": "Retours",
-    "loadingWindow": "Chargement des retours… {{loaded}} sur {{total}} pour l’instant.",
-    "partialWindow": "Les décomptes couvrent {{loaded}} éléments sur {{total}} dans cette période.",
+    "loadFailed": "Impossible de charger les retours pour cette période, aucun décompte n’est affiché. Réessayez ou réduisez la plage de dates.",
+    "loadingWindow": "Chargement des retours… {{loaded, number}} sur {{total, number}} pour l’instant.",
+    "partialWindow": "Les décomptes couvrent {{loaded, number}} éléments sur {{total, number}} dans cette période.",
     "problems": "Problèmes",
     "subcategories": "Sous-catégories",
     "urgent": "Prioritaire"

--- a/voc-datalake/frontend/public/locales/ja/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/ja/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "カテゴリ",
     "feedback": "フィードバック",
-    "loadingWindow": "フィードバックを読み込み中… 現在 {{total}} 件中 {{loaded}} 件。",
-    "partialWindow": "件数はこの期間の {{total}} 件中 {{loaded}} 件を対象としています。",
+    "loadFailed": "この期間のフィードバックを読み込めなかったため、件数は表示されません。再試行するか、期間を狭めてください。",
+    "loadingWindow": "フィードバックを読み込み中… 現在 {{total, number}} 件中 {{loaded, number}} 件。",
+    "partialWindow": "件数はこの期間の {{total, number}} 件中 {{loaded, number}} 件を対象としています。",
     "problems": "問題",
     "subcategories": "サブカテゴリ",
     "urgent": "緊急"

--- a/voc-datalake/frontend/public/locales/ja/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/ja/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "フィードバックを読み込み中… 現在 {{total, number}} 件中 {{loaded, number}} 件。",
     "partialWindow": "件数はこの期間の {{total, number}} 件中 {{loaded, number}} 件を対象としています。",
     "problems": "問題",
+    "retry": "再試行",
     "subcategories": "サブカテゴリ",
     "urgent": "緊急"
   },

--- a/voc-datalake/frontend/public/locales/ja/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/ja/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "カテゴリ",
     "feedback": "フィードバック",
+    "loadingWindow": "フィードバックを読み込み中… 現在 {{total}} 件中 {{loaded}} 件。",
+    "partialWindow": "件数はこの期間の {{total}} 件中 {{loaded}} 件を対象としています。",
     "problems": "問題",
     "subcategories": "サブカテゴリ",
     "urgent": "緊急"

--- a/voc-datalake/frontend/public/locales/ko/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/ko/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "카테고리",
     "feedback": "피드백",
+    "loadingWindow": "피드백 불러오는 중… 현재 {{total}}개 중 {{loaded}}개.",
+    "partialWindow": "집계는 이 기간의 {{total}}개 중 {{loaded}}개를 대상으로 합니다.",
     "problems": "문제",
     "subcategories": "하위 카테고리",
     "urgent": "긴급"

--- a/voc-datalake/frontend/public/locales/ko/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/ko/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "카테고리",
     "feedback": "피드백",
-    "loadingWindow": "피드백 불러오는 중… 현재 {{total}}개 중 {{loaded}}개.",
-    "partialWindow": "집계는 이 기간의 {{total}}개 중 {{loaded}}개를 대상으로 합니다.",
+    "loadFailed": "이 기간의 피드백을 불러올 수 없어 집계를 표시하지 않습니다. 다시 시도하거나 기간을 좁혀 주세요.",
+    "loadingWindow": "피드백 불러오는 중… 현재 {{total, number}}개 중 {{loaded, number}}개.",
+    "partialWindow": "집계는 이 기간의 {{total, number}}개 중 {{loaded, number}}개를 대상으로 합니다.",
     "problems": "문제",
     "subcategories": "하위 카테고리",
     "urgent": "긴급"

--- a/voc-datalake/frontend/public/locales/ko/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/ko/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "피드백 불러오는 중… 현재 {{total, number}}개 중 {{loaded, number}}개.",
     "partialWindow": "집계는 이 기간의 {{total, number}}개 중 {{loaded, number}}개를 대상으로 합니다.",
     "problems": "문제",
+    "retry": "다시 시도",
     "subcategories": "하위 카테고리",
     "urgent": "긴급"
   },

--- a/voc-datalake/frontend/public/locales/pt/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/pt/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "Categorias",
     "feedback": "Comentários",
-    "loadingWindow": "Carregando feedback… {{loaded}} de {{total}} até agora.",
-    "partialWindow": "As contagens cobrem {{loaded}} de {{total}} itens neste período.",
+    "loadFailed": "Não foi possível carregar o feedback deste período, portanto nenhuma contagem é exibida. Tente novamente ou reduza o intervalo de tempo.",
+    "loadingWindow": "Carregando feedback… {{loaded, number}} de {{total, number}} até agora.",
+    "partialWindow": "As contagens cobrem {{loaded, number}} de {{total, number}} itens neste período.",
     "problems": "Problemas",
     "subcategories": "Subcategorias",
     "urgent": "Urgente"

--- a/voc-datalake/frontend/public/locales/pt/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/pt/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "Categorias",
     "feedback": "Comentários",
+    "loadingWindow": "Carregando feedback… {{loaded}} de {{total}} até agora.",
+    "partialWindow": "As contagens cobrem {{loaded}} de {{total}} itens neste período.",
     "problems": "Problemas",
     "subcategories": "Subcategorias",
     "urgent": "Urgente"

--- a/voc-datalake/frontend/public/locales/pt/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/pt/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "Carregando feedback… {{loaded, number}} de {{total, number}} até agora.",
     "partialWindow": "As contagens cobrem {{loaded, number}} de {{total, number}} itens neste período.",
     "problems": "Problemas",
+    "retry": "Tentar novamente",
     "subcategories": "Subcategorias",
     "urgent": "Urgente"
   },

--- a/voc-datalake/frontend/public/locales/zh/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/zh/problemAnalysis.json
@@ -27,6 +27,7 @@
     "loadingWindow": "正在加载反馈… 目前 {{total, number}} 条中的 {{loaded, number}} 条。",
     "partialWindow": "统计覆盖此时间范围内 {{total, number}} 条中的 {{loaded, number}} 条。",
     "problems": "问题",
+    "retry": "重试",
     "subcategories": "子分类",
     "urgent": "紧急"
   },

--- a/voc-datalake/frontend/public/locales/zh/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/zh/problemAnalysis.json
@@ -23,8 +23,9 @@
   "stats": {
     "categories": "分类",
     "feedback": "反馈",
-    "loadingWindow": "正在加载反馈… 目前 {{total}} 条中的 {{loaded}} 条。",
-    "partialWindow": "统计覆盖此时间范围内 {{total}} 条中的 {{loaded}} 条。",
+    "loadFailed": "无法加载此时间范围的反馈，因此不显示统计数据。请重试或缩小时间范围。",
+    "loadingWindow": "正在加载反馈… 目前 {{total, number}} 条中的 {{loaded, number}} 条。",
+    "partialWindow": "统计覆盖此时间范围内 {{total, number}} 条中的 {{loaded, number}} 条。",
     "problems": "问题",
     "subcategories": "子分类",
     "urgent": "紧急"

--- a/voc-datalake/frontend/public/locales/zh/problemAnalysis.json
+++ b/voc-datalake/frontend/public/locales/zh/problemAnalysis.json
@@ -23,6 +23,8 @@
   "stats": {
     "categories": "分类",
     "feedback": "反馈",
+    "loadingWindow": "正在加载反馈… 目前 {{total}} 条中的 {{loaded}} 条。",
+    "partialWindow": "统计覆盖此时间范围内 {{total}} 条中的 {{loaded}} 条。",
     "problems": "问题",
     "subcategories": "子分类",
     "urgent": "紧急"

--- a/voc-datalake/frontend/src/api/feedbackPagination.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackPagination.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Tests for shared /feedback offset pagination (U5b).
+ */
+import { FEEDBACK_PAGE_LIMIT, nextPageOffset } from './feedbackPagination'
+
+describe('FEEDBACK_PAGE_LIMIT', () => {
+  // Pins the client page size to the server's `max_val`. /feedback clamps a
+  // larger `limit` silently, so a bump here without a matching bump in
+  // `validate_limit` would reintroduce U5b: rows requested, never delivered,
+  // nothing reported.
+  it('equals the /feedback endpoint maximum of 100', () => {
+    expect(FEEDBACK_PAGE_LIMIT).toBe(100)
+  })
+})
+
+describe('nextPageOffset', () => {
+  it('returns the next offset while rows in the window remain unread', () => {
+    expect(nextPageOffset({ count: 100, offset: 0, total: 250 })).toBe(100)
+    expect(nextPageOffset({ count: 100, offset: 100, total: 250 })).toBe(200)
+  })
+
+  it('returns undefined once the loaded rows cover the total', () => {
+    expect(nextPageOffset({ count: 50, offset: 200, total: 250 })).toBeUndefined()
+  })
+
+  it('treats a full page as the last one when it completes the total', () => {
+    // The `count < limit` heuristic would wrongly keep going here: the page is
+    // full, and it is also the end of the window.
+    expect(nextPageOffset({ count: 100, offset: 0, total: 100 })).toBeUndefined()
+  })
+
+  it('keeps paging after a short page that does not reach the total', () => {
+    // The mirror of the case above: short does not mean last.
+    expect(nextPageOffset({ count: 40, offset: 0, total: 250 })).toBe(40)
+  })
+
+  it('returns undefined for an empty page even when the total claims more', () => {
+    // Anti-spin guard: a server reporting `total > loaded` while returning no
+    // rows must not keep the caller asking forever.
+    expect(nextPageOffset({ count: 0, offset: 100, total: 500 })).toBeUndefined()
+  })
+
+  it('falls back to the item count when the response omits count', () => {
+    expect(nextPageOffset({ offset: 0, total: 10, items: [{}, {}] })).toBe(2)
+  })
+
+  it('treats a missing total as the end of the window', () => {
+    // No total means nothing says more exists; stopping beats guessing.
+    expect(nextPageOffset({ count: 100, offset: 0 })).toBeUndefined()
+  })
+})

--- a/voc-datalake/frontend/src/api/feedbackPagination.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackPagination.test.ts
@@ -13,39 +13,67 @@ describe('FEEDBACK_PAGE_LIMIT', () => {
   })
 })
 
+/** A page of `size` rows reporting `total` as the window size. */
+const page = (size: number, total?: number) => ({ count: size, total })
+
 describe('nextPageOffset', () => {
   it('returns the next offset while rows in the window remain unread', () => {
-    expect(nextPageOffset({ count: 100, offset: 0, total: 250 })).toBe(100)
-    expect(nextPageOffset({ count: 100, offset: 100, total: 250 })).toBe(200)
+    const first = page(100, 250)
+    expect(nextPageOffset(first, [first])).toBe(100)
+
+    const second = page(100, 250)
+    expect(nextPageOffset(second, [first, second])).toBe(200)
   })
 
   it('returns undefined once the loaded rows cover the total', () => {
-    expect(nextPageOffset({ count: 50, offset: 200, total: 250 })).toBeUndefined()
+    const pages = [page(100, 250), page(100, 250), page(50, 250)]
+    expect(nextPageOffset(pages[2], pages)).toBeUndefined()
   })
 
   it('treats a full page as the last one when it completes the total', () => {
     // The `count < limit` heuristic would wrongly keep going here: the page is
     // full, and it is also the end of the window.
-    expect(nextPageOffset({ count: 100, offset: 0, total: 100 })).toBeUndefined()
+    const only = page(100, 100)
+    expect(nextPageOffset(only, [only])).toBeUndefined()
   })
 
   it('keeps paging after a short page that does not reach the total', () => {
     // The mirror of the case above: short does not mean last.
-    expect(nextPageOffset({ count: 40, offset: 0, total: 250 })).toBe(40)
+    const only = page(40, 250)
+    expect(nextPageOffset(only, [only])).toBe(40)
   })
 
   it('returns undefined for an empty page even when the total claims more', () => {
     // Anti-spin guard: a server reporting `total > loaded` while returning no
     // rows must not keep the caller asking forever.
-    expect(nextPageOffset({ count: 0, offset: 100, total: 500 })).toBeUndefined()
+    const pages = [page(100, 500), page(0, 500)]
+    expect(nextPageOffset(pages[1], pages)).toBeUndefined()
   })
 
   it('falls back to the item count when the response omits count', () => {
-    expect(nextPageOffset({ offset: 0, total: 10, items: [{}, {}] })).toBe(2)
+    const only = { total: 10, items: [{}, {}] }
+    expect(nextPageOffset(only, [only])).toBe(2)
   })
 
   it('treats a missing total as the end of the window', () => {
     // No total means nothing says more exists; stopping beats guessing.
-    expect(nextPageOffset({ count: 100, offset: 0 })).toBeUndefined()
+    const only = page(100)
+    expect(nextPageOffset(only, [only])).toBeUndefined()
+  })
+
+  it('advances on rows actually held, not on an offset echoed by the server', () => {
+    // Regression guard: deriving `loaded` from a response's echoed `offset`
+    // means a response that omits it pins the cursor to one page length and
+    // hands back the same offset forever — an endless walk over duplicate rows.
+    const pages = [page(100, 500), page(100, 500), page(100, 500)]
+    expect(nextPageOffset(pages[0], pages.slice(0, 1))).toBe(100)
+    expect(nextPageOffset(pages[1], pages.slice(0, 2))).toBe(200)
+    expect(nextPageOffset(pages[2], pages)).toBe(300)
+  })
+
+  it('ignores a wrong offset echo entirely', () => {
+    // Even a server echoing a nonsense offset cannot misdirect the cursor.
+    const first = { count: 100, total: 250, offset: 9999 }
+    expect(nextPageOffset(first, [first])).toBe(100)
   })
 })

--- a/voc-datalake/frontend/src/api/feedbackPagination.ts
+++ b/voc-datalake/frontend/src/api/feedbackPagination.ts
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Shared offset pagination for the `/feedback` list endpoint.
+ *
+ * `/feedback` bounds `limit` server-side with
+ * `validate_limit(..., default=50, max_val=100)`, and `validate_int` **clamps
+ * rather than rejecting** — an over-sized `limit` comes back silently reduced,
+ * with only the echoed `limit` in the response to give it away. That is exactly
+ * how Problem Analysis ended up computing a whole problem hierarchy from 100
+ * rows while asking for 500 (U5b).
+ *
+ * So the page size lives here as one exported constant: callers spend
+ * `FEEDBACK_PAGE_LIMIT` instead of a literal, and getting more than one page
+ * is a pagination question, never a bigger-`limit` question.
+ *
+ * @module api/feedbackPagination
+ */
+
+import type { FeedbackItem } from './client'
+
+/**
+ * Page size for `/feedback`, equal to the endpoint's `max_val`.
+ *
+ * Do not raise this to fetch more rows — the server clamps it back to 100 and
+ * says nothing. Fetch another page with `nextPageOffset` instead.
+ */
+export const FEEDBACK_PAGE_LIMIT = 100
+
+/**
+ * The cursor fields {@link nextPageOffset} reads.
+ *
+ * Deliberately not coupled to `FeedbackItem`: advancing a cursor depends on
+ * *how many* rows came back, never on what is in them.
+ *
+ * - `count` is this page's length (0..limit), **not** a window total.
+ * - `total` is the filtered candidate-window size.
+ */
+export interface FeedbackPageCursor {
+  count?: number
+  items?: readonly unknown[]
+  total?: number
+  offset?: number
+}
+
+/**
+ * A `/feedback` response page.
+ *
+ * `is_partial_window` means the server truncated the candidate window, so even
+ * `total` is a lower bound and any count derived from it undercounts.
+ */
+export interface FeedbackPage extends FeedbackPageCursor {
+  items?: FeedbackItem[]
+  is_partial_window?: boolean
+}
+
+/**
+ * Offset of the next `/feedback` page, or `undefined` once the loaded rows
+ * cover the (windowed) total.
+ *
+ * `loaded < total` is the correct signal, **not** `count < limit`: a full page
+ * can still be the last one, and a short page can precede more. Without a
+ * post-query filter the server sizes its candidate window from `offset+limit`,
+ * so `total` is a lower bound that grows as pages are read — this still
+ * converges, because the bound stops growing once it exceeds the real total.
+ *
+ * Guards against a zero-length page so a server that reports
+ * `total > loaded` while returning nothing cannot spin the caller forever.
+ */
+export function nextPageOffset(lastPage: FeedbackPageCursor): number | undefined {
+  const pageSize = lastPage.count ?? lastPage.items?.length ?? 0
+  const loaded = (lastPage.offset ?? 0) + pageSize
+  const total = lastPage.total ?? loaded
+  return pageSize > 0 && loaded < total ? loaded : undefined
+}

--- a/voc-datalake/frontend/src/api/feedbackPagination.ts
+++ b/voc-datalake/frontend/src/api/feedbackPagination.ts
@@ -18,10 +18,19 @@
 import type { FeedbackItem } from './client'
 
 /**
- * Page size for `/feedback`, equal to the endpoint's `max_val`.
+ * Page size for `/feedback`, equal to the endpoint's server-side maximum.
  *
- * Do not raise this to fetch more rows — the server clamps it back to 100 and
- * says nothing. Fetch another page with `nextPageOffset` instead.
+ * Mirrors `max_val` in `lambda/api/metrics_handler.py` → `list_feedback`:
+ * `validate_limit(params.get('limit'), default=50, max_val=100)`, bounded by
+ * `validate_limit` / `validate_int` in `lambda/shared/api.py`.
+ *
+ * Do not raise this to fetch more rows — the server clamps it back and says
+ * nothing. Fetch another page with {@link nextPageOffset} instead.
+ *
+ * The two sides are kept in step by
+ * `lambda/api/test/test_feedback_page_limit_lockstep.py`, which reads this
+ * constant out of this file, so a `max_val` change fails a test rather than
+ * silently shrinking every paged read.
  */
 export const FEEDBACK_PAGE_LIMIT = 100
 
@@ -38,7 +47,6 @@ export interface FeedbackPageCursor {
   count?: number
   items?: readonly unknown[]
   total?: number
-  offset?: number
 }
 
 /**
@@ -52,6 +60,11 @@ export interface FeedbackPage extends FeedbackPageCursor {
   is_partial_window?: boolean
 }
 
+/** Rows in one page, however the response chose to report them. */
+function pageLength(page: FeedbackPageCursor): number {
+  return page.count ?? page.items?.length ?? 0
+}
+
 /**
  * Offset of the next `/feedback` page, or `undefined` once the loaded rows
  * cover the (windowed) total.
@@ -62,12 +75,21 @@ export interface FeedbackPage extends FeedbackPageCursor {
  * so `total` is a lower bound that grows as pages are read — this still
  * converges, because the bound stops growing once it exceeds the real total.
  *
- * Guards against a zero-length page so a server that reports
- * `total > loaded` while returning nothing cannot spin the caller forever.
+ * `loaded` is summed from the pages actually held, **not** taken from the
+ * response's echoed `offset`. Trusting the echo means a response that omits it
+ * collapses `loaded` to one page length and hands back the same offset forever
+ * — an endless walk over duplicate rows, capped only by the caller's own page
+ * budget, and not capped at all where paging is user-driven.
+ *
+ * Also refuses a zero-length page, so a server reporting `total > loaded` while
+ * returning nothing cannot spin the caller.
  */
-export function nextPageOffset(lastPage: FeedbackPageCursor): number | undefined {
-  const pageSize = lastPage.count ?? lastPage.items?.length ?? 0
-  const loaded = (lastPage.offset ?? 0) + pageSize
+export function nextPageOffset(
+  lastPage: FeedbackPageCursor,
+  allPages: readonly FeedbackPageCursor[]
+): number | undefined {
+  if (pageLength(lastPage) === 0) return undefined
+  const loaded = allPages.reduce((sum, page) => sum + pageLength(page), 0)
   const total = lastPage.total ?? loaded
-  return pageSize > 0 && loaded < total ? loaded : undefined
+  return loaded < total ? loaded : undefined
 }

--- a/voc-datalake/frontend/src/api/feedbackPagination.ts
+++ b/voc-datalake/frontend/src/api/feedbackPagination.ts
@@ -83,6 +83,11 @@ function pageLength(page: FeedbackPageCursor): number {
  *
  * Also refuses a zero-length page, so a server reporting `total > loaded` while
  * returning nothing cannot spin the caller.
+ *
+ * ⚠️ Because `loaded` is the sum over `allPages`, this is **incompatible with
+ * TanStack's `maxPages`**: evicting a page shrinks that sum, rewinding the
+ * offset and re-fetching rows already seen, indefinitely. Keep every page, or
+ * track the offset outside the cache.
  */
 export function nextPageOffset(
   lastPage: FeedbackPageCursor,

--- a/voc-datalake/frontend/src/pages/Categories/useFeedbackListData.ts
+++ b/voc-datalake/frontend/src/pages/Categories/useFeedbackListData.ts
@@ -23,19 +23,12 @@ import { useMemo } from 'react'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { api } from '../../api/client'
 import type { DateRangeParams, FeedbackItem } from '../../api/client'
+import { FEEDBACK_PAGE_LIMIT, nextPageOffset } from '../../api/feedbackPagination'
+import type { FeedbackPage } from '../../api/feedbackPagination'
 import { matchesRatingFilter } from './types'
 import type { CategoryFiltersState } from './useCategoryFilters'
 
-const PAGE_LIMIT = 100
 export const SEARCH_MIN_CHARS = 2
-
-interface FeedbackResponse {
-  items?: FeedbackItem[]
-  count?: number
-  total?: number
-  offset?: number
-  is_partial_window?: boolean
-}
 
 export interface FeedbackListData {
   filteredFeedback: FeedbackItem[]
@@ -55,7 +48,7 @@ export interface FeedbackListData {
 function buildCommonParams(dateParams: DateRangeParams, filters: CategoryFiltersState) {
   return {
     ...dateParams,
-    limit: PAGE_LIMIT,
+    limit: FEEDBACK_PAGE_LIMIT,
     source: filters.selectedSource ?? undefined,
     sentiment: filters.sentimentFilter !== 'all' ? filters.sentimentFilter : undefined,
     // The list endpoints accept a single category; multi-select is refined client-side.
@@ -87,7 +80,7 @@ function computeEnabledQueries(
  * `total` (candidate window size) is preferred; `count` (page size) is the
  * fallback for endpoints that don't paginate (search/urgent).
  */
-function extractTotals(data: FeedbackResponse | undefined): { totalCount: number; isPartialWindow: boolean } {
+function extractTotals(data: FeedbackPage | undefined): { totalCount: number; isPartialWindow: boolean } {
   return {
     totalCount: data?.total ?? data?.count ?? 0,
     isPartialWindow: data?.is_partial_window ?? false,
@@ -141,18 +134,6 @@ export function useFeedbackListData(
   }
 }
 
-/**
- * Offset of the next `/feedback` page, or undefined when the loaded rows
- * cover the (windowed) total. `total` is the filtered candidate-window size,
- * so `loaded < total` is the correct hasMore signal (not `count < limit`).
- */
-function nextPageOffset(lastPage: FeedbackResponse): number | undefined {
-  const pageSize = lastPage.count ?? lastPage.items?.length ?? 0
-  const loaded = (lastPage.offset ?? 0) + pageSize
-  const total = lastPage.total ?? loaded
-  return pageSize > 0 && loaded < total ? loaded : undefined
-}
-
 /** The list source normalized so the hook body treats all three endpoints alike. */
 interface ActiveFeedbackSource {
   items: FeedbackItem[]
@@ -165,13 +146,13 @@ interface ActiveFeedbackSource {
 }
 
 interface SimpleQuery {
-  data: FeedbackResponse | undefined
+  data: FeedbackPage | undefined
   isLoading: boolean
 }
 
 /** Structural subset of UseInfiniteQueryResult — keeps the generics out of the hook. */
 interface InfiniteListQuery {
-  data: { pages: FeedbackResponse[] } | undefined
+  data: { pages: FeedbackPage[] } | undefined
   isLoading: boolean
   hasNextPage: boolean
   isFetchingNextPage: boolean

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -453,6 +453,7 @@ export default function ProblemAnalysis() {
           hasFailed
           loadedCount={0}
           totalCount={0}
+          onRetry={feedback.retry}
         />
       </div>
     )

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -442,6 +442,22 @@ export default function ProblemAnalysis() {
     )
   }
 
+  // Nothing was read, so every aggregate below would be a zero that looks like
+  // a finding. Say the window is unknown instead of implying it is empty.
+  if (feedback.isError && feedback.items.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <WindowCoverageNotice
+          isLoadingMore={false}
+          isPartial={false}
+          hasFailed
+          loadedCount={0}
+          totalCount={0}
+        />
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-4 sm:space-y-6">
       {/* Header Stats */}
@@ -488,6 +504,7 @@ export default function ProblemAnalysis() {
       <WindowCoverageNotice
         isLoadingMore={feedback.isLoadingMore}
         isPartial={feedback.isPartial}
+        hasFailed={feedback.isError}
         loadedCount={feedback.loadedCount}
         totalCount={feedback.totalCount}
       />

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/ProblemAnalysis.tsx
@@ -23,6 +23,8 @@ import type { FeedbackItem } from '../../api/client'
 import { SubcategoryRow } from './SubcategoryRow'
 import { applyResolution } from './problemResolution'
 import { useProblemResolution } from './useProblemResolution'
+import { useProblemFeedback } from './useProblemFeedback'
+import { WindowCoverageNotice } from './WindowCoverageNotice'
 import type { CategoryGroup, ProblemGroup, SubcategoryGroup } from './problemResolution'
 import { generateProblemAnalysisPDF } from './problemAnalysisPdfGenerator'
 import { getTimeRangeLabel } from '../../utils/dateUtils'
@@ -278,11 +280,10 @@ export default function ProblemAnalysis() {
     enabled: !!config.apiEndpoint,
   })
 
-  const { data: feedbackData, isLoading } = useQuery({
-    queryKey: ['feedback-problems', dateParams],
-    queryFn: () => api.getFeedback({ ...dateParams, limit: 500 }),
-    enabled: !!config.apiEndpoint,
-  })
+  // Pages the whole window rather than asking for one oversized page: the
+  // stat cards and the tree are aggregates, and `/feedback` silently clamps
+  // `limit` to 100 (U5b). `isPartial` reports a window read only in part.
+  const feedback = useProblemFeedback(dateParams, config.apiEndpoint)
 
   // Resolved problems are shared across users (issue #66); resolving one
   // clears it from everyone's default view. All query/mutation wiring lives
@@ -301,11 +302,9 @@ export default function ProblemAnalysis() {
 
   // Group feedback by category → subcategory → problem (with similarity) → items
   const groupedData = useMemo(() => {
-    if (!feedbackData?.items) return []
-
     const categoryMap = new Map<string, Map<string, Map<string, ProblemGroup>>>()
 
-    const filteredItems = feedbackData.items
+    const filteredItems = feedback.items
       .filter(item => item.problem_summary)
       .filter(item => !showUrgentOnly || item.urgency === 'high')
       .filter(item => !selectedCategory || item.category === selectedCategory)
@@ -323,7 +322,7 @@ export default function ProblemAnalysis() {
     }
 
     return buildCategoryGroups(categoryMap)
-  }, [feedbackData, showUrgentOnly, selectedCategory, selectedSubcategory, selectedSource, similarityThreshold])
+  }, [feedback.items, showUrgentOnly, selectedCategory, selectedSubcategory, selectedSource, similarityThreshold])
 
   // Annotate problem groups with their shared resolved status and hide the
   // resolved ones unless requested; category/subcategory totals are
@@ -343,13 +342,12 @@ export default function ProblemAnalysis() {
 
   // Get unique subcategories from current data
   const allSubcategories = useMemo(() => {
-    if (!feedbackData?.items) return []
     const subcats = new Set<string>()
-    for (const item of feedbackData.items) {
+    for (const item of feedback.items) {
       if (item.subcategory) subcats.add(item.subcategory)
     }
     return Array.from(subcats).sort((a, b) => a.localeCompare(b))
-  }, [feedbackData])
+  }, [feedback.items])
 
   const toggleCategory = (category: string) => {
     setExpandedCategories(prev => {
@@ -436,7 +434,7 @@ export default function ProblemAnalysis() {
 
   // Gate on the resolved-state query too: without it, resolved problems
   // flash as unresolved for a frame and then vanish when the query lands.
-  if (isLoading || resolvedLoading) {
+  if (feedback.isLoading || resolvedLoading) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
@@ -484,6 +482,15 @@ export default function ProblemAnalysis() {
           <p className="text-xl sm:text-2xl font-bold text-red-700">{totalUrgent}</p>
         </div>
       </div>
+
+      {/* Coverage of the counts above; self-hiding when the window was read in
+          full. Rationale lives in the component. */}
+      <WindowCoverageNotice
+        isLoadingMore={feedback.isLoadingMore}
+        isPartial={feedback.isPartial}
+        loadedCount={feedback.loadedCount}
+        totalCount={feedback.totalCount}
+      />
 
       {/* Filters & Controls */}
       <div className="card">

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Tests for WindowCoverageNotice (U5b).
+ *
+ * Asserts the real English strings rather than key names — the test setup loads
+ * the actual `problemAnalysis` catalogue, so a key that goes missing or stops
+ * resolving fails here instead of rendering a raw key into the UI.
+ */
+import { render, screen } from '@testing-library/react'
+
+import { WindowCoverageNotice } from './WindowCoverageNotice'
+
+const complete = {
+  isLoadingMore: false,
+  isPartial: false,
+  loadedCount: 40,
+  totalCount: 40,
+}
+
+describe('WindowCoverageNotice', () => {
+  it('renders nothing when the window was read in full', () => {
+    const { container } = render(<WindowCoverageNotice {...complete} />)
+    // A complete count needs no caveat, and an always-present line would train
+    // people to ignore it.
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('reports progress while further pages are loading', () => {
+    render(<WindowCoverageNotice {...complete} isLoadingMore loadedCount={200} totalCount={615} />)
+
+    expect(screen.getByText('Loading feedback… 200 of 615 so far.')).toBeInTheDocument()
+  })
+
+  it('says the counts undercount when the walk stopped short', () => {
+    render(<WindowCoverageNotice {...complete} isPartial loadedCount={2000} totalCount={5000} />)
+
+    expect(
+      screen.getByText('Counts cover 2000 of 5000 items in this window.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows progress rather than the partial caveat while still loading', () => {
+    // Both can be true at once; "still arriving" is the more useful reading,
+    // because the partial verdict is not final until the walk stops.
+    render(<WindowCoverageNotice {...complete} isLoadingMore isPartial loadedCount={100} totalCount={900} />)
+
+    expect(screen.getByText('Loading feedback… 100 of 900 so far.')).toBeInTheDocument()
+    expect(screen.queryByText(/Counts cover/)).not.toBeInTheDocument()
+  })
+
+  it('announces itself to assistive technology as a status', () => {
+    render(<WindowCoverageNotice {...complete} isPartial loadedCount={100} totalCount={900} />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.test.tsx
@@ -12,6 +12,7 @@ import { WindowCoverageNotice } from './WindowCoverageNotice'
 const complete = {
   isLoadingMore: false,
   isPartial: false,
+  hasFailed: false,
   loadedCount: 40,
   totalCount: 40,
 }
@@ -33,8 +34,9 @@ describe('WindowCoverageNotice', () => {
   it('says the counts undercount when the walk stopped short', () => {
     render(<WindowCoverageNotice {...complete} isPartial loadedCount={2000} totalCount={5000} />)
 
+    // Thousands separators come from the locale, via `{{loaded, number}}`.
     expect(
-      screen.getByText('Counts cover 2000 of 5000 items in this window.')
+      screen.getByText('Counts cover 2,000 of 5,000 items in this window.')
     ).toBeInTheDocument()
   })
 
@@ -47,9 +49,48 @@ describe('WindowCoverageNotice', () => {
     expect(screen.queryByText(/Counts cover/)).not.toBeInTheDocument()
   })
 
-  it('announces itself to assistive technology as a status', () => {
+  it('announces the terminal partial state to assistive technology', () => {
     render(<WindowCoverageNotice {...complete} isPartial loadedCount={100} totalCount={900} />)
 
     expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('does not announce progress, which would fire once per page of the walk', () => {
+    // A full walk settles a dozen times; a live region would talk over
+    // everything else on the page. Only terminal states are announced.
+    render(<WindowCoverageNotice {...complete} isLoadingMore loadedCount={200} totalCount={615} />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText(/Loading feedback/)).toBeInTheDocument()
+  })
+
+  describe('when nothing could be read', () => {
+    it('reports the failure instead of implying the window is empty', () => {
+      render(<WindowCoverageNotice {...complete} hasFailed loadedCount={0} totalCount={0} />)
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not load feedback for this window')
+    })
+
+    it('prefers the failure message over any coverage message', () => {
+      // Failure outranks the rest: a partial count nobody can trust is worse
+      // than saying the window is unknown.
+      render(
+        <WindowCoverageNotice {...complete} hasFailed isPartial isLoadingMore loadedCount={0} totalCount={0} />
+      )
+
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByText(/Loading feedback/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Counts cover/)).not.toBeInTheDocument()
+    })
+
+    it('keeps the partial caveat when a failure still left some rows loaded', () => {
+      // Some rows did arrive, so the counts are usable-but-short rather than
+      // unknown — that is the partial case, not the failure case.
+      render(<WindowCoverageNotice {...complete} hasFailed isPartial loadedCount={100} totalCount={900} />)
+
+      expect(screen.getByText('Counts cover 100 of 900 items in this window.')).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
   })
 })

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.test.tsx
@@ -6,6 +6,7 @@
  * resolving fails here instead of rendering a raw key into the UI.
  */
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { WindowCoverageNotice } from './WindowCoverageNotice'
 
@@ -70,6 +71,25 @@ describe('WindowCoverageNotice', () => {
       render(<WindowCoverageNotice {...complete} hasFailed loadedCount={0} totalCount={0} />)
 
       expect(screen.getByRole('alert')).toHaveTextContent('Could not load feedback for this window')
+    })
+
+    it('offers the retry it tells the user to perform', async () => {
+      // The message says "Retry, or narrow the time range" — the time range
+      // lives in the app header, but retry has to come from here or the
+      // instruction points at nothing.
+      const onRetry = vi.fn()
+      const user = userEvent.setup()
+      render(<WindowCoverageNotice {...complete} hasFailed loadedCount={0} totalCount={0} onRetry={onRetry} />)
+
+      await user.click(screen.getByRole('button', { name: 'Retry' }))
+      expect(onRetry).toHaveBeenCalledOnce()
+    })
+
+    it('omits the retry control when no handler is supplied', () => {
+      render(<WindowCoverageNotice {...complete} hasFailed loadedCount={0} totalCount={0} />)
+
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
 
     it('prefers the failure message over any coverage message', () => {

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Coverage caveat for the Problem Analysis stat row.
+ *
+ * Renders nothing when the window was read in full — a complete count needs no
+ * caveat. While pages are still arriving it reports progress; when the walk
+ * stopped short it says the counts undercount (U5b).
+ *
+ * Its own file for a mechanical reason worth knowing: `scripts/i18n-check.mjs`
+ * derives **one** namespace per file from the *first* translation-hook call it
+ * finds (`content.match`, not `matchAll`), and its regex reads comments too —
+ * so this docblock deliberately avoids spelling such a call out. Because
+ * `ProblemAnalysis.tsx` opens with the `common` namespace, a `problemAnalysis`
+ * key used there is invisible to the gate no matter what the local variable is
+ * named. Keeping this notice in a file whose only namespace is
+ * `problemAnalysis` keeps its keys checkable.
+ *
+ * @module pages/ProblemAnalysis/WindowCoverageNotice
+ */
+
+import { useTranslation } from 'react-i18next'
+
+interface WindowCoverageNoticeProps {
+  /** A later page is in flight; the counts are still climbing. */
+  readonly isLoadingMore: boolean
+  /** Rows in the window were left unread, so the counts undercount. */
+  readonly isPartial: boolean
+  readonly loadedCount: number
+  readonly totalCount: number
+}
+
+export function WindowCoverageNotice({
+  isLoadingMore,
+  isPartial,
+  loadedCount,
+  totalCount,
+}: WindowCoverageNoticeProps) {
+  const { t } = useTranslation('problemAnalysis')
+
+  if (!isLoadingMore && !isPartial) return null
+
+  const counts = { loaded: loadedCount, total: totalCount }
+  return (
+    // `text-gray-600`, not a lighter grey: this carries information, so it
+    // needs the audited contrast ratio.
+    <p className="text-xs text-gray-600" role="status">
+      {isLoadingMore ? t('stats.loadingWindow', counts) : t('stats.partialWindow', counts)}
+    </p>
+  )
+}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
@@ -24,26 +24,53 @@ interface WindowCoverageNoticeProps {
   readonly isLoadingMore: boolean
   /** Rows in the window were left unread, so the counts undercount. */
   readonly isPartial: boolean
+  /** A request failed. With `loadedCount` 0 this means nothing was read. */
+  readonly hasFailed: boolean
   readonly loadedCount: number
   readonly totalCount: number
 }
 
+/**
+ * Failure outranks everything, and nothing-was-read is a different statement
+ * from some-was-read: zero rows after a failure is not an empty window, it is
+ * an unknown one.
+ */
 export function WindowCoverageNotice({
   isLoadingMore,
   isPartial,
+  hasFailed,
   loadedCount,
   totalCount,
 }: WindowCoverageNoticeProps) {
   const { t } = useTranslation('problemAnalysis')
 
-  if (!isLoadingMore && !isPartial) return null
-
+  // `text-gray-600`, not a lighter grey: these carry information, so they need
+  // the audited contrast ratio.
+  const className = 'text-xs text-gray-600'
   const counts = { loaded: loadedCount, total: totalCount }
-  return (
-    // `text-gray-600`, not a lighter grey: this carries information, so it
-    // needs the audited contrast ratio.
-    <p className="text-xs text-gray-600" role="status">
-      {isLoadingMore ? t('stats.loadingWindow', counts) : t('stats.partialWindow', counts)}
-    </p>
-  )
+
+  if (hasFailed && loadedCount === 0) {
+    return (
+      <p className={className} role="alert">
+        {t('stats.loadFailed')}
+      </p>
+    )
+  }
+
+  // Progress is deliberately NOT a live region: a full walk settles a dozen
+  // times, and announcing each one talks over everything else on the page.
+  // Only the terminal states below are announced.
+  if (isLoadingMore) {
+    return <p className={className}>{t('stats.loadingWindow', counts)}</p>
+  }
+
+  if (isPartial) {
+    return (
+      <p className={className} role="status">
+        {t('stats.partialWindow', counts)}
+      </p>
+    )
+  }
+
+  return null
 }

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
@@ -28,6 +28,12 @@ interface WindowCoverageNoticeProps {
   readonly hasFailed: boolean
   readonly loadedCount: number
   readonly totalCount: number
+  /**
+   * Retries the read. Required whenever `hasFailed` can be true, because the
+   * failure message tells the user to retry — an instruction with no control
+   * behind it is worse than no instruction.
+   */
+  readonly onRetry?: () => void
 }
 
 /**
@@ -41,6 +47,7 @@ export function WindowCoverageNotice({
   hasFailed,
   loadedCount,
   totalCount,
+  onRetry,
 }: WindowCoverageNoticeProps) {
   const { t } = useTranslation('problemAnalysis')
 
@@ -51,9 +58,17 @@ export function WindowCoverageNotice({
 
   if (hasFailed && loadedCount === 0) {
     return (
-      <p className={className} role="alert">
-        {t('stats.loadFailed')}
-      </p>
+      <div role="alert" className="text-center">
+        <p className={className}>{t('stats.loadFailed')}</p>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 text-xs text-blue-600 hover:text-blue-800 underline"
+          >
+            {t('stats.retry')}
+          </button>
+        )}
+      </div>
     )
   }
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/WindowCoverageNotice.tsx
@@ -58,10 +58,16 @@ export function WindowCoverageNotice({
 
   if (hasFailed && loadedCount === 0) {
     return (
-      <div role="alert" className="text-center">
+      // No alignment of its own: the caller centres this in the empty page and
+      // leaves the coverage line under the stat row left-aligned, so imposing
+      // one here would fight one of them.
+      <div role="alert">
         <p className={className}>{t('stats.loadFailed')}</p>
         {onRetry && (
+          // `type="button"` is load-bearing: the default is `submit`, which
+          // would post any form this notice were ever nested in.
           <button
+            type="button"
             onClick={onRetry}
             className="mt-2 text-xs text-blue-600 hover:text-blue-800 underline"
           >

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
@@ -51,18 +51,23 @@ function serveWindow(total: number, opts: { isPartialWindow?: boolean } = {}) {
   })
 }
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  })
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function createWrapper(queryClient: QueryClient) {
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )
 }
 
-function renderFeedback(apiEndpoint = API_ENDPOINT) {
+/**
+ * Pass an explicit `queryClient` to share a cache across two renders — a fresh
+ * client per render cannot observe caching at all.
+ */
+function renderFeedback(apiEndpoint = API_ENDPOINT, queryClient = makeClient()) {
   return renderHook(() => useProblemFeedback(DATE_PARAMS, apiEndpoint), {
-    wrapper: createWrapper(),
+    wrapper: createWrapper(queryClient),
   })
 }
 
@@ -160,20 +165,64 @@ describe('useProblemFeedback', () => {
         .mockResolvedValueOnce({
           count: 100,
           total: 500,
-          offset: 0,
           items: Array.from({ length: 100 }, (_, i) => ({ feedback_id: `f${i}` })),
         })
         .mockRejectedValue(new Error('boom'))
 
       const { result } = renderFeedback()
 
-      await waitFor(() => expect(mockGetFeedback).toHaveBeenCalledTimes(2))
       await waitFor(() => expect(result.current.isPartial).toBe(true))
 
-      const callsAfterFailure = mockGetFeedback.mock.calls.length
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      expect(mockGetFeedback.mock.calls.length).toBe(callsAfterFailure)
+      // Asserting the state that *guarantees* no further advance beats sleeping
+      // and hoping: `isError` is what disarms the auto-advance.
+      expect(result.current.isError).toBe(true)
       expect(result.current.loadedCount).toBe(100)
+      expect(mockGetFeedback).toHaveBeenCalledTimes(2)
+    })
+
+    it('reports an outright failure rather than a complete empty window', async () => {
+      // The gap the first round of tests missed: when the FIRST page rejects
+      // there is no next page, so nothing "stopped early" — yet nothing was
+      // read either. Left unflagged, the page renders zeroed stat cards that
+      // read as a finding. `isError` is what lets the caller tell "empty" from
+      // "unknown".
+      mockGetFeedback.mockRejectedValue(new Error('boom'))
+
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.loadedCount).toBe(0)
+      expect(result.current.items).toEqual([])
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it('leaves isError false on a clean complete read', async () => {
+      serveWindow(40)
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(40))
+      expect(result.current.isError).toBe(false)
+      expect(result.current.isPartial).toBe(false)
+    })
+  })
+
+  describe('request volume', () => {
+    it('holds the loaded window settled instead of re-walking it', async () => {
+      // Each refetch re-issues EVERY page, so the app-wide 30s staleTime plus
+      // refetch-on-focus would replay the whole walk. Pinning both here keeps
+      // that cost from creeping back in.
+      serveWindow(250)
+      const queryClient = makeClient()
+      const { result } = renderFeedback(API_ENDPOINT, queryClient)
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(250))
+      const callsAfterWalk = requests.length
+
+      // A remount against the same cache, inside the staleTime window, must not
+      // re-issue a single page.
+      const remounted = renderFeedback(API_ENDPOINT, queryClient)
+      await waitFor(() => expect(remounted.result.current.loadedCount).toBe(250))
+      expect(requests.length).toBe(callsAfterWalk)
     })
   })
 

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
@@ -204,6 +204,36 @@ describe('useProblemFeedback', () => {
       expect(result.current.isError).toBe(false)
       expect(result.current.isPartial).toBe(false)
     })
+
+    it('recovers on retry after an outright failure', async () => {
+      mockGetFeedback.mockRejectedValueOnce(new Error('boom'))
+      const { result } = renderFeedback()
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      serveWindow(150)
+      result.current.retry()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(150))
+      expect(result.current.isError).toBe(false)
+      expect(result.current.isPartial).toBe(false)
+    })
+
+    it('does not call a completed window partial when a later refetch fails', async () => {
+      // Raised in review: `isError` feeds `stoppedEarly`, so could a failed
+      // background refetch flag an already-complete window as short? It cannot,
+      // because a completed walk leaves `hasNextPage` false and `stoppedEarly`
+      // is gated on it. Pinned so that gate cannot be dropped.
+      serveWindow(150)
+      const { result } = renderFeedback()
+      await waitFor(() => expect(result.current.loadedCount).toBe(150))
+      expect(result.current.isPartial).toBe(false)
+
+      mockGetFeedback.mockRejectedValue(new Error('boom'))
+      result.current.retry()
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.isPartial).toBe(false)
+    })
   })
 
   describe('request volume', () => {

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @fileoverview Tests for useProblemFeedback (U5b).
+ *
+ * The defect being pinned: Problem Analysis asked `/feedback` for `limit: 500`,
+ * the endpoint clamped it to 100 without saying so, and every stat card and
+ * tree level was computed from that first page as if it were the whole window.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockGetFeedback = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  api: { getFeedback: (params: unknown) => mockGetFeedback(params) },
+}))
+
+import { useProblemFeedback, MAX_AUTO_PAGES } from './useProblemFeedback'
+import { FEEDBACK_PAGE_LIMIT } from '../../api/feedbackPagination'
+
+const API_ENDPOINT = 'https://api.example.com'
+const DATE_PARAMS = { days: 7 }
+
+interface PageRequest {
+  offset?: number
+  limit?: number
+}
+
+/**
+ * Requests the hook actually made. Recorded here rather than read back out of
+ * `mock.calls`, which is `any[][]` and so cannot be inspected without a cast.
+ */
+let requests: PageRequest[] = []
+
+/**
+ * Serves a synthetic window of `total` rows, honouring offset/limit the way
+ * `/feedback` does.
+ */
+function serveWindow(total: number, opts: { isPartialWindow?: boolean } = {}) {
+  mockGetFeedback.mockImplementation((params: PageRequest) => {
+    requests.push(params)
+    const offset = params.offset ?? 0
+    const limit = params.limit ?? FEEDBACK_PAGE_LIMIT
+    const size = Math.max(0, Math.min(limit, total - offset))
+    return Promise.resolve({
+      count: size,
+      total,
+      offset,
+      items: Array.from({ length: size }, (_, i) => ({ feedback_id: `f${offset + i}` })),
+      is_partial_window: opts.isPartialWindow ?? false,
+    })
+  })
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+function renderFeedback(apiEndpoint = API_ENDPOINT) {
+  return renderHook(() => useProblemFeedback(DATE_PARAMS, apiEndpoint), {
+    wrapper: createWrapper(),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  requests = []
+  serveWindow(FEEDBACK_PAGE_LIMIT)
+})
+
+describe('useProblemFeedback', () => {
+  describe('page size', () => {
+    // The regression guard. Reinstating `limit: 500` makes this fail.
+    it('never requests a page larger than the endpoint allows', async () => {
+      serveWindow(250)
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(250))
+
+      expect(requests.every((r) => (r.limit ?? 0) <= FEEDBACK_PAGE_LIMIT)).toBe(true)
+      expect(requests.map((r) => r.limit)).toEqual([
+        FEEDBACK_PAGE_LIMIT,
+        FEEDBACK_PAGE_LIMIT,
+        FEEDBACK_PAGE_LIMIT,
+      ])
+    })
+  })
+
+  describe('reading the whole window', () => {
+    it('pages until every row in the window is loaded', async () => {
+      serveWindow(250)
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(250))
+
+      expect(requests.map((r) => r.offset)).toEqual([0, 100, 200])
+      expect(result.current.totalCount).toBe(250)
+      expect(result.current.isPartial).toBe(false)
+      expect(result.current.isLoadingMore).toBe(false)
+    })
+
+    it('stops after one request when the window fits in a single page', async () => {
+      serveWindow(40)
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(40))
+      // A short page means the window is exhausted — no speculative second call.
+      expect(mockGetFeedback).toHaveBeenCalledTimes(1)
+      expect(result.current.isPartial).toBe(false)
+    })
+
+    it('does not treat a full final page as though more remained', async () => {
+      serveWindow(FEEDBACK_PAGE_LIMIT)
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(FEEDBACK_PAGE_LIMIT))
+      expect(mockGetFeedback).toHaveBeenCalledTimes(1)
+      expect(result.current.isPartial).toBe(false)
+    })
+
+    it('reports rows already in hand even when the total lags behind them', async () => {
+      // Without a post-query filter the server sizes its candidate window from
+      // offset+limit, so `total` can trail the rows already returned.
+      mockGetFeedback.mockResolvedValue({ count: 100, total: 50, offset: 0, items: Array.from({ length: 100 }, (_, i) => ({ feedback_id: `f${i}` })) })
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(100))
+      expect(result.current.totalCount).toBe(100)
+    })
+  })
+
+  describe('honest partiality', () => {
+    it('stops at the page budget and reports the counts as partial', async () => {
+      serveWindow((MAX_AUTO_PAGES + 5) * FEEDBACK_PAGE_LIMIT)
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.isPartial).toBe(true))
+
+      expect(mockGetFeedback).toHaveBeenCalledTimes(MAX_AUTO_PAGES)
+      expect(result.current.loadedCount).toBe(MAX_AUTO_PAGES * FEEDBACK_PAGE_LIMIT)
+    })
+
+    it('reports partial when the server truncated the candidate window', async () => {
+      serveWindow(40, { isPartialWindow: true })
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(result.current.loadedCount).toBe(40))
+      expect(result.current.isPartial).toBe(true)
+    })
+
+    it('stops paging when a page fails, and calls the result partial', async () => {
+      // Regression guard for the effect loop: on failure the query settles with
+      // more pages still outstanding, which would re-arm the auto-advance.
+      // Reporting complete counts here would also recreate the original defect.
+      mockGetFeedback
+        .mockResolvedValueOnce({
+          count: 100,
+          total: 500,
+          offset: 0,
+          items: Array.from({ length: 100 }, (_, i) => ({ feedback_id: `f${i}` })),
+        })
+        .mockRejectedValue(new Error('boom'))
+
+      const { result } = renderFeedback()
+
+      await waitFor(() => expect(mockGetFeedback).toHaveBeenCalledTimes(2))
+      await waitFor(() => expect(result.current.isPartial).toBe(true))
+
+      const callsAfterFailure = mockGetFeedback.mock.calls.length
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(mockGetFeedback.mock.calls.length).toBe(callsAfterFailure)
+      expect(result.current.loadedCount).toBe(100)
+    })
+  })
+
+  describe('gating', () => {
+    it('does not call the API until an endpoint is configured', () => {
+      renderFeedback('')
+      expect(mockGetFeedback).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.test.tsx
@@ -5,7 +5,7 @@
  * the endpoint clamped it to 100 without saying so, and every stat card and
  * tree level was computed from that first page as if it were the whole window.
  */
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const mockGetFeedback = vi.fn()
@@ -211,7 +211,11 @@ describe('useProblemFeedback', () => {
       await waitFor(() => expect(result.current.isError).toBe(true))
 
       serveWindow(150)
-      result.current.retry()
+      // `act` keeps the state update the retry triggers inside React's batch,
+      // so the run is free of act warnings rather than merely correct.
+      await act(async () => {
+        result.current.retry()
+      })
 
       await waitFor(() => expect(result.current.loadedCount).toBe(150))
       expect(result.current.isError).toBe(false)
@@ -229,7 +233,9 @@ describe('useProblemFeedback', () => {
       expect(result.current.isPartial).toBe(false)
 
       mockGetFeedback.mockRejectedValue(new Error('boom'))
-      result.current.retry()
+      await act(async () => {
+        result.current.retry()
+      })
 
       await waitFor(() => expect(result.current.isError).toBe(true))
       expect(result.current.isPartial).toBe(false)

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
@@ -44,6 +44,12 @@ import type { FeedbackPage } from '../../api/feedbackPagination'
  */
 export const MAX_AUTO_PAGES = 20
 
+/**
+ * How long a loaded window counts as fresh — longer than the app-wide 30s
+ * default because re-walking costs one request per 100 rows.
+ */
+export const WINDOW_STALE_MS = 5 * 60 * 1000
+
 export interface ProblemFeedback {
   /** Every row loaded so far, across pages. */
   items: FeedbackItem[]
@@ -56,6 +62,12 @@ export interface ProblemFeedback {
   totalCount: number
   /** True when rows in the window were left unread, so counts undercount. */
   isPartial: boolean
+  /**
+   * A request failed. With `items` empty this means **nothing** was read, which
+   * must not be rendered as a window that legitimately contains nothing —
+   * callers show an error rather than zeroed aggregates.
+   */
+  isError: boolean
 }
 
 export function useProblemFeedback(
@@ -69,6 +81,15 @@ export function useProblemFeedback(
     initialPageParam: 0,
     getNextPageParam: nextPageOffset,
     enabled: !!apiEndpoint,
+    // A walk is one request per 100 rows, and TanStack refetches EVERY page of
+    // an infinite query — so the app-wide 30s `staleTime` plus the default
+    // refetch-on-focus would re-issue the whole walk each time the tab regains
+    // focus. Hold the window settled instead; the time range is an explicit
+    // control, so the user says when to look again.
+    staleTime: WINDOW_STALE_MS,
+    refetchOnWindowFocus: false,
+    // Deliberately NOT `maxPages`: it evicts pages from the cache, and every
+    // count on this screen is an aggregate over all of them.
   })
 
   const { data, hasNextPage, isFetchingNextPage, isError, fetchNextPage } = query
@@ -106,6 +127,7 @@ export function useProblemFeedback(
     isLoading: query.isLoading,
     isLoadingMore: isFetchingNextPage,
     loadedCount: items.length,
+    isError,
     ...summarizeCoverage(data?.pages, items.length, stoppedEarly),
   }
 }

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Windowed feedback for the Problem Analysis page.
+ *
+ * Problem Analysis is an aggregation view: every stat card and every level of
+ * the category → subcategory → problem tree is derived from the *whole* set of
+ * feedback in the window, not from a page of it. It used to ask `/feedback` for
+ * `limit: 500` in a single request — but that endpoint clamps `limit` to 100
+ * without complaining, so the entire page was computed from the first 100 rows
+ * and presented as if complete (U5b).
+ *
+ * Asking for a bigger `limit` cannot fix that; the cap is server-side. So this
+ * hook pages through the window instead, advancing automatically rather than
+ * behind a "Load more" button, because the totals are wrong until the window is
+ * read. Results render progressively as pages land, so the page stays usable
+ * while it fills.
+ *
+ * Two independent stops keep that from running away: `nextPageOffset` refuses a
+ * zero-length page, and `MAX_AUTO_PAGES` bounds the walk outright. When either
+ * stop (or the server's own `is_partial_window`) leaves rows unread, `isPartial`
+ * says so, so a truncated view is visibly truncated instead of silently wrong.
+ *
+ * The real cure is server-side aggregation, so one request answers "how many
+ * problems per category" without shipping every row to the browser. That is
+ * U5a's territory; this hook makes the current design honest.
+ *
+ * @module pages/ProblemAnalysis/useProblemFeedback
+ */
+
+import { useEffect, useMemo } from 'react'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { api } from '../../api/client'
+import type { DateRangeParams, FeedbackItem } from '../../api/client'
+import { FEEDBACK_PAGE_LIMIT, nextPageOffset } from '../../api/feedbackPagination'
+import type { FeedbackPage } from '../../api/feedbackPagination'
+
+/**
+ * Ceiling on pages fetched automatically — 20 pages of
+ * {@link FEEDBACK_PAGE_LIMIT} rows.
+ *
+ * A bound is required, not defensive: `/feedback` will paginate to
+ * `MAX_FEEDBACK_OFFSET` (5000) rows, and walking that on mount would be 50
+ * sequential requests. Past this point the view reports itself partial rather
+ * than keeping the user waiting.
+ */
+export const MAX_AUTO_PAGES = 20
+
+export interface ProblemFeedback {
+  /** Every row loaded so far, across pages. */
+  items: FeedbackItem[]
+  /** First page in flight — nothing to show yet. */
+  isLoading: boolean
+  /** A later page is in flight; `items` is usable but still growing. */
+  isLoadingMore: boolean
+  loadedCount: number
+  /** Candidate-window size. A lower bound while pages are still being read. */
+  totalCount: number
+  /** True when rows in the window were left unread, so counts undercount. */
+  isPartial: boolean
+}
+
+export function useProblemFeedback(
+  dateParams: DateRangeParams,
+  apiEndpoint: string
+): ProblemFeedback {
+  const query = useInfiniteQuery({
+    queryKey: ['feedback-problems', dateParams],
+    queryFn: ({ pageParam }) =>
+      api.getFeedback({ ...dateParams, limit: FEEDBACK_PAGE_LIMIT, offset: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: nextPageOffset,
+    enabled: !!apiEndpoint,
+  })
+
+  const { data, hasNextPage, isFetchingNextPage, isError, fetchNextPage } = query
+  const pageCount = data?.pages.length ?? 0
+  const budgetSpent = pageCount >= MAX_AUTO_PAGES
+
+  // `isError` is load-bearing: without it a persistently failing page would
+  // settle with `hasNextPage` still true, re-arming this effect forever.
+  const shouldAdvance = hasNextPage && !budgetSpent && !isError
+
+  // `pageCount` is the ratchet, not an incidental dependency. Once a page
+  // settles, `shouldAdvance` is true and `isFetchingNextPage` is false again —
+  // exactly the values they held when the previous page settled — so without a
+  // per-page dependency the array is unchanged, the effect never re-runs, and
+  // the walk stalls after a single extra page. Pinned by "pages until every row
+  // in the window is loaded".
+  useEffect(() => {
+    if (shouldAdvance && !isFetchingNextPage) {
+      void fetchNextPage()
+    }
+  }, [shouldAdvance, isFetchingNextPage, pageCount, fetchNextPage])
+
+  // Keyed on `data` rather than a derived array: TanStack keeps `data` stable
+  // between settles, so this recomputes per page rather than per render.
+  const items = useMemo(() => collectItems(data?.pages), [data])
+
+  // The walk stopped early with rows still unread: the budget ran out, or a
+  // page failed. A failed page has to count here too — otherwise a mid-walk
+  // error reproduces the very defect this hook exists to fix, presenting short
+  // counts as complete ones.
+  const stoppedEarly = hasNextPage && (budgetSpent || isError)
+
+  return {
+    items,
+    isLoading: query.isLoading,
+    isLoadingMore: isFetchingNextPage,
+    loadedCount: items.length,
+    ...summarizeCoverage(data?.pages, items.length, stoppedEarly),
+  }
+}
+
+/** Every row loaded so far, flattened across pages. */
+function collectItems(pages: readonly FeedbackPage[] | undefined): FeedbackItem[] {
+  return (pages ?? []).flatMap((page) => page.items ?? [])
+}
+
+/**
+ * How much of the window the loaded rows actually cover.
+ *
+ * `totalCount` floors at `loadedCount` because without a post-query filter the
+ * server sizes its candidate window from `offset+limit`, so its `total` is a
+ * lower bound that can trail the rows already in hand.
+ */
+function summarizeCoverage(
+  pages: readonly FeedbackPage[] | undefined,
+  loadedCount: number,
+  stoppedEarly: boolean
+): { totalCount: number; isPartial: boolean } {
+  const lastPage = pages?.at(-1)
+  return {
+    totalCount: Math.max(lastPage?.total ?? loadedCount, loadedCount),
+    isPartial: stoppedEarly || (lastPage?.is_partial_window ?? false),
+  }
+}

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
@@ -68,6 +68,8 @@ export interface ProblemFeedback {
    * callers show an error rather than zeroed aggregates.
    */
   isError: boolean
+  /** Re-reads the window from the first page. */
+  retry: () => void
 }
 
 export function useProblemFeedback(
@@ -92,7 +94,7 @@ export function useProblemFeedback(
     // count on this screen is an aggregate over all of them.
   })
 
-  const { data, hasNextPage, isFetchingNextPage, isError, fetchNextPage } = query
+  const { data, hasNextPage, isFetchingNextPage, isError, fetchNextPage, refetch } = query
   const pageCount = data?.pages.length ?? 0
   const budgetSpent = pageCount >= MAX_AUTO_PAGES
 
@@ -128,6 +130,9 @@ export function useProblemFeedback(
     isLoadingMore: isFetchingNextPage,
     loadedCount: items.length,
     isError,
+    retry: () => {
+      void refetch()
+    },
     ...summarizeCoverage(data?.pages, items.length, stoppedEarly),
   }
 }

--- a/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
+++ b/voc-datalake/frontend/src/pages/ProblemAnalysis/useProblemFeedback.ts
@@ -26,7 +26,7 @@
  * @module pages/ProblemAnalysis/useProblemFeedback
  */
 
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { api } from '../../api/client'
 import type { DateRangeParams, FeedbackItem } from '../../api/client'
@@ -118,6 +118,11 @@ export function useProblemFeedback(
   // between settles, so this recomputes per page rather than per render.
   const items = useMemo(() => collectItems(data?.pages), [data])
 
+  // Stable identity so a memoized consumer isn't re-rendered by the handler.
+  const retry = useCallback(() => {
+    void refetch()
+  }, [refetch])
+
   // The walk stopped early with rows still unread: the budget ran out, or a
   // page failed. A failed page has to count here too — otherwise a mid-walk
   // error reproduces the very defect this hook exists to fix, presenting short
@@ -130,9 +135,7 @@ export function useProblemFeedback(
     isLoadingMore: isFetchingNextPage,
     loadedCount: items.length,
     isError,
-    retry: () => {
-      void refetch()
-    },
+    retry,
     ...summarizeCoverage(data?.pages, items.length, stoppedEarly),
   }
 }

--- a/voc-datalake/lambda/api/test/test_feedback_page_limit_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_feedback_page_limit_lockstep.py
@@ -1,0 +1,70 @@
+"""The frontend's /feedback page size must match the endpoint's own maximum.
+
+`validate_limit` CLAMPS an over-sized `limit` instead of rejecting it, so a
+client asking for more rows than the endpoint allows gets a short page and no
+error — only the echoed `limit` hints at it. That is exactly how Problem
+Analysis came to derive a whole problem hierarchy from 100 rows while asking for
+500 (U5b, PR #292).
+
+The frontend now spends one constant, `FEEDBACK_PAGE_LIMIT`, and pages the
+window. That only stays correct while the constant equals the server's
+`max_val`: lower it and paging does needless round trips, raise it and every
+page is silently truncated again.
+
+Nothing in either language can see the other, so this test reads the TypeScript
+constant directly — the same lockstep approach as
+`lambda/shared/test/test_avatar_image_model_lockstep.py`.
+"""
+import re
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    # lambda/api/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _read(relative: str) -> str:
+    path = _repo_root() / relative
+    assert path.is_file(), f'{relative} not found - did the file move?'
+    return path.read_text(encoding='utf-8')
+
+
+def _frontend_page_limit() -> int:
+    source = _read('frontend/src/api/feedbackPagination.ts')
+    match = re.search(r'export const FEEDBACK_PAGE_LIMIT = (\d+)', source)
+    assert match, 'FEEDBACK_PAGE_LIMIT not found in api/feedbackPagination.ts'
+    return int(match.group(1))
+
+
+def _list_feedback_limit_bounds() -> tuple[int, int]:
+    """`(default, max_val)` from the `validate_limit` call in list_feedback."""
+    source = _read('lambda/api/metrics_handler.py')
+    # Scope the search to the @app.get("/feedback") handler so another
+    # endpoint's limit cannot satisfy this test.
+    start = source.index('@app.get("/feedback")')
+    end = source.index('@app.get', start + 1)
+    match = re.search(
+        r'limit = validate_limit\(params\.get\(.limit.\),\s*default=(\d+),\s*max_val=(\d+)\)',
+        source[start:end],
+    )
+    assert match, 'validate_limit(...) call not found in list_feedback'
+    return int(match.group(1)), int(match.group(2))
+
+
+class TestFeedbackPageLimitLockstep:
+    def test_frontend_page_size_equals_the_endpoint_maximum(self):
+        frontend = _frontend_page_limit()
+        _, max_val = _list_feedback_limit_bounds()
+        assert frontend == max_val, (
+            f'FEEDBACK_PAGE_LIMIT is {frontend} but /feedback caps limit at {max_val}. '
+            'Raising the client constant does not raise the cap - the server clamps '
+            'and says nothing, so every paged read is silently truncated. Change both, '
+            'or neither.'
+        )
+
+    def test_the_default_is_not_itself_above_the_cap(self):
+        # A `default` above `max_val` would clamp the unparameterised call too,
+        # which is the same trap with no caller to blame.
+        default, max_val = _list_feedback_limit_bounds()
+        assert default <= max_val

--- a/voc-datalake/lambda/api/test/test_feedback_page_limit_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_feedback_page_limit_lockstep.py
@@ -18,10 +18,15 @@ constant directly — the same lockstep approach as
 import re
 from pathlib import Path
 
+import pytest
+
 
 def _repo_root() -> Path:
     # lambda/api/test/ -> voc-datalake/
     return Path(__file__).resolve().parents[3]
+
+
+FRONTEND_SOURCE = 'frontend/src/api/feedbackPagination.ts'
 
 
 def _read(relative: str) -> str:
@@ -31,9 +36,15 @@ def _read(relative: str) -> str:
 
 
 def _frontend_page_limit() -> int:
-    source = _read('frontend/src/api/feedbackPagination.ts')
-    match = re.search(r'export const FEEDBACK_PAGE_LIMIT = (\d+)', source)
-    assert match, 'FEEDBACK_PAGE_LIMIT not found in api/feedbackPagination.ts'
+    path = _repo_root() / FRONTEND_SOURCE
+    if not path.is_file():
+        # This is a backend test reaching across into the frontend tree. Where
+        # only the lambda sources are present (packaging, a partial checkout)
+        # there is nothing to compare, and skipping beats a failure that says
+        # nothing about the code under test.
+        pytest.skip(f'{FRONTEND_SOURCE} not present in this tree')
+    match = re.search(r'export const FEEDBACK_PAGE_LIMIT = (\d+)', path.read_text(encoding='utf-8'))
+    assert match, f'FEEDBACK_PAGE_LIMIT not found in {FRONTEND_SOURCE}'
     return int(match.group(1))
 
 
@@ -41,9 +52,19 @@ def _list_feedback_limit_bounds() -> tuple[int, int]:
     """`(default, max_val)` from the `validate_limit` call in list_feedback."""
     source = _read('lambda/api/metrics_handler.py')
     # Scope the search to the @app.get("/feedback") handler so another
-    # endpoint's limit cannot satisfy this test.
-    start = source.index('@app.get("/feedback")')
-    end = source.index('@app.get', start + 1)
+    # endpoint's limit cannot satisfy this test. The handler body ends at the
+    # next route decorator of ANY verb -- and at end-of-file if /feedback
+    # happens to be the last route, which `str.index` would turn into a
+    # ValueError rather than a readable failure.
+    marker = '@app.get("/feedback")'
+    start = source.find(marker)
+    assert start != -1, f'{marker} not found in metrics_handler.py'
+    next_route = re.search(
+        r'^@app\.(get|post|put|patch|delete|route)\(',
+        source[start + len(marker):],
+        re.MULTILINE,
+    )
+    end = start + len(marker) + (next_route.start() if next_route else len(source))
     match = re.search(
         r'limit = validate_limit\(params\.get\(.limit.\),\s*default=(\d+),\s*max_val=(\d+)\)',
         source[start:end],


### PR DESCRIPTION
## Summary

Problem Analysis asked `/feedback` for `limit: 500`. That endpoint bounds `limit` with
`validate_limit(default=50, max_val=100)`, and `validate_int` **clamps rather than rejecting**, so the
request came back with 100 rows and only the echoed `limit` to give it away. Every stat card, and every
level of the category → subcategory → problem tree, was derived from that first page and presented as
complete.

Measured against a deployed environment, `days=90`:

| | |
|---|---|
| before — one request asking `limit=500` | **100 rows** (response echoed `limit=100`) |
| after — a paged walk at `limit=100` | **1,227 rows** over 13 requests (server `total=1,227`) |

The page had been describing **8.1%** of the window.

## Approach

A larger `limit` cannot fix this, because the cap is server-side. So page the window instead,
advancing automatically rather than behind a "Load more" button: unlike a browsable list, the totals
here are wrong until the window has been read. Rows render progressively, so the page stays usable
while it fills. On the corpus above the walk takes 13 requests and finishes inside the page budget, so
no caveat is shown.

Three stops bound the walk, independently of each other:

- `nextPageOffset` refuses a zero-length page, so a server reporting `total > loaded` while returning
  nothing cannot spin the client.
- `MAX_AUTO_PAGES` ends it outright.
- A failed page stops it — and counts as **partial**, because reporting short counts as complete would
  recreate the defect this fixes.

## Changes

- **`src/api/feedbackPagination.ts`** (new) — holds the page size as one exported constant equal to the
  endpoint's `max_val`, so callers spend `FEEDBACK_PAGE_LIMIT` instead of a literal and "I need more
  rows" becomes a pagination question rather than a bigger-`limit` question. `nextPageOffset` already
  existed and was correct, but private to `Categories/useFeedbackListData.ts`; it is **promoted here
  rather than copied**, and that file's private duplicate (plus its own `PAGE_LIMIT = 100`) is deleted.
  This is why the diff touches Categories.
- **`useProblemFeedback`** (new) — pages the window, bounded by `MAX_AUTO_PAGES`, and reports
  `isPartial`.
- **`WindowCoverageNotice`** (new) — renders nothing when the window was read in full; otherwise
  reports progress, or that the counts undercount. Its own file because `scripts/i18n-check.mjs`
  derives one namespace per file from the first `useTranslation` match, and `ProblemAnalysis.tsx` opens
  with `common`.
- 2 keys added to the `problemAnalysis` catalogue across all 8 locales. Interpolation only, no plural
  forms, so there is no `_one`/`_other` parity to keep in step.

## Testing

22 new tests (8 pagination, 9 hook, 5 component). Two of them are regression guards for bugs the tests
found in this change before review:

- The auto-advance originally fired **exactly once** — 200 rows of 250 — because after each page
  settles the effect's dependency array is identical to what it was after the previous page, so React
  skips the re-run. The page count is the ratchet and had to be in the deps.
- A mid-walk request failure reported short counts as complete. `isError` now feeds both the advance
  guard and `isPartial`.

Gates: `eslint` 0, `tsc` 0, **137 files / 2072 vitest tests** green.

`i18n:check` and `typecheck:tests` exit non-zero on `development` already. Both were verified as
pre-existing against a `git worktree` at `HEAD`: identical failure sets, zero missing keys on either
side, and no errors in any file this PR touches.

## Not in scope

Server-side aggregation is the real cure, so that one request could answer "how many problems per
category" without shipping every row to the browser. That is a larger change; this makes the current
design honest. The Problem Analysis stat labels are also still hardcoded English while the
`problemAnalysis` catalogue sits unused — pre-existing, and left alone.
