### PR TITLE
fix(ui): tie the prototype confirm to the question that raised it

### DIFF
--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
@@ -99,6 +99,15 @@ function buildButton() {
   return screen.getByRole('button', { name: /build prototype/i })
 }
 
+/**
+ * The modal's confirm action, queried rather than got: the tests below assert on
+ * its ABSENCE, which is the load-bearing half of a dialog that must not be
+ * clickable once its question no longer applies.
+ */
+function confirmButton() {
+  return screen.queryByRole('button', { name: /build anyway/i })
+}
+
 describe('prototype card confirm gate (U12)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -278,7 +287,56 @@ describe('prototype card rebuild guard', () => {
 
     rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1')]))
 
+    // The role, the question and the action, so this cannot go vacuous if the
+    // shell's ARIA role ever changes: the bug being pinned was a dialog that was
+    // still THERE and still clickable, just with nothing written in it.
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
+    expect(confirmButton()).not.toBeInTheDocument()
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
+  })
+
+  it('closes the confirm rather than swapping its question for a costlier one', async () => {
+    // Same refetch, a different outcome: a prototype arriving while the
+    // single-document confirm is open changes what "Build anyway" MEANS — from
+    // "build from the PRD alone" to "build a second prototype and keep the first".
+    // Rewriting the message under an open dialog would have the button answer a
+    // question the user never read, so the dialog closes and the next click asks.
+    const user = userEvent.setup()
+    const { rerender } = renderCard({ hasPrd: true, hasPrfaq: false })
+
+    await user.click(buildButton())
+    expect(screen.getByText(/No PR-FAQ yet/i)).toBeInTheDocument()
+
+    rerender(overviewTab([doc('prd', 'prd_1'), doc('prototype', 'proto_1')]))
+
+    expect(screen.queryByText(/already has a prototype/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
+  })
+
+  it('does not re-open the confirm when a later reason to ask arrives', async () => {
+    // An open flag outlives the question it was raised for: once the reason
+    // disappeared the flag stayed set, so the NEXT reason to ask put a modal back
+    // on screen that the user never asked for — one reflexive click from a
+    // multi-minute billable build. Tracking which question was asked is what makes
+    // this unreachable.
+    const user = userEvent.setup()
+    const { rerender } = renderCard({ hasPrd: true, hasPrfaq: false })
+
+    await user.click(buildButton())
+    expect(screen.getByText(/No PR-FAQ yet/i)).toBeInTheDocument()
+
+    // The reason to ask disappears: the PR-FAQ generation completes.
+    rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1')]))
+    expect(confirmButton()).not.toBeInTheDocument()
+
+    // A later job produces a prototype, which is a new reason to ask.
+    rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1'), doc('prototype', 'proto_1')]))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText(/already has a prototype/i)).not.toBeInTheDocument()
+    expect(confirmButton()).not.toBeInTheDocument()
     expect(mockBuildPrototype).not.toHaveBeenCalled()
   })
 })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
@@ -67,13 +67,9 @@ function doc(documentType: ProjectDocument['document_type'], id: string): Projec
  * `hasPrd`/`hasPrfaq` props become the presence of a PRD / PR-FAQ document — the
  * same condition, now derived where the rest of the grid derives its state.
  */
-function renderCard(props: { hasPrd: boolean; hasPrfaq: boolean; hasPrototype?: boolean }) {
-  const documents: ProjectDocument[] = []
-  if (props.hasPrd) documents.push(doc('prd', 'prd_1'))
-  if (props.hasPrfaq) documents.push(doc('prfaq', 'prfaq_1'))
-  if (props.hasPrototype === true) documents.push(doc('prototype', 'proto_1'))
-
-  return render(
+/** The tab for a given document set, so a test can re-render with a different one. */
+function overviewTab(documents: ProjectDocument[]) {
+  return (
     <OverviewTab
       project={project}
       personas={[]}
@@ -85,8 +81,17 @@ function renderCard(props: { hasPrd: boolean; hasPrfaq: boolean; hasPrototype?: 
       onOpenProductTool={vi.fn()}
       onSaveKiroPrompt={vi.fn()}
       onJobStarted={mockJobStarted}
-    />,
+    />
   )
+}
+
+function renderCard(props: { hasPrd: boolean; hasPrfaq: boolean; hasPrototype?: boolean }) {
+  const documents: ProjectDocument[] = []
+  if (props.hasPrd) documents.push(doc('prd', 'prd_1'))
+  if (props.hasPrfaq) documents.push(doc('prfaq', 'prfaq_1'))
+  if (props.hasPrototype === true) documents.push(doc('prototype', 'proto_1'))
+
+  return render(overviewTab(documents))
 }
 
 /** The build trigger, not the modal's confirm button. */
@@ -258,6 +263,23 @@ describe('prototype card rebuild guard', () => {
     renderCard({ hasPrd: true, hasPrfaq: true, hasPrototype: true })
 
     expect(screen.getByText('Prototypes built: 1')).toBeInTheDocument()
+  })
+
+  it('closes the confirm rather than emptying it when the reason to ask disappears', async () => {
+    // The confirm reason is derived from live data, and this page refetches
+    // documents whenever a job completes. So a PR-FAQ generation finishing while
+    // the single-document dialog is open removes the thing being confirmed — and
+    // gating the dialog on its own open flag alone left it up with no message.
+    const user = userEvent.setup()
+    const { rerender } = renderCard({ hasPrd: true, hasPrfaq: false })
+
+    await user.click(buildButton())
+    expect(screen.getByText(/No PR-FAQ yet/i)).toBeInTheDocument()
+
+    rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1')]))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
   })
 })
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
@@ -167,17 +167,10 @@ export function usePrototypeBuild({
 
   const onCancel = useCallback(() => setAskedKey(null), [])
 
-  // The question actually on screen: the one the click raised, and only while it is
-  // still the one that applies. `confirmKey` is derived from live data — this page
-  // refetches documents whenever a job completes — so a PR-FAQ generation finishing
-  // can remove the reason to ask, or replace it with the costlier rebuild one.
-  //
-  // Comparing keys covers both, where a boolean covered neither: it cannot leave a
-  // titled modal up with an empty message, it cannot rewrite the text under the
-  // cursor so that "Build anyway" answers a question that was never displayed, and
-  // it cannot re-open on a reason the user never saw, because a flag that outlived
-  // its question stayed set. A reason that comes back comes back as the same
-  // question, which is the one still unanswered.
+  // The question on screen: the one the click raised, and only while it still
+  // applies. `confirmKey` is derived from live data that changes under an open dialog
+  // (documents refetch when a job completes), so a boolean open-flag beside it could
+  // disagree with the message — leaving it blank, rewritten, or re-raised unasked.
   const openKey = askedKey != null && askedKey === confirmKey ? askedKey : null
 
   return {
@@ -186,9 +179,6 @@ export function usePrototypeBuild({
     error,
     started: started.isSet,
     confirm: {
-      // One derivation feeding both, for the same reason `confirmKeyFor` is one
-      // function: two readings of this state could disagree, and the disagreement
-      // looks like a dialog with no question in it.
       isOpen: openKey != null,
       message: openKey == null ? '' : t(openKey),
       onConfirm,

--- a/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
@@ -82,7 +82,11 @@ export interface PrototypeBuildControl {
   readonly error: string | null
   /** True briefly after a successful start, covering the gap before the panel refetches. */
   readonly started: boolean
-  /** State for the confirm dialog the single-source-document case needs. */
+  /**
+   * State for the confirm dialog. Open only while the reason it was opened for is
+   * still the reason that applies, so `message` is empty exactly when `isOpen` is
+   * false rather than needing its own check at the call site.
+   */
   readonly confirm: {
     readonly isOpen: boolean
     readonly message: string
@@ -114,7 +118,8 @@ export function usePrototypeBuild({
   // Lowers itself: the panel takes over, so the line must not outlive the gap.
   const started = useTransientFlag()
   const [error, setError] = useState<string | null>(null)
-  const [showConfirm, setShowConfirm] = useState(false)
+  // The question that was asked, not a bare "a dialog is open" flag — see `openKey`.
+  const [askedKey, setAskedKey] = useState<ConfirmKey | null>(null)
 
   // Two reasons to stop and ask, through the ConfirmModal pattern every other
   // guarded action uses (this began as a window.confirm, which cannot be styled):
@@ -149,18 +154,31 @@ export function usePrototypeBuild({
 
   const onClick = useCallback(() => {
     if (confirmKey != null) {
-      setShowConfirm(true)
+      setAskedKey(confirmKey)
       return
     }
     void runBuild()
   }, [confirmKey, runBuild])
 
   const onConfirm = useCallback(() => {
-    setShowConfirm(false)
+    setAskedKey(null)
     void runBuild()
   }, [runBuild])
 
-  const onCancel = useCallback(() => setShowConfirm(false), [])
+  const onCancel = useCallback(() => setAskedKey(null), [])
+
+  // The question actually on screen: the one the click raised, and only while it is
+  // still the one that applies. `confirmKey` is derived from live data — this page
+  // refetches documents whenever a job completes — so a PR-FAQ generation finishing
+  // can remove the reason to ask, or replace it with the costlier rebuild one.
+  //
+  // Comparing keys covers both, where a boolean covered neither: it cannot leave a
+  // titled modal up with an empty message, it cannot rewrite the text under the
+  // cursor so that "Build anyway" answers a question that was never displayed, and
+  // it cannot re-open on a reason the user never saw, because a flag that outlived
+  // its question stayed set. A reason that comes back comes back as the same
+  // question, which is the one still unanswered.
+  const openKey = askedKey != null && askedKey === confirmKey ? askedKey : null
 
   return {
     onClick,
@@ -168,14 +186,11 @@ export function usePrototypeBuild({
     error,
     started: started.isSet,
     confirm: {
-      // Both conditions, because `confirmKey` is derived from live data that can
-      // change while the dialog is open: a PR-FAQ generation completing turns a
-      // one-document project into a two-document one, at which point there is
-      // nothing left to confirm. Gating on `showConfirm` alone would leave the
-      // dialog up with an empty message — worse than the pre-move behaviour, which
-      // at least still had a (by then wrong) string to show.
-      isOpen: showConfirm && confirmKey != null,
-      message: confirmKey == null ? '' : t(confirmKey),
+      // One derivation feeding both, for the same reason `confirmKeyFor` is one
+      // function: two readings of this state could disagree, and the disagreement
+      // looks like a dialog with no question in it.
+      isOpen: openKey != null,
+      message: openKey == null ? '' : t(openKey),
       onConfirm,
       onCancel,
     },

--- a/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
@@ -168,8 +168,13 @@ export function usePrototypeBuild({
     error,
     started: started.isSet,
     confirm: {
-      isOpen: showConfirm,
-      // Empty only in the state where the dialog is never opened.
+      // Both conditions, because `confirmKey` is derived from live data that can
+      // change while the dialog is open: a PR-FAQ generation completing turns a
+      // one-document project into a two-document one, at which point there is
+      // nothing left to confirm. Gating on `showConfirm` alone would leave the
+      // dialog up with an empty message — worse than the pre-move behaviour, which
+      // at least still had a (by then wrong) string to show.
+      isOpen: showConfirm && confirmKey != null,
       message: confirmKey == null ? '' : t(confirmKey),
       onConfirm,
       onCancel,


### PR DESCRIPTION
## What this fixes, in plain terms

Building a prototype starts a multi-minute **billable** AI job, so the app stops and asks first when
something is off — either *"you only have a PRD, no PR-FAQ, build from just the PRD?"* or *"you already
have a prototype, this makes a second one, continue?"*

Which of those questions applies is computed from the project's documents, and this page refreshes
documents in the background whenever a generation job finishes. So the documents can change **while
that dialog is open on screen**, and the dialog was not reacting to it. Three ways it went wrong:

1. **The dialog went blank.** Your missing PR-FAQ finishes generating, so there is nothing left to warn
   about — and the modal stayed up with its text emptied: a title, Cancel, "Build anyway", and no question.
2. **The dialog silently changed what it was asking.** A prototype finishes instead, so the real warning
   becomes the *more expensive* one. The text was rewritten under the cursor, so "Build anyway" answered
   a costlier question than the one displayed when the user started reading.
3. **The dialog re-opened on its own.** After (1) closed it, the app still believed a dialog was open, so
   the next reason to warn put a modal back on screen with no user action — one reflex from a paid build.

The fix is one idea: **remember which question was asked, not merely that one was asked**, and show the
dialog only while that exact question still applies. The old code kept a boolean, which outlived the
question that raised it.

---

## Summary

Follow-up to #294, found while re-reading the merged hook. The confirm's *reason* is derived from
live data, but its *lifetime* was not.

`confirmKeyFor` reads `hasPrd` / `hasPrfaq` / `hasExistingPrototype`, all derived from the project's
documents — and this page refetches documents whenever a job completes (`useProjectData`, ten-second
window). So the reason to stop and ask can change, or vanish, while the dialog is open.

Holding a boolean `showConfirm` beside that live key gave the dialog a lifetime of its own, with
three ways to misfire:

| Live data changes to… | Boolean flag did | Now |
|---|---|---|
| no reason to ask (PR-FAQ arrives) | stayed up with `message: ''` — a titled modal, Cancel and "Build anyway", **no question** | closes |
| a *different* reason (prototype arrives) | rewrote the text under the cursor, so "Build anyway" answers a **costlier** question than the one displayed | closes; the next click asks again |
| reason gone, then a later one arrives | re-opened a modal the user never asked for, one reflexive click from a multi-minute billable build | stays closed |

The fix is to stop tracking *that* a dialog is open and track *which question was asked*, then open
only while it still matches the derived one:

```diff
-  const [showConfirm, setShowConfirm] = useState(false)
+  const [askedKey, setAskedKey] = useState<ConfirmKey | null>(null)

+  const openKey = askedKey != null && askedKey === confirmKey ? askedKey : null
-      isOpen: showConfirm,
-      message: confirmKey == null ? '' : t(confirmKey),
+      isOpen: openKey != null,
+      message: openKey == null ? '' : t(openKey),
```

All three rows collapse into one rule: **the dialog can only ever show the question the user's own
click raised.** A reason that comes back comes back as the same question, which is the one still
unanswered — so that case is left alone rather than special-cased.

One derivation feeds both `isOpen` and `message`, so they cannot disagree. That is the same reason
`confirmKeyFor` is one function rather than a `needsConfirm` boolean beside a separate message
expression: two readings of one state can disagree, and here the disagreement *is* the bug.

## Why this belongs with #294 rather than being written off as a quirk

It is a **regression against the pre-#294 behaviour**, not a pre-existing edge. The old code computed
the message unconditionally from `hasPrd ? 'prd' : 'prfaq'`, so the same race showed a *wrong but
non-empty* string. Introducing a null-able confirm key is what made blank reachable, so the fix
belongs to the change that introduced it.

## Testing

Three tests, one per row of the table above:

- `closes the confirm rather than emptying it when the reason to ask disappears`
- `closes the confirm rather than swapping its question for a costlier one`
- `does not re-open the confirm when a later reason to ask arrives`

Each opens the single-document confirm, re-renders with a new document set, and asserts the dialog is
gone and no build was started. To make the re-render possible I extracted the element builder
(`overviewTab(documents)`) out of `renderCard`, which is why the test diff is larger than the fix.

**Verified non-vacuous by mutation**, not by inspection — reverting the hook to each earlier
behaviour and re-running the suite:

| Hook reverted to | Tests that fail |
|---|---|
| pre-#296 (`isOpen: showConfirm`) | all 3 |
| #296 as first submitted (`showConfirm && confirmKey != null`) | exactly the 2 new ones |

So the first commit's guard is still load-bearing, and each new test pins something it did not.

Gates: eslint 0, `tsc -b` 0, **2101 tests / 138 files**. (`typecheck:tests` reports 77 errors and
`i18n:check` exits 1 — both identical on the clean base, neither touching these files.)

## Browser-verified against the deployed stack

The earlier revision of this description said the race could not be reliably staged. That was wrong —
it can, without spending a Bedrock job. The refetch does not have to come from a completing job: the
project query inherits the app's 30s `staleTime` and refetches on window focus, so writing the
document straight into DynamoDB and then tabbing back reproduces the identical state transition.

Run against a throwaway fixture project on the live deployment (deleted afterwards; no existing
project touched), reading the dialog out of the DOM rather than eyeballing screenshots:

| Test | Refetch landed | Dialog after |
|---|---|---|
| reason disappears (PRD arrives) | `Documents (1)` → `(2)` | **closed**, not blank |
| reason changes (prototype arrives) | `Prototypes built: 1` appears | **closed**, message *not* swapped to the rebuild text |
| later reason arrives, same page session | `Documents (2)` → `(3)` | **stays closed** |

Non-regression on the same fixture: clicking Build Prototype with a prototype present still opens the
rebuild confirm with the correct message, and Cancel dismisses it. No console errors or warnings
throughout. "Build anyway" was deliberately never clicked — that starts a real billable build.

Deployment itself was verified rather than assumed: the shipped ProjectDetail chunk contains the new
derivation (`g!=null&&g===b?g:null`, `isOpen:_!=null`) and is the chunk the deployed entry bundle
actually references.

