### PR TITLE
fix(security): stop logging raw Lambda event; guard against reintroduction

### DIFF
--- a/.github/workflows/no-event-logging-guard.yml
+++ b/.github/workflows/no-event-logging-guard.yml
@@ -8,8 +8,10 @@
 # here would produce a permanently red, ignored check — which is worse than
 # no check at all.
 #
-# Widening this workflow to the full suite is tracked separately; see the
-# `Gates` section of the repository README before doing so.
+# The repo's real gate is `npm run check` in the root package.json, which chains
+# lint, typecheck:all, the frontend/CDK/stream suites and test:backend.  Widening
+# this workflow towards that would first need the deps missing from
+# requirements-dev.txt and the layer build.
 name: no-event-logging guard
 
 on:
@@ -40,8 +42,17 @@ jobs:
       # one stdlib-only file), and pytest treats the unknown --cov flags as a
       # usage error, so the defaults must be cleared rather than just disabling
       # the plugin with -p no:cov.
+      #
+      # --noconftest: this file uses no fixtures, but pytest would still load
+      # lambda/conftest.py and lambda/api/test/conftest.py.  Those import boto3
+      # and cryptography inside fixture bodies today, so nothing heavy is
+      # imported — an incidental property, not a guarantee.  Hoisting one of
+      # those imports to module scope would turn this check red with a
+      # ModuleNotFoundError that reads like a security-guard failure.  The local
+      # `npm run test:backend` run does load the conftests, so that coupling is
+      # still exercised, just not here.
       - name: Run guard
         working-directory: voc-datalake
         run: >-
           python -m pytest lambda/api/test/test_no_event_logging.py
-          -o addopts="" -p no:cacheprovider --no-header -q
+          -o addopts="" --noconftest -p no:cacheprovider --no-header -q

--- a/.github/workflows/no-event-logging-guard.yml
+++ b/.github/workflows/no-event-logging-guard.yml
@@ -1,0 +1,47 @@
+# Runs the raw-event logging guard (issue #245) on every pull request.
+#
+# Deliberately narrow: this executes ONE test file, not the backend suite.
+# The guard depends only on `re` and `pathlib`, so it needs no application
+# dependencies and no Lambda layer build, and it finishes in well under a
+# second.  The rest of the suite currently cannot run in a bare environment
+# (it needs pydantic, aws_xray_sdk and the built layers), so attempting it
+# here would produce a permanently red, ignored check — which is worse than
+# no check at all.
+#
+# Widening this workflow to the full suite is tracked separately; see the
+# `Gates` section of the repository README before doing so.
+name: no-event-logging guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - development
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: raw Lambda event is not logged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install pytest
+        run: python -m pip install --disable-pip-version-check pytest
+
+      # -o addopts="": pytest.ini's addopts enables pytest-cov for the whole
+      # backend suite.  pytest-cov is not installed here (and is not wanted for
+      # one stdlib-only file), and pytest treats the unknown --cov flags as a
+      # usage error, so the defaults must be cleared rather than just disabling
+      # the plugin with -p no:cov.
+      - name: Run guard
+        working-directory: voc-datalake
+        run: >-
+          python -m pytest lambda/api/test/test_no_event_logging.py
+          -o addopts="" -p no:cacheprovider --no-header -q

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -630,18 +630,18 @@ def api_generate_product_report(project_id: str):
 def lambda_handler(event: dict, context: Any) -> dict:
     """Main Lambda handler for projects API."""
     try:
-        # Do NOT log the raw event here: the serialised payload carries the
-        # caller's Authorization header (Cognito bearer token) and the full
-        # request body.  Powertools' @logger.inject_lambda_context already
-        # attaches request-id, function name, and cold-start flag — no
-        # diagnostic value is lost.  (issue #245)
-
-        # Normal API Gateway request
+        # Never log the raw event or the resolved result here (issue #245).
+        # The event carries the caller's Authorization header (Cognito bearer
+        # token) and request body; the result carries user-generated content
+        # (project text, verbatims, persona data).  Powertools'
+        # @logger.inject_lambda_context already attaches request-id, function
+        # name and cold-start, so only the status code is added below.
+        # Status code alone is not sensitive, so this stays at INFO to keep the
+        # per-invocation completion signal that LOG_LEVEL=INFO would drop at
+        # DEBUG — it is the absence of the body, not the log level, that
+        # protects the data.
         result = app.resolve(event, context)
-        # Do NOT log the full response body here: it may contain user-generated
-        # content (project text, verbatims, persona data).  Status code is
-        # sufficient for operational monitoring.  (issue #245)
-        logger.debug("Returning response", extra={"status_code": result.get("statusCode")})
+        logger.info("Returning response", extra={"status_code": result.get("statusCode")})
         return result
         
     except Exception as e:

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -630,8 +630,12 @@ def api_generate_product_report(project_id: str):
 def lambda_handler(event: dict, context: Any) -> dict:
     """Main Lambda handler for projects API."""
     try:
-        logger.info(f"Received event: {json.dumps(event)}")
-        
+        # Do NOT log the raw event here: the serialised payload carries the
+        # caller's Authorization header (Cognito bearer token) and the full
+        # request body.  Powertools' @logger.inject_lambda_context already
+        # attaches request-id, function name, and cold-start flag — no
+        # diagnostic value is lost.  (issue #245)
+
         # Normal API Gateway request
         result = app.resolve(event, context)
         logger.info(f"Returning result: {json.dumps(result, cls=DecimalEncoder)}")

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from shared.logging import logger, tracer
 from shared.aws import invoke_lambda_async
-from shared.api import create_api_resolver, validate_days, validate_int, api_handler, DecimalEncoder, validate_date_basis
+from shared.api import create_api_resolver, validate_days, validate_int, api_handler, validate_date_basis
 from shared.tables import get_jobs_table, get_aggregates_table, get_projects_table
 from shared.jobs import create_job
 from shared.exceptions import NotFoundError, ServiceError, ValidationError
@@ -638,7 +638,10 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
         # Normal API Gateway request
         result = app.resolve(event, context)
-        logger.info(f"Returning result: {json.dumps(result, cls=DecimalEncoder)}")
+        # Do NOT log the full response body here: it may contain user-generated
+        # content (project text, verbatims, persona data).  Status code is
+        # sufficient for operational monitoring.  (issue #245)
+        logger.debug("Returning response", extra={"status_code": result.get("statusCode")})
         return result
         
     except Exception as e:

--- a/voc-datalake/lambda/api/test/test_no_event_logging.py
+++ b/voc-datalake/lambda/api/test/test_no_event_logging.py
@@ -1,7 +1,35 @@
 """Guard: no handler source may write the raw Lambda event to logs.
 
-This test walks every non-test Python source under lambda/ and fails on any
-of the five spellings of the defect identified in issue #245:
+The rule
+--------
+
+**A violation is the *whole* ``event`` object reaching a log record.  Selecting
+something out of the event first is not a violation.**
+
+That is the single distinction every pattern below encodes, and it is the thing
+to preserve when one of them is edited.  ``event`` is the API Gateway request:
+it carries the caller's ``Authorization`` header (a Cognito bearer token) and
+the full request body, so serialising it — by any spelling — writes the token to
+CloudWatch (issue #245).  ``event['path']``, ``event.get('httpMethod')`` and
+``list(event.keys())`` are *selections*: they name what they disclose, they are
+the remediation a developer should apply when this guard fires, and flagging them
+would train people to disable the guard instead of using it.
+
+Two corollaries follow, and they explain shapes that look inconsistent at first
+glance:
+
+  * A bare ``event`` handed to something that is *not* a logger is not a
+    violation — forwarding it to a downstream service
+    (``lambda_client.invoke(Payload=json.dumps(event))``) discloses nothing to
+    the log.  So every pattern except 3 requires a ``logger.`` call to be
+    present as well.
+  * A bare ``event`` passed to a *helper* inside a logger call
+    (``logger.info("route=%s", route_for(method, event))``) is not a violation
+    either: what reaches the record is the helper's return value.  Patterns 4
+    and 5 therefore inspect only the arguments passed *directly* to the logger,
+    with nested parenthesised groups elided (see ``_logger_call_arg_texts``).
+
+The five spellings the rule is enforced against:
 
   1. ``json.dumps(event[, ...])`` on a line that also calls a logger method
         The whole event is serialised; the output contains the caller's
@@ -13,11 +41,11 @@ of the five spellings of the defect identified in issue #245:
   2. ``f"...{event}..."`` on a line that also calls a logger method — the
      str() of the whole event object is interpolated into the log message.
      Variants caught are the ones that stringify the *entire* event:
-     ``{event}``, ``{event!r}``, ``{event!s}`` and ``{event:...}``.
-     Logging a single named field (``{event['path']}``,
+     ``{event}``, ``{event!r}``, ``{event!s}``, ``{event:...}`` and the
+     self-documenting form ``{event=}`` / ``{event = }`` (which implies
+     ``!r``).  Logging a single named field (``{event['path']}``,
      ``{event.get('httpMethod')}``, ``{list(event.keys())}``) is *permitted by
-     design* — that is the recommended remediation when this guard fires, so
-     subscript and attribute access are deliberately not matched.
+     design* — subscript and attribute access are deliberately not matched.
 
   3. ``logger.<level>(event)`` / ``logger.<level>(event, ...)``
         The event is passed directly as the log-message argument.
@@ -25,15 +53,26 @@ of the five spellings of the defect identified in issue #245:
   4. ``logger.<level>("...%s", event)`` — printf-style lazy formatting, where
      the event is a non-first positional argument.  This is the spelling the
      stdlib ``logging`` docs recommend over f-strings, so it is a likely
-     accidental reintroduction.
+     accidental reintroduction.  Matched against the logger call's *direct*
+     arguments, so ``logger.info("%s %s", ctx.get_id(), event)`` is caught
+     (a ``)`` in an earlier argument does not hide it) while
+     ``logger.info("route=%s", route_for(method, event))`` is not.
 
   5. ``logger.<level>("msg", extra={"event": event})`` and
      ``logger.append_keys(event=event)`` — Powertools structured fields.  The
      event is serialised into the JSON log record, so the leak is identical.
      ``extra=`` is the house idiom in ``projects_handler.py`` after this fix,
-     which makes this spelling especially easy to reach for.  As with pattern 1,
-     a ``logger.`` call must be present on the same line, so plain forwarding
-     such as ``handler(event=event)`` is not flagged.
+     which makes this spelling especially easy to reach for.  Also matched
+     against the direct arguments, so nesting inside ``extra=``
+     (``extra={"meta": {"x": 1}, "event": event}``) is caught and plain
+     forwarding such as ``handler(event=event)`` is not.
+
+Separately from the five event patterns, ``test_response_log_does_not_include_the_body``
+pins the *egress* side of the same handler: the response log in
+``projects_handler.py`` must record the status code and not the body, which may
+contain user-generated content.  That check reads the line out of the handler
+rather than restating it, so it cannot drift from — or pass despite — the code it
+protects.
 
 Spellings the guard does NOT catch (documented to set honest expectations):
 
@@ -54,6 +93,25 @@ Spellings the guard does NOT catch (documented to set honest expectations):
   * Handler sources under ``plugins/`` (ingestor Lambda functions for S3/SQS
     events) — ``_SCAN_ROOTS`` covers ``lambda/`` subdirectories only; the
     ``plugins/`` tree is outside this guard's scope.
+  * ``@logger.inject_lambda_context(log_event=True)`` and the
+    ``POWERTOOLS_LOGGER_LOG_EVENT=true`` environment variable, either of which
+    makes Powertools log the event itself.  Neither appears in any Python or CDK
+    source today; covering them means scanning TypeScript as well, which this
+    Python-only walk cannot do.
+  * ``event`` reaching the log via a *keyword* argument other than ``extra=`` or
+    ``event=`` (e.g. a bespoke ``logger.structure(payload=event)`` helper).
+
+Residual imprecisions in the patterns themselves — known and accepted:
+
+  * Patterns 4 and 5 elide nested parenthesised groups before looking for a bare
+    ``event`` argument, so a bare ``event`` appearing *inside* a nested call is
+    invisible to them: ``logger.info("%s", wrap(event))`` is not flagged.  That
+    is the intended reading (the helper's return value is what is logged), but it
+    also means ``logger.info("%s", identity(event))`` — a helper that returns the
+    event unchanged — slips through.
+  * Pattern 5's bare ``event=event`` alternative is scoped to the logger call's
+    own arguments, so ``logger.info("x", extra=f(event=event))`` is not flagged
+    while ``logger.append_keys(event=event)`` is.
 
 How this guard is executed
 --------------------------
@@ -126,11 +184,13 @@ def _source_files():
 # Patterns
 # ---------------------------------------------------------------------------
 
+_PAT_LOGGER_CALL = re.compile(r'\blogger\.\w+\(')
+
 # Pattern 1 — json.dumps(event) or json.dumps(event, ...) on a logger line.
 # Matches the opening of the call; does not require a closing paren so that
 # multi-arg variants like json.dumps(event, cls=DecimalEncoder) are caught.
-# The test pairs this with _PAT_LOGGER_CALL so that legitimate event-forwarding
-# lines (e.g. Payload=json.dumps(event)) are not false-positived.
+# Paired with _PAT_LOGGER_CALL so that legitimate event-forwarding lines
+# (e.g. Payload=json.dumps(event)) are not false-positived.
 _PAT_JSON_DUMPS_EVENT = re.compile(r'\bjson\.dumps\(\s*event\s*[,)]')
 
 # Pattern 2 — {event...} inside an f-string on a line that also contains a
@@ -140,32 +200,156 @@ _PAT_JSON_DUMPS_EVENT = re.compile(r'\bjson\.dumps\(\s*event\s*[,)]')
 #   {event}                — bare embed (} after event)
 #   {event!r}, {event!s}   — conversion flags (! after event)
 #   {event:...}            — format spec (: after event)
+#   {event=}, {event = }   — self-documenting form, which implies !r (= after
+#                            event, with optional space as PEP 501 permits)
 # Deliberately NOT matched: {event["key"]} and {event.get("path")}.  Logging a
 # single named field is the recommended remediation when this guard fires, so
 # flagging it would reject the correct fix (and would fire on the existing
 # f"keys={list(event.keys())}" lines in lambda/jobs/*, which log key names
 # only, never values).
-_PAT_LOGGER_CALL = re.compile(r'\blogger\.\w+\(')
-_PAT_FSTRING_EVENT = re.compile(r'\{event[}!:]')
+_PAT_FSTRING_EVENT = re.compile(r'\{event\s*[}!:=]')
 
-# Pattern 3 — logger.<level>(event) or logger.<level>(event, ...)
-_PAT_LOGGER_EVENT_DIRECT = re.compile(r'\blogger\.\w+\(\s*event\s*[,)]')
+# Pattern 3 — logger.<level>(event) or logger.<level>(event, ...): the event is
+# the log message itself, so str(event) — the full dict — becomes the record.
+_PAT_EVENT_FIRST_ARG = re.compile(r'^\s*event\s*[,)]')
 
-# Pattern 4 — event passed as a non-first positional argument to a logger call,
-# i.e. printf-style lazy formatting: logger.info("event: %s", event).
-# Pattern 3 cannot see this because it requires `event` to be the first argument.
-_PAT_LOGGER_EVENT_ARG = re.compile(r'\blogger\.\w+\([^)]*,\s*event\s*[,)]')
+# Pattern 4 — event as a non-first positional argument, i.e. printf-style lazy
+# formatting: logger.info("event: %s", event).  Pattern 3 cannot see this
+# because it requires `event` to be the first argument.
+_PAT_EVENT_LATER_ARG = re.compile(r',\s*event\s*[,)]')
 
-# Pattern 5 — event embedded in a Powertools structured field on a logger line:
+# Pattern 5 — event embedded in a Powertools structured field:
 #   logger.info("msg", extra={"event": event})   — value inside an extra= dict
 #   logger.append_keys(event=event)              — sticky key
-# Both serialise the event into the JSON log record.  The test pairs this with
-# _PAT_LOGGER_CALL so that non-logging keyword forwarding (e.g.
-# handler(event=event)) is not flagged.
-_PAT_LOGGER_EVENT_STRUCTURED = re.compile(
-    r'extra\s*=\s*\{[^}]*[:,]\s*event\s*[,}]'
+# Both serialise the event into the JSON log record.  The value position accepts
+# a preceding ':' ',' or '[' so the event is found whether it is the dict value
+# itself or an element of a list value (extra={"a": [event]}); `event[` is not a
+# bare event, so selections stay unflagged.
+_PAT_EVENT_STRUCTURED = re.compile(
+    r'extra\s*=\s*\{[^}]*[:,\[]\s*event\s*[,}\]]'
     r'|\bevent\s*=\s*event\b'
 )
+
+# Patterns 3, 4 and 5 are matched against the arguments passed *directly* to a
+# logger call, not against the raw line.  Scanning the raw line for a prefix
+# (the previous `logger\.\w+\([^)]*,` shape) errs in both directions: a ')' in
+# an earlier argument stops the scan and hides a real violation
+# (`logger.info("%s %s", ctx.get_id(), event)`), while a bare `event` handed to
+# a helper inside the call is flagged even though only the helper's return value
+# is logged (`logger.info("route=%s", route_for(method, event))`).  Extracting
+# the argument list once, with nested groups elided, removes both errors.
+
+
+def _is_elided(stack) -> bool:
+    """True while inside a group whose contents are not the logger's own argument.
+
+    Any parenthesised group is elided: what it contains belongs to an inner call,
+    and what reaches the log record is that call's return value.  A *single* set
+    of braces is kept, because ``extra={...}`` is itself a direct argument and
+    pattern 5 has to see inside it; braces nested within it are elided so that
+    ``extra={"meta": {"x": 1}, "event": event}`` still exposes the ``event`` key.
+    """
+    return '(' in stack or stack.count('{') > 1
+
+
+def _logger_call_arg_texts(line: str):
+    """Yield the direct-argument text of each ``logger.<level>(...)`` call in `line`.
+
+    Two normalisations make the argument text safe to match simple patterns
+    against:
+
+    * **Nested groups are elided** — a parenthesised group becomes ``(...)`` and a
+      brace group nested inside another becomes ``...`` (see ``_is_elided``).
+      Subscripts are preserved, so ``event['path']`` remains visible as a
+      selection rather than a bare ``event``.
+    * **String-literal contents are dropped**, keeping the quotes.  Prose in a
+      log message must not be mistaken for code — a message that happens to read
+      ``"..., event)"`` is not a violation.
+
+    A ``)`` sentinel is appended so the final argument has a terminator whether
+    or not the call closes on this line.
+    """
+    for match in _PAT_LOGGER_CALL.finditer(line):
+        out = []
+        stack = []
+        quote = None
+        i = match.end()
+        while i < len(line):
+            char = line[i]
+            if quote is not None:
+                if char == '\\':
+                    i += 2
+                    continue
+                if char == quote:
+                    quote = None
+                    if not _is_elided(stack):
+                        out.append(char)
+                i += 1
+                continue
+            if char in '"\'':
+                quote = char
+                if not _is_elided(stack):
+                    out.append(char)
+            elif char in '({':
+                was_elided = _is_elided(stack)
+                stack.append(char)
+                if _is_elided(stack):
+                    if not was_elided:
+                        # Placeholders must not contain a brace: pattern 5 scans
+                        # the inside of extra={...} with a [^}]* run.
+                        out.append('(...)' if char == '(' else '...')
+                else:
+                    out.append(char)
+            elif char in ')}':
+                if not stack:
+                    if char == ')':
+                        break  # the logger call's own closing paren
+                    i += 1
+                    continue
+                was_elided = _is_elided(stack)
+                stack.pop()
+                if not was_elided and not _is_elided(stack):
+                    out.append(char)
+            elif not _is_elided(stack):
+                out.append(char)
+            i += 1
+        yield ''.join(out) + ')'
+
+
+def _flags_json_dumps_event(line: str) -> bool:
+    """Pattern 1: the event is serialised on a line that also logs."""
+    return bool(_PAT_LOGGER_CALL.search(line) and _PAT_JSON_DUMPS_EVENT.search(line))
+
+
+def _flags_fstring_event(line: str) -> bool:
+    """Pattern 2: the whole event is interpolated into an f-string that is logged."""
+    return bool(_PAT_LOGGER_CALL.search(line) and _PAT_FSTRING_EVENT.search(line))
+
+
+def _flags_event_as_first_arg(line: str) -> bool:
+    """Pattern 3: the event is the log message."""
+    return any(_PAT_EVENT_FIRST_ARG.search(args) for args in _logger_call_arg_texts(line))
+
+
+def _flags_event_as_later_arg(line: str) -> bool:
+    """Pattern 4: the event is a printf-style argument to the log message."""
+    return any(_PAT_EVENT_LATER_ARG.search(args) for args in _logger_call_arg_texts(line))
+
+
+def _flags_event_in_structured_field(line: str) -> bool:
+    """Pattern 5: the event is attached as a Powertools structured field."""
+    return any(_PAT_EVENT_STRUCTURED.search(args) for args in _logger_call_arg_texts(line))
+
+
+def _scan(predicate):
+    """Return ``file:line: source`` for every scanned line satisfying `predicate`."""
+    violations = []
+    for path in _source_files():
+        text = path.read_text(encoding='utf-8')
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if predicate(line):
+                violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
+    return violations
 
 
 # ---------------------------------------------------------------------------
@@ -223,13 +407,7 @@ class TestNoRawEventLogging:
         downstream service (e.g. ``Payload=json.dumps(event)``) are not flagged
         because they do not also contain a logger call.
         """
-        violations = []
-        for path in _source_files():
-            text = path.read_text(encoding='utf-8')
-            for lineno, line in enumerate(text.splitlines(), 1):
-                if _PAT_LOGGER_CALL.search(line) and _PAT_JSON_DUMPS_EVENT.search(line):
-                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
-
+        violations = _scan(_flags_json_dumps_event)
         assert not violations, (
             'Found logger call with json.dumps(event) in handler source(s) — this writes the\n'
             'caller\'s Authorization header (bearer token) to CloudWatch logs:\n'
@@ -248,8 +426,8 @@ class TestNoRawEventLogging:
             logger.info(f"received {event}")
 
         Only the forms that stringify the whole event are flagged: ``{event}``,
-        ``{event!r}``, ``{event!s}`` and ``{event:...}``.  Logging an individual
-        field — ``logger.info(f"path={event['path']}")`` or
+        ``{event!r}``, ``{event!s}``, ``{event:...}`` and ``{event=}``.  Logging
+        an individual field — ``logger.info(f"path={event['path']}")`` or
         ``f"keys={list(event.keys())}"`` — is permitted by design; it is the
         remediation a developer should apply when this guard fires.
 
@@ -257,13 +435,7 @@ class TestNoRawEventLogging:
         the same source line.  Multi-line log statements spanning several
         physical lines are outside this guard's scope (see module docstring).
         """
-        violations = []
-        for path in _source_files():
-            text = path.read_text(encoding='utf-8')
-            for lineno, line in enumerate(text.splitlines(), 1):
-                if _PAT_LOGGER_CALL.search(line) and _PAT_FSTRING_EVENT.search(line):
-                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
-
+        violations = _scan(_flags_fstring_event)
         assert not violations, (
             'Found {event} inside a logger call — this stringifies the whole\n'
             'event (including headers) into the log message:\n'
@@ -280,13 +452,7 @@ class TestNoRawEventLogging:
         Passing the event object directly as the log message is equivalent
         to logging str(event) — the full dict including headers.
         """
-        violations = []
-        for path in _source_files():
-            text = path.read_text(encoding='utf-8')
-            for lineno, line in enumerate(text.splitlines(), 1):
-                if _PAT_LOGGER_EVENT_DIRECT.search(line):
-                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
-
+        violations = _scan(_flags_event_as_first_arg)
         assert not violations, (
             'Found logger.<level>(event) in handler source(s) — this logs the\n'
             'full event dict (including the Authorization header) as a message:\n'
@@ -308,14 +474,12 @@ class TestNoRawEventLogging:
         f-strings, so this is the spelling a developer following general Python
         best practice would write — and the one pattern 3 cannot see, because
         it requires ``event`` to be the first argument.
-        """
-        violations = []
-        for path in _source_files():
-            text = path.read_text(encoding='utf-8')
-            for lineno, line in enumerate(text.splitlines(), 1):
-                if _PAT_LOGGER_EVENT_ARG.search(line):
-                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
 
+        Matched against the logger call's direct arguments, so a ``)`` in an
+        earlier argument cannot hide a violation, and a bare ``event`` handed to
+        a helper inside the call is not one.
+        """
+        violations = _scan(_flags_event_as_later_arg)
         assert not violations, (
             'Found the event passed as a printf-style logger argument — the\n'
             'full event dict (including the Authorization header) is interpolated\n'
@@ -340,14 +504,12 @@ class TestNoRawEventLogging:
         ``json.dumps(event)``.  ``extra=`` is the house idiom in
         ``projects_handler.py`` after this fix, which makes it an easy spelling
         to reach for by accident.
-        """
-        violations = []
-        for path in _source_files():
-            text = path.read_text(encoding='utf-8')
-            for lineno, line in enumerate(text.splitlines(), 1):
-                if _PAT_LOGGER_CALL.search(line) and _PAT_LOGGER_EVENT_STRUCTURED.search(line):
-                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
 
+        Matched against the logger call's direct arguments, so a nested dict
+        inside ``extra=`` cannot hide a violation and non-logging keyword
+        forwarding (``handler(event=event)``) is not one.
+        """
+        violations = _scan(_flags_event_in_structured_field)
         assert not violations, (
             'Found the event attached to a logger call as a structured field —\n'
             'Powertools serialises it into the JSON log record, including the\n'
@@ -369,11 +531,20 @@ class TestPatternCalibration:
     narrowing of a pattern has a test here that fails if it is reverted.
     """
 
+    # Every predicate, so the "no safe line is flagged" cases below assert
+    # against all five patterns rather than whichever ones were remembered.
+    _ALL = (
+        _flags_json_dumps_event,
+        _flags_fstring_event,
+        _flags_event_as_first_arg,
+        _flags_event_as_later_arg,
+        _flags_event_in_structured_field,
+    )
+
     # --- must be flagged (whole event reaches the log record) ---------- #
 
     def test_flags_json_dumps_event_on_logger_line(self):
-        line = 'logger.info(f"Received event: {json.dumps(event)}")'
-        assert _PAT_LOGGER_CALL.search(line) and _PAT_JSON_DUMPS_EVENT.search(line)
+        assert _flags_json_dumps_event('logger.info(f"Received event: {json.dumps(event)}")')
 
     def test_flags_whole_event_fstring_variants(self):
         for line in (
@@ -381,24 +552,42 @@ class TestPatternCalibration:
             'logger.info(f"received {event!r}")',
             'logger.info(f"received {event!s}")',
             'logger.info(f"received {event:>10}")',
+            # Self-documenting form (PEP 501); `=` implies !r, so the whole
+            # event repr — Authorization header included — reaches the record.
+            'logger.debug(f"{event=}")',
+            'logger.info(f"dbg {event = }")',
         ):
-            assert _PAT_FSTRING_EVENT.search(line), line
+            assert _flags_fstring_event(line), line
+
+    def test_flags_event_as_message(self):
+        for line in (
+            'logger.info(event)',
+            'logger.info(event, extra={"a": 1})',
+        ):
+            assert _flags_event_as_first_arg(line), line
 
     def test_flags_event_as_printf_argument(self):
         for line in (
             'logger.info("event: %s", event)',
             'logger.warning("e=%r", event)',
             'logger.info("a %s b %s", other, event)',
+            # A ')' in an earlier argument must not hide the event.
+            'logger.info("%s %s", ctx.get_id(), event)',
+            'logger.warning("%s %s", event.get("path"), event)',
         ):
-            assert _PAT_LOGGER_EVENT_ARG.search(line), line
+            assert _flags_event_as_later_arg(line), line
 
     def test_flags_event_in_structured_fields(self):
         for line in (
             'logger.info("msg", extra={"event": event})',
             "logger.info('msg', extra={'request': req, 'event': event})",
             'logger.append_keys(event=event)',
+            # A nested dict inside extra= must not hide the event.
+            'logger.info("m", extra={"meta": {"x": 1}, "event": event})',
+            # Nor a list value.
+            'logger.info("m", extra={"events": [event]})',
         ):
-            assert _PAT_LOGGER_CALL.search(line) and _PAT_LOGGER_EVENT_STRUCTURED.search(line), line
+            assert _flags_event_in_structured_field(line), line
 
     # --- must NOT be flagged (no sensitive value reaches the log) ------ #
 
@@ -410,10 +599,20 @@ class TestPatternCalibration:
             'logger.info(f"keys={event.keys()}")',
             'logger.info(f"Persona generator invoked with event keys: {list(event.keys())}")',
             'logger.info("path: %s", event["path"])',
+            'logger.info("keys: %s", list(event.keys()))',
         ):
-            assert not _PAT_FSTRING_EVENT.search(line), line
-            assert not _PAT_LOGGER_EVENT_ARG.search(line), line
-            assert not _PAT_LOGGER_EVENT_DIRECT.search(line), line
+            for predicate in self._ALL:
+                assert not predicate(line), f'{predicate.__name__}: {line}'
+
+    def test_does_not_flag_event_passed_to_a_helper(self):
+        """What reaches the record is the helper's return value, not the event."""
+        for line in (
+            'logger.info("route=%s", route_for(method, event))',
+            'logger.info(f"route={route_for(method, event)}")',
+            'logger.info("summary=%s", summarise(event))',
+        ):
+            for predicate in self._ALL:
+                assert not predicate(line), f'{predicate.__name__}: {line}'
 
     def test_does_not_flag_event_forwarding(self):
         """Serialising the event for a downstream service is legitimate."""
@@ -422,13 +621,61 @@ class TestPatternCalibration:
             'sqs.send_message(QueueUrl=url, MessageBody=json.dumps(event))',
             'inner_handler(event=event, context=context)',
         ):
-            assert not _PAT_LOGGER_CALL.search(line), line
+            for predicate in self._ALL:
+                assert not predicate(line), f'{predicate.__name__}: {line}'
 
-    def test_does_not_flag_status_code_only_response_log(self):
-        """The replacement log in projects_handler.py must stay clean."""
-        line = 'logger.debug("Returning response", extra={"status_code": result.get("statusCode")})'
-        assert not _PAT_JSON_DUMPS_EVENT.search(line)
-        assert not _PAT_FSTRING_EVENT.search(line)
-        assert not _PAT_LOGGER_EVENT_DIRECT.search(line)
-        assert not _PAT_LOGGER_EVENT_ARG.search(line)
-        assert not _PAT_LOGGER_EVENT_STRUCTURED.search(line)
+    def test_does_not_flag_prose_in_a_log_message(self):
+        """A log message that merely reads like code is not a violation."""
+        for line in (
+            'logger.info("did not log the event) at all")',
+            'logger.info("event: redacted")',
+        ):
+            for predicate in self._ALL:
+                assert not predicate(line), f'{predicate.__name__}: {line}'
+
+
+# ---------------------------------------------------------------------------
+# Egress side of the same handler
+# ---------------------------------------------------------------------------
+
+class TestResponseBodyNotLogged:
+    """The response log in projects_handler.py must not carry the body.
+
+    Separate from the five event patterns above, which all key on the identifier
+    ``event`` and so cannot see anything done to ``result``.  The response may
+    contain user-generated content (project text, verbatims, persona data), so
+    the egress log records the status code only.
+    """
+
+    def test_response_log_does_not_include_the_body(self):
+        """Read the real egress log line; do not restate it.
+
+        Asserting against a copy of the line cannot fail when the handler
+        changes — it only pins the copy.  Reading the source means reintroducing
+        the body actually fails this test.
+        """
+        source = (_lambda_root() / 'api' / 'projects_handler.py').read_text(encoding='utf-8')
+        egress = [
+            line.strip()
+            for line in source.splitlines()
+            if 'Returning' in line and _PAT_LOGGER_CALL.search(line)
+        ]
+
+        # Non-vacuity: without this the test silently becomes a no-op the moment
+        # the line is renamed — the same hole test_scan_covers_projects_handler
+        # closes for the file walk.
+        assert egress, (
+            'No egress log line found in projects_handler.py (a logger call '
+            'mentioning "Returning").  If it was renamed, update this test; if it '
+            'was deleted, delete this test.'
+        )
+
+        for line in egress:
+            assert 'json.dumps(result' not in line, (
+                f'The response body is serialised into the egress log: {line!r}\n'
+                'It may contain user-generated content; log the status code only.'
+            )
+            assert '{result' not in line, (
+                f'The response is interpolated into the egress log: {line!r}\n'
+                'It may contain user-generated content; log the status code only.'
+            )

--- a/voc-datalake/lambda/api/test/test_no_event_logging.py
+++ b/voc-datalake/lambda/api/test/test_no_event_logging.py
@@ -3,12 +3,17 @@
 This test walks every non-test Python source under lambda/ and fails on any
 of the three spellings of the defect identified in issue #245:
 
-  1. ``json.dumps(event[, ...])``
+  1. ``json.dumps(event[, ...])`` on a line that also calls a logger method
         The whole event is serialised; the output contains the caller's
         ``Authorization`` header (Cognito bearer token) in plain text.
+        Note: the guard requires both a ``logger.`` call and ``json.dumps(event...)`
+        on the same line, so legitimate event-forwarding to downstream services
+        (e.g. ``lambda_client.invoke(Payload=json.dumps(event))``) is not flagged.
 
-  2. ``f"...{event}..."`` on a line that also calls a logger method
-        The str() of the event object is interpolated into the log message.
+  2. ``f"...{event}..."`` (and common variants) on a line that also calls a
+     logger method — the str() of the event object is interpolated into the log
+     message.  Variants caught include ``{event!r}``, ``{event!s}``,
+     ``{event["key"]}``, and ``{event.method()}``.
 
   3. ``logger.<level>(event)`` / ``logger.<level>(event, ...)``
         The event is passed directly as the log-message argument.
@@ -24,6 +29,9 @@ Spellings the guard does NOT catch (documented to set honest expectations):
   * Variables aliased to something other than ``event``
     (e.g. ``evt = event; logger.info(evt)``).
   * Custom serialisers other than ``json.dumps``.
+  * Handler sources under ``plugins/`` (ingestor Lambda functions for S3/SQS
+    events) — ``_SCAN_ROOTS`` covers ``lambda/`` subdirectories only; the
+    ``plugins/`` tree is outside this guard's scope.
 """
 
 import re
@@ -78,16 +86,23 @@ def _source_files():
 # Patterns
 # ---------------------------------------------------------------------------
 
-# Pattern 1 — json.dumps(event) or json.dumps(event, ...)
+# Pattern 1 — json.dumps(event) or json.dumps(event, ...) on a logger line.
 # Matches the opening of the call; does not require a closing paren so that
 # multi-arg variants like json.dumps(event, cls=DecimalEncoder) are caught.
+# The test pairs this with _PAT_LOGGER_CALL so that legitimate event-forwarding
+# lines (e.g. Payload=json.dumps(event)) are not false-positived.
 _PAT_JSON_DUMPS_EVENT = re.compile(r'\bjson\.dumps\(\s*event\s*[,)]')
 
-# Pattern 2 — {event} inside an f-string on a line that also contains a
+# Pattern 2 — {event...} inside an f-string on a line that also contains a
 # logger call.  The two sub-patterns are checked independently so a line
 # with neither is not flagged.
+# _PAT_FSTRING_EVENT matches bare {event} as well as common variants:
+#   {event!r}, {event!s}   — conversion flags
+#   {event["key"]}         — key access ([ after event)
+#   {event.method()}       — attribute/method access (. after event)
+#   {event:...}            — format spec (: after event)
 _PAT_LOGGER_CALL = re.compile(r'\blogger\.\w+\(')
-_PAT_FSTRING_EVENT = re.compile(r'\{event\}')
+_PAT_FSTRING_EVENT = re.compile(r'\{event[}!:\[.]')
 
 # Pattern 3 — logger.<level>(event) or logger.<level>(event, ...)
 _PAT_LOGGER_EVENT_DIRECT = re.compile(r'\blogger\.\w+\(\s*event\s*[,)]')
@@ -137,21 +152,26 @@ class TestNoRawEventLogging:
     # ------------------------------------------------------------------ #
 
     def test_no_json_dumps_event(self):
-        """json.dumps(event[, ...]) must not appear in any handler source.
+        """logger.<level>(...json.dumps(event[, ...])...) must not appear in handler source.
 
         This is the canonical spelling of the defect.  The event dict
         contains the full API Gateway request including the Authorization
         header; serialising it writes the bearer token to CloudWatch.
+
+        Both a logger call and json.dumps(event...) must appear on the same line
+        for a violation to be reported.  Lines that forward the event to a
+        downstream service (e.g. ``Payload=json.dumps(event)``) are not flagged
+        because they do not also contain a logger call.
         """
         violations = []
         for path in _source_files():
             text = path.read_text(encoding='utf-8')
             for lineno, line in enumerate(text.splitlines(), 1):
-                if _PAT_JSON_DUMPS_EVENT.search(line):
+                if _PAT_LOGGER_CALL.search(line) and _PAT_JSON_DUMPS_EVENT.search(line):
                     violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
 
         assert not violations, (
-            'Found json.dumps(event) in handler source(s) — this writes the\n'
+            'Found logger call with json.dumps(event) in handler source(s) — this writes the\n'
             'caller\'s Authorization header (bearer token) to CloudWatch logs:\n'
             + '\n'.join(f'  {v}' for v in violations)
         )
@@ -161,7 +181,7 @@ class TestNoRawEventLogging:
     # ------------------------------------------------------------------ #
 
     def test_no_fstring_event_in_logger_calls(self):
-        """{{event}} must not be embedded in an f-string passed to a logger method.
+        """`{event}` must not be embedded in an f-string passed to a logger method.
 
         Example of the banned pattern::
 

--- a/voc-datalake/lambda/api/test/test_no_event_logging.py
+++ b/voc-datalake/lambda/api/test/test_no_event_logging.py
@@ -1,0 +1,206 @@
+"""Guard: no handler source may write the raw Lambda event to logs.
+
+This test walks every non-test Python source under lambda/ and fails on any
+of the three spellings of the defect identified in issue #245:
+
+  1. ``json.dumps(event[, ...])``
+        The whole event is serialised; the output contains the caller's
+        ``Authorization`` header (Cognito bearer token) in plain text.
+
+  2. ``f"...{event}..."`` on a line that also calls a logger method
+        The str() of the event object is interpolated into the log message.
+
+  3. ``logger.<level>(event)`` / ``logger.<level>(event, ...)``
+        The event is passed directly as the log-message argument.
+
+Spellings the guard does NOT catch (documented to set honest expectations):
+
+  * Multi-line expressions where the logger call and the event embed are on
+    different source lines — only single-line matching is performed.
+  * ``print(event)`` — only ``logger.*`` calls are checked.
+  * ``logging.getLogger().info(event)`` — only the ``logger`` name is matched.
+  * ``json.dumps(event.copy())`` or ``json.dumps(dict(event))`` — the event
+    wrapped by a further call is not matched.
+  * Variables aliased to something other than ``event``
+    (e.g. ``evt = event; logger.info(evt)``).
+  * Custom serialisers other than ``json.dumps``.
+"""
+
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Scope
+# ---------------------------------------------------------------------------
+
+# Source trees to walk.  Only first-party handler code; not build outputs,
+# vendored packages, or test helpers.
+_SCAN_ROOTS = [
+    'api',
+    'aggregator',
+    'custom_resources',
+    'jobs',
+    'processor',
+    'research',
+    'shared',
+    'stream',
+]
+
+# Directory names that stop the descent when encountered.
+_EXCLUDE_DIR_NAMES = frozenset({'test', 'layers', 'cdk.out', '__pycache__', '.venv', 'node_modules'})
+
+
+def _lambda_root() -> Path:
+    # This file lives at lambda/api/test/; resolve four levels up for lambda/.
+    return Path(__file__).resolve().parents[3] / 'lambda'
+
+
+def _source_files():
+    """Yield every .py source file in the scan scope, excluding test directories."""
+    root = _lambda_root()
+    for rel in _SCAN_ROOTS:
+        scan_root = root / rel
+        if not scan_root.is_dir():
+            continue
+        for path in scan_root.rglob('*.py'):
+            # Skip any path whose components include an excluded directory name.
+            # Using parts[1:] because parts[0] is the drive/root on Windows;
+            # on POSIX it is '/'.  The relevant names are the relative parts.
+            relative_parts = path.relative_to(root).parts
+            if any(part in _EXCLUDE_DIR_NAMES for part in relative_parts):
+                continue
+            yield path
+
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# Pattern 1 — json.dumps(event) or json.dumps(event, ...)
+# Matches the opening of the call; does not require a closing paren so that
+# multi-arg variants like json.dumps(event, cls=DecimalEncoder) are caught.
+_PAT_JSON_DUMPS_EVENT = re.compile(r'\bjson\.dumps\(\s*event\s*[,)]')
+
+# Pattern 2 — {event} inside an f-string on a line that also contains a
+# logger call.  The two sub-patterns are checked independently so a line
+# with neither is not flagged.
+_PAT_LOGGER_CALL = re.compile(r'\blogger\.\w+\(')
+_PAT_FSTRING_EVENT = re.compile(r'\{event\}')
+
+# Pattern 3 — logger.<level>(event) or logger.<level>(event, ...)
+_PAT_LOGGER_EVENT_DIRECT = re.compile(r'\blogger\.\w+\(\s*event\s*[,)]')
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNoRawEventLogging:
+    """No handler source may write the raw Lambda event to logs (issue #245)."""
+
+    # ------------------------------------------------------------------ #
+    # Sanity: verify the walk actually reaches the handler that had the   #
+    # defect.  A wrong root path or overly-broad exclusion would make     #
+    # subsequent tests pass vacuously — catching nothing and reporting    #
+    # clean.                                                              #
+    # ------------------------------------------------------------------ #
+
+    def test_scan_covers_projects_handler(self):
+        """The scanned file set must include projects_handler.py.
+
+        If this assertion fails it means SCAN_ROOTS or EXCLUDE_DIR_NAMES is
+        misconfigured and the subsequent pattern checks are unreliable.
+        """
+        file_names = {p.name for p in _source_files()}
+        assert 'projects_handler.py' in file_names, (
+            'projects_handler.py was not found in the scanned source set.\n'
+            'Check _SCAN_ROOTS and _EXCLUDE_DIR_NAMES in this test file.\n'
+            f'Lambda root resolved to: {_lambda_root()}'
+        )
+
+    def test_scan_covers_multiple_handler_files(self):
+        """The scanned set must be non-trivial (more than one file).
+
+        Complements test_scan_covers_projects_handler: ensures we are not
+        accidentally scanning a single file or an empty subtree.
+        """
+        count = sum(1 for _ in _source_files())
+        assert count > 5, (
+            f'Only {count} source file(s) found — expected many more.\n'
+            f'Lambda root: {_lambda_root()}'
+        )
+
+    # ------------------------------------------------------------------ #
+    # Pattern 1: json.dumps(event)                                        #
+    # ------------------------------------------------------------------ #
+
+    def test_no_json_dumps_event(self):
+        """json.dumps(event[, ...]) must not appear in any handler source.
+
+        This is the canonical spelling of the defect.  The event dict
+        contains the full API Gateway request including the Authorization
+        header; serialising it writes the bearer token to CloudWatch.
+        """
+        violations = []
+        for path in _source_files():
+            text = path.read_text(encoding='utf-8')
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if _PAT_JSON_DUMPS_EVENT.search(line):
+                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
+
+        assert not violations, (
+            'Found json.dumps(event) in handler source(s) — this writes the\n'
+            'caller\'s Authorization header (bearer token) to CloudWatch logs:\n'
+            + '\n'.join(f'  {v}' for v in violations)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Pattern 2: {event} in an f-string on a logger call line             #
+    # ------------------------------------------------------------------ #
+
+    def test_no_fstring_event_in_logger_calls(self):
+        """{{event}} must not be embedded in an f-string passed to a logger method.
+
+        Example of the banned pattern::
+
+            logger.info(f"received {event}")
+
+        The check is single-line: the logger call and {event} must appear on
+        the same source line.  Multi-line log statements spanning several
+        physical lines are outside this guard's scope (see module docstring).
+        """
+        violations = []
+        for path in _source_files():
+            text = path.read_text(encoding='utf-8')
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if _PAT_LOGGER_CALL.search(line) and _PAT_FSTRING_EVENT.search(line):
+                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
+
+        assert not violations, (
+            'Found {event} inside a logger call — this stringifies the whole\n'
+            'event (including headers) into the log message:\n'
+            + '\n'.join(f'  {v}' for v in violations)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Pattern 3: logger.<level>(event)                                    #
+    # ------------------------------------------------------------------ #
+
+    def test_no_logger_event_direct(self):
+        """logger.<level>(event) must not appear in any handler source.
+
+        Passing the event object directly as the log message is equivalent
+        to logging str(event) — the full dict including headers.
+        """
+        violations = []
+        for path in _source_files():
+            text = path.read_text(encoding='utf-8')
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if _PAT_LOGGER_EVENT_DIRECT.search(line):
+                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
+
+        assert not violations, (
+            'Found logger.<level>(event) in handler source(s) — this logs the\n'
+            'full event dict (including the Authorization header) as a message:\n'
+            + '\n'.join(f'  {v}' for v in violations)
+        )

--- a/voc-datalake/lambda/api/test/test_no_event_logging.py
+++ b/voc-datalake/lambda/api/test/test_no_event_logging.py
@@ -65,14 +65,26 @@ The five spellings the rule is enforced against:
      which makes this spelling especially easy to reach for.  Also matched
      against the direct arguments, so nesting inside ``extra=``
      (``extra={"meta": {"x": 1}, "event": event}``) is caught and plain
-     forwarding such as ``handler(event=event)`` is not.
+     forwarding such as ``handler(event=event)`` is not.  A list value
+     (``extra={"a": [event]}``) is caught; a *subscript* keyed by the event
+     (``extra={"a": foo[event]}``) is not, since only the looked-up value
+     reaches the record.
 
-Separately from the five event patterns, ``test_response_log_does_not_include_the_body``
-pins the *egress* side of the same handler: the response log in
-``projects_handler.py`` must record the status code and not the body, which may
-contain user-generated content.  That check reads the line out of the handler
-rather than restating it, so it cannot drift from — or pass despite — the code it
-protects.
+Separately from the five event patterns, ``TestResponseBodyNotLogged`` pins the
+*egress* side of the same handler: the response log in ``projects_handler.py``
+must record the status code and not the body, which may contain user-generated
+content.  Both of its checks read the line out of the handler rather than
+restating it, so neither can drift from — or pass despite — the code it protects.
+
+The same rule applies there, spelled against ``result`` rather than ``event``:
+the whole response must not reach the record, by any of the spellings patterns
+1-5 cover — serialised, interpolated, printf-style, or attached through
+``extra=``.  That last one is the spelling this fix itself makes idiomatic on
+that very line, so it is guarded rather than merely documented.  Because a
+deny-list of spellings can always be outrun by the next serialisation idiom, a
+second check *allow-lists* the record's ``extra=`` keys
+(``_EGRESS_ALLOWED_EXTRA_KEYS``): whatever expression produces it, a field that
+is not ``status_code`` fails.
 
 Spellings the guard does NOT catch (documented to set honest expectations):
 
@@ -112,6 +124,12 @@ Residual imprecisions in the patterns themselves — known and accepted:
   * Pattern 5's bare ``event=event`` alternative is scoped to the logger call's
     own arguments, so ``logger.info("x", extra=f(event=event))`` is not flagged
     while ``logger.append_keys(event=event)`` is.
+  * The egress deny-list inherits both of the above, since it reuses the same
+    shapes against ``result``.  The ``extra=`` key allow-list does not — it reads
+    the field names off the raw line, so it holds regardless of what expression
+    the value is.  It does assume the keys are string literals: a computed key
+    (``extra={key_name: result}``) is invisible to it, though the deny-list still
+    catches the bare ``result`` in that example.
 
 How this guard is executed
 --------------------------
@@ -222,11 +240,14 @@ _PAT_EVENT_LATER_ARG = re.compile(r',\s*event\s*[,)]')
 #   logger.info("msg", extra={"event": event})   — value inside an extra= dict
 #   logger.append_keys(event=event)              — sticky key
 # Both serialise the event into the JSON log record.  The value position accepts
-# a preceding ':' ',' or '[' so the event is found whether it is the dict value
-# itself or an element of a list value (extra={"a": [event]}); `event[` is not a
-# bare event, so selections stay unflagged.
+# a preceding ':' or ',' (the event is the dict value) or a '[' that *opens a
+# collection* (the event is an element of a list value, extra={"a": [event]}).
+# The `(?<![\w\]\)])` lookbehind is what distinguishes a list literal from a
+# subscript: in `extra={"a": foo[event]}` the '[' follows an identifier, so only
+# the looked-up value reaches the record and the line is not flagged.  Likewise
+# `event[` is a selection, not a bare event, so selections stay unflagged.
 _PAT_EVENT_STRUCTURED = re.compile(
-    r'extra\s*=\s*\{[^}]*[:,\[]\s*event\s*[,}\]]'
+    r'extra\s*=\s*\{[^}]*(?:[:,]|(?<![\w\]\)])\[)\s*event\s*[,}\]]'
     r'|\bevent\s*=\s*event\b'
 )
 
@@ -314,6 +335,68 @@ def _logger_call_arg_texts(line: str):
                 out.append(char)
             i += 1
         yield ''.join(out) + ')'
+
+
+# ---------------------------------------------------------------------------
+# Egress side: the same rule, expressed against `result`
+# ---------------------------------------------------------------------------
+#
+# The five patterns above are all keyed on the identifier ``event``, so they are
+# structurally blind to whatever is done to the *response*.  The response log in
+# projects_handler.py gets the same rule — the whole object must not reach the
+# record — spelled against ``result``, because the response carries
+# user-generated content.
+#
+# Deny-listing spellings alone loses a race it cannot win: whichever
+# serialisation idiom the surrounding code makes fashionable next is by
+# definition not on the list.  So the egress check pairs the deny-list with an
+# allow-list on the ``extra=`` keys: that log record may carry ``status_code``
+# and nothing else, whatever expression produces it.
+
+_PAT_RESULT_FIRST_ARG = re.compile(r'^\s*result\s*[,)]')
+_PAT_RESULT_LATER_ARG = re.compile(r',\s*result\s*[,)]')
+_PAT_RESULT_STRUCTURED = re.compile(
+    r'extra\s*=\s*\{[^}]*(?:[:,]|(?<![\w\]\)])\[)\s*result\s*[,}\]]'
+    r'|\bresult\s*=\s*result\b'
+)
+
+# The extra= mapping of the egress log, read off the raw line (the argument
+# extractor drops string contents, so key *names* are only visible here).
+_PAT_EXTRA_MAPPING = re.compile(r'extra\s*=\s*\{([^}]*)\}')
+_PAT_MAPPING_KEY = re.compile(r'''['"](\w+)['"]\s*:''')
+
+# The only field the response log may attach.  The status code is not user
+# content; anything else on that record has to be argued for by widening this
+# set, which is a visible decision rather than an accidental one.
+_EGRESS_ALLOWED_EXTRA_KEYS = frozenset({'status_code'})
+
+
+def _flags_result_reaching_the_record(line: str) -> bool:
+    """True if the whole ``result`` object reaches a log record on `line`.
+
+    The ``result`` counterpart of patterns 3-5: the response as the log message,
+    as a printf-style argument, or attached as a Powertools structured field.
+    """
+    return any(
+        _PAT_RESULT_FIRST_ARG.search(args)
+        or _PAT_RESULT_LATER_ARG.search(args)
+        or _PAT_RESULT_STRUCTURED.search(args)
+        for args in _logger_call_arg_texts(line)
+    )
+
+
+def _extra_keys(line: str) -> set:
+    """Return the literal key names of every ``extra={...}`` mapping on `line`."""
+    return {
+        key
+        for mapping in _PAT_EXTRA_MAPPING.findall(line)
+        for key in _PAT_MAPPING_KEY.findall(mapping)
+    }
+
+
+def _unexpected_extra_keys(line: str) -> set:
+    """Return the ``extra=`` field names on `line` that the egress log may not carry."""
+    return _extra_keys(line) - _EGRESS_ALLOWED_EXTRA_KEYS
 
 
 def _flags_json_dumps_event(line: str) -> bool:
@@ -633,10 +716,97 @@ class TestPatternCalibration:
             for predicate in self._ALL:
                 assert not predicate(line), f'{predicate.__name__}: {line}'
 
+    def test_does_not_flag_a_subscript_keyed_by_the_event(self):
+        """Only the looked-up value reaches the record, not the event.
+
+        Pattern 5's value position accepts a leading '[' so a list value
+        (``extra={"a": [event]}``) is caught; the lookbehind is what keeps that
+        from also matching a subscript, where the '[' follows an identifier.
+        """
+        for line in (
+            'logger.info("m", extra={"a": foo[event]})',
+            'logger.info("m", extra={"k": d[event]})',
+        ):
+            for predicate in self._ALL:
+                assert not predicate(line), f'{predicate.__name__}: {line}'
+
 
 # ---------------------------------------------------------------------------
 # Egress side of the same handler
 # ---------------------------------------------------------------------------
+
+class TestEgressCalibration:
+    """The result-side predicates, pinned the same way as the event patterns.
+
+    ``test_response_log_does_not_include_the_body`` reads one line out of one
+    file, so it passes whenever that line happens to be clean — it cannot tell a
+    working predicate from a no-op one.  These cases pin the boundary directly.
+    """
+
+    def test_flags_the_whole_response_reaching_the_record(self):
+        for line in (
+            # The spelling this PR makes idiomatic on that very line.
+            'logger.info("Returning response", extra={"response": result})',
+            'logger.info("Returning response", extra={"status_code": code, "body": result})',
+            'logger.info("Returning response", extra={"responses": [result]})',
+            'logger.append_keys(result=result)',
+            'logger.info("Returning %s", result)',
+            'logger.info(result)',
+        ):
+            assert _flags_result_reaching_the_record(line), line
+
+    def test_does_not_flag_selecting_a_field_of_the_response(self):
+        for line in (
+            'logger.info("Returning response", extra={"status_code": result.get("statusCode")})',
+            'logger.info("Returning response", extra={"status_code": result["statusCode"]})',
+            'logger.info("Returning %s", result["statusCode"])',
+            # A subscript keyed by the result is a lookup, not a disclosure.
+            'logger.info("m", extra={"a": codes[result]})',
+        ):
+            assert not _flags_result_reaching_the_record(line), line
+
+    def test_extra_keys_reads_the_field_names(self):
+        line = 'logger.info("Returning response", extra={"status_code": result.get("statusCode")})'
+        assert _extra_keys(line) == {'status_code'}
+        assert _extra_keys('logger.info("m", extra={"a": 1, "b": 2})') == {'a', 'b'}
+        # No extra= mapping at all means nothing to allow-list.
+        assert _extra_keys('logger.info("plain message")') == set()
+
+    def test_allow_list_rejects_any_field_but_the_status_code(self):
+        """The allow-list half, pinned independently of the handler's current line.
+
+        Without this, emptying ``_EGRESS_ALLOWED_EXTRA_KEYS`` of its meaning — or
+        adding ``response`` to it — leaves the suite green, because
+        ``test_response_log_attaches_only_the_status_code`` only ever reads the
+        one line that is already clean.
+        """
+        assert _unexpected_extra_keys(
+            'logger.info("Returning response", extra={"status_code": result.get("statusCode")})'
+        ) == set()
+
+        for line, expected in (
+            ('logger.info("Returning response", extra={"response": result})', {'response'}),
+            ('logger.info("Returning response", extra={"status_code": c, "body": b})', {'body'}),
+            ('logger.info("Returning response", extra={"headers": h})', {'headers'}),
+        ):
+            assert _unexpected_extra_keys(line) == expected, line
+
+
+def _egress_log_lines():
+    """Return the egress log line(s) of projects_handler.py, read from source.
+
+    A logger call mentioning "Returning".  Read rather than restated: asserting
+    against a copy of the line can only ever verify the copy, which is how the
+    first version of this check both drifted from the handler and passed while
+    the body was reintroduced.
+    """
+    source = (_lambda_root() / 'api' / 'projects_handler.py').read_text(encoding='utf-8')
+    return [
+        line.strip()
+        for line in source.splitlines()
+        if 'Returning' in line and _PAT_LOGGER_CALL.search(line)
+    ]
+
 
 class TestResponseBodyNotLogged:
     """The response log in projects_handler.py must not carry the body.
@@ -645,30 +815,33 @@ class TestResponseBodyNotLogged:
     ``event`` and so cannot see anything done to ``result``.  The response may
     contain user-generated content (project text, verbatims, persona data), so
     the egress log records the status code only.
+
+    Guarded from both sides, because a deny-list of spellings cannot anticipate
+    the next serialisation idiom:
+
+    * ``test_response_log_does_not_include_the_body`` rejects the whole
+      ``result`` reaching the record by any of the spellings patterns 1-5 cover
+      for ``event`` — serialised, interpolated, printf-style, or attached through
+      ``extra=``.  The last of those is the one this PR itself makes idiomatic on
+      that very line.
+    * ``test_response_log_attaches_only_the_status_code`` allow-lists the
+      ``extra=`` keys, so a new field cannot be added to that record without
+      changing ``_EGRESS_ALLOWED_EXTRA_KEYS`` — a visible decision.
     """
 
+    # Non-vacuity, shared by both tests below: without it either silently
+    # becomes a no-op the moment the line is renamed — the same hole
+    # test_scan_covers_projects_handler closes for the file walk.
+    _NO_EGRESS = (
+        'No egress log line found in projects_handler.py (a logger call '
+        'mentioning "Returning").  If it was renamed, update this test; if it '
+        'was deleted, delete this test.'
+    )
+
     def test_response_log_does_not_include_the_body(self):
-        """Read the real egress log line; do not restate it.
-
-        Asserting against a copy of the line cannot fail when the handler
-        changes — it only pins the copy.  Reading the source means reintroducing
-        the body actually fails this test.
-        """
-        source = (_lambda_root() / 'api' / 'projects_handler.py').read_text(encoding='utf-8')
-        egress = [
-            line.strip()
-            for line in source.splitlines()
-            if 'Returning' in line and _PAT_LOGGER_CALL.search(line)
-        ]
-
-        # Non-vacuity: without this the test silently becomes a no-op the moment
-        # the line is renamed — the same hole test_scan_covers_projects_handler
-        # closes for the file walk.
-        assert egress, (
-            'No egress log line found in projects_handler.py (a logger call '
-            'mentioning "Returning").  If it was renamed, update this test; if it '
-            'was deleted, delete this test.'
-        )
+        """The whole response must not reach the egress log record."""
+        egress = _egress_log_lines()
+        assert egress, self._NO_EGRESS
 
         for line in egress:
             assert 'json.dumps(result' not in line, (
@@ -678,4 +851,29 @@ class TestResponseBodyNotLogged:
             assert '{result' not in line, (
                 f'The response is interpolated into the egress log: {line!r}\n'
                 'It may contain user-generated content; log the status code only.'
+            )
+            assert not _flags_result_reaching_the_record(line), (
+                f'The whole response reaches the egress log record: {line!r}\n'
+                'Powertools serialises extra= values and printf-style arguments '
+                'into the JSON record, so this leaks the body exactly as '
+                'json.dumps(result) did.  Log the status code only.'
+            )
+
+    def test_response_log_attaches_only_the_status_code(self):
+        """The egress record's ``extra=`` may carry the status code and nothing else.
+
+        The allow-list is the half of this guard that cannot be outrun by a new
+        spelling: whatever expression is used, a field that is not
+        ``status_code`` fails here.
+        """
+        egress = _egress_log_lines()
+        assert egress, self._NO_EGRESS
+
+        for line in egress:
+            unexpected = _unexpected_extra_keys(line)
+            assert not unexpected, (
+                f'The egress log attaches unexpected field(s) {sorted(unexpected)}: {line!r}\n'
+                'The response may contain user-generated content, so this record '
+                f'carries only {sorted(_EGRESS_ALLOWED_EXTRA_KEYS)}.  If a new field is '
+                'genuinely safe, add it to _EGRESS_ALLOWED_EXTRA_KEYS deliberately.'
             )

--- a/voc-datalake/lambda/api/test/test_no_event_logging.py
+++ b/voc-datalake/lambda/api/test/test_no_event_logging.py
@@ -1,22 +1,39 @@
 """Guard: no handler source may write the raw Lambda event to logs.
 
 This test walks every non-test Python source under lambda/ and fails on any
-of the three spellings of the defect identified in issue #245:
+of the five spellings of the defect identified in issue #245:
 
   1. ``json.dumps(event[, ...])`` on a line that also calls a logger method
         The whole event is serialised; the output contains the caller's
         ``Authorization`` header (Cognito bearer token) in plain text.
-        Note: the guard requires both a ``logger.`` call and ``json.dumps(event...)`
+        Note: the guard requires both a ``logger.`` call and ``json.dumps(event...)``
         on the same line, so legitimate event-forwarding to downstream services
         (e.g. ``lambda_client.invoke(Payload=json.dumps(event))``) is not flagged.
 
-  2. ``f"...{event}..."`` (and common variants) on a line that also calls a
-     logger method — the str() of the event object is interpolated into the log
-     message.  Variants caught include ``{event!r}``, ``{event!s}``,
-     ``{event["key"]}``, and ``{event.method()}``.
+  2. ``f"...{event}..."`` on a line that also calls a logger method — the
+     str() of the whole event object is interpolated into the log message.
+     Variants caught are the ones that stringify the *entire* event:
+     ``{event}``, ``{event!r}``, ``{event!s}`` and ``{event:...}``.
+     Logging a single named field (``{event['path']}``,
+     ``{event.get('httpMethod')}``, ``{list(event.keys())}``) is *permitted by
+     design* — that is the recommended remediation when this guard fires, so
+     subscript and attribute access are deliberately not matched.
 
   3. ``logger.<level>(event)`` / ``logger.<level>(event, ...)``
         The event is passed directly as the log-message argument.
+
+  4. ``logger.<level>("...%s", event)`` — printf-style lazy formatting, where
+     the event is a non-first positional argument.  This is the spelling the
+     stdlib ``logging`` docs recommend over f-strings, so it is a likely
+     accidental reintroduction.
+
+  5. ``logger.<level>("msg", extra={"event": event})`` and
+     ``logger.append_keys(event=event)`` — Powertools structured fields.  The
+     event is serialised into the JSON log record, so the leak is identical.
+     ``extra=`` is the house idiom in ``projects_handler.py`` after this fix,
+     which makes this spelling especially easy to reach for.  As with pattern 1,
+     a ``logger.`` call must be present on the same line, so plain forwarding
+     such as ``handler(event=event)`` is not flagged.
 
 Spellings the guard does NOT catch (documented to set honest expectations):
 
@@ -28,10 +45,33 @@ Spellings the guard does NOT catch (documented to set honest expectations):
     wrapped by a further call is not matched.
   * Variables aliased to something other than ``event``
     (e.g. ``evt = event; logger.info(evt)``).
+  * The *serialised* event aliased into a variable first, e.g.
+    ``payload = json.dumps(event)`` on one line followed by
+    ``logger.info(payload)`` on the next: pattern 1 needs the logger call and
+    ``json.dumps(event...)`` on the same line, and pattern 3 only matches a
+    literal ``event`` argument.
   * Custom serialisers other than ``json.dumps``.
   * Handler sources under ``plugins/`` (ingestor Lambda functions for S3/SQS
     events) — ``_SCAN_ROOTS`` covers ``lambda/`` subdirectories only; the
     ``plugins/`` tree is outside this guard's scope.
+
+How this guard is executed
+--------------------------
+
+``.github/workflows/no-event-logging-guard.yml`` runs this file on every pull
+request and on pushes to ``development``.  That workflow deliberately runs this
+one file rather than the whole backend suite: the guard imports only ``re`` and
+``pathlib``, so it needs no application dependencies and no Lambda layer build,
+whereas the rest of the suite cannot yet run in a bare environment.
+
+It is also picked up by the local backend gate, ``npm run test:backend``
+(``pytest``; ``pytest.ini`` sets ``testpaths = lambda plugins``).
+
+One caveat on "impossible to reintroduce": at the time of writing
+``development`` is **not** a protected branch and has no required status checks,
+so a red run of this workflow surfaces a failing check on the pull request but
+does not by itself block a merge.  Making it blocking needs a branch-protection
+rule, which is a repository-settings change and cannot live in this file.
 """
 
 import re
@@ -96,16 +136,36 @@ _PAT_JSON_DUMPS_EVENT = re.compile(r'\bjson\.dumps\(\s*event\s*[,)]')
 # Pattern 2 — {event...} inside an f-string on a line that also contains a
 # logger call.  The two sub-patterns are checked independently so a line
 # with neither is not flagged.
-# _PAT_FSTRING_EVENT matches bare {event} as well as common variants:
-#   {event!r}, {event!s}   — conversion flags
-#   {event["key"]}         — key access ([ after event)
-#   {event.method()}       — attribute/method access (. after event)
+# _PAT_FSTRING_EVENT matches only the forms that stringify the WHOLE event:
+#   {event}                — bare embed (} after event)
+#   {event!r}, {event!s}   — conversion flags (! after event)
 #   {event:...}            — format spec (: after event)
+# Deliberately NOT matched: {event["key"]} and {event.get("path")}.  Logging a
+# single named field is the recommended remediation when this guard fires, so
+# flagging it would reject the correct fix (and would fire on the existing
+# f"keys={list(event.keys())}" lines in lambda/jobs/*, which log key names
+# only, never values).
 _PAT_LOGGER_CALL = re.compile(r'\blogger\.\w+\(')
-_PAT_FSTRING_EVENT = re.compile(r'\{event[}!:\[.]')
+_PAT_FSTRING_EVENT = re.compile(r'\{event[}!:]')
 
 # Pattern 3 — logger.<level>(event) or logger.<level>(event, ...)
 _PAT_LOGGER_EVENT_DIRECT = re.compile(r'\blogger\.\w+\(\s*event\s*[,)]')
+
+# Pattern 4 — event passed as a non-first positional argument to a logger call,
+# i.e. printf-style lazy formatting: logger.info("event: %s", event).
+# Pattern 3 cannot see this because it requires `event` to be the first argument.
+_PAT_LOGGER_EVENT_ARG = re.compile(r'\blogger\.\w+\([^)]*,\s*event\s*[,)]')
+
+# Pattern 5 — event embedded in a Powertools structured field on a logger line:
+#   logger.info("msg", extra={"event": event})   — value inside an extra= dict
+#   logger.append_keys(event=event)              — sticky key
+# Both serialise the event into the JSON log record.  The test pairs this with
+# _PAT_LOGGER_CALL so that non-logging keyword forwarding (e.g.
+# handler(event=event)) is not flagged.
+_PAT_LOGGER_EVENT_STRUCTURED = re.compile(
+    r'extra\s*=\s*\{[^}]*[:,]\s*event\s*[,}]'
+    r'|\bevent\s*=\s*event\b'
+)
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +247,12 @@ class TestNoRawEventLogging:
 
             logger.info(f"received {event}")
 
+        Only the forms that stringify the whole event are flagged: ``{event}``,
+        ``{event!r}``, ``{event!s}`` and ``{event:...}``.  Logging an individual
+        field — ``logger.info(f"path={event['path']}")`` or
+        ``f"keys={list(event.keys())}"`` — is permitted by design; it is the
+        remediation a developer should apply when this guard fires.
+
         The check is single-line: the logger call and {event} must appear on
         the same source line.  Multi-line log statements spanning several
         physical lines are outside this guard's scope (see module docstring).
@@ -226,3 +292,143 @@ class TestNoRawEventLogging:
             'full event dict (including the Authorization header) as a message:\n'
             + '\n'.join(f'  {v}' for v in violations)
         )
+
+    # ------------------------------------------------------------------ #
+    # Pattern 4: logger.<level>("...%s", event)                           #
+    # ------------------------------------------------------------------ #
+
+    def test_no_logger_event_as_positional_arg(self):
+        """The event must not be passed as a printf-style logger argument.
+
+        Example of the banned pattern::
+
+            logger.info("received event: %s", event)
+
+        The stdlib logging docs recommend %s-style lazy formatting over
+        f-strings, so this is the spelling a developer following general Python
+        best practice would write — and the one pattern 3 cannot see, because
+        it requires ``event`` to be the first argument.
+        """
+        violations = []
+        for path in _source_files():
+            text = path.read_text(encoding='utf-8')
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if _PAT_LOGGER_EVENT_ARG.search(line):
+                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
+
+        assert not violations, (
+            'Found the event passed as a printf-style logger argument — the\n'
+            'full event dict (including the Authorization header) is interpolated\n'
+            'into the log record:\n'
+            + '\n'.join(f'  {v}' for v in violations)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Pattern 5: extra={"event": event} / append_keys(event=event)        #
+    # ------------------------------------------------------------------ #
+
+    def test_no_event_in_structured_logger_fields(self):
+        """The event must not be attached as a Powertools structured field.
+
+        Examples of the banned patterns::
+
+            logger.info("handled", extra={"event": event})
+            logger.append_keys(event=event)
+
+        Powertools serialises ``extra=`` values and sticky keys into the JSON log
+        record, so the Authorization header is leaked exactly as it would be by
+        ``json.dumps(event)``.  ``extra=`` is the house idiom in
+        ``projects_handler.py`` after this fix, which makes it an easy spelling
+        to reach for by accident.
+        """
+        violations = []
+        for path in _source_files():
+            text = path.read_text(encoding='utf-8')
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if _PAT_LOGGER_CALL.search(line) and _PAT_LOGGER_EVENT_STRUCTURED.search(line):
+                    violations.append(f'{path.relative_to(_lambda_root())}:{lineno}: {line.strip()!r}')
+
+        assert not violations, (
+            'Found the event attached to a logger call as a structured field —\n'
+            'Powertools serialises it into the JSON log record, including the\n'
+            'caller\'s Authorization header:\n'
+            + '\n'.join(f'  {v}' for v in violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pattern calibration
+# ---------------------------------------------------------------------------
+
+class TestPatternCalibration:
+    """The regexes must fire on real leaks and stay quiet on safe logging.
+
+    The source-scan tests above pass whenever the tree happens to be clean, so
+    they cannot tell a correct pattern from one that matches nothing.  These
+    cases pin the intended boundary in both directions: every widening or
+    narrowing of a pattern has a test here that fails if it is reverted.
+    """
+
+    # --- must be flagged (whole event reaches the log record) ---------- #
+
+    def test_flags_json_dumps_event_on_logger_line(self):
+        line = 'logger.info(f"Received event: {json.dumps(event)}")'
+        assert _PAT_LOGGER_CALL.search(line) and _PAT_JSON_DUMPS_EVENT.search(line)
+
+    def test_flags_whole_event_fstring_variants(self):
+        for line in (
+            'logger.info(f"received {event}")',
+            'logger.info(f"received {event!r}")',
+            'logger.info(f"received {event!s}")',
+            'logger.info(f"received {event:>10}")',
+        ):
+            assert _PAT_FSTRING_EVENT.search(line), line
+
+    def test_flags_event_as_printf_argument(self):
+        for line in (
+            'logger.info("event: %s", event)',
+            'logger.warning("e=%r", event)',
+            'logger.info("a %s b %s", other, event)',
+        ):
+            assert _PAT_LOGGER_EVENT_ARG.search(line), line
+
+    def test_flags_event_in_structured_fields(self):
+        for line in (
+            'logger.info("msg", extra={"event": event})',
+            "logger.info('msg', extra={'request': req, 'event': event})",
+            'logger.append_keys(event=event)',
+        ):
+            assert _PAT_LOGGER_CALL.search(line) and _PAT_LOGGER_EVENT_STRUCTURED.search(line), line
+
+    # --- must NOT be flagged (no sensitive value reaches the log) ------ #
+
+    def test_does_not_flag_selective_field_logging(self):
+        """Logging one named field is the recommended fix, not a violation."""
+        for line in (
+            'logger.info(f"path={event[\'path\']}")',
+            'logger.info(f"method={event.get(\'httpMethod\')}")',
+            'logger.info(f"keys={event.keys()}")',
+            'logger.info(f"Persona generator invoked with event keys: {list(event.keys())}")',
+            'logger.info("path: %s", event["path"])',
+        ):
+            assert not _PAT_FSTRING_EVENT.search(line), line
+            assert not _PAT_LOGGER_EVENT_ARG.search(line), line
+            assert not _PAT_LOGGER_EVENT_DIRECT.search(line), line
+
+    def test_does_not_flag_event_forwarding(self):
+        """Serialising the event for a downstream service is legitimate."""
+        for line in (
+            'lambda_client.invoke(FunctionName=name, Payload=json.dumps(event))',
+            'sqs.send_message(QueueUrl=url, MessageBody=json.dumps(event))',
+            'inner_handler(event=event, context=context)',
+        ):
+            assert not _PAT_LOGGER_CALL.search(line), line
+
+    def test_does_not_flag_status_code_only_response_log(self):
+        """The replacement log in projects_handler.py must stay clean."""
+        line = 'logger.debug("Returning response", extra={"status_code": result.get("statusCode")})'
+        assert not _PAT_JSON_DUMPS_EVENT.search(line)
+        assert not _PAT_FSTRING_EVENT.search(line)
+        assert not _PAT_LOGGER_EVENT_DIRECT.search(line)
+        assert not _PAT_LOGGER_EVENT_ARG.search(line)
+        assert not _PAT_LOGGER_EVENT_STRUCTURED.search(line)

--- a/voc-datalake/lambda/api/test/test_no_event_logging.py
+++ b/voc-datalake/lambda/api/test/test_no_event_logging.py
@@ -43,7 +43,8 @@ _SCAN_ROOTS = [
     'processor',
     'research',
     'shared',
-    'stream',
+    # 'stream' is omitted: lambda/stream/ contains only TypeScript source;
+    # rglob('*.py') would find nothing there.
 ]
 
 # Directory names that stop the descent when encountered.
@@ -51,8 +52,9 @@ _EXCLUDE_DIR_NAMES = frozenset({'test', 'layers', 'cdk.out', '__pycache__', '.ve
 
 
 def _lambda_root() -> Path:
-    # This file lives at lambda/api/test/; resolve four levels up for lambda/.
-    return Path(__file__).resolve().parents[3] / 'lambda'
+    # This file lives at lambda/api/test/test_no_event_logging.py.
+    # parents[0] = lambda/api/test, parents[1] = lambda/api, parents[2] = lambda/
+    return Path(__file__).resolve().parents[2]
 
 
 def _source_files():
@@ -125,7 +127,7 @@ class TestNoRawEventLogging:
         accidentally scanning a single file or an empty subtree.
         """
         count = sum(1 for _ in _source_files())
-        assert count > 5, (
+        assert count > 5, (  # currently ~56 files; any credible lambda tree has well more than 5
             f'Only {count} source file(s) found — expected many more.\n'
             f'Lambda root: {_lambda_root()}'
         )


### PR DESCRIPTION
## Summary

- Removes the `logger.info(f"Received event: {json.dumps(event)}")` statement from `projects_handler.py::lambda_handler` — this line wrote the caller's Cognito bearer token (in the `Authorization` header) and full request body to CloudWatch Logs in plain text on every invocation (issue #245).
- Stops logging the full **response** body on the next line, replacing it with a status-code-only record.
- Adds `lambda/api/test/test_no_event_logging.py`, a static source-scan guard against reintroduction, calibrated in both directions.
- Adds `.github/workflows/no-event-logging-guard.yml` so the guard actually runs on every pull request.

Closes #245.

## The rule the guard enforces

**A violation is the whole object reaching a log record. Selecting something out of it first is not a violation.**

That one sentence is the guard's contract, and it leads the module docstring. `event` is the API Gateway request, so serialising it by any spelling writes the bearer token to CloudWatch. `event['path']`, `event.get('httpMethod')` and `list(event.keys())` are *selections*: they name what they disclose, and they are the remediation a developer should apply when the guard fires. Flagging them would reject the correct fix and train people to disable the guard, so it is the rule — not an accumulation of examples — that decides each case.

Two corollaries explain shapes that otherwise look inconsistent:

- A bare `event` handed to something that is **not** a logger discloses nothing to the log, so `lambda_client.invoke(Payload=json.dumps(event))` is fine. Every pattern except 3 additionally requires a `logger.` call on the line.
- A bare `event` passed to a **helper** inside a logger call is not a violation either — what reaches the record is the helper's return value. So `logger.info("route=%s", route_for(method, event))` is permitted. Likewise a *subscript* keyed by the event (`extra={"a": foo[event]}`) discloses only the looked-up value.

## What the guard catches

| # | Spelling | Example |
|---|---|---|
| 1 | `json.dumps(event)` on a logger line | `logger.info(f"event: {json.dumps(event)}")` |
| 2 | whole-event f-string embed | `{event}`, `{event!r}`, `{event!s}`, `{event:...}`, `{event=}` |
| 3 | event as the log message | `logger.info(event)` |
| 4 | event as a printf-style argument | `logger.info("event: %s", event)` |
| 5 | Powertools structured fields | `extra={"event": event}`, `extra={"a": [event]}`, `logger.append_keys(event=event)` |

Patterns 4 and 5 are the two spellings that serialise the whole object and were previously missed. `%s`-style is what the stdlib `logging` docs recommend over f-strings, and `extra=` is the idiom this PR itself introduces two lines away — so both are likely accidental reintroductions rather than exotic edge cases, and both are covered by the pattern rather than merely documented as out of scope.

**Permitted by design:**

```python
logger.info(f"path={event['path']}")
logger.info(f"keys={list(event.keys())}")            # four existing lines in lambda/jobs/* rely on this
logger.info("route=%s", route_for(method, event))    # the helper's return value is logged
logger.info("m", extra={"a": foo[event]})            # only the looked-up value is logged
```

## Changes in this revision

**The egress log's `extra=` field is now guarded, both ways.** `TestResponseBodyNotLogged` rejected only `json.dumps(result` and `{result`, so `logger.info("Returning response", extra={"response": result})` passed with `17 passed` while leaking the entire response body. That is the spelling this PR itself makes idiomatic *on that very line*, which made it the likeliest reintroduction rather than a corner case — a gap in the enforcement, not in the documentation. The response side now enforces the same rule as the event side, spelled against `result`: the whole object must not reach the record, whether as the log message, a printf-style argument, or an `extra=` / `append_keys` field.

Because a deny-list of spellings is always one idiom behind — whichever serialisation the surrounding code makes fashionable next is by definition not on the list — a second check **allow-lists** the record's `extra=` keys:

```python
_EGRESS_ALLOWED_EXTRA_KEYS = frozenset({'status_code'})
```

Whatever expression produces the value, a field that is not `status_code` fails. That is the half that cannot be outrun. It caught a case the deny-list structurally cannot: `extra={"status_code": ..., "body": result.get("body")}` selects a field (so no bare `result` appears) yet still puts the body on the record.

**Pattern 5 no longer flags a subscript keyed by the event.** The value position accepted a bare `[` so that a list value (`extra={"a": [event]}`) is caught, but that cannot tell a list literal from a subscript, so `extra={"a": foo[event]}` was reported as a bearer-token leak although only the looked-up value is logged. A `(?<![\w\]\)])` lookbehind now requires the `[` to *open a collection*. Verified in both directions: the list-value case stays flagged, and the two subscript spellings are clean. This was graded a nit, but by the standard already established twice in this review — a guard that rejects safe code trains developers to disable it — a verified false positive is a defect in the guard rather than a matter of taste, so it is fixed rather than documented.

The `ast`-rewrite suggestion is deliberately **not** taken in this PR; see *Out of scope*.

## Was removing the response-status log intended?

**No — and it is back.** An earlier revision replaced the response-body log with `logger.debug(...)`. Since `api-stack.ts:483` sets `LOG_LEVEL: 'INFO'`, that line emitted **nothing in any deployed environment**, so that revision silently traded a security fix for the loss of the per-invocation completion signal. That was an unintended regression, now corrected:

```python
logger.info("Returning response", extra={"status_code": result.get("statusCode")})
```

It is deliberately at `INFO`. The status code carries no user content — it is the absence of the body, not the log level, that protects the data. API Gateway access logging (`api-stack.ts:891-892`, `jsonWithStandardFields()`) remains a useful independent record, but per-invocation status belongs in the Lambda's own log group where it correlates with the Powertools `request_id`/`cold_start` context on surrounding lines.

## Which test catches which revert

Verified by **actually performing each revert** and recording which test failed — not by inspection. Every row below was reproduced against this head.

| Revert this | This test fails |
|---|---|
| Restore `logger.info(f"Received event: {json.dumps(event)}")` | `test_no_json_dumps_event` |
| Add `logger.info("event: %s", event)` | `test_no_logger_event_as_positional_arg` |
| Add `logger.info("%s %s", ctx.get_id(), event)` | `test_no_logger_event_as_positional_arg` |
| Add `logger.append_keys(event=event)` / `extra={"event": event}` / `extra={"a": [event]}` | `test_no_event_in_structured_logger_fields` |
| Add `logger.info(f"raw {event!r}")` | `test_no_fstring_event_in_logger_calls` |
| Add `logger.debug(f"{event=}")` | `test_no_fstring_event_in_logger_calls` |
| Add `logger.info(event)` | `test_no_logger_event_direct` |
| Egress log → `extra={"response": result}` | `test_response_log_does_not_include_the_body` **and** `test_response_log_attaches_only_the_status_code` |
| Egress log → `json.dumps(result)` / `"Returning %s", result` / `append_keys(result=result)` | `test_response_log_does_not_include_the_body` |
| Egress log → `extra={"status_code": c, "body": result.get("body")}` | `test_response_log_attaches_only_the_status_code` (the deny-list cannot see this) |
| No-op the result predicate, or drop its `extra=` alternative | `test_flags_the_whole_response_reaching_the_record` |
| Widen `_EGRESS_ALLOWED_EXTRA_KEYS` to include `response` | `test_allow_list_rejects_any_field_but_the_status_code` |
| No-op `_extra_keys` | `test_allow_list_rejects_any_field_but_the_status_code`, `test_extra_keys_reads_the_field_names` |
| Revert the event subscript lookbehind to a bare `[` | `test_does_not_flag_a_subscript_keyed_by_the_event` |
| Revert the result subscript lookbehind to a bare `[` | `test_does_not_flag_selecting_a_field_of_the_response` |
| Widen pattern 2 back to `[}!:\[.]` | `test_does_not_flag_selective_field_logging` |
| Drop `=` from pattern 2 | `test_flags_whole_event_fstring_variants` |
| Revert pattern 4 to the raw-line prefix scan | `test_flags_event_as_printf_argument`, `test_does_not_flag_event_passed_to_a_helper` |
| Revert pattern 5 to the raw-line scan | `test_flags_event_in_structured_fields` |

One honest exception: pattern 3's move to the argument extractor is **behaviour-preserving** — reverting it alone keeps all 23 tests green. It is there for uniformity with 4 and 5, not to fix a defect, so no revert test is claimed for it.

## Guard reliability

**The walk is non-vacuous.** `test_scan_covers_projects_handler` asserts the scanned set includes the file that had the defect; `test_scan_covers_multiple_handler_files` asserts more than 5 files are found (currently 56). A misconfigured root or exclusion fails loudly instead of reporting clean.

**The patterns are calibrated in both directions.** The source-scan tests pass whenever the tree happens to be clean, so they cannot distinguish a correct regex from an over-broad or no-op one — a real hole, since an earlier over-broad version of pattern 2 matched safe code and nothing failed. `TestPatternCalibration` pins each event regex with literal sample lines, and `TestEgressCalibration` does the same for the two result-side predicates and the key extractor. The must-not-fire cases assert against **all five** event predicates rather than a hand-picked subset.

That calibration is what caught two problems in *this* revision before they shipped: a naive `set()`-returning mutation of `_extra_keys` initially left the suite green (fixed by pinning the extractor directly), and widening the allow-list was initially unpinned.

## Not caught — documented, not implied

Multi-line log statements; `print(event)`; `logging.getLogger().info(event)`; `json.dumps(event.copy())`; a variable aliased to the event; the *serialised* event aliased first (`payload = json.dumps(event)` then `logger.info(payload)`); custom serialisers; handler sources under `plugins/`; and `@logger.inject_lambda_context(log_event=True)` / `POWERTOOLS_LOGGER_LOG_EVENT=true` — neither appears in any Python or CDK source today, and covering them means scanning TypeScript, which this Python-only walk cannot do.

Residual imprecisions in the patterns are listed in the docstring too, including that a helper which returns the event unchanged (`logger.info("%s", identity(event))`) slips through — the flip side of not flagging helper calls — and that the `extra=` key allow-list reads string-literal keys, so a computed key (`extra={key_name: result}`) is invisible to it, though the deny-list still catches the bare `result` there.

## How the guard is enforced

`.github/workflows/no-event-logging-guard.yml` runs on `pull_request` and pushes to `development`, using `actions/setup-python` with `python-version-file: .python-version` (root `.python-version` = `3.14`, confirmed resolving to CPython 3.14.6 from the step logs — a minor-version specifier resolving to its latest patch, not a fallback). That matches `lambda.Runtime.PYTHON_3_14` in the CDK stacks, so the guard runs on the same minor version as production. It installs only `pytest` and runs this one file — the guard imports just `re` and `pathlib`, so it needs no application dependencies and no layer build, unlike the rest of the suite. It runs with `--noconftest`: the file uses no fixtures, but pytest still loads `lambda/conftest.py` and `lambda/api/test/conftest.py`, whose `boto3`/`cryptography` imports sit inside fixture bodies *today* — incidental, not guaranteed. The local `npm run test:backend` run still loads the conftests, so that coupling remains exercised.

**Verified in real CI on this head:** [run 31437836127](https://github.com/aws-samples/sample-voice-of-customer-datalake/actions/runs/31437836127) → `23 passed in 0.16s`, with `Resolved .python-version as 3.14` / `Successfully set up CPython (3.14.6)` in the setup step. This workflow is the repository's only committed workflow file; before it, `development` had none.

**Honest limit:** `development` is not a protected branch and has no required status checks, so a red run *surfaces* a failing check but does not by itself block a merge. Making it blocking needs a branch-protection rule — a repository-settings change that cannot live in a file in this PR. The docstring says so explicitly rather than implying the guard is airtight.

## Build and test results

All run locally in this container. `mise run build` is **not** a valid command in this repo (`mise ERROR no tasks defined`; there is no `mise.toml`) — the real gates are the npm scripts in the root `package.json`. This diff contains **no TypeScript**, so the frontend/CDK/stream gates are unaffected by it; they are also unrunnable here because their `node_modules` are not installed.

| Gate | Command | Result |
|---|---|---|
| Full backend suite | `npm run test:backend` (`pytest`, `testpaths = lambda plugins`) | ✅ **1358 passed** in 45.49s |
| Guard file alone | `pytest lambda/api/test/test_no_event_logging.py` | ✅ **23 passed** |
| Guard with `--noconftest` (as CI runs it) | — | ✅ **23 passed** |
| Revert verification | each row of the table above, performed | ✅ every row reproduced |
| Workflow YAML | `yaml.safe_load` | ✅ parses |
| Lint, files this PR touches | `ruff check lambda/api/test/test_no_event_logging.py` | ✅ All checks passed |
| Lint, `projects_handler.py` | `ruff check lambda/api/projects_handler.py` | ⚠️ 5 errors (1×`I001`, 4×`BLE001`) — **identical on `origin/development`**, verified via `git stash`; not a regression |
| Lint, repo-wide | `npm run lint:python` (`ruff check lambda plugins`) | ⚠️ 552 errors, all pre-existing |
| `mise run build` | — | n/a: no mise tasks defined in this repo |
| Frontend/CDK/stream typecheck + tests | `npm run typecheck:all`, `npm run test` | not run: `node_modules` absent in this container; no TypeScript in this diff |

The backend suite requires six deps absent from `requirements-dev.txt` (`pydantic`, `beautifulsoup4`, `aws_xray_sdk`, `tenacity`, `google-play-scraper`, `app-store-web-scraper`). After installing those, the entire suite passes with zero failures — the "439 failed" state reported in early revisions of this PR was purely missing dependencies, not broken tests.

## Out of scope

- **The `ast` rewrite** — a fair observation that the ~60-line extractor is heading somewhere a syntax tree expresses better, and the calibration class is exactly what would make that swap safe later. Not done here: it replaces the matching core six rounds into a security review, and it is not a drop-in (a naive `ast.walk` descends *into* nested calls, so it would flag `route_for(method, event)` and the four in-tree `list(event.keys())` lines that the rule says must stay permitted). It deserves its own PR.
- **`_SCAN_ROOTS` allow-list** — deliberately unchanged. Exactly one first-party `.py` file falls outside the walk: `lambda/conftest.py`, which logs nothing.
- **Existing log data** — CloudWatch log groups still contain tokens written before this fix. Purging them is an operational decision with data-loss consequences and needs account access.
- **`requirements-dev.txt`** — missing the six deps listed above.
- **Two-sided calibration for the other source-scan guards** (`test_model_config.py`, `test_avatar_image_model_lockstep.py`, `test_kiro_exportable_types_lockstep.py`), several of which are one-sided in the way this class corrects.
- **Branch protection** — required to make the new check actually blocking.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).
