### PR TITLE
Put Export and MCP Access side by side, with pickers collapsed

### DIFF
--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.structure.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.structure.test.tsx
@@ -256,6 +256,36 @@ describe('McpAccessTab — export guard is enforced in the UI', () => {
   })
 })
 
+describe('McpAccessTab — the picker sections start collapsed', () => {
+  it('shows each selection count without rendering its rows', async () => {
+    renderTab(onePersona, oneDocument)
+
+    // The count and the bulk control are what a user needs before copying, so
+    // they must be visible with the section shut.
+    expect(await screen.findByRole('button', { name: /Personas \(1\/1\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Documents \(1\/1\)/ })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /^Deselect all$/ })).toHaveLength(2)
+
+    // The rows themselves are not rendered until asked for.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
+  })
+
+  it('renders the rows once a section is expanded', async () => {
+    renderTab(onePersona, oneDocument)
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByRole('button', { name: /Personas \(1\/1\)/ }))
+
+    // Named, not counted: a bare toHaveLength(1) also passes when the personas
+    // section is shut and the DOCUMENT row is the one on screen — verified by
+    // mutation, where it went green against the old expanded-by-default state.
+    const personaRow = screen.getByRole('checkbox', { name: /Persona A/ })
+    expect(personaRow).toBeChecked()
+    // and the other section stayed shut
+    expect(screen.queryByRole('checkbox', { name: /Doc A/ })).not.toBeInTheDocument()
+  })
+})
+
 describe('McpAccessTab — Card 2 hides the curl snippet when it would mean "everything"', () => {
   it('suppresses the autoseed prompt, not just its copy button, once a section is emptied', async () => {
     renderTab(onePersona, oneDocument)
@@ -321,6 +351,13 @@ describe('McpAccessTab — autoseed group labels resolve', () => {
     // catch a deletion. A render assertion is the only check that would fail.
     // Needs a document: the group heading is per document-type.
     renderTab(onePersona, oneDocument)
+
+    // The documents picker is collapsed by default and the group heading lives in
+    // its body, so expand it the way a user would. Matched on the header's
+    // accessible name, which carries the "1/1" selection count.
+    await userEvent.setup().click(
+      await screen.findByRole('button', { name: /Documents \(1\/1\)/ }),
+    )
 
     expect(await screen.findByText(enProjectDetail.autoseed.docTypes.prd)).toBeInTheDocument()
     expect(screen.queryByText(/autoseed\.docTypes\./)).not.toBeInTheDocument()

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.structure.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.structure.test.tsx
@@ -256,6 +256,38 @@ describe('McpAccessTab — export guard is enforced in the UI', () => {
   })
 })
 
+describe('McpAccessTab — the tab body lays out as exactly two columns', () => {
+  // The layout is a two-column grid, so a THIRD sibling would silently start a
+  // second row at half width. Asserting the child COUNT pins that invariant
+  // without coupling to the Tailwind classes that implement it — the token-error
+  // path in particular has to wrap its two elements to satisfy this.
+  const columnCount = () => {
+    const card = screen.getByText(enProjectDetail.export.title).closest('div.border')
+    const grid = card?.parentElement
+    return grid == null ? null : grid.children.length
+  }
+
+  it('gives the grid exactly two children when tokens load', async () => {
+    mockListApiTokens.mockResolvedValue({ tokens: [] })
+    renderTab(onePersona, oneDocument)
+
+    await screen.findByText(enProjectDetail.export.title)
+    expect(columnCount()).toBe(2)
+  })
+
+  it('gives the grid exactly two children when the token request fails', async () => {
+    mockListApiTokens.mockRejectedValue(new Error('token fetch failed'))
+    renderTab(onePersona, oneDocument)
+
+    // Waits on error-branch-ONLY copy. Awaiting export.title instead would prove
+    // nothing here: the Export card renders in both branches, so the assertion
+    // could run before the rejection settled and silently check the normal
+    // branch twice.
+    await screen.findByText(enProjectDetail.mcp.notAvailable)
+    expect(columnCount()).toBe(2)
+  })
+})
+
 describe('McpAccessTab — the picker sections start collapsed', () => {
   it('shows each selection count without rendering its rows', async () => {
     renderTab(onePersona, oneDocument)

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.structure.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.structure.test.tsx
@@ -21,7 +21,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import i18n from 'i18next'
-import McpAccessTab from './McpAccessTab'
+import McpAccessTab, { COLUMNS_TESTID } from './McpAccessTab'
 import { canCopyExport } from './autoseedSelection'
 import deProjectDetail from '../../../public/locales/de/projectDetail.json'
 import enProjectDetail from '../../../public/locales/en/projectDetail.json'
@@ -261,11 +261,11 @@ describe('McpAccessTab — the tab body lays out as exactly two columns', () => 
   // second row at half width. Asserting the child COUNT pins that invariant
   // without coupling to the Tailwind classes that implement it — the token-error
   // path in particular has to wrap its two elements to satisfy this.
-  const columnCount = () => {
-    const card = screen.getByText(enProjectDetail.export.title).closest('div.border')
-    const grid = card?.parentElement
-    return grid == null ? null : grid.children.length
-  }
+  //
+  // Found by test id rather than by walking up from the card: reaching through
+  // `.closest('div.border')` would break for the wrong reason the day the card
+  // gains a wrapper or a nested bordered element.
+  const columnCount = () => screen.getByTestId(COLUMNS_TESTID).children.length
 
   it('gives the grid exactly two children when tokens load', async () => {
     mockListApiTokens.mockResolvedValue({ tokens: [] })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -98,9 +98,12 @@ function renderTabWithData(projectId = 'proj-123') {
  * spin to the test timeout instead of failing here with a usable message. There
  * are only ever two sections.
  */
+/** Personas and documents — the two sections a picker can offer. */
+const PICKER_SECTION_COUNT = 2
+
 async function deselectEverySection(user: ReturnType<typeof userEvent.setup>) {
   const deselectAll = () => screen.queryAllByRole('button', { name: /^Deselect all$/ })
-  for (let guard = 0; guard < 4; guard += 1) {
+  for (let attempt = 0; attempt <= PICKER_SECTION_COUNT; attempt += 1) {
     const remaining = deselectAll()
     if (remaining.length === 0) return
     await user.click(remaining[0])

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -86,6 +86,28 @@ function renderTabWithData(projectId = 'proj-123') {
   )
 }
 
+/**
+ * Empties every picker section via its bulk control.
+ *
+ * Bulk rather than per-checkbox because the sections are collapsed by default, so
+ * the individual rows are not rendered — but each header's Select all / Deselect
+ * all always is. Each click flips that section's control to "Select all", so the
+ * query is re-run rather than holding stale handles.
+ *
+ * Bounded: if a regression stopped the label flipping, an unbounded loop would
+ * spin to the test timeout instead of failing here with a usable message. There
+ * are only ever two sections.
+ */
+async function deselectEverySection(user: ReturnType<typeof userEvent.setup>) {
+  const deselectAll = () => screen.queryAllByRole('button', { name: /^Deselect all$/ })
+  for (let guard = 0; guard < 4; guard += 1) {
+    const remaining = deselectAll()
+    if (remaining.length === 0) return
+    await user.click(remaining[0])
+  }
+  throw new Error('Deselect all never stopped appearing — the bulk control is not flipping state')
+}
+
 const mockToken = {
   token_id: 'tok-1',
   name: 'My Kiro token',
@@ -352,14 +374,7 @@ describe('McpAccessTab \u2014 AutoseedContent', () => {
     // Starts enabled \u2014 all items are pre-selected
     expect(copyBtn).toBeEnabled()
 
-    // Empty the selection via each section's bulk control. The picker sections are
-    // collapsed by default so the individual rows are not rendered, but the
-    // header's Select all / Deselect all always is.
-    for (;;) {
-      const remaining = screen.queryAllByRole('button', { name: /^Deselect all$/ })
-      if (remaining.length === 0) break
-      await user.click(remaining[0])
-    }
+    await deselectEverySection(user)
 
     expect(copyBtn).toBeDisabled()
   })
@@ -415,20 +430,10 @@ describe('McpAccessTab \u2014 ExportCard', () => {
     renderTabWithData()
 
     // The copy button starts enabled because all items are pre-selected.
-    // Empty the selection via each section's bulk control, then verify the button
-    // becomes disabled. Bulk rather than per-checkbox because the picker sections
-    // are collapsed by default, so the individual rows are not rendered — but the
-    // header's Select all / Deselect all always is.
     const copyBtn = screen.getByRole('button', { name: /Copy to clipboard/i })
     expect(copyBtn).toBeEnabled()
 
-    // Each click flips that section's control to "Select all", so re-query rather
-    // than holding stale handles.
-    for (;;) {
-      const remaining = screen.queryAllByRole('button', { name: /^Deselect all$/ })
-      if (remaining.length === 0) break
-      await user.click(remaining[0])
-    }
+    await deselectEverySection(user)
 
     expect(copyBtn).toBeDisabled()
   })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -86,6 +86,9 @@ function renderTabWithData(projectId = 'proj-123') {
   )
 }
 
+/** Personas and documents — the two sections a picker can offer. */
+const PICKER_SECTION_COUNT = 2
+
 /**
  * Empties every picker section via its bulk control.
  *
@@ -95,12 +98,8 @@ function renderTabWithData(projectId = 'proj-123') {
  * query is re-run rather than holding stale handles.
  *
  * Bounded: if a regression stopped the label flipping, an unbounded loop would
- * spin to the test timeout instead of failing here with a usable message. There
- * are only ever two sections.
+ * spin to the test timeout instead of failing here with a usable message.
  */
-/** Personas and documents — the two sections a picker can offer. */
-const PICKER_SECTION_COUNT = 2
-
 async function deselectEverySection(user: ReturnType<typeof userEvent.setup>) {
   const deselectAll = () => screen.queryAllByRole('button', { name: /^Deselect all$/ })
   for (let attempt = 0; attempt <= PICKER_SECTION_COUNT; attempt += 1) {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -352,12 +352,13 @@ describe('McpAccessTab \u2014 AutoseedContent', () => {
     // Starts enabled \u2014 all items are pre-selected
     expect(copyBtn).toBeEnabled()
 
-    // Deselect every checkbox to produce an empty selection
-    const checkboxes = screen.getAllByRole('checkbox')
-    for (const cb of checkboxes) {
-      if ((cb as HTMLInputElement).checked) {
-        await user.click(cb)
-      }
+    // Empty the selection via each section's bulk control. The picker sections are
+    // collapsed by default so the individual rows are not rendered, but the
+    // header's Select all / Deselect all always is.
+    for (;;) {
+      const remaining = screen.queryAllByRole('button', { name: /^Deselect all$/ })
+      if (remaining.length === 0) break
+      await user.click(remaining[0])
     }
 
     expect(copyBtn).toBeDisabled()
@@ -414,16 +415,19 @@ describe('McpAccessTab \u2014 ExportCard', () => {
     renderTabWithData()
 
     // The copy button starts enabled because all items are pre-selected.
-    // Uncheck every checkbox to produce an empty selection, then verify
-    // the button becomes disabled.
+    // Empty the selection via each section's bulk control, then verify the button
+    // becomes disabled. Bulk rather than per-checkbox because the picker sections
+    // are collapsed by default, so the individual rows are not rendered — but the
+    // header's Select all / Deselect all always is.
     const copyBtn = screen.getByRole('button', { name: /Copy to clipboard/i })
     expect(copyBtn).toBeEnabled()
 
-    const checkboxes = screen.getAllByRole('checkbox')
-    for (const cb of checkboxes) {
-      if ((cb as HTMLInputElement).checked) {
-        await user.click(cb)
-      }
+    // Each click flips that section's control to "Select all", so re-query rather
+    // than holding stale handles.
+    for (;;) {
+      const remaining = screen.queryAllByRole('button', { name: /^Deselect all$/ })
+      if (remaining.length === 0) break
+      await user.click(remaining[0])
     }
 
     expect(copyBtn).toBeDisabled()

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -91,6 +91,13 @@ function buildMcpConfig(baseUrl: string, projectId: string): string {
  */
 const TWO_COLUMN_LAYOUT = 'grid grid-cols-1 lg:grid-cols-2 gap-4 items-start'
 
+/**
+ * Marks the grid so a test can count its columns without reaching through the
+ * card's utility classes. Exported because the assertion belongs to this
+ * container, and a literal duplicated in the test would drift from it.
+ */
+export const COLUMNS_TESTID = 'export-mcp-columns'
+
 type DocType = 'prd' | 'prfaq' | 'research' | 'custom'
 
 function isValidDocType(value: string): value is DocType {
@@ -593,7 +600,7 @@ export default function McpAccessTab({
   // ── Card 2 — MCP Access (error branch) ───────────────────────────────────
   if (isError) {
     return (
-      <div className={TWO_COLUMN_LAYOUT}>
+      <div className={TWO_COLUMN_LAYOUT} data-testid={COLUMNS_TESTID}>
         {exportCard}
         {/* Wrapped so the grid still has exactly two children: the error state
             and the autoseed section together are the MCP column. */}
@@ -618,7 +625,7 @@ export default function McpAccessTab({
 
   // ── Card 2 — MCP Access (normal branch) ──────────────────────────────────
   return (
-    <div className={TWO_COLUMN_LAYOUT}>
+    <div className={TWO_COLUMN_LAYOUT} data-testid={COLUMNS_TESTID}>
       {/* Card 1 — Export (no API token); the template editor is a section inside it */}
       {exportCard}
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -80,6 +80,21 @@ function buildMcpConfig(baseUrl: string, projectId: string): string {
   }, null, 2)
 }
 
+/**
+ * The two cards sit side by side from `lg` up, and stack below it.
+ *
+ * Side by side rather than stacked because the selection lives in the Export
+ * card while the MCP card's curl URL is built from it — stacked, the control and
+ * the thing it changes are never on screen together. It also stops the MCP card
+ * being pushed below the fold, which matters because the token it issues is a
+ * PREREQUISITE for the autoseed snippet that sits beside it.
+ *
+ * `items-start` so the shorter card keeps its own height instead of being
+ * stretched to match its neighbour. Named once because both return paths (normal
+ * and token-error) must lay out identically.
+ */
+const TWO_COLUMN_LAYOUT = 'grid gap-4 lg:grid-cols-2 items-start'
+
 type DocType = 'prd' | 'prfaq' | 'research' | 'custom'
 
 function isValidDocType(value: string): value is DocType {
@@ -445,8 +460,12 @@ export default function McpAccessTab({
   // that arrive after mount.
   const [deselectedPersonaIds, setDeselectedPersonaIds] = useState<Set<string>>(() => new Set())
   const [deselectedDocumentIds, setDeselectedDocumentIds] = useState<Set<string>>(() => new Set())
+  // Collapsed by default. Each section's header already states its selection as
+  // "Personas (3/4)" and carries the Select all / Deselect all control, so the
+  // count — the thing a user needs before copying — is visible without the rows.
+  // Expanding is for changing the selection, not for reading it.
   const [expandedSections, setExpandedSections] = useState<Set<string>>(
-    () => new Set(['personas', 'documents']),
+    () => new Set(),
   )
 
   const selectedPersonaIds = useMemo(
@@ -577,28 +596,32 @@ export default function McpAccessTab({
   // ── Card 2 — MCP Access (error branch) ───────────────────────────────────
   if (isError) {
     return (
-      <div className="space-y-4">
+      <div className={TWO_COLUMN_LAYOUT}>
         {exportCard}
-        <McpAccessErrorState />
-        <CollapsibleSection
-          title={t('autoseed.title')}
-          expanded={autoseedExpanded}
-          onToggle={() => setAutoseedExpanded((prev) => !prev)}
-        >
-          <AutoseedContent
-            personas={personas}
-            documents={documents}
-            curlUrl={autoseedCurlUrl}
-            hasSelection={hasPickerSelection}
-          />
-        </CollapsibleSection>
+        {/* Wrapped so the grid still has exactly two children: the error state
+            and the autoseed section together are the MCP column. */}
+        <div className="space-y-4">
+          <McpAccessErrorState />
+          <CollapsibleSection
+            title={t('autoseed.title')}
+            expanded={autoseedExpanded}
+            onToggle={() => setAutoseedExpanded((prev) => !prev)}
+          >
+            <AutoseedContent
+              personas={personas}
+              documents={documents}
+              curlUrl={autoseedCurlUrl}
+              hasSelection={hasPickerSelection}
+            />
+          </CollapsibleSection>
+        </div>
       </div>
     )
   }
 
   // ── Card 2 — MCP Access (normal branch) ──────────────────────────────────
   return (
-    <div className="space-y-4">
+    <div className={TWO_COLUMN_LAYOUT}>
       {/* Card 1 — Export (no API token); the template editor is a section inside it */}
       {exportCard}
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -81,19 +81,15 @@ function buildMcpConfig(baseUrl: string, projectId: string): string {
 }
 
 /**
- * The two cards sit side by side from `lg` up, and stack below it.
+ * Side by side from `lg` up, stacked below. Named because both return paths
+ * (normal and token-error) must lay out identically, and takes EXACTLY two
+ * children — the token-error path wraps its two for that reason.
  *
- * Side by side rather than stacked because the selection lives in the Export
- * card while the MCP card's curl URL is built from it — stacked, the control and
- * the thing it changes are never on screen together. It also stops the MCP card
- * being pushed below the fold, which matters because the token it issues is a
- * PREREQUISITE for the autoseed snippet that sits beside it.
- *
- * `items-start` so the shorter card keeps its own height instead of being
- * stretched to match its neighbour. Named once because both return paths (normal
- * and token-error) must lay out identically.
+ * `items-start` keeps the shorter card at its own height. Grid children need
+ * `min-w-0`: they default to `min-width: auto`, so the curl snippet's long
+ * unbroken URL would otherwise push its track past the even split.
  */
-const TWO_COLUMN_LAYOUT = 'grid gap-4 lg:grid-cols-2 items-start'
+const TWO_COLUMN_LAYOUT = 'grid grid-cols-1 lg:grid-cols-2 gap-4 items-start'
 
 type DocType = 'prd' | 'prfaq' | 'research' | 'custom'
 
@@ -337,7 +333,8 @@ function ExportCard({
   }, [projectId, selectedPersonaIds, selectedDocumentIds, personas.length, documents.length, markCopied, t])
 
   return (
-    <div className="bg-white rounded-xl p-6 border">
+    // min-w-0: this is a grid child in TWO_COLUMN_LAYOUT.
+    <div className="bg-white rounded-xl p-6 border min-w-0">
       <div className="flex items-center gap-3 mb-4">
         <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center flex-shrink-0">
           <Download size={20} className="text-green-600" />
@@ -600,7 +597,7 @@ export default function McpAccessTab({
         {exportCard}
         {/* Wrapped so the grid still has exactly two children: the error state
             and the autoseed section together are the MCP column. */}
-        <div className="space-y-4">
+        <div className="space-y-4 min-w-0">
           <McpAccessErrorState />
           <CollapsibleSection
             title={t('autoseed.title')}
@@ -626,7 +623,7 @@ export default function McpAccessTab({
       {exportCard}
 
       {/* Card 2 — MCP Access (API token required) */}
-      <div className="bg-white rounded-xl p-6 border space-y-4">
+      <div className="bg-white rounded-xl p-6 border space-y-4 min-w-0">
         <McpHeader
           showCreateForm={showCreateForm}
           newlyCreatedToken={newlyCreatedToken}


### PR DESCRIPTION
Two changes to the Export / MCP tab, together because either alone reads worse than both. Frontend only; no backend, no new dependency, no new locale keys.

## Side by side, from `lg` up

Stacked, the MCP Access card sat below the fold — and that is backwards for the flow, because the token it issues is a **prerequisite** for the autoseed snippet beside it (the paste hint says "Requires an API token from the MCP Access tab").

It also split cause from effect. The persona/document selection lives in the Export card, while the MCP card's `curl` URL is built from that same selection — so changing a checkbox altered something that was off screen.

The layout string is named once, because both return paths (normal and token-error) have to match, and the error path needed its two children wrapped so the grid still gets exactly two columns. `items-start` keeps the shorter card from being stretched to its neighbour's height.

All three grid children also carry `min-w-0`, which is **defensive rather than load-bearing** — and I'd rather state that accurately than repeat the reasoning it was added under. The theory was that grid children default to `min-width: auto` so they cannot shrink below their content, and the autoseed `curl` snippet is a long unbroken URL that `whitespace-pre-wrap` cannot break, so its track would push past the even split.

Measured on the deployed page, that does not happen, with or without the class: the snippet's container is `overflow-y-auto`, and per CSS a non-`visible` value on one axis makes the other compute to `auto`, so it is already a scroll port and the long token never contributes to any ancestor's min-content width. Removing `min-w-0` from both children at CSS 2000px and at CSS 1062px left the tracks identical (840/840 and 371/371) with no page overflow.

Keeping it as cheap insurance for a future descendant that isn't inside a scroll port, but happy to drop it if you'd rather the diff carried nothing unjustified.

## Picker sections start collapsed

The rows were the tallest thing on the tab and the least often needed. Each section header already states its selection as `Personas (3/4)` and carries Select all / Deselect all, so the count — the thing you need before copying — is visible without them. Expanding is for *changing* a selection, not for reading it.

This is also what makes two columns look right, rather than one very tall card beside a short one.

## Verified

Against `npm run mock` rather than by deploying, since this is layout:

| Check | Result |
|---|---|
| Two columns on a wide viewport | computed `gridTemplateColumns` = two equal columns at CSS 2000px |
| Stacks below the `lg` breakpoint | **one** column at CSS 950px and 750px |
| Collapsed on load | 0 checkboxes rendered, both counts visible |
| Expanding still works | reveals exactly the expanded section's rows |

It happened to run in German, so the counts were confirmed as `Zielgruppen (2/2)` / `Dokumente (2/2)` rather than only in English.

**Now verified on the deployed site too, including the gap this section used to name.** The normal (tokens-present) branch is not reachable in local dev — the mock has no `api-tokens` endpoint — so it was previously covered only by unit tests. Deployed and checked against a real project (4 personas, 10 documents, one active token):

| Check | Result |
|---|---|
| Normal branch, not the error state | MCP card shows Generate Token / Active Tokens (1) / MCP Client Configuration / Kiro Autoseed |
| Two columns, evenly split | `gridTemplateColumns` 840px + 840px at CSS 2000px; 371 + 371 at CSS 1062px; equal `top` |
| Grid has exactly two children | `childCount` 2 on the normal branch |
| Stacks below `lg` | CSS 875px → a single 827px track, cards at different tops, no page overflow |
| Collapsed on load | 0 checkboxes rendered at both widths |
| Counts visible while collapsed | headers read `Personas (4/4)` and `Documents (10/10)` |
| Expanding still works | reveals exactly the 4 persona rows, all checked |
| Console | 0 errors, 0 warnings |

One pre-existing detail, unchanged by this PR and worth knowing rather than fixing here: at narrow-but-still-two-column widths the `curl` snippet scrolls horizontally inside its own dark box (~119px of scroll at CSS 1062px). It is contained by that box's own scroll port and causes no page-level overflow.

**What is and isn't asserted about the layout.** The *structure* is pinned: both return paths are asserted to give the grid exactly two children, since a third sibling would silently start a second row at half width, and the token-error path is the one that has to wrap its two elements to satisfy that. The *styling* is deliberately not asserted — no Tailwind class assertions and no `gridTemplateColumns` read — because this suite is already criticised for class coupling, and a jsdom assertion would pin something a browser check confirms better.

The grid is located by an exported `data-testid`, not by walking up from the card with `.closest('div.border')`, so the assertion doesn't break for the wrong reason the day a card gains a wrapper or a nested bordered element.

## Test changes

Three existing tests emptied the selection by iterating checkboxes, which are no longer rendered by default. They now use the bulk control — visible when collapsed, and closer to what a user actually does. The `docTypes` group-label test expands the section first, since that heading lives in the section body.

Two new tests pin the default, both mutation-verified against the old expanded-by-default state. The second needed strengthening to earn that: `toHaveLength(1)` passed under mutation for the wrong reason, because with both sections open the *document* row satisfied the count while the personas section was shut. It now names the row it expects and asserts the other section stayed closed.

The second commit fixes two defects in those same tests: the deselect loop was unbounded, and its exit condition is the behaviour under test — so a regression in the bulk control would have spun it to the test timeout instead of failing with a usable message. It is now bounded with an explicit throw, and shared rather than duplicated across two tests.

Two further tests came out of review, one per return path, asserting the two-children invariant described above. They were made to *discriminate* the branches rather than merely go red: the token-error test waits on error-branch-only copy (`mcp.notAvailable`) instead of the Export card title, which renders in **both** branches — awaiting the shared string let the assertion check the normal branch twice while appearing to cover the error one. Confirmed by mutation: unwrapping the error branch's column so the grid gets three children fails exactly that one test (`expected 3 to be 2`) and leaves the tokens-load test green.

## Gates

`tsc -b --noEmit` clean, `eslint . --max-warnings 0` clean, `vitest` 138 files / **2117** tests. Measured at `e28ab82`.

`i18n-check` is **unchanged from `development`** and worth a note so it is not read as this branch's doing: `development` reports `missing 0 | empty 0 | extra 12 | untranslated 7`. I confirmed that baseline on a clean worktree of `development`. All seven untranslated are one key, `prioritization.docType.prfaq` = `PR/FAQ` across the seven non-English catalogues, new since #293. That value is correct — it is a product acronym and should be identical everywhere — and the checker has no allowlist for legitimate cognates while its short-string hatch does not reach six characters. Translating it would ship seven mistranslations, so it wants the per-entry allowlist instead and is left alone here.

## Note for whoever merges

There is an in-flight change to the same file that excludes prototype and product-report documents from the export. It touches the picker's grouping and types near the top of `McpAccessTab.tsx`, while this touches the selection default and the card container, so they should merge cleanly — but whichever lands second is worth a re-run of the tab's tests.


