### PR TITLE
fix(auth): disable deprecated Cognito implicit OAuth grant (issue #252)

### DIFF
--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -327,3 +327,51 @@ describe('VocCoreStack CloudFront private asset paths (issue #229)', () => {
     expect(synthCoreTemplate().toJSON()).toEqual(synthCoreTemplate().toJSON());
   });
 });
+
+/**
+ * Regression guard for issue #252: the implicit OAuth grant was enabled
+ * alongside authorization-code grant. The implicit grant returns tokens
+ * in the URL fragment (browser history / Referer leakage) and cannot be
+ * protected by PKCE — OAuth 2.1 drops it entirely.
+ *
+ * The application signs in via SRP (amazon-cognito-identity-js) and never
+ * uses the hosted-UI redirect flow, so disabling it is safe. A repository-
+ * wide search at the time of writing found core-stack.ts to be the only
+ * file referencing the implicit flow or the hosted-UI domain.
+ *
+ * Tests here assert the flow set POSITIVELY — the code flow present AND the
+ * implicit flow absent — so that (a) neither assertion is vacuous and (b) a
+ * silent re-enable of implicitCodeGrant causes a test failure.
+ */
+describe('VocCoreStack Cognito OAuth flow set (issue #252)', () => {
+  /**
+   * Parse the AllowedOAuthFlows array from the synthesized UserPoolClient.
+   * AllowedOAuthFlows is typed `unknown` by Template.toJSON(), so we
+   * validate the shape with Zod to surface CDK property renames as schema
+   * errors rather than silent `undefined` values that pass every assertion.
+   */
+  const UserPoolClientSchema = z.object({
+    AllowedOAuthFlows: z.array(z.string()),
+  });
+
+  function allowedOAuthFlows(): string[] {
+    const clients = Object.values(synthCoreTemplate().findResources('AWS::Cognito::UserPoolClient'));
+    expect(clients, 'expected exactly one UserPoolClient').toHaveLength(1);
+    return UserPoolClientSchema.parse(clients[0].Properties).AllowedOAuthFlows;
+  }
+
+  it('enables the authorization-code flow ("code")', () => {
+    // Authorization-code grant with PKCE is the recommended flow for browser
+    // clients. It must stay present so the hosted-UI path remains available
+    // for future use.
+    expect(allowedOAuthFlows()).toContain('code');
+  });
+
+  it('does NOT enable the implicit flow ("implicit")', () => {
+    // The implicit grant returns tokens directly in the redirect URL fragment,
+    // which leaks them into browser history and via the Referer header, and
+    // it cannot be protected with PKCE. OAuth 2.1 removes it. The app uses
+    // SRP sign-in exclusively, so nothing depends on this flow.
+    expect(allowedOAuthFlows()).not.toContain('implicit');
+  });
+});

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -649,7 +649,15 @@ export class VocCoreStack extends cdk.Stack {
       userPoolClientName: uniqueName('voc-web-client'),
       authFlows: { userPassword: true, userSrp: true },
       oAuth: {
-        flows: { authorizationCodeGrant: true, implicitCodeGrant: true },
+        flows: {
+          authorizationCodeGrant: true,
+          // implicitCodeGrant is disabled: it is deprecated in OAuth 2.1, returns
+          // tokens in the URL fragment (browser history / Referer leakage), and
+          // cannot be protected by PKCE. The app signs in via SRP
+          // (amazon-cognito-identity-js) and never uses the hosted-UI redirect
+          // flow, so nothing here depends on it.
+          implicitCodeGrant: false,
+        },
         scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
         callbackUrls,
         logoutUrls,


### PR DESCRIPTION
## Summary

- Sets `implicitCodeGrant: false` in the Cognito `UserPoolClient` OAuth flows configuration in `core-stack.ts`, replacing the previous `true`
- Adds an explanatory inline comment explaining why (deprecated in OAuth 2.1, tokens in the URL fragment, app uses SRP)
- Adds a new `describe` block `VocCoreStack Cognito OAuth flow set (issue #252)` with two CDK unit tests that pin the flow set positively

Closes #252

## Repository-wide search confirming safety

Before disabling the flow, I searched for any consumer of the hosted-UI implicit flow:

```
grep -r "implicit|hosted.ui|hosted_ui|IMPLICIT|ImplicitCode|implicitCode" (all files)
```

Results: `implicitCodeGrant` appeared **only in `core-stack.ts` line 652** (the line being changed). All other hits were unrelated uses of the English word "implicit" in comments or test descriptions. No file references the hosted-UI domain, `response_type=token`, or any other implicit-flow consumer. It is safe to disable.

## Template before/after for the synthesized UserPoolClient

**Before** (with `implicitCodeGrant: true`):
```json
"AllowedOAuthFlows": ["implicit", "code"]
```

**After** (with `implicitCodeGrant: false`):
```json
"AllowedOAuthFlows": ["code"]
```

The `"implicit"` string is the CloudFormation representation confirmed by reading `node_modules/aws-cdk-lib/aws-cognito/lib/user-pool-client.js` — specifically the `configureOAuthFlows()` method which pushes `"implicit"` when `implicitCodeGrant` is truthy and `"code"` when `authorizationCodeGrant` is truthy.

## Non-vacuity proof

I temporarily set `implicitCodeGrant: true` and ran `vitest run lib/stacks/core-stack.test.ts`. The test **`does NOT enable the implicit flow ("implicit")`** failed with:

```
AssertionError: expected [ 'implicit', 'code' ] to not include 'implicit'
```

Then restored `false` and confirmed all 22 tests in that file pass. The test that caught the revert is: **`VocCoreStack Cognito OAuth flow set (issue #252) > does NOT enable the implicit flow ("implicit")`**

## Build and test results

**`npm run typecheck:cdk`** (CDK TypeScript — the relevant gate for this change):
```
# clean, exit 0
```

**`npm run test:cdk`** (`vitest run` scoped to `lib/**/*.test.ts`):
```
Test Files  1 failed | 11 passed (12)
      Tests  15 failed | 143 passed (158)
```

- `core-stack.test.ts`: **22/22 passed** (20 pre-existing + 2 new)
- The 15 failures are all in `api-stack.test.ts` due to a missing `frontend/dist` asset — a pre-existing failure on `development` unrelated to this change

**`cdk synth`** was not run: the task notes that synth bundles Python Lambdas in a container and no container runtime is available. The CDK unit tests synthesize in-process and are the check that matters per the issue description.

## Explicitly not in scope

A deploy is required to confirm that sign-in still works end-to-end. **A human must verify login after deploying**, since this touches the auth client configuration. The auth flows (`userPassword`, `userSrp`), token validity periods, scopes, callback/logout URLs, domain configuration, and all other stacks are untouched.

## Agent notes

**What went well:**
- The CDK L2 construct code in `node_modules/aws-cdk-lib/aws-cognito/lib/user-pool-client.js` clearly maps `implicitCodeGrant` → `"implicit"` and `authorizationCodeGrant` → `"code"` in `configureOAuthFlows()`, making it easy to write positive assertions on the CloudFormation `AllowedOAuthFlows` array rather than guessing
- The existing test file uses Zod for template shape validation — I followed the same pattern, which is the house style and avoids the `as` cast

**What was difficult:**
- `mise install` pre-ran but `vitest` wasn't on `$PATH`. The binary was missing from `node_modules/.bin/` in `voc-datalake/` — needed to run `npm install` first. After that, running `./node_modules/.bin/vitest run` worked

**Patterns discovered:**
- Template values are `unknown` — use Zod to validate the shape, never `as`. This is enforced by the existing tests and mentioned in the issue
- The CDK typecheck gate is `npm run typecheck:cdk` (not `npm run check`, which includes a broken Python lint leg)
- `npm run test:cdk` maps to `vitest run` scoped to `lib/**/*.test.ts` in `voc-datalake/`
- The `api-stack.test.ts` failures are pre-existing on `development` (missing `frontend/dist` asset)

**Suggestions for future tasks:**
- The pre-existing `api-stack.test.ts` failures could be fixed by either building the frontend first or adding a context flag to skip asset resolution similar to `skipFrontendBuildCheck`
- Consider documenting the `npm install` prerequisite in a CONTRIBUTING section for agent tasks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).