### PR TITLE
feat(feedback-forms): show a form's public page as a scannable QR

### DIFF
--- a/voc-datalake/frontend/package-lock.json
+++ b/voc-datalake/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^3.0.2",
         "lucide-react": "^0.554.0",
+        "qrcode.react": "4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.8",
@@ -11479,6 +11480,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/quick-temp": {

--- a/voc-datalake/frontend/package.json
+++ b/voc-datalake/frontend/package.json
@@ -31,6 +31,7 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^3.0.2",
     "lucide-react": "^0.554.0",
+    "qrcode.react": "4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.8",

--- a/voc-datalake/frontend/public/locales/de/components.json
+++ b/voc-datalake/frontend/public/locales/de/components.json
@@ -112,7 +112,8 @@
   },
   "formQrCode": {
     "accessibleName": "QR-Code für das Feedback-Formular {{formName}}",
-    "caption": "Scannen, um dieses Formular auf dem Smartphone zu öffnen"
+    "caption": "Scannen, um dieses Formular auf dem Smartphone zu öffnen",
+    "unavailable": "QR-Code nicht verfügbar, bis der API-Endpunkt in den Einstellungen konfiguriert ist"
   },
   "personaExport": {
     "copied": "Kopiert!",

--- a/voc-datalake/frontend/public/locales/de/components.json
+++ b/voc-datalake/frontend/public/locales/de/components.json
@@ -110,6 +110,10 @@
     "viewDetails": "Details anzeigen",
     "webScraper": "Web-Scraper"
   },
+  "formQrCode": {
+    "accessibleName": "QR-Code für das Feedback-Formular {{formName}}",
+    "caption": "Scannen, um dieses Formular auf dem Smartphone zu öffnen"
+  },
   "personaExport": {
     "copied": "Kopiert!",
     "copyMarkdown": "Als Markdown kopieren",

--- a/voc-datalake/frontend/public/locales/de/prioritization.json
+++ b/voc-datalake/frontend/public/locales/de/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "Mittlere Priorität",
     "none": "Nicht bewertet"
   },
+  "qr": {
+    "close": "Schließen",
+    "show": "QR-Code anzeigen",
+    "title": "QR-Code"
+  },
   "scores": {
     "confidence": "Konfidenz",
     "confidenceDescription": "Sicherheit bei Auswirkungs- und MeZ-Schätzungen",

--- a/voc-datalake/frontend/public/locales/en/components.json
+++ b/voc-datalake/frontend/public/locales/en/components.json
@@ -112,7 +112,8 @@
   },
   "formQrCode": {
     "accessibleName": "QR code for the {{formName}} feedback form",
-    "caption": "Scan to open this form on a phone"
+    "caption": "Scan to open this form on a phone",
+    "unavailable": "QR code unavailable until the API endpoint is configured in Settings"
   },
   "personaExport": {
     "copied": "Copied!",

--- a/voc-datalake/frontend/public/locales/en/components.json
+++ b/voc-datalake/frontend/public/locales/en/components.json
@@ -110,6 +110,10 @@
     "viewDetails": "View Details",
     "webScraper": "Web Scraper"
   },
+  "formQrCode": {
+    "accessibleName": "QR code for the {{formName}} feedback form",
+    "caption": "Scan to open this form on a phone"
+  },
   "personaExport": {
     "copied": "Copied!",
     "copyMarkdown": "Copy as Markdown",

--- a/voc-datalake/frontend/public/locales/en/prioritization.json
+++ b/voc-datalake/frontend/public/locales/en/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "Medium Priority",
     "none": "Not Scored"
   },
+  "qr": {
+    "close": "Close",
+    "show": "Show QR code",
+    "title": "QR code"
+  },
   "scores": {
     "confidence": "Confidence",
     "confidenceDescription": "Certainty in impact and TTM estimates",

--- a/voc-datalake/frontend/public/locales/es/components.json
+++ b/voc-datalake/frontend/public/locales/es/components.json
@@ -119,7 +119,8 @@
   },
   "formQrCode": {
     "accessibleName": "Código QR del formulario de opinión {{formName}}",
-    "caption": "Escanea para abrir este formulario en el móvil"
+    "caption": "Escanea para abrir este formulario en el móvil",
+    "unavailable": "Código QR no disponible hasta que se configure el endpoint de la API en Configuración"
   },
   "personaExport": {
     "copied": "¡Copiado!",

--- a/voc-datalake/frontend/public/locales/es/components.json
+++ b/voc-datalake/frontend/public/locales/es/components.json
@@ -117,6 +117,10 @@
     "viewDetails": "Ver detalles",
     "webScraper": "Recolector web"
   },
+  "formQrCode": {
+    "accessibleName": "Código QR del formulario de opinión {{formName}}",
+    "caption": "Escanea para abrir este formulario en el móvil"
+  },
   "personaExport": {
     "copied": "¡Copiado!",
     "copyMarkdown": "Copiar como Markdown",

--- a/voc-datalake/frontend/public/locales/es/prioritization.json
+++ b/voc-datalake/frontend/public/locales/es/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "Prioridad media",
     "none": "Sin puntuar"
   },
+  "qr": {
+    "close": "Cerrar",
+    "show": "Mostrar código QR",
+    "title": "Código QR"
+  },
   "scores": {
     "confidence": "Confianza",
     "confidenceDescription": "Certeza en las estimaciones de impacto y TdC",

--- a/voc-datalake/frontend/public/locales/fr/components.json
+++ b/voc-datalake/frontend/public/locales/fr/components.json
@@ -119,7 +119,8 @@
   },
   "formQrCode": {
     "accessibleName": "Code QR du formulaire de retour {{formName}}",
-    "caption": "Scannez pour ouvrir ce formulaire sur un téléphone"
+    "caption": "Scannez pour ouvrir ce formulaire sur un téléphone",
+    "unavailable": "Code QR indisponible jusqu'à la configuration du point de terminaison API dans les Paramètres"
   },
   "personaExport": {
     "copied": "Copié !",

--- a/voc-datalake/frontend/public/locales/fr/components.json
+++ b/voc-datalake/frontend/public/locales/fr/components.json
@@ -117,6 +117,10 @@
     "viewDetails": "Voir les détails",
     "webScraper": "Collecteur web"
   },
+  "formQrCode": {
+    "accessibleName": "Code QR du formulaire de retour {{formName}}",
+    "caption": "Scannez pour ouvrir ce formulaire sur un téléphone"
+  },
   "personaExport": {
     "copied": "Copié !",
     "copyMarkdown": "Copier en Markdown",

--- a/voc-datalake/frontend/public/locales/fr/prioritization.json
+++ b/voc-datalake/frontend/public/locales/fr/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "Priorité moyenne",
     "none": "Non évalué"
   },
+  "qr": {
+    "close": "Fermer",
+    "show": "Afficher le code QR",
+    "title": "Code QR"
+  },
   "scores": {
     "confidence": "Confiance",
     "confidenceDescription": "Certitude dans les estimations d'impact et de DmM",

--- a/voc-datalake/frontend/public/locales/ja/components.json
+++ b/voc-datalake/frontend/public/locales/ja/components.json
@@ -112,7 +112,8 @@
   },
   "formQrCode": {
     "accessibleName": "フィードバックフォーム「{{formName}}」のQRコード",
-    "caption": "スキャンしてこのフォームをスマートフォンで開きます"
+    "caption": "スキャンしてこのフォームをスマートフォンで開きます",
+    "unavailable": "設定でAPIエンドポイントを構成するまでQRコードは利用できません"
   },
   "personaExport": {
     "copied": "コピーしました！",

--- a/voc-datalake/frontend/public/locales/ja/components.json
+++ b/voc-datalake/frontend/public/locales/ja/components.json
@@ -110,6 +110,10 @@
     "viewDetails": "詳細を表示",
     "webScraper": "ウェブスクレイパー"
   },
+  "formQrCode": {
+    "accessibleName": "フィードバックフォーム「{{formName}}」のQRコード",
+    "caption": "スキャンしてこのフォームをスマートフォンで開きます"
+  },
   "personaExport": {
     "copied": "コピーしました！",
     "copyMarkdown": "Markdownとしてコピー",

--- a/voc-datalake/frontend/public/locales/ja/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ja/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "中優先度",
     "none": "未評価"
   },
+  "qr": {
+    "close": "閉じる",
+    "show": "QRコードを表示",
+    "title": "QRコード"
+  },
   "scores": {
     "confidence": "確信度",
     "confidenceDescription": "インパクトとTTM見積もりの確実性",

--- a/voc-datalake/frontend/public/locales/ko/components.json
+++ b/voc-datalake/frontend/public/locales/ko/components.json
@@ -112,7 +112,8 @@
   },
   "formQrCode": {
     "accessibleName": "{{formName}} 피드백 양식의 QR 코드",
-    "caption": "스캔하여 이 양식을 휴대전화에서 열기"
+    "caption": "스캔하여 이 양식을 휴대전화에서 열기",
+    "unavailable": "설정에서 API 엔드포인트를 구성할 때까지 QR 코드를 사용할 수 없습니다"
   },
   "personaExport": {
     "copied": "복사됨!",

--- a/voc-datalake/frontend/public/locales/ko/components.json
+++ b/voc-datalake/frontend/public/locales/ko/components.json
@@ -110,6 +110,10 @@
     "viewDetails": "세부정보 보기",
     "webScraper": "웹 스크래퍼"
   },
+  "formQrCode": {
+    "accessibleName": "{{formName}} 피드백 양식의 QR 코드",
+    "caption": "스캔하여 이 양식을 휴대전화에서 열기"
+  },
   "personaExport": {
     "copied": "복사됨!",
     "copyMarkdown": "Markdown으로 복사",

--- a/voc-datalake/frontend/public/locales/ko/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ko/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "중간 우선순위",
     "none": "평가되지 않음"
   },
+  "qr": {
+    "close": "닫기",
+    "show": "QR 코드 표시",
+    "title": "QR 코드"
+  },
   "scores": {
     "confidence": "신뢰도",
     "confidenceDescription": "영향도 및 출시 시간 추정의 확실성",

--- a/voc-datalake/frontend/public/locales/pt/components.json
+++ b/voc-datalake/frontend/public/locales/pt/components.json
@@ -117,6 +117,10 @@
     "viewDetails": "Ver Detalhes",
     "webScraper": "Coletor web"
   },
+  "formQrCode": {
+    "accessibleName": "Código QR do formulário de feedback {{formName}}",
+    "caption": "Escaneie para abrir este formulário no celular"
+  },
   "personaExport": {
     "copied": "Copiado!",
     "copyMarkdown": "Copiar como Markdown",

--- a/voc-datalake/frontend/public/locales/pt/components.json
+++ b/voc-datalake/frontend/public/locales/pt/components.json
@@ -119,7 +119,8 @@
   },
   "formQrCode": {
     "accessibleName": "Código QR do formulário de feedback {{formName}}",
-    "caption": "Escaneie para abrir este formulário no celular"
+    "caption": "Escaneie para abrir este formulário no celular",
+    "unavailable": "Código QR indisponível até que o endpoint da API seja configurado nas Configurações"
   },
   "personaExport": {
     "copied": "Copiado!",

--- a/voc-datalake/frontend/public/locales/pt/prioritization.json
+++ b/voc-datalake/frontend/public/locales/pt/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "Média Prioridade",
     "none": "Não Pontuado"
   },
+  "qr": {
+    "close": "Fechar",
+    "show": "Mostrar código QR",
+    "title": "Código QR"
+  },
   "scores": {
     "confidence": "Confiança",
     "confidenceDescription": "Certeza nas estimativas de impacto e TTM",

--- a/voc-datalake/frontend/public/locales/zh/components.json
+++ b/voc-datalake/frontend/public/locales/zh/components.json
@@ -112,7 +112,8 @@
   },
   "formQrCode": {
     "accessibleName": "“{{formName}}”反馈表单的二维码",
-    "caption": "扫码在手机上打开此表单"
+    "caption": "扫码在手机上打开此表单",
+    "unavailable": "在设置中配置API端点后才能显示二维码"
   },
   "personaExport": {
     "copied": "已复制！",

--- a/voc-datalake/frontend/public/locales/zh/components.json
+++ b/voc-datalake/frontend/public/locales/zh/components.json
@@ -110,6 +110,10 @@
     "viewDetails": "查看详情",
     "webScraper": "网页爬虫"
   },
+  "formQrCode": {
+    "accessibleName": "“{{formName}}”反馈表单的二维码",
+    "caption": "扫码在手机上打开此表单"
+  },
   "personaExport": {
     "copied": "已复制！",
     "copyMarkdown": "复制为 Markdown",

--- a/voc-datalake/frontend/public/locales/zh/prioritization.json
+++ b/voc-datalake/frontend/public/locales/zh/prioritization.json
@@ -46,6 +46,11 @@
     "medium": "中优先级",
     "none": "未评分"
   },
+  "qr": {
+    "close": "关闭",
+    "show": "显示二维码",
+    "title": "二维码"
+  },
   "scores": {
     "confidence": "置信度",
     "confidenceDescription": "对影响力和上市时间估计的确定性",

--- a/voc-datalake/frontend/src/api/feedbackFormUrls.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormUrls.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tests for the one builder of a feedback form's public address.
+ *
+ * Worth its own file because a QR gives no feedback when it is wrong: the
+ * modules look identical whatever they encode, so a malformed address is only
+ * discovered by a room full of phones failing to open it.
+ */
+import { describe, it, expect } from 'vitest'
+import { feedbackFormPublicUrl } from './feedbackFormUrls'
+
+describe('a feedback form public URL', () => {
+  it('addresses the form\'s hosted public page', () => {
+    // Spelled out rather than assembled from the same pieces the builder uses:
+    // this is the address printed on the card, copied into customers' embed
+    // snippets and encoded into the QR, so the literal IS the contract.
+    expect(feedbackFormPublicUrl('https://api.example.com', 'form_1'))
+      .toBe('https://api.example.com/feedback-forms/form_1/iframe')
+  })
+
+  it('tolerates an endpoint configured with a trailing slash', () => {
+    // The endpoint is user-entered configuration and `…/v1/` is a normal paste;
+    // a doubled slash would encode an address the API may not route.
+    expect(feedbackFormPublicUrl('https://api.example.com/v1/', 'form_1'))
+      .toBe('https://api.example.com/v1/feedback-forms/form_1/iframe')
+  })
+})

--- a/voc-datalake/frontend/src/api/feedbackFormUrls.test.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormUrls.test.ts
@@ -23,4 +23,35 @@ describe('a feedback form public URL', () => {
     expect(feedbackFormPublicUrl('https://api.example.com/v1/', 'form_1'))
       .toBe('https://api.example.com/v1/feedback-forms/form_1/iframe')
   })
+
+  it('builds no address at all when no endpoint is configured', () => {
+    // The failure this exists to prevent: '/feedback-forms/form_1/iframe' is a
+    // perfectly good relative path and a perfectly scannable QR, and it resolves
+    // to nothing on the phone that scans it.
+    expect(feedbackFormPublicUrl('', 'form_1')).toBeNull()
+  })
+
+  it('builds no address from an endpoint that is not absolute', () => {
+    // '/api' is the relative fallback `getBaseUrl` uses for fetches the app makes
+    // itself. It is a working API base and a useless public address.
+    expect(feedbackFormPublicUrl('/api', 'form_1')).toBeNull()
+    expect(feedbackFormPublicUrl('api.example.com', 'form_1')).toBeNull()
+  })
+
+  it('builds no address from an endpoint that is not http', () => {
+    // Parses as a valid URL, is not a valid API, and this string ends up in an
+    // href and an iframe src on a customer's own page.
+    expect(feedbackFormPublicUrl('javascript:alert(1)', 'form_1')).toBeNull()
+    expect(feedbackFormPublicUrl('data:text/html,<p>x', 'form_1')).toBeNull()
+  })
+
+  it('percent-encodes the form id it is given', () => {
+    // Server-minted today. It is also a path segment in a snippet customers paste
+    // and in a QR nobody can proofread, so an id carrying a slash must not
+    // silently address a different resource.
+    expect(feedbackFormPublicUrl('https://api.example.com', 'form/../admin'))
+      .toBe('https://api.example.com/feedback-forms/form%2F..%2Fadmin/iframe')
+    expect(feedbackFormPublicUrl('https://api.example.com', 'a b?c=1'))
+      .toBe('https://api.example.com/feedback-forms/a%20b%3Fc%3D1/iframe')
+  })
 })

--- a/voc-datalake/frontend/src/api/feedbackFormUrls.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormUrls.ts
@@ -23,16 +23,62 @@
  * difference nobody could see. (It costs no extra weight in any chunk: both
  * render sites already import `api/client`, which imports `baseUrl`.)
  *
+ * Because that argument cuts both ways, the answer to an endpoint this cannot
+ * build on is null rather than a best effort. `getBaseUrl` may fall back to the
+ * relative '/api' — correct for a fetch the app itself issues — but a QR carrying
+ * '/feedback-forms/{id}/iframe' is scanned by a phone with no idea what it is
+ * relative to, and that failure looks exactly like success until a room full of
+ * browsers opens nothing. The decision lives here, once, so neither render site
+ * re-derives it.
+ *
  * @module api/feedbackFormUrls
  */
 import { stripTrailingSlashes } from './baseUrl'
 
 /**
- * The hosted public page for one feedback form.
+ * The API bases a public form address can be built on.
+ *
+ * The endpoint is user-entered configuration, and the string built from it goes
+ * into an `<a href>`, an `<iframe src>` the customer pastes into their own page,
+ * and a QR a phone opens. `javascript:` and `data:` bases parse as perfectly
+ * valid URLs; they are not valid APIs, and not things to hand a browser.
+ */
+const ADDRESSABLE_PROTOCOLS = ['http:', 'https:']
+
+/**
+ * The endpoint as an absolute base to build on, or null if it is not one.
+ *
+ * Parsed rather than pattern-matched: `new URL` in a try/catch is already how
+ * `prototypeLinkLifetime` asks this exact question, the URL grammar is the only
+ * honest authority on it, and a hand-rolled expression would be both wrong at the
+ * edges and a `sonarjs/slow-regex` finding.
+ */
+function addressableBase(apiEndpoint: string): string | null {
+  const base = stripTrailingSlashes(apiEndpoint)
+  try {
+    return ADDRESSABLE_PROTOCOLS.includes(new URL(base).protocol) ? base : null
+  } catch {
+    // Not absolute. '' (nothing configured yet) and '/api' (the relative fetch
+    // fallback) both land here, and neither addresses anything off-device.
+    return null
+  }
+}
+
+/**
+ * The hosted public page for one feedback form, or null when the configured
+ * endpoint cannot address it.
+ *
+ * Callers must render something other than a link or a QR for null — see
+ * `FormQrCode`, which says so in words, because a QR cannot.
  *
  * @param apiEndpoint the configured API base, with or without a trailing slash.
  * @param formId the form's server-minted id.
  */
-export function feedbackFormPublicUrl(apiEndpoint: string, formId: string): string {
-  return `${stripTrailingSlashes(apiEndpoint)}/feedback-forms/${formId}/iframe`
+export function feedbackFormPublicUrl(apiEndpoint: string, formId: string): string | null {
+  const base = addressableBase(apiEndpoint)
+  if (base === null) return null
+  // Encoded even though the id is minted server-side: it is now a path segment in
+  // a snippet customers paste and in a QR nobody can read. An id carrying a slash
+  // or a '?' would quietly address a different resource instead of failing.
+  return `${base}/feedback-forms/${encodeURIComponent(formId)}/iframe`
 }

--- a/voc-datalake/frontend/src/api/feedbackFormUrls.ts
+++ b/voc-datalake/frontend/src/api/feedbackFormUrls.ts
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview The public address of a feedback form's hosted page.
+ *
+ * `GET /feedback-forms/{id}/iframe` returns a complete, mobile-ready HTML
+ * document — a phone can open it directly — so it is the form's public page as
+ * well as its embed target. Two features now point at it: the form's own card
+ * offers it as a link, a copyable URL and an `<iframe>` snippet, and the QR shown
+ * beside both renders the same address as scannable modules.
+ *
+ * One exported builder rather than a template literal per call site, for the same
+ * reason `feedbackFormQueryKeys` exists: a second spelling drifts silently. A QR
+ * is the worst possible place for that — nothing on screen reveals which address
+ * was encoded, so a stale or malformed one is only discovered by a room full of
+ * phones failing to load it.
+ *
+ * `iframe` is deliberately the route name: it is public, unauthenticated, and
+ * already pasted into customers' embed snippets, so it cannot be renamed here.
+ *
+ * The endpoint is normalized with `baseUrl`'s own `stripTrailingSlashes` rather
+ * than a local trim: it is user-entered configuration, `…amazonaws.com/v1/` is a
+ * normal thing to paste, and every API request already goes through that
+ * function — a QR that resolved differently from the requests would be a
+ * difference nobody could see. (It costs no extra weight in any chunk: both
+ * render sites already import `api/client`, which imports `baseUrl`.)
+ *
+ * @module api/feedbackFormUrls
+ */
+import { stripTrailingSlashes } from './baseUrl'
+
+/**
+ * The hosted public page for one feedback form.
+ *
+ * @param apiEndpoint the configured API base, with or without a trailing slash.
+ * @param formId the form's server-minted id.
+ */
+export function feedbackFormPublicUrl(apiEndpoint: string, formId: string): string {
+  return `${stripTrailingSlashes(apiEndpoint)}/feedback-forms/${formId}/iframe`
+}

--- a/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.test.tsx
+++ b/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for the feedback-form QR.
+ *
+ * The encoder is wrapped rather than replaced: the real library still renders,
+ * so the assertions run against a genuine SVG, while the wrapper records what it
+ * was asked to encode. Nothing in a rendered QR reveals its payload, and that is
+ * exactly the property that has to be guarded.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import i18n from 'i18next'
+import type { ComponentProps } from 'react'
+
+const spy = vi.hoisted(() => ({
+  encoded: new Array<{
+    value: string | string[]
+    size?: number
+    marginSize?: number
+  }>(),
+}))
+
+vi.mock('qrcode.react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('qrcode.react')>()
+  const Real = actual.QRCodeSVG
+  return {
+    ...actual,
+    QRCodeSVG: (props: ComponentProps<typeof Real>) => {
+      spy.encoded.push({ value: props.value, size: props.size, marginSize: props.marginSize })
+      return <Real {...props} />
+    },
+  }
+})
+
+import FormQrCode from './FormQrCode'
+
+const { t } = i18n
+
+function renderQr(formId = 'form_1') {
+  return render(
+    <FormQrCode apiEndpoint="https://api.example.com" formId={formId} formName="Website Feedback" />,
+  )
+}
+
+/** The QR, found the way assistive technology finds it. */
+function findQr(): HTMLElement {
+  return screen.getByRole('img', {
+    name: t('components:formQrCode.accessibleName', { formName: 'Website Feedback' }),
+  })
+}
+
+describe('a feedback form QR', () => {
+  beforeEach(() => {
+    spy.encoded.length = 0
+  })
+
+  it('renders an inline SVG QR named for the form it opens', () => {
+    renderQr()
+
+    const qr = findQr()
+    // Inline SVG, not a canvas and not a remote image: crisp when projected, and
+    // no form URL leaves the browser to be rendered by someone else.
+    expect(qr.tagName.toLowerCase()).toBe('svg')
+    // Background plus the module path — an SVG frame with nothing drawn in it
+    // would still satisfy the role query above.
+    expect(qr.querySelectorAll('path').length).toBeGreaterThan(1)
+    expect(screen.getByText(t('components:formQrCode.caption'))).toBeInTheDocument()
+  })
+
+  it('encodes the form\'s own hosted public page', () => {
+    renderQr()
+
+    expect(spy.encoded).toHaveLength(1)
+    expect(spy.encoded[0].value).toBe('https://api.example.com/feedback-forms/form_1/iframe')
+  })
+
+  it('points a different form\'s QR at that form', () => {
+    renderQr('form_42')
+
+    expect(spy.encoded[0].value).toBe('https://api.example.com/feedback-forms/form_42/iframe')
+  })
+
+  it('renders large enough, with the quiet zone, to scan from across a room', () => {
+    renderQr()
+
+    // Both are scan requirements rather than styling: below roughly 200px a
+    // phone a few metres from a projector cannot resolve the modules, and the
+    // library defaults the quiet zone to 0 modules, which leaves a scanner
+    // unable to find the symbol's edges against a busy card.
+    expect(spy.encoded[0].size).toBeGreaterThanOrEqual(200)
+    expect(spy.encoded[0].marginSize).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.test.tsx
+++ b/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.test.tsx
@@ -16,6 +16,7 @@ const spy = vi.hoisted(() => ({
     value: string | string[]
     size?: number
     marginSize?: number
+    level?: string
   }>(),
 }))
 
@@ -25,7 +26,9 @@ vi.mock('qrcode.react', async (importOriginal) => {
   return {
     ...actual,
     QRCodeSVG: (props: ComponentProps<typeof Real>) => {
-      spy.encoded.push({ value: props.value, size: props.size, marginSize: props.marginSize })
+      spy.encoded.push({
+        value: props.value, size: props.size, marginSize: props.marginSize, level: props.level,
+      })
       return <Real {...props} />
     },
   }
@@ -35,9 +38,9 @@ import FormQrCode from './FormQrCode'
 
 const { t } = i18n
 
-function renderQr(formId = 'form_1') {
+function renderQr(formId = 'form_1', apiEndpoint = 'https://api.example.com') {
   return render(
-    <FormQrCode apiEndpoint="https://api.example.com" formId={formId} formName="Website Feedback" />,
+    <FormQrCode apiEndpoint={apiEndpoint} formId={formId} formName="Website Feedback" />,
   )
 }
 
@@ -79,14 +82,37 @@ describe('a feedback form QR', () => {
     expect(spy.encoded[0].value).toBe('https://api.example.com/feedback-forms/form_42/iframe')
   })
 
-  it('renders large enough, with the quiet zone, to scan from across a room', () => {
+  it('renders large enough, with the quiet zone and the error correction, to scan from across a room', () => {
     renderQr()
 
-    // Both are scan requirements rather than styling: below roughly 200px a
-    // phone a few metres from a projector cannot resolve the modules, and the
+    // All three are scan requirements rather than styling: below roughly 200px a
+    // phone a few metres from a projector cannot resolve the modules, the
     // library defaults the quiet zone to 0 modules, which leaves a scanner
-    // unable to find the symbol's edges against a busy card.
+    // unable to find the symbol's edges against a busy card, and 'M' is what
+    // recovers a symbol partly lost to glare or a head in the way. Dropping to
+    // the library's cheaper 'L' would still render a valid QR — and fail in the
+    // room, which is the only place anyone would find out.
     expect(spy.encoded[0].size).toBeGreaterThanOrEqual(200)
     expect(spy.encoded[0].marginSize).toBeGreaterThanOrEqual(4)
+    expect(spy.encoded[0].level).toBe('M')
+  })
+
+  it('says so in words instead of encoding an address that resolves nowhere', () => {
+    // No endpoint configured. The alternative is a flawless, scannable symbol
+    // for '/feedback-forms/form_1/iframe' — which a phone cannot resolve, and
+    // which looks exactly like a working QR to everyone in the room.
+    renderQr('form_1', '')
+
+    expect(spy.encoded).toHaveLength(0)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText(t('components:formQrCode.unavailable'))).toBeInTheDocument()
+  })
+
+  it('encodes nothing for an endpoint that is not an absolute address', () => {
+    // '/api' is the relative base the app itself fetches against quite happily.
+    renderQr('form_1', '/api')
+
+    expect(spy.encoded).toHaveLength(0)
+    expect(screen.getByText(t('components:formQrCode.unavailable'))).toBeInTheDocument()
   })
 })

--- a/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.tsx
+++ b/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.tsx
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview A feedback form's public page as a scannable QR code.
+ *
+ * Exists for the room: getting a group's ratings in otherwise means reading a
+ * URL aloud or pasting it into a chat channel, while a QR on the screen is
+ * scanned off a projector. Rendered on the form's own card and on the
+ * prioritization row of the document that form validates — one component, so the
+ * two never diverge.
+ *
+ * Takes the endpoint and the form id, NOT a URL: `feedbackFormPublicUrl` is the
+ * only place a form's public address is built, and accepting a ready-made string
+ * would invite a second construction site whose drift nothing on screen reveals.
+ *
+ * Encoded in the browser as SVG. Crisp when projected (a canvas at these sizes
+ * is not), no third-party image service — that would ship form URLs to an
+ * external endpoint for no benefit and fail in a room with poor connectivity —
+ * and no hand-rolled encoder, because Reed–Solomon error correction is not a
+ * place to be clever.
+ *
+ * @module components/FormQrCode
+ */
+import { QRCodeSVG } from 'qrcode.react'
+import { useTranslation } from 'react-i18next'
+import { feedbackFormPublicUrl } from '../../api/feedbackFormUrls'
+import type { ReactElement } from 'react'
+
+/**
+ * Rendered edge, in CSS pixels.
+ *
+ * A phone camera a few metres from a projected screen needs roughly this much
+ * before it resolves the modules, which is the entire point of the feature — a
+ * QR too small to scan from a seat is decoration.
+ */
+const QR_SIZE_PX = 200
+
+/**
+ * Quiet zone, in modules. The QR specification requires 4, and the library
+ * defaults to 0: without it a scanner cannot find the symbol's edges against a
+ * busy card or slide.
+ */
+const QR_MARGIN_MODULES = 4
+
+/**
+ * Error correction level. `M` recovers ~15% of a damaged or partly obscured
+ * symbol — the realistic failure mode here is glare and heads in the way, not a
+ * pristine scan — and costs only a slightly denser grid at this URL length.
+ */
+const QR_ERROR_CORRECTION = 'M'
+
+/**
+ * The QR for one feedback form's public page.
+ *
+ * @param apiEndpoint the configured API base.
+ * @param formId the form whose public page the QR opens.
+ * @param formName the form's display name, used to name the QR for assistive
+ *   technology — a page can show several.
+ */
+export default function FormQrCode({
+  apiEndpoint, formId, formName,
+}: {
+  readonly apiEndpoint: string
+  readonly formId: string
+  readonly formName: string
+}): ReactElement {
+  const { t } = useTranslation('components')
+  const url = feedbackFormPublicUrl(apiEndpoint, formId)
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {/* `title` becomes the SVG's <title>, which is what assistive tech
+          announces for its role="img" — an unnamed QR is an unlabelled image. */}
+      <QRCodeSVG
+        value={url}
+        size={QR_SIZE_PX}
+        level={QR_ERROR_CORRECTION}
+        marginSize={QR_MARGIN_MODULES}
+        title={t('formQrCode.accessibleName', { formName })}
+        className="bg-white"
+      />
+      <p className="text-xs text-gray-500 text-center">{t('formQrCode.caption')}</p>
+    </div>
+  )
+}

--- a/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.tsx
+++ b/voc-datalake/frontend/src/components/FormQrCode/FormQrCode.tsx
@@ -10,6 +10,11 @@
  * Takes the endpoint and the form id, NOT a URL: `feedbackFormPublicUrl` is the
  * only place a form's public address is built, and accepting a ready-made string
  * would invite a second construction site whose drift nothing on screen reveals.
+ * It also decides when there is no address to encode at all, which is why this
+ * component has a second thing it can render: an endpoint that resolves nowhere
+ * would otherwise produce a flawless, scannable symbol for an address that does
+ * not exist, and no viewer could tell. Saying so is the whole guard — a room
+ * pointing phones at a dead QR gets no error message.
  *
  * Encoded in the browser as SVG. Crisp when projected (a canvas at these sizes
  * is not), no third-party image service — that would ship form URLs to an
@@ -64,6 +69,13 @@ export default function FormQrCode({
 }): ReactElement {
   const { t } = useTranslation('components')
   const url = feedbackFormPublicUrl(apiEndpoint, formId)
+  // A QR cannot report its own failure: whatever it encodes, it looks like a QR
+  // and scans like one, so an unusable endpoint would reach the room as a symbol
+  // that resolves to nothing. `feedbackFormPublicUrl` decides — the only thing
+  // left to do here is say it in words rather than draw it.
+  if (url === null) {
+    return <p className="text-xs text-gray-500 text-center">{t('formQrCode.unavailable')}</p>
+  }
   return (
     <div className="flex flex-col items-center gap-2">
       {/* `title` becomes the SVG's <title>, which is what assistive tech

--- a/voc-datalake/frontend/src/components/FormQrCode/index.tsx
+++ b/voc-datalake/frontend/src/components/FormQrCode/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './FormQrCode'

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.test.tsx
@@ -48,9 +48,9 @@ function buildForm(): FeedbackForm {
 
 const noop = () => undefined
 
-function renderCard(form: FeedbackForm) {
+function renderCard(form: FeedbackForm, apiEndpoint = 'https://api.example.com') {
   return render(
-    <FormCard form={form} onEdit={noop} onDelete={noop} onToggle={noop} apiEndpoint="https://api.example.com" />,
+    <FormCard form={form} onEdit={noop} onDelete={noop} onToggle={noop} apiEndpoint={apiEndpoint} />,
     { wrapper: createWrapper() },
   )
 }
@@ -119,6 +119,34 @@ describe('FormCard (issue #171)', () => {
     expect(screen.getByRole('img', {
       name: i18n.t('components:formQrCode.accessibleName', { formName: 'Website Feedback' }),
     })).toBeInTheDocument()
+  })
+
+  it('escapes a double quote in the form name so the embed snippet stays well formed', async () => {
+    const user = userEvent.setup()
+    renderCard({ ...buildForm(), name: 'The "Best" Form & Co' })
+
+    await user.click(screen.getByText('Show Embed Code'))
+
+    // The snippet is pasted verbatim into the customer's own page: a raw quote
+    // closes title=" early and hands them broken markup to debug.
+    const snippet = screen.getByText((_, node) => node?.tagName === 'CODE' && (node.textContent ?? '').includes('<iframe'))
+    expect(snippet.textContent).toContain('title="The &quot;Best&quot; Form &amp; Co"')
+    expect(snippet.textContent).not.toContain('title="The "Best"')
+  })
+
+  it('offers no link, snippet or QR when the endpoint cannot address the form', async () => {
+    const user = userEvent.setup()
+    // Reachable with a non-absolute endpoint: the page gate only checks for a
+    // non-empty string, so '/api' or a scheme-less paste arrives here.
+    renderCard(buildForm(), '/api')
+
+    await user.click(screen.getByText('Show Embed Code'))
+
+    expect(screen.getByText(i18n.t('feedbackForms:configureApiFirst'))).toBeInTheDocument()
+    expect(screen.queryByText(/feedback-forms\/form_1\/iframe/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('img', {
+      name: i18n.t('components:formQrCode.accessibleName', { formName: 'Website Feedback' }),
+    })).not.toBeInTheDocument()
   })
 
   it('survives a runtime record without a theme (the #171 crash)', () => {

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.test.tsx
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import i18n from 'i18next'
 
@@ -104,6 +105,20 @@ describe('FormCard (issue #171)', () => {
     const { t } = i18n
     expect(screen.getByRole('button', { name: t('feedbackForms:card.enableForm') })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: t('feedbackForms:card.disableForm') })).not.toBeInTheDocument()
+  })
+
+  it('offers a scannable QR beside the public URL it already prints', async () => {
+    const user = userEvent.setup()
+    renderCard(buildForm())
+
+    await user.click(screen.getByText('Show Embed Code'))
+
+    // The address a customer pastes into a page and the address a phone scans in
+    // a meeting are the same string, built once — so both appear here together.
+    expect(screen.getByText('https://api.example.com/feedback-forms/form_1/iframe')).toBeInTheDocument()
+    expect(screen.getByRole('img', {
+      name: i18n.t('components:formQrCode.accessibleName', { formName: 'Website Feedback' }),
+    })).toBeInTheDocument()
   })
 
   it('survives a runtime record without a theme (the #171 crash)', () => {

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.tsx
@@ -77,22 +77,43 @@ function FormStats({ stats, onViewSubmissions }: FormStatsProps) {
   )
 }
 
+/**
+ * A form name safe to sit inside a double-quoted HTML attribute.
+ *
+ * The snippet below is pasted verbatim into a customer's own page, so a name
+ * containing a double quote closes `title="` early and hands them broken markup
+ * to debug. `&` is escaped first, or the `&` this very substitution introduces
+ * would be escaped a second time.
+ */
+function escapeAttributeValue(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;')
+}
+
 interface EmbedCodeSectionProps {
-  readonly form: FeedbackForm
+  /** Just the two fields the snippets need — not the whole form record. */
+  readonly formId: string
+  readonly formName: string
   readonly apiEndpoint: string
   readonly copied: string | null
   readonly onCopy: (text: string, id: string) => void
 }
 
-function EmbedCodeSection({ form, apiEndpoint, copied, onCopy }: EmbedCodeSectionProps) {
+function EmbedCodeSection({ formId, formName, apiEndpoint, copied, onCopy }: EmbedCodeSectionProps) {
+  const { t } = useTranslation('feedbackForms')
   // Built here, from the one shared builder, because this section is the only
   // consumer of both spellings — and the QR below encodes the same string, so a
   // second construction site would let the printed URL and the scanned one drift.
-  const iframeUrl = feedbackFormPublicUrl(apiEndpoint, form.form_id)
+  const iframeUrl = feedbackFormPublicUrl(apiEndpoint, formId)
+  if (iframeUrl === null) {
+    // Without an addressable endpoint the link, the snippet and the QR are all
+    // equally dead, so say the one useful thing once instead of printing three
+    // broken artifacts for a customer to paste into their site.
+    return <p className="mt-3 text-xs text-gray-500">{t('configureApiFirst')}</p>
+  }
   const iframeEmbed = `<iframe 
   src="${iframeUrl}"
   style="width: 100%; min-height: 400px; border: none;"
-  title="${form.name}"
+  title="${escapeAttributeValue(formName)}"
 ></iframe>`
   return (
     <div className="mt-3 space-y-3">
@@ -125,7 +146,7 @@ function EmbedCodeSection({ form, apiEndpoint, copied, onCopy }: EmbedCodeSectio
       </div>
       {/* Same address as the Direct Link above, as scannable modules — for the
           room, where nobody is going to type that URL off a slide. */}
-      <FormQrCode apiEndpoint={apiEndpoint} formId={form.form_id} formName={form.name} />
+      <FormQrCode apiEndpoint={apiEndpoint} formId={formId} formName={formName} />
     </div>
   )
 }
@@ -235,7 +256,8 @@ export default function FormCard({ form, onEdit, onDelete, onToggle, apiEndpoint
           
           {showEmbed && (
             <EmbedCodeSection
-              form={form}
+              formId={form.form_id}
+              formName={form.name}
               apiEndpoint={apiEndpoint}
               copied={copied}
               onCopy={copyToClipboard}

--- a/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/FormCard.tsx
@@ -8,6 +8,8 @@ import { Trash2, Copy, Check, Code, ExternalLink, ToggleLeft, ToggleRight, Edit2
 import type { FeedbackForm } from '../../api/client'
 import { api } from '../../api/client'
 import { formStatsKey, FORM_STATS_STALE_TIME_MS } from '../../api/feedbackFormQueryKeys'
+import { feedbackFormPublicUrl } from '../../api/feedbackFormUrls'
+import FormQrCode from '../../components/FormQrCode'
 import { defaultFormConfig } from './formTemplates'
 import clsx from 'clsx'
 import SubmissionsModal from './SubmissionsModal'
@@ -76,13 +78,22 @@ function FormStats({ stats, onViewSubmissions }: FormStatsProps) {
 }
 
 interface EmbedCodeSectionProps {
-  readonly iframeUrl: string
-  readonly iframeEmbed: string
+  readonly form: FeedbackForm
+  readonly apiEndpoint: string
   readonly copied: string | null
   readonly onCopy: (text: string, id: string) => void
 }
 
-function EmbedCodeSection({ iframeUrl, iframeEmbed, copied, onCopy }: EmbedCodeSectionProps) {
+function EmbedCodeSection({ form, apiEndpoint, copied, onCopy }: EmbedCodeSectionProps) {
+  // Built here, from the one shared builder, because this section is the only
+  // consumer of both spellings — and the QR below encodes the same string, so a
+  // second construction site would let the printed URL and the scanned one drift.
+  const iframeUrl = feedbackFormPublicUrl(apiEndpoint, form.form_id)
+  const iframeEmbed = `<iframe 
+  src="${iframeUrl}"
+  style="width: 100%; min-height: 400px; border: none;"
+  title="${form.name}"
+></iframe>`
   return (
     <div className="mt-3 space-y-3">
       <div>
@@ -112,6 +123,9 @@ function EmbedCodeSection({ iframeUrl, iframeEmbed, copied, onCopy }: EmbedCodeS
           <code>{iframeEmbed}</code>
         </pre>
       </div>
+      {/* Same address as the Direct Link above, as scannable modules — for the
+          room, where nobody is going to type that URL off a slide. */}
+      <FormQrCode apiEndpoint={apiEndpoint} formId={form.form_id} formName={form.name} />
     </div>
   )
 }
@@ -140,13 +154,6 @@ export default function FormCard({ form, onEdit, onDelete, onToggle, apiEndpoint
     setCopied(id)
     setTimeout(() => setCopied(null), 2000)
   }
-
-  const iframeUrl = `${apiEndpoint}/feedback-forms/${form.form_id}/iframe`
-  const iframeEmbed = `<iframe 
-  src="${iframeUrl}"
-  style="width: 100%; min-height: 400px; border: none;"
-  title="${form.name}"
-></iframe>`
 
   return (
     <>
@@ -228,8 +235,8 @@ export default function FormCard({ form, onEdit, onDelete, onToggle, apiEndpoint
           
           {showEmbed && (
             <EmbedCodeSection
-              iframeUrl={iframeUrl}
-              iframeEmbed={iframeEmbed}
+              form={form}
+              apiEndpoint={apiEndpoint}
               copied={copied}
               onCopy={copyToClipboard}
             />

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
@@ -34,8 +34,15 @@ vi.mock('../../api/client', () => ({
   },
 }))
 
+/**
+ * Mutable so one test can drive the page with an endpoint that cannot address a
+ * form's public page. The panel itself takes the endpoint as a prop; the page is
+ * where it is read, which is exactly the seam this exercises.
+ */
+const mockConfig = vi.hoisted(() => ({ apiEndpoint: 'https://api.example.com' }))
+
 vi.mock('../../store/configStore', () => ({
-  useConfigStore: () => ({ config: { apiEndpoint: 'https://api.example.com' } }),
+  useConfigStore: () => ({ config: mockConfig }),
 }))
 
 vi.mock('react-markdown', () => ({
@@ -98,6 +105,7 @@ function qrName(formName: string): string {
 describe('collected feedback on a prioritization row', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockConfig.apiEndpoint = 'https://api.example.com'
     mockGetProjects.mockResolvedValue({ projects: [project] })
     mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq, prd] })
     mockGetPrioritizationScores.mockResolvedValue({ scores: {} })
@@ -299,6 +307,27 @@ describe('collected feedback on a prioritization row', () => {
     // fetch here would be paid on a page that is already N+1 on project reads.
     expect(mockGetFeedbackFormStats).toHaveBeenCalledTimes(1)
     expect(mockGetFeedbackForms.mock.calls.length).toBe(formsListCalls)
+  })
+
+  it('says why there is no QR when the endpoint cannot address the form', async () => {
+    // A scheme-less paste: non-empty, so the page's queries run and the row is
+    // fully populated, but nothing built from it opens on a phone.
+    mockConfig.apiEndpoint = 'api.example.com'
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'PR/FAQ concept test', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+    const user = userEvent.setup()
+
+    await expandRow('Feature A PR/FAQ')
+    await waitFor(() => {
+      expect(screen.getByText('PR/FAQ concept test')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: t('prioritization:qr.show') }))
+
+    // The dialog opens and explains itself rather than presenting a symbol that
+    // scans perfectly and opens nothing.
+    expect(screen.getByText(t('components:formQrCode.unavailable'))).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: qrName('PR/FAQ concept test') })).not.toBeInTheDocument()
   })
 
   it('withholds the QR when the linked form no longer exists', async () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.test.tsx
@@ -90,6 +90,11 @@ function readMetricValue(label: string): string | null {
   return labelNode.parentElement?.firstElementChild?.textContent ?? null
 }
 
+/** How assistive technology names the QR of one form — the QR carries no text. */
+function qrName(formName: string): string {
+  return t('components:formQrCode.accessibleName', { formName })
+}
+
 describe('collected feedback on a prioritization row', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -230,6 +235,85 @@ describe('collected feedback on a prioritization row', () => {
       expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
     })
     expect(mockGetFeedbackFormStats).not.toHaveBeenCalled()
+  })
+
+  it('keeps the QR out of the row until it is asked for', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'PR/FAQ concept test', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText('PR/FAQ concept test')).toBeInTheDocument()
+    })
+    // A QR needs ~200px to scan, and a pitch discusses one artifact at a time —
+    // the row's resting state stays the count and the average it shipped with.
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('3.2')).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: qrName('PR/FAQ concept test') })).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens a scannable QR for the linked form, and closes it again', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'PR/FAQ concept test', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+    const user = userEvent.setup()
+
+    await expandRow('Feature A PR/FAQ')
+    await waitFor(() => {
+      expect(screen.getByText('PR/FAQ concept test')).toBeInTheDocument()
+    })
+    // A button, so it is reachable and operable from the keyboard.
+    await user.click(screen.getByRole('button', { name: t('prioritization:qr.show') }))
+
+    const dialog = screen.getByRole('dialog')
+    // Named, not an anonymous overlay — and the QR inside it names its form.
+    expect(dialog).toHaveAccessibleName(t('prioritization:qr.title'))
+    expect(screen.getByRole('img', { name: qrName('PR/FAQ concept test') })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('spends no extra request on the QR beyond what the row already fetched', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_1', name: 'PR/FAQ concept test', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+    const user = userEvent.setup()
+
+    await expandRow('Feature A PR/FAQ')
+    await waitFor(() => {
+      expect(mockGetFeedbackFormStats).toHaveBeenCalledTimes(1)
+    })
+    const formsListCalls = mockGetFeedbackForms.mock.calls.length
+
+    await user.click(screen.getByRole('button', { name: t('prioritization:qr.show') }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    // The row already holds the form object; the QR is derived from its id. A
+    // fetch here would be paid on a page that is already N+1 on project reads.
+    expect(mockGetFeedbackFormStats).toHaveBeenCalledTimes(1)
+    expect(mockGetFeedbackForms.mock.calls.length).toBe(formsListCalls)
+  })
+
+  it('withholds the QR when the linked form no longer exists', async () => {
+    mockGetFeedbackForms.mockResolvedValue({
+      forms: [{ form_id: 'form_gone', name: 'Deleted form', project_id: 'p1', document_id: 'doc_prfaq' }],
+    })
+    mockGetFeedbackFormStats.mockRejectedValue(new Error('Form not found'))
+
+    await expandRow('Feature A PR/FAQ')
+
+    await waitFor(() => {
+      expect(screen.getByText(t('prioritization:evidence.unavailable'))).toBeInTheDocument()
+    })
+    // Its public page is gone too, so a QR would send the room to a 404.
+    expect(screen.queryByRole('button', { name: t('prioritization:qr.show') })).not.toBeInTheDocument()
   })
 
   it('renders the row when the forms list request fails', async () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
@@ -30,7 +30,6 @@ import { api } from '../../api/client'
 import { formStatsKey, FORM_STATS_STALE_TIME_MS } from '../../api/feedbackFormQueryKeys'
 import FormQrCode from '../../components/FormQrCode'
 import ModalShell from '../../components/ModalShell'
-import { useConfigStore } from '../../store/configStore'
 import type { LinkedForm } from './formLinkUtils'
 import type { ReactElement } from 'react'
 
@@ -64,10 +63,21 @@ function EvidenceMetric({
  *
  * No request is made here: `form` is already in hand from the forms list the
  * page fetched once, and the QR is derived from `form_id` alone.
+ *
+ * The endpoint arrives as a prop rather than out of the config store, the way
+ * `FormCard` already receives it. A store subscription here would make this
+ * component re-render for every unrelated config change (time range, date basis,
+ * brand) on a page that renders one of these per linked form per row, and it
+ * would make the component impossible to render without a store — this file's own
+ * tests reach it only through the whole page for exactly that reason.
  */
-function LinkedFormQrButton({ form }: { readonly form: LinkedForm }): ReactElement {
+function LinkedFormQrButton({
+  form, apiEndpoint,
+}: {
+  readonly form: LinkedForm
+  readonly apiEndpoint: string
+}): ReactElement {
   const { t } = useTranslation('prioritization')
-  const { config } = useConfigStore()
   const [isOpen, setIsOpen] = useState(false)
   // Names the dialog after the heading it already shows, so the accessible name
   // cannot drift from what is on screen. `useId` because a document can have
@@ -94,7 +104,12 @@ function LinkedFormQrButton({ form }: { readonly form: LinkedForm }): ReactEleme
             {t('qr.title')}
           </h3>
           <p className="text-sm text-gray-600 text-center truncate">{form.name}</p>
-          <FormQrCode apiEndpoint={config.apiEndpoint} formId={form.form_id} formName={form.name} />
+          <FormQrCode apiEndpoint={apiEndpoint} formId={form.form_id} formName={form.name} />
+          {/* Not a duplicate of anything the shell provides: `ModalShell` renders
+              the overlay, the panel and these children, and nothing else — its
+              own dismissal affordances are Escape and an overlay click, neither
+              of which is visible. This is also the panel's first focusable, so it
+              is where the shell puts focus on open. */}
           <button
             type="button"
             onClick={() => setIsOpen(false)}
@@ -114,7 +129,12 @@ function LinkedFormQrButton({ form }: { readonly form: LinkedForm }): ReactEleme
  * Its own component, so each form owns its own `useQuery` — a hook cannot be
  * called in a loop, and several forms can validate the same document.
  */
-function LinkedFormStats({ form }: { readonly form: LinkedForm }): ReactElement {
+function LinkedFormStats({
+  form, apiEndpoint,
+}: {
+  readonly form: LinkedForm
+  readonly apiEndpoint: string
+}): ReactElement {
   const { t } = useTranslation('prioritization')
   const {
     data, isPending, isError,
@@ -159,7 +179,7 @@ function LinkedFormStats({ form }: { readonly form: LinkedForm }): ReactElement 
           {/* Inside this branch, so a form whose stats read failed offers no QR:
               that is how a deleted form presents here, and its public page is
               gone too, so the QR would send the room to a 404. */}
-          <LinkedFormQrButton form={form} />
+          <LinkedFormQrButton form={form} apiEndpoint={apiEndpoint} />
         </>
       )}
     </div>
@@ -171,11 +191,14 @@ function LinkedFormStats({ form }: { readonly form: LinkedForm }): ReactElement 
  *
  * @param forms every form that validates this row's document — possibly none,
  *   possibly several.
+ * @param apiEndpoint the configured API base, threaded down from the page rather
+ *   than read from the store here, so nothing in this file needs one to render.
  */
 export default function LinkedFormEvidence({
-  forms,
+  forms, apiEndpoint,
 }: {
   readonly forms: readonly LinkedForm[]
+  readonly apiEndpoint: string
 }): ReactElement {
   const { t } = useTranslation('prioritization')
   return (
@@ -185,7 +208,9 @@ export default function LinkedFormEvidence({
         <p className="text-sm text-gray-500">{t('evidence.noLinkedForm')}</p>
       ) : (
         <div className="space-y-2">
-          {forms.map((form) => <LinkedFormStats key={form.form_id} form={form} />)}
+          {forms.map((form) => (
+            <LinkedFormStats key={form.form_id} form={form} apiEndpoint={apiEndpoint} />
+          ))}
         </div>
       )}
     </div>

--- a/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/LinkedFormEvidence.tsx
@@ -23,10 +23,14 @@
  */
 
 import { useQuery } from '@tanstack/react-query'
-import { MessageSquare, Star } from 'lucide-react'
+import { MessageSquare, QrCode, Star } from 'lucide-react'
+import { useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import { formStatsKey, FORM_STATS_STALE_TIME_MS } from '../../api/feedbackFormQueryKeys'
+import FormQrCode from '../../components/FormQrCode'
+import ModalShell from '../../components/ModalShell'
+import { useConfigStore } from '../../store/configStore'
 import type { LinkedForm } from './formLinkUtils'
 import type { ReactElement } from 'react'
 
@@ -46,6 +50,61 @@ function EvidenceMetric({
         <p className="text-xs text-gray-500">{label}</p>
       </div>
     </div>
+  )
+}
+
+/**
+ * The linked form's QR, behind a button rather than inline in the row.
+ *
+ * A QR needs around 200px before it scans from a few metres, and a pitch looks
+ * at one artifact at a time, so one per row would be noise on a page that
+ * already reads N+1 projects. The row's resting state — the submission count and
+ * the average — is unchanged; opening this is a deliberate act, and `ModalShell`
+ * renders nothing at all until it happens.
+ *
+ * No request is made here: `form` is already in hand from the forms list the
+ * page fetched once, and the QR is derived from `form_id` alone.
+ */
+function LinkedFormQrButton({ form }: { readonly form: LinkedForm }): ReactElement {
+  const { t } = useTranslation('prioritization')
+  const { config } = useConfigStore()
+  const [isOpen, setIsOpen] = useState(false)
+  // Names the dialog after the heading it already shows, so the accessible name
+  // cannot drift from what is on screen. `useId` because a document can have
+  // several linked forms, each with its own dialog.
+  const headingId = useId()
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="mt-2 flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-700"
+      >
+        <QrCode size={14} />
+        {t('qr.show')}
+      </button>
+      <ModalShell
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        ariaLabelledBy={headingId}
+        panelClassName="max-w-xs"
+      >
+        <div className="p-4 space-y-3">
+          <h3 id={headingId} className="font-medium text-gray-900 text-center">
+            {t('qr.title')}
+          </h3>
+          <p className="text-sm text-gray-600 text-center truncate">{form.name}</p>
+          <FormQrCode apiEndpoint={config.apiEndpoint} formId={form.form_id} formName={form.name} />
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            className="w-full px-3 py-2 text-sm text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
+          >
+            {t('qr.close')}
+          </button>
+        </div>
+      </ModalShell>
+    </>
   )
 }
 
@@ -75,25 +134,34 @@ function LinkedFormStats({ form }: { readonly form: LinkedForm }): ReactElement 
   return (
     <div className="bg-gray-50 rounded-lg border p-3">
       <p className="text-sm font-medium text-gray-800 truncate">{form.name}</p>
+      {/* One branch for the failed read and one for everything else, rather than
+          three siblings each re-testing isError — that spelling put this
+          component over the lint complexity ceiling. */}
       {isError ? (
         <p className="text-xs text-gray-500 mt-1">{t('evidence.unavailable')}</p>
       ) : (
-        <div className="grid grid-cols-2 gap-3 mt-2">
-          <EvidenceMetric
-            icon={<MessageSquare size={14} className="text-blue-600" />}
-            label={t('evidence.submissions')}
-            value={isPending || !stats ? '—' : String(stats.total_submissions)}
-          />
-          <EvidenceMetric
-            icon={<Star size={14} className="text-yellow-600" />}
-            label={t('evidence.avgRating')}
-            value={average === null ? '—' : average.toFixed(1)}
-          />
-        </div>
+        <>
+          <div className="grid grid-cols-2 gap-3 mt-2">
+            <EvidenceMetric
+              icon={<MessageSquare size={14} className="text-blue-600" />}
+              label={t('evidence.submissions')}
+              value={isPending || !stats ? '—' : String(stats.total_submissions)}
+            />
+            <EvidenceMetric
+              icon={<Star size={14} className="text-yellow-600" />}
+              label={t('evidence.avgRating')}
+              value={average === null ? '—' : average.toFixed(1)}
+            />
+          </div>
+          {!isPending && stats && average === null ? (
+            <p className="text-xs text-gray-500 mt-2">{t('evidence.noRatings')}</p>
+          ) : null}
+          {/* Inside this branch, so a form whose stats read failed offers no QR:
+              that is how a deleted form presents here, and its public page is
+              gone too, so the QR would send the room to a 404. */}
+          <LinkedFormQrButton form={form} />
+        </>
       )}
-      {!isError && !isPending && stats && average === null ? (
-        <p className="text-xs text-gray-500 mt-2">{t('evidence.noRatings')}</p>
-      ) : null}
     </div>
   )
 }

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -114,11 +114,12 @@ function PRFAQRowHeader({
 }
 
 function PRFAQRowExpanded({
-  prfaq, score, linkedForms, onUpdateScore,
+  prfaq, score, linkedForms, apiEndpoint, onUpdateScore,
 }: {
   readonly prfaq: PRFAQWithProject
   readonly score: PrioritizationScore
   readonly linkedForms: readonly LinkedForm[]
+  readonly apiEndpoint: string
   readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
 }) {
   const { t } = useTranslation('prioritization')
@@ -138,7 +139,7 @@ function PRFAQRowExpanded({
           {/* Ratings already collected about this document, beside the sliders
               that score it. Mounted here (expand-only) because the stats read is
               expensive per form — see LinkedFormEvidence. */}
-          <LinkedFormEvidence forms={linkedForms} />
+          <LinkedFormEvidence forms={linkedForms} apiEndpoint={apiEndpoint} />
         </div>
         <div className="space-y-3">
           <div className="flex items-center justify-between">
@@ -223,13 +224,19 @@ function PrototypePanel({
 }
 
 export default function PRFAQRow({
-  prfaq, index, score, linkedForms, isExpanded, onToggle, onUpdateScore,
+  prfaq, index, score, linkedForms, apiEndpoint, isExpanded, onToggle, onUpdateScore,
 }: {
   readonly prfaq: PRFAQWithProject
   readonly index: number
   readonly score: PrioritizationScore
   /** Forms that validate this document — see formLinkUtils.selectLinkedForms. */
   readonly linkedForms: readonly LinkedForm[]
+  /**
+   * The configured API base, needed only to address a linked form's public page
+   * in `LinkedFormEvidence`. Threaded rather than read from the store there, so
+   * that panel and its QR stay renderable without one.
+   */
+  readonly apiEndpoint: string
   readonly isExpanded: boolean
   readonly onToggle: () => void
   readonly onUpdateScore: (field: keyof PrioritizationScore, value: number | string) => void
@@ -241,7 +248,7 @@ export default function PRFAQRow({
   return (
     <div className="bg-white rounded-lg border shadow-sm">
       <PRFAQRowHeader prfaq={prfaq} index={index} priority={priority} score={score} isExpanded={isExpanded} onToggle={onToggle} />
-      {isExpanded ? <PRFAQRowExpanded prfaq={prfaq} score={score} linkedForms={linkedForms} onUpdateScore={onUpdateScore} /> : null}
+      {isExpanded ? <PRFAQRowExpanded prfaq={prfaq} score={score} linkedForms={linkedForms} apiEndpoint={apiEndpoint} onUpdateScore={onUpdateScore} /> : null}
     </div>
   )
 }

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -112,12 +112,14 @@ function SortControls({
 const NO_LINKED_FORMS: readonly LinkedForm[] = []
 
 function PRFAQList({
-  isLoading, prfaqs, scores, linkedFormsByDocument, expandedId, onToggleExpand, onUpdateScore, hasNonScorableOnly,
+  isLoading, prfaqs, scores, linkedFormsByDocument, apiEndpoint, expandedId, onToggleExpand, onUpdateScore, hasNonScorableOnly,
 }: {
   readonly isLoading: boolean
   readonly prfaqs: PRFAQWithProject[]
   readonly scores: Record<string, PrioritizationScore>
   readonly linkedFormsByDocument: ReadonlyMap<string, readonly LinkedForm[]>
+  /** Passed through to each row's linked-form panel — see PRFAQRow. */
+  readonly apiEndpoint: string
   readonly expandedId: string | null
   readonly onToggleExpand: (id: string) => void
   readonly onUpdateScore: (docId: string, field: keyof PrioritizationScore, value: number | string) => void
@@ -143,6 +145,7 @@ function PRFAQList({
           index={index}
           score={getScore(scores, prfaq.document_id)}
           linkedForms={linkedFormsByDocument.get(prfaq.document_id) ?? NO_LINKED_FORMS}
+          apiEndpoint={apiEndpoint}
           isExpanded={expandedId === prfaq.document_id}
           onToggle={() => onToggleExpand(prfaq.document_id)}
           onUpdateScore={(field, value) => onUpdateScore(prfaq.document_id, field, value)}
@@ -333,6 +336,7 @@ export default function Prioritization() {
         prfaqs={sortedPRFAQs}
         scores={scores}
         linkedFormsByDocument={linkedFormsByDocument}
+        apiEndpoint={config.apiEndpoint}
         expandedId={expandedId}
         onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
         onUpdateScore={updateScore}


### PR DESCRIPTION
The QR half of #314. The prototype-expand half of that issue is **not** here, so this references the issue rather than closing it.

## Why

Getting a room's ratings into the product means someone reads a URL aloud or pastes it into a chat channel. The form already has a public, mobile-ready page — `GET /feedback-forms/{id}/iframe` returns a complete HTML document with a mobile viewport — so all that was missing was a scannable rendering of an address the card already prints.

Nothing new is exposed. The QR encodes the same static, unauthenticated URL the card already offers as "Direct Link" and as an `<iframe>` snippet. It changes how that URL reaches a phone, not who can reach it.

## What changed

**One construction site for the address.** `FormCard` used to build `${apiEndpoint}/feedback-forms/${form.form_id}/iframe` inline. That moved to `api/feedbackFormUrls.ts` as `feedbackFormPublicUrl()`, and both render sites call it. A QR is the worst place for a second spelling to drift: nothing on screen reveals which address was encoded, so a stale one is discovered only by a room full of phones failing to load it. The endpoint is normalised through `baseUrl.ts`'s existing `stripTrailingSlashes`, so the QR resolves the endpoint identically to every API request.

**`components/FormQrCode/`** takes the endpoint and the form id, never a ready-made URL, which makes a second construction site structurally impossible. It renders `QRCodeSVG` at 200px with a 4-module quiet zone at level `M`:

- 200px because a phone a few metres from a projected screen needs roughly that before it resolves the modules. A QR too small to scan from a seat is decoration.
- The quiet zone because the spec requires 4 modules and the library defaults to 0; without it a scanner cannot find the symbol's edges against a busy card.
- Level `M` because the realistic failure mode is glare and heads in the way, not a pristine scan.

**On the Prioritization row it sits behind a button, not inline.** One QR per row would be noise on a page that already reads N+1 projects, and a pitch looks at one artifact at a time. The row's resting state — the submission count and average from #311 — is unchanged, and the QR opens in the existing `ModalShell` with a dialog role, an accessible name, and Escape/overlay/Close dismissal. No request is made: the form object is already in hand, so the QR costs nothing extra.

**SVG, generated in the browser.** Crisp when projected, where a canvas at this size is not. No third-party QR image service — that would ship form URLs to an external endpoint for no benefit and fail in a room with poor connectivity — and no hand-rolled encoder, because Reed–Solomon error correction is not a place to be clever.

## Dependency

One, `qrcode.react`, pinned to exactly `4.2.0` rather than a range. Its peer range accepts React 19. Not added to `manualChunks`: it is small and reached only from two already-loaded pages.

## Tested

From `voc-datalake/frontend`:

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors, 0 warnings (`--max-warnings 0`) |
| `npm run typecheck` | clean |
| `vitest run` | 152 files, **2240 tests**, 0 failed |

New keys are in all eight locale catalogues with real translations. The i18n gate's only failures are pre-existing and unrelated (`prioritization.docType.prfaq` and some `categories.json` plural extras); `Total missing: 0 | empty: 0`.

**Revert-sensitivity was checked rather than assumed.** Eleven mutations at the narrowest point of each new guard, eleven named test failures, tree clean afterwards. The one that matters most: changing `/iframe` to `/config` in the builder fails four tests across both files.

## Two judgement calls worth a reviewer's eye

**The QR is withheld when a form's stats read fails.** A deleted form presents exactly that way on the row, and its public page is gone too, so showing a QR would send a room to a 404. The cost is that a transient stats error also hides it. I took the 404 as the worse outcome.

**A third `isError`-testing sibling in `LinkedFormStats` tripped ESLint's `complexity: 12`.** The restructure into a single branch was required rather than cosmetic, and it moves no rendered output.

## Not in scope

The prototype-expand half of #314, and with it the signed-URL refresh scheduler that Prioritization still lacks. Also no QR pointing at a prototype (its address is a short-lived signed credential, so a QR over it is broken by construction), no "create a form for this document" affordance, and no change to the public routes, the widget, the feedback corpus, or the prioritization score write path.
