### PR TITLE
feat(documents): record and show how each document was built

### DIFF
--- a/voc-datalake/frontend/public/locales/de/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/de/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "Dokument löschen",
+    "derivation": {
+      "builtFrom": "Erstellt aus",
+      "feedbackUsed_one": "{{count}} Feedback-Eintrag verwendet",
+      "feedbackUsed_other": "{{count}} Feedback-Einträge verwendet",
+      "personasUsed_one": "{{count}} Persona verwendet",
+      "personasUsed_other": "{{count}} Personas verwendet",
+      "productContext": "Produktkontext einbezogen",
+      "roles": {
+        "mergeInput": "Zusammengeführt",
+        "prototypePrd": "Prototyp-Quelle PRD",
+        "prototypePrfaq": "Prototyp-Quelle PR/FAQ",
+        "reference": "Referenz"
+      },
+      "selectedUsed": "{{used}} von {{selected}} ausgewählten Dokumenten verwendet",
+      "unavailable": "Nicht mehr verfügbar"
+    },
     "editDocument": "Dokument bearbeiten",
     "newDocument": "Neues Dokument",
     "noDocuments": "Keine Dokumente",

--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "Delete document",
+    "derivation": {
+      "builtFrom": "Built from",
+      "feedbackUsed_one": "{{count}} feedback item used",
+      "feedbackUsed_other": "{{count}} feedback items used",
+      "personasUsed_one": "{{count}} persona used",
+      "personasUsed_other": "{{count}} personas used",
+      "productContext": "Product context included",
+      "roles": {
+        "mergeInput": "Merged in",
+        "prototypePrd": "Prototype source PRD",
+        "prototypePrfaq": "Prototype source PR/FAQ",
+        "reference": "Reference"
+      },
+      "selectedUsed": "{{used}} of {{selected}} selected documents used",
+      "unavailable": "No longer available"
+    },
     "editDocument": "Edit document",
     "newDocument": "New Document",
     "noDocuments": "No documents",

--- a/voc-datalake/frontend/public/locales/es/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/es/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "Eliminar documento",
+    "derivation": {
+      "builtFrom": "Creado a partir de",
+      "feedbackUsed_one": "{{count}} comentario utilizado",
+      "feedbackUsed_other": "{{count}} comentarios utilizados",
+      "personasUsed_one": "{{count}} persona utilizada",
+      "personasUsed_other": "{{count}} personas utilizadas",
+      "productContext": "Contexto del producto incluido",
+      "roles": {
+        "mergeInput": "Fusionado",
+        "prototypePrd": "PRD de origen del prototipo",
+        "prototypePrfaq": "PR/FAQ de origen del prototipo",
+        "reference": "Referencia"
+      },
+      "selectedUsed": "{{used}} de {{selected}} documentos seleccionados utilizados",
+      "unavailable": "Ya no está disponible"
+    },
     "editDocument": "Editar documento",
     "newDocument": "Nuevo Documento",
     "noDocuments": "Sin documentos",

--- a/voc-datalake/frontend/public/locales/fr/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/fr/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "Supprimer le document",
+    "derivation": {
+      "builtFrom": "Créé à partir de",
+      "feedbackUsed_one": "{{count}} retour client utilisé",
+      "feedbackUsed_other": "{{count}} retours clients utilisés",
+      "personasUsed_one": "{{count}} persona utilisé",
+      "personasUsed_other": "{{count}} personas utilisés",
+      "productContext": "Contexte produit inclus",
+      "roles": {
+        "mergeInput": "Fusionné",
+        "prototypePrd": "PRD source du prototype",
+        "prototypePrfaq": "PR/FAQ source du prototype",
+        "reference": "Référence"
+      },
+      "selectedUsed": "{{used}} document(s) utilisé(s) sur {{selected}} sélectionné(s)",
+      "unavailable": "Plus disponible"
+    },
     "editDocument": "Modifier le document",
     "newDocument": "Nouveau document",
     "noDocuments": "Aucun document",

--- a/voc-datalake/frontend/public/locales/ja/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ja/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "ドキュメントを削除",
+    "derivation": {
+      "builtFrom": "作成元",
+      "feedbackUsed_one": "フィードバック{{count}}件を使用",
+      "feedbackUsed_other": "フィードバック{{count}}件を使用",
+      "personasUsed_one": "ペルソナ{{count}}件を使用",
+      "personasUsed_other": "ペルソナ{{count}}件を使用",
+      "productContext": "製品コンテキストを含む",
+      "roles": {
+        "mergeInput": "マージ元",
+        "prototypePrd": "プロトタイプの元PRD",
+        "prototypePrfaq": "プロトタイプの元PR/FAQ",
+        "reference": "参照"
+      },
+      "selectedUsed": "選択された{{selected}}件のうち{{used}}件を使用",
+      "unavailable": "現在は利用できません"
+    },
     "editDocument": "ドキュメントを編集",
     "newDocument": "新規ドキュメント",
     "noDocuments": "ドキュメントなし",

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "문서 삭제",
+    "derivation": {
+      "builtFrom": "생성 출처",
+      "feedbackUsed_one": "피드백 {{count}}건 사용",
+      "feedbackUsed_other": "피드백 {{count}}건 사용",
+      "personasUsed_one": "페르소나 {{count}}개 사용",
+      "personasUsed_other": "페르소나 {{count}}개 사용",
+      "productContext": "제품 컨텍스트 포함",
+      "roles": {
+        "mergeInput": "병합 원본",
+        "prototypePrd": "프로토타입 원본 PRD",
+        "prototypePrfaq": "프로토타입 원본 PR/FAQ",
+        "reference": "참조"
+      },
+      "selectedUsed": "선택한 {{selected}}개 중 {{used}}개 사용",
+      "unavailable": "더 이상 사용할 수 없음"
+    },
     "editDocument": "문서 편집",
     "newDocument": "새 문서",
     "noDocuments": "문서 없음",

--- a/voc-datalake/frontend/public/locales/pt/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/pt/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "Deletar documento",
+    "derivation": {
+      "builtFrom": "Criado a partir de",
+      "feedbackUsed_one": "{{count}} comentário utilizado",
+      "feedbackUsed_other": "{{count}} comentários utilizados",
+      "personasUsed_one": "{{count}} persona utilizada",
+      "personasUsed_other": "{{count}} personas utilizadas",
+      "productContext": "Contexto do produto incluído",
+      "roles": {
+        "mergeInput": "Mesclado",
+        "prototypePrd": "PRD de origem do protótipo",
+        "prototypePrfaq": "PR/FAQ de origem do protótipo",
+        "reference": "Referência"
+      },
+      "selectedUsed": "{{used}} de {{selected}} documentos selecionados utilizados",
+      "unavailable": "Não está mais disponível"
+    },
     "editDocument": "Editar documento",
     "newDocument": "Novo Documento",
     "noDocuments": "Nenhum documento",

--- a/voc-datalake/frontend/public/locales/zh/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/zh/projectDetail.json
@@ -57,6 +57,22 @@
   },
   "documents": {
     "deleteDocument": "删除文档",
+    "derivation": {
+      "builtFrom": "构建来源",
+      "feedbackUsed_one": "已使用 {{count}} 条反馈",
+      "feedbackUsed_other": "已使用 {{count}} 条反馈",
+      "personasUsed_one": "已使用 {{count}} 个用户角色",
+      "personasUsed_other": "已使用 {{count}} 个用户角色",
+      "productContext": "已包含产品上下文",
+      "roles": {
+        "mergeInput": "合并来源",
+        "prototypePrd": "原型来源 PRD",
+        "prototypePrfaq": "原型来源 PR/FAQ",
+        "reference": "参考文档"
+      },
+      "selectedUsed": "已选择 {{selected}} 个文档，使用 {{used}} 个",
+      "unavailable": "已不可用"
+    },
     "editDocument": "编辑文档",
     "newDocument": "新建文档",
     "noDocuments": "无文档",

--- a/voc-datalake/frontend/src/api/derivation.test.ts
+++ b/voc-datalake/frontend/src/api/derivation.test.ts
@@ -68,6 +68,42 @@ describe('a document with a declared derivation', () => {
   })
 })
 
+describe('a declared derivation whose every selected document was dropped', () => {
+  // The generator records the selected count before it reads the documents, so
+  // a request whose selected documents had all been deleted stores "5 selected,
+  // 0 used". That record is the contract working, not an empty one.
+  const noneReached = {
+    document_id: 'prd_3',
+    derivation: {
+      sources: [],
+      selected_document_count: 5,
+      feedback_count: 0,
+      persona_ids: [],
+      product_context_included: false,
+    },
+  }
+
+  it('is not treated as having no derivation', () => {
+    expect(resolveDerivation(noneReached).origin).toBe('declared')
+  })
+
+  it('reports the count it recorded, so a consumer can say none of five was used', () => {
+    const resolved = resolveDerivation(noneReached)
+    expect(resolved.sources).toEqual([])
+    expect(resolved.selected_document_count).toBe(5)
+  })
+
+  it('does not fall back to the legacy fields of the same document', () => {
+    // The decisive case: the fallback would report one merge_input source and
+    // origin 'legacy', silently replacing "none of the five reached the model"
+    // with a lineage this document does not have.
+    const resolved = resolveDerivation({ ...noneReached, source_documents: ['legacy_1'] })
+    expect(resolved.origin).toBe('declared')
+    expect(resolved.sources).toEqual([])
+    expect(resolved.selected_document_count).toBe(5)
+  })
+})
+
 describe('resolving sources against the project documents', () => {
   const doc = {
     derivation: {

--- a/voc-datalake/frontend/src/api/derivation.test.ts
+++ b/voc-datalake/frontend/src/api/derivation.test.ts
@@ -1,0 +1,318 @@
+/**
+ * The derivation contract at the query boundary: a document always answers
+ * "what was I built from", a legacy document answers it in the same form, and no
+ * sparse or malformed record can break a consumer.
+ *
+ * Every expectation is a literal — nothing here is derived from the code under
+ * test.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  DERIVATION_ROLES,
+  emptyDerivation,
+  normalizeDerivation,
+  resolveDerivation,
+} from './derivation'
+
+const PRD = { document_id: 'prd_1', document_type: 'prd', title: 'Onboarding PRD' }
+const PRFAQ = { document_id: 'prfaq_1', document_type: 'prfaq', title: 'Onboarding PR/FAQ' }
+
+describe('the role vocabulary', () => {
+  it('is closed and lists the four relations the backend creates', () => {
+    expect(DERIVATION_ROLES).toEqual(['reference', 'prototype_prd', 'prototype_prfaq', 'merge_input'])
+  })
+})
+
+describe('a document with a declared derivation', () => {
+  const doc = {
+    document_id: 'prd_2',
+    derivation: {
+      sources: [
+        { document_id: 'doc_e', role: 'reference' },
+        { document_id: 'doc_d', role: 'reference' },
+      ],
+      selected_document_count: 5,
+      feedback_count: 12,
+      persona_ids: ['persona_1'],
+      product_context_included: true,
+    },
+  }
+
+  it('reports the sources in the order they were recorded', () => {
+    expect(resolveDerivation(doc).sources.map((s) => s.document_id)).toEqual(['doc_e', 'doc_d'])
+  })
+
+  it('reports the selected count separately, so the dropped documents are visible', () => {
+    const resolved = resolveDerivation(doc)
+    expect(resolved.sources).toHaveLength(2)
+    expect(resolved.selected_document_count).toBe(5)
+  })
+
+  it('reports the non-document inputs', () => {
+    const resolved = resolveDerivation(doc)
+    expect(resolved.feedback_count).toBe(12)
+    expect(resolved.persona_ids).toEqual(['persona_1'])
+    expect(resolved.product_context_included).toBe(true)
+  })
+
+  it('says the answer came from the declared field', () => {
+    expect(resolveDerivation(doc).origin).toBe('declared')
+  })
+
+  it('coerces counts that arrive as strings or DynamoDB floats', () => {
+    const resolved = resolveDerivation({
+      derivation: { ...doc.derivation, selected_document_count: '5', feedback_count: 12.0 },
+    })
+    expect(resolved.selected_document_count).toBe(5)
+    expect(resolved.feedback_count).toBe(12)
+  })
+})
+
+describe('resolving sources against the project documents', () => {
+  const doc = {
+    derivation: {
+      sources: [
+        { document_id: 'prd_1', role: 'prototype_prd' },
+        { document_id: 'deleted_1', role: 'prototype_prfaq' },
+      ],
+      selected_document_count: 2,
+      feedback_count: 0,
+      persona_ids: [],
+      product_context_included: false,
+    },
+  }
+
+  it('names a source that still exists', () => {
+    expect(resolveDerivation(doc, [PRD]).sources[0]).toEqual({
+      document_id: 'prd_1',
+      role: 'prototype_prd',
+      title: 'Onboarding PRD',
+      document_type: 'prd',
+      resolved: true,
+    })
+  })
+
+  it('keeps a source whose document no longer exists, marked unresolved', () => {
+    expect(resolveDerivation(doc, [PRD]).sources[1]).toEqual({
+      document_id: 'deleted_1',
+      role: 'prototype_prfaq',
+      title: null,
+      document_type: null,
+      resolved: false,
+    })
+  })
+
+  it('returns one entry per source even when nothing resolves', () => {
+    const resolved = resolveDerivation(doc)
+    expect(resolved.sources).toHaveLength(2)
+    expect(
+      resolved.sources.every((s) => s.resolved === false && s.title === null && s.document_type === null),
+    ).toBe(true)
+  })
+
+  it('reports what kind of document each source is, not only its title', () => {
+    // The role says how a source contributed; only document_type says what it
+    // is. A consumer that renders a type badge beside a title must get both
+    // from this one call rather than searching the document list again.
+    const resolved = resolveDerivation(doc, [PRD, PRFAQ])
+    expect(resolved.sources.map((s) => s.document_type)).toEqual(['prd', null])
+  })
+
+  it('reports an empty type for a source that resolved without one', () => {
+    // Mirrors title exactly: present-but-unusable is '', absent is null, so no
+    // consumer has to tell "resolved with no type" from "not resolved".
+    const untyped = { document_id: 'doc_x', title: 'No type on the wire' }
+    const resolved = resolveDerivation(
+      { derivation: { sources: [{ document_id: 'doc_x', role: 'reference' }] } },
+      [untyped],
+    )
+    expect(resolved.sources[0]).toEqual({
+      document_id: 'doc_x',
+      role: 'reference',
+      title: 'No type on the wire',
+      document_type: '',
+      resolved: true,
+    })
+  })
+})
+
+describe('a legacy document with no declared derivation', () => {
+  it('reads a prototype built from a PRD and a PR/FAQ', () => {
+    const resolved = resolveDerivation(
+      { document_id: 'prototype_1', source_prd_id: 'prd_1', source_prfaq_id: 'prfaq_1' },
+      [PRD, PRFAQ],
+    )
+    expect(resolved.sources).toEqual([
+      { document_id: 'prd_1', role: 'prototype_prd', title: 'Onboarding PRD', document_type: 'prd', resolved: true },
+      { document_id: 'prfaq_1', role: 'prototype_prfaq', title: 'Onboarding PR/FAQ', document_type: 'prfaq', resolved: true },
+    ])
+    expect(resolved.origin).toBe('legacy')
+  })
+
+  it('treats a real stored null exactly like an absent key', () => {
+    // A prototype built from a PR/FAQ alone stores source_prd_id: null; the
+    // sibling key is absent entirely. Both must read as "no such source".
+    const storedNull = resolveDerivation({ source_prd_id: null, source_prfaq_id: 'prfaq_1' })
+    const absent = resolveDerivation({ source_prfaq_id: 'prfaq_1' })
+    expect(storedNull.sources).toEqual([
+      { document_id: 'prfaq_1', role: 'prototype_prfaq', title: null, document_type: null, resolved: false },
+    ])
+    expect(storedNull).toEqual(absent)
+  })
+
+  it('reads a merge output built from a list of documents', () => {
+    const resolved = resolveDerivation({
+      source_documents: ['doc_1', 'doc_2'],
+      merge_instructions: 'Combine them',
+    })
+    expect(resolved.sources).toEqual([
+      { document_id: 'doc_1', role: 'merge_input', title: null, document_type: null, resolved: false },
+      { document_id: 'doc_2', role: 'merge_input', title: null, document_type: null, resolved: false },
+    ])
+    expect(resolved.origin).toBe('legacy')
+  })
+
+  it('reads a research report that only ever recorded a feedback count', () => {
+    const resolved = resolveDerivation({ document_type: 'research', feedback_count: 42 })
+    expect(resolved.feedback_count).toBe(42)
+    expect(resolved.sources).toEqual([])
+    expect(resolved.origin).toBe('legacy')
+  })
+
+  it('prefers the declared field when a document carries both', () => {
+    const resolved = resolveDerivation({
+      source_prd_id: 'prd_legacy',
+      derivation: {
+        sources: [{ document_id: 'prd_1', role: 'prototype_prd' }],
+        selected_document_count: 1,
+        feedback_count: 0,
+        persona_ids: [],
+        product_context_included: false,
+      },
+    })
+    expect(resolved.sources.map((s) => s.document_id)).toEqual(['prd_1'])
+    expect(resolved.origin).toBe('declared')
+  })
+})
+
+describe('a document with no recoverable lineage', () => {
+  it.each([
+    ['no lineage fields at all', { document_id: 'doc_1', title: 'Hand written' }],
+    ['a null derivation', { derivation: null }],
+    ['an empty declared derivation', { derivation: emptyDerivation() }],
+    ['an empty source list', { derivation: { ...emptyDerivation(), sources: [] } }],
+    ['a derivation that is not an object', { derivation: 'built from vibes' }],
+    ['an empty legacy list', { source_documents: [] }],
+    ['a null document', null],
+    ['a string instead of a document', 'not a document'],
+    ['an array instead of a document', []],
+  ])('reports exactly that, and does not throw: %s', (_case, input) => {
+    const resolved = resolveDerivation(input)
+    expect(resolved.origin).toBe('none')
+    expect(resolved).toEqual({ ...emptyDerivation(), sources: [], origin: 'none' })
+  })
+})
+
+describe('a malformed record', () => {
+  it('drops only the malformed entries, keeping the readable ones', () => {
+    const resolved = resolveDerivation({
+      derivation: {
+        sources: [
+          { document_id: 'doc_1', role: 'reference' },
+          { role: 'reference' }, // no id: points at nothing
+          { document_id: '', role: 'reference' }, // empty id: same
+          { document_id: 'doc_2', role: 'inspired_by' }, // role outside the vocabulary
+          'doc_3', // not an entry at all
+          null,
+          { document_id: 'doc_4', role: 'merge_input' },
+        ],
+        selected_document_count: 7,
+        feedback_count: 0,
+        persona_ids: [],
+        product_context_included: false,
+      },
+    })
+    expect(resolved.sources).toEqual([
+      { document_id: 'doc_1', role: 'reference', title: null, document_type: null, resolved: false },
+      { document_id: 'doc_4', role: 'merge_input', title: null, document_type: null, resolved: false },
+    ])
+    expect(resolved.selected_document_count).toBe(7)
+  })
+
+  it('degrades individual bad fields without losing the rest', () => {
+    const resolved = resolveDerivation({
+      derivation: {
+        sources: 'not a list',
+        selected_document_count: 'nonsense',
+        feedback_count: -3,
+        persona_ids: ['persona_1', 42, null, ''],
+        product_context_included: 'yes',
+      },
+    })
+    expect(resolved.sources).toEqual([])
+    expect(resolved.selected_document_count).toBe(0)
+    expect(resolved.feedback_count).toBe(0)
+    expect(resolved.persona_ids).toEqual(['persona_1'])
+    expect(resolved.product_context_included).toBe(false)
+  })
+
+  it('does not let a malformed sibling reject the surrounding documents', () => {
+    const documents: unknown[] = [
+      { document_id: 'a', derivation: { sources: [{ document_id: 'prd_1', role: 'prototype_prd' }] } },
+      { document_id: 'b', derivation: 'garbage' },
+      { document_id: 'c', source_documents: ['doc_1'] },
+    ]
+    const resolved = documents.map((d) => resolveDerivation(d, [PRD]))
+    expect(resolved.map((r) => r.origin)).toEqual(['declared', 'none', 'legacy'])
+    expect(resolved).toHaveLength(3)
+  })
+
+  it('normalizes any value to a usable derivation', () => {
+    for (const raw of [undefined, null, 0, '', [], 'x', { sources: null }]) {
+      expect(normalizeDerivation(raw)).toEqual(emptyDerivation())
+    }
+  })
+})
+
+describe('a cyclic reference chain', () => {
+  it('resolves each document once, without traversing into the cycle', () => {
+    // A says it was built from B; B says it was built from A. The resolver reads
+    // only a document's own sources, so there is no chain to follow and no way
+    // to loop.
+    const a = {
+      document_id: 'a',
+      document_type: 'custom',
+      title: 'A',
+      derivation: { sources: [{ document_id: 'b', role: 'merge_input' }] },
+    }
+    const b = {
+      document_id: 'b',
+      document_type: 'custom',
+      title: 'B',
+      derivation: { sources: [{ document_id: 'a', role: 'merge_input' }] },
+    }
+
+    const fromA = resolveDerivation(a, [a, b])
+    const fromB = resolveDerivation(b, [a, b])
+
+    expect(fromA.sources).toEqual([
+      { document_id: 'b', role: 'merge_input', title: 'B', document_type: 'custom', resolved: true },
+    ])
+    expect(fromB.sources).toEqual([
+      { document_id: 'a', role: 'merge_input', title: 'A', document_type: 'custom', resolved: true },
+    ])
+  })
+
+  it('resolves a document that names itself as its own source, once', () => {
+    const self = {
+      document_id: 'self',
+      document_type: 'prd',
+      title: 'Self',
+      derivation: { sources: [{ document_id: 'self', role: 'reference' }] },
+    }
+
+    expect(resolveDerivation(self, [self]).sources).toEqual([
+      { document_id: 'self', role: 'reference', title: 'Self', document_type: 'prd', resolved: true },
+    ])
+  })
+})

--- a/voc-datalake/frontend/src/api/derivation.ts
+++ b/voc-datalake/frontend/src/api/derivation.ts
@@ -221,9 +221,22 @@ function derivationFromLegacyFields(document: Record<string, unknown>): Document
   }
 }
 
+/**
+ * True when the derivation can say nothing at all about how the document was
+ * built — every recorded input, not just the sources.
+ *
+ * `selected_document_count` counts even with no sources. "Five selected, none
+ * used" is a real record, not an empty one: the generator sets the count before
+ * it reads the documents, so a request whose every selected document had since
+ * been deleted produces exactly that. Omitting the count here treated such a
+ * document as having no derivation, fell through to the legacy path, and
+ * reported `origin: 'none'` — so the Documents tab rendered nothing for the one
+ * document with the most to explain.
+ */
 function isEmpty(derivation: DocumentDerivation): boolean {
   return (
     derivation.sources.length === 0 &&
+    derivation.selected_document_count === 0 &&
     derivation.feedback_count === 0 &&
     derivation.persona_ids.length === 0 &&
     !derivation.product_context_included

--- a/voc-datalake/frontend/src/api/derivation.ts
+++ b/voc-datalake/frontend/src/api/derivation.ts
@@ -1,0 +1,319 @@
+/**
+ * @fileoverview The document-derivation contract: "what was this document built
+ * from", declared and validated at the query boundary.
+ *
+ * Every backend path that creates a project document writes a `derivation` map
+ * (see lambda/shared/derivation.py): an ordered list of contributing documents,
+ * each naming a source document id and the role it played, plus the non-document
+ * inputs (how much feedback, which personas, whether the project's
+ * product-context block was included). Documents written BEFORE that field
+ * existed still explain themselves: `resolveDerivation` reconstructs the same
+ * shape from the three lineage shapes that were already on the wire —
+ * `source_prd_id`/`source_prfaq_id` on a prototype, `source_documents` on a
+ * merge output, and `feedback_count` on a research report — none of which was
+ * declared anywhere in the frontend until now.
+ *
+ * Everything here is lenient on purpose, following the repository's
+ * schema-at-the-query-boundary convention (api/feedbackSchema.ts,
+ * api/scrapersSchema.ts, pages/FeedbackForms/formSchema.ts — the last of those
+ * exists because a sparse record blanked a whole route). Absent, null, an empty
+ * list and a malformed entry all read as "no lineage", and only the lineage is
+ * validated: a document is never rejected because its provenance is unreadable.
+ *
+ * `resolveDerivation` is pure and total — it renders nothing, imports no React,
+ * never throws, and always returns one entry per readable source.
+ *
+ * @module api/derivation
+ */
+import { z } from 'zod'
+
+/**
+ * The closed role vocabulary, in the order a resolved derivation reports it.
+ *
+ * Derived from what the backend actually does, and kept in lockstep with
+ * lambda/shared/derivation.py by
+ * lambda/shared/test/test_derivation_roles_lockstep.py. Adding a role here is a
+ * compile error in every place that maps one (see LEGACY_SOURCE_BY_ROLE below).
+ */
+export const DERIVATION_ROLES = [
+  /** A reference document the request selected and the generator fed the model. */
+  'reference',
+  /** The PRD a prototype was built from. */
+  'prototype_prd',
+  /** The PR/FAQ a prototype was built from. */
+  'prototype_prfaq',
+  /** A document fed to a merge. */
+  'merge_input',
+] as const
+
+export type DerivationRole = (typeof DERIVATION_ROLES)[number]
+
+/**
+ * Where a resolved derivation came from. `'none'` means no lineage was
+ * recoverable — a legitimate answer for a hand-authored document, never an
+ * error.
+ */
+export type DerivationOrigin = 'declared' | 'legacy' | 'none'
+
+/** One contributing document, resolved against the project's documents. */
+export interface DerivationSource {
+  document_id: string
+  role: DerivationRole
+  /** Title of the source document, or null when it was not resolved. */
+  title: string | null
+  /**
+   * Type of the source document ('prd', 'prototype', …), or null when it was
+   * not resolved — degrading exactly as `title` does, from the same lookup, so a
+   * consumer that renders a type badge beside a title gets both from one pass.
+   *
+   * NOT interchangeable with `role`: `role` says how the document contributed
+   * ('merge_input'), `document_type` says what it is ('prd'). Left as a plain
+   * string rather than the ProjectDocument union because it is whatever the wire
+   * supplied, and a newer backend may name a type this bundle has never heard of.
+   */
+  document_type: string | null
+  /**
+   * False when the source document was not among the documents supplied to the
+   * resolver — either because it has since been deleted, or because no
+   * documents were supplied to resolve against.
+   */
+  resolved: boolean
+}
+
+/** The stored shape, as written by lambda/shared/derivation.py. */
+export interface DocumentDerivation {
+  sources: Array<{ document_id: string; role: DerivationRole }>
+  /**
+   * How many reference documents the request selected. Can EXCEED
+   * `sources.length`: the generator feeds the model at most the first three, so
+   * the difference is the silent drop, recorded rather than implied.
+   */
+  selected_document_count: number
+  feedback_count: number
+  persona_ids: string[]
+  product_context_included: boolean
+}
+
+/** A derivation resolved for display: sources plus the non-document inputs. */
+export interface ResolvedDerivation extends Omit<DocumentDerivation, 'sources'> {
+  sources: DerivationSource[]
+  origin: DerivationOrigin
+}
+
+/** Coerce DynamoDB/JSON number round-trips ("3", 3.0) to a count, else 0. */
+function toCount(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0
+}
+
+/** Keep non-empty string items, drop junk instead of discarding the array. */
+const idListSchema = z
+  .array(z.unknown())
+  .catch(() => [])
+  .transform((items) => items.filter((item): item is string => typeof item === 'string' && item !== ''))
+
+/**
+ * One `sources` entry. Neither field can be salvaged when absent: an entry with
+ * no document id points at nothing, and a role outside the closed vocabulary
+ * cannot be named (it means a newer backend than this bundle). Such entries are
+ * dropped by `sourceListSchema` rather than defaulted, so one malformed entry
+ * costs exactly itself.
+ */
+const sourceSchema = z.object({
+  document_id: z.string().min(1),
+  role: z.enum(DERIVATION_ROLES),
+})
+
+const sourceListSchema = z
+  .array(z.unknown())
+  .catch(() => [])
+  .transform((items) =>
+    items.flatMap((item) => {
+      const parsed = sourceSchema.safeParse(item)
+      return parsed.success ? [parsed.data] : []
+    }),
+  )
+
+/**
+ * The stored derivation. Object-level catch makes a non-object — including the
+ * real stored `null` some backends write in place of an omitted key — degrade to
+ * an empty derivation, so null and absent are indistinguishable to every
+ * consumer.
+ */
+export const DocumentDerivationSchema = z
+  .object({
+    sources: sourceListSchema,
+    selected_document_count: z.preprocess(toCount, z.number()),
+    feedback_count: z.preprocess(toCount, z.number()),
+    persona_ids: idListSchema,
+    product_context_included: z.boolean().catch(false),
+  })
+  .catch(() => emptyDerivation())
+
+/** A derivation that records nothing. */
+export function emptyDerivation(): DocumentDerivation {
+  return {
+    sources: [],
+    selected_document_count: 0,
+    feedback_count: 0,
+    persona_ids: [],
+    product_context_included: false,
+  }
+}
+
+/**
+ * Make the declared derivation contract true for one wire value. Total: any
+ * input, including null/undefined/a string, yields a usable derivation.
+ */
+export function normalizeDerivation(raw: unknown): DocumentDerivation {
+  return DocumentDerivationSchema.parse(raw ?? {})
+}
+
+/**
+ * The pre-`derivation` field that carries each role, keyed by role so that
+ * adding a role to DERIVATION_ROLES is a compile error here. `null` means no
+ * legacy shape ever expressed that role — plain reference documents were never
+ * recorded at all, which is the gap this contract closes.
+ */
+const LEGACY_SOURCE_BY_ROLE = {
+  reference: null,
+  prototype_prd: { field: 'source_prd_id', arity: 'one' },
+  prototype_prfaq: { field: 'source_prfaq_id', arity: 'one' },
+  merge_input: { field: 'source_documents', arity: 'many' },
+} as const satisfies Record<DerivationRole, { field: string; arity: 'one' | 'many' } | null>
+
+/**
+ * A wire value as a readable bag of fields, or null when it is not one.
+ * Parsed rather than asserted (repo convention: no `as`), which also rejects the
+ * array and primitive shapes an API can deliver in place of a document.
+ */
+const recordSchema = z.record(z.string(), z.unknown())
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  const parsed = recordSchema.safeParse(value)
+  return parsed.success ? parsed.data : null
+}
+
+/** Reconstruct a derivation from the lineage shapes that predate this contract. */
+function derivationFromLegacyFields(document: Record<string, unknown>): DocumentDerivation {
+  const sources: DocumentDerivation['sources'] = []
+  for (const role of DERIVATION_ROLES) {
+    const legacy = LEGACY_SOURCE_BY_ROLE[role]
+    if (legacy === null) continue
+    const raw = document[legacy.field]
+    // A legacy prototype stores `source_prd_id: null` (a REAL stored null, from
+    // `(prd or {}).get('document_id')`) when it was built from a PR/FAQ alone.
+    // Reading null exactly like an absent key is what keeps such a prototype
+    // from claiming a source it never had.
+    const ids = legacy.arity === 'many' ? idListSchema.parse(raw) : idListSchema.parse([raw])
+    for (const id of ids) sources.push({ document_id: id, role })
+  }
+  return {
+    ...emptyDerivation(),
+    sources,
+    // Legacy records cannot distinguish used from requested — a merge stored the
+    // ids it was ASKED for — so the two numbers are reported as equal rather
+    // than inventing a drop that may not have happened.
+    selected_document_count: sources.length,
+    // The one non-document input any legacy shape recorded: a research report's
+    // feedback item count.
+    feedback_count: toCount(document.feedback_count),
+  }
+}
+
+function isEmpty(derivation: DocumentDerivation): boolean {
+  return (
+    derivation.sources.length === 0 &&
+    derivation.feedback_count === 0 &&
+    derivation.persona_ids.length === 0 &&
+    !derivation.product_context_included
+  )
+}
+
+/** What a source carries once its document was found. */
+type ResolvedSourceFields = Pick<DerivationSource, 'title' | 'document_type'>
+
+/** A displayable string, or '' for a field the wire did not supply as one. */
+function displayString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * Index of document_id → the fields a source displays, over whatever the caller
+ * supplied. One index for every resolved field, so a consumer needs one pass
+ * over the document list rather than one per field it wants to render.
+ */
+function sourceFieldIndex(documents: readonly unknown[]): Map<string, ResolvedSourceFields> {
+  const index = new Map<string, ResolvedSourceFields>()
+  for (const raw of documents) {
+    const record = asRecord(raw)
+    if (!record) continue
+    const id = record.document_id
+    if (typeof id !== 'string' || id === '') continue
+    index.set(id, {
+      title: displayString(record.title),
+      document_type: displayString(record.document_type),
+    })
+  }
+  return index
+}
+
+/**
+ * Answer "what was this document built from" for any document, new or legacy.
+ *
+ * Reads the declared `derivation` first and falls back to the pre-existing
+ * lineage fields, so the result is indistinguishable in form either way. A
+ * document with nothing recoverable reports `origin: 'none'` and empty inputs.
+ *
+ * @param document A project document from the wire. Anything unreadable —
+ *   null, a string, a document whose derivation is malformed — yields an empty
+ *   result rather than an error, so no consumer can be broken by a sparse
+ *   record and no surrounding document is ever rejected.
+ * @param projectDocuments The project's documents, used only to look up what
+ *   each source is — its title and its document type. A source that is not among
+ *   them (deleted since, or none supplied) comes back with `resolved: false` and
+ *   both fields null instead of being dropped — the relation survives its target.
+ *
+ * Depth-1 by construction: only the document's own direct sources are read,
+ * never a source's sources. A cyclic chain (A built from B, B built from A) is
+ * therefore inert — each call returns the other document, once, and there is no
+ * traversal to loop.
+ */
+export function resolveDerivation(
+  document: unknown,
+  projectDocuments: readonly unknown[] = [],
+): ResolvedDerivation {
+  const record = asRecord(document)
+  if (!record) return { ...emptyDerivation(), sources: [], origin: 'none' }
+
+  const declared = normalizeDerivation(record.derivation)
+  const useDeclared = !isEmpty(declared)
+  const derivation = useDeclared ? declared : derivationFromLegacyFields(record)
+
+  const fields = sourceFieldIndex(projectDocuments)
+  return {
+    ...derivation,
+    origin: originOf(derivation, useDeclared),
+    sources: derivation.sources.map((source) => {
+      // One lookup decides all three: an unresolved source degrades every
+      // resolved field to null together, so a consumer cannot render a type
+      // without a title or vice versa.
+      const found = fields.get(source.document_id)
+      return {
+        document_id: source.document_id,
+        role: source.role,
+        title: found?.title ?? null,
+        document_type: found?.document_type ?? null,
+        resolved: found !== undefined,
+      }
+    }),
+  }
+}
+
+/** Nothing recoverable reads as 'none' wherever it was read from, so
+ * `origin === 'none'` is exactly "this document cannot say what it was built
+ * from" — including a declared-but-empty record. */
+function originOf(derivation: DocumentDerivation, fromDeclaredField: boolean): DerivationOrigin {
+  if (isEmpty(derivation)) return 'none'
+  return fromDeclaredField ? 'declared' : 'legacy'
+}

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -1,5 +1,9 @@
 // API Types - extracted from client.ts to reduce file size
 
+// The derivation contract lives with its schema and resolver, so the runtime
+// validation and the declared type cannot drift apart.
+import type { DocumentDerivation } from './derivation'
+
 export interface FeedbackItem {
   feedback_id: string
   source_id: string
@@ -318,6 +322,36 @@ export interface ProjectDocument {
   // served from the /prototypes/* cache behavior with its own permissive CSP).
   // Absent on legacy prototypes; callers fall back to `content`/srcDoc.
   prototype_url?: string
+  /**
+   * What this document was built from — the one shape every document type uses
+   * (see api/derivation.ts). Absent on every document created before the field
+   * existed, and written as a sparse record when a document has no inputs, so
+   * read it through `resolveDerivation` rather than directly: that also
+   * reconstructs the answer from the legacy fields below.
+   */
+  derivation?: DocumentDerivation | null
+  // ── Pre-`derivation` lineage, still written, now declared ──
+  // These were on the wire long before this interface acknowledged them, and
+  // `resolveDerivation` reads them for documents that predate `derivation`.
+  // Both prototype ids are written as a REAL stored null (not an omitted key)
+  // when a prototype was built from only one of the two, hence `| null`.
+  /** The PRD a prototype was built from. */
+  source_prd_id?: string | null
+  /** The PR/FAQ a prototype was built from. */
+  source_prfaq_id?: string | null
+  /** The document ids a merge output was asked to merge (requested, not used). */
+  source_documents?: string[]
+  /** The instructions a merge output was produced with. */
+  merge_instructions?: string
+  /** Feedback items analyzed, on a research report. */
+  feedback_count?: number
+  /**
+   * The prototype this one revises, and the feedback that drove the revision.
+   * "This replaces that" is a DIFFERENT relation from "this was built from
+   * that", so these are deliberately not part of `derivation`.
+   */
+  revised_from_id?: string | null
+  revision_feedback?: string
   created_at: string
   updated_at?: string
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.derivation.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.derivation.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * The Documents tab states what the selected document was built from.
+ *
+ * Fixtures are chosen so no assertion here can pass by accident: the truncated
+ * record names more documents selected than used, one source is absent from the
+ * document list, one document carries no `derivation` field at all (so the
+ * reconstruction path is exercised through the UI), and one has no recoverable
+ * provenance at all.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import DocumentsTab from './DocumentsTab'
+import type { DocumentDerivation } from '../../api/derivation'
+import type { ProjectDocument, Project } from '../../api/types'
+
+const project: Project = {
+  project_id: 'proj-1',
+  name: 'Test Project',
+  description: '',
+  status: 'active',
+  created_at: '2026-01-05T00:00:00Z',
+  updated_at: '2026-01-05T00:00:00Z',
+  persona_count: 0,
+  document_count: 0,
+}
+
+function makeDoc(overrides: Partial<ProjectDocument> & Pick<ProjectDocument, 'document_id'>): ProjectDocument {
+  return {
+    document_type: 'prd',
+    title: `Title of ${overrides.document_id}`,
+    content: 'Body',
+    created_at: '2026-01-05T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function derivation(overrides: Partial<DocumentDerivation> = {}): DocumentDerivation {
+  return {
+    sources: [],
+    selected_document_count: 0,
+    feedback_count: 0,
+    persona_ids: [],
+    product_context_included: false,
+    ...overrides,
+  }
+}
+
+const REFERENCE_PRFAQ = makeDoc({
+  document_id: 'prfaq_1',
+  document_type: 'prfaq',
+  title: 'Onboarding PR/FAQ',
+})
+
+const REFERENCE_RESEARCH = makeDoc({
+  document_id: 'research_1',
+  document_type: 'research',
+  title: 'Churn research',
+})
+
+/** Five reference documents selected, three fed to the model, one since deleted. */
+const TRUNCATED_PRD = makeDoc({
+  document_id: 'prd_truncated',
+  title: 'PRD from five references',
+  derivation: derivation({
+    sources: [
+      { document_id: 'prfaq_1', role: 'reference' },
+      { document_id: 'research_1', role: 'reference' },
+      { document_id: 'deleted_1', role: 'reference' },
+    ],
+    selected_document_count: 5,
+    feedback_count: 12,
+    persona_ids: ['persona_1', 'persona_2'],
+    product_context_included: true,
+  }),
+})
+
+/** Nothing dropped: as many sources as documents selected. */
+const EXACT_PRD = makeDoc({
+  document_id: 'prd_exact',
+  title: 'PRD from one reference',
+  derivation: derivation({
+    sources: [{ document_id: 'prfaq_1', role: 'reference' }],
+    selected_document_count: 1,
+  }),
+})
+
+/** Pre-`derivation` prototype: only the old fixed-arity lineage fields. */
+const LEGACY_PROTOTYPE = makeDoc({
+  document_id: 'proto_legacy',
+  document_type: 'prototype',
+  title: 'Legacy prototype',
+  content: '{}',
+  source_prfaq_id: 'prfaq_1',
+})
+
+/** Hand-authored: no derivation, no legacy lineage, nothing to reconstruct. */
+const HAND_AUTHORED = makeDoc({ document_id: 'custom_1', document_type: 'custom', title: 'Hand written' })
+
+const ALL_DOCUMENTS = [TRUNCATED_PRD, EXACT_PRD, LEGACY_PROTOTYPE, HAND_AUTHORED, REFERENCE_PRFAQ, REFERENCE_RESEARCH]
+
+function renderTab(selectedDoc: ProjectDocument, onSelectDoc = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <DocumentsTab
+        project={project}
+        documents={ALL_DOCUMENTS}
+        selectedDoc={selectedDoc}
+        onSelectDoc={onSelectDoc}
+        onEditDoc={vi.fn()}
+        onDeleteDoc={vi.fn()}
+        onCreateDoc={vi.fn()}
+        isDeleting={false}
+      />
+    </MemoryRouter>,
+  )
+  return { onSelectDoc }
+}
+
+const provenance = () => screen.getByTestId('document-derivation')
+
+describe('the provenance of the selected document', () => {
+  it('names each contributing document with its type, its title and its role', () => {
+    renderTab(TRUNCATED_PRD)
+    const panel = provenance()
+    expect(within(panel).getByText('Built from')).toBeInTheDocument()
+    expect(within(panel).getByText('Onboarding PR/FAQ')).toBeInTheDocument()
+    expect(within(panel).getByText('Churn research')).toBeInTheDocument()
+    expect(within(panel).getAllByText('Reference')).toHaveLength(3)
+  })
+
+  it('shows what kind of document each source is, not just the role it played', () => {
+    // The badge is keyed on the source's document_type, which the resolver now
+    // returns: 'reference' says how it contributed, 'PRFAQ' says what it is.
+    renderTab(TRUNCATED_PRD)
+    const panel = provenance()
+    expect(within(panel).getByText('PRFAQ')).toBeInTheDocument()
+    expect(within(panel).getByText('RESEARCH')).toBeInTheDocument()
+  })
+
+  it('states the non-document inputs, so a document generated from feedback is not built from nothing', () => {
+    renderTab(TRUNCATED_PRD)
+    const panel = provenance()
+    expect(within(panel).getByText(/12 feedback items used/)).toBeInTheDocument()
+    expect(within(panel).getByText(/2 personas used/)).toBeInTheDocument()
+    expect(within(panel).getByText(/Product context included/)).toBeInTheDocument()
+  })
+
+  it('opens a source that still exists when it is clicked', async () => {
+    const user = userEvent.setup()
+    const { onSelectDoc } = renderTab(TRUNCATED_PRD)
+    await user.click(within(provenance()).getByRole('button', { name: /Onboarding PR\/FAQ/ }))
+    expect(onSelectDoc).toHaveBeenCalledWith(REFERENCE_PRFAQ)
+  })
+
+  it('shows a source deleted since as plain text, never as a control', () => {
+    renderTab(TRUNCATED_PRD)
+    const panel = provenance()
+    // Visible: the relation outlived its target.
+    expect(within(panel).getByText('deleted_1')).toBeInTheDocument()
+    expect(within(panel).getByText('No longer available')).toBeInTheDocument()
+    // Not navigable: every button in the panel is one of the two live sources.
+    const names = within(panel).getAllByRole('button').map((b) => b.textContent ?? '')
+    expect(names).toHaveLength(2)
+    expect(names.some((n) => n.includes('deleted_1'))).toBe(false)
+  })
+})
+
+describe('the difference between documents selected and documents used', () => {
+  it('states both numbers when the generator used fewer than were selected', () => {
+    renderTab(TRUNCATED_PRD)
+    expect(within(provenance()).getByText('3 of 5 selected documents used')).toBeInTheDocument()
+  })
+
+  it('says nothing at all when the two numbers agree', () => {
+    renderTab(EXACT_PRD)
+    expect(within(provenance()).queryByText(/selected documents used/)).not.toBeInTheDocument()
+  })
+
+  it('reads as neutral information: no warning colour and no icon', () => {
+    renderTab(TRUNCATED_PRD)
+    const panel = provenance()
+    const line = within(panel).getByText('3 of 5 selected documents used')
+    // The cap is deliberate. Nothing from the line up to the panel may style it
+    // as a fault, and the panel carries no icon that would imply one.
+    for (let node: HTMLElement | null = line; node !== null && node !== panel.parentElement; node = node.parentElement) {
+      expect(node.className).not.toMatch(/red|amber|yellow|orange/)
+    }
+    expect(panel.querySelectorAll('svg')).toHaveLength(0)
+  })
+})
+
+describe('a document written before the derivation field existed', () => {
+  it('still says what it was built from, reconstructed from its old lineage fields', () => {
+    renderTab(LEGACY_PROTOTYPE)
+    const panel = provenance()
+    expect(within(panel).getByText('Onboarding PR/FAQ')).toBeInTheDocument()
+    expect(within(panel).getByText('Prototype source PR/FAQ')).toBeInTheDocument()
+    // Legacy records cannot tell used from requested, so there is no drop to report.
+    expect(within(panel).queryByText(/selected documents used/)).not.toBeInTheDocument()
+  })
+})
+
+describe('a document with no recoverable provenance', () => {
+  it('renders nothing at all — no panel, no placeholder', () => {
+    renderTab(HAND_AUTHORED)
+    expect(screen.queryByTestId('document-derivation')).not.toBeInTheDocument()
+    expect(screen.queryByText('Built from')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['a null derivation', null],
+    ['an empty derivation', derivation()],
+  ])('renders nothing for %s', (_case, value) => {
+    renderTab(makeDoc({ document_id: 'sparse_1', title: 'Sparse', derivation: value }))
+    expect(screen.queryByTestId('document-derivation')).not.toBeInTheDocument()
+  })
+})
+
+describe('a sparse derivation record', () => {
+  it('costs the provenance footer only, leaving the rest of the tab intact', () => {
+    // The resolver is total, so an unreadable record is not an error state —
+    // the document still renders, and so do its siblings in the list.
+    renderTab(makeDoc({ document_id: 'sparse_2', title: 'Sparse record', derivation: derivation() }))
+    expect(screen.queryByTestId('document-derivation')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Sparse record' })).toBeInTheDocument()
+    expect(screen.getByText('PRD from five references')).toBeInTheDocument()
+    expect(screen.getByText('Legacy prototype')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.derivation.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.derivation.test.tsx
@@ -86,6 +86,13 @@ const EXACT_PRD = makeDoc({
   }),
 })
 
+/** Five selected, none reached the model — every one had been deleted since. */
+const NONE_REACHED_PRD = makeDoc({
+  document_id: 'prd_none_reached',
+  title: 'PRD whose references all vanished',
+  derivation: derivation({ selected_document_count: 5 }),
+})
+
 /** Pre-`derivation` prototype: only the old fixed-arity lineage fields. */
 const LEGACY_PROTOTYPE = makeDoc({
   document_id: 'proto_legacy',
@@ -176,6 +183,15 @@ describe('the difference between documents selected and documents used', () => {
   it('says nothing at all when the two numbers agree', () => {
     renderTab(EXACT_PRD)
     expect(within(provenance()).queryByText(/selected documents used/)).not.toBeInTheDocument()
+  })
+
+  it('still renders when none of the selected documents reached the model', () => {
+    // The count is recorded before the documents are read, so a request whose
+    // selected documents had all been deleted stores "5 selected, 0 used". That
+    // is the document with the most to explain, so it must not read as
+    // hand-authored.
+    renderTab(NONE_REACHED_PRD)
+    expect(within(provenance()).getByText('0 of 5 selected documents used')).toBeInTheDocument()
   })
 
   it('reads as neutral information: no warning colour and no icon', () => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
@@ -11,13 +11,12 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { projectsApi } from '../../api/projectsApi'
-import { resolveDerivation } from '../../api/derivation'
+import { resolveDerivation, type DerivationRole, type DerivationSource } from '../../api/derivation'
 import { useTransientFlag } from './useTransientFlag'
 import DocumentExportMenu from '../../components/DocumentExportMenu'
 import PrototypeLinkActions, { PrototypeLinkLifetimeNote } from '../../components/PrototypeLinkActions'
 import PrototypeRenderer, { HtmlPrototypeFrame } from '../../components/PrototypeRenderer'
 import { parsePrototypeSpec, looksLikeHtmlDocument } from '../../components/prototypeSpec'
-import type { DerivationRole, DerivationSource } from '../../api/derivation'
 import type {
   ProjectDocument, Project,
 } from '../../api/types'
@@ -545,6 +544,7 @@ function DerivationSourceRow({
   return (
     <span className="flex items-center gap-2 min-w-0">
       <button
+        type="button"
         onClick={() => onSelect(source.document_id)}
         className="flex items-center gap-2 min-w-0 text-left text-blue-600 hover:underline"
       >

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
@@ -11,11 +11,13 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { projectsApi } from '../../api/projectsApi'
+import { resolveDerivation } from '../../api/derivation'
 import { useTransientFlag } from './useTransientFlag'
 import DocumentExportMenu from '../../components/DocumentExportMenu'
 import PrototypeLinkActions, { PrototypeLinkLifetimeNote } from '../../components/PrototypeLinkActions'
 import PrototypeRenderer, { HtmlPrototypeFrame } from '../../components/PrototypeRenderer'
 import { parsePrototypeSpec, looksLikeHtmlDocument } from '../../components/prototypeSpec'
+import type { DerivationRole, DerivationSource } from '../../api/derivation'
 import type {
   ProjectDocument, Project,
 } from '../../api/types'
@@ -146,6 +148,11 @@ export default function DocumentsTab({
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{selectedDoc.content}</ReactMarkdown>
                 </div>
               )}
+              {/* Below the content, not above it: provenance is what the document
+                  was made from, not what it says. Both branches above own the
+                  pane's flexible height, so a footer here stays visible without
+                  pushing the preview down the page. */}
+              <DerivationFooter doc={selectedDoc} documents={documents} onSelectDoc={onSelectDoc} />
             </div>
           ) : (
             <div className="flex items-center justify-center h-full text-gray-400">{t('documents.selectDocument')}</div>
@@ -411,6 +418,140 @@ function PrototypeView({
         <PrototypeRenderer spec={spec} />
       </div>
     </div>
+  )
+}
+
+// ── Provenance: what the selected document was built from ────────────────────
+// First consumer of api/derivation.ts. `resolveDerivation` is already total —
+// absent, null, empty and malformed records all read as "no lineage", and it
+// reconstructs the answer for documents written before the field existed — so
+// this calls it and trusts it instead of parsing defensively on top.
+//
+// In the detail pane rather than on the list cards: a card is 224px wide and
+// already carries a badge, a date and a two-line title.
+
+function DerivationFooter({
+  doc, documents, onSelectDoc,
+}: {
+  readonly doc: ProjectDocument
+  readonly documents: readonly ProjectDocument[]
+  readonly onSelectDoc: (doc: ProjectDocument) => void
+}) {
+  const { t } = useTranslation('projectDetail')
+  const derivation = useMemo(() => resolveDerivation(doc, documents), [doc, documents])
+
+  // The resolver hands back ids, not documents, and `onSelectDoc` needs the
+  // document — so the list is searched here, once, on click only.
+  const onSelectSource = useCallback((documentId: string) => {
+    const target = documents.find((d) => d.document_id === documentId)
+    if (target) onSelectDoc(target)
+  }, [documents, onSelectDoc])
+
+  // 'none' is a legitimate answer — a hand-authored document, or an old record
+  // with nothing to reconstruct — not a gap to advertise. Nothing renders: no
+  // panel, no "unknown", no invented provenance to fill the space.
+  if (derivation.origin === 'none') return null
+
+  // Literal keys so the i18n extractor still sees them, in a record so that
+  // adding a role to DERIVATION_ROLES is a compile error here rather than a
+  // silently missing label.
+  const roleLabels: Record<DerivationRole, string> = {
+    reference: t('documents.derivation.roles.reference'),
+    prototype_prd: t('documents.derivation.roles.prototypePrd'),
+    prototype_prfaq: t('documents.derivation.roles.prototypePrfaq'),
+    merge_input: t('documents.derivation.roles.mergeInput'),
+  }
+
+  // The non-document inputs. Most PRDs are generated from feedback alone, and
+  // without these such a document would read as built from nothing.
+  const inputs = [
+    derivation.feedback_count > 0
+      ? t('documents.derivation.feedbackUsed', { count: derivation.feedback_count })
+      : null,
+    derivation.persona_ids.length > 0
+      ? t('documents.derivation.personasUsed', { count: derivation.persona_ids.length })
+      : null,
+    derivation.product_context_included ? t('documents.derivation.productContext') : null,
+  ].filter((label): label is string => label !== null)
+
+  return (
+    <section data-testid="document-derivation" className="mt-4 pt-3 border-t text-xs text-gray-500">
+      <h3 className="font-medium text-gray-600 mb-1.5">{t('documents.derivation.builtFrom')}</h3>
+      {derivation.sources.length > 0 ? (
+        <ul className="space-y-1">
+          {derivation.sources.map((source) => (
+            // Role in the key too: the same document can contribute twice under
+            // two roles, and neither entry should be dropped as a duplicate.
+            <li key={`${source.role}:${source.document_id}`}>
+              <DerivationSourceRow
+                source={source}
+                roleLabel={roleLabels[source.role]}
+                unavailableLabel={t('documents.derivation.unavailable')}
+                onSelect={onSelectSource}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {/* The generator feeds the model at most three of the reference documents
+          selected, so a record can say five selected and three used. Said in the
+          same neutral grey as the rest, with no icon and no warning colour: the
+          cap is deliberate, and fixing it is a separate issue from showing it.
+          Nothing is said at all when the two numbers agree. */}
+      {derivation.selected_document_count > derivation.sources.length ? (
+        <p className="mt-1.5">
+          {t('documents.derivation.selectedUsed', {
+            used: derivation.sources.length,
+            selected: derivation.selected_document_count,
+          })}
+        </p>
+      ) : null}
+      {inputs.length > 0 ? <p className="mt-1.5">{inputs.join(' · ')}</p> : null}
+    </section>
+  )
+}
+
+/** One contributing document: navigable while it exists, plain text once it does not. */
+function DerivationSourceRow({
+  source, roleLabel, unavailableLabel, onSelect,
+}: {
+  readonly source: DerivationSource
+  readonly roleLabel: string
+  readonly unavailableLabel: string
+  readonly onSelect: (documentId: string) => void
+}) {
+  const label = (
+    <>
+      {/* The same badge the list cards use, keyed on the document_type the
+          resolver now returns alongside the title. */}
+      {source.document_type ? <DocumentTypeBadge type={source.document_type} /> : null}
+      <span className="truncate">{source.title || source.document_id}</span>
+    </>
+  )
+  const role = <span className="flex-shrink-0 text-gray-400">{roleLabel}</span>
+
+  // A source whose document has been deleted stays visible — the relation
+  // outlived its target — but must not be a control that leads nowhere.
+  if (!source.resolved) {
+    return (
+      <span className="flex items-center gap-2 min-w-0">
+        {label}
+        <span className="flex-shrink-0">{unavailableLabel}</span>
+        {role}
+      </span>
+    )
+  }
+
+  return (
+    <span className="flex items-center gap-2 min-w-0">
+      <button
+        onClick={() => onSelect(source.document_id)}
+        className="flex items-center gap-2 min-w-0 text-left text-blue-600 hover:underline"
+      >
+        {label}
+      </button>
+      {role}
+    </span>
   )
 }
 

--- a/voc-datalake/lambda/api/product_context.py
+++ b/voc-datalake/lambda/api/product_context.py
@@ -26,6 +26,7 @@ from shared.exceptions import (
     ConfigurationError, NotFoundError, ValidationError, ServiceError,
 )
 from shared.tables import get_projects_table
+from shared.derivation import DERIVATION_FIELD, build_derivation
 
 
 projects_table = get_projects_table()
@@ -631,6 +632,12 @@ def generate_report(project_id: str, body: dict) -> dict:
         'document_type': 'product_report',
         'title': title,
         'content': content,
+        # This report is synthesized from the project's product-context block
+        # (structured fields + extracted internal documents) and nothing else —
+        # no project documents, no feedback, no personas. Recording that is what
+        # keeps it from reading as "built from nothing": the block is always
+        # present here, because generate_report refuses to run without it.
+        DERIVATION_FIELD: build_derivation(product_context_included=True),
         'created_at': now,
     }
     projects_table.put_item(Item=item)

--- a/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
@@ -78,24 +78,81 @@ def _leading_literal(node: ast.expr) -> str | None:
     return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
 
 
-def _section_headers() -> list[str | None]:
-    """The leading literal of every `sections.append(...)` in the producer."""
-    source = _read(PRODUCER_SOURCE)
+PRODUCER_FUNCTION = 'build_product_context_block'
+
+#: The list whose members become the returned block. Named once: every helper
+#: below reasons about mutations of this name.
+SECTIONS = 'sections'
+
+
+def _producer_function() -> ast.FunctionDef:
+    """The producer's AST node, with the two conditions its readers depend on.
+
+    Both are asserted here rather than at the call sites: a rename must produce
+    the message that names the rename, not an `IndexError`; and `ast.walk`
+    descends into nested definitions, so a nested function's statements would be
+    collected as the producer's own (the same leak the research handler's test
+    guards against, demonstrated there by mutation).
+    """
     functions = [
-        node for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.FunctionDef) and node.name == 'build_product_context_block'
+        node for node in ast.walk(ast.parse(_read(PRODUCER_SOURCE)))
+        if isinstance(node, ast.FunctionDef) and node.name == PRODUCER_FUNCTION
     ]
-    assert len(functions) == 1, f'Expected one build_product_context_block; found {len(functions)}.'
-    return [
-        _leading_literal(node.args[0])
-        for node in ast.walk(functions[0])
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == 'append'
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == 'sections'
-        and node.args
+    assert len(functions) == 1, (
+        f'Expected exactly one {PRODUCER_FUNCTION} in {PRODUCER_SOURCE}; found '
+        f'{len(functions)}. If it was renamed or duplicated, update '
+        f'PRODUCER_FUNCTION in this test file.'
+    )
+    nested = [
+        node.name for node in ast.walk(functions[0])
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node is not functions[0]
     ]
+    assert nested == [], (
+        f'{PRODUCER_FUNCTION} now defines nested function(s) {nested}, whose '
+        f'statements ast.walk cannot tell from the producer\'s own. Scope the '
+        f'helpers below to the function body before trusting them again.'
+    )
+    return functions[0]
+
+
+def _section_mutations() -> list[tuple[int, str, ast.expr | None]]:
+    """Every statement that changes `sections`, as (line, kind, value).
+
+    `kind` is `'append'`, `'init'` for `sections … = []`, or the shape of whatever
+    else was found: a method name as written (`'extend'`, `'insert'`, …), `'+='`,
+    `'setitem'`, or `'rebind'` for an assignment of anything but an empty list.
+    Every kind in that list is one this function can actually emit — a label it
+    could not produce would be a promise the reader cannot rely on.
+
+    The heading check can only reason about `append`, so collecting every kind
+    rather than only the appends is what stops it passing vacuously over a form it
+    never looks at. Read uses like `'\\n\\n'.join(sections)` are not mutations and
+    are deliberately not collected.
+    """
+    found: list[tuple[int, str, ast.expr | None]] = []
+    for node in ast.walk(_producer_function()):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == SECTIONS
+        ):
+            found.append((node.lineno, node.func.attr, node.args[0] if node.args else None))
+        elif isinstance(node, (ast.AnnAssign, ast.Assign, ast.AugAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == SECTIONS:
+                    if isinstance(node, ast.AugAssign):
+                        kind = '+='
+                    elif isinstance(node.value, ast.List) and not node.value.elts:
+                        kind = 'init'
+                    else:
+                        kind = 'rebind'
+                    found.append((node.lineno, kind, node.value))
+                elif isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) \
+                        and target.value.id == SECTIONS:
+                    found.append((node.lineno, 'setitem', node.value))
+    return found
 
 
 class TestProductContextPlaceholderLockstep:
@@ -126,36 +183,64 @@ class TestNoBlockCanBeBlankWithoutBeingThePlaceholder:
     its own content list is non-empty.
 
     That is an argument, so it is worth exactly nothing unless something enforces
-    it. These two tests are the enforcement: a future section that could be blank,
-    or a third return, fails here and asks for the guard to be reconsidered. Until
-    then the guard is unreachable, and an unreachable guard is dead code that
-    reads as protection.
+    it. These tests are the enforcement: a third return, a section that could be
+    blank, or a way of adding a section that the heading check cannot read, each
+    fail here and ask for the guard to be reconsidered. Until then the guard is
+    unreachable, and an unreachable guard is dead code that reads as protection.
+
+    The last of the three exists because the check's own failure direction is the
+    dangerous one. A heading check that inspects only `sections.append(...)`
+    passes vacuously the moment a section arrives by `extend`, `+=` or a
+    comprehension — it would stop watching without saying so, which is exactly
+    the fail-open shape it was written to rule out. So the enumeration of HOW
+    sections may be added is asserted first, and the headings second.
     """
 
     def test_the_producer_has_exactly_two_returns(self):
-        source = _read(PRODUCER_SOURCE)
-        functions = [
-            node for node in ast.walk(ast.parse(source))
-            if isinstance(node, ast.FunctionDef) and node.name == 'build_product_context_block'
-        ]
-        returns = [node for node in ast.walk(functions[0]) if isinstance(node, ast.Return)]
+        returns = [node for node in ast.walk(_producer_function()) if isinstance(node, ast.Return)]
         assert len(returns) == 2, (
-            f'build_product_context_block now has {len(returns)} returns, not 2. '
-            f'The generator decides product_context_included by comparing the '
-            f"result against one placeholder literal — check that every new exit "
-            f'either is that placeholder or carries real content.'
+            f'{PRODUCER_FUNCTION} now has {len(returns)} returns, not 2. The '
+            f'generator decides product_context_included by comparing the result '
+            f'against one placeholder literal — check that every new exit either '
+            f'is that placeholder or carries real content.'
+        )
+
+    def test_sections_is_only_ever_built_by_append(self):
+        """Fail CLOSED on an unrecognised mutation, rather than ignoring it.
+
+        Asserted as a closed set, not as "no extend": a form nobody has thought
+        of yet is a finding here instead of a silent gap in the test below.
+        """
+        unreadable = [(line, kind) for line, kind, _ in _section_mutations() if kind not in ('append', 'init')]
+        assert unreadable == [], (
+            f'{SECTIONS} is mutated by something other than append at '
+            f'{unreadable} in {PRODUCER_SOURCE}. The heading check below can only '
+            f'read appends, so it would pass while watching nothing. Either build '
+            f'sections with append, or extend that check to cover this form — and '
+            f'until then treat the missing `bool(block and block.strip())` guard '
+            f'in {CONSUMER_SOURCE}::_product_context as no longer justified.'
+        )
+
+    def test_sections_starts_empty_exactly_once(self):
+        """The `if not sections:` fallback means what it says only if the list
+        begins empty and is never rebound to something non-empty."""
+        inits = [line for line, kind, _ in _section_mutations() if kind == 'init']
+        assert len(inits) == 1, (
+            f'Expected exactly one `{SECTIONS} … = []` in {PRODUCER_FUNCTION}; '
+            f'found {len(inits)} at lines {inits}.'
         )
 
     def test_every_section_starts_with_a_visible_heading(self):
-        headers = _section_headers()
-        assert headers, 'No sections.append(...) found — did the producer change shape?'
-        for header in headers:
+        appends = [(line, value) for line, kind, value in _section_mutations() if kind == 'append']
+        assert appends, f'No {SECTIONS}.append(...) found — did the producer change shape?'
+        for line, value in appends:
+            header = _leading_literal(value) if value is not None else None
             assert header is not None and header.strip().startswith('###'), (
-                f'A section is appended without a leading "###" heading literal '
-                f'({header!r}). A section that can be blank makes a non-placeholder '
-                f'block blank too, and _product_context would then record '
-                f'product_context_included: True for a document with no product '
-                f'context. Either keep the heading, or add the '
+                f'The section appended at {PRODUCER_SOURCE}:{line} has no leading '
+                f'"###" heading literal ({header!r}). A section that can be blank '
+                f'makes a non-placeholder block blank too, and _product_context '
+                f'would then record product_context_included: True for a document '
+                f'with no product context. Either keep the heading, or add the '
                 f'`bool(block and block.strip())` guard in '
                 f'{CONSUMER_SOURCE}::_product_context.'
             )

--- a/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
@@ -18,6 +18,7 @@ needs neither module's AWS-shaped import graph.
 
 Pattern follows test_kiro_exportable_types_lockstep.py (same directory).
 """
+import ast
 import re
 from pathlib import Path
 
@@ -64,6 +65,39 @@ def _consumer_placeholder() -> str:
     return matches[0]
 
 
+def _leading_literal(node: ast.expr) -> str | None:
+    """The string literal a concatenation expression starts with, if any.
+
+    Every section in the producer is `"### header…" + something`, so the header is
+    the left-most leaf of a `+` chain. Returns None for an expression that does
+    not begin with a literal — which the test below treats as a finding rather
+    than a pass, because such a section's emptiness could not be reasoned about.
+    """
+    while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        node = node.left
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def _section_headers() -> list[str | None]:
+    """The leading literal of every `sections.append(...)` in the producer."""
+    source = _read(PRODUCER_SOURCE)
+    functions = [
+        node for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.FunctionDef) and node.name == 'build_product_context_block'
+    ]
+    assert len(functions) == 1, f'Expected one build_product_context_block; found {len(functions)}.'
+    return [
+        _leading_literal(node.args[0])
+        for node in ast.walk(functions[0])
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == 'append'
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == 'sections'
+        and node.args
+    ]
+
+
 class TestProductContextPlaceholderLockstep:
     def test_producer_and_consumer_use_the_same_placeholder(self):
         assert _producer_placeholder() == _consumer_placeholder(), (
@@ -78,3 +112,50 @@ class TestProductContextPlaceholderLockstep:
         """Named as a literal so this file cannot derive its expectation from
         either side of the comparison it is checking."""
         assert _producer_placeholder() == '(No product context provided.)'
+
+
+class TestNoBlockCanBeBlankWithoutBeingThePlaceholder:
+    """Why `_product_context` needs no `bool(block and block.strip())` guard.
+
+    The flag is `block != NO_PRODUCT_CONTEXT`, which would be wrong if the
+    producer could return a non-placeholder block that is nonetheless empty or
+    whitespace — a document would then record product context it never had. It
+    cannot, and the reason is structural rather than incidental: the producer has
+    exactly two returns, and the non-placeholder one joins `sections`, every
+    member of which begins with a visible `###` heading and is appended only when
+    its own content list is non-empty.
+
+    That is an argument, so it is worth exactly nothing unless something enforces
+    it. These two tests are the enforcement: a future section that could be blank,
+    or a third return, fails here and asks for the guard to be reconsidered. Until
+    then the guard is unreachable, and an unreachable guard is dead code that
+    reads as protection.
+    """
+
+    def test_the_producer_has_exactly_two_returns(self):
+        source = _read(PRODUCER_SOURCE)
+        functions = [
+            node for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == 'build_product_context_block'
+        ]
+        returns = [node for node in ast.walk(functions[0]) if isinstance(node, ast.Return)]
+        assert len(returns) == 2, (
+            f'build_product_context_block now has {len(returns)} returns, not 2. '
+            f'The generator decides product_context_included by comparing the '
+            f"result against one placeholder literal — check that every new exit "
+            f'either is that placeholder or carries real content.'
+        )
+
+    def test_every_section_starts_with_a_visible_heading(self):
+        headers = _section_headers()
+        assert headers, 'No sections.append(...) found — did the producer change shape?'
+        for header in headers:
+            assert header is not None and header.strip().startswith('###'), (
+                f'A section is appended without a leading "###" heading literal '
+                f'({header!r}). A section that can be blank makes a non-placeholder '
+                f'block blank too, and _product_context would then record '
+                f'product_context_included: True for a document with no product '
+                f'context. Either keep the heading, or add the '
+                f'`bool(block and block.strip())` guard in '
+                f'{CONSUMER_SOURCE}::_product_context.'
+            )

--- a/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
@@ -116,18 +116,25 @@ def _producer_function() -> ast.FunctionDef:
 
 
 def _section_mutations() -> list[tuple[int, str, ast.expr | None]]:
-    """Every statement that changes `sections`, as (line, kind, value).
+    """Every statement that writes to `sections` or calls a method on it, as
+    (line, kind, value).
 
-    `kind` is `'append'`, `'init'` for `sections … = []`, or the shape of whatever
-    else was found: a method name as written (`'extend'`, `'insert'`, …), `'+='`,
-    `'setitem'`, or `'rebind'` for an assignment of anything but an empty list.
-    Every kind in that list is one this function can actually emit — a label it
-    could not produce would be a promise the reader cannot rely on.
+    `kind` is `'append'`, `'init'` for `sections … = []`, a method name exactly as
+    written (`'extend'`, `'insert'`, …), `'+='`, `'setitem'`, or `'rebind'` for an
+    assignment of anything but an empty list. Every one of those is a label this
+    function can actually emit; one it could not produce would be a promise the
+    reader cannot rely on.
 
-    The heading check can only reason about `append`, so collecting every kind
-    rather than only the appends is what stops it passing vacuously over a form it
-    never looks at. Read uses like `'\\n\\n'.join(sections)` are not mutations and
-    are deliberately not collected.
+    Deliberately NOT limited to calls that mutate. Classifying `.copy()` or
+    `.index(…)` as harmless would mean keeping a list of method names known to be
+    read-only, which is denylist-shaped and fails OPEN for the next method nobody
+    thought of — the precise failure this helper exists to prevent. So any method
+    call is reported and the reader decides; a read-only call surfaces as a loud
+    question rather than a silent gap. Reads that name no method
+    (`'\\n\\n'.join(sections)`, `if not sections:`) are not collected.
+
+    A bare annotation (`sections: list[str]` with no value) is skipped: it writes
+    nothing, so reporting it would be a false positive with no question behind it.
     """
     found: list[tuple[int, str, ast.expr | None]] = []
     for node in ast.walk(_producer_function()):
@@ -138,6 +145,8 @@ def _section_mutations() -> list[tuple[int, str, ast.expr | None]]:
             and node.func.value.id == SECTIONS
         ):
             found.append((node.lineno, node.func.attr, node.args[0] if node.args else None))
+        elif isinstance(node, ast.AnnAssign) and node.value is None:
+            continue
         elif isinstance(node, (ast.AnnAssign, ast.Assign, ast.AugAssign)):
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
             for target in targets:

--- a/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_product_context_placeholder_lockstep.py
@@ -1,0 +1,80 @@
+"""Lockstep test: the "no product context" placeholder is one string in two files.
+
+`build_product_context_block` (lambda/api/product_context.py) returns a literal
+placeholder when a project has nothing to say about its product, and the document
+generator decides `derivation.product_context_included` by comparing the block it
+got back against its own copy of that literal
+(lambda/jobs/document_generator/handler.py::_product_context).
+
+The comparison is therefore a string equality across a module boundary, and it
+fails OPEN: whitespace or wording drift in the producer's copy makes every
+context-less project record `product_context_included: True`, claiming an input
+the document never had. Nothing else would notice — the prompts keep working,
+because the placeholder is only ever read by a human.
+
+Both literals are read as SOURCE TEXT rather than imported, so this test cannot
+be satisfied by whatever either module happens to resolve at import time, and it
+needs neither module's AWS-shaped import graph.
+
+Pattern follows test_kiro_exportable_types_lockstep.py (same directory).
+"""
+import re
+from pathlib import Path
+
+PRODUCER_SOURCE = 'lambda/api/product_context.py'
+CONSUMER_SOURCE = 'lambda/jobs/document_generator/handler.py'
+
+
+def _read(relative: str) -> str:
+    # lambda/api/test/ -> voc-datalake/
+    path = Path(__file__).resolve().parents[3] / relative
+    assert path.is_file(), (
+        f'{relative} not found — did the file move? '
+        f'If so, update the path constant in this test file.'
+    )
+    return path.read_text(encoding='utf-8')
+
+
+def _producer_placeholder() -> str:
+    """The string build_product_context_block returns when it has no sections.
+
+    Anchored to that branch specifically: the placeholder's meaning is "nothing
+    was assembled", so a second unrelated `return "…"` elsewhere in the module
+    must not be mistaken for it.
+    """
+    source = _read(PRODUCER_SOURCE)
+    matches = re.findall(r'if not sections:\s*\n\s*return\s+"([^"]*)"', source)
+    assert len(matches) == 1, (
+        f'Expected exactly one `if not sections: return "…"` fallback in '
+        f'{PRODUCER_SOURCE}; found {len(matches)}. If the fallback moved or was '
+        f'restructured, update this helper — and check that whatever replaced it '
+        f'still agrees with the consumer.'
+    )
+    return matches[0]
+
+
+def _consumer_placeholder() -> str:
+    """The NO_PRODUCT_CONTEXT constant the generator compares against."""
+    source = _read(CONSUMER_SOURCE)
+    matches = re.findall(r'^NO_PRODUCT_CONTEXT\s*=\s*"([^"]*)"', source, re.MULTILINE)
+    assert len(matches) == 1, (
+        f'Expected exactly one module-level NO_PRODUCT_CONTEXT assignment in '
+        f'{CONSUMER_SOURCE}; found {len(matches)}.'
+    )
+    return matches[0]
+
+
+class TestProductContextPlaceholderLockstep:
+    def test_producer_and_consumer_use_the_same_placeholder(self):
+        assert _producer_placeholder() == _consumer_placeholder(), (
+            'The "no product context" placeholder is compared by value across '
+            f'{PRODUCER_SOURCE} and {CONSUMER_SOURCE}. They have drifted, so '
+            'every project with no product context now records '
+            'product_context_included: True. Change both, or give them a shared '
+            'constant.'
+        )
+
+    def test_the_placeholder_is_pinned_literally(self):
+        """Named as a literal so this file cannot derive its expectation from
+        either side of the comparison it is checking."""
+        assert _producer_placeholder() == '(No product context provided.)'

--- a/voc-datalake/lambda/api/test/test_product_report_derivation.py
+++ b/voc-datalake/lambda/api/test/test_product_report_derivation.py
@@ -1,0 +1,52 @@
+"""A product report records that it was built from the project's product context.
+
+It is the one generated document with no document, feedback or persona inputs at
+all, so without this it would read as "built from nothing" — which is exactly the
+gap the derivation contract closes.
+"""
+from unittest.mock import MagicMock, patch
+
+CONTEXT = {
+    'product_name': 'Acme',
+    'one_liner': 'Does the thing',
+    'current_state': 'ga',
+    'target_users': '',
+    'problem_solved': '',
+    'key_features': '',
+    'differentiators': '',
+    'known_limitations': '',
+    'non_goals': '',
+    'success_metrics': '',
+    'free_form_notes': '',
+}
+
+
+def _generate(table):
+    import product_context
+    with patch.object(product_context, 'projects_table', table), \
+         patch.object(product_context, 'get_context', return_value={'context': CONTEXT}), \
+         patch.object(product_context, 'build_product_context_block', return_value='### Structured product context\n**Product**: Acme'), \
+         patch('shared.converse.converse', return_value='# Product description\n\nAcme does the thing.'):
+        return product_context.generate_report('proj-1', {})
+
+
+class TestProductReportDerivation:
+    def test_records_the_product_context_as_its_input(self):
+        table = MagicMock()
+
+        result = _generate(table)
+
+        derivation = table.put_item.call_args.kwargs['Item']['derivation']
+        assert derivation['product_context_included'] is True
+        assert result['document']['derivation'] is derivation
+
+    def test_records_no_documents_feedback_or_personas(self):
+        table = MagicMock()
+
+        _generate(table)
+
+        derivation = table.put_item.call_args.kwargs['Item']['derivation']
+        assert derivation['sources'] == []
+        assert derivation['selected_document_count'] == 0
+        assert derivation['feedback_count'] == 0
+        assert derivation['persona_ids'] == []

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -22,6 +22,14 @@ from shared.feedback import query_feedback_by_date
 from shared.api import validate_date_basis
 from shared.prompts import get_prd_generation_steps, get_prfaq_generation_steps
 from shared.prototypes import prototype_s3_key
+from shared.derivation import (
+    DERIVATION_FIELD,
+    ROLE_PROTOTYPE_PRD,
+    ROLE_PROTOTYPE_PRFAQ,
+    ROLE_REFERENCE,
+    build_derivation,
+    derivation_source,
+)
 
 # Environment
 PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
@@ -46,15 +54,23 @@ def _gather_context(
     feedback_table,
     project_id: str,
     doc_config: dict,
-) -> tuple[str, str]:
+) -> tuple[str, str, dict]:
     """Gather feedback, document, and persona context for document generation.
 
     Returns:
-        (feedback_context, personas_context) formatted for LLM prompts.
+        (feedback_context, personas_context, inputs) where the first two are
+        formatted for LLM prompts and `inputs` records what actually reached
+        them — the reference documents used (not the ones requested), how many
+        were selected, the feedback items included, and the personas used. The
+        caller folds `inputs` into the document's `derivation` (shared.derivation).
     """
     data_sources = doc_config.get('data_sources', {})
     feedback_context = ''
     personas_context = ''
+    used_sources: list[dict] = []
+    used_feedback_count = 0
+    used_persona_ids: list[str] = []
+    selected_document_count = 0
 
     # Gather feedback
     if data_sources.get('feedback'):
@@ -77,6 +93,8 @@ def _gather_context(
                     f"{item.get('original_text', '')[:300]}"
                 )
             feedback_context = '\n\n'.join(parts)
+            # Count what went into the prompt, not what the query returned.
+            used_feedback_count = len(parts)
 
     # Query project items once if we need personas or documents
     all_project_items = []
@@ -100,28 +118,68 @@ def _gather_context(
                     f"- Goals: {', '.join(p.get('goals', [])[:3])}\n"
                     f"- Frustrations: {', '.join(p.get('frustrations', [])[:3])}"
                 )
+                pid = p.get('persona_id')
+                if pid:
+                    used_persona_ids.append(pid)
             personas_context = '\n\n'.join(parts)
 
     # Gather reference documents and append to feedback context
     if data_sources.get('documents') or data_sources.get('research'):
         ctx.update_progress(40, 'fetching_documents')
         selected_ids = doc_config.get('selected_document_ids', [])
+        selected_document_count = len(selected_ids)
         docs = [i for i in all_project_items if i.get('sk', '').startswith(('RESEARCH#', 'PRD#', 'PRFAQ#', 'DOC#'))]
         if selected_ids:
             docs = [d for d in docs if d.get('document_id') in selected_ids]
         if docs:
             doc_parts = []
+            # The [:3] cap silently drops the rest of the selection. Recording
+            # each document from THIS loop (rather than from selected_ids) is
+            # what makes the recorded provenance the documents that actually
+            # reached the model; selected_document_count above states how many
+            # were asked for, so the drop is visible. The cap itself is a
+            # separate known issue and is deliberately left alone.
             for d in docs[:3]:
                 doc_parts.append(f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:3000]}")
+                source = derivation_source(d.get('document_id'), ROLE_REFERENCE)
+                if source:
+                    used_sources.append(source)
             doc_text = "## Reference Documents\n\n" + '\n\n'.join(doc_parts)
             feedback_context = f"{feedback_context}\n\n{doc_text}" if feedback_context else doc_text
 
-    return feedback_context, personas_context
+    inputs = {
+        'sources': used_sources,
+        'selected_document_count': selected_document_count,
+        'feedback_count': used_feedback_count,
+        'persona_ids': used_persona_ids,
+    }
+    return feedback_context, personas_context, inputs
+
+
+NO_PRODUCT_CONTEXT = "(No product context provided.)"
+
+
+def _product_context(project_id: str) -> tuple[str, bool]:
+    """The product-context block for the prompts, plus whether it carries anything.
+
+    The flag is what the document's derivation records: a PRD built from the
+    project's product context and nothing else must not read as "built from
+    nothing". A failure to build the block is not fatal — the prompts fall back
+    to the same placeholder they always did, and the derivation says the block
+    was not included.
+    """
+    try:
+        from api.product_context import build_product_context_block
+        block = build_product_context_block(project_id)
+    except Exception as e:
+        logger.warning(f"Failed to build product context: {e}")
+        return NO_PRODUCT_CONTEXT, False
+    return block, block != NO_PRODUCT_CONTEXT
 
 
 def _generate_prd(ctx: JobContext, feature_idea: str, feedback_context: str,
                   personas_context: str, doc_config: dict,
-                  product_context: str = "(No product context provided.)") -> tuple[str, dict]:
+                  product_context: str = NO_PRODUCT_CONTEXT) -> tuple[str, dict]:
     """Generate PRD using multi-step LLM chain.
 
     Returns:
@@ -153,7 +211,7 @@ def _generate_prd(ctx: JobContext, feature_idea: str, feedback_context: str,
 
 def _generate_prfaq(ctx: JobContext, feature_idea: str, feedback_context: str,
                     personas_context: str, doc_config: dict,
-                    product_context: str = "(No product context provided.)") -> tuple[str, dict]:
+                    product_context: str = NO_PRODUCT_CONTEXT) -> tuple[str, dict]:
     """Generate PR-FAQ using multi-step LLM chain.
 
     Returns:
@@ -501,10 +559,25 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
         'job_id': job_id,
         'source_prd_id': (prd or {}).get('document_id'),
         'source_prfaq_id': (prfaq or {}).get('document_id'),
+        # Same relation as source_prd_id/source_prfaq_id above, in the one shape
+        # every document type uses. Those two stay exactly as they are (existing
+        # readers, and pre-change prototypes, depend on them); this is additive.
+        # A prototype built from only one of the two records only that one —
+        # derivation_source drops the None that `(prd or {}).get(...)` yields.
+        DERIVATION_FIELD: build_derivation(
+            sources=[
+                derivation_source((prd or {}).get('document_id'), ROLE_PROTOTYPE_PRD),
+                derivation_source((prfaq or {}).get('document_id'), ROLE_PROTOTYPE_PRFAQ),
+            ],
+            selected_document_count=len([d for d in (prd, prfaq) if d]),
+        ),
         'created_at': now,
     }
     if feedback:
         # Record that this prototype is a feedback-driven revision of a prior one.
+        # Deliberately NOT folded into `derivation`: "this replaces that" is a
+        # different relation from "this was built from that" (a held product
+        # decision), so the revision fields stay as they are.
         item['revised_from_id'] = base_prototype_id or None
         item['revision_feedback'] = feedback[:2000]
     projects_table.put_item(Item=item)
@@ -570,17 +643,12 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) 
         ctx.update_progress(20, 'loading_source_documents')
         return _generate_prototype(ctx, projects_table, project_id, job_id, doc_config)
 
-    feedback_context, personas_context = _gather_context(
+    feedback_context, personas_context, inputs = _gather_context(
         ctx, projects_table, feedback_table, project_id, doc_config
     )
 
     # Inject the per-project product/service context (structured fields + uploaded internal docs).
-    try:
-        from api.product_context import build_product_context_block
-        product_context_str = build_product_context_block(project_id)
-    except Exception as e:
-        logger.warning(f"Failed to build product context: {e}")
-        product_context_str = "(No product context provided.)"
+    product_context_str, product_context_included = _product_context(project_id)
 
     ctx.update_progress(50, 'generating_document')
 
@@ -605,6 +673,9 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, doc_config: dict) 
         'feature_idea': feature_idea,
         'content': content,
         'job_id': job_id,
+        DERIVATION_FIELD: build_derivation(
+            **inputs, product_context_included=product_context_included
+        ),
         'created_at': now,
     }
     if analysis:
@@ -666,6 +737,22 @@ def _get_text(key: str) -> str:
     return _s3().get_object(Bucket=SCRATCH_BUCKET, Key=key)['Body'].read().decode('utf-8')
 
 
+def _read_derivation(job_id: str) -> dict:
+    """Read back the derivation the gather step stashed, or an empty one.
+
+    Never raises: a document that reaches the save step must be saved even if
+    its provenance could not be read back (an execution replayed against a
+    scratch prefix that was already cleaned, say). An empty derivation reads as
+    "no lineage", which is a legitimate answer, not an error.
+    """
+    import json as _json
+    try:
+        return _json.loads(_get_text(_scratch_key(job_id, 'derivation')))
+    except Exception as e:
+        logger.warning(f"Could not read derivation for job {job_id}: {e}")
+        return build_derivation()
+
+
 def _build_steps(project_id: str, job_id: str, doc_config: dict) -> dict:
     """gather step: fetch context, build chain steps, stash them in S3.
 
@@ -682,16 +769,11 @@ def _build_steps(project_id: str, job_id: str, doc_config: dict) -> dict:
     doc_type = doc_config.get('doc_type', 'prd')
     feature_idea = doc_config.get('feature_idea', '')
 
-    feedback_context, personas_context = _gather_context(
+    feedback_context, personas_context, inputs = _gather_context(
         ctx, projects_table, feedback_table, project_id, doc_config
     )
 
-    try:
-        from api.product_context import build_product_context_block
-        product_context_str = build_product_context_block(project_id)
-    except Exception as e:
-        logger.warning(f"Failed to build product context: {e}")
-        product_context_str = "(No product context provided.)"
+    product_context_str, product_context_included = _product_context(project_id)
 
     builder = get_prd_generation_steps if doc_type == 'prd' else get_prfaq_generation_steps
     chain_steps = builder(
@@ -704,6 +786,15 @@ def _build_steps(project_id: str, job_id: str, doc_config: dict) -> dict:
 
     import json as _json
     _put_text(_scratch_key(job_id, 'steps'), _json.dumps(chain_steps))
+    # The derivation is decided here (this is where the inputs are read) but
+    # written by the save step several Lambda invocations later. It rides the
+    # same claim-check as the step prompts rather than Step Functions state, so
+    # the state machine definition needs no new field and an in-flight execution
+    # started on the previous definition still saves a derivation.
+    _put_text(
+        _scratch_key(job_id, 'derivation'),
+        _json.dumps(build_derivation(**inputs, product_context_included=product_context_included)),
+    )
 
     ctx.update_progress(15, 'context_ready')
     # S3 keys are deterministic from (job_id, index), so SF state carries only
@@ -806,6 +897,7 @@ def _assemble_and_save(project_id: str, job_id: str, doc_type: str, title: str,
         'feature_idea': feature_idea,
         'content': content,
         'job_id': job_id,
+        DERIVATION_FIELD: _read_derivation(job_id),
         'created_at': now,
     }
     if analysis:
@@ -820,7 +912,7 @@ def _assemble_and_save(project_id: str, job_id: str, doc_type: str, title: str,
 
     # Best-effort cleanup of the scratch prefix for this job.
     try:
-        keys = [{'Key': _scratch_key(job_id, 'steps')}] + \
+        keys = [{'Key': _scratch_key(job_id, 'steps')}, {'Key': _scratch_key(job_id, 'derivation')}] + \
                [{'Key': _scratch_key(job_id, f'result_{i}')} for i in range(num_steps)]
         _s3().delete_objects(Bucket=SCRATCH_BUCKET, Delete={'Objects': keys})
     except Exception as e:

--- a/voc-datalake/lambda/jobs/document_generator/test/test_derivation.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_derivation.py
@@ -1,0 +1,336 @@
+"""Every document the generator creates records what it was built from.
+
+The fixture here deliberately selects MORE reference documents than the
+generator consumes (five selected, three used) and orders them so the used
+three are not the first three of the selection. A fixture with three or fewer
+selected documents cannot tell "what was used" from "what was requested", and a
+fixture whose selection order matches the query order cannot tell either apart
+from a slice of the request.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The wizard selected five reference documents...
+SELECTED_IDS = ['doc_a', 'doc_b', 'doc_c', 'doc_d', 'doc_e']
+
+# ...and the project table returns them in the REVERSE order, so the three the
+# generator actually feeds the model (the first three it iterates) are doc_e,
+# doc_d, doc_c — not the first three of the selection.
+PROJECT_DOCS = [
+    {'sk': f'PRD#{doc_id}', 'document_id': doc_id, 'title': doc_id.upper(), 'content': f'body of {doc_id}'}
+    for doc_id in reversed(SELECTED_IDS)
+]
+
+USED_SOURCES = [
+    {'document_id': 'doc_e', 'role': 'reference'},
+    {'document_id': 'doc_d', 'role': 'reference'},
+    {'document_id': 'doc_c', 'role': 'reference'},
+]
+
+
+def _saved_item(mock_dynamodb):
+    return mock_dynamodb['table'].put_item.call_args.kwargs['Item']
+
+
+class TestReferenceDocumentProvenance:
+    """The PRD/PR-FAQ path: records the documents that reached the model."""
+
+    @pytest.fixture
+    def event(self, sample_job_event):
+        return {
+            **sample_job_event,
+            'doc_config': {
+                'doc_type': 'prd',
+                'title': 'Test PRD',
+                'feature_idea': 'Improve onboarding',
+                'data_sources': {'feedback': False, 'personas': False, 'documents': True},
+                'selected_document_ids': SELECTED_IDS,
+                'days': 30,
+            },
+        }
+
+    @pytest.fixture(autouse=True)
+    def wire_project_documents(self, mock_dynamodb):
+        mock_dynamodb['table'].query.return_value = {'Items': PROJECT_DOCS}
+
+    def test_records_the_three_documents_used_not_the_five_selected(
+        self, mock_dynamodb, mock_jobs_table, mock_converse_chain, mock_prompt_steps,
+        event, lambda_context,
+    ):
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        assert _saved_item(mock_dynamodb)['derivation']['sources'] == USED_SOURCES
+
+    def test_states_how_many_were_selected_so_the_drop_is_visible(
+        self, mock_dynamodb, mock_jobs_table, mock_converse_chain, mock_prompt_steps,
+        event, lambda_context,
+    ):
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        assert _saved_item(mock_dynamodb)['derivation']['selected_document_count'] == 5
+
+    def test_a_selected_document_that_no_longer_exists_counts_as_selected_only(
+        self, mock_dynamodb, mock_jobs_table, mock_converse_chain, mock_prompt_steps,
+        event, lambda_context,
+    ):
+        """A deleted document can still be in the request. It cannot be a source
+        (it never reached the model) but it was selected, so the count includes it."""
+        event['doc_config']['selected_document_ids'] = ['doc_deleted'] + SELECTED_IDS
+
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        derivation = _saved_item(mock_dynamodb)['derivation']
+        assert derivation['sources'] == USED_SOURCES
+        assert derivation['selected_document_count'] == 6
+
+    def test_records_feedback_and_persona_inputs_actually_used(
+        self, mock_dynamodb, mock_jobs_table, mock_converse_chain, mock_prompt_steps,
+        event, lambda_context,
+    ):
+        """A PRD built from feedback and personas must not read as built from
+        nothing: the counts and persona ids that reached the prompt are recorded."""
+        event['doc_config']['data_sources'] = {'feedback': True, 'personas': True, 'documents': False}
+        # One day of lookback, so the mocked table answers the date loop once.
+        event['doc_config']['days'] = 1
+        mock_dynamodb['table'].query.return_value = {
+            'Items': [
+                {'sk': 'PERSONA#persona_1', 'persona_id': 'persona_1', 'name': 'Ana'},
+                {'sk': 'PERSONA#persona_2', 'persona_id': 'persona_2', 'name': 'Bo'},
+            ],
+        }
+        feedback_table = MagicMock()
+        feedback_table.query.return_value = {
+            'Items': [
+                {'original_text': f'review {i}', 'source_platform': 'webscraper', 'sentiment_label': 'negative'}
+                for i in range(4)
+            ],
+        }
+        mock_dynamodb['resource'].Table.side_effect = (
+            lambda name: feedback_table if 'feedback' in name.lower() else mock_dynamodb['table']
+        )
+
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        derivation = _saved_item(mock_dynamodb)['derivation']
+        assert derivation['feedback_count'] == 4
+        assert derivation['persona_ids'] == ['persona_1', 'persona_2']
+        assert derivation['sources'] == []
+
+    def test_records_whether_the_product_context_block_was_included(
+        self, mock_dynamodb, mock_jobs_table, mock_converse_chain, mock_prompt_steps,
+        event, lambda_context,
+    ):
+        from jobs.document_generator import handler
+
+        with patch.object(handler, '_product_context', return_value=('### Product\nreal context', True)):
+            handler.lambda_handler(event, lambda_context)
+
+        assert _saved_item(mock_dynamodb)['derivation']['product_context_included'] is True
+
+    def test_a_document_with_no_inputs_records_an_empty_derivation(
+        self, mock_dynamodb, mock_jobs_table, mock_converse_chain, mock_prompt_steps,
+        event, lambda_context,
+    ):
+        """The question must always be answerable — "nothing" is an answer, and
+        it is recorded with every key present rather than by omission."""
+        event['doc_config']['data_sources'] = {'feedback': False, 'personas': False, 'documents': False}
+
+        from jobs.document_generator.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        assert _saved_item(mock_dynamodb)['derivation'] == {
+            'sources': [],
+            'selected_document_count': 0,
+            'feedback_count': 0,
+            'persona_ids': [],
+            'product_context_included': False,
+        }
+
+
+class TestProductContextFlag:
+    """_product_context reports whether the block carries anything, without
+    letting a failure to build it fail the job."""
+
+    def test_a_real_block_reports_included(self):
+        from jobs.document_generator.handler import _product_context
+
+        fake = MagicMock()
+        fake.build_product_context_block.return_value = '### Structured product context\n**Product**: Acme'
+        with patch.dict(sys.modules, {'api.product_context': fake}):
+            block, included = _product_context('proj_1')
+
+        assert included is True
+        assert block == '### Structured product context\n**Product**: Acme'
+
+    def test_the_empty_placeholder_reports_not_included(self):
+        from jobs.document_generator.handler import _product_context
+
+        fake = MagicMock()
+        fake.build_product_context_block.return_value = '(No product context provided.)'
+        with patch.dict(sys.modules, {'api.product_context': fake}):
+            _, included = _product_context('proj_1')
+
+        assert included is False
+
+    def test_a_failure_falls_back_to_the_placeholder_and_reports_not_included(self):
+        from jobs.document_generator.handler import _product_context
+
+        fake = MagicMock()
+        fake.build_product_context_block.side_effect = RuntimeError('table gone')
+        with patch.dict(sys.modules, {'api.product_context': fake}):
+            block, included = _product_context('proj_1')
+
+        assert block == '(No product context provided.)'
+        assert included is False
+
+
+class TestPrototypeProvenance:
+    """A prototype records the PRD and PR/FAQ it was built from in the shared
+    shape as well as in its own two fixed fields."""
+
+    HTML = '<!DOCTYPE html><html><body><h1>Demo</h1></body></html>'
+
+    def _event(self, sample_job_event):
+        return {
+            **sample_job_event,
+            'doc_config': {'doc_type': 'build_prototype', 'title': 'Test Prototype'},
+        }
+
+    def _latest(self, prd, prfaq):
+        """Stand in for the per-prefix "newest document" lookup, whose real
+        DynamoDB key condition a MagicMock table cannot distinguish."""
+        return lambda _table, _project_id, prefix: prd if prefix == 'PRD#' else prfaq
+
+    def test_records_both_source_documents_with_distinct_roles(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        mock_dynamodb['table'].get_item.return_value = {'Item': {'name': 'My Project'}}
+        mock_converse.return_value = self.HTML
+
+        from jobs.document_generator import handler
+        with patch.object(handler, '_latest_doc_by_prefix', self._latest(
+            {'document_id': 'prd_1', 'content': 'PRD body'},
+            {'document_id': 'prfaq_1', 'content': 'PRFAQ body'},
+        )):
+            handler.lambda_handler(self._event(sample_job_event), lambda_context)
+
+        item = _saved_item(mock_dynamodb)
+        assert item['derivation']['sources'] == [
+            {'document_id': 'prd_1', 'role': 'prototype_prd'},
+            {'document_id': 'prfaq_1', 'role': 'prototype_prfaq'},
+        ]
+        assert item['derivation']['selected_document_count'] == 2
+        # The original fixed-arity fields are untouched.
+        assert item['source_prd_id'] == 'prd_1'
+        assert item['source_prfaq_id'] == 'prfaq_1'
+
+    def test_a_prototype_built_from_one_document_records_only_that_one(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """`source_prfaq_id` is written as a REAL stored null here; the shared
+        shape must not turn that null into a source."""
+        mock_dynamodb['table'].get_item.return_value = {'Item': {'name': 'My Project'}}
+        mock_converse.return_value = self.HTML
+
+        from jobs.document_generator import handler
+        with patch.object(handler, '_latest_doc_by_prefix', self._latest(
+            {'document_id': 'prd_1', 'content': 'PRD body'}, None,
+        )):
+            handler.lambda_handler(self._event(sample_job_event), lambda_context)
+
+        item = _saved_item(mock_dynamodb)
+        assert item['derivation']['sources'] == [{'document_id': 'prd_1', 'role': 'prototype_prd'}]
+        assert item['derivation']['selected_document_count'] == 1
+        assert item['source_prfaq_id'] is None
+
+
+class TestStepFunctionsPath:
+    """PRD/PR-FAQ generation is split across Lambda invocations; the derivation
+    is decided at gather and must survive to the save step."""
+
+    def test_gather_stashes_the_derivation_and_save_writes_it(
+        self, mock_dynamodb, mock_jobs_table, mock_prompt_steps, mock_s3,
+        sample_job_event, lambda_context,
+    ):
+        from jobs.document_generator import handler
+        lambda_handler = handler.lambda_handler
+
+        mock_dynamodb['table'].query.return_value = {'Items': PROJECT_DOCS}
+        stash: dict[str, bytes] = {}
+        mock_s3.put_object.side_effect = lambda **kw: stash.__setitem__(kw['Key'], kw['Body'])
+
+        def get_object(Bucket=None, Key=None, **kwargs):
+            body = MagicMock()
+            body.read.return_value = stash[Key]
+            return {'Body': body}
+        mock_s3.get_object.side_effect = get_object
+
+        gathered = lambda_handler({
+            'step': 'gather',
+            **sample_job_event,
+            'doc_config': {
+                'doc_type': 'prd',
+                'title': 'Test PRD',
+                'feature_idea': 'Improve onboarding',
+                'data_sources': {'documents': True},
+                'selected_document_ids': SELECTED_IDS,
+            },
+        }, lambda_context)
+
+        # Each chain step runs in its own invocation; the module-level converse
+        # binding is what run_step calls.
+        with patch.object(handler, 'converse', return_value='step output'):
+            for index in range(gathered['num_steps']):
+                lambda_handler({'step': 'run_step', **sample_job_event, 'index': index}, lambda_context)
+
+        lambda_handler({
+            'step': 'save',
+            **sample_job_event,
+            'doc_type': 'prd',
+            'title': 'Test PRD',
+            'feature_idea': 'Improve onboarding',
+            'num_steps': gathered['num_steps'],
+        }, lambda_context)
+
+        derivation = _saved_item(mock_dynamodb)['derivation']
+        assert derivation['sources'] == USED_SOURCES
+        assert derivation['selected_document_count'] == 5
+
+    def test_save_still_writes_a_document_when_the_derivation_is_unreadable(
+        self, mock_dynamodb, mock_jobs_table, mock_s3, sample_job_event, lambda_context,
+    ):
+        """An execution replayed against a cleaned scratch prefix must still save
+        the document; "no lineage" is a legitimate answer, not a failure."""
+        from jobs.document_generator.handler import _assemble_and_save
+
+        def get_object(Bucket=None, Key=None, **kwargs):
+            if Key.endswith('derivation.txt'):
+                raise RuntimeError('NoSuchKey')
+            body = MagicMock()
+            body.read.return_value = b'step output'
+            return {'Body': body}
+        mock_s3.get_object.side_effect = get_object
+
+        _assemble_and_save(
+            sample_job_event['project_id'], sample_job_event['job_id'],
+            'prd', 'Test PRD', 'Improve onboarding', 3,
+        )
+
+        assert _saved_item(mock_dynamodb)['derivation'] == {
+            'sources': [],
+            'selected_document_count': 0,
+            'feedback_count': 0,
+            'persona_ids': [],
+            'product_context_included': False,
+        }

--- a/voc-datalake/lambda/jobs/document_merger/handler.py
+++ b/voc-datalake/lambda/jobs/document_merger/handler.py
@@ -18,6 +18,12 @@ from shared.jobs import job_handler, JobContext
 from shared.aws import get_dynamodb_resource
 from shared.converse import converse
 from shared.feedback import query_feedback_by_date
+from shared.derivation import (
+    DERIVATION_FIELD,
+    ROLE_MERGE_INPUT,
+    build_derivation,
+    derivation_source,
+)
 
 # Environment
 PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
@@ -62,10 +68,19 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict
     ctx.update_progress(20, 'preparing_context')
     
     doc_context = "## SOURCE DOCUMENTS TO MERGE\n\n"
+    # Built from THIS loop, so it lists the documents that actually reached the
+    # model. selected_doc_ids can name a document that no longer exists — it is
+    # filtered out above, and only selected_document_count below still counts it.
+    used_sources = []
     for i, doc in enumerate(selected_docs, 1):
         doc_context += f"### Document {i}: {doc.get('title', 'Untitled')} ({doc.get('document_type', 'unknown').upper()})\n\n{doc.get('content', '')[:8000]}\n\n---\n\n"
+        source = derivation_source(doc.get('document_id'), ROLE_MERGE_INPUT)
+        if source:
+            used_sources.append(source)
     
     context_parts = [doc_context]
+    used_persona_ids = []
+    used_feedback_count = 0
     
     if selected_persona_ids:
         ctx.update_progress(30, 'fetching_personas')
@@ -75,6 +90,8 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict
             persona_text = "## USER PERSONAS FOR CONTEXT\n\n"
             for p in selected_personas:
                 persona_text += f"**{p.get('name')}**: {p.get('tagline', '')}\n- Goals: {', '.join(p.get('goals', [])[:3])}\n- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n\n"
+                if p.get('persona_id'):
+                    used_persona_ids.append(p['persona_id'])
             context_parts.append(persona_text)
     
     if use_feedback:
@@ -95,6 +112,7 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict
             feedback_text = "## ADDITIONAL CUSTOMER FEEDBACK\n\n"
             for i, item in enumerate(feedback_items[:20], 1):
                 feedback_text += f"**Review {i}** ({item.get('source_platform', 'unknown')}, {item.get('sentiment_label', 'unknown')}): {item.get('original_text', '')[:250]}\n\n"
+                used_feedback_count += 1
             context_parts.append(feedback_text)
     
     ctx.update_progress(50, 'generating_merged_document')
@@ -130,8 +148,17 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict
         'title': title,
         'content': content,
         'job_id': job_id,
+        # Unchanged: the requested ids, in the merger's own long-standing shape.
         'source_documents': selected_doc_ids,
         'merge_instructions': instructions,
+        # The same relation in the one shape every document type uses — and
+        # unlike source_documents above, the documents that were actually merged.
+        DERIVATION_FIELD: build_derivation(
+            sources=used_sources,
+            selected_document_count=len(selected_doc_ids),
+            feedback_count=used_feedback_count,
+            persona_ids=used_persona_ids,
+        ),
         'created_at': now,
     })
     projects_table.update_item(

--- a/voc-datalake/lambda/jobs/document_merger/test/test_derivation.py
+++ b/voc-datalake/lambda/jobs/document_merger/test/test_derivation.py
@@ -1,0 +1,102 @@
+"""A merge output records the documents that were actually merged.
+
+The merger has always stored `source_documents` — the ids it was ASKED for — so
+this is the one path where used and requested can differ without any cap: a
+requested document that no longer exists is silently skipped. The shared
+derivation records the ones that reached the model, and the selected count keeps
+the missing one visible.
+"""
+import pytest
+
+
+def _saved_item(mock_dynamodb):
+    return mock_dynamodb['table'].put_item.call_args.kwargs['Item']
+
+
+class TestMergeProvenance:
+    @pytest.fixture
+    def event(self, sample_job_event):
+        return {
+            **sample_job_event,
+            'merge_config': {
+                'output_type': 'prd',
+                'title': 'Merged PRD',
+                'instructions': 'Combine the key insights',
+                # Three requested; doc_gone was deleted after the wizard listed it.
+                'selected_document_ids': ['doc_1', 'doc_gone', 'doc_2'],
+                'selected_persona_ids': ['persona_1'],
+                'use_feedback': False,
+            },
+        }
+
+    @pytest.fixture(autouse=True)
+    def wire_project(self, mock_dynamodb, mock_project_documents):
+        mock_dynamodb['table'].query.return_value = {
+            'Items': [
+                *mock_project_documents,
+                {'sk': 'PERSONA#persona_1', 'persona_id': 'persona_1', 'name': 'Ana'},
+            ],
+        }
+
+    def test_records_the_documents_merged_not_the_ones_requested(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, event, lambda_context,
+    ):
+        from jobs.document_merger.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        item = _saved_item(mock_dynamodb)
+        assert item['derivation']['sources'] == [
+            {'document_id': 'doc_1', 'role': 'merge_input'},
+            {'document_id': 'doc_2', 'role': 'merge_input'},
+        ]
+        assert item['derivation']['selected_document_count'] == 3
+
+    def test_keeps_writing_its_original_shape_unchanged(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, event, lambda_context,
+    ):
+        """Additive: `source_documents` and `merge_instructions` are untouched,
+        so every existing reader keeps working."""
+        from jobs.document_merger.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        item = _saved_item(mock_dynamodb)
+        assert item['source_documents'] == ['doc_1', 'doc_gone', 'doc_2']
+        assert item['merge_instructions'] == 'Combine the key insights'
+
+    def test_records_the_personas_used(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, event, lambda_context,
+    ):
+        from jobs.document_merger.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        assert _saved_item(mock_dynamodb)['derivation']['persona_ids'] == ['persona_1']
+
+    def test_records_the_feedback_items_used(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, event, lambda_context,
+    ):
+        from unittest.mock import MagicMock
+
+        event['merge_config']['use_feedback'] = True
+        # One day of lookback, so the mocked table answers the date loop once.
+        event['merge_config']['days'] = 1
+        feedback_table = MagicMock()
+        feedback_table.query.return_value = {
+            'Items': [
+                {'original_text': f'review {i}', 'source_platform': 'webscraper', 'sentiment_label': 'negative'}
+                for i in range(3)
+            ],
+        }
+        mock_dynamodb['resource'].Table.side_effect = (
+            lambda name: feedback_table if 'feedback' in name.lower() else mock_dynamodb['table']
+        )
+
+        from jobs.document_merger.handler import lambda_handler
+
+        lambda_handler(event, lambda_context)
+
+        derivation = _saved_item(mock_dynamodb)['derivation']
+        assert derivation['feedback_count'] == 3
+        assert derivation['product_context_included'] is False

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -27,6 +27,12 @@ from shared.feedback import (
 )
 from shared.tables import get_projects_table, get_feedback_table
 from shared.jobs import update_job_status
+from shared.derivation import (
+    DERIVATION_FIELD,
+    ROLE_REFERENCE,
+    build_derivation,
+    derivation_source,
+)
 from shared.agentic_search import run_agentic_web_search
 from shared.web_search import is_web_search_configured
 
@@ -148,6 +154,7 @@ def step_initialize(event: dict) -> dict:
     
     # Optional: Get selected personas context
     personas_context = ""
+    used_persona_ids: list[str] = []
     selected_persona_ids = config.get('selected_persona_ids', [])
     proj_table = _get_projects_table()
     if selected_persona_ids and proj_table:
@@ -163,9 +170,12 @@ def step_initialize(event: dict) -> dict:
                 personas_context += f"- Goals: {', '.join(p.get('goals', [])[:3])}\n"
                 personas_context += f"- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n"
                 personas_context += f"- Quote: \"{p.get('quote', '')}\"\n\n"
+                if p.get('persona_id'):
+                    used_persona_ids.append(p['persona_id'])
     
     # Optional: Get selected documents context
     documents_context = ""
+    used_sources: list[dict] = []
     selected_document_ids = config.get('selected_document_ids', [])
     if selected_document_ids and proj_table:
         update_job_status(project_id, job_id, 'running', 18, 'fetching_documents')
@@ -175,9 +185,16 @@ def step_initialize(event: dict) -> dict:
         
         if selected_docs:
             documents_context = "## Reference Documents\n\n"
+            # Recorded from THIS loop, so the report's provenance names the
+            # documents that actually reached the model rather than every id the
+            # request selected; selected_document_count keeps the difference
+            # visible. The [:3] cap is left exactly as it is.
             for d in selected_docs[:3]:  # Limit to 3 docs to avoid context overflow
                 content = d.get('content', '')[:5000]  # Truncate long docs
                 documents_context += f"### {d.get('title', 'Untitled')} ({d.get('document_type', 'doc').upper()})\n\n{content}\n\n---\n\n"
+                source = derivation_source(d.get('document_id'), ROLE_REFERENCE)
+                if source:
+                    used_sources.append(source)
     
     # Optional: web search grounding (AgentCore Web Search Tool) via a bounded
     # agentic loop — the model plans several queries, reviews results, and
@@ -220,7 +237,18 @@ def step_initialize(event: dict) -> dict:
         'personas_context': personas_context,
         'documents_context': documents_context,
         'web_context': web_context,
-        'web_search_queries': web_search_queries
+        'web_search_queries': web_search_queries,
+        # What this research report was built from. Decided here — this is the
+        # only step that reads the inputs — and written by step_save, so it
+        # travels the state machine like web_search_queries does. ALWAYS
+        # present (empty when nothing was selected), because the resultSelector
+        # references it unconditionally and an absent key fails the state.
+        'derivation': build_derivation(
+            sources=used_sources,
+            selected_document_count=len(selected_document_ids),
+            feedback_count=len(feedback_items),
+            persona_ids=used_persona_ids,
+        ),
     }
 @tracer.capture_method
 def step_analyze(event: dict) -> dict:
@@ -472,6 +500,12 @@ Public-web grounding for this report came from the following searches:
             'content': full_report,
             'feedback_count': feedback_count,
             'job_id': job_id,
+            # Built by step_initialize and threaded through the state machine.
+            # The .get() default covers the rollout skew where an in-flight
+            # execution is still pinned to a definition that does not forward it
+            # (same pattern as web_search_queries): an empty derivation reads as
+            # "no lineage", which is a legitimate answer rather than an error.
+            DERIVATION_FIELD: event.get('derivation') or build_derivation(),
             'created_at': now,
         }
         proj_table.put_item(Item=item)

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -243,6 +243,11 @@ def step_initialize(event: dict) -> dict:
         # travels the state machine like web_search_queries does. ALWAYS
         # present (empty when nothing was selected), because the resultSelector
         # references it unconditionally and an absent key fails the state.
+        # Spelled literally, NOT as DERIVATION_FIELD: this is the Step Functions
+        # payload key, whose counterparts are `event.get('derivation')` in
+        # step_save and 'derivation.$': '$.Payload.derivation' in the CDK.
+        # DERIVATION_FIELD is the DynamoDB attribute name, and coupling the two
+        # would make renaming the stored column silently change the wire.
         'derivation': build_derivation(
             sources=used_sources,
             selected_document_count=len(selected_document_ids),

--- a/voc-datalake/lambda/research/test/test_research_derivation.py
+++ b/voc-datalake/lambda/research/test/test_research_derivation.py
@@ -1,0 +1,145 @@
+"""A research report records what it was built from.
+
+The inputs are read in the initialize step and the document is written by the
+save step, several Lambda invocations later, so the derivation has to travel the
+state machine (asserted in lib/stacks/processing-stack-consolidated.test.ts).
+These tests cover both ends and the rollout skew in between.
+
+The fixture selects FIVE reference documents while the step consumes three, and
+returns them in reverse order, so an implementation that recorded the requested
+ids — or a slice of them — could not pass.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SELECTED_IDS = ['doc_a', 'doc_b', 'doc_c', 'doc_d', 'doc_e']
+
+PROJECT_ITEMS = [
+    {'sk': f'PRD#{doc_id}', 'document_id': doc_id, 'title': doc_id.upper(), 'content': f'body of {doc_id}'}
+    for doc_id in reversed(SELECTED_IDS)
+] + [
+    {'sk': 'PERSONA#persona_1', 'persona_id': 'persona_1', 'name': 'Ana', 'tagline': 'Busy'},
+]
+
+USED_SOURCES = [
+    {'document_id': 'doc_e', 'role': 'reference'},
+    {'document_id': 'doc_d', 'role': 'reference'},
+    {'document_id': 'doc_c', 'role': 'reference'},
+]
+
+
+@pytest.fixture
+def mock_tables():
+    mock_fb = MagicMock()
+    mock_proj = MagicMock()
+    mock_proj.query.return_value = {'Items': PROJECT_ITEMS}
+    with patch('research_step_handler._get_feedback_table', return_value=mock_fb), \
+         patch('research_step_handler._get_projects_table', return_value=mock_proj):
+        yield {'feedback': mock_fb, 'projects': mock_proj}
+
+
+@pytest.fixture
+def mock_job_status():
+    with patch('research_step_handler.update_job_status') as m:
+        yield m
+
+
+@pytest.fixture
+def config():
+    return {
+        'question': 'What hurts most?',
+        'title': 'Test Research',
+        'days': 30,
+        'selected_persona_ids': ['persona_1'],
+        'selected_document_ids': SELECTED_IDS,
+    }
+
+
+class TestInitializeRecordsInputs:
+    @patch('research_step_handler.get_feedback_context')
+    @patch('research_step_handler.format_feedback_for_llm', return_value='formatted feedback')
+    @patch('research_step_handler.get_feedback_statistics', return_value='stats')
+    def _run(self, mock_stats, mock_format, mock_get_fb, config=None, feedback_count=7):
+        from research_step_handler import step_initialize
+        mock_get_fb.return_value = [{'original_text': f'review {i}'} for i in range(feedback_count)]
+        return step_initialize({
+            'project_id': 'proj_1', 'job_id': 'job_1', 'research_config': config,
+        })
+
+    def test_records_the_three_documents_used_not_the_five_selected(
+        self, mock_tables, mock_job_status, config,
+    ):
+        result = self._run(config=config)
+
+        assert result['derivation']['sources'] == USED_SOURCES
+        assert result['derivation']['selected_document_count'] == 5
+
+    def test_records_the_feedback_and_personas_used(self, mock_tables, mock_job_status, config):
+        result = self._run(config=config)
+
+        assert result['derivation']['feedback_count'] == 7
+        assert result['derivation']['persona_ids'] == ['persona_1']
+
+    def test_always_returns_a_derivation_even_when_nothing_was_selected(
+        self, mock_tables, mock_job_status,
+    ):
+        """The state machine's resultSelector references the key unconditionally,
+        so an absent key would fail the whole execution."""
+        result = self._run(config={'question': 'Q', 'days': 30}, feedback_count=2)
+
+        assert result['derivation'] == {
+            'sources': [],
+            'selected_document_count': 0,
+            'feedback_count': 2,
+            'persona_ids': [],
+            'product_context_included': False,
+        }
+
+
+class TestSaveWritesDerivation:
+    def _save(self, mock_tables, event_extra):
+        from research_step_handler import step_save
+        step_save({
+            'project_id': 'proj_1',
+            'job_id': 'job_1',
+            'research_config': {'question': 'Q', 'title': 'T'},
+            'feedback_count': 7,
+            'analysis': 'A',
+            'synthesis': 'S',
+            'validation': 'V',
+            **event_extra,
+        })
+        return mock_tables['projects'].put_item.call_args.kwargs['Item']
+
+    def test_persists_the_derivation_it_was_handed(self, mock_tables, mock_job_status):
+        derivation = {
+            'sources': USED_SOURCES,
+            'selected_document_count': 5,
+            'feedback_count': 7,
+            'persona_ids': ['persona_1'],
+            'product_context_included': False,
+        }
+
+        item = self._save(mock_tables, {'derivation': derivation})
+
+        assert item['derivation'] == derivation
+
+    def test_an_execution_pinned_to_the_previous_definition_still_saves(
+        self, mock_tables, mock_job_status,
+    ):
+        """In-flight executions keep the state machine definition they started
+        with, which does not forward the derivation. That must read as "no
+        lineage" rather than failing the save."""
+        item = self._save(mock_tables, {})
+
+        assert item['derivation'] == {
+            'sources': [],
+            'selected_document_count': 0,
+            'feedback_count': 0,
+            'persona_ids': [],
+            'product_context_included': False,
+        }
+        # The report itself is unaffected.
+        assert item['document_type'] == 'research'
+        assert item['feedback_count'] == 7

--- a/voc-datalake/lambda/research/test/test_research_derivation.py
+++ b/voc-datalake/lambda/research/test/test_research_derivation.py
@@ -9,6 +9,8 @@ The fixture selects FIVE reference documents while the step consumes three, and
 returns them in reverse order, so an implementation that recorded the requested
 ids — or a slice of them — could not pass.
 """
+import ast
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -95,6 +97,65 @@ class TestInitializeRecordsInputs:
             'persona_ids': [],
             'product_context_included': False,
         }
+
+
+class TestEveryExitCarriesTheDerivation:
+    """Structural, not behavioural: EVERY return out of step_initialize must
+    carry the key, not just the ones a test happens to drive.
+
+    The state machine's resultSelector references `$.Payload.derivation`
+    unconditionally, and a JSONPath miss there raises `States.Runtime` — which a
+    `States.ALL` catch does NOT intercept. So a future early return that omits
+    the key would fail OUTSIDE the error handler and leave the job stuck at
+    `running` rather than `failed`: no report, no failure, no diagnosis. Reading
+    the function's returns out of its AST is the only check that covers the paths
+    nobody has written yet.
+    """
+
+    @staticmethod
+    def _step_initialize() -> ast.FunctionDef:
+        # lambda/research/test/ -> lambda/research/
+        source = (Path(__file__).resolve().parents[1] / 'research_step_handler.py').read_text(encoding='utf-8')
+        functions = [
+            node for node in ast.walk(ast.parse(source))
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == 'step_initialize'
+        ]
+        assert len(functions) == 1, f'Expected one step_initialize; found {len(functions)}.'
+        return functions[0]
+
+    def test_it_contains_no_nested_function_whose_returns_this_test_would_miss(self):
+        """Guards the guard: `ast.walk` would collect a nested function's returns
+        as if they were the step's own, so this test only means what it says
+        while there is no nested function."""
+        fn = self._step_initialize()
+        nested = [
+            node.name for node in ast.walk(fn)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node is not fn
+        ]
+        assert nested == [], (
+            f'step_initialize now defines nested function(s) {nested}. Scope the '
+            f'return collection below to the step body before trusting it again.'
+        )
+
+    def test_every_return_is_a_dict_literal_declaring_derivation(self):
+        returns = [node for node in ast.walk(self._step_initialize()) if isinstance(node, ast.Return)]
+        assert returns, 'step_initialize has no return statement at all.'
+
+        for node in returns:
+            assert isinstance(node.value, ast.Dict), (
+                f'The return at research_step_handler.py:{node.lineno} is not a dict '
+                f'literal, so this test can no longer tell whether it declares '
+                f'derivation. Keep the returns literal, or assert the key another way.'
+            )
+            keys = [k.value for k in node.value.keys if isinstance(k, ast.Constant)]
+            assert 'derivation' in keys, (
+                f"The return at research_step_handler.py:{node.lineno} omits "
+                f"'derivation'. The state machine's resultSelector references "
+                f"$.Payload.derivation unconditionally and a JSONPath miss raises "
+                f"States.Runtime, which the States.ALL catch does not intercept — "
+                f"the execution would die outside handleError, leaving the job at "
+                f"'running'. Add the key (build_derivation() is the empty value)."
+            )
 
 
 class TestSaveWritesDerivation:

--- a/voc-datalake/lambda/shared/derivation.py
+++ b/voc-datalake/lambda/shared/derivation.py
@@ -1,0 +1,120 @@
+"""
+One shape for "what was this document built from", written by every path that
+creates a project document.
+
+Before this module the same relation was stored three ways and absent in three
+places: the merger wrote `source_documents` (a list), a prototype wrote
+`source_prd_id`/`source_prfaq_id` (fixed arity, so it cannot express "built from
+two PRDs"), and PRD/PR-FAQ/research/product-report wrote nothing at all. So a
+document could not answer how it was made.
+
+Every creating path now ALSO writes a single `derivation` map:
+
+    {
+      'sources': [{'document_id': 'prd_1', 'role': 'reference'}, ...],
+      'selected_document_count': 5,
+      'feedback_count': 12,
+      'persona_ids': ['persona_1'],
+      'product_context_included': True,
+    }
+
+Two properties the callers must preserve:
+
+- `sources` records what was USED, never what was requested. Several paths cap
+  the reference documents they feed the model (the document generator keeps the
+  first three of the selected ids); `sources` lists the documents that actually
+  reached the model and `selected_document_count` states how many were selected,
+  so the drop is visible rather than implied. Recording the drop is not fixing
+  it — the cap and its ordering are a separate known issue.
+- The existing shapes keep being written unchanged. This is additive: nothing is
+  removed, renamed, or migrated, and documents written before this module still
+  explain themselves through the read-side resolver in the frontend
+  (`frontend/src/api/derivation.ts`), which interprets the three legacy shapes.
+
+The role vocabulary is CLOSED and mirrors what the code actually does. It is
+kept in lockstep with the frontend's copy by
+`lambda/shared/test/test_derivation_roles_lockstep.py`.
+"""
+
+# A reference document the caller selected and the generator fed to the model.
+ROLE_REFERENCE = 'reference'
+# The PRD a prototype was built from.
+ROLE_PROTOTYPE_PRD = 'prototype_prd'
+# The PR/FAQ a prototype was built from.
+ROLE_PROTOTYPE_PRFAQ = 'prototype_prfaq'
+# A document fed to a merge.
+ROLE_MERGE_INPUT = 'merge_input'
+
+#: The closed vocabulary, in the order a resolver reports it.
+DERIVATION_ROLES = (
+    ROLE_REFERENCE,
+    ROLE_PROTOTYPE_PRD,
+    ROLE_PROTOTYPE_PRFAQ,
+    ROLE_MERGE_INPUT,
+)
+
+#: Attribute name on a ProjectDocument item.
+DERIVATION_FIELD = 'derivation'
+
+
+def _count(value) -> int:
+    """A non-negative int, or 0 for anything that is not one.
+
+    Provenance bookkeeping runs inside document generation, so a surprising
+    value must degrade to 0 rather than fail the job that produced the document.
+    """
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def derivation_source(document_id: str | None, role: str) -> dict | None:
+    """One `sources` entry, or None when there is nothing to record.
+
+    A caller may hold an absent document (`(prd or {}).get('document_id')` is a
+    real stored None for a prototype built from a PR/FAQ alone), and "no source"
+    must not become an entry with an empty id.
+
+    Raises:
+        ValueError: for a role outside DERIVATION_ROLES. Roles are literals at
+            every call site, so this fires only for a new role that was added
+            without being declared here — the same failure the frontend gets as
+            a compile error.
+    """
+    if role not in DERIVATION_ROLES:
+        raise ValueError(f'Unknown derivation role: {role!r}')
+    if not document_id or not isinstance(document_id, str):
+        return None
+    return {'document_id': document_id, 'role': role}
+
+
+def build_derivation(
+    *,
+    sources=(),
+    selected_document_count: int = 0,
+    feedback_count: int = 0,
+    persona_ids=(),
+    product_context_included: bool = False,
+) -> dict:
+    """Assemble the `derivation` map for a document item.
+
+    Args:
+        sources: entries from `derivation_source`; None entries are dropped, so
+            callers can pass optional sources without pre-filtering.
+        selected_document_count: how many reference documents the request
+            selected — may exceed len(sources) when the caller capped them.
+        feedback_count: feedback items actually used, not the requested limit.
+        persona_ids: persona ids actually used.
+        product_context_included: whether the project product-context block was
+            injected into the prompt.
+
+    Counts and identifiers only — never copied content.
+    """
+    return {
+        'sources': [s for s in sources if s],
+        'selected_document_count': _count(selected_document_count),
+        'feedback_count': _count(feedback_count),
+        'persona_ids': [p for p in persona_ids if isinstance(p, str) and p],
+        'product_context_included': bool(product_context_included),
+    }

--- a/voc-datalake/lambda/shared/test/test_derivation.py
+++ b/voc-datalake/lambda/shared/test/test_derivation.py
@@ -1,0 +1,127 @@
+"""Tests for shared.derivation — the one shape every document-creating path
+writes to answer "what was this built from".
+
+Expectations are literals: nothing here re-derives its expected value from the
+code under test.
+"""
+import pytest
+
+from shared.derivation import (
+    DERIVATION_FIELD,
+    DERIVATION_ROLES,
+    ROLE_MERGE_INPUT,
+    ROLE_PROTOTYPE_PRD,
+    ROLE_PROTOTYPE_PRFAQ,
+    ROLE_REFERENCE,
+    build_derivation,
+    derivation_source,
+)
+
+
+class TestVocabulary:
+    def test_role_vocabulary_is_exactly_the_four_relations_the_code_creates(self):
+        assert DERIVATION_ROLES == (
+            'reference',
+            'prototype_prd',
+            'prototype_prfaq',
+            'merge_input',
+        )
+
+    def test_field_name_is_derivation(self):
+        assert DERIVATION_FIELD == 'derivation'
+
+
+class TestDerivationSource:
+    def test_names_the_document_and_the_role_it_played(self):
+        assert derivation_source('prd_1', ROLE_PROTOTYPE_PRD) == {
+            'document_id': 'prd_1',
+            'role': 'prototype_prd',
+        }
+
+    def test_absent_source_is_no_entry_rather_than_an_empty_id(self):
+        """`(prd or {}).get('document_id')` yields None when a prototype was
+        built from a PR/FAQ alone; that must not become a source."""
+        assert derivation_source(None, ROLE_PROTOTYPE_PRD) is None
+        assert derivation_source('', ROLE_PROTOTYPE_PRFAQ) is None
+
+    def test_non_string_id_is_no_entry(self):
+        assert derivation_source(42, ROLE_REFERENCE) is None
+
+    def test_role_outside_the_closed_vocabulary_is_rejected(self):
+        with pytest.raises(ValueError, match='Unknown derivation role'):
+            derivation_source('doc_1', 'inspired_by')
+
+
+class TestBuildDerivation:
+    def test_records_used_sources_and_the_larger_selected_count_separately(self):
+        """The generator caps reference documents; the record must show both the
+        documents that reached the model and how many were asked for."""
+        derivation = build_derivation(
+            sources=[
+                derivation_source('doc_1', ROLE_REFERENCE),
+                derivation_source('doc_2', ROLE_REFERENCE),
+                derivation_source('doc_3', ROLE_REFERENCE),
+            ],
+            selected_document_count=5,
+        )
+        assert derivation['sources'] == [
+            {'document_id': 'doc_1', 'role': 'reference'},
+            {'document_id': 'doc_2', 'role': 'reference'},
+            {'document_id': 'doc_3', 'role': 'reference'},
+        ]
+        assert derivation['selected_document_count'] == 5
+
+    def test_drops_none_entries_so_callers_need_no_prefiltering(self):
+        derivation = build_derivation(
+            sources=[
+                derivation_source(None, ROLE_PROTOTYPE_PRD),
+                derivation_source('prfaq_9', ROLE_PROTOTYPE_PRFAQ),
+            ],
+        )
+        assert derivation['sources'] == [{'document_id': 'prfaq_9', 'role': 'prototype_prfaq'}]
+
+    def test_records_non_document_inputs(self):
+        derivation = build_derivation(
+            feedback_count=12,
+            persona_ids=['persona_1', 'persona_2'],
+            product_context_included=True,
+        )
+        assert derivation['feedback_count'] == 12
+        assert derivation['persona_ids'] == ['persona_1', 'persona_2']
+        assert derivation['product_context_included'] is True
+
+    def test_empty_derivation_answers_no_inputs_without_missing_keys(self):
+        assert build_derivation() == {
+            'sources': [],
+            'selected_document_count': 0,
+            'feedback_count': 0,
+            'persona_ids': [],
+            'product_context_included': False,
+        }
+
+    def test_counts_degrade_to_zero_rather_than_failing_the_generation(self):
+        derivation = build_derivation(feedback_count='not a number', selected_document_count=-4)
+        assert derivation['feedback_count'] == 0
+        assert derivation['selected_document_count'] == 0
+
+    def test_persona_ids_keep_only_usable_identifiers(self):
+        derivation = build_derivation(persona_ids=['persona_1', '', None, 7])
+        assert derivation['persona_ids'] == ['persona_1']
+
+    def test_records_identifiers_and_counts_only_never_content(self):
+        """Guards the privacy line: a derivation is metadata, so no field may
+        carry document text, feedback text, or instructions."""
+        derivation = build_derivation(
+            sources=[derivation_source('doc_1', ROLE_MERGE_INPUT)],
+            feedback_count=3,
+            persona_ids=['persona_1'],
+            product_context_included=True,
+        )
+        assert set(derivation) == {
+            'sources',
+            'selected_document_count',
+            'feedback_count',
+            'persona_ids',
+            'product_context_included',
+        }
+        assert set(derivation['sources'][0]) == {'document_id', 'role'}

--- a/voc-datalake/lambda/shared/test/test_derivation_roles_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_derivation_roles_lockstep.py
@@ -1,0 +1,58 @@
+"""Lockstep test: the derivation role vocabulary is closed, and the backend's
+copy and the frontend's copy must never drift apart.
+
+The backend writes roles (lambda/shared/derivation.py); the frontend declares,
+validates and maps them (frontend/src/api/derivation.ts). Adding a role on the
+frontend side is already a compile error there — the role→legacy-field map is
+keyed by role — but nothing would otherwise stop the backend from writing a
+role the frontend cannot name, which would silently drop that source at the
+query boundary. This test is that stop.
+
+Pattern follows lambda/api/test/test_kiro_exportable_types_lockstep.py.
+"""
+import re
+from pathlib import Path
+
+from shared.derivation import DERIVATION_ROLES
+
+FRONTEND_SOURCE = 'frontend/src/api/derivation.ts'
+
+
+def _frontend_roles() -> tuple[str, ...]:
+    """Parse DERIVATION_ROLES out of the frontend module, in declared order."""
+    # lambda/shared/test/ -> voc-datalake/
+    path = Path(__file__).resolve().parents[3] / FRONTEND_SOURCE
+    assert path.is_file(), (
+        f'{FRONTEND_SOURCE} not found — did the file move? '
+        f'If so, update FRONTEND_SOURCE in this test file.'
+    )
+    source = path.read_text(encoding='utf-8')
+    matches = re.findall(
+        r"export const DERIVATION_ROLES\s*=\s*\[(.*?)\]\s*as const",
+        source,
+        re.DOTALL,
+    )
+    assert len(matches) == 1, (
+        f'Expected exactly one DERIVATION_ROLES definition in {FRONTEND_SOURCE}; '
+        f'found {len(matches)}.'
+    )
+    return tuple(re.findall(r"'([^']+)'", matches[0]))
+
+
+class TestDerivationRolesLockstep:
+    def test_backend_and_frontend_declare_the_same_roles_in_the_same_order(self):
+        assert DERIVATION_ROLES == _frontend_roles(), (
+            'The derivation role vocabulary is closed and shared. Update both '
+            'lambda/shared/derivation.py and frontend/src/api/derivation.ts '
+            '(and the frontend role→legacy-field map, which is keyed by role).'
+        )
+
+    def test_vocabulary_is_the_four_relations_the_code_creates(self):
+        """Pinned literally: a new role is a deliberate product decision about a
+        new relation, not an incidental addition."""
+        assert _frontend_roles() == (
+            'reference',
+            'prototype_prd',
+            'prototype_prfaq',
+            'merge_input',
+        )

--- a/voc-datalake/lambda/shared/test/test_derivation_roles_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_derivation_roles_lockstep.py
@@ -36,7 +36,13 @@ def _frontend_roles() -> tuple[str, ...]:
         f'Expected exactly one DERIVATION_ROLES definition in {FRONTEND_SOURCE}; '
         f'found {len(matches)}.'
     )
-    return tuple(re.findall(r"'([^']+)'", matches[0]))
+    # Anchored to whole entry LINES ("  'reference'," and nothing else) rather
+    # than to every quoted run in the array body. The array is JSDoc-commented
+    # between entries, and an apostrophe in one of those comments ("the model's
+    # input") re-pairs every quote after it: an even number injects a phantom
+    # role, an odd number garbles all four. No comment line ends in "',", so
+    # scanning entry lines only keeps this immune to the prose around them.
+    return tuple(re.findall(r"^\s*'([^']+)',", matches[0], re.MULTILINE))
 
 
 class TestDerivationRolesLockstep:

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -111,6 +111,15 @@ describe('research state machine wiring (issue #157)', () => {
     expect(state.definition).toContain('"web_search_queries.$":"$.Payload.web_search_queries"');
     expect(state.definition).toContain('"web_search_queries.$":"$.initialize_result.web_search_queries"');
   });
+
+  it('flows the derivation to the save step, so the report records its inputs', () => {
+    // step_initialize is the only step that reads the reference documents,
+    // personas and feedback; step_save is what writes the document. Drop
+    // either half of this wiring and every research report silently loses the
+    // answer to "what was this built from".
+    expect(state.definition).toContain('"derivation.$":"$.Payload.derivation"');
+    expect(state.definition).toContain('"derivation.$":"$.initialize_result.derivation"');
+  });
 });
 
 /** Narrow a CloudFormation resource to its Properties without a bare cast. */

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -335,6 +335,13 @@ export class VocProcessingStack extends VocStack {
         'web_search_queries.$': '$.Payload.web_search_queries',
         // Always returned by step_initialize ('' when unused) — see #157.
         'documents_context.$': '$.Payload.documents_context',
+        // What the report was built from (reference documents actually used,
+        // how many were selected, feedback count, persona ids). step_initialize
+        // is the only step that reads those inputs, and step_save is what
+        // persists them, so it rides the state like web_search_queries does.
+        // ALWAYS returned by step_initialize (empty when nothing was selected)
+        // — an absent key here would fail the state outright.
+        'derivation.$': '$.Payload.derivation',
       },
     });
     initializeStep.addRetry({ errors: ['Lambda.ServiceException', 'Lambda.TooManyRequestsException', 'States.Timeout'], interval: cdk.Duration.seconds(2), maxAttempts: 3, backoffRate: 2 });
@@ -400,6 +407,8 @@ export class VocProcessingStack extends VocStack {
         'feedback_count.$': '$.initialize_result.feedback_count',
         // Executed web-search queries for the report disclosure (#207).
         'web_search_queries.$': '$.initialize_result.web_search_queries',
+        // Provenance decided at initialize, persisted on the document here.
+        'derivation.$': '$.initialize_result.derivation',
         'analysis.$': '$.analysis_result.analysis',
         'synthesis.$': '$.synthesis_result.synthesis',
         'validation.$': '$.validate_result.validation',

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -181,7 +181,7 @@
       }
     },
     "VocProcessingStack": {
-      "templateSha256": "c74c86f3519bbb806c3d02cf5a5ce319293d95c25a0ee4792b78d54707ed5194",
+      "templateSha256": "18fde97c1540237227e2e168b01da842c18d2f50fc95700445096ac83ad94a42",
       "names": {
         "physicalNames": [
           "AWS::Lambda::Function FunctionName = voc-aggregation-processor-<AWS::AccountId>-<AWS::Region>",


### PR DESCRIPTION
## What this does

This product builds documents out of other documents — a PRD, then a PR/FAQ, then a prototype from those,
sometimes a merge of several. Afterwards nothing could say what went into what. A document in the Documents
tab showed a type badge, a date, a title and a preview, and that was the whole story of how it came to exist.

Underneath it was messier than simply missing. The same relation — *this was built from those* — was already
stored **three different ways and absent in three more**:

| document type | what it recorded before |
|---|---|
| merge output | `source_documents` (a list of ids) + `merge_instructions` |
| prototype | `source_prd_id` + `source_prfaq_id` — fixed arity, so it cannot express "built from two PRDs" |
| PRD, PR/FAQ, research, product report | nothing at all |

And **none of those fields was declared anywhere in the frontend**, so all of them arrived on every project
read and were discarded at the type boundary.

Every path that creates a document now also writes one `derivation` record: an ordered list of
`(source document id, role)` entries, plus the inputs that are not documents — feedback items used, personas
used, and whether the project's product-context block was included. The Documents tab renders it.

## Two commits, deliberately

1. **`record and expose how every document was built`** — the data and the read model, plus the frontend
   contract. No UI.
2. **`show what each document was built from`** — the Documents tab, plus copy in all eight locale catalogues.

The contract fix that the UI exposed is folded into the first commit rather than appearing as a correction in
the second, so no commit in this branch publishes the contract in a shape its first consumer immediately has
to change.

## Two properties worth preserving

**It records what was USED, never what was requested.** The generator selects reference documents by id and
then feeds the model at most the first three. `sources` lists the ones that actually reached it, and
`selected_document_count` states how many were selected, so the tab can say "3 of 5 selected documents used".
That difference was previously invisible.

This makes the drop **observable, not fixed** — the three-document cap and its ordering are a known separate
issue and are deliberately untouched here. The display is correspondingly neutral: same grey as everything
around it, no warning colour, no icon, and silent when the two numbers agree. A test walks the DOM from that
line up to the panel asserting no alarm styling, so a future change in that direction fails rather than
slipping through.

**Counts and identifiers only, never copied content.** A test pins the exact key set.

## Additive, with no migration

Nothing is removed, renamed or migrated, and every pre-existing lineage field is still written. Documents
created before this change explain themselves through `resolveDerivation`, which reconstructs the same shape
from the three legacy forms and reports whether the answer came from the declared field, from legacy fields,
or is not recoverable. It is pure, total and depth-1 by construction, which is why a cyclic reference is
inert. A source document deleted since stays listed and marked unavailable rather than silently vanishing —
the relation outlived its target — but is not rendered as a control that leads nowhere. A document with no
recoverable provenance renders nothing at all, which is the honest answer for a hand-authored document.

## Deliberately out of scope

These are different relations and separate product decisions, and none of them is started here:

- **Succession** — "this document replaces that one". Regenerating a PRD still produces two unrelated PRDs.
  The prototype's existing `revised_from_id` / `revision_feedback` are left exactly as they are and are not
  folded into derivation. No version, ordinal or supersedes field is introduced.
- **Grouping** — whether a PRD and a PR/FAQ generated together are one proposal. No grouping key invented.
- **The three-document input cap**, per above. Reviewing this PR turned up that the cap is really three
  separate decisions with different answers — *which* documents get dropped is a bug (ascending `sk` order
  means `RESEARCH#` is always dropped first, and the oldest documents are always kept), *how much* gets
  through is a judgment call the repo currently answers four different ways, and two document types the
  picker offers are filtered out before the cap even applies. A concrete fix is proposed in the review
  thread and recommended as its own PR on top of this one, so that a change to what the model sees is
  revertable independently of the record that measures it.

## ⚠️ One thing to look at consciously

`voc-datalake/lib/test-support/baseline.json` carries a regenerated `VocProcessingStack.templateSha256`.
Provenance for a research report is decided in `step_initialize` and persisted by `step_save`, so it rides the
state machine the way `web_search_queries` already does — which legitimately changes that one template. It is
a one-line diff, and the readable name inventory is byte-identical across all five stacks, so no resource is
replaced. The resultSelector references `derivation` unconditionally, matching the existing
`web_search_queries` precedent; `step_save` tolerates its absence for executions in flight across a deploy.

Only one deploy-order skew is possible here, and it is the one covered. A new state-machine definition cannot
run against not-yet-updated Lambda code: the definition `GetAtt`s the function, so CloudFormation always
updates the Lambda first. The reachable skew is the opposite one — an execution already in flight keeps the
definition it started with — and that is exactly what `step_save`'s `.get()` default covers. One thing to know
if this is ever restructured: a JSONPath miss in a `resultSelector` raises `States.Runtime`, which a
`States.ALL` catch does **not** intercept, so a future return path omitting the key would fail outside
`handleError` and leave the job at `running` rather than `failed`. That is what
`test_always_returns_a_derivation_even_when_nothing_was_selected` protects, and why it is worth keeping.

## Verification

Run per leg rather than through the root aggregate, which chains with `&&` and hides later legs:

| leg | result |
|---|---|
| `pytest lambda/shared lambda/jobs lambda/research lambda/api` | 1092 passed |
| `vitest run` (frontend, full) | 2318 passed / 157 files |
| `vitest run src/pages/ProjectDetail src/api/derivation.test.ts` | 368 passed / 35 files |
| `vitest run lib` (CDK) | 231 passed / 17 files |
| `tsc -b` (frontend) | clean |
| `eslint src` (frontend) | clean |
| `ruff check` on both touched Python files | clean |

Those figures include three review rounds: +8 backend (a placeholder lockstep test, then four structural tests
enforcing invariants the review asked me to confirm, then two closing a fail-open in one of those very tests)
and +4 frontend (the sources-empty-but-selected case, in the resolver and in the pane). An earlier revision of
this section claimed
2299 / 156 for the full frontend suite; that was captured at the first commit and was wrong even there. The
true baselines are 2301 / 156 at `1b592e6` and 2314 / 157 at `2580e6d` — the second commit adds
`DocumentsTab.derivation.test.tsx`, which is the whole file delta. Measured in throwaway worktrees at each
commit rather than inferred.

All eight locale catalogues were checked programmatically for the same key set, case-insensitive sort order at
every level, and no empty values.

**Revert-sensitivity was demonstrated by mutation, not asserted.** Recording the requested document ids
instead of the used ones fails `test_records_the_three_documents_used_not_the_five_selected` and two others —
and the fixture deliberately selects five reference documents against a cap of three, because a fixture with
three or fewer could not tell the two cases apart. Forcing the resolver never to return a source's type fails
seven tests across both the resolver and the pane. Removing `selected_document_count` from the resolver's
emptiness check — the first review round's fix — fails exactly the four tests added for it and nothing else.

The second round's four tests are structural, reading production code out of its AST, so each was
positive-controlled rather than trusted: an early `return` omitting `derivation` in `step_initialize`, a nested
`def` inside it, a product-context section appended without its `###` heading, and a third `return` in
`build_product_context_block` each fail exactly the test that claims to watch for them, with the offending
line, function or count in the message. The nested-`def` probe also justified a test I nearly cut: it made the
first test report `assert 'derivation' in ['nope']`, attributing an inner return to the step — the `ast.walk`
leak its companion exists to catch, shown rather than argued.

**And one of those guards was itself fail-open, which the third round caught.** The heading check read only
`sections.append(...)`, so a section arriving by `extend`, `+=` or a comprehension would leave its view while it
kept reporting success — the same defect as the one it was written to rule out, one level up. Measured rather
than reasoned about: rewriting one append as `extend` leaves the heading test **green** while the replacement
fails and names the form. The fix asserts a closed set of ways `sections` may be built, so an unrecognised form
is a finding rather than a silent gap; five positive controls (`extend`, `+=`, a renamed producer, a nested
`def`, a second initialisation) all fire.

Every mutated file was restored byte-identically after every probe, verified by hash.

**Pre-existing and untouched:** `ruff check lambda plugins` sits at 548 findings, **delta 0** against the
previous commit — measured with the same command in a throwaway worktree rather than assumed. The three
findings in `research_step_handler.py` (import order, blind `except`, naive `datetime.now()`) are all older
than this branch; the only change to that file this round is a comment. `i18n:check` exits 1 byte-identically
to a baseline captured on the clean tree, with findings in
`categories.json` and `prioritization.json`; `typecheck:tests` is red at 77 errors in test files this diff
does not touch.

## Follow-ups this enables

The natural next step is the prototype build accepting explicit source document ids, which needs the
client-supplied id treated as untrusted input — it must be confirmed to exist, to belong to the project in the
path, and to be of the type the parameter names, and it must never silently fall back to newest-of-type.

