### PR TITLE
feat(feedback-forms): show a linked form's collected ratings on the Prioritization row

### DIFF
--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -42,6 +42,14 @@ The VoC platform provides a customizable feedback form system that:
 | `subcategory` | Pre-assign subcategory |
 | `success_message` | Message shown after submission |
 | `theme` | Color and styling options |
+| `project_id` | Optional. The project this form collects feedback about. Empty string means the form validates nothing in particular — a standalone website survey. |
+| `document_id` | Optional. A specific PRD or PR/FAQ within that project. Empty string means the whole project, which is also what keeps the link alive across a regeneration (regenerating a document mints a new `document_id`). |
+
+`project_id` and `document_id` are internal identifiers. They exist so the
+Prioritization page can show the ratings a form collected next to the document
+being scored. Both are accepted by `POST`/`PUT` and returned by
+`GET /feedback-forms/{id}`, but deliberately **never** by the public config
+endpoint — see the note in [API Endpoints](#api-endpoints).
 
 ## Embedding Forms
 
@@ -104,7 +112,7 @@ Customize the form appearance:
 | GET | `/feedback-forms/{id}` | Get form details |
 | PUT | `/feedback-forms/{id}` | Update form |
 | DELETE | `/feedback-forms/{id}` | Delete form |
-| GET | `/feedback-forms/{id}/config` | Public config endpoint |
+| GET | `/feedback-forms/{id}/config` | Public config endpoint. **Unauthenticated** and fetched cross-origin by the embedded widget, so it returns only the widget-rendering fields, via a separate allowlist (`item_to_widget_config` in `lambda/api/feedback_form_handler.py`) rather than the projection the authenticated routes use. It never returns internal identifiers such as `project_id` / `document_id`. |
 | POST | `/feedback-forms/{id}/submit` | Submit feedback |
 | GET | `/feedback-forms/{id}/iframe` | Embeddable HTML page |
 

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -204,9 +204,19 @@ const mockFeedbackForms = [
     form_id: 'form_4', name: 'Checkout Survey', enabled: true,
     title: 'How was checkout?', theme: { primary_color: '#F97316' },
     created_at: new Date().toISOString(),
-    // A second form validating the SAME document as form_2, with a null average
-    // in mockFormStats below: one expanded row therefore exercises both the
-    // several-forms-per-document case and the ratings-disabled rendering.
+    // Deliberately keeps its healthy 4.6 average below: it is the only 4.x card
+    // in the /feedback-forms grid, so repurposing it as the null-average case
+    // would have cost that grid its "healthy ratings" appearance.
+    project_id: '', document_id: '',
+  },
+  // A second form validating the SAME document as form_2, with a null average in
+  // mockFormStats below: one expanded Prioritization row therefore exercises
+  // both the several-forms-per-document case and the ratings-disabled rendering.
+  {
+    form_id: 'form_5', name: 'PR/FAQ Concept Test', enabled: true,
+    title: 'Would you use this?', theme: mockFormTheme('#8B5CF6'),
+    rating_enabled: false,
+    created_at: new Date().toISOString(),
     project_id: 'proj_1', document_id: 'prfaq_1',
   },
 ];
@@ -214,7 +224,8 @@ const mockFormStats = {
   form_1: { total_submissions: 234, avg_rating: 4.2, rating_count: 180 },
   form_2: { total_submissions: 567, avg_rating: 3.8, rating_count: 512 },
   form_3: { total_submissions: 89, avg_rating: null, rating_count: 0 },
-  form_4: { total_submissions: 41, avg_rating: null, rating_count: 0 },
+  form_4: { total_submissions: 41, avg_rating: 4.6, rating_count: 38 },
+  form_5: { total_submissions: 27, avg_rating: null, rating_count: 0 },
 };
 
 // Mock Cognito users (issue #177) — stateful so create/enable/disable/delete

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -179,6 +179,9 @@ const mockFeedbackForms = [
     submit_button_text: 'Submit Feedback', success_message: 'Thank you for your feedback!',
     theme: mockFormTheme('#3B82F6'), collect_email: false, collect_name: false, custom_fields: [],
     category: 'website', subcategory: '', created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+    // Validates nothing: a standalone website survey. Must stay off every
+    // Prioritization row.
+    project_id: '', document_id: '',
   },
   {
     form_id: 'form_2', name: 'Post-Purchase Survey', enabled: true,
@@ -188,8 +191,12 @@ const mockFeedbackForms = [
     submit_button_text: 'Submit', success_message: 'Thanks for rating your experience!',
     theme: mockFormTheme('#22C55E'), collect_email: true, collect_name: false, custom_fields: [],
     category: 'delivery', subcategory: '', created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+    // Linked to proj_1's PR/FAQ: its stats appear on that document's row in
+    // Prioritization once the row is expanded.
+    project_id: 'proj_1', document_id: 'prfaq_1',
   },
-  // Sparse legacy record: only identity fields on the wire.
+  // Sparse legacy record: only identity fields on the wire — no link fields at
+  // all, exercising the "persisted before the link existed" path.
   { form_id: 'form_3', name: 'Support Feedback', enabled: false, created_at: new Date().toISOString() },
   // Partial theme: exercises the deep-merge branch (set color survives,
   // missing theme keys default) rather than the fully-missing-theme branch.
@@ -197,13 +204,17 @@ const mockFeedbackForms = [
     form_id: 'form_4', name: 'Checkout Survey', enabled: true,
     title: 'How was checkout?', theme: { primary_color: '#F97316' },
     created_at: new Date().toISOString(),
+    // A second form validating the SAME document as form_2, with a null average
+    // in mockFormStats below: one expanded row therefore exercises both the
+    // several-forms-per-document case and the ratings-disabled rendering.
+    project_id: 'proj_1', document_id: 'prfaq_1',
   },
 ];
 const mockFormStats = {
   form_1: { total_submissions: 234, avg_rating: 4.2, rating_count: 180 },
   form_2: { total_submissions: 567, avg_rating: 3.8, rating_count: 512 },
   form_3: { total_submissions: 89, avg_rating: null, rating_count: 0 },
-  form_4: { total_submissions: 41, avg_rating: 4.6, rating_count: 38 },
+  form_4: { total_submissions: 41, avg_rating: null, rating_count: 0 },
 };
 
 // Mock Cognito users (issue #177) — stateful so create/enable/disable/delete

--- a/voc-datalake/frontend/public/locales/de/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/de/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "Erfassen Sie optional, zu welchem Projekt — und zu welchem PRD oder PR/FAQ — dieses Formular Feedback sammelt. Die erfassten Bewertungen erscheinen dann neben diesem Dokument auf der Priorisierungsseite. Lassen Sie beide Felder leer für ein eigenständiges Formular, etwa eine Website-Umfrage.",
     "validationDocumentHint": "Belassen Sie es beim gesamten Projekt, damit die Verknüpfung erhalten bleibt, wenn ein Dokument neu erzeugt wird.",
     "validationDocumentLabel": "Dokument (optional)",
+    "validationLoadingLink": "Verknüpfung wird geladen …",
     "validationNoProject": "-- Nicht verknüpft --",
     "validationProjectHint": "Wird das Projekt geleert, ist dieses Formular nicht mehr verknüpft.",
     "validationProjectLabel": "Projekt",
     "validationTitle": "Was dieses Formular validiert",
     "validationUnknownDocument": "Verknüpftes Dokument (nicht mehr verfügbar)",
+    "validationUnknownProject": "Verknüpftes Projekt (nicht mehr verfügbar)",
     "validationWholeProject": "-- Gesamtes Projekt --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/de/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/de/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "Was dieses Formular validiert",
     "validationUnknownDocument": "Verknüpftes Dokument (nicht mehr verfügbar)",
     "validationUnknownProject": "Verknüpftes Projekt (nicht mehr verfügbar)",
+    "validationUnverifiedDocument": "Verknüpftes Dokument (nicht überprüfbar)",
+    "validationUnverifiedProject": "Verknüpftes Projekt (nicht überprüfbar)",
     "validationWholeProject": "-- Gesamtes Projekt --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/de/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/de/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "Kategorie-Routing",
       "formSettings": "Formulareinstellungen",
       "settings": "Einstellungen",
-      "theme": "Design"
+      "theme": "Design",
+      "validates": "Validiert",
+      "validatesShort": "Validiert"
     },
-    "textColor": "Textfarbe"
+    "textColor": "Textfarbe",
+    "validationDescription": "Erfassen Sie optional, zu welchem Projekt — und zu welchem PRD oder PR/FAQ — dieses Formular Feedback sammelt. Die erfassten Bewertungen erscheinen dann neben diesem Dokument auf der Priorisierungsseite. Lassen Sie beide Felder leer für ein eigenständiges Formular, etwa eine Website-Umfrage.",
+    "validationDocumentHint": "Belassen Sie es beim gesamten Projekt, damit die Verknüpfung erhalten bleibt, wenn ein Dokument neu erzeugt wird.",
+    "validationDocumentLabel": "Dokument (optional)",
+    "validationNoProject": "-- Nicht verknüpft --",
+    "validationProjectHint": "Wird das Projekt geleert, ist dieses Formular nicht mehr verknüpft.",
+    "validationProjectLabel": "Projekt",
+    "validationTitle": "Was dieses Formular validiert",
+    "validationUnknownDocument": "Verknüpftes Dokument (nicht mehr verfügbar)",
+    "validationWholeProject": "-- Gesamtes Projekt --"
   },
   "empty": {
     "createButton": "Erstes Formular erstellen",

--- a/voc-datalake/frontend/public/locales/de/prioritization.json
+++ b/voc-datalake/frontend/public/locales/de/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "Ihre Projekte haben Dokumente, aber keine PRDs oder PR/FAQs. Öffnen Sie ein Projekt und erstellen Sie ein PRD oder PR/FAQ, um es hier zu bewerten.",
     "wrongTypeTitle": "Keine bewertbaren Dokumente"
   },
+  "evidence": {
+    "avgRating": "Durchschnittliche Bewertung",
+    "noLinkedForm": "Mit diesem Dokument ist kein Feedback-Formular verknüpft.",
+    "noRatings": "Keine Bewertungen erfasst",
+    "submissions": "Einsendungen",
+    "title": "Erfasstes Feedback",
+    "unavailable": "Bewertungen nicht verfügbar"
+  },
   "framework": {
     "description": "Bewerten Sie jedes Dokument nach: <strong>Auswirkung</strong>, <strong>Markteinführungszeit</strong>, <strong>Strategische Passung</strong> und <strong>Konfidenz</strong>.",
     "title": "Priorisierungsrahmen"

--- a/voc-datalake/frontend/public/locales/en/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/en/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "What This Form Validates",
     "validationUnknownDocument": "Linked document (no longer available)",
     "validationUnknownProject": "Linked project (no longer available)",
+    "validationUnverifiedDocument": "Linked document (could not be checked)",
+    "validationUnverifiedProject": "Linked project (could not be checked)",
     "validationWholeProject": "-- Whole project --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/en/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/en/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "Category Routing",
       "formSettings": "Form Settings",
       "settings": "Settings",
-      "theme": "Theme"
+      "theme": "Theme",
+      "validates": "Validates",
+      "validatesShort": "Validates"
     },
-    "textColor": "Text Color"
+    "textColor": "Text Color",
+    "validationDescription": "Optionally record which project — and which PRD or PR/FAQ — this form collects feedback about. The ratings it gathers then appear next to that document on the Prioritization page. Leave both empty for a standalone form such as a website survey.",
+    "validationDocumentHint": "Leave on the whole project to keep the link when a document is regenerated.",
+    "validationDocumentLabel": "Document (Optional)",
+    "validationNoProject": "-- Not linked --",
+    "validationProjectHint": "Clearing the project unlinks this form.",
+    "validationProjectLabel": "Project",
+    "validationTitle": "What This Form Validates",
+    "validationUnknownDocument": "Linked document (no longer available)",
+    "validationWholeProject": "-- Whole project --"
   },
   "empty": {
     "createButton": "Create Your First Form",

--- a/voc-datalake/frontend/public/locales/en/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/en/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "Optionally record which project — and which PRD or PR/FAQ — this form collects feedback about. The ratings it gathers then appear next to that document on the Prioritization page. Leave both empty for a standalone form such as a website survey.",
     "validationDocumentHint": "Leave on the whole project to keep the link when a document is regenerated.",
     "validationDocumentLabel": "Document (Optional)",
+    "validationLoadingLink": "Loading link…",
     "validationNoProject": "-- Not linked --",
     "validationProjectHint": "Clearing the project unlinks this form.",
     "validationProjectLabel": "Project",
     "validationTitle": "What This Form Validates",
     "validationUnknownDocument": "Linked document (no longer available)",
+    "validationUnknownProject": "Linked project (no longer available)",
     "validationWholeProject": "-- Whole project --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/en/prioritization.json
+++ b/voc-datalake/frontend/public/locales/en/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "Your projects have documents, but none are PRDs or PR/FAQs. Open a project and generate a PRD or PR/FAQ to score it here.",
     "wrongTypeTitle": "No Scorable Documents"
   },
+  "evidence": {
+    "avgRating": "Avg Rating",
+    "noLinkedForm": "No feedback form is linked to this document.",
+    "noRatings": "No ratings collected",
+    "submissions": "Submissions",
+    "title": "Collected Feedback",
+    "unavailable": "Ratings unavailable"
+  },
   "framework": {
     "description": "Score each document on: <strong>Impact</strong>, <strong>Time to Market</strong>, <strong>Strategic Fit</strong>, and <strong>Confidence</strong>.",
     "title": "Prioritization Framework"

--- a/voc-datalake/frontend/public/locales/es/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/es/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "Opcionalmente registre a qué proyecto — y a qué PRD o PR/FAQ — se refieren los comentarios de este formulario. Las valoraciones recopiladas aparecerán junto a ese documento en la página de Priorización. Deje ambos vacíos para un formulario independiente, como una encuesta del sitio web.",
     "validationDocumentHint": "Déjelo en el proyecto completo para mantener el vínculo cuando se regenere un documento.",
     "validationDocumentLabel": "Documento (opcional)",
+    "validationLoadingLink": "Cargando el vínculo…",
     "validationNoProject": "-- Sin vincular --",
     "validationProjectHint": "Borrar el proyecto desvincula este formulario.",
     "validationProjectLabel": "Proyecto",
     "validationTitle": "Qué valida este formulario",
     "validationUnknownDocument": "Documento vinculado (ya no disponible)",
+    "validationUnknownProject": "Proyecto vinculado (ya no disponible)",
     "validationWholeProject": "-- Todo el proyecto --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/es/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/es/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "Qué valida este formulario",
     "validationUnknownDocument": "Documento vinculado (ya no disponible)",
     "validationUnknownProject": "Proyecto vinculado (ya no disponible)",
+    "validationUnverifiedDocument": "Documento vinculado (no se pudo comprobar)",
+    "validationUnverifiedProject": "Proyecto vinculado (no se pudo comprobar)",
     "validationWholeProject": "-- Todo el proyecto --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/es/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/es/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "Enrutamiento de categoría",
       "formSettings": "Configuración del formulario",
       "settings": "Configuración",
-      "theme": "Tema"
+      "theme": "Tema",
+      "validates": "Valida",
+      "validatesShort": "Valida"
     },
-    "textColor": "Color de texto"
+    "textColor": "Color de texto",
+    "validationDescription": "Opcionalmente registre a qué proyecto — y a qué PRD o PR/FAQ — se refieren los comentarios de este formulario. Las valoraciones recopiladas aparecerán junto a ese documento en la página de Priorización. Deje ambos vacíos para un formulario independiente, como una encuesta del sitio web.",
+    "validationDocumentHint": "Déjelo en el proyecto completo para mantener el vínculo cuando se regenere un documento.",
+    "validationDocumentLabel": "Documento (opcional)",
+    "validationNoProject": "-- Sin vincular --",
+    "validationProjectHint": "Borrar el proyecto desvincula este formulario.",
+    "validationProjectLabel": "Proyecto",
+    "validationTitle": "Qué valida este formulario",
+    "validationUnknownDocument": "Documento vinculado (ya no disponible)",
+    "validationWholeProject": "-- Todo el proyecto --"
   },
   "empty": {
     "createButton": "Crear su primer formulario",

--- a/voc-datalake/frontend/public/locales/es/prioritization.json
+++ b/voc-datalake/frontend/public/locales/es/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "Sus proyectos tienen documentos, pero ninguno es PRD ni PR/FAQ. Abra un proyecto y genere un PRD o PR/FAQ para puntuarlo aquí.",
     "wrongTypeTitle": "No hay documentos puntuables"
   },
+  "evidence": {
+    "avgRating": "Valoración media",
+    "noLinkedForm": "Ningún formulario de comentarios está vinculado a este documento.",
+    "noRatings": "Sin valoraciones recopiladas",
+    "submissions": "Respuestas",
+    "title": "Comentarios recopilados",
+    "unavailable": "Valoraciones no disponibles"
+  },
   "framework": {
     "description": "Puntúe cada documento en: <strong>Impacto</strong>, <strong>Tiempo de comercialización</strong>, <strong>Ajuste estratégico</strong> y <strong>Confianza</strong>.",
     "title": "Marco de priorización"

--- a/voc-datalake/frontend/public/locales/fr/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/fr/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "Routage par catégorie",
       "formSettings": "Paramètres du formulaire",
       "settings": "Paramètres",
-      "theme": "Thème"
+      "theme": "Thème",
+      "validates": "Valide",
+      "validatesShort": "Valide"
     },
-    "textColor": "Couleur du texte"
+    "textColor": "Couleur du texte",
+    "validationDescription": "Indiquez éventuellement à quel projet — et à quel PRD ou PR/FAQ — se rapportent les retours de ce formulaire. Les notes recueillies apparaîtront alors à côté de ce document sur la page Priorisation. Laissez les deux champs vides pour un formulaire autonome, comme une enquête sur un site web.",
+    "validationDocumentHint": "Laissez sur l'ensemble du projet pour conserver le lien lorsqu'un document est régénéré.",
+    "validationDocumentLabel": "Document (facultatif)",
+    "validationNoProject": "-- Non lié --",
+    "validationProjectHint": "Effacer le projet délie ce formulaire.",
+    "validationProjectLabel": "Projet",
+    "validationTitle": "Ce que ce formulaire valide",
+    "validationUnknownDocument": "Document lié (plus disponible)",
+    "validationWholeProject": "-- Tout le projet --"
   },
   "empty": {
     "createButton": "Créer votre premier formulaire",

--- a/voc-datalake/frontend/public/locales/fr/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/fr/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "Ce que ce formulaire valide",
     "validationUnknownDocument": "Document lié (plus disponible)",
     "validationUnknownProject": "Projet lié (plus disponible)",
+    "validationUnverifiedDocument": "Document lié (vérification impossible)",
+    "validationUnverifiedProject": "Projet lié (vérification impossible)",
     "validationWholeProject": "-- Tout le projet --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/fr/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/fr/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "Indiquez éventuellement à quel projet — et à quel PRD ou PR/FAQ — se rapportent les retours de ce formulaire. Les notes recueillies apparaîtront alors à côté de ce document sur la page Priorisation. Laissez les deux champs vides pour un formulaire autonome, comme une enquête sur un site web.",
     "validationDocumentHint": "Laissez sur l'ensemble du projet pour conserver le lien lorsqu'un document est régénéré.",
     "validationDocumentLabel": "Document (facultatif)",
+    "validationLoadingLink": "Chargement du lien…",
     "validationNoProject": "-- Non lié --",
     "validationProjectHint": "Effacer le projet délie ce formulaire.",
     "validationProjectLabel": "Projet",
     "validationTitle": "Ce que ce formulaire valide",
     "validationUnknownDocument": "Document lié (plus disponible)",
+    "validationUnknownProject": "Projet lié (plus disponible)",
     "validationWholeProject": "-- Tout le projet --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/fr/prioritization.json
+++ b/voc-datalake/frontend/public/locales/fr/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "Vos projets contiennent des documents, mais aucun PRD ni PR/FAQ. Ouvrez un projet et générez un PRD ou un PR/FAQ pour l'évaluer ici.",
     "wrongTypeTitle": "Aucun document évaluable"
   },
+  "evidence": {
+    "avgRating": "Note moyenne",
+    "noLinkedForm": "Aucun formulaire de retour n'est lié à ce document.",
+    "noRatings": "Aucune note recueillie",
+    "submissions": "Réponses",
+    "title": "Retours recueillis",
+    "unavailable": "Notes indisponibles"
+  },
   "framework": {
     "description": "Évaluez chaque document sur : <strong>Impact</strong>, <strong>Délai de mise sur le marché</strong>, <strong>Adéquation stratégique</strong> et <strong>Confiance</strong>.",
     "title": "Cadre de priorisation"

--- a/voc-datalake/frontend/public/locales/ja/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ja/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "このフォームがどのプロジェクトの、どのPRDまたはPR/FAQについてフィードバックを集めるのかを任意で記録できます。収集した評価は優先順位付けページの該当ドキュメントの横に表示されます。ウェブサイトのアンケートなど単独のフォームでは両方を空のままにしてください。",
     "validationDocumentHint": "プロジェクト全体のままにすると、ドキュメントを再生成してもリンクが維持されます。",
     "validationDocumentLabel": "ドキュメント（任意）",
+    "validationLoadingLink": "リンクを読み込み中…",
     "validationNoProject": "-- リンクなし --",
     "validationProjectHint": "プロジェクトを空にするとこのフォームのリンクが解除されます。",
     "validationProjectLabel": "プロジェクト",
     "validationTitle": "このフォームが検証する対象",
     "validationUnknownDocument": "リンク済みドキュメント（現在利用できません）",
+    "validationUnknownProject": "リンク済みプロジェクト（現在利用できません）",
     "validationWholeProject": "-- プロジェクト全体 --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/ja/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ja/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "このフォームが検証する対象",
     "validationUnknownDocument": "リンク済みドキュメント（現在利用できません）",
     "validationUnknownProject": "リンク済みプロジェクト（現在利用できません）",
+    "validationUnverifiedDocument": "リンク済みドキュメント（確認できません）",
+    "validationUnverifiedProject": "リンク済みプロジェクト（確認できません）",
     "validationWholeProject": "-- プロジェクト全体 --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/ja/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ja/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "カテゴリルーティング",
       "formSettings": "フォーム設定",
       "settings": "設定",
-      "theme": "テーマ"
+      "theme": "テーマ",
+      "validates": "検証対象",
+      "validatesShort": "検証"
     },
-    "textColor": "テキスト色"
+    "textColor": "テキスト色",
+    "validationDescription": "このフォームがどのプロジェクトの、どのPRDまたはPR/FAQについてフィードバックを集めるのかを任意で記録できます。収集した評価は優先順位付けページの該当ドキュメントの横に表示されます。ウェブサイトのアンケートなど単独のフォームでは両方を空のままにしてください。",
+    "validationDocumentHint": "プロジェクト全体のままにすると、ドキュメントを再生成してもリンクが維持されます。",
+    "validationDocumentLabel": "ドキュメント（任意）",
+    "validationNoProject": "-- リンクなし --",
+    "validationProjectHint": "プロジェクトを空にするとこのフォームのリンクが解除されます。",
+    "validationProjectLabel": "プロジェクト",
+    "validationTitle": "このフォームが検証する対象",
+    "validationUnknownDocument": "リンク済みドキュメント（現在利用できません）",
+    "validationWholeProject": "-- プロジェクト全体 --"
   },
   "empty": {
     "createButton": "最初のフォームを作成",

--- a/voc-datalake/frontend/public/locales/ja/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ja/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "プロジェクトにドキュメントはありますが、PRDもPR/FAQもありません。プロジェクトを開き、PRDまたはPR/FAQを生成してここで評価してください。",
     "wrongTypeTitle": "スコアリング可能なドキュメントがありません"
   },
+  "evidence": {
+    "avgRating": "平均評価",
+    "noLinkedForm": "このドキュメントにリンクされたフィードバックフォームはありません。",
+    "noRatings": "評価は収集されていません",
+    "submissions": "回答数",
+    "title": "収集されたフィードバック",
+    "unavailable": "評価を取得できません"
+  },
   "framework": {
     "description": "各ドキュメントを次の基準で評価: <strong>インパクト</strong>、<strong>市場投入時間</strong>、<strong>戦略的適合性</strong>、<strong>確信度</strong>。",
     "title": "優先順位付けフレームワーク"

--- a/voc-datalake/frontend/public/locales/ko/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ko/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "이 양식이 어떤 프로젝트의, 어떤 PRD 또는 PR/FAQ에 대한 피드백을 수집하는지 선택적으로 기록할 수 있습니다. 수집된 평점은 우선순위 지정 페이지의 해당 문서 옆에 표시됩니다. 웹사이트 설문처럼 독립적인 양식이라면 두 항목을 비워 두세요.",
     "validationDocumentHint": "프로젝트 전체로 두면 문서를 다시 생성해도 연결이 유지됩니다.",
     "validationDocumentLabel": "문서(선택 사항)",
+    "validationLoadingLink": "연결 정보를 불러오는 중…",
     "validationNoProject": "-- 연결되지 않음 --",
     "validationProjectHint": "프로젝트를 비우면 이 양식의 연결이 해제됩니다.",
     "validationProjectLabel": "프로젝트",
     "validationTitle": "이 양식이 검증하는 대상",
     "validationUnknownDocument": "연결된 문서(더 이상 사용할 수 없음)",
+    "validationUnknownProject": "연결된 프로젝트(더 이상 사용할 수 없음)",
     "validationWholeProject": "-- 프로젝트 전체 --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/ko/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ko/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "카테고리 라우팅",
       "formSettings": "양식 설정",
       "settings": "설정",
-      "theme": "테마"
+      "theme": "테마",
+      "validates": "검증 대상",
+      "validatesShort": "검증"
     },
-    "textColor": "텍스트 색상"
+    "textColor": "텍스트 색상",
+    "validationDescription": "이 양식이 어떤 프로젝트의, 어떤 PRD 또는 PR/FAQ에 대한 피드백을 수집하는지 선택적으로 기록할 수 있습니다. 수집된 평점은 우선순위 지정 페이지의 해당 문서 옆에 표시됩니다. 웹사이트 설문처럼 독립적인 양식이라면 두 항목을 비워 두세요.",
+    "validationDocumentHint": "프로젝트 전체로 두면 문서를 다시 생성해도 연결이 유지됩니다.",
+    "validationDocumentLabel": "문서(선택 사항)",
+    "validationNoProject": "-- 연결되지 않음 --",
+    "validationProjectHint": "프로젝트를 비우면 이 양식의 연결이 해제됩니다.",
+    "validationProjectLabel": "프로젝트",
+    "validationTitle": "이 양식이 검증하는 대상",
+    "validationUnknownDocument": "연결된 문서(더 이상 사용할 수 없음)",
+    "validationWholeProject": "-- 프로젝트 전체 --"
   },
   "empty": {
     "createButton": "첫 번째 양식 만들기",

--- a/voc-datalake/frontend/public/locales/ko/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ko/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "이 양식이 검증하는 대상",
     "validationUnknownDocument": "연결된 문서(더 이상 사용할 수 없음)",
     "validationUnknownProject": "연결된 프로젝트(더 이상 사용할 수 없음)",
+    "validationUnverifiedDocument": "연결된 문서(확인할 수 없음)",
+    "validationUnverifiedProject": "연결된 프로젝트(확인할 수 없음)",
     "validationWholeProject": "-- 프로젝트 전체 --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/ko/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ko/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "프로젝트에 문서가 있지만 PRD 또는 PR/FAQ가 없습니다. 프로젝트를 열고 PRD 또는 PR/FAQ를 생성하여 여기서 평가하세요.",
     "wrongTypeTitle": "평가 가능한 문서 없음"
   },
+  "evidence": {
+    "avgRating": "평균 평점",
+    "noLinkedForm": "이 문서에 연결된 피드백 양식이 없습니다.",
+    "noRatings": "수집된 평점 없음",
+    "submissions": "제출 수",
+    "title": "수집된 피드백",
+    "unavailable": "평점을 사용할 수 없음"
+  },
   "framework": {
     "description": "각 문서를 다음 항목으로 평가하세요: <strong>영향도</strong>, <strong>출시 시간</strong>, <strong>전략적 부합도</strong>, <strong>신뢰도</strong>.",
     "title": "우선순위 지정 프레임워크"

--- a/voc-datalake/frontend/public/locales/pt/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/pt/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "O Que Este Formulário Valida",
     "validationUnknownDocument": "Documento vinculado (não mais disponível)",
     "validationUnknownProject": "Projeto vinculado (não mais disponível)",
+    "validationUnverifiedDocument": "Documento vinculado (não foi possível verificar)",
+    "validationUnverifiedProject": "Projeto vinculado (não foi possível verificar)",
     "validationWholeProject": "-- Projeto inteiro --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/pt/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/pt/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "Roteamento de categoria",
       "formSettings": "Configurações do formulário",
       "settings": "Configurações",
-      "theme": "Tema"
+      "theme": "Tema",
+      "validates": "Valida",
+      "validatesShort": "Valida"
     },
-    "textColor": "Cor do texto"
+    "textColor": "Cor do texto",
+    "validationDescription": "Opcionalmente registre sobre qual projeto — e qual PRD ou PR/FAQ — este formulário coleta feedback. As avaliações reunidas aparecerão ao lado desse documento na página de Priorização. Deixe ambos vazios para um formulário independente, como uma pesquisa de site.",
+    "validationDocumentHint": "Mantenha no projeto inteiro para preservar o vínculo quando um documento for regerado.",
+    "validationDocumentLabel": "Documento (Opcional)",
+    "validationNoProject": "-- Não vinculado --",
+    "validationProjectHint": "Limpar o projeto desvincula este formulário.",
+    "validationProjectLabel": "Projeto",
+    "validationTitle": "O Que Este Formulário Valida",
+    "validationUnknownDocument": "Documento vinculado (não mais disponível)",
+    "validationWholeProject": "-- Projeto inteiro --"
   },
   "empty": {
     "createButton": "Criar seu primeiro formulário",

--- a/voc-datalake/frontend/public/locales/pt/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/pt/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "Opcionalmente registre sobre qual projeto — e qual PRD ou PR/FAQ — este formulário coleta feedback. As avaliações reunidas aparecerão ao lado desse documento na página de Priorização. Deixe ambos vazios para um formulário independente, como uma pesquisa de site.",
     "validationDocumentHint": "Mantenha no projeto inteiro para preservar o vínculo quando um documento for regerado.",
     "validationDocumentLabel": "Documento (Opcional)",
+    "validationLoadingLink": "Carregando o vínculo…",
     "validationNoProject": "-- Não vinculado --",
     "validationProjectHint": "Limpar o projeto desvincula este formulário.",
     "validationProjectLabel": "Projeto",
     "validationTitle": "O Que Este Formulário Valida",
     "validationUnknownDocument": "Documento vinculado (não mais disponível)",
+    "validationUnknownProject": "Projeto vinculado (não mais disponível)",
     "validationWholeProject": "-- Projeto inteiro --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/pt/prioritization.json
+++ b/voc-datalake/frontend/public/locales/pt/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "Seus projetos têm documentos, mas nenhum é PRD nem PR/FAQ. Abra um projeto e gere um PRD ou PR/FAQ para pontuá-lo aqui.",
     "wrongTypeTitle": "Nenhum Documento Pontuável"
   },
+  "evidence": {
+    "avgRating": "Avaliação Média",
+    "noLinkedForm": "Nenhum formulário de feedback está vinculado a este documento.",
+    "noRatings": "Nenhuma avaliação coletada",
+    "submissions": "Respostas",
+    "title": "Feedback Coletado",
+    "unavailable": "Avaliações indisponíveis"
+  },
   "framework": {
     "description": "Pontue cada documento em: <strong>Impacto</strong>, <strong>Tempo para o Mercado</strong>, <strong>Alinhamento Estratégico</strong> e <strong>Confiança</strong>.",
     "title": "Framework de Priorização"

--- a/voc-datalake/frontend/public/locales/zh/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/zh/feedbackForms.json
@@ -75,11 +75,13 @@
     "validationDescription": "可选择记录此表单收集的反馈针对哪个项目，以及哪个 PRD 或 PR/FAQ。收集到的评分随后会显示在优先级排序页面上该文档的旁边。对于网站调查等独立表单，请将两项留空。",
     "validationDocumentHint": "保留为整个项目，可在文档重新生成后仍保持关联。",
     "validationDocumentLabel": "文档（可选）",
+    "validationLoadingLink": "正在加载关联信息…",
     "validationNoProject": "-- 未关联 --",
     "validationProjectHint": "清空项目将解除此表单的关联。",
     "validationProjectLabel": "项目",
     "validationTitle": "此表单验证的内容",
     "validationUnknownDocument": "已关联的文档（不再可用）",
+    "validationUnknownProject": "已关联的项目（不再可用）",
     "validationWholeProject": "-- 整个项目 --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/zh/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/zh/feedbackForms.json
@@ -67,9 +67,20 @@
       "categoryRouting": "类别路由",
       "formSettings": "表单设置",
       "settings": "设置",
-      "theme": "主题"
+      "theme": "主题",
+      "validates": "验证对象",
+      "validatesShort": "验证"
     },
-    "textColor": "文字颜色"
+    "textColor": "文字颜色",
+    "validationDescription": "可选择记录此表单收集的反馈针对哪个项目，以及哪个 PRD 或 PR/FAQ。收集到的评分随后会显示在优先级排序页面上该文档的旁边。对于网站调查等独立表单，请将两项留空。",
+    "validationDocumentHint": "保留为整个项目，可在文档重新生成后仍保持关联。",
+    "validationDocumentLabel": "文档（可选）",
+    "validationNoProject": "-- 未关联 --",
+    "validationProjectHint": "清空项目将解除此表单的关联。",
+    "validationProjectLabel": "项目",
+    "validationTitle": "此表单验证的内容",
+    "validationUnknownDocument": "已关联的文档（不再可用）",
+    "validationWholeProject": "-- 整个项目 --"
   },
   "empty": {
     "createButton": "创建第一个表单",

--- a/voc-datalake/frontend/public/locales/zh/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/zh/feedbackForms.json
@@ -82,6 +82,8 @@
     "validationTitle": "此表单验证的内容",
     "validationUnknownDocument": "已关联的文档（不再可用）",
     "validationUnknownProject": "已关联的项目（不再可用）",
+    "validationUnverifiedDocument": "已关联的文档（无法验证）",
+    "validationUnverifiedProject": "已关联的项目（无法验证）",
     "validationWholeProject": "-- 整个项目 --"
   },
   "empty": {

--- a/voc-datalake/frontend/public/locales/zh/prioritization.json
+++ b/voc-datalake/frontend/public/locales/zh/prioritization.json
@@ -17,6 +17,14 @@
     "wrongTypeDescription": "您的项目有文档，但没有 PRD 或 PR/FAQ。请打开项目并生成 PRD 或 PR/FAQ 以在此处评分。",
     "wrongTypeTitle": "没有可评分的文档"
   },
+  "evidence": {
+    "avgRating": "平均评分",
+    "noLinkedForm": "没有反馈表单与此文档关联。",
+    "noRatings": "未收集到评分",
+    "submissions": "提交数",
+    "title": "已收集的反馈",
+    "unavailable": "评分不可用"
+  },
   "framework": {
     "description": "对每个文档进行评分：<strong>影响力</strong>、<strong>上市时间</strong>、<strong>战略契合度</strong>和<strong>置信度</strong>。",
     "title": "优先级排序框架"

--- a/voc-datalake/frontend/src/api/feedbackFormQueryKeys.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormQueryKeys.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Guards that every reader of a shared feedback-form query key uses the helper.
+ *
+ * Lives beside the helper rather than in one of the four consumers' test files:
+ * someone editing `FormCard.tsx` looks here, not in
+ * `pages/Prioritization/LinkedFormEvidence.test.tsx`.
+ *
+ * Neither key drifts loudly, which is why this is asserted over the source text
+ * instead of through behaviour:
+ *
+ * - `['feedback-forms']` renamed on one side gives that reader its own cache
+ *   entry that no mutation invalidates, so it serves a stale list until reload.
+ * - `['form-stats', id]` renamed gives the evidence panel its own entry, and it
+ *   pays again for a brand-wide partition scan the form card had already cached.
+ *
+ * Both keep working. Nothing fails. That is the whole problem.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import {
+  feedbackFormsKey, formStatsKey, FORM_STATS_STALE_TIME_MS,
+} from './feedbackFormQueryKeys'
+
+/** Every consumer, relative to this file, and the symbols it must be using. */
+const CONSUMERS: Readonly<Record<string, readonly string[]>> = {
+  '../pages/FeedbackForms/FeedbackForms.tsx': ['feedbackFormsKey()'],
+  '../pages/FeedbackForms/FormCard.tsx': ['formStatsKey(', 'FORM_STATS_STALE_TIME_MS'],
+  '../pages/Prioritization/Prioritization.tsx': ['feedbackFormsKey()'],
+  '../pages/Prioritization/LinkedFormEvidence.tsx': ['formStatsKey(', 'FORM_STATS_STALE_TIME_MS'],
+}
+
+describe('shared feedback-form query keys', () => {
+  it('produces the keys the cache is actually addressed by', () => {
+    // Pins the literals themselves: renaming one here would silently move every
+    // consumer to a new cache entry at once, which no consumer-side test can see.
+    expect(feedbackFormsKey()).toEqual(['feedback-forms'])
+    expect(formStatsKey('abc123')).toEqual(['form-stats', 'abc123'])
+    expect(FORM_STATS_STALE_TIME_MS).toBe(30000)
+  })
+
+  it('is used by every consumer, with no literal left behind', () => {
+    for (const [file, symbols] of Object.entries(CONSUMERS)) {
+      const source = readFileSync(join(__dirname, file), 'utf-8')
+
+      expect(source, `${file} must import the shared keys`)
+        .toContain("api/feedbackFormQueryKeys'")
+      for (const symbol of symbols) {
+        expect(source, `${file} should use ${symbol}`).toContain(symbol)
+      }
+      expect(source, `${file} still spells a feedback-form query key literally`)
+        .not.toMatch(/queryKey: \['(feedback-forms|form-stats)/)
+    }
+  })
+})

--- a/voc-datalake/frontend/src/api/feedbackFormQueryKeys.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormQueryKeys.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Query keys for feedback-form data read from more than one feature.
+ *
+ * Both keys here crossed the "second feature reads it" line when the
+ * prioritization row started showing a linked form's collected ratings, and each
+ * drifts silently rather than loudly:
+ *
+ * - `['feedback-forms']` — the Feedback Forms page owns the list and invalidates
+ *   it on create, update and delete. Prioritization reads the same list to learn
+ *   which form validates which document. Spelled as a literal in both places, a
+ *   rename gives the second reader its own cache entry that no mutation ever
+ *   invalidates, so it serves a stale list until the page is reloaded.
+ * - `['form-stats', id]` — read by the form card and by the evidence panel on an
+ *   expanded prioritization row. Sharing it is the entire cost argument for that
+ *   panel: `GET /feedback-forms/{id}/stats` scans a brand-wide feedback partition
+ *   with a filter expression, so a row opened after visiting the Feedback Forms
+ *   page must reuse the cached payload rather than pay for it twice. If the two
+ *   spellings drift, nothing breaks and nothing fails — it just quietly costs
+ *   double.
+ *
+ * `FORM_STATS_STALE_TIME_MS` lives here for the same reason: matching keys buy
+ * nothing if one side considers the entry stale on arrival.
+ *
+ * Same rule as `projectQueryKeys`: a query key stays private to its page until a
+ * second feature reads it, and moves here when one does. No imports, so importing
+ * it drags no data layer into another chunk.
+ *
+ * @module api/feedbackFormQueryKeys
+ */
+
+/** The feedback-form list — `api.getFeedbackForms`. */
+export const feedbackFormsKey = () => ['feedback-forms'] as const
+
+/** One form's submission count and average rating — `api.getFeedbackFormStats`. */
+export const formStatsKey = (formId: string) => ['form-stats', formId] as const
+
+/**
+ * How long a stats payload stays fresh.
+ *
+ * Shared rather than repeated at each `useQuery`: the point of sharing the key is
+ * that the second reader does not re-fetch, and a shorter window on either side
+ * would defeat that without failing anything.
+ */
+export const FORM_STATS_STALE_TIME_MS = 30000

--- a/voc-datalake/frontend/src/api/feedbackFormTypes.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormTypes.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Guards the type boundary between the authenticated feedback-form shape and the
+ * public widget shape.
+ *
+ * `FeedbackFormFields` is shared: `FeedbackFormConfig` extends it and is the
+ * response body of `GET /feedback-forms/{id}/config`, which is unauthenticated
+ * and fetched cross-origin from customers' own websites. The project/document a
+ * form validates are internal identifiers, so they belong on `FeedbackForm`
+ * alone. Moving them up to the shared base would publish them.
+ *
+ * A type-level constraint cannot fail a test run, so this asserts over the
+ * declaration text instead — the same approach `lib/stacks/api-stack.test.ts`
+ * takes for its authorization invariant.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+const LINK_FIELDS = ['project_id', 'document_id']
+
+/** The body of one `interface X { ... }` declaration in types.ts. */
+function interfaceBody(source: string, name: string): string {
+  const start = source.indexOf(`interface ${name} `)
+  expect(start, `interface ${name} not found — was it renamed?`).toBeGreaterThanOrEqual(0)
+  const open = source.indexOf('{', start)
+  const close = source.indexOf('\n}', open)
+  expect(close, `interface ${name} is not brace-delimited as expected`).toBeGreaterThan(open)
+  return source.slice(open, close)
+}
+
+describe('feedback form type boundary', () => {
+  const source = readFileSync(join(__dirname, 'types.ts'), 'utf-8')
+
+  it('declares the validation link on FeedbackForm', () => {
+    const body = interfaceBody(source, 'FeedbackForm')
+
+    for (const field of LINK_FIELDS) {
+      expect(body, `FeedbackForm should declare ${field}`).toContain(field)
+    }
+  })
+
+  it('keeps the validation link off the shared base FeedbackFormFields', () => {
+    const body = interfaceBody(source, 'FeedbackFormFields')
+
+    for (const field of LINK_FIELDS) {
+      expect(
+        body,
+        `${field} on FeedbackFormFields would publish it through FeedbackFormConfig, `
+        + 'the body of the unauthenticated widget config route.',
+      ).not.toContain(field)
+    }
+  })
+
+  it('keeps the validation link off the public widget shape FeedbackFormConfig', () => {
+    const body = interfaceBody(source, 'FeedbackFormConfig')
+
+    for (const field of LINK_FIELDS) {
+      expect(body).not.toContain(field)
+    }
+  })
+})

--- a/voc-datalake/frontend/src/api/feedbackFormTypes.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormTypes.test.ts
@@ -18,7 +18,15 @@ import { describe, it, expect } from 'vitest'
 
 const LINK_FIELDS = ['project_id', 'document_id']
 
-/** The body of one `interface X { ... }` declaration in types.ts. */
+/**
+ * The body of one `interface X { ... }` declaration in types.ts, with comments
+ * stripped.
+ *
+ * The assertions below are about what an interface *declares*. A comment inside
+ * `FeedbackFormFields` that merely mentions `project_id` — to record why it is
+ * deliberately absent, say — declares nothing, and failing on it would punish
+ * exactly the documentation that keeps this invariant understood.
+ */
 function interfaceBody(source: string, name: string): string {
   const start = source.indexOf(`interface ${name} `)
   expect(start, `interface ${name} not found — was it renamed?`).toBeGreaterThanOrEqual(0)
@@ -26,6 +34,8 @@ function interfaceBody(source: string, name: string): string {
   const close = source.indexOf('\n}', open)
   expect(close, `interface ${name} is not brace-delimited as expected`).toBeGreaterThan(open)
   return source.slice(open, close)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '')
 }
 
 describe('feedback form type boundary', () => {

--- a/voc-datalake/frontend/src/api/projectQueryKeys.ts
+++ b/voc-datalake/frontend/src/api/projectQueryKeys.ts
@@ -22,3 +22,13 @@
 
 /** The project detail record — `projectsApi.getProject`. */
 export const projectKey = (id: string | undefined) => ['project', id] as const
+
+/**
+ * The project list — `projectsApi.getProjects`.
+ *
+ * Earned its place here by the rule above: three features read it (Projects,
+ * Prioritization, and the feedback-form editor's validation-link picker), and
+ * Projects invalidates it on every mutation — so every reader is coupled to an
+ * invalidation it had better be able to name.
+ */
+export const projectsKey = () => ['projects'] as const

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -413,7 +413,15 @@ export interface S3ImportFile {
   status: 'pending' | 'processed'
 }
 
-/** Shared form configuration fields used by both FeedbackFormConfig and FeedbackForm. */
+/**
+ * Shared form configuration fields used by both FeedbackFormConfig and FeedbackForm.
+ *
+ * Only fields safe to publish belong here: FeedbackFormConfig extends this and
+ * is the body of the UNAUTHENTICATED widget config route. Internal identifiers
+ * — the project_id/document_id a form validates, for instance — go on
+ * FeedbackForm instead. `feedbackFormTypes.test.ts` asserts that boundary over
+ * this declaration.
+ */
 interface FeedbackFormFields {
   title: string
   description: string

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -451,6 +451,20 @@ export interface FeedbackForm extends FeedbackFormFields {
   enabled: boolean
   category: string
   subcategory: string
+  // Optional link to the artefact this form validates. Declared here rather
+  // than on FeedbackFormFields ON PURPOSE: FeedbackFormFields is shared with
+  // FeedbackFormConfig, which is the response of the UNAUTHENTICATED widget
+  // config route served to customers' own websites. These are internal
+  // identifiers and must never appear there.
+  //
+  // Optional in the type as well as at rest: absent or '' both mean
+  // "validates nothing" — the standalone website-survey case, and the shape
+  // every form template and every record persisted before this field existed
+  // still has. project_id is the durable half of the link: regenerating a
+  // document mints a new document_id, so readers match on project first and
+  // treat document_id as a refinement.
+  project_id?: string
+  document_id?: string
   created_at: string
   updated_at: string
 }

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FeedbackForms.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FeedbackForms.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import clsx from 'clsx'
 import { api } from '../../api/client'
+import { feedbackFormsKey } from '../../api/feedbackFormQueryKeys'
 import type { LucideIcon } from 'lucide-react'
 import type { FeedbackForm } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
@@ -515,7 +516,7 @@ export default function FeedbackForms() {
   const [deleteFormId, setDeleteFormId] = useState<string | null>(null)
 
   const { data: formsData, isLoading } = useQuery({
-    queryKey: ['feedback-forms'],
+    queryKey: feedbackFormsKey(),
     queryFn: () => api.getFeedbackForms(),
     // Stored forms can predate newer fields (and fixtures can be sparse):
     // normalize once at the query boundary so FeedbackForm's declared
@@ -534,7 +535,7 @@ export default function FeedbackForms() {
     mutationFn: (form: Omit<FeedbackForm, 'form_id' | 'created_at' | 'updated_at'> & { form_id?: string }) =>
       form.form_id ? api.updateFeedbackForm(form.form_id, form) : api.createFeedbackForm(form),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feedback-forms'] })
+      queryClient.invalidateQueries({ queryKey: feedbackFormsKey() })
       setEditingForm(null)
       setTemplateConfig(null)
     },
@@ -543,7 +544,7 @@ export default function FeedbackForms() {
   const deleteMutation = useMutation({
     mutationFn: (formId: string) => api.deleteFeedbackForm(formId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feedback-forms'] })
+      queryClient.invalidateQueries({ queryKey: feedbackFormsKey() })
     },
   })
 
@@ -551,7 +552,7 @@ export default function FeedbackForms() {
     mutationFn: ({ formId, enabled }: { formId: string; enabled: boolean }) =>
       api.updateFeedbackForm(formId, { enabled }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feedback-forms'] })
+      queryClient.invalidateQueries({ queryKey: feedbackFormsKey() })
     },
   })
 

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FeedbackForms.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FeedbackForms.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import clsx from 'clsx'
 import { api } from '../../api/client'
+import type { LucideIcon } from 'lucide-react'
 import type { FeedbackForm } from '../../api/client'
 import { useConfigStore } from '../../store/configStore'
 import ConfirmModal from '../../components/ConfirmModal'
@@ -35,13 +36,12 @@ type FormConfigWithId = FormConfig & { form_id?: string }
 
 type EditorTabId = 'settings' | 'category' | 'validation' | 'theme'
 
-const EDITOR_TAB_IDS: readonly EditorTabId[] = ['settings', 'category', 'validation', 'theme']
-
-/** Narrow a tab id read back off the rendered list without a type assertion. */
-function isEditorTabId(value: string): value is EditorTabId {
-  // `.includes` on a readonly string-literal array needs a widened receiver;
-  // comparing element-wise keeps this assertion-free (repo bans `as`).
-  return EDITOR_TAB_IDS.some((id) => id === value)
+/** One entry in the editor's tab strip. */
+interface EditorTab {
+  readonly id: EditorTabId
+  readonly label: string
+  readonly shortLabel: string
+  readonly icon: LucideIcon
 }
 
 function stripTrailingSlashes(str: string): string {
@@ -149,20 +149,24 @@ function EditorTabBar({ activeTab, onSelect }: Readonly<{
   onSelect: (tab: EditorTabId) => void
 }>) {
   const { t } = useTranslation('feedbackForms')
-  const tabs = [
-    { id: 'settings', label: 'Form Settings', shortLabel: 'Settings', icon: Settings2 },
-    { id: 'category', label: 'Category Routing', shortLabel: 'Category', icon: Settings2 },
+  // Annotated, not inferred: with `id` typed as EditorTabId, `onSelect(tab.id)`
+  // typechecks directly, so no runtime narrowing guard is needed and a mistyped
+  // id fails to compile instead of rendering a button that silently does
+  // nothing. All four labels come from the catalogues — the keys already exist
+  // in all eight locales, and a half-translated tab strip reads worse than
+  // either extreme.
+  const tabs: readonly EditorTab[] = [
+    { id: 'settings', label: t('editor.tabs.formSettings'), shortLabel: t('editor.tabs.settings'), icon: Settings2 },
+    { id: 'category', label: t('editor.tabs.categoryRouting'), shortLabel: t('editor.tabs.category'), icon: Settings2 },
     { id: 'validation', label: t('editor.tabs.validates'), shortLabel: t('editor.tabs.validatesShort'), icon: Link2 },
-    { id: 'theme', label: 'Theme', shortLabel: 'Theme', icon: Palette },
+    { id: 'theme', label: t('editor.tabs.theme'), shortLabel: t('editor.tabs.theme'), icon: Palette },
   ]
   return (
     <div className="flex gap-1 sm:gap-2 px-3 sm:px-4 pt-3 sm:pt-4 border-b border-gray-200 overflow-x-auto">
       {tabs.map((tab) => (
         <button
           key={tab.id}
-          onClick={() => {
-            if (isEditorTabId(tab.id)) onSelect(tab.id)
-          }}
+          onClick={() => onSelect(tab.id)}
           className={clsx(
             'flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 border-b-2 -mb-px transition-colors whitespace-nowrap text-sm',
             activeTab === tab.id ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FeedbackForms.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FeedbackForms.tsx
@@ -12,9 +12,10 @@
  */
 
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { 
-  Plus, Loader2, Palette, Settings2, Save, X, Eye
+import {
+  Plus, Loader2, Palette, Settings2, Save, X, Eye, Link2
 } from 'lucide-react'
 import clsx from 'clsx'
 import { api } from '../../api/client'
@@ -25,10 +26,23 @@ import { defaultFormConfig } from './formTemplates'
 import { normalizeFeedbackForms } from './formSchema'
 import TemplateWizard from './TemplateWizard'
 import FormCard from './FormCard'
+import ValidationLinkPicker from './ValidationLinkPicker'
+import type { ValidationLink } from './ValidationLinkPicker'
 
 
 type FormConfig = Omit<FeedbackForm, 'form_id' | 'created_at' | 'updated_at'>
 type FormConfigWithId = FormConfig & { form_id?: string }
+
+type EditorTabId = 'settings' | 'category' | 'validation' | 'theme'
+
+const EDITOR_TAB_IDS: readonly EditorTabId[] = ['settings', 'category', 'validation', 'theme']
+
+/** Narrow a tab id read back off the rendered list without a type assertion. */
+function isEditorTabId(value: string): value is EditorTabId {
+  // `.includes` on a readonly string-literal array needs a widened receiver;
+  // comparing element-wise keeps this assertion-free (repo bans `as`).
+  return EDITOR_TAB_IDS.some((id) => id === value)
+}
 
 function stripTrailingSlashes(str: string): string {
   if (str.length === 0 || str[str.length - 1] !== '/') return str
@@ -97,6 +111,9 @@ interface FormEditorProps {
   readonly onSave: (form: FormConfigWithId) => void
   readonly onCancel: () => void
   readonly isSaving?: boolean
+  /** False before the API endpoint is configured — the validation-link picker
+   *  reads projects, so it must not fire a request without one. */
+  readonly validationPickerEnabled: boolean
 }
 
 function getInitialFormData(form: FeedbackForm | null, initialConfig: FormConfig | null | undefined): FormConfigWithId {
@@ -105,13 +122,63 @@ function getInitialFormData(form: FeedbackForm | null, initialConfig: FormConfig
   return { ...defaultFormConfig }
 }
 
+/**
+ * The link fields as the picker's controlled selects need them: '' rather than
+ * undefined, so a record persisted before these fields existed still renders.
+ * A module-level helper rather than inline JSX, to keep `FormEditor` under the
+ * repo's complexity ceiling.
+ */
+function toValidationLink(formData: FormConfigWithId): ValidationLink {
+  return {
+    project_id: formData.project_id ?? '',
+    document_id: formData.document_id ?? '',
+  }
+}
+
 function getSaveButtonText(isSaving: boolean, isEditing: boolean): string {
   if (isSaving) return isEditing ? 'Saving...' : 'Creating...'
   return isEditing ? 'Save Changes' : 'Create Form'
 }
 
-function FormEditor({ form, initialConfig, categories, onSave, onCancel, isSaving }: FormEditorProps) {
-  const [activeTab, setActiveTab] = useState<'settings' | 'theme' | 'category'>('settings')
+/**
+ * The editor's tab strip. Extracted from `FormEditor` when the fourth tab
+ * pushed that function past the repo's complexity ceiling.
+ */
+function EditorTabBar({ activeTab, onSelect }: Readonly<{
+  activeTab: EditorTabId
+  onSelect: (tab: EditorTabId) => void
+}>) {
+  const { t } = useTranslation('feedbackForms')
+  const tabs = [
+    { id: 'settings', label: 'Form Settings', shortLabel: 'Settings', icon: Settings2 },
+    { id: 'category', label: 'Category Routing', shortLabel: 'Category', icon: Settings2 },
+    { id: 'validation', label: t('editor.tabs.validates'), shortLabel: t('editor.tabs.validatesShort'), icon: Link2 },
+    { id: 'theme', label: 'Theme', shortLabel: 'Theme', icon: Palette },
+  ]
+  return (
+    <div className="flex gap-1 sm:gap-2 px-3 sm:px-4 pt-3 sm:pt-4 border-b border-gray-200 overflow-x-auto">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => {
+            if (isEditorTabId(tab.id)) onSelect(tab.id)
+          }}
+          className={clsx(
+            'flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 border-b-2 -mb-px transition-colors whitespace-nowrap text-sm',
+            activeTab === tab.id ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'
+          )}
+        >
+          <tab.icon size={16} />
+          <span className="hidden sm:inline">{tab.label}</span>
+          <span className="sm:hidden">{tab.shortLabel}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function FormEditor({ form, initialConfig, categories, onSave, onCancel, isSaving, validationPickerEnabled }: FormEditorProps) {
+  const [activeTab, setActiveTab] = useState<EditorTabId>('settings')
   const [formData, setFormData] = useState<FormConfigWithId>(() => getInitialFormData(form, initialConfig))
 
   const selectedCategory = categories.find(c => c.id === formData.category)
@@ -129,30 +196,7 @@ function FormEditor({ form, initialConfig, categories, onSave, onCancel, isSavin
           </button>
         </div>
 
-        {/* Tabs */}
-        <div className="flex gap-1 sm:gap-2 px-3 sm:px-4 pt-3 sm:pt-4 border-b border-gray-200 overflow-x-auto">
-          {[
-            { id: 'settings', label: 'Form Settings', shortLabel: 'Settings', icon: Settings2 },
-            { id: 'category', label: 'Category Routing', shortLabel: 'Category', icon: Settings2 },
-            { id: 'theme', label: 'Theme', shortLabel: 'Theme', icon: Palette },
-          ].map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => { 
-                const tabId = tab.id
-                if (tabId === 'settings' || tabId === 'category' || tabId === 'theme') setActiveTab(tabId) 
-              }}
-              className={clsx(
-                'flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 border-b-2 -mb-px transition-colors whitespace-nowrap text-sm',
-                activeTab === tab.id ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'
-              )}
-            >
-              <tab.icon size={16} />
-              <span className="hidden sm:inline">{tab.label}</span>
-              <span className="sm:hidden">{tab.shortLabel}</span>
-            </button>
-          ))}
-        </div>
+        <EditorTabBar activeTab={activeTab} onSelect={setActiveTab} />
 
         {/* Content */}
         <div className="flex-1 overflow-auto p-3 sm:p-4">
@@ -331,6 +375,14 @@ function FormEditor({ form, initialConfig, categories, onSave, onCancel, isSavin
                 </div>
               )}
             </div>
+          )}
+
+          {activeTab === 'validation' && (
+            <ValidationLinkPicker
+              value={toValidationLink(formData)}
+              onChange={(link) => setFormData({ ...formData, ...link })}
+              enabled={validationPickerEnabled}
+            />
           )}
 
           {activeTab === 'theme' && (
@@ -581,6 +633,7 @@ export default function FeedbackForms() {
             setTemplateConfig(null)
           }}
           isSaving={saveMutation.isPending}
+          validationPickerEnabled={!!config.apiEndpoint}
         />
       )}
 

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Trash2, Copy, Check, Code, ExternalLink, ToggleLeft, ToggleRight, Edit2, MessageSquare, Star, BarChart3 } from 'lucide-react'
 import type { FeedbackForm } from '../../api/client'
 import { api } from '../../api/client'
+import { formStatsKey, FORM_STATS_STALE_TIME_MS } from '../../api/feedbackFormQueryKeys'
 import { defaultFormConfig } from './formTemplates'
 import clsx from 'clsx'
 import SubmissionsModal from './SubmissionsModal'
@@ -129,9 +130,9 @@ export default function FormCard({ form, onEdit, onDelete, onToggle, apiEndpoint
   const theme = form.theme ?? defaultFormConfig.theme
 
   const { data: statsData } = useQuery({
-    queryKey: ['form-stats', form.form_id],
+    queryKey: formStatsKey(form.form_id),
     queryFn: () => api.getFeedbackFormStats(form.form_id),
-    staleTime: 30000,
+    staleTime: FORM_STATS_STALE_TIME_MS,
   })
 
   const copyToClipboard = (text: string, id: string) => {

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -14,6 +14,7 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import i18n from 'i18next'
+import { SCORABLE_TYPE_META } from '../Prioritization/prioritizationUtils'
 
 const mockGetFeedbackForms = vi.fn()
 const mockUpdateFeedbackForm = vi.fn()
@@ -352,5 +353,86 @@ describe('validation link in the form editor', () => {
     expect(source).toContain('queryKey: projectsKey()')
     expect(source, 'query keys must come from the shared helper, not literals')
       .not.toMatch(/queryKey: \['project/)
+  })
+
+  it('offers every document type the Prioritization page scores', async () => {
+    // Lockstep, not a restatement of the test above: SCORABLE_TYPE_META
+    // documents itself as the single source of truth for which types are
+    // scorable, and a form can only show its ratings on a row that exists. A
+    // third type added there must become linkable here with no second edit —
+    // this fails if the picker ever hardcodes its own narrower list again.
+    const scorableTypes = Object.keys(SCORABLE_TYPE_META)
+    expect(scorableTypes.length, 'nothing is scorable — fixture is broken')
+      .toBeGreaterThan(0)
+
+    mockGetProject.mockResolvedValue({
+      project_id: 'p1',
+      documents: scorableTypes.map((type) => ({
+        document_id: `doc_${type}`,
+        document_type: type,
+        title: `Doc ${type}`,
+        content: '',
+        created_at: '',
+      })),
+    })
+
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(screen.getByText(`Doc ${scorableTypes[0]}`)).toBeInTheDocument()
+    })
+    for (const type of scorableTypes) {
+      expect(
+        screen.getByText(`Doc ${type}`),
+        `${type} is scorable on Prioritization but the picker will not link to it`,
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('does not claim to be loading when the project list request fails', async () => {
+    // A rejected query is not "loading" and it is not "no longer available"
+    // either — nobody managed to look. Saying either is a false statement next
+    // to a link the admin is about to Save.
+    mockGetProjects.mockRejectedValue(new Error('projects unavailable'))
+
+    const user = await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(t('feedbackForms:editor.validationUnverifiedProject')),
+      ).toBeInTheDocument()
+    })
+    expect(projectSelect()).toHaveValue('p1')
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationLoadingLink')),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationUnknownProject')),
+    ).not.toBeInTheDocument()
+
+    // And the link still round-trips: a failed lookup must not clear it.
+    await user.click(screen.getByText('Save Changes'))
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({
+      project_id: 'p1', document_id: 'doc_prfaq',
+    })
+  })
+
+  it('does not claim to be loading when the project detail request fails', async () => {
+    mockGetProject.mockRejectedValue(new Error('detail unavailable'))
+
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(t('feedbackForms:editor.validationUnverifiedDocument')),
+      ).toBeInTheDocument()
+    })
+    expect(documentSelect()).toHaveValue('doc_prfaq')
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationUnknownDocument')),
+    ).not.toBeInTheDocument()
   })
 })

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Tests for the validation link in the form editor.
+ *
+ * The load-bearing behaviours: a stored link survives an edit round-trip through
+ * the editor (rather than being silently cleared on Save), the link can be
+ * cleared on purpose, and a form that validates nothing keeps saving exactly the
+ * payload it did before these fields existed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import i18n from 'i18next'
+
+const mockGetFeedbackForms = vi.fn()
+const mockUpdateFeedbackForm = vi.fn()
+const mockCreateFeedbackForm = vi.fn()
+const mockGetProjects = vi.fn()
+const mockGetProject = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getFeedbackForms: () => mockGetFeedbackForms(),
+    createFeedbackForm: (form: unknown) => mockCreateFeedbackForm(form),
+    updateFeedbackForm: (id: string, form: unknown) => mockUpdateFeedbackForm(id, form),
+    deleteFeedbackForm: () => Promise.resolve({ success: true }),
+    getCategoriesConfig: () => Promise.resolve({ categories: [] }),
+  },
+}))
+
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    getProjects: () => mockGetProjects(),
+    getProject: (id: string) => mockGetProject(id),
+  },
+}))
+
+vi.mock('../../store/configStore', () => ({
+  useConfigStore: () => ({ config: { apiEndpoint: 'https://api.example.com' } }),
+}))
+
+vi.mock('./TemplateWizard', () => ({
+  default: () => <div data-testid="template-wizard" />,
+}))
+
+vi.mock('./FormCard', () => ({
+  default: ({ form, onEdit }: {
+    form: { form_id: string; name: string }
+    onEdit: (f: unknown) => void
+  }) => (
+    <div data-testid={`form-card-${form.form_id}`}>
+      <button onClick={() => onEdit(form)}>Edit {form.name}</button>
+    </div>
+  ),
+}))
+
+import FeedbackForms from './FeedbackForms'
+
+const { t } = i18n
+
+const linkedForm = {
+  form_id: 'form_1',
+  name: 'PR/FAQ concept test',
+  enabled: true,
+  project_id: 'p1',
+  document_id: 'doc_prfaq',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const unlinkedForm = {
+  form_id: 'form_9',
+  name: 'Website Footer Form',
+  enabled: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+/** Open the editor for one form and switch to the validation tab. */
+async function openValidationTab(formName: string) {
+  const user = userEvent.setup()
+  render(<FeedbackForms />, { wrapper: createWrapper() })
+
+  await waitFor(() => {
+    expect(screen.getByText(`Edit ${formName}`)).toBeInTheDocument()
+  })
+  await user.click(screen.getByText(`Edit ${formName}`))
+  await user.click(screen.getAllByText(t('feedbackForms:editor.tabs.validates'))[0])
+  return user
+}
+
+const projectSelect = () => screen.getByLabelText(t('feedbackForms:editor.validationProjectLabel'))
+const documentSelect = () => screen.getByLabelText(t('feedbackForms:editor.validationDocumentLabel'))
+
+describe('validation link in the form editor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetFeedbackForms.mockResolvedValue({ forms: [linkedForm, unlinkedForm] })
+    mockUpdateFeedbackForm.mockResolvedValue({ success: true })
+    mockCreateFeedbackForm.mockResolvedValue({ success: true })
+    mockGetProjects.mockResolvedValue({
+      projects: [
+        { project_id: 'p1', name: 'Project One', status: 'active', created_at: '', updated_at: '', persona_count: 0, document_count: 1 },
+        { project_id: 'p2', name: 'Project Two', status: 'active', created_at: '', updated_at: '', persona_count: 0, document_count: 0 },
+      ],
+    })
+    mockGetProject.mockResolvedValue({
+      project_id: 'p1',
+      documents: [
+        { document_id: 'doc_prfaq', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '' },
+        { document_id: 'doc_research', document_type: 'research', title: 'Research Notes', content: '', created_at: '' },
+      ],
+    })
+  })
+
+  it('shows the stored link when the editor opens', async () => {
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('p1')
+    })
+    expect(documentSelect()).toHaveValue('doc_prfaq')
+  })
+
+  it('round-trips a stored link through Save untouched', async () => {
+    // The regression this guards: opening the editor and saving without
+    // touching the link must not clear it.
+    const user = await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('p1')
+    })
+    await user.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({
+      project_id: 'p1',
+      document_id: 'doc_prfaq',
+    })
+  })
+
+  it('lets an admin clear the link, and clears the document with the project', async () => {
+    const user = await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('p1')
+    })
+    await user.selectOptions(projectSelect(), '')
+    await user.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    // Empty strings, not undefined: the backend PUT only writes fields present
+    // in the body, so an omitted field would leave the old link in place.
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({
+      project_id: '',
+      document_id: '',
+    })
+  })
+
+  it('lets an admin link an unlinked form to a project and document', async () => {
+    const user = await openValidationTab('Website Footer Form')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('')
+    })
+    await user.selectOptions(projectSelect(), 'p1')
+    await waitFor(() => {
+      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+    })
+    await user.selectOptions(documentSelect(), 'doc_prfaq')
+    await user.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({
+      project_id: 'p1',
+      document_id: 'doc_prfaq',
+    })
+  })
+
+  it('saves a form that validates nothing as unlinked', async () => {
+    const user = await openValidationTab('Website Footer Form')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('')
+    })
+    await user.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({
+      project_id: '',
+      document_id: '',
+    })
+  })
+
+  it('offers only scorable document types — a form on research notes shows on no row', async () => {
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Research Notes')).not.toBeInTheDocument()
+  })
+
+  it('keeps a link whose document no longer exists rather than silently clearing it', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ ...linkedForm, document_id: 'doc_v1' }],
+    })
+
+    const user = await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(documentSelect()).toHaveValue('doc_v1')
+    })
+    expect(screen.getByText(t('feedbackForms:editor.validationUnknownDocument'))).toBeInTheDocument()
+
+    await user.click(screen.getByText('Save Changes'))
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({ document_id: 'doc_v1' })
+  })
+
+  it('disables the document select until a project is chosen', async () => {
+    await openValidationTab('Website Footer Form')
+
+    await waitFor(() => {
+      expect(documentSelect()).toBeDisabled()
+    })
+  })
+})

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -420,6 +420,31 @@ describe('validation link in the form editor', () => {
     })
   })
 
+  it('does not claim to be loading a document list it will never request', async () => {
+    // A document_id with no project_id is reachable — the API validates the two
+    // link fields independently, so `PUT {"document_id": "..."}` alone persists
+    // this shape. It disables the detail query, so the list can never resolve and
+    // "Loading link…" would sit there forever: the same defect one level down
+    // from the one this control was fixed for.
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ ...linkedForm, project_id: '', document_id: 'doc_orphan' }],
+    })
+
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(t('feedbackForms:editor.validationUnverifiedDocument')),
+      ).toBeInTheDocument()
+    })
+    expect(documentSelect()).toBeDisabled()
+    expect(documentSelect()).toHaveValue('doc_orphan')
+    expect(mockGetProject).not.toHaveBeenCalled()
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationLoadingLink')),
+    ).not.toBeInTheDocument()
+  })
+
   it('does not claim to be loading when the project detail request fails', async () => {
     mockGetProject.mockRejectedValue(new Error('detail unavailable'))
 

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -6,6 +6,8 @@
  * cleared on purpose, and a form that validates nothing keeps saving exactly the
  * payload it did before these fields existed.
  */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -244,5 +246,111 @@ describe('validation link in the form editor', () => {
     await waitFor(() => {
       expect(documentSelect()).toBeDisabled()
     })
+  })
+
+  it('does not call an intact link unavailable while the project detail is still loading', async () => {
+    // The document list is empty on the first render of EVERY linked form, so
+    // deciding "missing" from an empty list alarms the admin about a link that
+    // is perfectly fine. The stored id must still be the select's value — Save
+    // has to round-trip it either way — but under a neutral label.
+    let resolveDetail: (detail: unknown) => void = () => {}
+    mockGetProject.mockImplementation(() => new Promise((resolve) => {
+      resolveDetail = resolve
+    }))
+
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(documentSelect()).toHaveValue('doc_prfaq')
+    })
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationUnknownDocument')),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(t('feedbackForms:editor.validationLoadingLink'))).toBeInTheDocument()
+
+    resolveDetail({
+      project_id: 'p1',
+      documents: [
+        { document_id: 'doc_prfaq', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '' },
+      ],
+    })
+
+    // Once it lands, the real title replaces the placeholder and no "missing"
+    // label ever appeared.
+    await waitFor(() => {
+      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationLoadingLink')),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationUnknownDocument')),
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps a link whose project no longer exists rather than showing it as unlinked', async () => {
+    // Symmetric to the stale document: the id is still in formData, so showing
+    // "-- Not linked --" tells the admin the form is unlinked while Save
+    // persists the link anyway.
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ ...linkedForm, project_id: 'p_deleted' }],
+    })
+
+    const user = await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('p_deleted')
+    })
+    expect(screen.getByText(t('feedbackForms:editor.validationUnknownProject'))).toBeInTheDocument()
+
+    await user.click(screen.getByText('Save Changes'))
+    await waitFor(() => {
+      expect(mockUpdateFeedbackForm).toHaveBeenCalled()
+    })
+    expect(mockUpdateFeedbackForm.mock.calls[0][1]).toMatchObject({ project_id: 'p_deleted' })
+  })
+
+  it('does not call an intact project link unavailable while the project list loads', async () => {
+    let resolveProjects: (projects: unknown) => void = () => {}
+    mockGetProjects.mockImplementation(() => new Promise((resolve) => {
+      resolveProjects = resolve
+    }))
+
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(projectSelect()).toHaveValue('p1')
+    })
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationUnknownProject')),
+    ).not.toBeInTheDocument()
+
+    resolveProjects({
+      projects: [
+        { project_id: 'p1', name: 'Project One', status: 'active', created_at: '', updated_at: '', persona_count: 0, document_count: 1 },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Project One')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByText(t('feedbackForms:editor.validationUnknownProject')),
+    ).not.toBeInTheDocument()
+  })
+
+  it('reuses the shared project query keys so the cache is not split', async () => {
+    // A literal key here would still work — it would just address a separate
+    // cache entry and miss Projects.tsx's invalidations. Nothing observable
+    // fails, hence this test.
+    const source = readFileSync(
+      join(__dirname, 'ValidationLinkPicker.tsx'), 'utf-8',
+    )
+
+    expect(source).toContain("from '../../api/projectQueryKeys'")
+    expect(source).toContain('queryKey: projectKey(')
+    expect(source).toContain('queryKey: projectsKey()')
+    expect(source, 'query keys must come from the shared helper, not literals')
+      .not.toMatch(/queryKey: \['project/)
   })
 })

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -117,12 +117,18 @@ export default function ValidationLinkPicker({
 
   // Only the selected project's documents are fetched — the picker never needs
   // the whole corpus, and the query is skipped entirely while unlinked.
+  // Held in a const because `storedOptionState` below needs the SAME condition:
+  // if this query cannot run, its list can never resolve, and calling that
+  // "still loading" is the very thing this control stopped doing. A record with
+  // a document_id but no project_id is reachable (`PUT {"document_id": ...}`
+  // validates each field independently), and it disables this query.
+  const detailEnabled = enabled && value.project_id !== ''
   const {
     data: projectDetail, isSuccess: detailResolved, isError: detailFailed,
   } = useQuery({
     queryKey: projectKey(value.project_id),
     queryFn: () => projectsApi.getProject(value.project_id),
-    enabled: enabled && value.project_id !== '',
+    enabled: detailEnabled,
   })
   // `isScorable` rather than a local set of types: it reads SCORABLE_TYPE_META,
   // which documents itself as the single source of truth for which document
@@ -138,7 +144,7 @@ export default function ValidationLinkPicker({
   // the list is empty and every intact link looks missing.
   const storedDocument = storedOptionState(
     value.document_id, documents.map((doc) => doc.document_id),
-    { resolved: detailResolved, canResolve: enabled && !detailFailed },
+    { resolved: detailResolved, canResolve: detailEnabled && !detailFailed },
   )
   const storedProject = storedOptionState(
     value.project_id, projects.map((project) => project.project_id),

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -15,6 +15,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
+import { projectKey, projectsKey } from '../../api/projectQueryKeys'
 import { projectsApi } from '../../api/projectsApi'
 import type { Project, ProjectDocument } from '../../api/types'
 import type { ReactElement } from 'react'
@@ -33,6 +34,30 @@ export interface ValidationLink {
  */
 const LINKABLE_DOCUMENT_TYPES: ReadonlySet<ProjectDocument['document_type']> = new Set(['prd', 'prfaq'])
 
+/**
+ * Whether a select needs an extra option to hold an id that its fetched list
+ * does not offer, and how to label it.
+ *
+ * - `null`  — nothing stored, or the stored id is in the list: no extra option.
+ * - `'pending'` — stored, absent from the list, but the list has not arrived
+ *   yet. The option must still exist so the select keeps the stored value and
+ *   Save round-trips it, but it must NOT claim the link is broken: on the first
+ *   render of every intact link the list is still empty, and labelling that
+ *   "no longer available" tells the admin their link is gone when it is fine.
+ * - `'missing'` — the list has resolved and genuinely does not contain the id
+ *   (a regenerated document, a deleted project). Only then is the alarming
+ *   label the truth.
+ */
+type StoredOptionState = 'pending' | 'missing' | null
+
+function storedOptionState(
+  storedId: string, availableIds: readonly string[], listHasResolved: boolean,
+): StoredOptionState {
+  if (storedId === '') return null
+  if (availableIds.includes(storedId)) return null
+  return listHasResolved ? 'missing' : 'pending'
+}
+
 export default function ValidationLinkPicker({
   value, onChange, enabled,
 }: {
@@ -43,8 +68,13 @@ export default function ValidationLinkPicker({
 }): ReactElement {
   const { t } = useTranslation('feedbackForms')
 
-  const { data: projectsData } = useQuery({
-    queryKey: ['projects'],
+  // Shared keys, not literals: `['projects']` and `['project', id]` are both
+  // read by other features (Projects, Prioritization, the project page and
+  // Breadcrumbs). Spelling them here would silently address a separate cache
+  // entry the day either is renamed — the picker would keep working and just
+  // re-fetch, and miss the invalidations Projects.tsx fires on mutate.
+  const { data: projectsData, isSuccess: projectsResolved } = useQuery({
+    queryKey: projectsKey(),
     queryFn: () => projectsApi.getProjects(),
     enabled,
   })
@@ -52,8 +82,8 @@ export default function ValidationLinkPicker({
 
   // Only the selected project's documents are fetched — the picker never needs
   // the whole corpus, and the query is skipped entirely while unlinked.
-  const { data: projectDetail } = useQuery({
-    queryKey: ['project', value.project_id],
+  const { data: projectDetail, isSuccess: detailResolved } = useQuery({
+    queryKey: projectKey(value.project_id),
     queryFn: () => projectsApi.getProject(value.project_id),
     enabled: enabled && value.project_id !== '',
   })
@@ -61,11 +91,17 @@ export default function ValidationLinkPicker({
     (doc) => LINKABLE_DOCUMENT_TYPES.has(doc.document_type),
   )
 
-  // A stored document_id whose document no longer exists (regenerated, or from
-  // another project) must not silently vanish from the control: showing '' would
-  // make Save write a cleared link the admin never asked for.
-  const hasStoredDocument = value.document_id !== ''
-    && !documents.some((doc) => doc.document_id === value.document_id)
+  // A stored id whose record no longer exists (a regenerated document, a
+  // deleted project) must not silently vanish from the control: showing ''
+  // would make Save write a cleared link the admin never asked for. Both states
+  // are gated on the corresponding query having RESOLVED, because until it does
+  // the list is empty and every intact link looks missing.
+  const storedDocument = storedOptionState(
+    value.document_id, documents.map((doc) => doc.document_id), detailResolved,
+  )
+  const storedProject = storedOptionState(
+    value.project_id, projects.map((project) => project.project_id), projectsResolved,
+  )
 
   return (
     <div className="space-y-4 sm:space-y-6">
@@ -88,6 +124,13 @@ export default function ValidationLinkPicker({
             className="input"
           >
             <option value="">{t('editor.validationNoProject')}</option>
+            {storedProject === null ? null : (
+              <option value={value.project_id}>
+                {storedProject === 'missing'
+                  ? t('editor.validationUnknownProject')
+                  : t('editor.validationLoadingLink')}
+              </option>
+            )}
             {projects.map((project) => (
               <option key={project.project_id} value={project.project_id}>{project.name}</option>
             ))}
@@ -107,9 +150,13 @@ export default function ValidationLinkPicker({
             disabled={value.project_id === ''}
           >
             <option value="">{t('editor.validationWholeProject')}</option>
-            {hasStoredDocument ? (
-              <option value={value.document_id}>{t('editor.validationUnknownDocument')}</option>
-            ) : null}
+            {storedDocument === null ? null : (
+              <option value={value.document_id}>
+                {storedDocument === 'missing'
+                  ? t('editor.validationUnknownDocument')
+                  : t('editor.validationLoadingLink')}
+              </option>
+            )}
             {documents.map((doc) => (
               <option key={doc.document_id} value={doc.document_id}>{doc.title}</option>
             ))}

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview Editor control for the project/document a feedback form validates.
+ *
+ * The link is optional, and staying optional is the point: a form that validates
+ * nothing keeps both fields at '' and behaves exactly as it did before this
+ * control existed. Every select therefore has a "not linked" option, and
+ * clearing the project clears the document with it.
+ *
+ * Extracted into its own module rather than added inline to `FeedbackForms.tsx`:
+ * that file is already at the repo's `max-lines` ceiling and `FormEditor` at its
+ * complexity ceiling.
+ *
+ * @module pages/FeedbackForms/ValidationLinkPicker
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { projectsApi } from '../../api/projectsApi'
+import type { Project, ProjectDocument } from '../../api/types'
+import type { ReactElement } from 'react'
+
+/** The link, as the editor holds it. '' on either field means "not set". */
+export interface ValidationLink {
+  readonly project_id: string
+  readonly document_id: string
+}
+
+/**
+ * Document types worth validating with a feedback form: the same two the
+ * Prioritization page scores. Anything else (research notes, prototypes) is not
+ * a proposal a reviewer scores, so linking a form to it would show ratings on no
+ * row at all.
+ */
+const LINKABLE_DOCUMENT_TYPES: ReadonlySet<ProjectDocument['document_type']> = new Set(['prd', 'prfaq'])
+
+export default function ValidationLinkPicker({
+  value, onChange, enabled,
+}: {
+  readonly value: ValidationLink
+  readonly onChange: (link: ValidationLink) => void
+  /** False before the API endpoint is configured — skips the projects fetch. */
+  readonly enabled: boolean
+}): ReactElement {
+  const { t } = useTranslation('feedbackForms')
+
+  const { data: projectsData } = useQuery({
+    queryKey: ['projects'],
+    queryFn: () => projectsApi.getProjects(),
+    enabled,
+  })
+  const projects: Project[] = projectsData?.projects ?? []
+
+  // Only the selected project's documents are fetched — the picker never needs
+  // the whole corpus, and the query is skipped entirely while unlinked.
+  const { data: projectDetail } = useQuery({
+    queryKey: ['project', value.project_id],
+    queryFn: () => projectsApi.getProject(value.project_id),
+    enabled: enabled && value.project_id !== '',
+  })
+  const documents = (projectDetail?.documents ?? []).filter(
+    (doc) => LINKABLE_DOCUMENT_TYPES.has(doc.document_type),
+  )
+
+  // A stored document_id whose document no longer exists (regenerated, or from
+  // another project) must not silently vanish from the control: showing '' would
+  // make Save write a cleared link the admin never asked for.
+  const hasStoredDocument = value.document_id !== ''
+    && !documents.some((doc) => doc.document_id === value.document_id)
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 sm:p-4">
+        <h4 className="font-medium text-blue-900 mb-2 text-sm sm:text-base">{t('editor.validationTitle')}</h4>
+        <p className="text-xs sm:text-sm text-blue-800">{t('editor.validationDescription')}</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="validation-project">
+            {t('editor.validationProjectLabel')}
+          </label>
+          <select
+            id="validation-project"
+            value={value.project_id}
+            // Clearing or switching the project clears the document: a document
+            // id only means anything inside its own project.
+            onChange={(e) => onChange({ project_id: e.target.value, document_id: '' })}
+            className="input"
+          >
+            <option value="">{t('editor.validationNoProject')}</option>
+            {projects.map((project) => (
+              <option key={project.project_id} value={project.project_id}>{project.name}</option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 mt-1">{t('editor.validationProjectHint')}</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="validation-document">
+            {t('editor.validationDocumentLabel')}
+          </label>
+          <select
+            id="validation-document"
+            value={value.document_id}
+            onChange={(e) => onChange({ project_id: value.project_id, document_id: e.target.value })}
+            className="input"
+            disabled={value.project_id === ''}
+          >
+            <option value="">{t('editor.validationWholeProject')}</option>
+            {hasStoredDocument ? (
+              <option value={value.document_id}>{t('editor.validationUnknownDocument')}</option>
+            ) : null}
+            {documents.map((doc) => (
+              <option key={doc.document_id} value={doc.document_id}>{doc.title}</option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 mt-1">{t('editor.validationDocumentHint')}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -17,7 +17,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { projectKey, projectsKey } from '../../api/projectQueryKeys'
 import { projectsApi } from '../../api/projectsApi'
-import type { Project, ProjectDocument } from '../../api/types'
+import { isScorable } from '../Prioritization/prioritizationUtils'
+import type { Project } from '../../api/types'
 import type { ReactElement } from 'react'
 
 /** The link, as the editor holds it. '' on either field means "not set". */
@@ -27,35 +28,67 @@ export interface ValidationLink {
 }
 
 /**
- * Document types worth validating with a feedback form: the same two the
- * Prioritization page scores. Anything else (research notes, prototypes) is not
- * a proposal a reviewer scores, so linking a form to it would show ratings on no
- * row at all.
- */
-const LINKABLE_DOCUMENT_TYPES: ReadonlySet<ProjectDocument['document_type']> = new Set(['prd', 'prfaq'])
-
-/**
  * Whether a select needs an extra option to hold an id that its fetched list
  * does not offer, and how to label it.
  *
+ * Every state here exists to avoid printing something untrue next to a link the
+ * admin is about to Save. The stored id stays the select's value in all of them
+ * — Save has to round-trip it either way — only the label differs.
+ *
  * - `null`  — nothing stored, or the stored id is in the list: no extra option.
- * - `'pending'` — stored, absent from the list, but the list has not arrived
- *   yet. The option must still exist so the select keeps the stored value and
- *   Save round-trips it, but it must NOT claim the link is broken: on the first
- *   render of every intact link the list is still empty, and labelling that
- *   "no longer available" tells the admin their link is gone when it is fine.
- * - `'missing'` — the list has resolved and genuinely does not contain the id
- *   (a regenerated document, a deleted project). Only then is the alarming
- *   label the truth.
+ * - `'pending'` — stored, absent from the list, and the list is still on its
+ *   way. On the first render of EVERY intact link the list is empty, so
+ *   labelling that "no longer available" tells the admin their link is gone
+ *   when it is fine.
+ * - `'unverified'` — the list will never arrive: the request was rejected, or
+ *   there is no API endpoint configured so it was never made. "Loading" is
+ *   false (nothing is loading) and "no longer available" is false too (nobody
+ *   managed to look), so the label says only that it could not be checked.
+ * - `'missing'` — the list resolved and genuinely does not contain the id (a
+ *   regenerated document, a deleted project). Only then is the alarming label
+ *   the truth.
  */
-type StoredOptionState = 'pending' | 'missing' | null
+type StoredOptionState = 'pending' | 'unverified' | 'missing' | null
 
 function storedOptionState(
-  storedId: string, availableIds: readonly string[], listHasResolved: boolean,
+  storedId: string,
+  availableIds: readonly string[],
+  list: { readonly resolved: boolean; readonly canResolve: boolean },
 ): StoredOptionState {
   if (storedId === '') return null
   if (availableIds.includes(storedId)) return null
-  return listHasResolved ? 'missing' : 'pending'
+  if (list.resolved) return 'missing'
+  return list.canResolve ? 'pending' : 'unverified'
+}
+
+/**
+ * The label for one non-null state.
+ *
+ * A helper taking `t` rather than nested ternaries in the JSX (three states in
+ * two selects is four branches of markup, and this editor is already at the
+ * repo's complexity ceiling) — and rather than a key lookup table, so that every
+ * key stays a literal argument to `t()`. `scripts/i18n-check.mjs` only sees keys
+ * written that way or as an `xKey: 'ns:key'` data property; a key held in a plain
+ * map is reported unreferenced and is then a candidate for deletion in a cleanup
+ * pass, which would leave this select rendering a raw key path.
+ *
+ * Shaped as one function because `pending` is deliberately the same sentence for
+ * both selects; only the other two name which thing is linked.
+ */
+function storedOptionLabel(
+  state: Exclude<StoredOptionState, null>,
+  select: 'project' | 'document',
+  t: (key: string) => string,
+): string {
+  if (state === 'pending') return t('editor.validationLoadingLink')
+  if (select === 'project') {
+    return state === 'missing'
+      ? t('editor.validationUnknownProject')
+      : t('editor.validationUnverifiedProject')
+  }
+  return state === 'missing'
+    ? t('editor.validationUnknownDocument')
+    : t('editor.validationUnverifiedDocument')
 }
 
 export default function ValidationLinkPicker({
@@ -73,7 +106,9 @@ export default function ValidationLinkPicker({
   // Breadcrumbs). Spelling them here would silently address a separate cache
   // entry the day either is renamed — the picker would keep working and just
   // re-fetch, and miss the invalidations Projects.tsx fires on mutate.
-  const { data: projectsData, isSuccess: projectsResolved } = useQuery({
+  const {
+    data: projectsData, isSuccess: projectsResolved, isError: projectsFailed,
+  } = useQuery({
     queryKey: projectsKey(),
     queryFn: () => projectsApi.getProjects(),
     enabled,
@@ -82,14 +117,19 @@ export default function ValidationLinkPicker({
 
   // Only the selected project's documents are fetched — the picker never needs
   // the whole corpus, and the query is skipped entirely while unlinked.
-  const { data: projectDetail, isSuccess: detailResolved } = useQuery({
+  const {
+    data: projectDetail, isSuccess: detailResolved, isError: detailFailed,
+  } = useQuery({
     queryKey: projectKey(value.project_id),
     queryFn: () => projectsApi.getProject(value.project_id),
     enabled: enabled && value.project_id !== '',
   })
-  const documents = (projectDetail?.documents ?? []).filter(
-    (doc) => LINKABLE_DOCUMENT_TYPES.has(doc.document_type),
-  )
+  // `isScorable` rather than a local set of types: it reads SCORABLE_TYPE_META,
+  // which documents itself as the single source of truth for which document
+  // types the Prioritization page scores. A form can only show its ratings on a
+  // row that exists, so "linkable here" and "scorable there" are the same
+  // question and must not be answerable twice.
+  const documents = (projectDetail?.documents ?? []).filter(isScorable)
 
   // A stored id whose record no longer exists (a regenerated document, a
   // deleted project) must not silently vanish from the control: showing ''
@@ -97,10 +137,12 @@ export default function ValidationLinkPicker({
   // are gated on the corresponding query having RESOLVED, because until it does
   // the list is empty and every intact link looks missing.
   const storedDocument = storedOptionState(
-    value.document_id, documents.map((doc) => doc.document_id), detailResolved,
+    value.document_id, documents.map((doc) => doc.document_id),
+    { resolved: detailResolved, canResolve: enabled && !detailFailed },
   )
   const storedProject = storedOptionState(
-    value.project_id, projects.map((project) => project.project_id), projectsResolved,
+    value.project_id, projects.map((project) => project.project_id),
+    { resolved: projectsResolved, canResolve: enabled && !projectsFailed },
   )
 
   return (
@@ -126,9 +168,7 @@ export default function ValidationLinkPicker({
             <option value="">{t('editor.validationNoProject')}</option>
             {storedProject === null ? null : (
               <option value={value.project_id}>
-                {storedProject === 'missing'
-                  ? t('editor.validationUnknownProject')
-                  : t('editor.validationLoadingLink')}
+                {storedOptionLabel(storedProject, 'project', t)}
               </option>
             )}
             {projects.map((project) => (
@@ -152,9 +192,7 @@ export default function ValidationLinkPicker({
             <option value="">{t('editor.validationWholeProject')}</option>
             {storedDocument === null ? null : (
               <option value={value.document_id}>
-                {storedDocument === 'missing'
-                  ? t('editor.validationUnknownDocument')
-                  : t('editor.validationLoadingLink')}
+                {storedOptionLabel(storedDocument, 'document', t)}
               </option>
             )}
             {documents.map((doc) => (

--- a/voc-datalake/frontend/src/pages/FeedbackForms/formSchema.test.ts
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/formSchema.test.ts
@@ -99,6 +99,10 @@ describe('normalizeFeedbackForm (issue #171)', () => {
       enabled: true,
       category: 'delivery',
       subcategory: 'late',
+      // Complete means complete: the schema fills these in when absent, so a
+      // record omitting them is not what this test claims to cover.
+      project_id: 'proj_1',
+      document_id: 'doc_1',
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-02-01T00:00:00Z',
       theme: { primary_color: '#111111', background_color: '#222222', text_color: '#333333', border_radius: '4px' },

--- a/voc-datalake/frontend/src/pages/FeedbackForms/formSchema.test.ts
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/formSchema.test.ts
@@ -91,6 +91,35 @@ describe('normalizeFeedbackForm (issue #171)', () => {
     expect(form).toMatchObject({ brand_name: 'Acme', future_field: { nested: true } })
   })
 
+  it('defaults the validation link to unlinked on a record that predates it', () => {
+    // The schema declares project_id/document_id rather than leaving them to
+    // the loose object's passthrough, so a form persisted before the link
+    // existed reads as deliberately unlinked instead of undefined — which is
+    // what the editor's controlled selects need.
+    const form = normalizeFeedbackForm(sparseForm)
+
+    expect(form.project_id).toBe('')
+    expect(form.document_id).toBe('')
+  })
+
+  it('preserves a stored validation link so the editor can round-trip it', () => {
+    const form = normalizeFeedbackForm({
+      ...sparseForm,
+      project_id: 'proj_1',
+      document_id: 'doc_prfaq',
+    })
+
+    expect(form.project_id).toBe('proj_1')
+    expect(form.document_id).toBe('doc_prfaq')
+  })
+
+  it('degrades a wrong-typed validation link to unlinked, not to a crash', () => {
+    const form = normalizeFeedbackForm({ ...sparseForm, project_id: 7, document_id: null })
+
+    expect(form.project_id).toBe('')
+    expect(form.document_id).toBe('')
+  })
+
   it('keeps a complete record unchanged', () => {
     const complete: FeedbackForm = {
       ...defaultFormConfig,

--- a/voc-datalake/frontend/src/pages/FeedbackForms/formSchema.ts
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/formSchema.ts
@@ -104,6 +104,15 @@ export const FeedbackFormSchema = z.looseObject({
   custom_fields: customFieldsSchema,
   category: z.string().catch(''),
   subcategory: z.string().catch(''),
+  // Optional link to the project/document this form validates. Defaults to ''
+  // like every other absent string field, so a record persisted before the
+  // link existed — or one that deliberately validates nothing — normalizes to
+  // "unlinked" rather than being dropped. Declaring both fields explicitly
+  // (rather than relying on the loose object's passthrough) is what makes a
+  // stored link survive the edit round-trip with a known type: the editor
+  // reads them off a normalized record and writes them straight back.
+  project_id: z.string().catch(''),
+  document_id: z.string().catch(''),
   created_at: z.string().catch(''),
   updated_at: z.string().catch(''),
 })

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
@@ -243,5 +243,4 @@ describe('collected feedback on a prioritization row', () => {
     })
     expect(screen.getByText(t('prioritization:evidence.noLinkedForm'))).toBeInTheDocument()
   })
-
 })

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
@@ -5,8 +5,6 @@
  * the behaviours under test are properties of the page: which form matches which
  * row, and that no stats request is made until a row is expanded.
  */
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -246,30 +244,4 @@ describe('collected feedback on a prioritization row', () => {
     expect(screen.getByText(t('prioritization:evidence.noLinkedForm'))).toBeInTheDocument()
   })
 
-  it('reads both shared feedback-form query keys from the helper, on all four sides', () => {
-    // Neither key drifts loudly. `['feedback-forms']` renamed on one side gives
-    // that reader a cache entry no mutation invalidates, so it serves a stale
-    // list; `['form-stats', id]` renamed gives this panel its own entry and it
-    // pays again for the brand-wide partition scan the form card had already
-    // cached. Both spellings keep working, which is why this is asserted over
-    // the source instead of through behaviour.
-    const expectedSymbols: Record<string, readonly string[]> = {
-      'Prioritization.tsx': ['feedbackFormsKey()'],
-      'LinkedFormEvidence.tsx': ['formStatsKey(', 'FORM_STATS_STALE_TIME_MS'],
-      '../FeedbackForms/FeedbackForms.tsx': ['feedbackFormsKey()'],
-      '../FeedbackForms/FormCard.tsx': ['formStatsKey(', 'FORM_STATS_STALE_TIME_MS'],
-    }
-
-    for (const [file, symbols] of Object.entries(expectedSymbols)) {
-      const source = readFileSync(join(__dirname, file), 'utf-8')
-
-      expect(source, `${file} must import the shared keys`)
-        .toContain("from '../../api/feedbackFormQueryKeys'")
-      for (const symbol of symbols) {
-        expect(source, `${file} should use ${symbol}`).toContain(symbol)
-      }
-      expect(source, `${file} still spells a feedback-form query key literally`)
-        .not.toMatch(/queryKey: \['(feedback-forms|form-stats)/)
-    }
-  })
 })

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Tests for the collected-feedback panel on a prioritization row.
+ *
+ * These drive the whole page rather than the panel in isolation, because two of
+ * the behaviours under test are properties of the page: which form matches which
+ * row, and that no stats request is made until a row is expanded.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import i18n from 'i18next'
+
+const mockGetProjects = vi.fn()
+const mockGetProject = vi.fn()
+const mockGetPrioritizationScores = vi.fn()
+const mockGetFeedbackForms = vi.fn()
+const mockGetFeedbackFormStats = vi.fn()
+
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    getProjects: () => mockGetProjects(),
+    getProject: (id: string) => mockGetProject(id),
+  },
+}))
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getPrioritizationScores: () => mockGetPrioritizationScores(),
+    patchPrioritizationScores: () => Promise.resolve({ success: true }),
+    getFeedbackForms: () => mockGetFeedbackForms(),
+    getFeedbackFormStats: (formId: string) => mockGetFeedbackFormStats(formId),
+  },
+}))
+
+vi.mock('../../store/configStore', () => ({
+  useConfigStore: () => ({ config: { apiEndpoint: 'https://api.example.com' } }),
+}))
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}))
+
+import Prioritization from './Prioritization'
+
+const project = {
+  project_id: 'p1', name: 'Project 1', status: 'active',
+  created_at: '2025-01-01', updated_at: '2025-01-01', persona_count: 0, document_count: 2,
+}
+
+const prfaq = {
+  document_id: 'doc_prfaq', document_type: 'prfaq', title: 'Feature A PR/FAQ',
+  content: '# Feature A', created_at: '2025-01-01',
+}
+const prd = {
+  document_id: 'doc_prd', document_type: 'prd', title: 'Feature A PRD',
+  content: 'PRD content', created_at: '2025-01-02',
+}
+
+const { t } = i18n
+
+function renderPrioritization() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createMemoryRouter([{ path: '/', element: <Prioritization /> }])
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+/** Render the page and open one row — the panel is expand-only by design. */
+async function expandRow(title: string) {
+  const user = userEvent.setup()
+  renderPrioritization()
+  await waitFor(() => {
+    expect(screen.getByText(title)).toBeInTheDocument()
+  })
+  await user.click(screen.getByText(title))
+}
+
+/**
+ * The value rendered next to an evidence metric's label. Reads the sibling of
+ * the label node, so the assertion is about that metric rather than about any
+ * text anywhere on the page.
+ */
+function readMetricValue(label: string): string | null {
+  const labelNode = screen.getByText(label)
+  return labelNode.parentElement?.firstElementChild?.textContent ?? null
+}
+
+describe('collected feedback on a prioritization row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetProjects.mockResolvedValue({ projects: [project] })
+    mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq, prd] })
+    mockGetPrioritizationScores.mockResolvedValue({ scores: {} })
+    mockGetFeedbackForms.mockResolvedValue({ forms: [] })
+    mockGetFeedbackFormStats.mockResolvedValue({
+      success: true, form_id: 'form_1',
+      stats: { total_submissions: 12, avg_rating: 3.2, rating_count: 10 },
+    })
+  })
+
+  it('shows the submission count and average rating of the form linked to the row', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'PR/FAQ concept test', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText('PR/FAQ concept test')).toBeInTheDocument()
+    })
+    // The end state the change exists for: "12 submissions, average 3.2" on the
+    // row being scored.
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('3.2')).toBeInTheDocument()
+    expect(mockGetFeedbackFormStats).toHaveBeenCalledWith('form_1')
+  })
+
+  it('says so when no form is linked to the row', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      // A standalone website survey: linked to nothing, so it belongs to no row.
+      forms: [{ form_id: 'form_9', name: 'Website Footer Form' }],
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText(t('prioritization:evidence.noLinkedForm'))).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Website Footer Form')).not.toBeInTheDocument()
+    // And no money is spent on stats for a row with nothing to show.
+    expect(mockGetFeedbackFormStats).not.toHaveBeenCalled()
+  })
+
+  it('renders a null average as no ratings, never as zero', async () => {
+    // What a ratings-disabled form actually returns: submissions but no average.
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'Text-only form', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+    mockGetFeedbackFormStats.mockResolvedValue({
+      success: true, form_id: 'form_1',
+      stats: { total_submissions: 7, avg_rating: null, rating_count: 0 },
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText(t('prioritization:evidence.noRatings'))).toBeInTheDocument()
+    })
+    expect(screen.getByText('7')).toBeInTheDocument()
+    // A 0 or 0.0 here would read as unanimously terrible feedback. Read the
+    // rendered value out of the average metric itself rather than searching the
+    // page, which also contains the "0 High Priority" stats cards.
+    expect(readMetricValue(t('prioritization:evidence.avgRating'))).toBe('—')
+  })
+
+  it('shows every form validating the same document', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [
+        { form_id: 'form_1', name: 'Concept test', project_id: 'p1', document_id: 'doc_prfaq' },
+        { form_id: 'form_2', name: 'Pricing test', project_id: 'p1', document_id: 'doc_prfaq' },
+      ],
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText('Concept test')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Pricing test')).toBeInTheDocument()
+  })
+
+  it('still shows a project\'s evidence after its document was regenerated', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      // doc_v1 no longer exists — regenerating minted doc_prfaq.
+      forms: [{ form_id: 'form_1', name: 'Concept test', project_id: 'p1', document_id: 'doc_v1' }],
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText('Concept test')).toBeInTheDocument()
+    })
+    expect(screen.getByText('3.2')).toBeInTheDocument()
+  })
+
+  it('degrades gracefully when a linked form no longer exists', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_gone', name: 'Deleted form', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+    mockGetFeedbackFormStats.mockRejectedValue(new Error('Form not found'))
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText(t('prioritization:evidence.unavailable'))).toBeInTheDocument()
+    })
+  })
+
+  it('fetches stats only for the row that is expanded', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [
+        { form_id: 'form_1', name: 'PR/FAQ form', project_id: 'p1', document_id: 'doc_prfaq' },
+        { form_id: 'form_2', name: 'PRD form', project_id: 'p1', document_id: 'doc_prd' },
+      ],
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(mockGetFeedbackFormStats).toHaveBeenCalledWith('form_1')
+    })
+    // The stats endpoint scans a whole brand-wide partition per call, so a page
+    // of rows must not fan out on load.
+    expect(mockGetFeedbackFormStats).not.toHaveBeenCalledWith('form_2')
+  })
+
+  it('makes no stats request at all until a row is expanded', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'PR/FAQ form', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+
+    renderPrioritization()
+
+    await waitFor(() => {
+      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+    })
+    expect(mockGetFeedbackFormStats).not.toHaveBeenCalled()
+  })
+
+  it('renders the row when the forms list request fails', async () => {
+    // Evidence is a nice-to-have; scoring must not become impossible without it.
+    mockGetFeedbackForms.mockRejectedValue(new Error('boom'))
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText(t('prioritization:scores.title'))).toBeInTheDocument()
+    })
+    expect(screen.getByText(t('prioritization:evidence.noLinkedForm'))).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
@@ -5,6 +5,8 @@
  * the behaviours under test are properties of the page: which form matches which
  * row, and that no stats request is made until a row is expanded.
  */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -242,5 +244,32 @@ describe('collected feedback on a prioritization row', () => {
       expect(screen.getByText(t('prioritization:scores.title'))).toBeInTheDocument()
     })
     expect(screen.getByText(t('prioritization:evidence.noLinkedForm'))).toBeInTheDocument()
+  })
+
+  it('reads both shared feedback-form query keys from the helper, on all four sides', () => {
+    // Neither key drifts loudly. `['feedback-forms']` renamed on one side gives
+    // that reader a cache entry no mutation invalidates, so it serves a stale
+    // list; `['form-stats', id]` renamed gives this panel its own entry and it
+    // pays again for the brand-wide partition scan the form card had already
+    // cached. Both spellings keep working, which is why this is asserted over
+    // the source instead of through behaviour.
+    const expectedSymbols: Record<string, readonly string[]> = {
+      'Prioritization.tsx': ['feedbackFormsKey()'],
+      'LinkedFormEvidence.tsx': ['formStatsKey(', 'FORM_STATS_STALE_TIME_MS'],
+      '../FeedbackForms/FeedbackForms.tsx': ['feedbackFormsKey()'],
+      '../FeedbackForms/FormCard.tsx': ['formStatsKey(', 'FORM_STATS_STALE_TIME_MS'],
+    }
+
+    for (const [file, symbols] of Object.entries(expectedSymbols)) {
+      const source = readFileSync(join(__dirname, file), 'utf-8')
+
+      expect(source, `${file} must import the shared keys`)
+        .toContain("from '../../api/feedbackFormQueryKeys'")
+      for (const symbol of symbols) {
+        expect(source, `${file} should use ${symbol}`).toContain(symbol)
+      }
+      expect(source, `${file} still spells a feedback-form query key literally`)
+        .not.toMatch(/queryKey: \['(feedback-forms|form-stats)/)
+    }
   })
 })

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview The ratings collected by the feedback forms that validate a
+ * document, shown on that document's prioritization row.
+ *
+ * Rendered only inside the expanded part of a row. That is the whole cost
+ * strategy: `GET /feedback-forms/{id}/stats` scans a brand-wide feedback
+ * partition with a filter expression and no index on the submission-to-form
+ * link, so it is expensive per call and gets more expensive as the corpus grows.
+ * Mounting this component is what triggers the fetch, so a page of 40 rows makes
+ * zero stats calls until a reviewer opens one — the sliders and the prototype
+ * preview are already expand-only for the same reason.
+ *
+ * The query key and `staleTime` match `FormCard`'s (`['form-stats', form_id]`,
+ * 30s) on purpose: opening a row after visiting the Feedback Forms page reuses
+ * the cached payload rather than paying for it twice.
+ *
+ * This panel only displays evidence. It deliberately does not derive, suggest or
+ * pre-fill any score — the reviewer reads it and moves the sliders themselves.
+ *
+ * @module pages/Prioritization/LinkedFormEvidence
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { MessageSquare, Star } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import type { LinkedForm } from './formLinkUtils'
+import type { ReactElement } from 'react'
+
+/** One metric: a label and either a value or an em dash. */
+function EvidenceMetric({
+  icon, label, value,
+}: {
+  readonly icon: ReactElement
+  readonly label: string
+  readonly value: string
+}): ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="p-1.5 bg-white rounded border">{icon}</div>
+      <div>
+        <p className="text-base font-bold text-gray-900">{value}</p>
+        <p className="text-xs text-gray-500">{label}</p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One linked form's collected ratings.
+ *
+ * Its own component, so each form owns its own `useQuery` — a hook cannot be
+ * called in a loop, and several forms can validate the same document.
+ */
+function LinkedFormStats({ form }: { readonly form: LinkedForm }): ReactElement {
+  const { t } = useTranslation('prioritization')
+  const {
+    data, isPending, isError,
+  } = useQuery({
+    queryKey: ['form-stats', form.form_id],
+    queryFn: () => api.getFeedbackFormStats(form.form_id),
+    staleTime: 30000,
+  })
+
+  const stats = data?.stats
+  // A null average is what a ratings-disabled form (or one with only unrated
+  // text submissions) actually returns. It must read as "no ratings", never as
+  // a score of 0 — a 0 would look like unanimously terrible feedback. Held as
+  // the narrowed number (not a boolean) so the render site cannot re-widen it.
+  const average = typeof stats?.avg_rating === 'number' ? stats.avg_rating : null
+
+  return (
+    <div className="bg-gray-50 rounded-lg border p-3">
+      <p className="text-sm font-medium text-gray-800 truncate">{form.name}</p>
+      {isError ? (
+        <p className="text-xs text-gray-500 mt-1">{t('evidence.unavailable')}</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 mt-2">
+          <EvidenceMetric
+            icon={<MessageSquare size={14} className="text-blue-600" />}
+            label={t('evidence.submissions')}
+            value={isPending || !stats ? '—' : String(stats.total_submissions)}
+          />
+          <EvidenceMetric
+            icon={<Star size={14} className="text-yellow-600" />}
+            label={t('evidence.avgRating')}
+            value={average === null ? '—' : average.toFixed(1)}
+          />
+        </div>
+      )}
+      {!isError && !isPending && stats && average === null ? (
+        <p className="text-xs text-gray-500 mt-2">{t('evidence.noRatings')}</p>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * The collected-evidence panel for one row.
+ *
+ * @param forms every form that validates this row's document — possibly none,
+ *   possibly several.
+ */
+export default function LinkedFormEvidence({
+  forms,
+}: {
+  readonly forms: readonly LinkedForm[]
+}): ReactElement {
+  const { t } = useTranslation('prioritization')
+  return (
+    <div className="space-y-2">
+      <h4 className="font-medium text-gray-900">{t('evidence.title')}</h4>
+      {forms.length === 0 ? (
+        <p className="text-sm text-gray-500">{t('evidence.noLinkedForm')}</p>
+      ) : (
+        <div className="space-y-2">
+          {forms.map((form) => <LinkedFormStats key={form.form_id} form={form} />)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
@@ -10,9 +10,11 @@
  * zero stats calls until a reviewer opens one — the sliders and the prototype
  * preview are already expand-only for the same reason.
  *
- * The query key and `staleTime` match `FormCard`'s (`['form-stats', form_id]`,
- * 30s) on purpose: opening a row after visiting the Feedback Forms page reuses
- * the cached payload rather than paying for it twice.
+ * The query key and `staleTime` are shared with `FormCard` through
+ * `api/feedbackFormQueryKeys` rather than spelled the same in both places:
+ * opening a row after visiting the Feedback Forms page has to reuse the cached
+ * payload rather than pay for it twice, and two matching literals would drift
+ * without anything failing.
  *
  * This panel only displays evidence. It deliberately does not derive, suggest or
  * pre-fill any score — the reviewer reads it and moves the sliders themselves.
@@ -24,6 +26,7 @@ import { useQuery } from '@tanstack/react-query'
 import { MessageSquare, Star } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
+import { formStatsKey, FORM_STATS_STALE_TIME_MS } from '../../api/feedbackFormQueryKeys'
 import type { LinkedForm } from './formLinkUtils'
 import type { ReactElement } from 'react'
 
@@ -57,9 +60,9 @@ function LinkedFormStats({ form }: { readonly form: LinkedForm }): ReactElement 
   const {
     data, isPending, isError,
   } = useQuery({
-    queryKey: ['form-stats', form.form_id],
+    queryKey: formStatsKey(form.form_id),
     queryFn: () => api.getFeedbackFormStats(form.form_id),
-    staleTime: 30000,
+    staleTime: FORM_STATS_STALE_TIME_MS,
   })
 
   const stats = data?.stats

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -13,11 +13,13 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import PrototypeRenderer, { HtmlPrototypeFrame } from '../../components/PrototypeRenderer'
 import { parsePrototypeSpec, looksLikeHtmlDocument } from '../../components/prototypeSpec'
+import LinkedFormEvidence from './LinkedFormEvidence'
 import {
   calculatePriorityScore, getPriorityLabel, SCORABLE_TYPE_META,
 } from './prioritizationUtils'
 import ScoreSlider from './ScoreSlider'
 import type { PRFAQWithProject } from './prioritizationUtils'
+import type { LinkedForm } from './formLinkUtils'
 import type {
   PrioritizationScore, ProjectDocument,
 } from '../../api/types'
@@ -112,10 +114,11 @@ function PRFAQRowHeader({
 }
 
 function PRFAQRowExpanded({
-  prfaq, score, onUpdateScore,
+  prfaq, score, linkedForms, onUpdateScore,
 }: {
   readonly prfaq: PRFAQWithProject
   readonly score: PrioritizationScore
+  readonly linkedForms: readonly LinkedForm[]
   readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
 }) {
   const { t } = useTranslation('prioritization')
@@ -132,6 +135,10 @@ function PRFAQRowExpanded({
             <label className="text-sm font-medium text-gray-700">{t('notes.label')}</label>
             <textarea value={score.notes} onChange={(e) => onUpdateScore('notes', e.target.value)} placeholder={t('notes.placeholder')} rows={2} className="mt-1 w-full px-3 py-2 border rounded-lg text-sm" />
           </div>
+          {/* Ratings already collected about this document, beside the sliders
+              that score it. Mounted here (expand-only) because the stats read is
+              expensive per form — see LinkedFormEvidence. */}
+          <LinkedFormEvidence forms={linkedForms} />
         </div>
         <div className="space-y-3">
           <div className="flex items-center justify-between">
@@ -216,11 +223,13 @@ function PrototypePanel({
 }
 
 export default function PRFAQRow({
-  prfaq, index, score, isExpanded, onToggle, onUpdateScore,
+  prfaq, index, score, linkedForms, isExpanded, onToggle, onUpdateScore,
 }: {
   readonly prfaq: PRFAQWithProject
   readonly index: number
   readonly score: PrioritizationScore
+  /** Forms that validate this document — see formLinkUtils.selectLinkedForms. */
+  readonly linkedForms: readonly LinkedForm[]
   readonly isExpanded: boolean
   readonly onToggle: () => void
   readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
@@ -232,7 +241,7 @@ export default function PRFAQRow({
   return (
     <div className="bg-white rounded-lg border shadow-sm">
       <PRFAQRowHeader prfaq={prfaq} index={index} priority={priority} score={score} isExpanded={isExpanded} onToggle={onToggle} />
-      {isExpanded ? <PRFAQRowExpanded prfaq={prfaq} score={score} onUpdateScore={onUpdateScore} /> : null}
+      {isExpanded ? <PRFAQRowExpanded prfaq={prfaq} score={score} linkedForms={linkedForms} onUpdateScore={onUpdateScore} /> : null}
     </div>
   )
 }

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-i18next'
 import { useBlocker } from 'react-router-dom'
 import { api } from '../../api/client'
+import { projectsKey } from '../../api/projectQueryKeys'
 import { projectsApi } from '../../api/projectsApi'
 import ConfirmModal from '../../components/ConfirmModal'
 import { useConfigStore } from '../../store/configStore'
@@ -197,7 +198,7 @@ export default function Prioritization() {
   const {
     data: projectsData, isLoading: loadingProjects,
   } = useQuery({
-    queryKey: ['projects'],
+    queryKey: projectsKey(),
     queryFn: () => projectsApi.getProjects(),
     enabled: config.apiEndpoint.length > 0,
   })

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-i18next'
 import { useBlocker } from 'react-router-dom'
 import { api } from '../../api/client'
+import { feedbackFormsKey } from '../../api/feedbackFormQueryKeys'
 import { projectsKey } from '../../api/projectQueryKeys'
 import { projectsApi } from '../../api/projectsApi'
 import ConfirmModal from '../../components/ConfirmModal'
@@ -224,7 +225,7 @@ export default function Prioritization() {
   // part — each form's collected ratings — is fetched per form when a row is
   // expanded (see LinkedFormEvidence), not here.
   const { data: formsData } = useQuery({
-    queryKey: ['feedback-forms'],
+    queryKey: feedbackFormsKey(),
     queryFn: () => api.getFeedbackForms(),
     // Validate at the query boundary, per project convention: stored forms
     // predate the link fields, so the record on the wire can omit them

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -21,6 +21,9 @@ import { api } from '../../api/client'
 import { projectsApi } from '../../api/projectsApi'
 import ConfirmModal from '../../components/ConfirmModal'
 import { useConfigStore } from '../../store/configStore'
+import {
+  buildLinkedFormsByDocument, collectProjectDocumentIds, normalizeLinkedForms,
+} from './formLinkUtils'
 import PRFAQRow from './PRFAQRow'
 import {
   calculatePriorityScore, getScore, collectPRFAQs, comparePRFAQs, isScorable,
@@ -28,6 +31,7 @@ import {
 import type {
   PRFAQWithProject, SortField, SortDirection,
 } from './prioritizationUtils'
+import type { LinkedForm } from './formLinkUtils'
 import type {
   Project, PrioritizationScore,
 } from '../../api/types'
@@ -103,12 +107,15 @@ function SortControls({
   )
 }
 
+const NO_LINKED_FORMS: readonly LinkedForm[] = []
+
 function PRFAQList({
-  isLoading, prfaqs, scores, expandedId, onToggleExpand, onUpdateScore, hasNonScorableOnly,
+  isLoading, prfaqs, scores, linkedFormsByDocument, expandedId, onToggleExpand, onUpdateScore, hasNonScorableOnly,
 }: {
   readonly isLoading: boolean
   readonly prfaqs: PRFAQWithProject[]
   readonly scores: Record<string, PrioritizationScore>
+  readonly linkedFormsByDocument: ReadonlyMap<string, readonly LinkedForm[]>
   readonly expandedId: string | null
   readonly onToggleExpand: (id: string) => void
   readonly onUpdateScore: (docId: string, field: keyof PrioritizationScore, value: number | string) => void
@@ -133,6 +140,7 @@ function PRFAQList({
           prfaq={prfaq}
           index={index}
           score={getScore(scores, prfaq.document_id)}
+          linkedForms={linkedFormsByDocument.get(prfaq.document_id) ?? NO_LINKED_FORMS}
           isExpanded={expandedId === prfaq.document_id}
           onToggle={() => onToggleExpand(prfaq.document_id)}
           onUpdateScore={(field, value) => onUpdateScore(prfaq.document_id, field, value)}
@@ -211,6 +219,19 @@ export default function Prioritization() {
     enabled: config.apiEndpoint.length > 0,
   })
 
+  // One list read to learn WHICH forms validate which document. The expensive
+  // part — each form's collected ratings — is fetched per form when a row is
+  // expanded (see LinkedFormEvidence), not here.
+  const { data: formsData } = useQuery({
+    queryKey: ['feedback-forms'],
+    queryFn: () => api.getFeedbackForms(),
+    // Validate at the query boundary, per project convention: stored forms
+    // predate the link fields, so the record on the wire can omit them
+    // entirely — an unlinked form must read as "not linked", not crash the page.
+    select: (data) => normalizeLinkedForms(data.forms ?? []),
+    enabled: config.apiEndpoint.length > 0,
+  })
+
   const scores = useMemo(
     () => ({ ...savedScores?.scores, ...localEdits }),
     [savedScores, localEdits],
@@ -233,6 +254,17 @@ export default function Prioritization() {
     const sorted = [...allPRFAQs].sort((a, b) => comparePRFAQs(a, b, scores, sortField))
     return sortDirection === 'desc' ? sorted.reverse() : sorted
   }, [allPRFAQs, scores, sortField, sortDirection])
+
+  // Which forms validate which row. Pure bookkeeping over data already fetched;
+  // no per-row request happens here.
+  const linkedFormsByDocument = useMemo(
+    () => buildLinkedFormsByDocument(
+      formsData ?? [],
+      allPRFAQs,
+      collectProjectDocumentIds(allProjectDetails, projects),
+    ),
+    [formsData, allPRFAQs, allProjectDetails, projects],
+  )
 
   const saveMutation = useMutation({
     mutationFn: () => api.patchPrioritizationScores(localEdits),
@@ -298,6 +330,7 @@ export default function Prioritization() {
         isLoading={isLoading}
         prfaqs={sortedPRFAQs}
         scores={scores}
+        linkedFormsByDocument={linkedFormsByDocument}
         expandedId={expandedId}
         onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
         onUpdateScore={updateScore}

--- a/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.test.ts
@@ -48,6 +48,16 @@ describe('selectLinkedForms', () => {
     expect(selectLinkedForms([standalone], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)).toEqual([])
   })
 
+  it('matches nothing to a row with no project of its own', () => {
+    // Guards the `row.project_id === ''` short-circuit. Without it an unlinked
+    // form ('' project) would pair with an identity-less row, so a standalone
+    // website survey could surface on the page after all.
+    const standalone = form({ form_id: 'f1', name: 'Website Footer Form' })
+    const projectWide = form({ form_id: 'f2', project_id: 'p1' })
+
+    expect(selectLinkedForms([standalone, projectWide], { project_id: '', document_id: 'doc_prfaq' })).toEqual([])
+  })
+
   it('returns every form validating the same document', () => {
     const first = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_prfaq' })
     const second = form({ form_id: 'f2', project_id: 'p1', document_id: 'doc_prfaq' })

--- a/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for matching a prioritization row to the feedback forms that validate it.
+ *
+ * The load-bearing behaviour here is that `project_id` is matched first and
+ * `document_id` is only a refinement: regenerating a document mints a new id, so
+ * a link stored against the old id must not silently detach.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildLinkedFormsByDocument, collectProjectDocumentIds, normalizeLinkedForms, selectLinkedForms,
+} from './formLinkUtils'
+import type { LinkedForm } from './formLinkUtils'
+import type { Project, ProjectDocument } from '../../api/types'
+
+function form(overrides: Partial<LinkedForm> & { form_id: string }): LinkedForm {
+  return {
+    name: 'A form',
+    project_id: '',
+    document_id: '',
+    ...overrides,
+  }
+}
+
+const liveDocs = new Set(['doc_prfaq', 'doc_prd'])
+
+describe('selectLinkedForms', () => {
+  it('matches a form pinned to this exact document', () => {
+    const pinned = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_prfaq' })
+
+    const matched = selectLinkedForms([pinned], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)
+
+    expect(matched).toEqual([pinned])
+  })
+
+  it('returns nothing for a row with no linked form', () => {
+    const elsewhere = form({ form_id: 'f1', project_id: 'p2', document_id: 'doc_other' })
+
+    const matched = selectLinkedForms([elsewhere], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)
+
+    expect(matched).toEqual([])
+  })
+
+  it('never matches an unlinked standalone survey to any row', () => {
+    // The whole point of the fields being optional: a website form validates
+    // nothing and must stay off this page.
+    const standalone = form({ form_id: 'f1', name: 'Website Footer Form' })
+
+    expect(selectLinkedForms([standalone], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)).toEqual([])
+  })
+
+  it('returns every form validating the same document', () => {
+    const first = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_prfaq' })
+    const second = form({ form_id: 'f2', project_id: 'p1', document_id: 'doc_prfaq' })
+
+    const matched = selectLinkedForms([first, second], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)
+
+    expect(matched.map((f) => f.form_id)).toEqual(['f1', 'f2'])
+  })
+
+  it('matches a project-wide link (no document_id) on every scorable row', () => {
+    const projectWide = form({ form_id: 'f1', project_id: 'p1' })
+
+    expect(selectLinkedForms([projectWide], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs))
+      .toEqual([projectWide])
+    expect(selectLinkedForms([projectWide], { project_id: 'p1', document_id: 'doc_prd' }, liveDocs))
+      .toEqual([projectWide])
+  })
+
+  it('keeps showing a form whose document was regenerated', () => {
+    // The regression this fallback exists for: 'doc_old' is gone from the
+    // project, so the link would otherwise resolve to nothing and the collected
+    // evidence would disappear from the page.
+    const stale = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_old' })
+
+    const matched = selectLinkedForms([stale], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)
+
+    expect(matched).toEqual([stale])
+  })
+
+  it('does not show a document-pinned form on a live sibling document', () => {
+    // Without this, the PR/FAQ's ratings would also appear on the PRD row.
+    const pinnedToSibling = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_prd' })
+
+    const matched = selectLinkedForms([pinnedToSibling], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)
+
+    expect(matched).toEqual([])
+  })
+
+  it('prefers the exact document match over the project fallback', () => {
+    const exact = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_prfaq' })
+    const projectWide = form({ form_id: 'f2', project_id: 'p1' })
+
+    const matched = selectLinkedForms([exact, projectWide], { project_id: 'p1', document_id: 'doc_prfaq' }, liveDocs)
+
+    expect(matched.map((f) => f.form_id)).toEqual(['f1'])
+  })
+
+  it('treats no link as stale while the project detail is still loading', () => {
+    // liveDocumentIds undefined: matching on the project is the safe read, so
+    // evidence appears rather than flickering to "no linked form".
+    const pinned = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_old' })
+
+    expect(selectLinkedForms([pinned], { project_id: 'p1', document_id: 'doc_prfaq' })).toEqual([pinned])
+  })
+})
+
+describe('normalizeLinkedForms', () => {
+  it('reads a stored link off a wire record', () => {
+    const [normalized] = normalizeLinkedForms([
+      { form_id: 'f1', name: 'PR/FAQ validation', project_id: 'p1', document_id: 'doc_prfaq' },
+    ])
+
+    expect(normalized.project_id).toBe('p1')
+    expect(normalized.document_id).toBe('doc_prfaq')
+  })
+
+  it('defaults the link to unlinked on a record that predates the fields', () => {
+    const [normalized] = normalizeLinkedForms([{ form_id: 'f1', name: 'Legacy Form' }])
+
+    expect(normalized.project_id).toBe('')
+    expect(normalized.document_id).toBe('')
+  })
+
+  it('degrades a wrong-typed link to unlinked rather than dropping the form', () => {
+    const [normalized] = normalizeLinkedForms([{ form_id: 'f1', project_id: 42, document_id: null }])
+
+    expect(normalized.project_id).toBe('')
+    expect(normalized.document_id).toBe('')
+  })
+
+  it('drops records without a usable form_id — it keys the stats query', () => {
+    expect(normalizeLinkedForms([{ name: 'No identity' }, { form_id: '' }, 'nonsense', null])).toEqual([])
+  })
+})
+
+describe('collectProjectDocumentIds', () => {
+  it('indexes each project\'s document ids by project_id', () => {
+    const project = (id: string): Project => ({
+      project_id: id,
+      name: id.toUpperCase(),
+      description: '',
+      status: 'active',
+      created_at: '',
+      updated_at: '',
+      persona_count: 0,
+      document_count: 0,
+    })
+    const document = (id: string): ProjectDocument => ({
+      document_id: id,
+      document_type: 'prfaq',
+      title: id,
+      content: '',
+      created_at: '',
+    })
+
+    const byProject = collectProjectDocumentIds(
+      [
+        { documents: [document('doc_a'), document('doc_b')] },
+        { documents: [document('doc_c')] },
+      ],
+      [project('p1'), project('p2')],
+    )
+
+    expect([...(byProject.get('p1') ?? [])]).toEqual(['doc_a', 'doc_b'])
+    expect([...(byProject.get('p2') ?? [])]).toEqual(['doc_c'])
+  })
+
+  it('returns an empty index before the data has loaded', () => {
+    expect(collectProjectDocumentIds(undefined, undefined).size).toBe(0)
+  })
+})
+
+describe('buildLinkedFormsByDocument', () => {
+  it('keys each row\'s forms by document_id', () => {
+    const pinned = form({ form_id: 'f1', project_id: 'p1', document_id: 'doc_prfaq' })
+    const rows = [
+      { project_id: 'p1', document_id: 'doc_prfaq' },
+      { project_id: 'p1', document_id: 'doc_prd' },
+    ]
+
+    const byDocument = buildLinkedFormsByDocument([pinned], rows, new Map([['p1', liveDocs]]))
+
+    expect(byDocument.get('doc_prfaq')).toEqual([pinned])
+    expect(byDocument.get('doc_prd')).toEqual([])
+  })
+})

--- a/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.ts
@@ -81,7 +81,7 @@ type DetailWithDocuments = Pick<Partial<ProjectDetail>, 'documents'>
  * aligns them.
  */
 export function collectProjectDocumentIds(
-  allProjectDetails: readonly DetailWithDocuments[] | undefined,
+  allProjectDetails: readonly (DetailWithDocuments | undefined)[] | undefined,
   projects: readonly Project[] | undefined,
 ): Map<string, Set<string>> {
   const byProject = new Map<string, Set<string>>()
@@ -89,6 +89,10 @@ export function collectProjectDocumentIds(
   for (const [index, detail] of allProjectDetails.entries()) {
     const project = projects[index]
     if (!project) continue
+    // A detail can be absent even when the array is not: a caller mapping
+    // `useQueries().map((q) => q.data)` yields undefined for every entry still
+    // loading, and dereferencing that would throw mid-load.
+    if (!detail) continue
     byProject.set(project.project_id, new Set((detail.documents ?? []).map((doc) => doc.document_id)))
   }
   return byProject
@@ -139,6 +143,12 @@ export function buildLinkedFormsByDocument(
 ): Map<string, LinkedForm[]> {
   const byDocument = new Map<string, LinkedForm[]>()
   for (const row of rows) {
+    // Keyed by document_id alone even though the value was computed from
+    // (project_id, document_id): document ids are server-minted and globally
+    // unique, and this is already the key `scores`/`getScore` in
+    // prioritizationUtils.ts and `expandedId` in Prioritization.tsx are
+    // addressed by. A composite key here would have to be unpacked at every
+    // one of those read sites for no gain.
     byDocument.set(
       row.document_id,
       selectLinkedForms(forms, row, documentIdsByProject.get(row.project_id)),

--- a/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/formLinkUtils.ts
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Matching a scorable document's row to the feedback forms that
+ * validate it.
+ *
+ * The link lives on the form (`project_id`, `document_id` — both optional), not
+ * on the document, so matching is a read-side concern.
+ *
+ * `project_id` is matched first and `document_id` is treated as a refinement,
+ * deliberately: regenerating a PRD or PR/FAQ mints a new `document_id`, so a
+ * link stored against the old id would silently detach and the evidence
+ * collected about that proposal would vanish from the page. Matching on the
+ * project keeps it visible.
+ *
+ * A form pinned to a document that still exists is NOT shown on that document's
+ * siblings, though — otherwise a PR/FAQ's ratings would also appear on the PRD
+ * row of the same project. The project-level fallback applies only to forms
+ * whose stored `document_id` is empty (a deliberate project-wide link) or no
+ * longer names a live document (the regenerated case).
+ *
+ * @module pages/Prioritization/formLinkUtils
+ */
+
+import { z } from 'zod'
+import type {
+  Project, ProjectDetail,
+} from '../../api/types'
+
+/** The row identity this module matches against. */
+export interface DocumentRowIdentity {
+  readonly project_id: string
+  readonly document_id: string
+}
+
+/**
+ * The three fields this page reads off a feedback form, validated at the query
+ * boundary the same way `pages/FeedbackForms/formSchema.ts` validates the full
+ * record.
+ *
+ * A narrow schema rather than a reuse of `FeedbackFormSchema`, for two reasons:
+ * this page needs identity plus the link and nothing else, and importing the
+ * full schema would pull `formTemplates` (and its icon imports) into the
+ * prioritization chunk for defaults it never renders.
+ *
+ * Lenient in the same spirit: every field degrades to '' rather than rejecting
+ * the record, because stored forms predate the link fields and a form that
+ * fails to normalize should read as "not linked", never crash the page. A form
+ * without a usable `form_id` IS dropped — it feeds the `['form-stats', form_id]`
+ * query key, so an invented identity would collide across records.
+ */
+const LinkedFormSchema = z.looseObject({
+  form_id: z.string().min(1),
+  name: z.string().catch(''),
+  project_id: z.string().catch(''),
+  document_id: z.string().catch(''),
+})
+
+/** The shape `selectLinkedForms` needs — structurally a subset of FeedbackForm. */
+export type LinkedForm = z.infer<typeof LinkedFormSchema>
+
+/**
+ * Normalize the wire's form list down to the link fields, dropping records
+ * without a usable identity.
+ */
+export function normalizeLinkedForms(rawForms: readonly unknown[]): LinkedForm[] {
+  return rawForms.flatMap((raw) => {
+    const parsed = LinkedFormSchema.safeParse(raw)
+    return parsed.success ? [parsed.data] : []
+  })
+}
+
+/** The subset of a project detail response this module reads. */
+type DetailWithDocuments = Pick<Partial<ProjectDetail>, 'documents'>
+
+/**
+ * Live document ids per project, keyed by `project_id`.
+ *
+ * Needed to tell a project-wide link apart from a stale one: a form pointing at
+ * a document that is still present belongs to that document alone, while a form
+ * pointing at a document that is gone (regenerated) falls back to the project.
+ * Details are aligned with `projects` by index, the same way `collectPRFAQs`
+ * aligns them.
+ */
+export function collectProjectDocumentIds(
+  allProjectDetails: readonly DetailWithDocuments[] | undefined,
+  projects: readonly Project[] | undefined,
+): Map<string, Set<string>> {
+  const byProject = new Map<string, Set<string>>()
+  if (!allProjectDetails || !projects) return byProject
+  for (const [index, detail] of allProjectDetails.entries()) {
+    const project = projects[index]
+    if (!project) continue
+    byProject.set(project.project_id, new Set((detail.documents ?? []).map((doc) => doc.document_id)))
+  }
+  return byProject
+}
+
+/**
+ * The feedback forms whose collected ratings are evidence about this row.
+ *
+ * Returns every exact `document_id` match when there is one — several forms can
+ * validate the same document — and otherwise the project's forms that are not
+ * pinned to some other live document. A form with no `project_id` never matches
+ * any row, which is what keeps standalone website surveys off this page.
+ *
+ * @param liveDocumentIds document ids currently present in the row's project;
+ *   `undefined` while the project detail is still loading, in which case no
+ *   link is treated as stale.
+ */
+export function selectLinkedForms(
+  forms: readonly LinkedForm[],
+  row: DocumentRowIdentity,
+  liveDocumentIds?: ReadonlySet<string>,
+): LinkedForm[] {
+  if (row.project_id === '') return []
+  const projectForms = forms.filter((form) => form.project_id === row.project_id)
+
+  const exact = projectForms.filter((form) => form.document_id === row.document_id)
+  if (exact.length > 0) return exact
+
+  return projectForms.filter((form) => {
+    const linkedDocumentId = form.document_id
+    // Project-wide link, or a link to a document that no longer exists
+    // (regenerated): both are evidence about this project's proposal.
+    return linkedDocumentId === '' || !(liveDocumentIds?.has(linkedDocumentId) ?? false)
+  })
+}
+
+/**
+ * The linked forms for every row, keyed by `document_id`.
+ *
+ * Resolved for the whole list up front because it is pure bookkeeping over data
+ * already in hand — no request is made here. The expensive per-form stats read
+ * stays behind row expansion (see `LinkedFormEvidence`).
+ */
+export function buildLinkedFormsByDocument(
+  forms: readonly LinkedForm[],
+  rows: readonly DocumentRowIdentity[],
+  documentIdsByProject: ReadonlyMap<string, ReadonlySet<string>>,
+): Map<string, LinkedForm[]> {
+  const byDocument = new Map<string, LinkedForm[]>()
+  for (const row of rows) {
+    byDocument.set(
+      row.document_id,
+      selectLinkedForms(forms, row, documentIdsByProject.get(row.project_id)),
+    )
+  }
+  return byDocument
+}

--- a/voc-datalake/frontend/src/pages/Projects/Projects.tsx
+++ b/voc-datalake/frontend/src/pages/Projects/Projects.tsx
@@ -19,6 +19,7 @@ import {
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { projectsKey } from '../../api/projectQueryKeys'
 import { projectsApi } from '../../api/projectsApi'
 import ConfirmModal from '../../components/ConfirmModal'
 import { useConfigStore } from '../../store/configStore'
@@ -132,7 +133,7 @@ export default function Projects() {
   const {
     data, isLoading,
   } = useQuery({
-    queryKey: ['projects'],
+    queryKey: projectsKey(),
     queryFn: () => projectsApi.getProjects(),
     enabled: config.apiEndpoint.length > 0,
   })
@@ -143,7 +144,7 @@ export default function Projects() {
       description: string
     }) => projectsApi.createProject(projectData),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['projects'] })
+      void queryClient.invalidateQueries({ queryKey: projectsKey() })
       setShowCreate(false)
       setNewProject({
         name: '',
@@ -155,7 +156,7 @@ export default function Projects() {
   const deleteMutation = useMutation({
     mutationFn: (id: string) => projectsApi.deleteProject(id),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['projects'] })
+      void queryClient.invalidateQueries({ queryKey: projectsKey() })
     },
   })
 

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -117,7 +117,13 @@ def validate_link_fields(body: dict) -> None:
 
 
 def build_form_item(body: dict, form_id: str | None = None) -> dict:
-    """Build DynamoDB item from request body with defaults."""
+    """Build DynamoDB item from request body with defaults.
+
+    Validates the link fields here rather than leaving it to the caller: this is
+    the only way a new record is constructed, so a future second caller cannot
+    reach the table with an unvalidated link by forgetting a line.
+    """
+    validate_link_fields(body)
     now = datetime.now(timezone.utc).isoformat()
     fid = form_id or str(uuid.uuid4())[:8]
     
@@ -276,7 +282,7 @@ def list_forms():
 def create_form():
     """Create a new feedback form."""
     body = app.current_event.json_body or {}
-    validate_link_fields(body)
+    # Link fields are validated inside build_form_item, structurally.
     item = build_form_item(body)
     
     try:

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -62,6 +62,14 @@ DEFAULT_FORM_CONFIG = {
     'custom_fields': [],
     'category': '',
     'subcategory': '',
+    # Optional link to the artefact this form validates (issue: prioritization
+    # evidence). Empty string means "validates nothing in particular" — the
+    # standalone website-survey case, which must keep behaving exactly as it
+    # did before these fields existed. `project_id` is the durable half of the
+    # link: regenerating a document mints a new document_id, so readers match
+    # on project first and treat document_id as a refinement.
+    'project_id': '',
+    'document_id': '',
 }
 
 # Fields that can be updated via PUT
@@ -69,7 +77,7 @@ UPDATABLE_FIELDS = [
     'name', 'enabled', 'title', 'description', 'question', 'placeholder',
     'rating_enabled', 'rating_type', 'rating_max', 'submit_button_text',
     'success_message', 'theme', 'collect_email', 'collect_name',
-    'custom_fields', 'category', 'subcategory'
+    'custom_fields', 'category', 'subcategory', 'project_id', 'document_id'
 ]
 
 
@@ -115,9 +123,44 @@ def item_to_form(item: dict) -> dict:
         'custom_fields': item.get('custom_fields', []),
         'category': item.get('category', ''),
         'subcategory': item.get('subcategory', ''),
+        # Optional validation link — authenticated callers only. Deliberately
+        # absent from item_to_widget_config below.
+        'project_id': item.get('project_id', ''),
+        'document_id': item.get('document_id', ''),
         'brand_name': item.get('brand_name', ''),
         'created_at': item.get('created_at', ''),
         'updated_at': item.get('updated_at', ''),
+    }
+
+
+def item_to_widget_config(item: dict) -> dict:
+    """Convert DynamoDB item to the PUBLIC widget config response.
+
+    Deliberately a separate, narrower projection from `item_to_form` rather
+    than "item_to_form minus a few keys": `GET /feedback-forms/<id>/config` is
+    unauthenticated and fetched by the widget from the customer's own website,
+    so every field here is one someone chose to publish. Adding a field to
+    `item_to_form` must not leak it; it has to be added here too, on purpose.
+
+    Mirrors `FeedbackFormConfig` in frontend/src/api/types.ts — the rendering
+    fields the widget reads plus `enabled` and `brand_name`.
+    """
+    return {
+        'enabled': item.get('enabled', False),
+        'title': item.get('title', ''),
+        'description': item.get('description', ''),
+        'question': item.get('question', ''),
+        'placeholder': item.get('placeholder', ''),
+        'rating_enabled': item.get('rating_enabled', True),
+        'rating_type': item.get('rating_type', 'stars'),
+        'rating_max': int(item.get('rating_max', 5)),
+        'submit_button_text': item.get('submit_button_text', ''),
+        'success_message': item.get('success_message', ''),
+        'theme': item.get('theme', {}),
+        'collect_email': item.get('collect_email', False),
+        'collect_name': item.get('collect_name', False),
+        'custom_fields': item.get('custom_fields', []),
+        'brand_name': item.get('brand_name', ''),
     }
 
 
@@ -299,8 +342,9 @@ def get_form_config_by_id(form_id: str):
         
         if not item:
             raise NotFoundError('Form not found')
-        
-        return {'success': True, 'config': item_to_form(item)}
+
+        # Narrower projection than item_to_form on purpose: this route is public.
+        return {'success': True, 'config': item_to_widget_config(item)}
     except NotFoundError:
         raise
     except Exception as e:

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -81,6 +81,41 @@ UPDATABLE_FIELDS = [
 ]
 
 
+# The link fields hold server-minted identifiers (`proj_20260101120000`,
+# `prfaq_...`), so anything long is not one. A cap keeps a client from writing an
+# arbitrarily large blob into an attribute the Prioritization page then reads
+# back, and keeps the item within DynamoDB's 400 KB limit for reasons a caller
+# cannot argue with.
+LINK_FIELD_MAX_LENGTH = 128
+
+# Fields whose value is an identifier the API mints, not free text the caller
+# composes. Validated on the way in — see validate_link_fields.
+LINK_FIELDS = ('project_id', 'document_id')
+
+
+def validate_link_fields(body: dict) -> None:
+    """Reject a malformed project_id / document_id before it is persisted.
+
+    These two are the only writable fields whose values another surface later
+    matches on (Prioritization pairs a form to a document by them), so a
+    non-string — a dict, a list, a number — would be stored verbatim and then
+    silently match nothing. Failing the request says so instead.
+
+    Absent is always fine: the link is optional, and '' is how "validates
+    nothing" is spelled.
+    """
+    for field in LINK_FIELDS:
+        if field not in body:
+            continue
+        value = body[field]
+        if not isinstance(value, str):
+            raise ValidationError(f'{field} must be a string')
+        if len(value) > LINK_FIELD_MAX_LENGTH:
+            raise ValidationError(
+                f'{field} must be at most {LINK_FIELD_MAX_LENGTH} characters'
+            )
+
+
 def build_form_item(body: dict, form_id: str | None = None) -> dict:
     """Build DynamoDB item from request body with defaults."""
     now = datetime.now(timezone.utc).isoformat()
@@ -241,6 +276,7 @@ def list_forms():
 def create_form():
     """Create a new feedback form."""
     body = app.current_event.json_body or {}
+    validate_link_fields(body)
     item = build_form_item(body)
     
     try:
@@ -278,6 +314,7 @@ def get_form(form_id: str):
 def update_form(form_id: str):
     """Update a feedback form."""
     body = app.current_event.json_body or {}
+    validate_link_fields(body)
     now = datetime.now(timezone.utc).isoformat()
     
     # Build update expression dynamically

--- a/voc-datalake/lambda/api/test/conftest.py
+++ b/voc-datalake/lambda/api/test/conftest.py
@@ -32,6 +32,20 @@ os.environ['USER_POOL_ID'] = 'us-east-1_testpool'
 
 
 @pytest.fixture
+def feedback_form_handler():
+    """The imported `feedback_form_handler` module.
+
+    `sys.path` already carries `lambda/api` (set at the top of this file), so the
+    import needs no per-test path juggling. A fixture rather than a module-level
+    import so that a test importing it is still what triggers the import, and a
+    handler that cannot be imported fails the tests that use it rather than
+    collection of the whole file.
+    """
+    import feedback_form_handler
+    return feedback_form_handler
+
+
+@pytest.fixture
 def mock_dynamodb_table():
     """Create a mock DynamoDB table with common methods."""
     table = MagicMock()

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2,7 +2,33 @@
 Tests for feedback_form_handler.py - /feedback-forms/* endpoints.
 """
 import json
+import re
+from pathlib import Path
 from unittest.mock import patch
+
+WIDGET_SOURCE = Path(__file__).resolve().parents[1] / 'static' / 'feedback-widget.js'
+
+# How the widget reaches its config: `config.x` in the fetch callback,
+# `this.config.x`, and `c.x` after `var c = this.config`.
+_WIDGET_CONFIG_READ = re.compile(r'(?:this\.config|\bconfig|\bc)\.([a-z_]+)')
+
+
+def _fields_the_widget_reads() -> set[str]:
+    """Config field names read by static/feedback-widget.js, read off the widget.
+
+    Derived rather than hand-listed. The list this replaced had already drifted:
+    it claimed the widget reads `custom_fields`, which appears nowhere in the
+    widget, so it asserted a dependency that does not exist while a genuinely new
+    read would have gone unnoticed.
+
+    Errs wide, which is the safe direction: if `c` is ever aliased to something
+    other than the config this over-collects and the assertion fails loudly
+    instead of quietly passing.
+    """
+    source = WIDGET_SOURCE.read_text(encoding='utf-8')
+    fields = set(_WIDGET_CONFIG_READ.findall(source))
+    assert fields, f'found no config reads in {WIDGET_SOURCE.name} — did it move?'
+    return fields
 
 
 class TestListForms:
@@ -680,13 +706,12 @@ class TestPublicConfigDoesNotLeakTheLink:
 
         body = json.loads(feedback_form_handler.lambda_handler(event, lambda_context)['body'])
 
-        # Field names read by lambda/api/static/feedback-widget.js.
-        for field in (
-            'enabled', 'title', 'description', 'question', 'rating_enabled',
-            'rating_type', 'rating_max', 'placeholder', 'collect_name',
-            'collect_email', 'success_message', 'theme', 'custom_fields',
-        ):
-            assert field in body['config'], f'widget reads config.{field}'
+        read_by_widget = _fields_the_widget_reads()
+        missing = sorted(read_by_widget - set(body['config']))
+        assert not missing, (
+            f'the widget reads config.{missing} but the public projection no '
+            'longer serves it.'
+        )
 
 
 class TestValidationLinkBoundary:
@@ -789,6 +814,19 @@ class TestValidationLinkBoundary:
         invariant is asserted over the actual tuples rather than left to review.
         """
         link_fields = set(feedback_form_handler.LINK_FIELDS)
+        updatable = set(feedback_form_handler.UPDATABLE_FIELDS)
 
-        assert link_fields <= set(feedback_form_handler.UPDATABLE_FIELDS)
+        assert link_fields <= updatable
         assert link_fields <= set(feedback_form_handler.DEFAULT_FORM_CONFIG)
+
+        # The direction the docstring is about, and the one the two assertions
+        # above do NOT cover: a writable identifier that nobody validates. Keyed
+        # off the `_id` suffix, because being an identifier another surface
+        # matches on is exactly what earns a field validation here; a writable
+        # free-text field is out of scope and stays out.
+        writable_identifiers = {field for field in updatable if field.endswith('_id')}
+        assert writable_identifiers <= link_fields, (
+            f'{sorted(writable_identifiers - link_fields)} can be written by a '
+            'PUT but is absent from LINK_FIELDS, so validate_link_fields never '
+            'sees it.'
+        )

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -467,3 +467,263 @@ class TestItemToForm:
         assert result['rating_enabled'] is True
         assert result['rating_max'] == 5
         assert result['theme'] == {}
+
+
+class TestValidationLink:
+    """Tests for the optional project_id / document_id validation link.
+
+    A feedback form may record which project — and, as a refinement, which
+    document — it validates, so the Prioritization page can show the ratings
+    collected about the artefact being scored. Both fields are optional: a
+    standalone website survey stores neither and must behave exactly as it
+    did before they existed.
+    """
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_create_persists_and_returns_the_link(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """A create request carrying the link persists it and echoes it back.
+
+        Asserts on the *persisted item*, not only the response: the two are
+        built by different code paths (DEFAULT_FORM_CONFIG seeding vs. the
+        item_to_form allowlist), and a field declared in only one of them is
+        silently dropped on the next read.
+        """
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={
+                'name': 'PR/FAQ validation',
+                'project_id': 'proj-1',
+                'document_id': 'doc-9',
+            },
+        )
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert body['form']['project_id'] == 'proj-1'
+        assert body['form']['document_id'] == 'doc-9'
+
+        stored_item = mock_table.put_item.call_args.kwargs['Item']
+        assert stored_item['project_id'] == 'proj-1'
+        assert stored_item['document_id'] == 'doc-9'
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_create_without_the_link_stores_empty_strings(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """A form that validates nothing keeps working: link fields default empty."""
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST', path='/feedback-forms', body={'name': 'Website Footer Form'}
+        )
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert body['form']['project_id'] == ''
+        assert body['form']['document_id'] == ''
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_get_returns_a_stored_link(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """A stored link is readable back through the authenticated get route."""
+        mock_table.get_item.return_value = {
+            'Item': {
+                'form_id': 'form-123',
+                'name': 'Test Form',
+                'enabled': True,
+                'project_id': 'proj-1',
+                'document_id': 'doc-9',
+            }
+        }
+
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert body['form']['project_id'] == 'proj-1'
+        assert body['form']['document_id'] == 'doc-9'
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_update_writes_the_link(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """PUT accepts the link fields — they are in UPDATABLE_FIELDS."""
+        mock_table.update_item.return_value = {
+            'Attributes': {
+                'form_id': 'form-123',
+                'name': 'Test Form',
+                'project_id': 'proj-2',
+                'document_id': 'doc-7',
+            }
+        }
+
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/form-123',
+            path_params={'form_id': 'form-123'},
+            body={'project_id': 'proj-2', 'document_id': 'doc-7'},
+        )
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert body['form']['project_id'] == 'proj-2'
+        expr_values = mock_table.update_item.call_args.kwargs['ExpressionAttributeValues']
+        assert expr_values[':project_id'] == 'proj-2'
+        assert expr_values[':document_id'] == 'doc-7'
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_update_can_clear_the_link(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """Clearing the link (empty strings) reaches DynamoDB rather than being
+        dropped as falsy — an admin must be able to unlink a form."""
+        mock_table.update_item.return_value = {
+            'Attributes': {'form_id': 'form-123', 'project_id': '', 'document_id': ''}
+        }
+
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/form-123',
+            path_params={'form_id': 'form-123'},
+            body={'project_id': '', 'document_id': ''},
+        )
+
+        lambda_handler(event, lambda_context)
+
+        expr_values = mock_table.update_item.call_args.kwargs['ExpressionAttributeValues']
+        assert expr_values[':project_id'] == ''
+        assert expr_values[':document_id'] == ''
+
+    def test_item_to_form_declares_every_default_config_field(self):
+        """Every DEFAULT_FORM_CONFIG field must also be in the item_to_form
+        allowlist. build_form_item seeds the record from that dict and
+        item_to_form projects it on read, so a field in one and not the other
+        persists but is never returned (or vice versa)."""
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import DEFAULT_FORM_CONFIG, UPDATABLE_FIELDS, item_to_form
+
+        projected = set(item_to_form({}))
+
+        assert set(DEFAULT_FORM_CONFIG) <= projected
+        assert set(UPDATABLE_FIELDS) <= projected
+
+
+class TestPublicConfigDoesNotLeakTheLink:
+    """The widget config route is UNAUTHENTICATED and fetched cross-origin from
+    customers' own websites (lambda/api/static/feedback-widget.js). Internal
+    identifiers for the project and document a form validates must never appear
+    in it. This is the security-relevant assertion for this change."""
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_public_config_omits_project_and_document_ids(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """GET /feedback-forms/<id>/config must not expose the link fields."""
+        mock_table.get_item.return_value = {
+            'Item': {
+                'form_id': 'form-123',
+                'name': 'Internal name',
+                'enabled': True,
+                'title': 'Rate this concept',
+                'project_id': 'proj-secret',
+                'document_id': 'doc-secret',
+            }
+        }
+
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/config',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        config = body['config']
+        assert 'project_id' not in config
+        assert 'document_id' not in config
+        # Not merely absent-by-name: the values must not appear anywhere in the
+        # serialized public payload under any other key either.
+        assert 'proj-secret' not in response['body']
+        assert 'doc-secret' not in response['body']
+        # And the fields the widget actually renders are still served.
+        assert config['enabled'] is True
+        assert config['title'] == 'Rate this concept'
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_public_config_serves_every_field_the_widget_reads(
+        self, mock_table, api_gateway_event, lambda_context
+    ):
+        """The narrower public projection must not have dropped a field the
+        embedded widget depends on."""
+        mock_table.get_item.return_value = {
+            'Item': {
+                'form_id': 'form-123',
+                'enabled': True,
+                'theme': {'primary_color': '#3B82F6'},
+                'rating_max': 5,
+            }
+        }
+
+        import sys
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from feedback_form_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/config',
+            path_params={'form_id': 'form-123'},
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        # Field names read by lambda/api/static/feedback-widget.js.
+        for field in (
+            'enabled', 'title', 'description', 'question', 'rating_enabled',
+            'rating_type', 'rating_max', 'placeholder', 'collect_name',
+            'collect_email', 'success_message', 'theme', 'custom_fields',
+        ):
+            assert field in body['config'], f'widget reads config.{field}'

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -23,10 +23,21 @@ _WIDGET_CONFIG_READ = re.compile(r'(?:this\.config|\bconfig|\bc)\.([a-z_]+)\b')
 # letter, so the read pattern above is only safe while `c` means the config and
 # nothing else in this file.
 #
-# Deliberately captures the RHS instead of using `\bc\s*=\s*(?!this\.config)`:
-# `\s*` backtracks to zero width, which lets the negative lookahead land on the
-# space and succeed, so that spelling flags the one assignment it means to allow.
-_WIDGET_C_ASSIGNMENT = re.compile(r'\bc\s*=\s*([^;,\n]+)')
+# `(?<![.\w])` excludes a property named `c` (`foo.c = 1`) and `(?!=)` excludes a
+# comparison (`c === x`), either of which would otherwise be reported as a stray
+# alias — a failure with nothing to do with the projection under test.
+#
+# Captures the RHS instead of using `\bc\s*=\s*(?!this\.config)`: `\s*` backtracks
+# to zero width, which lets that negative lookahead land on the space and succeed,
+# so that spelling flags the one assignment it means to allow.
+_WIDGET_C_ASSIGNMENT = re.compile(r'(?<![.\w])c\s*=(?!=)\s*([^;,\n]+)')
+
+# Comments are stripped before scanning: a `config.x` inside a docblock is not a
+# read, and collecting it would fail the assertion below in the one direction that
+# tempts a reader to widen the public projection. Same approach as
+# `_interface_body` in test_widget_config_type_lockstep.py.
+_JS_BLOCK_COMMENT = re.compile(r'/\*[\s\S]*?\*/')
+_JS_LINE_COMMENT = re.compile(r'//[^\n]*')
 
 
 def _fields_the_widget_reads() -> set[str]:
@@ -44,7 +55,8 @@ def _fields_the_widget_reads() -> set[str]:
     to publish something on an unauthenticated route. The assumptions are
     therefore asserted rather than hoped for.
     """
-    source = WIDGET_SOURCE.read_text(encoding='utf-8')
+    raw = WIDGET_SOURCE.read_text(encoding='utf-8')
+    source = _JS_LINE_COMMENT.sub('', _JS_BLOCK_COMMENT.sub('', raw))
 
     # `c` must mean the config and nothing else, or `c.style` on a DOM node would
     # be collected as a config field.
@@ -851,7 +863,12 @@ class TestValidationLinkBoundary:
         # sys.path insert that makes `shared` importable lives in the fixture.
         validation_error = feedback_form_handler.ValidationError
 
-        for bad in ({'project_id': 123}, {'document_id': 'x' * 129}):
+        # Length derived from the cap, like the neighbouring tests: a hardcoded
+        # 129 would quietly become a VALID length the day the cap is raised, and
+        # this case would then assert nothing.
+        too_long = 'x' * (feedback_form_handler.LINK_FIELD_MAX_LENGTH + 1)
+
+        for bad in ({'project_id': 123}, {'document_id': too_long}):
             with pytest.raises(validation_error):
                 feedback_form_handler.build_form_item(bad)
 

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -6,11 +6,27 @@ import re
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 WIDGET_SOURCE = Path(__file__).resolve().parents[1] / 'static' / 'feedback-widget.js'
 
 # How the widget reaches its config: `config.x` in the fetch callback,
-# `this.config.x`, and `c.x` after `var c = this.config`.
-_WIDGET_CONFIG_READ = re.compile(r'(?:this\.config|\bconfig|\bc)\.([a-z_]+)')
+# `this.config.x`, and `c.x` after the `var c = this.config` alias.
+#
+# The trailing \b is load-bearing rather than tidy: without it a camelCase DOM
+# property (`c.appendChild`) matches partially and contributes a bogus field name
+# (`append`), which fails the assertion below for a reason that has nothing to do
+# with the projection. With it, such a property yields no match at all.
+_WIDGET_CONFIG_READ = re.compile(r'(?:this\.config|\bconfig|\bc)\.([a-z_]+)\b')
+
+# Every `c = ...` assignment, with its right-hand side captured. `c` is a single
+# letter, so the read pattern above is only safe while `c` means the config and
+# nothing else in this file.
+#
+# Deliberately captures the RHS instead of using `\bc\s*=\s*(?!this\.config)`:
+# `\s*` backtracks to zero width, which lets the negative lookahead land on the
+# space and succeed, so that spelling flags the one assignment it means to allow.
+_WIDGET_C_ASSIGNMENT = re.compile(r'\bc\s*=\s*([^;,\n]+)')
 
 
 def _fields_the_widget_reads() -> set[str]:
@@ -21,11 +37,29 @@ def _fields_the_widget_reads() -> set[str]:
     widget, so it asserted a dependency that does not exist while a genuinely new
     read would have gone unnoticed.
 
-    Errs wide, which is the safe direction: if `c` is ever aliased to something
-    other than the config this over-collects and the assertion fails loudly
-    instead of quietly passing.
+    Over-collecting is NOT harmless here, which is why the two assertions below
+    exist. The caller subtracts this set from the served payload, so a bogus name
+    fails the test — and the obvious way to "fix" a red test that names a field
+    the widget does not read is to add that field to the public projection, i.e.
+    to publish something on an unauthenticated route. The assumptions are
+    therefore asserted rather than hoped for.
     """
     source = WIDGET_SOURCE.read_text(encoding='utf-8')
+
+    # `c` must mean the config and nothing else, or `c.style` on a DOM node would
+    # be collected as a config field.
+    c_assignments = [rhs.strip() for rhs in _WIDGET_C_ASSIGNMENT.findall(source)]
+    assert c_assignments, (
+        f'{WIDGET_SOURCE.name} no longer aliases the config to `c` — the read '
+        'pattern below expects it. Update both together.'
+    )
+    stray = [rhs for rhs in c_assignments if rhs != 'this.config']
+    assert not stray, (
+        f'{WIDGET_SOURCE.name} assigns `c` to {stray}, not just this.config. '
+        'This derivation reads `c.<field>` as a config access, so that variable '
+        'would be collected as a field name; rename it or narrow the pattern.'
+    )
+
     fields = set(_WIDGET_CONFIG_READ.findall(source))
     assert fields, f'found no config reads in {WIDGET_SOURCE.name} — did it move?'
     return fields
@@ -805,6 +839,25 @@ class TestValidationLinkBoundary:
         response = feedback_form_handler.lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 200
+
+    def test_the_record_constructor_itself_rejects_a_bad_link(self, feedback_form_handler):
+        """Validation is structural, not a line the route remembers to call.
+
+        build_form_item is the only way a new record is constructed, so a future
+        second caller cannot reach the table with an unvalidated link by omitting
+        a call. Asserted against the function directly, with no route involved.
+        """
+        # Taken off the module under test rather than imported directly: the
+        # sys.path insert that makes `shared` importable lives in the fixture.
+        validation_error = feedback_form_handler.ValidationError
+
+        for bad in ({'project_id': 123}, {'document_id': 'x' * 129}):
+            with pytest.raises(validation_error):
+                feedback_form_handler.build_form_item(bad)
+
+        # And a link-free body still builds, so the guard cannot have become
+        # "reject everything".
+        assert feedback_form_handler.build_form_item({'name': 'ok'})['name'] == 'ok'
 
     def test_every_link_field_is_updatable_and_validated(self, feedback_form_handler):
         """The validated set must not drift from the writable set.

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -490,8 +490,8 @@ class TestValidationLink:
         item_to_form allowlist), and a field declared in only one of them is
         silently dropped on the next read.
         """
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 
@@ -520,8 +520,8 @@ class TestValidationLink:
         self, mock_table, api_gateway_event, lambda_context
     ):
         """A form that validates nothing keeps working: link fields default empty."""
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 
@@ -550,8 +550,8 @@ class TestValidationLink:
             }
         }
 
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 
@@ -581,8 +581,8 @@ class TestValidationLink:
             }
         }
 
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 
@@ -611,8 +611,8 @@ class TestValidationLink:
             'Attributes': {'form_id': 'form-123', 'project_id': '', 'document_id': ''}
         }
 
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 
@@ -634,10 +634,14 @@ class TestValidationLink:
         allowlist. build_form_item seeds the record from that dict and
         item_to_form projects it on read, so a field in one and not the other
         persists but is never returned (or vice versa)."""
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import DEFAULT_FORM_CONFIG, UPDATABLE_FIELDS, item_to_form
+        from feedback_form_handler import (
+            DEFAULT_FORM_CONFIG,
+            UPDATABLE_FIELDS,
+            item_to_form,
+        )
 
         projected = set(item_to_form({}))
 
@@ -667,8 +671,8 @@ class TestPublicConfigDoesNotLeakTheLink:
             }
         }
 
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 
@@ -707,8 +711,8 @@ class TestPublicConfigDoesNotLeakTheLink:
             }
         }
 
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         from feedback_form_handler import lambda_handler
 

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -32,12 +32,37 @@ _WIDGET_CONFIG_READ = re.compile(r'(?:this\.config|\bconfig|\bc)\.([a-z_]+)\b')
 # so that spelling flags the one assignment it means to allow.
 _WIDGET_C_ASSIGNMENT = re.compile(r'(?<![.\w])c\s*=(?!=)\s*([^;,\n]+)')
 
-# Comments are stripped before scanning: a `config.x` inside a docblock is not a
-# read, and collecting it would fail the assertion below in the one direction that
-# tempts a reader to widen the public projection. Same approach as
-# `_interface_body` in test_widget_config_type_lockstep.py.
-_JS_BLOCK_COMMENT = re.compile(r'/\*[\s\S]*?\*/')
-_JS_LINE_COMMENT = re.compile(r'//[^\n]*')
+def _widget_code_lines(source: str) -> list[str]:
+    """The widget's lines with comment-ONLY lines dropped, nothing rewritten.
+
+    Comments have to be excluded because a `config.x` inside a docblock is not a
+    read, and collecting it fails the assertion below in the direction that tempts
+    a reader to widen the public projection.
+
+    But this drops whole lines rather than substituting `//[^\\n]*` away, because
+    that pattern also matches inside a string literal — a `https://…` URL, a regex
+    literal — truncating the rest of that line and silently dropping any config
+    read after it. That is an UNDER-collection, i.e. fail-open in the opposite
+    direction: a field genuinely dropped from `item_to_widget_config` would stop
+    failing the test. Dropping only comment-only lines cannot truncate anything.
+
+    Residue, deliberately accepted: a trailing comment on a code line is kept, so a
+    `config.x` mentioned there is collected. That is the loud direction.
+    """
+    kept: list[str] = []
+    in_block = False
+    for line in source.split('\n'):
+        text = line.strip()
+        if in_block:
+            in_block = '*/' not in text
+            continue
+        if text.startswith('/*'):
+            in_block = '*/' not in text
+            continue
+        if text.startswith('//'):
+            continue
+        kept.append(line)
+    return kept
 
 
 def _fields_the_widget_reads() -> set[str]:
@@ -56,7 +81,15 @@ def _fields_the_widget_reads() -> set[str]:
     therefore asserted rather than hoped for.
     """
     raw = WIDGET_SOURCE.read_text(encoding='utf-8')
-    source = _JS_LINE_COMMENT.sub('', _JS_BLOCK_COMMENT.sub('', raw))
+    code_lines = _widget_code_lines(raw)
+    # Sanity bound on the line filter itself: an unterminated block comment would
+    # otherwise swallow the file and leave nothing to scan.
+    assert len(code_lines) > len(raw.split('\n')) // 2, (
+        f'comment filtering kept only {len(code_lines)} of '
+        f'{len(raw.split(chr(10)))} lines in {WIDGET_SOURCE.name} — an '
+        'unterminated block comment, or the file is now mostly prose.'
+    )
+    source = '\n'.join(code_lines)
 
     # `c` must mean the config and nothing else, or `c.style` on a DOM node would
     # be collected as a config field.

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -32,6 +32,7 @@ _WIDGET_CONFIG_READ = re.compile(r'(?:this\.config|\bconfig|\bc)\.([a-z_]+)\b')
 # so that spelling flags the one assignment it means to allow.
 _WIDGET_C_ASSIGNMENT = re.compile(r'(?<![.\w])c\s*=(?!=)\s*([^;,\n]+)')
 
+
 def _widget_code_lines(source: str) -> list[str]:
     """The widget's lines with comment-ONLY lines dropped, nothing rewritten.
 
@@ -44,10 +45,21 @@ def _widget_code_lines(source: str) -> list[str]:
     literal — truncating the rest of that line and silently dropping any config
     read after it. That is an UNDER-collection, i.e. fail-open in the opposite
     direction: a field genuinely dropped from `item_to_widget_config` would stop
-    failing the test. Dropping only comment-only lines cannot truncate anything.
+    failing the test.
 
-    Residue, deliberately accepted: a trailing comment on a code line is kept, so a
-    `config.x` mentioned there is collected. That is the loud direction.
+    Exactly what this does and does not handle, since a guard that overstates
+    itself is the thing being fixed here:
+
+    - Comment-only lines and block-comment bodies are dropped. Nothing is
+      rewritten, so no line is ever truncated mid-way.
+    - A trailing comment on a code line is KEPT, so a `config.x` mentioned there is
+      collected. Loud direction — it can only fail the test, never weaken it.
+    - `/* note */ config.foo` and `*/ config.foo` are dropped whole, because the
+      line starts with a comment token. That is still the quiet direction, just far
+      narrower than the substitution it replaced; the widget has no such line, and
+      the alternative is a tokenizer.
+    - A block opened mid-line (`init(); /* note`) is not detected, so its body
+      lines are kept and may over-collect. Loud direction again.
     """
     kept: list[str] = []
     in_block = False

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -481,7 +481,7 @@ class TestValidationLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_create_persists_and_returns_the_link(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """A create request carrying the link persists it and echoes it back.
 
@@ -490,11 +490,6 @@ class TestValidationLink:
         item_to_form allowlist), and a field declared in only one of them is
         silently dropped on the next read.
         """
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
-
         event = api_gateway_event(
             method='POST',
             path='/feedback-forms',
@@ -505,7 +500,7 @@ class TestValidationLink:
             },
         )
 
-        response = lambda_handler(event, lambda_context)
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
 
         assert body['form']['project_id'] == 'proj-1'
@@ -517,19 +512,14 @@ class TestValidationLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_create_without_the_link_stores_empty_strings(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """A form that validates nothing keeps working: link fields default empty."""
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
-
         event = api_gateway_event(
             method='POST', path='/feedback-forms', body={'name': 'Website Footer Form'}
         )
 
-        response = lambda_handler(event, lambda_context)
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
 
         assert body['form']['project_id'] == ''
@@ -537,7 +527,7 @@ class TestValidationLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_get_returns_a_stored_link(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """A stored link is readable back through the authenticated get route."""
         mock_table.get_item.return_value = {
@@ -550,18 +540,13 @@ class TestValidationLink:
             }
         }
 
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
-
         event = api_gateway_event(
             method='GET',
             path='/feedback-forms/form-123',
             path_params={'form_id': 'form-123'},
         )
 
-        response = lambda_handler(event, lambda_context)
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
 
         assert body['form']['project_id'] == 'proj-1'
@@ -569,7 +554,7 @@ class TestValidationLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_update_writes_the_link(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """PUT accepts the link fields — they are in UPDATABLE_FIELDS."""
         mock_table.update_item.return_value = {
@@ -581,11 +566,6 @@ class TestValidationLink:
             }
         }
 
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
-
         event = api_gateway_event(
             method='PUT',
             path='/feedback-forms/form-123',
@@ -593,7 +573,7 @@ class TestValidationLink:
             body={'project_id': 'proj-2', 'document_id': 'doc-7'},
         )
 
-        response = lambda_handler(event, lambda_context)
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
 
         assert body['form']['project_id'] == 'proj-2'
@@ -603,18 +583,13 @@ class TestValidationLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_update_can_clear_the_link(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """Clearing the link (empty strings) reaches DynamoDB rather than being
         dropped as falsy — an admin must be able to unlink a form."""
         mock_table.update_item.return_value = {
             'Attributes': {'form_id': 'form-123', 'project_id': '', 'document_id': ''}
         }
-
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
 
         event = api_gateway_event(
             method='PUT',
@@ -623,30 +598,21 @@ class TestValidationLink:
             body={'project_id': '', 'document_id': ''},
         )
 
-        lambda_handler(event, lambda_context)
+        feedback_form_handler.lambda_handler(event, lambda_context)
 
         expr_values = mock_table.update_item.call_args.kwargs['ExpressionAttributeValues']
         assert expr_values[':project_id'] == ''
         assert expr_values[':document_id'] == ''
 
-    def test_item_to_form_declares_every_default_config_field(self):
+    def test_item_to_form_declares_every_default_config_field(self, feedback_form_handler):
         """Every DEFAULT_FORM_CONFIG field must also be in the item_to_form
         allowlist. build_form_item seeds the record from that dict and
         item_to_form projects it on read, so a field in one and not the other
         persists but is never returned (or vice versa)."""
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import (
-            DEFAULT_FORM_CONFIG,
-            UPDATABLE_FIELDS,
-            item_to_form,
-        )
+        projected = set(feedback_form_handler.item_to_form({}))
 
-        projected = set(item_to_form({}))
-
-        assert set(DEFAULT_FORM_CONFIG) <= projected
-        assert set(UPDATABLE_FIELDS) <= projected
+        assert set(feedback_form_handler.DEFAULT_FORM_CONFIG) <= projected
+        assert set(feedback_form_handler.UPDATABLE_FIELDS) <= projected
 
 
 class TestPublicConfigDoesNotLeakTheLink:
@@ -657,7 +623,7 @@ class TestPublicConfigDoesNotLeakTheLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_public_config_omits_project_and_document_ids(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """GET /feedback-forms/<id>/config must not expose the link fields."""
         mock_table.get_item.return_value = {
@@ -671,18 +637,13 @@ class TestPublicConfigDoesNotLeakTheLink:
             }
         }
 
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
-
         event = api_gateway_event(
             method='GET',
             path='/feedback-forms/form-123/config',
             path_params={'form_id': 'form-123'},
         )
 
-        response = lambda_handler(event, lambda_context)
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
 
         config = body['config']
@@ -698,7 +659,7 @@ class TestPublicConfigDoesNotLeakTheLink:
 
     @patch('feedback_form_handler.aggregates_table')
     def test_public_config_serves_every_field_the_widget_reads(
-        self, mock_table, api_gateway_event, lambda_context
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
         """The narrower public projection must not have dropped a field the
         embedded widget depends on."""
@@ -711,18 +672,13 @@ class TestPublicConfigDoesNotLeakTheLink:
             }
         }
 
-        import os
-        import sys
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        from feedback_form_handler import lambda_handler
-
         event = api_gateway_event(
             method='GET',
             path='/feedback-forms/form-123/config',
             path_params={'form_id': 'form-123'},
         )
 
-        body = json.loads(lambda_handler(event, lambda_context)['body'])
+        body = json.loads(feedback_form_handler.lambda_handler(event, lambda_context)['body'])
 
         # Field names read by lambda/api/static/feedback-widget.js.
         for field in (
@@ -731,3 +687,108 @@ class TestPublicConfigDoesNotLeakTheLink:
             'collect_email', 'success_message', 'theme', 'custom_fields',
         ):
             assert field in body['config'], f'widget reads config.{field}'
+
+
+class TestValidationLinkBoundary:
+    """The link fields are writable, so they are validated on the way in.
+
+    They are the only writable fields whose values another surface later matches
+    on: the Prioritization page pairs a form to a document by them. A non-string
+    would be stored verbatim by DynamoDB and then silently match nothing, which
+    reads on the page as "this form collected no evidence" rather than as the
+    bad request it was.
+    """
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_create_rejects_a_non_string_project_id(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """A structured value is a client error, not something to persist."""
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'Bad form', 'project_id': {'nested': 'object'}},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        # Nothing may be written: rejecting after the put would leave the record
+        # behind and only fail the response.
+        mock_table.put_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_update_rejects_a_non_string_document_id(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """PUT is validated on the same path as POST."""
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/form-123',
+            path_params={'form_id': 'form-123'},
+            body={'document_id': ['doc-1', 'doc-2']},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        mock_table.update_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_create_rejects_an_over_long_link_field(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The values are server-minted identifiers, so anything long is not one."""
+        too_long = 'p' * (feedback_form_handler.LINK_FIELD_MAX_LENGTH + 1)
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'Bad form', 'project_id': too_long},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        mock_table.put_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_accepts_a_link_at_the_length_limit(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The cap is inclusive — an id exactly at the limit is still valid."""
+        at_limit = 'p' * feedback_form_handler.LINK_FIELD_MAX_LENGTH
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'Edge form', 'project_id': at_limit},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_table.put_item.call_args.kwargs['Item']['project_id'] == at_limit
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_request_without_the_link_is_untouched_by_validation(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """Absent is always valid: the link is optional and must stay so."""
+        event = api_gateway_event(
+            method='POST', path='/feedback-forms', body={'name': 'Website Footer Form'}
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+
+    def test_every_link_field_is_updatable_and_validated(self, feedback_form_handler):
+        """The validated set must not drift from the writable set.
+
+        A link field added to UPDATABLE_FIELDS but not to LINK_FIELDS would be
+        writable without validation — the exact gap this class closes — so the
+        invariant is asserted over the actual tuples rather than left to review.
+        """
+        link_fields = set(feedback_form_handler.LINK_FIELDS)
+
+        assert link_fields <= set(feedback_form_handler.UPDATABLE_FIELDS)
+        assert link_fields <= set(feedback_form_handler.DEFAULT_FORM_CONFIG)

--- a/voc-datalake/lambda/api/test/test_widget_config_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_widget_config_type_lockstep.py
@@ -61,12 +61,30 @@ def _declared_config_fields() -> set[str]:
 
     fields: set[str] = set()
     for name in ('FeedbackFormConfig', 'FeedbackFormFields'):
+        declared_here = set()
         for line in _interface_body(source, name).split('\n'):
             # Top-level members are indented exactly two spaces; anything deeper
             # belongs to a nested object literal.
-            match = re.fullmatch(r'  (\w+)\??:.*', line.rstrip())
+            #
+            # `readonly` is matched explicitly rather than left out: a member the
+            # pattern fails to recognise drops out of `declared`, and in the
+            # "declared but not served" direction that makes the comparison below
+            # PASS — i.e. the extractor fails OPEN on exactly one of the two
+            # drifts this test exists to catch. (Proven by probe: marking one
+            # served member `readonly` and removing it from the dict passed.)
+            match = re.fullmatch(r'  (?:readonly )?(\w+)\??:.*', line.rstrip())
             if match:
-                fields.add(match.group(1))
+                declared_here.add(match.group(1))
+        # An empty result means the extractor stopped recognising members — a
+        # reformat, a modifier it does not know — not that the interface is
+        # empty. Left unchecked that also fails open, silently.
+        assert declared_here, (
+            f'extracted no members from interface {name} in {TYPES_SOURCE}. '
+            'The declaration was probably reformatted, or a member modifier '
+            'this parser does not handle was introduced. Fix the pattern — an '
+            'empty set would make the comparison below vacuous.'
+        )
+        fields |= declared_here
     return fields
 
 
@@ -84,7 +102,11 @@ class TestWidgetConfigTypeLockstep:
             'The first publishes a field on an UNAUTHENTICATED route that no '
             'reviewer of types.ts saw; the second makes the frontend read '
             'undefined from a field the compiler swears exists. Change both, or '
-            'neither.'
+            'neither.\n'
+            f'If neither list looks wrong, {TYPES_SOURCE} was probably '
+            'reformatted: this assertion reads the TypeScript declaration as '
+            'text, so a member reflowed onto a continuation line or given a '
+            'modifier stops being recognised.'
         )
 
     def test_the_link_fields_are_in_neither(self, feedback_form_handler):

--- a/voc-datalake/lambda/api/test/test_widget_config_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_widget_config_type_lockstep.py
@@ -1,0 +1,97 @@
+"""`item_to_widget_config` and `FeedbackFormConfig` must describe the same body.
+
+`GET /feedback-forms/<id>/config` is registered without `authMethodOptions`
+(`lib/stacks/api-stack.ts`, "Intentionally unauthenticated: the widget runs on
+the customer's own site") and is fetched cross-origin by the embedded widget. It
+is served by its own narrow allowlist, `item_to_widget_config`, rather than the
+`item_to_form` projection the authenticated routes use — deliberately, so that a
+field added to `item_to_form` cannot leak by default.
+
+That split creates two ways to drift, in opposite directions and both silent:
+
+- A field declared on `FeedbackFormConfig` but absent from the dict is a lie the
+  compiler believes. The frontend reads `config.x`, gets `undefined`, and TypeScript
+  never says so.
+- A field added to the dict but not to the type publishes something on an
+  unauthenticated route that no reviewer of `types.ts` ever saw.
+
+Neither language can see the other, so this test reads the TypeScript
+declaration directly — the same lockstep approach as
+`test_feedback_page_limit_lockstep.py`.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    # lambda/api/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+TYPES_SOURCE = 'frontend/src/api/types.ts'
+
+
+def _interface_body(source: str, name: str) -> str:
+    """The body of one `interface X { ... }` declaration, comments stripped."""
+    start = source.find(f'interface {name} ')
+    assert start != -1, f'interface {name} not found in {TYPES_SOURCE} — renamed?'
+    open_brace = source.index('{', start)
+    close = source.index('\n}', open_brace)
+    body = source[open_brace:close]
+    body = re.sub(r'/\*[\s\S]*?\*/', '', body)
+    return re.sub(r'//[^\n]*', '', body)
+
+
+def _declared_config_fields() -> set[str]:
+    """Field names on `FeedbackFormConfig`, including its inherited base.
+
+    Only top-level members count: a nested object's own keys (`theme`'s colours,
+    `custom_fields`' entries) are not fields of the response body.
+    """
+    path = _repo_root() / TYPES_SOURCE
+    if not path.is_file():
+        # A backend test reaching into the frontend tree. Where only the lambda
+        # sources are present (packaging, a partial checkout) there is nothing
+        # to compare, and skipping beats a failure that says nothing about the
+        # code under test.
+        pytest.skip(f'{TYPES_SOURCE} not present in this tree')
+    source = path.read_text(encoding='utf-8')
+
+    fields: set[str] = set()
+    for name in ('FeedbackFormConfig', 'FeedbackFormFields'):
+        for line in _interface_body(source, name).split('\n'):
+            # Top-level members are indented exactly two spaces; anything deeper
+            # belongs to a nested object literal.
+            match = re.fullmatch(r'  (\w+)\??:.*', line.rstrip())
+            if match:
+                fields.add(match.group(1))
+    return fields
+
+
+class TestWidgetConfigTypeLockstep:
+    def test_public_projection_matches_the_declared_type_exactly(
+        self, feedback_form_handler
+    ):
+        served = set(feedback_form_handler.item_to_widget_config({}))
+        declared = _declared_config_fields()
+
+        assert served == declared, (
+            'item_to_widget_config and FeedbackFormConfig have drifted.\n'
+            f'  served but not declared: {sorted(served - declared)}\n'
+            f'  declared but not served: {sorted(declared - served)}\n'
+            'The first publishes a field on an UNAUTHENTICATED route that no '
+            'reviewer of types.ts saw; the second makes the frontend read '
+            'undefined from a field the compiler swears exists. Change both, or '
+            'neither.'
+        )
+
+    def test_the_link_fields_are_in_neither(self, feedback_form_handler):
+        """The reason the split exists, asserted from both sides at once."""
+        served = set(feedback_form_handler.item_to_widget_config({}))
+        declared = _declared_config_fields()
+
+        for field in ('project_id', 'document_id'):
+            assert field not in served, f'{field} must not be served publicly'
+            assert field not in declared, f'{field} must not be declared public'


### PR DESCRIPTION
## Summary

Feedback forms collected evidence about a proposal and the Prioritization page decided what to do about it, with nothing connecting them: `feedback_form_handler.py` had no notion of a project, and `Prioritization.tsx` never called a feedback-form endpoint. A reviewer set Impact / Time to Market / Strategic Fit / Confidence with the document and the prototype in view, and no access to the ratings collected about that same document.

A feedback form can now optionally record **which project — and, as a refinement, which PRD or PR/FAQ — it validates**, and expanding that document's row on Prioritization shows the linked form's submission count and average rating next to the sliders.

- **Backend** (`lambda/api/feedback_form_handler.py`): `project_id` / `document_id` added to `DEFAULT_FORM_CONFIG`, `UPDATABLE_FIELDS` and `item_to_form` — all three, since a field in only one of them silently fails to persist or to read back.
- **Public widget route gets its own projection.** `get_form_config_by_id` served `item_to_form(item)`, the same shape the authenticated routes use, on an **unauthenticated** route fetched cross-origin from customers' own sites. It now returns a new, deliberately narrower `item_to_widget_config` — so the next field added to `item_to_form` cannot leak by default either. Routing and authorization are untouched.
- **Frontend types**: the fields go on `FeedbackForm` only, never on the shared `FeedbackFormFields` base that `FeedbackFormConfig` (the widget shape) extends. A test asserts that boundary over the declaration text.
- **Editor**: a new "Validates" tab (`ValidationLinkPicker.tsx`) picks the project and document and clears either. Only scorable document types (`prd`, `prfaq`) are offered; a link to a document that no longer exists is preserved rather than silently cleared on Save.
- **Prioritization**: `formLinkUtils.ts` matches a row to its forms — `project_id` first, `document_id` as a refinement, so a **regenerated document** (which mints a new id) still shows its project's evidence, while a form pinned to a *live* sibling document does not bleed onto other rows. `LinkedFormEvidence.tsx` renders the stats.
- Eight locale catalogues updated, keys inserted in sorted position (no whole-file re-serialization), no `{{count}}` interpolation on new keys.
- Mock-server fixtures gained the link so this is exercisable with `npm run mock`.

### Decisions made where the task was open

- **Cost.** The stats panel is mounted only inside the expanded row, so mounting it *is* the trigger; a page of 40 rows makes zero stats calls until a reviewer opens one. It reuses `FormCard`'s existing `['form-stats', form_id]` key and 30s `staleTime`, so a row opened after visiting Feedback Forms is free. The `/feedback-forms` **list** read (one cheap call) does happen on load — that is only how rows learn *which* form to ask about; no per-row request is made from it. No index, no new endpoint, no batched endpoint.
- **`document_id` empty vs. stale.** Both fall back to the project, but a form pinned to a document that *still exists* is shown on that document alone — otherwise a PR/FAQ's ratings would also appear on the PRD row of the same project.
- **A narrow Zod schema on the Prioritization side** (`normalizeLinkedForms`) rather than reusing `FeedbackFormSchema`: this page needs identity plus the link, and importing the full schema would pull `formTemplates` and its icon imports into the prioritization chunk for defaults it never renders.
- `frontend/src/api/client.ts` is **not touched** (another PR owns it); nor are `lib/stacks/api-stack.ts` or its test.

## Build and test results

Run from the repo root / `voc-datalake` / `voc-datalake/frontend` as the steering docs specify.

| Command | Result |
|---|---|
| `npm run build` (`tsc -b && vite build`) | ✅ pass — see build note below |
| `npm run lint` (eslint, `--max-warnings 0`) | ✅ pass, 0 problems |
| `npm run typecheck` (`tsc -b --noEmit`) | ✅ pass |
| `npm run typecheck:tests` | ⚠️ 77 errors — **byte-identical to baseline** (diffed); none in files this PR adds or changes |
| `npm run i18n:check` | ⚠️ non-zero — **totals identical to baseline** (`missing 0 / extra 12 / empty 0 / untranslated 7`), and **636 unreferenced keys, unchanged**: the two keys added since are both referenced. Every reported entry is in `categories.json` or `prioritization.json`, neither of which this diff touches |
| `npm test` (vitest, frontend) | ✅ **2199 passed / 146 files** (was 2148 on `development`). The `RouteErrorBoundary.test.tsx` failure noted earlier did not reproduce in the latest runs. |
| `npm run test:cdk` | ✅ **158 passed**, including the "only the three embeddable-widget routes are unauthenticated" invariant — unchanged |
| `pytest lambda/api` | ✅ **478 passed** (33 in `test_feedback_form_handler.py`, up from 15, plus 2 lockstep tests) |
| `ruff check` on the changed Python files | ✅ **15 `I001`, exactly the baseline count** on the same files at the original head; zero new diagnostics |

Pre-existing failures NOT caused by this PR, for the record: `npm run lint`'s `lint:python` step reports 552 ruff errors repo-wide, and `pytest` over the whole tree cannot collect four plugin test modules (`tenacity`, `bs4`, `app_store_web_scraper` are not installed by `requirements-dev.txt`). `lambda/shared/test/test_http.py` has 14 failures from a missing `shared.http_utils`. All reproduce on `development`.

**Build note:** `vite build` fails intermittently in this container with `Rollup failed to resolve import "<some dependency>"`, naming a *different* dependency each run (`date-fns`, then `react-markdown`, then `amazon-cognito-identity-js`) — a file-descriptor/concurrency limit, not a code problem. It reproduces on unmodified `development`, and passes reliably with `UV_THREADPOOL_SIZE=1`. `tsc -b` passes every time.

### Mutation verification

Per the task's requirement, each behaviour added was reverted at its narrowest point and the suite re-run, to confirm no test passes against unmodified code. 14 mutations; every one failed exactly the tests that cover it, e.g.:

- `item_to_widget_config` → `item_to_form` on the public route → only `test_public_config_omits_project_and_document_ids` fails.
- link removed from `DEFAULT_FORM_CONFIG` → the persistence test fails; removed from `item_to_form` → 5 fail; removed from `UPDATABLE_FIELDS` → the two update tests fail.
- project-level fallback removed → the regenerated-document tests fail; fallback widened to always match → the sibling-document test fails.
- `avg_rating` null coerced to `0` → the ratings-disabled test fails.
- the evidence panel moved out of the expanded row → the expand-only tests fail.
- the link fields moved onto `FeedbackFormFields` → the type-boundary test fails.

Two mutations initially passed — a missing test for a row with no `project_id`, and the schema declaration only being covered indirectly. Both gaps are closed in the third commit, and the mutations now fail as expected. All source was restored afterwards (`git diff` against the source files is empty).

## Agent notes

**What went well.** The task description was unusually precise about the traps, and each one was real. `DEFAULT_FORM_CONFIG`-vs-`item_to_form` is a genuine silent-drop pair — the field only round-trips if it is in both, which is now pinned by a test that compares the two sets rather than by prose. And `item_to_form` really was shared between the authenticated routes and the public widget config route, so adding the field to it alone would have published internal project ids to every embedding site.

**What was difficult.**
- The ESLint complexity ceiling (12) bit exactly where predicted: adding a fourth editor tab pushed `FormEditor` to 14. Extracting `EditorTabBar` alone was not enough; the inline `{ project_id: … ?? '' }` object also had to become a module-level `toValidationLink` helper. `FeedbackForms.tsx` is also within ~40 lines of the 600-line `max-lines` ceiling, which is why the picker is a separate module.
- The repo bans `as` assertions outright (`consistent-type-assertions: never`), so narrowing the tab id needed a real type guard. Worth knowing before reaching for a cast.
- The container's build flakiness cost several cycles before I recognized the "different dependency each time" signature as environmental.
- A pre-existing `formSchema.test.ts` case named "keeps a complete record unchanged" broke, correctly: its fixture was no longer complete. Adding the fields to the fixture was the right fix, not loosening the assertion.

**Conventions discovered.**
- `.kiro/steering/` is the CLAUDE.md equivalent. `mise` defines no tasks here; the gates are the root `package.json` scripts, and `npm run check` runs all of them.
- Runtime validation genuinely lives at every query boundary. `formSchema.ts`'s loose-object rationale is documented and load-bearing (unknown fields must survive an edit round-trip) — following it, rather than tightening it, is what keeps the round-trip working.
- Comments in this codebase explain *why*, often naming the issue number and the failure mode. I matched that register; several of the comments I added exist to stop a future reader "simplifying" the public-projection split back into a filter.
- Locale catalogues are sorted case-insensitively and must be edited surgically. I inserted keys positionally with a script rather than re-serializing, so the diffs are added lines only.
- `api-stack.test.ts` is a good model for asserting an invariant that types cannot enforce; I reused its "read the source text" approach for the `FeedbackFormFields` boundary.

**Suggestions for future work on this repo.**
- `requirements-dev.txt` does not install `pydantic` or `aws-xray-sdk`, both of which are needed to import any `lambda/api` handler under test, nor the plugin deps (`bs4`, `tenacity`, `app_store_web_scraper`). A fresh clone cannot run `npm run test:backend` without guessing. Adding them would make the documented command work as documented.
- `npm run lint`'s `lint:python` step reports 552 pre-existing ruff errors, so the lint gate is red on `development`. Mostly `I001` import sorting and auto-fixable — a single `ruff check --fix` commit would restore lint as a signal, which currently cannot fail on new code because it already fails.
- `lambda/api/test/test_feedback_form_handler.py` re-does `sys.path.insert` + a local import in all 23 tests. A `conftest.py` fixture would remove ~70 lines and the ruff `I001` noise with it.
- `FeedbackForms.tsx` still has a lot of hardcoded English (`'Form Settings'`, `'Save Changes'`, the info banner) even though a full `feedbackForms` catalogue exists — the i18n checker flags it. This PR did not widen that (out of scope), but the editor is the obvious next candidate.

---

## Review history (added after six automated rounds)

The description above is the original change. Six review rounds followed; the
substance is unchanged but these were added, each with a mutation probe:

- **A separate narrow projection for the public widget route** — `item_to_widget_config`
  rather than `item_to_form`, so a field added to the authenticated shape cannot leak
  by default. Pinned by a Python↔TypeScript lockstep test in both directions. This
  also closes six pre-existing over-shares on that unauthenticated route
  (`form_id`, `name`, `category`, `subcategory`, `created_at`, `updated_at`).
- **Boundary validation** on the writable link fields, called from `build_form_item`
  so the only constructor of a record enforces it structurally.
- **An `'unverified'` state in the picker** so a *failed* or never-made lookup is not
  labelled "Loading link…". Three states, each of which is true when shown.
- **`LINKABLE_DOCUMENT_TYPES` deleted** in favour of `isScorable`, so "linkable here"
  and "scorable on Prioritization" cannot be answered twice.
- **`api/feedbackFormQueryKeys.ts`** — `['feedback-forms']` and `['form-stats', id]`
  are each read by two features and drift silently; sharing `['form-stats', id]` is
  what stops the evidence panel paying twice for a brand-wide partition scan.
- **Two guards that were derived rather than hand-maintained**: the widget-read field
  set is read out of `feedback-widget.js`, and the scorable-type fixture out of
  `SCORABLE_TYPE_META`.

### Verified on a deployment, not only in tests

On the dev environment, unauthenticated, against a form that **is** linked:
`GET /feedback-forms/{id}/config` serves exactly 15 keys and the raw body contains
neither the project id nor the document id. A `PUT` round-trips the link; a
non-string `project_id` and a 129-character `document_id` are both rejected 400 while
128 is accepted; the widget iframe still serves 200.

### Known residue, deliberately not fixed here

- `get_form_stats` swallows failures into a `200` with `total_submissions: 0` (#312).
  On the form card that was cosmetic; on a prioritization row it is decision input, so
  a failed read reads as "nobody rated this proposal". Worth doing before this feature
  is relied on.
- A `document_id` with an empty `project_id` (reachable only by a direct API call, and
  inert for every reader) is preserved rather than normalized away, because silently
  clearing a stored id is the behaviour this picker exists to avoid. Enforcing it at the
  API needs a read-modify-write.
- `_interface_body` in `test_widget_config_type_lockstep.py` strips comments with
  `re.sub(r'//[^\n]*', ...)`, which also matches inside a string literal and would
  truncate that line — the same fail-open the widget-read derivation was changed away
  from in `6d63c0d`, left inconsistent between the two files. **Measured as latent, not
  live**: no member is lost from any of the three interfaces today (all 12 `//` lines in
  `FeedbackForm` are comment-only), and it would take a member whose type is a string
  literal containing `//` (`endpoint: 'https://…'`). The tidy fix is to share the
  line-based comment filter between the two files, which would also give the
  "two independent parsers" review item a real answer — they can share the comment
  filter even though the member extraction genuinely differs.
- 27 test files mock `configStore` without `getState` while one file uses the real
  store, which under `singleFork: true` makes an order-dependent flake possible in
  `ProjectDetail.jobHandover.test.tsx`. Pre-existing (25 of the 27 predate this PR);
  the fix belongs in `src/test/setup.ts`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

