### PR TITLE
fix(export): keep product_report in the Kiro export, exclude only prototype

### DIFF
--- a/voc-datalake/frontend/public/locales/de/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/de/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "Benutzerdefiniert",
       "prd": "PRD",
       "prfaq": "PR/FAQ",
+      "product_report": "Produktberichte",
       "research": "Recherche"
     },
     "documents": "Dokumente ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "Custom",
       "prd": "PRDs",
       "prfaq": "PR/FAQs",
+      "product_report": "Product Reports",
       "research": "Research"
     },
     "documents": "Documents ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/es/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/es/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "Personalizado",
       "prd": "PRD",
       "prfaq": "PR/FAQ",
+      "product_report": "Informes de producto",
       "research": "Investigación"
     },
     "documents": "Documentos ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/fr/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/fr/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "Personnalisé",
       "prd": "PRD",
       "prfaq": "PR/FAQ",
+      "product_report": "Rapports produit",
       "research": "Recherche"
     },
     "documents": "Fichiers ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/ja/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ja/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "カスタム",
       "prd": "PRD",
       "prfaq": "PR/FAQ",
+      "product_report": "プロダクトレポート",
       "research": "リサーチ"
     },
     "documents": "ドキュメント ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "커스텀",
       "prd": "PRD",
       "prfaq": "PR/FAQ",
+      "product_report": "제품 보고서",
       "research": "리서치"
     },
     "documents": "문서 ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/pt/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/pt/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "Personalizado",
       "prd": "PRD",
       "prfaq": "PR/FAQ",
+      "product_report": "Relatórios de produto",
       "research": "Pesquisa"
     },
     "documents": "Documentos ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/public/locales/zh/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/zh/projectDetail.json
@@ -8,6 +8,7 @@
       "custom": "自定义",
       "prd": "PRD 文档",
       "prfaq": "PR/FAQ 文档",
+      "product_report": "产品报告",
       "research": "研究"
     },
     "documents": "文档 ({{selected}}/{{total}})",

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Acceptance criterion 5: the Export card's document picker renders no row for
+ * a `prototype` or `product_report` document, and still renders rows for the
+ * four exportable types (prd, prfaq, research, custom).
+ *
+ * This test file specifically covers the export-filter behaviour so a revert of
+ * the filterExportableDocs change fails here with a clear message.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import McpAccessTab from './McpAccessTab'
+import type { Project, ProjectDocument, ProjectPersona } from '../../api/types'
+
+// ---------------------------------------------------------------------------
+// Minimal mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../api/client', () => ({
+  api: {
+    listApiTokens: vi.fn().mockResolvedValue({ tokens: [] }),
+    createApiToken: vi.fn(),
+    deleteApiToken: vi.fn(),
+    autoseedProject: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/baseUrl', () => ({
+  stripTrailingSlashes: (url: string) => url.replace(/\/$/, ''),
+}))
+
+vi.mock('../../store/configStore', () => ({
+  useConfigStore: () => ({ config: { apiEndpoint: 'https://api.example.com/v1' } }),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockProject: Project = {
+  project_id: 'proj-filter',
+  name: 'Filter Test Project',
+  description: '',
+  status: 'active',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  persona_count: 0,
+  document_count: 0,
+}
+
+const onePersona: ProjectPersona[] = [
+  { persona_id: 'p1', name: 'Alice', tagline: 'A user', created_at: '' },
+]
+
+function makeDoc(id: string, docType: ProjectDocument['document_type'], title: string): ProjectDocument {
+  return {
+    document_id: id,
+    document_type: docType,
+    title,
+    content: `Content of ${title}`,
+    created_at: '',
+  }
+}
+
+const allSixDocTypes: ProjectDocument[] = [
+  makeDoc('d-prd', 'prd', 'My PRD'),
+  makeDoc('d-prfaq', 'prfaq', 'My PR/FAQ'),
+  makeDoc('d-research', 'research', 'My Research'),
+  makeDoc('d-custom', 'custom', 'My Custom Doc'),
+  makeDoc('d-proto', 'prototype', 'A Secret Prototype'),
+  makeDoc('d-report', 'product_report', 'Q4 Product Report'),
+]
+
+function renderTab(documents: ProjectDocument[], personas: ProjectPersona[] = onePersona) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <McpAccessTab
+        projectId="proj-filter"
+        project={mockProject}
+        personas={personas}
+        documents={documents}
+        onSaveKiroPrompt={vi.fn()}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('McpAccessTab — export picker excludes non-exportable document types', () => {
+  it('does not render a row for a prototype document', () => {
+    renderTab([makeDoc('d-proto', 'prototype', 'A Secret Prototype')])
+    expect(screen.queryByText('A Secret Prototype')).not.toBeInTheDocument()
+  })
+
+  it('does not render a row for a product_report document', () => {
+    renderTab([makeDoc('d-report', 'product_report', 'Q4 Product Report')])
+    expect(screen.queryByText('Q4 Product Report')).not.toBeInTheDocument()
+  })
+
+  it('renders rows for all four exportable types when present', () => {
+    renderTab(allSixDocTypes)
+
+    expect(screen.getByText('My PRD')).toBeInTheDocument()
+    expect(screen.getByText('My PR/FAQ')).toBeInTheDocument()
+    expect(screen.getByText('My Research')).toBeInTheDocument()
+    expect(screen.getByText('My Custom Doc')).toBeInTheDocument()
+  })
+
+  it('renders no row for prototype even when it is the only document', () => {
+    // Prototype-only project: the documents section should be absent entirely.
+    renderTab([makeDoc('d-proto', 'prototype', 'Only Prototype')])
+    // The document picker section must not appear (no exportable docs).
+    expect(screen.queryByText('Only Prototype')).not.toBeInTheDocument()
+  })
+
+  it('renders no row for product_report when mixed with exportable types', () => {
+    renderTab(allSixDocTypes)
+    // The non-exportable titles must be absent from the picker.
+    expect(screen.queryByText('A Secret Prototype')).not.toBeInTheDocument()
+    expect(screen.queryByText('Q4 Product Report')).not.toBeInTheDocument()
+  })
+
+  it('prototype does not appear under the Custom group heading', () => {
+    // Before the fix, prototypes were coerced into the "custom" bucket.
+    // After the fix they are excluded entirely — the Custom heading only holds
+    // genuine custom documents.
+    renderTab([makeDoc('d-proto', 'prototype', 'Prototype That Looked Custom')])
+    expect(screen.queryByText('Prototype That Looked Custom')).not.toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx
@@ -1,10 +1,19 @@
 /**
  * Acceptance criterion 5: the Export card's document picker renders no row for
- * a `prototype` or `product_report` document, and still renders rows for the
- * four exportable types (prd, prfaq, research, custom).
+ * a `prototype` document, and renders rows for the five exportable types
+ * (prd, prfaq, research, custom, product_report).
  *
  * This test file specifically covers the export-filter behaviour so a revert of
  * the filterExportableDocs change fails here with a clear message.
+ *
+ * NOTE: picker sections start collapsed (expandedSections = new Set()).
+ * PickerSection only renders its children when expanded. Tests that assert row
+ * presence/absence must either:
+ *   (a) expand the documents section first (fireEvent.click on the header), or
+ *   (b) assert on the section *header* being absent/present (when filterExportableDocs
+ *       produces 0 docs, SharedPickers returns null so the header is never rendered).
+ * Asserting on row text without expanding is vacuous — the rows are absent whether
+ * or not the filter is applied.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -97,17 +106,23 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('McpAccessTab — export picker excludes non-exportable document types', () => {
-  it('does not render a row for a prototype document', () => {
+  it('does not render a row for a prototype document — section header absent when prototype is only doc', () => {
+    // filterExportableDocs([prototype]) == [] → SharedPickers returns null → no header
     renderTab([makeDoc('d-proto', 'prototype', 'A Secret Prototype')])
-    expect(screen.queryByText('A Secret Prototype')).not.toBeInTheDocument()
+    // Section header would be "Documents (0/0)" if rendered, but SharedPickers returns null entirely
+    expect(screen.queryByText(/Documents \(/)).not.toBeInTheDocument()
   })
 
-  it('does not render a row for a product_report document', () => {
+  it('renders a row for a product_report document when section is expanded', () => {
+    // product_report is an exportable type — it must appear in the picker
     renderTab([makeDoc('d-report', 'product_report', 'Q4 Product Report')])
-    expect(screen.queryByText('Q4 Product Report')).not.toBeInTheDocument()
+    // Expand the documents section to see the rows
+    const docsToggle = screen.getByText(/Documents \(/)
+    fireEvent.click(docsToggle)
+    expect(screen.getByText('Q4 Product Report')).toBeInTheDocument()
   })
 
-  it('renders rows for all four exportable types when present', () => {
+  it('renders rows for all five exportable types when section is expanded', () => {
     renderTab(allSixDocTypes)
 
     // Picker sections start collapsed — expand the documents section first.
@@ -118,27 +133,31 @@ describe('McpAccessTab — export picker excludes non-exportable document types'
     expect(screen.getByText('My PR/FAQ')).toBeInTheDocument()
     expect(screen.getByText('My Research')).toBeInTheDocument()
     expect(screen.getByText('My Custom Doc')).toBeInTheDocument()
+    expect(screen.getByText('Q4 Product Report')).toBeInTheDocument()
   })
 
-  it('renders no row for prototype even when it is the only document', () => {
-    // Prototype-only project: the documents section should be absent entirely.
+  it('does not render a row for prototype even when it is the only document — section absent', () => {
+    // Prototype-only project: filterExportableDocs == [] → SharedPickers returns null
     renderTab([makeDoc('d-proto', 'prototype', 'Only Prototype')])
-    // The document picker section must not appear (no exportable docs).
-    expect(screen.queryByText('Only Prototype')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Documents \(/)).not.toBeInTheDocument()
   })
 
-  it('renders no row for product_report when mixed with exportable types', () => {
+  it('renders product_report row but not prototype row when section is expanded (mixed types)', () => {
     renderTab(allSixDocTypes)
-    // The non-exportable titles must be absent from the picker.
+    // Expand the section so rows are actually rendered
+    const docsToggle = screen.getByText(/Documents \(/)
+    fireEvent.click(docsToggle)
+    // product_report is exportable — must be visible
+    expect(screen.getByText('Q4 Product Report')).toBeInTheDocument()
+    // prototype is excluded — must be absent from the rows
     expect(screen.queryByText('A Secret Prototype')).not.toBeInTheDocument()
-    expect(screen.queryByText('Q4 Product Report')).not.toBeInTheDocument()
   })
 
-  it('prototype does not appear under the Custom group heading', () => {
+  it('prototype does not appear under any group heading — section absent when prototype is only doc', () => {
     // Before the fix, prototypes were coerced into the "custom" bucket.
-    // After the fix they are excluded entirely — the Custom heading only holds
-    // genuine custom documents.
+    // After the fix they are excluded entirely — filterExportableDocs([prototype]) == []
+    // so SharedPickers returns null, and no section header or rows appear.
     renderTab([makeDoc('d-proto', 'prototype', 'Prototype That Looked Custom')])
-    expect(screen.queryByText('Prototype That Looked Custom')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Documents \(/)).not.toBeInTheDocument()
   })
 })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx
@@ -9,14 +9,15 @@
  * NOTE: picker sections start collapsed (expandedSections = new Set()).
  * PickerSection only renders its children when expanded. Tests that assert row
  * presence/absence must either:
- *   (a) expand the documents section first (fireEvent.click on the header), or
+ *   (a) expand the documents section first (expandDocuments(), which clicks it by role), or
  *   (b) assert on the section *header* being absent/present (when filterExportableDocs
  *       produces 0 docs, SharedPickers returns null so the header is never rendered).
  * Asserting on row text without expanding is vacuous — the rows are absent whether
  * or not the filter is applied.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import McpAccessTab from './McpAccessTab'
 import type { Project, ProjectDocument, ProjectPersona } from '../../api/types'
@@ -105,6 +106,16 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
+/**
+ * Expand the documents picker section. Found by ROLE, not by text: if the header
+ * stops being a button this fails for the right reason instead of clicking a
+ * non-interactive node and silently proving nothing.
+ */
+async function expandDocuments(): Promise<void> {
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: /Documents \(/ }))
+}
+
 describe('McpAccessTab — export picker excludes non-exportable document types', () => {
   it('does not render a row for a prototype document — section header absent when prototype is only doc', () => {
     // filterExportableDocs([prototype]) == [] → SharedPickers returns null → no header
@@ -113,21 +124,17 @@ describe('McpAccessTab — export picker excludes non-exportable document types'
     expect(screen.queryByText(/Documents \(/)).not.toBeInTheDocument()
   })
 
-  it('renders a row for a product_report document when section is expanded', () => {
+  it('renders a row for a product_report document when section is expanded', async () => {
     // product_report is an exportable type — it must appear in the picker
     renderTab([makeDoc('d-report', 'product_report', 'Q4 Product Report')])
-    // Expand the documents section to see the rows
-    const docsToggle = screen.getByText(/Documents \(/)
-    fireEvent.click(docsToggle)
+    await expandDocuments()
     expect(screen.getByText('Q4 Product Report')).toBeInTheDocument()
   })
 
-  it('renders rows for all five exportable types when section is expanded', () => {
+  it('renders rows for all five exportable types when section is expanded', async () => {
     renderTab(allSixDocTypes)
 
-    // Picker sections start collapsed — expand the documents section first.
-    const docsToggle = screen.getByText(/Documents \(/)
-    fireEvent.click(docsToggle)
+    await expandDocuments()
 
     expect(screen.getByText('My PRD')).toBeInTheDocument()
     expect(screen.getByText('My PR/FAQ')).toBeInTheDocument()
@@ -142,11 +149,9 @@ describe('McpAccessTab — export picker excludes non-exportable document types'
     expect(screen.queryByText(/Documents \(/)).not.toBeInTheDocument()
   })
 
-  it('renders product_report row but not prototype row when section is expanded (mixed types)', () => {
+  it('renders product_report row but not prototype row when section is expanded (mixed types)', async () => {
     renderTab(allSixDocTypes)
-    // Expand the section so rows are actually rendered
-    const docsToggle = screen.getByText(/Documents \(/)
-    fireEvent.click(docsToggle)
+    await expandDocuments()
     // product_report is exportable — must be visible
     expect(screen.getByText('Q4 Product Report')).toBeInTheDocument()
     // prototype is excluded — must be absent from the rows

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -452,7 +452,9 @@ export default function McpAccessTab({
   const { t } = useTranslation('projectDetail')
 
   // Only exportable document types appear in the picker and the payload.
-  // Prototypes and product_reports are excluded from Kiro exports everywhere.
+  // Prototypes are the sole exclusion — see KIRO_EXPORT_EXCLUDED_TYPES in
+  // projects.py, which this list mirrors. Product reports ARE exported: they are
+  // markdown describing the current product, which is grounding a coding agent wants.
   const exportableDocs = useMemo(() => filterExportableDocs(documents), [documents])
 
   // ── Shared picker state (used by both cards) ──────────────────────────────

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -107,12 +107,13 @@ function groupDocumentsByType(documents: ProjectDocument[]): Record<KiroExportab
     prfaq: [],
     research: [],
     custom: [],
+    product_report: [],
   }
   for (const doc of documents) {
     if (isKiroExportableDocType(doc.document_type)) {
       groups[doc.document_type].push(doc)
     }
-    // Non-exportable types (prototype, product_report) are silently skipped.
+    // Non-exportable types (prototype) are silently skipped.
   }
   return groups
 }
@@ -231,7 +232,7 @@ function SharedPickers({
           onToggleAll={onToggleAllDocuments}
         >
           {Object.keys(docGroups)
-            .filter(isKiroExportableDocType)
+            .filter(isKiroExportableDocType) // narrows string[] → KiroExportableDocType[] for TS; runtime no-op (groupDocumentsByType only creates exportable-type keys)
             .filter((type) => docGroups[type].length > 0)
             .map((type) => {
               const docs = docGroups[type]

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -31,7 +31,10 @@ import { api } from '../../api/client'
 import { stripTrailingSlashes } from '../../api/baseUrl'
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard'
 import { useConfigStore } from '../../store/configStore'
-import { buildAutoseedParams, canCopyExport } from './autoseedSelection'
+import {
+  buildAutoseedParams, canCopyExport, filterExportableDocs,
+  isKiroExportableDocType, type KiroExportableDocType,
+} from './autoseedSelection'
 import AutoseedContent from './AutoseedContent'
 import CollapsibleSection from './CollapsibleSection'
 import KiroExportSettings from './KiroExportSettings'
@@ -80,11 +83,7 @@ function buildMcpConfig(baseUrl: string, projectId: string): string {
   }, null, 2)
 }
 
-type DocType = 'prd' | 'prfaq' | 'research' | 'custom'
-
-function isValidDocType(value: string): value is DocType {
-  return value === 'prd' || value === 'prfaq' || value === 'research' || value === 'custom'
-}
+type DocType = KiroExportableDocType
 
 function groupDocumentsByType(documents: ProjectDocument[]): Record<DocType, ProjectDocument[]> {
   const groups: Record<DocType, ProjectDocument[]> = {
@@ -94,8 +93,10 @@ function groupDocumentsByType(documents: ProjectDocument[]): Record<DocType, Pro
     custom: [],
   }
   for (const doc of documents) {
-    const docType = isValidDocType(doc.document_type) ? doc.document_type : 'custom'
-    groups[docType].push(doc)
+    if (isKiroExportableDocType(doc.document_type)) {
+      groups[doc.document_type].push(doc)
+    }
+    // Non-exportable types (prototype, product_report) are silently skipped.
   }
   return groups
 }
@@ -214,7 +215,7 @@ function SharedPickers({
           onToggleAll={onToggleAllDocuments}
         >
           {Object.keys(docGroups)
-            .filter(isValidDocType)
+            .filter(isKiroExportableDocType)
             .filter((type) => docGroups[type].length > 0)
             .map((type) => {
               const docs = docGroups[type]
@@ -432,6 +433,10 @@ export default function McpAccessTab({
   const { config } = useConfigStore()
   const { t } = useTranslation('projectDetail')
 
+  // Only exportable document types appear in the picker and the payload.
+  // Prototypes and product_reports are excluded from Kiro exports everywhere.
+  const exportableDocs = useMemo(() => filterExportableDocs(documents), [documents])
+
   // ── Shared picker state (used by both cards) ──────────────────────────────
   //
   // DESELECTED ids are stored, and the selection is DERIVED from the props. The
@@ -454,8 +459,8 @@ export default function McpAccessTab({
     [personas, deselectedPersonaIds],
   )
   const selectedDocumentIds = useMemo(
-    () => new Set(documents.map((d) => d.document_id).filter((id) => !deselectedDocumentIds.has(id))),
-    [documents, deselectedDocumentIds],
+    () => new Set(exportableDocs.map((d) => d.document_id).filter((id) => !deselectedDocumentIds.has(id))),
+    [exportableDocs, deselectedDocumentIds],
   )
 
   // Toggling a row flips its membership in the DESELECTED set, so the checkbox
@@ -483,8 +488,8 @@ export default function McpAccessTab({
   }, [personas])
 
   const toggleAllDocuments = useCallback((select: boolean) => {
-    setDeselectedDocumentIds(select ? new Set() : new Set(documents.map((d) => d.document_id)))
-  }, [documents])
+    setDeselectedDocumentIds(select ? new Set() : new Set(exportableDocs.map((d) => d.document_id)))
+  }, [exportableDocs])
 
   const toggleSection = useCallback((section: string) => {
     setExpandedSections((prev) => {
@@ -536,14 +541,14 @@ export default function McpAccessTab({
   // none selected would emit a curl that omits the filter and makes Kiro fetch
   // everything the user deselected. Both delivery paths share one guard.
   const hasPickerSelection = canCopyExport(
-    selectedPersonaIds, personas.length, selectedDocumentIds, documents.length,
+    selectedPersonaIds, personas.length, selectedDocumentIds, exportableDocs.length,
   )
 
   // Build the autoseed curl URL from shared selection (used by Card 2)
   const apiBase = stripTrailingSlashes(config.apiEndpoint === '' ? '' : config.apiEndpoint)
   const autoseedCurlUrl = useMemo(() => {
     const { personaIds, documentIds } = buildAutoseedParams(
-      selectedPersonaIds, personas.length, selectedDocumentIds, documents.length,
+      selectedPersonaIds, personas.length, selectedDocumentIds, exportableDocs.length,
     )
     const params = new URLSearchParams()
     if (personaIds != null) params.set('persona_ids', personaIds.join(','))
@@ -551,14 +556,14 @@ export default function McpAccessTab({
     const qs = params.toString()
     const base = `${apiBase}/mcp/autoseed/${projectId}`
     return qs === '' ? base : `${base}?${qs}`
-  }, [apiBase, projectId, selectedPersonaIds, selectedDocumentIds, personas.length, documents.length])
+  }, [apiBase, projectId, selectedPersonaIds, selectedDocumentIds, personas.length, exportableDocs.length])
 
   // ── Card 1 — Export ───────────────────────────────────────────────────────
   const exportCard = (
     <ExportCard
       projectId={projectId}
       personas={personas}
-      documents={documents}
+      documents={exportableDocs}
       selectedPersonaIds={selectedPersonaIds}
       selectedDocumentIds={selectedDocumentIds}
       expandedSections={expandedSections}
@@ -587,7 +592,7 @@ export default function McpAccessTab({
         >
           <AutoseedContent
             personas={personas}
-            documents={documents}
+            documents={exportableDocs}
             curlUrl={autoseedCurlUrl}
             hasSelection={hasPickerSelection}
           />
@@ -673,7 +678,7 @@ export default function McpAccessTab({
         >
           <AutoseedContent
             personas={personas}
-            documents={documents}
+            documents={exportableDocs}
             curlUrl={autoseedCurlUrl}
             hasSelection={hasPickerSelection}
           />

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -83,10 +83,8 @@ function buildMcpConfig(baseUrl: string, projectId: string): string {
   }, null, 2)
 }
 
-type DocType = KiroExportableDocType
-
-function groupDocumentsByType(documents: ProjectDocument[]): Record<DocType, ProjectDocument[]> {
-  const groups: Record<DocType, ProjectDocument[]> = {
+function groupDocumentsByType(documents: ProjectDocument[]): Record<KiroExportableDocType, ProjectDocument[]> {
+  const groups: Record<KiroExportableDocType, ProjectDocument[]> = {
     prd: [],
     prfaq: [],
     research: [],

--- a/voc-datalake/frontend/src/pages/ProjectDetail/autoseedSelection.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/autoseedSelection.ts
@@ -13,9 +13,9 @@ import type { ProjectDocument } from '../../api/types'
  *
  * Must stay in sync with KIRO_EXPORT_EXCLUDED_TYPES in projects.py — the
  * lockstep test test_kiro_exportable_types_lockstep.py fails if they drift.
- * Do NOT add 'prototype' or 'product_report' here.
+ * Do NOT add 'prototype' here.
  */
-export const KIRO_EXPORTABLE_DOC_TYPES = ['prd', 'prfaq', 'research', 'custom'] as const
+export const KIRO_EXPORTABLE_DOC_TYPES = ['prd', 'prfaq', 'research', 'custom', 'product_report'] as const
 
 export type KiroExportableDocType = typeof KIRO_EXPORTABLE_DOC_TYPES[number]
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/autoseedSelection.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/autoseedSelection.ts
@@ -6,6 +6,27 @@
  * and because both the Export card's clipboard copy and Card 2's `curl` URL build
  * their request from these functions — one definition, not two drifting copies.
  */
+import type { ProjectDocument } from '../../api/types'
+
+/**
+ * Document types that the Kiro export picker shows and the payload includes.
+ *
+ * Must stay in sync with KIRO_EXPORT_EXCLUDED_TYPES in projects.py — the
+ * lockstep test test_kiro_exportable_types_lockstep.py fails if they drift.
+ * Do NOT add 'prototype' or 'product_report' here.
+ */
+export const KIRO_EXPORTABLE_DOC_TYPES = ['prd', 'prfaq', 'research', 'custom'] as const
+
+export type KiroExportableDocType = typeof KIRO_EXPORTABLE_DOC_TYPES[number]
+
+export function isKiroExportableDocType(value: string): value is KiroExportableDocType {
+  return KIRO_EXPORTABLE_DOC_TYPES.some((t) => t === value)
+}
+
+/** Returns only the documents that are exportable to Kiro. */
+export function filterExportableDocs(documents: ProjectDocument[]): ProjectDocument[] {
+  return documents.filter((d) => isKiroExportableDocType(d.document_type))
+}
 
 /**
  * Builds the `personaIds` / `documentIds` filter params for the autoseed API.

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -1680,11 +1680,13 @@ def _build_steering_file(project: dict, personas: list, documents: list) -> str:
 
 
 # Document types that must never appear in a Kiro export payload.
-# Prototypes are generated HTML — exporting them anchors the model on old output.
-# Product reports are internal analytics snapshots, not implementation context.
+# Prototypes are generated HTML artifacts (or S3-backed rendered pages with no
+# text content) — exporting them anchors the coding agent on stale output.
+# DocumentExportMenu.tsx already returns null for S3-only prototypes; this
+# exclusion makes the two export paths agree rather than contradict each other.
 # This set is the backend authority; the frontend constant must match it
 # (enforced by test_kiro_exportable_types_lockstep.py).
-KIRO_EXPORT_EXCLUDED_TYPES: frozenset[str] = frozenset({'prototype', 'product_report'})
+KIRO_EXPORT_EXCLUDED_TYPES: frozenset[str] = frozenset({'prototype'})
 
 
 @tracer.capture_method

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -1679,7 +1679,6 @@ def _build_steering_file(project: dict, personas: list, documents: list) -> str:
     return '\n'.join(lines)
 
 
-
 # Document types that must never appear in a Kiro export payload.
 # Prototypes are generated HTML — exporting them anchors the model on old output.
 # Product reports are internal analytics snapshots, not implementation context.

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -1679,26 +1679,44 @@ def _build_steering_file(project: dict, personas: list, documents: list) -> str:
     return '\n'.join(lines)
 
 
+
+# Document types that must never appear in a Kiro export payload.
+# Prototypes are generated HTML — exporting them anchors the model on old output.
+# Product reports are internal analytics snapshots, not implementation context.
+# This set is the backend authority; the frontend constant must match it
+# (enforced by test_kiro_exportable_types_lockstep.py).
+KIRO_EXPORT_EXCLUDED_TYPES: frozenset[str] = frozenset({'prototype', 'product_report'})
+
+
 @tracer.capture_method
 def autoseed_project(project_id: str, persona_ids: list[str] | None = None, document_ids: list[str] | None = None) -> dict:
     """Generate a Kiro autoseed payload with selected project context as files.
-    
+
     Args:
         project_id: The project to export.
         persona_ids: Optional list of persona IDs to include. None means all.
         document_ids: Optional list of document IDs to include. None means all.
+
+    Documents whose document_type is in KIRO_EXPORT_EXCLUDED_TYPES are always
+    dropped, even if their ids appear in document_ids.
     """
     project_data = get_project(project_id)
     project = project_data['project']
     all_personas = project_data['personas']
     all_documents = project_data['documents']
 
-    # Filter to selected items (None = include all)
+    # Filter to selected items (None = include all), then strip excluded types.
+    # The type filter is applied AFTER the id filter so an explicitly requested
+    # prototype id is also dropped — callers cannot bypass the exclusion.
     personas = all_personas if persona_ids is None else [
         p for p in all_personas if p.get('persona_id') in persona_ids
     ]
-    documents = all_documents if document_ids is None else [
+    candidate_docs = all_documents if document_ids is None else [
         d for d in all_documents if d.get('document_id') in document_ids
+    ]
+    documents = [
+        d for d in candidate_docs
+        if d.get('document_type') not in KIRO_EXPORT_EXCLUDED_TYPES
     ]
 
     project_name = project.get('name', 'project')

--- a/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
+++ b/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
@@ -2,9 +2,10 @@
 Tests for the Kiro export exclusion rules in autoseed_project.
 
 Acceptance criteria covered:
-  1. autoseed_project returns no prototype or product_report, even when explicitly requested.
-  2. prd, prfaq, research, custom ARE returned; persona selection still works.
-  3. The steering file does not mention excluded documents.
+  1. autoseed_project returns no prototype, even when explicitly requested.
+     product_report IS returned (it is not excluded).
+  2. prd, prfaq, research, custom, product_report ARE returned; persona selection still works.
+  3. The steering file does not mention excluded (prototype) documents.
   4. GET /projects/{project_id} still returns prototypes in documents.
 """
 from unittest.mock import patch
@@ -44,7 +45,7 @@ def _project_data(documents: list[dict], personas: list[dict] | None = None) -> 
 # ---------------------------------------------------------------------------
 
 class TestAutoseedExcludesNonExportableTypes:
-    """autoseed_project must never include prototype or product_report documents."""
+    """autoseed_project must never include prototype documents."""
 
     @patch('projects.get_project')
     def test_prototype_excluded_when_no_ids_filter(self, mock_get_project):
@@ -69,8 +70,8 @@ class TestAutoseedExcludesNonExportableTypes:
         )
 
     @patch('projects.get_project')
-    def test_product_report_excluded_when_no_ids_filter(self, mock_get_project):
-        """Product report is dropped even when document_ids is None."""
+    def test_product_report_included_when_no_ids_filter(self, mock_get_project):
+        """Product report IS included — it is not excluded from Kiro exports."""
         mock_get_project.return_value = _project_data([
             _make_doc('d-prfaq', 'prfaq'),
             _make_doc('d-report', 'product_report'),
@@ -83,8 +84,8 @@ class TestAutoseedExcludesNonExportableTypes:
         assert any('d-prfaq' in p for p in doc_paths), (
             f'PRFAQ should be exported; paths: {doc_paths}'
         )
-        assert not any('d-report' in p or 'product-report' in p for p in doc_paths), (
-            'product_report must not appear in Kiro export'
+        assert any('d-report' in p for p in doc_paths), (
+            f'product_report must appear in Kiro export; paths: {doc_paths}'
         )
 
     @patch('projects.get_project')
@@ -105,8 +106,8 @@ class TestAutoseedExcludesNonExportableTypes:
         )
 
     @patch('projects.get_project')
-    def test_product_report_excluded_even_when_explicitly_requested(self, mock_get_project):
-        """A caller who passes a product_report id explicitly must still be denied."""
+    def test_product_report_included_even_when_explicitly_requested(self, mock_get_project):
+        """A caller who passes a product_report id gets it back — it is exportable."""
         report_id = 'd-report'
         mock_get_project.return_value = _project_data([
             _make_doc('d-research', 'research'),
@@ -117,16 +118,15 @@ class TestAutoseedExcludesNonExportableTypes:
 
         result = autoseed_project('proj-test', document_ids=[report_id, 'd-research'])
         doc_paths = [f['path'] for f in result['files'] if f['path'].startswith('.kiro/docs/')]
-        assert all(report_id not in p for p in doc_paths), (
-            'product_report must be dropped even when its id is in document_ids'
+        assert any(report_id in p for p in doc_paths), (
+            f'product_report must be included when its id is in document_ids; paths: {doc_paths}'
         )
 
     @patch('projects.get_project')
-    def test_all_excluded_types_produce_no_doc_files(self, mock_get_project):
-        """A project with only prototypes and product_reports exports zero doc files."""
+    def test_prototype_only_project_produces_no_doc_files(self, mock_get_project):
+        """A project with only prototypes exports zero doc files."""
         mock_get_project.return_value = _project_data([
             _make_doc('d-proto', 'prototype'),
-            _make_doc('d-report', 'product_report'),
         ])
 
         from projects import autoseed_project
@@ -134,31 +134,31 @@ class TestAutoseedExcludesNonExportableTypes:
         result = autoseed_project('proj-test')
         doc_files = [f for f in result['files'] if f['path'].startswith('.kiro/docs/')]
         assert doc_files == [], (
-            f'No doc files should be emitted; got: {doc_files}'
+            f'No doc files should be emitted for prototype-only project; got: {doc_files}'
         )
 
 
 class TestAutoseedIncludesExportableTypes:
-    """All four exportable types (prd, prfaq, research, custom) are passed through."""
+    """All five exportable types (prd, prfaq, research, custom, product_report) are passed through."""
 
     @patch('projects.get_project')
-    def test_all_four_exportable_types_are_included(self, mock_get_project):
-        """prd, prfaq, research, custom all appear in the payload."""
+    def test_all_five_exportable_types_are_included(self, mock_get_project):
+        """prd, prfaq, research, custom, product_report all appear in the payload."""
         mock_get_project.return_value = _project_data([
             _make_doc('d-prd', 'prd', 'My PRD'),
             _make_doc('d-prfaq', 'prfaq', 'My PR/FAQ'),
             _make_doc('d-research', 'research', 'My Research'),
             _make_doc('d-custom', 'custom', 'My Custom'),
+            _make_doc('d-report', 'product_report', 'My Product Report'),
             _make_doc('d-proto', 'prototype', 'A Prototype'),
-            _make_doc('d-report', 'product_report', 'A Report'),
         ])
 
         from projects import autoseed_project
 
         result = autoseed_project('proj-test')
         doc_files = [f for f in result['files'] if f['path'].startswith('.kiro/docs/')]
-        assert len(doc_files) == 4, (
-            f'Expected 4 exportable docs; got {len(doc_files)}: {[f["path"] for f in doc_files]}'
+        assert len(doc_files) == 5, (
+            f'Expected 5 exportable docs; got {len(doc_files)}: {[f["path"] for f in doc_files]}'
         )
 
     @patch('projects.get_project')
@@ -200,7 +200,7 @@ class TestAutoseedIncludesExportableTypes:
 # ---------------------------------------------------------------------------
 
 class TestSteeringFileExcludesNonExportableDocs:
-    """The steering file must not mention prototype or product_report documents."""
+    """The steering file must not mention prototype documents, but must mention product_report."""
 
     @patch('projects.get_project')
     def test_steering_file_omits_prototype_title(self, mock_get_project):
@@ -225,8 +225,8 @@ class TestSteeringFileExcludesNonExportableDocs:
         )
 
     @patch('projects.get_project')
-    def test_steering_file_omits_product_report_title(self, mock_get_project):
-        """Product report title does not appear in the steering file."""
+    def test_steering_file_includes_product_report_title(self, mock_get_project):
+        """Product report title appears in the steering file — it is an exportable type."""
         mock_get_project.return_value = _project_data([
             _make_doc('d-custom', 'custom', 'My Custom Doc'),
             _make_doc('d-report', 'product_report', 'Q4 Product Report'),
@@ -239,8 +239,8 @@ class TestSteeringFileExcludesNonExportableDocs:
             f['content'] for f in result['files']
             if f['path'].startswith('.kiro/steering/')
         )
-        assert 'Q4 Product Report' not in steering, (
-            'Product report title must not appear in the steering file'
+        assert 'Q4 Product Report' in steering, (
+            'Product report title must appear in the steering file (product_report is exportable)'
         )
         assert 'My Custom Doc' in steering, (
             'Custom doc title should still appear in the steering file'

--- a/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
+++ b/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
@@ -1,0 +1,303 @@
+"""
+Tests for the Kiro export exclusion rules in autoseed_project.
+
+Acceptance criteria covered:
+  1. autoseed_project returns no prototype or product_report, even when explicitly requested.
+  2. prd, prfaq, research, custom ARE returned; persona selection still works.
+  3. The steering file does not mention excluded documents.
+  4. GET /projects/{project_id} still returns prototypes in documents.
+"""
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_doc(doc_id: str, document_type: str, title: str | None = None) -> dict:
+    return {
+        'document_id': doc_id,
+        'document_type': document_type,
+        'title': title or f'Doc {doc_id}',
+        'content': f'Content of {doc_id}',
+    }
+
+
+def _make_persona(persona_id: str, name: str = 'Alice') -> dict:
+    return {'persona_id': persona_id, 'name': name, 'tagline': 'A persona'}
+
+
+def _project_data(documents: list[dict], personas: list[dict] | None = None) -> dict:
+    return {
+        'project': {
+            'project_id': 'proj-test',
+            'name': 'Test Project',
+            'description': 'Desc',
+            'kiro_export_prompt': '',
+        },
+        'personas': personas or [],
+        'documents': documents,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1 & 2. autoseed_project filters excluded types; exportable types pass through
+# ---------------------------------------------------------------------------
+
+class TestAutoseedExcludesNonExportableTypes:
+    """autoseed_project must never include prototype or product_report documents."""
+
+    @patch('projects.get_project')
+    def test_prototype_excluded_when_no_ids_filter(self, mock_get_project):
+        """Prototype is dropped even when document_ids is None (include-all)."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-prd', 'prd'),
+            _make_doc('d-proto', 'prototype'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test')
+        doc_types_in_files = {
+            f['path'] for f in result['files']
+            if f['path'].startswith('.kiro/docs/')
+        }
+        proto_path = '.kiro/docs/doc-d-proto.md'
+        assert any('d-prd' in p or 'prd' in p for p in doc_types_in_files), (
+            f'PRD should be exported; files: {doc_types_in_files}'
+        )
+        assert proto_path not in doc_types_in_files, (
+            'Prototype must not appear in Kiro export'
+        )
+
+    @patch('projects.get_project')
+    def test_product_report_excluded_when_no_ids_filter(self, mock_get_project):
+        """Product report is dropped even when document_ids is None."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-prfaq', 'prfaq'),
+            _make_doc('d-report', 'product_report'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test')
+        doc_paths = [f['path'] for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert any('d-report' in p or 'product-report' in p for p in doc_paths) is False, (
+            'product_report must not appear in Kiro export'
+        )
+
+    @patch('projects.get_project')
+    def test_prototype_excluded_even_when_explicitly_requested(self, mock_get_project):
+        """A caller who passes a prototype id explicitly must still be denied."""
+        proto_id = 'd-proto'
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-prd', 'prd'),
+            _make_doc(proto_id, 'prototype'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test', document_ids=[proto_id, 'd-prd'])
+        doc_paths = [f['path'] for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert all(proto_id not in p for p in doc_paths), (
+            'Prototype must be dropped even when its id is in document_ids'
+        )
+
+    @patch('projects.get_project')
+    def test_product_report_excluded_even_when_explicitly_requested(self, mock_get_project):
+        """A caller who passes a product_report id explicitly must still be denied."""
+        report_id = 'd-report'
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-research', 'research'),
+            _make_doc(report_id, 'product_report'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test', document_ids=[report_id, 'd-research'])
+        doc_paths = [f['path'] for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert all(report_id not in p for p in doc_paths), (
+            'product_report must be dropped even when its id is in document_ids'
+        )
+
+    @patch('projects.get_project')
+    def test_all_excluded_types_produce_no_doc_files(self, mock_get_project):
+        """A project with only prototypes and product_reports exports zero doc files."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-proto', 'prototype'),
+            _make_doc('d-report', 'product_report'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test')
+        doc_files = [f for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert doc_files == [], (
+            f'No doc files should be emitted; got: {doc_files}'
+        )
+
+
+class TestAutoseedIncludesExportableTypes:
+    """All four exportable types (prd, prfaq, research, custom) are passed through."""
+
+    @patch('projects.get_project')
+    def test_all_four_exportable_types_are_included(self, mock_get_project):
+        """prd, prfaq, research, custom all appear in the payload."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-prd', 'prd', 'My PRD'),
+            _make_doc('d-prfaq', 'prfaq', 'My PR/FAQ'),
+            _make_doc('d-research', 'research', 'My Research'),
+            _make_doc('d-custom', 'custom', 'My Custom'),
+            _make_doc('d-proto', 'prototype', 'A Prototype'),
+            _make_doc('d-report', 'product_report', 'A Report'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test')
+        doc_files = [f for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert len(doc_files) == 4, (
+            f'Expected 4 exportable docs; got {len(doc_files)}: {[f["path"] for f in doc_files]}'
+        )
+
+    @patch('projects.get_project')
+    def test_persona_selection_still_works(self, mock_get_project):
+        """Persona filtering still honours persona_ids."""
+        mock_get_project.return_value = _project_data(
+            documents=[_make_doc('d-prd', 'prd')],
+            personas=[
+                _make_persona('p1', 'Alice'),
+                _make_persona('p2', 'Bob'),
+            ],
+        )
+
+        from projects import autoseed_project
+
+        # Ask for only p1
+        result = autoseed_project('proj-test', persona_ids=['p1'])
+        persona_files = [f for f in result['files'] if f['path'].startswith('.kiro/personas/')]
+        assert len(persona_files) == 1
+        assert 'alice' in persona_files[0]['path']
+
+    @patch('projects.get_project')
+    def test_exportable_doc_with_explicit_id_is_included(self, mock_get_project):
+        """When document_ids is provided, exportable types are included."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-prd', 'prd', 'My PRD'),
+            _make_doc('d-other-prd', 'prd', 'Other PRD'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test', document_ids=['d-prd'])
+        doc_files = [f for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert len(doc_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Steering file does not mention excluded documents
+# ---------------------------------------------------------------------------
+
+class TestSteeringFileExcludesNonExportableDocs:
+    """The steering file must not mention prototype or product_report documents."""
+
+    @patch('projects.get_project')
+    def test_steering_file_omits_prototype_title(self, mock_get_project):
+        """Prototype title does not appear in the steering file."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-prd', 'prd', 'My PRD'),
+            _make_doc('d-proto', 'prototype', 'A Secret Prototype'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test')
+        steering = next(
+            f['content'] for f in result['files']
+            if f['path'].startswith('.kiro/steering/')
+        )
+        assert 'A Secret Prototype' not in steering, (
+            'Prototype title must not appear in the steering file'
+        )
+        assert 'My PRD' in steering, (
+            'PRD title should still appear in the steering file'
+        )
+
+    @patch('projects.get_project')
+    def test_steering_file_omits_product_report_title(self, mock_get_project):
+        """Product report title does not appear in the steering file."""
+        mock_get_project.return_value = _project_data([
+            _make_doc('d-custom', 'custom', 'My Custom Doc'),
+            _make_doc('d-report', 'product_report', 'Q4 Product Report'),
+        ])
+
+        from projects import autoseed_project
+
+        result = autoseed_project('proj-test')
+        steering = next(
+            f['content'] for f in result['files']
+            if f['path'].startswith('.kiro/steering/')
+        )
+        assert 'Q4 Product Report' not in steering, (
+            'Product report title must not appear in the steering file'
+        )
+        assert 'My Custom Doc' in steering, (
+            'Custom doc title should still appear in the steering file'
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. get_project still returns prototypes in its documents list
+# ---------------------------------------------------------------------------
+
+class TestGetProjectStillReturnsPrototypes:
+    """get_project must not be changed — it returns ALL document types."""
+
+    @patch('projects.projects_table')
+    def test_get_project_includes_prototype(self, mock_table):
+        """get_project returns prototype documents unchanged."""
+        mock_table.query.return_value = {
+            'Items': [
+                {
+                    'pk': 'PROJECT#proj-1', 'sk': 'META',
+                    'project_id': 'proj-1', 'name': 'Test',
+                },
+                {
+                    'pk': 'PROJECT#proj-1', 'sk': 'PROTOTYPE#p1',
+                    'document_id': 'p1', 'document_type': 'prototype',
+                    'title': 'My Prototype', 'content': '<html/>',
+                },
+            ]
+        }
+
+        from projects import get_project
+
+        result = get_project('proj-1')
+        doc_types = [d['document_type'] for d in result['documents']]
+        assert 'prototype' in doc_types, (
+            'get_project must still return prototype documents (Documents tab depends on it)'
+        )
+
+    @patch('projects.projects_table')
+    def test_get_project_includes_product_report(self, mock_table):
+        """get_project returns product_report documents unchanged."""
+        mock_table.query.return_value = {
+            'Items': [
+                {
+                    'pk': 'PROJECT#proj-1', 'sk': 'META',
+                    'project_id': 'proj-1', 'name': 'Test',
+                },
+                {
+                    'pk': 'PROJECT#proj-1', 'sk': 'PRODUCT_REPORT#r1',
+                    'document_id': 'r1', 'document_type': 'product_report',
+                    'title': 'Q4 Report', 'content': '...',
+                },
+            ]
+        }
+
+        from projects import get_project
+
+        result = get_project('proj-1')
+        doc_types = [d['document_type'] for d in result['documents']]
+        assert 'product_report' in doc_types, (
+            'get_project must still return product_report documents (Documents tab depends on it)'
+        )

--- a/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
+++ b/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
@@ -61,11 +61,10 @@ class TestAutoseedExcludesNonExportableTypes:
             f['path'] for f in result['files']
             if f['path'].startswith('.kiro/docs/')
         }
-        proto_path = '.kiro/docs/doc-d-proto.md'
-        assert any('d-prd' in p or 'prd' in p for p in doc_types_in_files), (
+        assert any('d-prd' in p for p in doc_types_in_files), (
             f'PRD should be exported; files: {doc_types_in_files}'
         )
-        assert proto_path not in doc_types_in_files, (
+        assert all('d-proto' not in p for p in doc_types_in_files), (
             'Prototype must not appear in Kiro export'
         )
 
@@ -81,7 +80,7 @@ class TestAutoseedExcludesNonExportableTypes:
 
         result = autoseed_project('proj-test')
         doc_paths = [f['path'] for f in result['files'] if f['path'].startswith('.kiro/docs/')]
-        assert any('d-report' in p or 'product-report' in p for p in doc_paths) is False, (
+        assert not any('d-report' in p or 'product-report' in p for p in doc_paths), (
             'product_report must not appear in Kiro export'
         )
 

--- a/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
+++ b/voc-datalake/lambda/api/test/test_autoseed_export_filter.py
@@ -80,6 +80,9 @@ class TestAutoseedExcludesNonExportableTypes:
 
         result = autoseed_project('proj-test')
         doc_paths = [f['path'] for f in result['files'] if f['path'].startswith('.kiro/docs/')]
+        assert any('d-prfaq' in p for p in doc_paths), (
+            f'PRFAQ should be exported; paths: {doc_paths}'
+        )
         assert not any('d-report' in p or 'product-report' in p for p in doc_paths), (
             'product_report must not appear in Kiro export'
         )

--- a/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
@@ -17,15 +17,16 @@ lambda/shared/test/test_avatar_image_model_lockstep.py.
 import re
 from pathlib import Path
 
-import pytest
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
 # All values in the `document_type` union from types.ts.
+# Cross-reference: frontend/src/api/types.ts line 303:
+#   document_type: 'prd' | 'prfaq' | 'research' | 'custom' | 'product_report' | 'prototype'
 # Kept here so this test fails if someone adds a new type without deciding
-# whether it belongs in the export.
+# whether it belongs in the export.  When you add a new document_type to
+# types.ts, also update this set and decide which constant it belongs in.
 ALL_DOCUMENT_TYPES: frozenset[str] = frozenset({
     'prd', 'prfaq', 'research', 'custom', 'product_report', 'prototype',
 })
@@ -65,8 +66,10 @@ def _backend_excluded_types() -> frozenset[str]:
 def _frontend_exportable_types() -> frozenset[str]:
     """Read KIRO_EXPORTABLE_DOC_TYPES from autoseedSelection.ts."""
     path = _repo_root() / FRONTEND_SOURCE
-    if not path.is_file():
-        pytest.skip(f'{FRONTEND_SOURCE} not present in this tree')
+    assert path.is_file(), (
+        f'{FRONTEND_SOURCE} not found — did the file move?\n'
+        f'If so, update FRONTEND_SOURCE in this test file.'
+    )
     source = path.read_text(encoding='utf-8')
     # Match: export const KIRO_EXPORTABLE_DOC_TYPES = ['prd', 'prfaq', ...] as const
     match = re.search(

--- a/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
@@ -58,15 +58,16 @@ def _all_document_types() -> frozenset[str]:
     updated to account for it.
     """
     source = _read(TYPES_TS_SOURCE)
-    match = re.search(
+    matches = re.findall(
         r"document_type\s*:\s*((?:'[^']+'(?:\s*\|\s*)?)+)",
         source,
     )
-    assert match, (
-        f"document_type union not found in {TYPES_TS_SOURCE} — "
-        "did the field name or file location change?"
+    assert len(matches) == 1, (
+        f"Expected exactly one 'document_type' union in {TYPES_TS_SOURCE}; "
+        f"found {len(matches)}. If another interface also declares document_type, "
+        f"anchor the regex to the ProjectDocument interface block."
     )
-    raw = match.group(1)
+    raw = matches[0]
     return frozenset(re.findall(r"'([^']+)'", raw))
 
 

--- a/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
@@ -1,0 +1,145 @@
+"""Lockstep test: backend KIRO_EXPORT_EXCLUDED_TYPES and frontend
+KIRO_EXPORTABLE_DOC_TYPES must be complementary subsets of the full
+document_type union, and must never drift apart.
+
+The full union is:
+    prd | prfaq | research | custom | product_report | prototype
+
+The backend defines which types are EXCLUDED.
+The frontend defines which types are INCLUDED (shown in the picker).
+
+Their union must equal the full document_type set, and their intersection
+must be empty.  If either changes without the other, this test fails.
+
+Pattern follows test_feedback_page_limit_lockstep.py (same repo) and
+lambda/shared/test/test_avatar_image_model_lockstep.py.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# All values in the `document_type` union from types.ts.
+# Kept here so this test fails if someone adds a new type without deciding
+# whether it belongs in the export.
+ALL_DOCUMENT_TYPES: frozenset[str] = frozenset({
+    'prd', 'prfaq', 'research', 'custom', 'product_report', 'prototype',
+})
+
+FRONTEND_SOURCE = 'frontend/src/pages/ProjectDetail/autoseedSelection.ts'
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _repo_root() -> Path:
+    # lambda/api/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _read(relative: str) -> str:
+    path = _repo_root() / relative
+    assert path.is_file(), f'{relative} not found — did the file move?'
+    return path.read_text(encoding='utf-8')
+
+
+def _backend_excluded_types() -> frozenset[str]:
+    """Read KIRO_EXPORT_EXCLUDED_TYPES from projects.py."""
+    source = _read('lambda/api/projects.py')
+    # Match: KIRO_EXPORT_EXCLUDED_TYPES: frozenset[str] = frozenset({...})
+    match = re.search(
+        r"KIRO_EXPORT_EXCLUDED_TYPES\s*[^=]*=\s*frozenset\(\{([^}]+)\}\)",
+        source,
+    )
+    assert match, 'KIRO_EXPORT_EXCLUDED_TYPES not found in lambda/api/projects.py'
+    raw = match.group(1)
+    # Extract quoted strings from the set literal
+    return frozenset(re.findall(r"'([^']+)'", raw))
+
+
+def _frontend_exportable_types() -> frozenset[str]:
+    """Read KIRO_EXPORTABLE_DOC_TYPES from autoseedSelection.ts."""
+    path = _repo_root() / FRONTEND_SOURCE
+    if not path.is_file():
+        pytest.skip(f'{FRONTEND_SOURCE} not present in this tree')
+    source = path.read_text(encoding='utf-8')
+    # Match: export const KIRO_EXPORTABLE_DOC_TYPES = ['prd', 'prfaq', ...] as const
+    match = re.search(
+        r"export const KIRO_EXPORTABLE_DOC_TYPES\s*=\s*\[([^\]]+)\]\s*as const",
+        source,
+    )
+    assert match, f'KIRO_EXPORTABLE_DOC_TYPES not found in {FRONTEND_SOURCE}'
+    raw = match.group(1)
+    return frozenset(re.findall(r"'([^']+)'", raw))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestKiroExportableTypesLockstep:
+    def test_frontend_exportable_and_backend_excluded_are_complementary(self):
+        """Excluded ∪ Exportable == ALL_DOCUMENT_TYPES and Excluded ∩ Exportable == ∅."""
+        excluded = _backend_excluded_types()
+        exportable = _frontend_exportable_types()
+
+        union = excluded | exportable
+        intersection = excluded & exportable
+
+        assert intersection == frozenset(), (
+            f'A type appears in BOTH the backend excluded set and the frontend '
+            f'exportable set: {intersection!r}. Remove it from one of them.'
+        )
+        assert union == ALL_DOCUMENT_TYPES, (
+            f'Excluded ∪ Exportable != ALL_DOCUMENT_TYPES.\n'
+            f'  Missing from either: {ALL_DOCUMENT_TYPES - union!r}\n'
+            f'  Extra (unknown types): {union - ALL_DOCUMENT_TYPES!r}\n'
+            f'  If you added a new document_type, decide whether it belongs in '
+            f'the Kiro export and update both constants, then update '
+            f'ALL_DOCUMENT_TYPES in this test.'
+        )
+
+    def test_backend_excludes_prototype(self):
+        """Regression pin: prototype is in the excluded set."""
+        assert 'prototype' in _backend_excluded_types(), (
+            'prototype must be excluded from Kiro exports'
+        )
+
+    def test_backend_excludes_product_report(self):
+        """Regression pin: product_report is in the excluded set."""
+        assert 'product_report' in _backend_excluded_types(), (
+            'product_report must be excluded from Kiro exports'
+        )
+
+    def test_frontend_exportable_includes_prd(self):
+        """Regression pin: prd is in the exportable set."""
+        assert 'prd' in _frontend_exportable_types()
+
+    def test_frontend_exportable_includes_prfaq(self):
+        """Regression pin: prfaq is in the exportable set."""
+        assert 'prfaq' in _frontend_exportable_types()
+
+    def test_frontend_exportable_includes_research(self):
+        """Regression pin: research is in the exportable set."""
+        assert 'research' in _frontend_exportable_types()
+
+    def test_frontend_exportable_includes_custom(self):
+        """Regression pin: custom is in the exportable set."""
+        assert 'custom' in _frontend_exportable_types()
+
+    def test_frontend_does_not_export_prototype(self):
+        """Regression pin: prototype must NOT be in the exportable set."""
+        assert 'prototype' not in _frontend_exportable_types(), (
+            'prototype must not be in KIRO_EXPORTABLE_DOC_TYPES'
+        )
+
+    def test_frontend_does_not_export_product_report(self):
+        """Regression pin: product_report must NOT be in the exportable set."""
+        assert 'product_report' not in _frontend_exportable_types(), (
+            'product_report must not be in KIRO_EXPORTABLE_DOC_TYPES'
+        )

--- a/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
@@ -98,12 +98,16 @@ def _frontend_exportable_types() -> frozenset[str]:
     )
     source = path.read_text(encoding='utf-8')
     # Match: export const KIRO_EXPORTABLE_DOC_TYPES = ['prd', 'prfaq', ...] as const
-    match = re.search(
+    matches = re.findall(
         r"export const KIRO_EXPORTABLE_DOC_TYPES\s*=\s*\[([^\]]+)\]\s*as const",
         source,
     )
-    assert match, f'KIRO_EXPORTABLE_DOC_TYPES not found in {FRONTEND_SOURCE}'
-    raw = match.group(1)
+    assert len(matches) == 1, (
+        f'Expected exactly one KIRO_EXPORTABLE_DOC_TYPES definition in {FRONTEND_SOURCE}; '
+        f'found {len(matches)}. If the constant was renamed or duplicated, '
+        f'update FRONTEND_SOURCE in this test file.'
+    )
+    raw = matches[0]
     return frozenset(re.findall(r"'([^']+)'", raw))
 
 
@@ -141,10 +145,11 @@ class TestKiroExportableTypesLockstep:
             'prototype must be excluded from Kiro exports'
         )
 
-    def test_backend_excludes_product_report(self):
-        """Regression pin: product_report is in the excluded set."""
-        assert 'product_report' in _backend_excluded_types(), (
-            'product_report must be excluded from Kiro exports'
+    def test_backend_does_not_exclude_product_report(self):
+        """Regression pin: product_report is NOT excluded — it is an exportable type."""
+        assert 'product_report' not in _backend_excluded_types(), (
+            'product_report must not be in KIRO_EXPORT_EXCLUDED_TYPES; '
+            'it is a prose Markdown document that provides current-state product context'
         )
 
     def test_frontend_exportable_includes_prd(self):
@@ -163,14 +168,15 @@ class TestKiroExportableTypesLockstep:
         """Regression pin: custom is in the exportable set."""
         assert 'custom' in _frontend_exportable_types()
 
+    def test_frontend_exportable_includes_product_report(self):
+        """Regression pin: product_report IS in the exportable set."""
+        assert 'product_report' in _frontend_exportable_types(), (
+            'product_report must be in KIRO_EXPORTABLE_DOC_TYPES; '
+            'it is a prose Markdown document that provides current-state product context'
+        )
+
     def test_frontend_does_not_export_prototype(self):
         """Regression pin: prototype must NOT be in the exportable set."""
         assert 'prototype' not in _frontend_exportable_types(), (
             'prototype must not be in KIRO_EXPORTABLE_DOC_TYPES'
-        )
-
-    def test_frontend_does_not_export_product_report(self):
-        """Regression pin: product_report must NOT be in the exportable set."""
-        assert 'product_report' not in _frontend_exportable_types(), (
-            'product_report must not be in KIRO_EXPORTABLE_DOC_TYPES'
         )

--- a/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_kiro_exportable_types_lockstep.py
@@ -2,8 +2,10 @@
 KIRO_EXPORTABLE_DOC_TYPES must be complementary subsets of the full
 document_type union, and must never drift apart.
 
-The full union is:
-    prd | prfaq | research | custom | product_report | prototype
+The full union is parsed dynamically from frontend/src/api/types.ts
+(the `document_type` field of `ProjectDocument`), so this test fails
+automatically when a new document type is added to the TypeScript union
+without also deciding which Kiro constant it belongs in.
 
 The backend defines which types are EXCLUDED.
 The frontend defines which types are INCLUDED (shown in the picker).
@@ -18,18 +20,12 @@ import re
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
-# Constants
+# Sources of truth
 # ---------------------------------------------------------------------------
 
-# All values in the `document_type` union from types.ts.
-# Cross-reference: frontend/src/api/types.ts line 303:
-#   document_type: 'prd' | 'prfaq' | 'research' | 'custom' | 'product_report' | 'prototype'
-# Kept here so this test fails if someone adds a new type without deciding
-# whether it belongs in the export.  When you add a new document_type to
-# types.ts, also update this set and decide which constant it belongs in.
-ALL_DOCUMENT_TYPES: frozenset[str] = frozenset({
-    'prd', 'prfaq', 'research', 'custom', 'product_report', 'prototype',
-})
+# The TypeScript file that defines the document_type union.
+# Update this path if the file moves.
+TYPES_TS_SOURCE = 'frontend/src/api/types.ts'
 
 FRONTEND_SOURCE = 'frontend/src/pages/ProjectDetail/autoseedSelection.ts'
 
@@ -47,6 +43,31 @@ def _read(relative: str) -> str:
     path = _repo_root() / relative
     assert path.is_file(), f'{relative} not found — did the file move?'
     return path.read_text(encoding='utf-8')
+
+
+def _all_document_types() -> frozenset[str]:
+    """Parse the document_type union from frontend/src/api/types.ts.
+
+    Matches a line like:
+        document_type: 'prd' | 'prfaq' | 'research' | 'custom' | 'product_report' | 'prototype'
+    and returns the set of type string values.
+
+    This is the authoritative source: adding a 7th type to the TypeScript union
+    causes this helper to return a 7-element set, and the complementarity test
+    then fails until KIRO_EXPORT_EXCLUDED_TYPES or KIRO_EXPORTABLE_DOC_TYPES is
+    updated to account for it.
+    """
+    source = _read(TYPES_TS_SOURCE)
+    match = re.search(
+        r"document_type\s*:\s*((?:'[^']+'(?:\s*\|\s*)?)+)",
+        source,
+    )
+    assert match, (
+        f"document_type union not found in {TYPES_TS_SOURCE} — "
+        "did the field name or file location change?"
+    )
+    raw = match.group(1)
+    return frozenset(re.findall(r"'([^']+)'", raw))
 
 
 def _backend_excluded_types() -> frozenset[str]:
@@ -87,9 +108,10 @@ def _frontend_exportable_types() -> frozenset[str]:
 
 class TestKiroExportableTypesLockstep:
     def test_frontend_exportable_and_backend_excluded_are_complementary(self):
-        """Excluded ∪ Exportable == ALL_DOCUMENT_TYPES and Excluded ∩ Exportable == ∅."""
+        """Excluded ∪ Exportable == all document_types from types.ts, and Excluded ∩ Exportable == ∅."""
         excluded = _backend_excluded_types()
         exportable = _frontend_exportable_types()
+        all_types = _all_document_types()
 
         union = excluded | exportable
         intersection = excluded & exportable
@@ -98,13 +120,14 @@ class TestKiroExportableTypesLockstep:
             f'A type appears in BOTH the backend excluded set and the frontend '
             f'exportable set: {intersection!r}. Remove it from one of them.'
         )
-        assert union == ALL_DOCUMENT_TYPES, (
-            f'Excluded ∪ Exportable != ALL_DOCUMENT_TYPES.\n'
-            f'  Missing from either: {ALL_DOCUMENT_TYPES - union!r}\n'
-            f'  Extra (unknown types): {union - ALL_DOCUMENT_TYPES!r}\n'
-            f'  If you added a new document_type, decide whether it belongs in '
-            f'the Kiro export and update both constants, then update '
-            f'ALL_DOCUMENT_TYPES in this test.'
+        assert union == all_types, (
+            f'Excluded ∪ Exportable != all document_types in {TYPES_TS_SOURCE}.\n'
+            f'  Missing from either constant: {all_types - union!r}\n'
+            f'  Extra (unknown types not in types.ts): {union - all_types!r}\n'
+            f'  If you added a new document_type to types.ts, decide whether it\n'
+            f'  belongs in the Kiro export and update KIRO_EXPORT_EXCLUDED_TYPES\n'
+            f'  (lambda/api/projects.py) or KIRO_EXPORTABLE_DOC_TYPES\n'
+            f'  (frontend/src/pages/ProjectDetail/autoseedSelection.ts).'
         )
 
     def test_backend_excludes_prototype(self):


### PR DESCRIPTION
**Scope changed during review.** This PR originally excluded **both** `prototype` and `product_report` from the Kiro export. That was wrong on `product_report` and has been reversed — the current behaviour is **export `product_report`, exclude only `prototype`**. The title and this description were updated to match; earlier review comments arguing the original direction are superseded.

## What this does

- `autoseed_project` in `projects.py` unconditionally drops documents whose `document_type` is `prototype` — both when no `document_ids` filter is provided (include-all) and when a prototype's id is passed explicitly by the caller. `KIRO_EXPORT_EXCLUDED_TYPES` is `frozenset({'prototype'})`.
- `product_report` **is** exported, and renders under its own group heading in the picker rather than being coerced into "Custom". It is markdown prose describing the current state of the product — the kind of grounding a coding agent wants — and `_document_to_markdown` already renders it correctly.
- The steering file produced by `_build_steering_file` no longer names excluded documents (they are dropped before the call).
- A derived `exportableDocs` variable is computed once via `filterExportableDocs` and threaded through all autoseed paths (picker, copy button, curl URL, payload) so what the user sees and what the payload contains agree.
- `KIRO_EXPORTABLE_DOC_TYPES` (frontend, `autoseedSelection.ts`) and `KIRO_EXPORT_EXCLUDED_TYPES` (backend, `projects.py`) are the single sources of truth; a lockstep test fails if they drift.
- `GET /projects/{project_id}` is **unchanged** — the Documents tab and the Prioritization page still receive all six document types.

### Why prototypes stay excluded

Two independent reasons, both measured on the dev deployment. Of six prototypes, two are legacy documents holding raw generated HTML (26,129 and 36,093 characters) — exporting those anchors a coding agent on stale rendered output. The other four have **no `content` key at all**, because prototypes are now stored in S3 and referenced by URL, so `_document_to_markdown` yields a title and a blank line: an **empty file**. S3-only is the current write path, so every future prototype would export empty. Separately, `DocumentExportMenu.tsx` already returns `null` for S3-only prototypes, so this makes the two export paths agree instead of contradicting each other.

## Changes

| File | What changed |
|------|-------------|
| `lambda/api/projects.py` | `KIRO_EXPORT_EXCLUDED_TYPES = frozenset({'prototype'})`; `autoseed_project` filters by it after the id filter |
| `frontend/src/pages/ProjectDetail/autoseedSelection.ts` | `KIRO_EXPORTABLE_DOC_TYPES` (`prd`, `prfaq`, `research`, `custom`, `product_report`), `KiroExportableDocType`, `isKiroExportableDocType`, `filterExportableDocs` |
| `frontend/src/pages/ProjectDetail/McpAccessTab.tsx` | Imports the types from `autoseedSelection`; `groupDocumentsByType` gained a `product_report` group so it renders under its own heading; `exportableDocs` threaded through picker, Export card and AutoseedContent |
| `public/locales/{en,de,es,fr,ja,ko,pt,zh}/projectDetail.json` | New `autoseed.docTypes.product_report` group label, translated per language |
| `lambda/api/test/test_autoseed_export_filter.py` | Backend tests for the filter, both directions |
| `lambda/api/test/test_kiro_exportable_types_lockstep.py` | Lockstep test tying the backend excluded set to the frontend exportable list |
| `frontend/src/pages/ProjectDetail/McpAccessTab.exportFilter.test.tsx` | Frontend picker tests |

## Mutation evidence

Re-measured against the current code, predicting the failing set before each run.

**Mutation A — re-exclude `product_report`** (`frozenset({'prototype', 'product_report'})`) → **6 failures**, all in the right places:

| Test | File |
|------|------|
| `test_product_report_included_when_no_ids_filter` | `test_autoseed_export_filter.py` |
| `test_product_report_included_even_when_explicitly_requested` | `test_autoseed_export_filter.py` |
| `test_all_five_exportable_types_are_included` | `test_autoseed_export_filter.py` |
| `test_steering_file_includes_product_report_title` | `test_autoseed_export_filter.py` |
| `test_frontend_exportable_and_backend_excluded_are_complementary` | `test_kiro_exportable_types_lockstep.py` |
| `test_backend_does_not_exclude_product_report` | `test_kiro_exportable_types_lockstep.py` |

**Mutation B — drop the `prototype` exclusion** (`frozenset()`) → **8 failures**, including `test_prototype_excluded_even_when_explicitly_requested`, `test_prototype_only_project_produces_no_doc_files`, `test_steering_file_omits_prototype_title`, `test_backend_excludes_prototype`, plus the lockstep complementarity check.

So both invariants are pinned in both directions.

**Mutation C — `filterExportableDocs` returns its input unchanged** → **3 of the 6 frontend tests fail** (the three prototype-only cases). Worth recording precisely, because a previous version of this description overstated it: the **mixed-types** test still passes under that mutation, because `groupDocumentsByType` has its *own* `isKiroExportableDocType` guard, so a prototype never reaches a group even when the list filter is removed. The two layers are independently defended — the three failing tests pin `filterExportableDocs` (list and counts), the mixed-types test pins the rendering guard.

## Build and test results

Measured on this branch at `0621810`, backend and frontend both deployed to the dev environment.

- **Backend pytest** (`lambda/api/test`, via `.venv/bin/python -m pytest`): **441 passed**
- **Frontend vitest**: **2123 passed across 139 files**, 0 failed
- **Frontend typecheck** (`tsc -b --noEmit`): clean
- **Frontend ESLint** (`eslint . --max-warnings 0`): clean
- **i18n**: 0 missing keys. The `product_report` group label is added to all eight catalogues with a real per-language translation. Note the picker renders this heading through a template-literal key, so a missing label would not be reported by the i18n gate — each catalogue was checked by reading it back.
- Pre-existing `ruff` findings under `lambda/` and `plugins/` are unchanged by this PR, which touches one Python file.

## Verified on the dev deployment

Deployed frontend **and** `VocApiStack` (the change is half Lambda, so a frontend-only deploy verifies half of it). Same endpoint, same project, same session, only the API stack differing between the two reads of `GET /projects/{id}/autoseed`:

| | doc files in payload | `prototype.md` files | product report |
|---|---|---|---|
| backend before this branch | 11 | **6** | present |
| backend at `0621810` | **5** | **0** | **exported** |

The prototype count moving 6 → 0 while the product report stays is what makes this non-vacuous — the product report appearing on its own proves nothing, since the previously deployed backend has no export filter at all and includes everything.

In the browser: the picker header moved **4/4 → 5/5** when a product report existed, so the count agrees with the exportable set; group headings render `PRDS`, `PR/FAQS`, `PRODUCT REPORTS` with the report under its own heading; and no prototype rows appear (10 documents in the project, 5 exportable rows). No product report existed anywhere on the deployment, so one was created directly in DynamoDB to exercise the new group and deleted afterwards.

## Known gap

No unit test pins the derived values (`selectedDocumentIds`, `toggleAllDocuments`, the curl's `document_ids` query params) against `exportableDocs`. The behaviour is confirmed live via the count and payload above, but it is untested at the unit level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).
