### PR TITLE
fix(documents): fail loudly when base_prototype_id resolves to nothing

### DIFF
--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -629,7 +629,15 @@ def api_build_prototype(project_id: str):
         # Optional feedback-driven regeneration: revise an existing prototype
         # centered on this feedback while still honoring the PRD/PR-FAQ.
         'feedback': body.get('feedback'),
-        'base_prototype_id': body.get('base_prototype_id'),
+        # The prototype being revised is a client-supplied id like the two below,
+        # and it is checked the same way — whenever it is supplied, whether or not
+        # `feedback` came with it. Unchecked, an id naming no prototype produced a
+        # document labelled a revision (it carries `revised_from_id`) that the
+        # model built without ever seeing the prototype it supposedly revises,
+        # after a billed multi-minute Bedrock call.
+        'base_prototype_id': _validated_source_id(
+            project_id, 'PROTOTYPE#', body.get('base_prototype_id'), 'base_prototype_id',
+        ),
         # Optional aiming: build from THESE documents instead of the newest of
         # each type. Validated before the job exists, so a bad id costs a 4xx
         # rather than a billable build that fails minutes later.

--- a/voc-datalake/lambda/api/test/test_build_prototype_sources.py
+++ b/voc-datalake/lambda/api/test/test_build_prototype_sources.py
@@ -1,10 +1,11 @@
 """
 POST /projects/{id}/build-prototype — the source-document trust boundary (U25).
 
-A build can name the PRD and PR/FAQ it should read. Those ids arrive from the
-client and their content is read straight into a Bedrock prompt, so an id that
-resolved outside this project would pull another project's document into this
-project's generation.
+A build can name the PRD and PR/FAQ it should read, and the prototype a
+revision is built on. Those ids arrive from the client and the documents they
+name are read straight into a Bedrock prompt, so an id that resolved outside
+this project would pull another project's document into this project's
+generation.
 
 Ownership and type are enforced by the key rather than by a check: `pk` is the
 project and `sk` is `{TYPE}#{id}`. This file pins that, plus the reason the
@@ -17,23 +18,39 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 PROJECT = 'proj_1'
+OTHER_PROJECT = 'proj_2'
 PATH = f'/projects/{PROJECT}/build-prototype'
 
 
 @pytest.fixture
 def build_prototype(api_gateway_event, lambda_context):
     """
-    Call the endpoint with a projects table holding one PRD and one PR/FAQ.
+    Call the endpoint with a projects table holding one PRD, one PR/FAQ and one
+    prototype in THIS project, plus one prototype in a DIFFERENT project.
 
-    Returns (response, job_config, table) where `job_config` is the doc_config
-    handed to the generator, or None when no job was created.
+    Reads are answered on the whole composite key rather than on `sk` alone.
+    That is what makes "a prototype belonging to another project" a distinct
+    fixture from "no such prototype": keyed on `sk` only, the two would be the
+    same table and the test could not tell a dropped partition key apart from a
+    working one.
+
+    Returns (response, job_config, table, invoke) where `job_config` is the
+    doc_config handed to the generator, or None when no job was created.
     """
     def _call(body):
         table = MagicMock()
-        documents = {'PRD#prd_1': {'document_id': 'prd_1'}, 'PRFAQ#prfaq_1': {'document_id': 'prfaq_1'}}
+        documents = {
+            (f'PROJECT#{PROJECT}', 'PRD#prd_1'): {'document_id': 'prd_1'},
+            (f'PROJECT#{PROJECT}', 'PRFAQ#prfaq_1'): {'document_id': 'prfaq_1'},
+            (f'PROJECT#{PROJECT}', 'PROTOTYPE#proto_1'): {'document_id': 'proto_1'},
+            # Real prototype, wrong project. Only reachable by a lookup that
+            # dropped `pk`.
+            (f'PROJECT#{OTHER_PROJECT}', 'PROTOTYPE#proto_other'): {'document_id': 'proto_other'},
+        }
 
         def get_item(Key=None, **kwargs):
-            item = documents.get((Key or {}).get('sk', ''))
+            key = (Key or {})
+            item = documents.get((key.get('pk', ''), key.get('sk', '')))
             return {'Item': item} if item else {}
 
         table.get_item.side_effect = get_item
@@ -149,3 +166,119 @@ class TestUnresolvableIdIsRejectedBeforeAnyCost:
             'x' * 5000 in str(call.kwargs.get('Key', {}))
             for call in table.get_item.call_args_list
         )
+
+
+class TestBasePrototypeIdIsCheckedLikeTheOtherTwo:
+    """
+    `base_prototype_id` — the prototype a revision is built on.
+
+    It was the one of the three client-supplied ids that reached `doc_config`
+    unchecked. An id naming nothing then produced a build that ran to completion
+    as a FRESH generation — no `EXISTING PROTOTYPE (revise this)` block in the
+    prompt — and saved a document labelled a revision (`revised_from_id`) that the
+    model never saw the base of, after a billed multi-minute Bedrock call.
+    """
+
+    def test_a_named_prototype_reaches_the_generator(self, build_prototype):
+        response, config, _table, invoke = build_prototype(
+            {'feedback': 'Make it admin-facing', 'base_prototype_id': 'proto_1'},
+        )
+
+        assert response['statusCode'] == 200
+        assert config['base_prototype_id'] == 'proto_1'
+        assert invoke.call_args.args[1]['doc_config']['base_prototype_id'] == 'proto_1'
+
+    def test_an_unknown_prototype_is_a_404_and_starts_no_job(self, build_prototype):
+        """The load-bearing assertion is `config is None`: a check that ran AFTER
+        `create_job` would still return 404 here while having created the job row
+        and, with it, the billable build this check exists to prevent."""
+        response, config, _table, invoke = build_prototype(
+            {'feedback': 'Make it admin-facing', 'base_prototype_id': 'proto_nope'},
+        )
+
+        assert response['statusCode'] == 404
+        assert 'base_prototype_id' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_another_projects_prototype_is_a_404(self, build_prototype):
+        """`proto_other` is a real prototype, in `proj_2`. This is the fixture that
+        fails if the partition key is ever dropped from the lookup — without it,
+        "belongs to someone else" and "does not exist" are the same table."""
+        response, config, table, invoke = build_prototype(
+            {'feedback': 'Make it admin-facing', 'base_prototype_id': 'proto_other'},
+        )
+
+        assert response['statusCode'] == 404
+        assert 'base_prototype_id' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+        # Asserted on the key as well: the id never addresses another partition.
+        keys = [call.kwargs.get('Key', {}) for call in table.get_item.call_args_list]
+        assert keys, 'expected at least one keyed read'
+        assert {k.get('pk') for k in keys} == {f'PROJECT#{PROJECT}'}
+
+    def test_a_prd_id_offered_as_a_base_prototype_is_a_404(self, build_prototype):
+        """`prd_1` is a real document in this project, just not a prototype. The
+        `sk` prefix is what separates the two, so this is the fixture that fails if
+        the `PROTOTYPE#` prefix is ever dropped from the lookup."""
+        response, config, _table, invoke = build_prototype(
+            {'feedback': 'Make it admin-facing', 'base_prototype_id': 'prd_1'},
+        )
+
+        assert response['statusCode'] == 404
+        assert 'base_prototype_id' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_an_unknown_prototype_is_a_404_even_without_feedback(self, build_prototype):
+        """The check does not hang off `feedback`. An id that is sent is an id that
+        is claimed, so it is resolved whenever it is supplied."""
+        response, config, _table, invoke = build_prototype({'base_prototype_id': 'proto_nope'})
+
+        assert response['statusCode'] == 404
+        assert 'base_prototype_id' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    @pytest.mark.parametrize('value', [
+        pytest.param(['proto_1'], id='list'),
+        pytest.param({'id': 'proto_1'}, id='object'),
+        pytest.param(7, id='number'),
+        pytest.param(True, id='bool'),
+    ])
+    def test_a_non_string_base_prototype_id_is_a_400(self, build_prototype, value):
+        response, config, _table, invoke = build_prototype({'base_prototype_id': value})
+
+        assert response['statusCode'] == 400
+        assert 'base_prototype_id' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_an_absurdly_long_base_prototype_id_is_a_400_not_a_500(self, build_prototype):
+        response, config, table, invoke = build_prototype({'base_prototype_id': 'x' * 5000})
+
+        assert response['statusCode'] == 400
+        assert 'base_prototype_id' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+        # Rejected before the key was ever built.
+        assert not any(
+            'x' * 5000 in str(call.kwargs.get('Key', {}))
+            for call in table.get_item.call_args_list
+        )
+
+    @pytest.mark.parametrize('body, label', [
+        pytest.param({}, 'absent', id='absent'),
+        pytest.param({'base_prototype_id': None}, 'null', id='null'),
+        pytest.param({'base_prototype_id': ''}, 'blank', id='blank'),
+        pytest.param({'base_prototype_id': '   '}, 'whitespace', id='whitespace'),
+    ])
+    def test_not_naming_a_base_prototype_still_builds(self, build_prototype, body, label):
+        """Every build that is not a revision sends one of these, and all of them
+        must keep meaning "not a revision" rather than "prototype ''"."""
+        response, config, _table, invoke = build_prototype({'title': 'Prototype', **body})
+
+        assert response['statusCode'] == 200, label
+        assert config['base_prototype_id'] is None
+        invoke.assert_called_once()

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -533,6 +533,37 @@ def _source_document(
     return doc
 
 
+def _base_prototype(projects_table, project_id: str, base_prototype_id: str) -> dict | None:
+    """
+    The prototype a revision is built on: the one the request named, or None when
+    it named none.
+
+    A named id that does not resolve RAISES, in the same shape and for the same
+    reason as `_source_document`. Left silent, the build carried on as a fresh
+    generation with no `EXISTING PROTOTYPE (revise this)` block, then saved a
+    document labelled a revision — it carries `revised_from_id` — that the model
+    produced without ever seeing the prototype it supposedly revises. Nothing in
+    the output said so, and the failure cost a full Bedrock call to reach.
+
+    The error condition is the ABSENT ITEM, not empty HTML. A prototype whose
+    stored content is legitimately empty resolved fine and stays buildable — see
+    the caller, which asks for no prior-HTML block in that case.
+
+    Resolved whenever an id is supplied, regardless of whether `feedback` came
+    with it: an id that is sent is an id that is claimed.
+    """
+    if not base_prototype_id:
+        return None
+    item = projects_table.get_item(
+        Key={'pk': f'PROJECT#{project_id}', 'sk': f'PROTOTYPE#{base_prototype_id}'},
+    ).get('Item')
+    if not item:
+        raise RuntimeError(
+            f'base_prototype_id: no PROTOTYPE document "{base_prototype_id}" in this project.'
+        )
+    return item
+
+
 def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_config: dict) -> dict:
     """
     Build a self-contained, offline-first HTML prototype from the latest PRD and
@@ -583,14 +614,15 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
     # revises it (e.g. "switch to an admin-facing view") rather than starting over.
     feedback = (doc_config.get('feedback') or '').strip()
     base_prototype_id = (doc_config.get('base_prototype_id') or '').strip()
+    # Resolved OUTSIDE the `if feedback:` below so an unresolvable id fails the
+    # job whether or not feedback was sent alongside it. Absent, null or blank
+    # still means "this build is not a revision".
+    base = _base_prototype(projects_table, project_id, base_prototype_id)
     feedback_section = ''
     system_prompt = PROTOTYPE_HTML_SYSTEM_PROMPT
     if feedback:
         prior_html = ''
-        if base_prototype_id:
-            base = projects_table.get_item(
-                Key={'pk': f'PROJECT#{project_id}', 'sk': f'PROTOTYPE#{base_prototype_id}'}
-            ).get('Item') or {}
+        if base is not None:
             # New (S3-only) prototypes have no `content` field — read the HTML
             # back from S3 via prototype_url instead. Old (pre-migration)
             # prototypes still have `content` inline in DynamoDB; fall back to

--- a/voc-datalake/lambda/jobs/document_generator/test/test_prototype_sources.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_prototype_sources.py
@@ -15,6 +15,13 @@ Two properties, both of which were previously unpinned:
    newest would produce a prototype built from a document the user did not
    choose, which no part of the output would reveal.
 
+3. **The same holds for the third client-supplied id, `base_prototype_id`.** It
+   used to be the asymmetry: an id resolving to nothing left the prior HTML
+   empty, dropped the `EXISTING PROTOTYPE (revise this)` block, and completed as
+   a fresh generation — saving a document labelled a revision that the model
+   never saw the base of. One handler failed loudly for one kind of missing
+   source and silently for another.
+
 Every fixture here holds at least TWO documents of a type with different
 `created_at`, because a single-document fixture cannot distinguish "picked the
 right PRD" from "picked the only PRD".
@@ -323,3 +330,162 @@ class TestAimedBuild:
 
         assert 'NEW PRD body' in _prompt(mock_converse)
         assert _saved(mock_dynamodb)['source_prd_id'] == 'aa_prd_new'
+
+
+PROTOTYPE_S3 = {'document_id': 'proto_1', 'prototype_url': 'https://cdn.example.com/prototypes/x.html'}
+
+
+class TestBasePrototypeOfARevision:
+    """
+    `base_prototype_id` — the third client-supplied id, and the one that used to
+    degrade silently.
+
+    An id resolving to nothing left the prior-HTML variable empty, dropped the
+    `EXISTING PROTOTYPE (revise this)` block from the prompt, and completed the
+    job as a FRESH generation — saving a document labelled a revision
+    (`revised_from_id`) that the model produced without ever seeing the prototype
+    it supposedly revises. It must raise, exactly as an unresolvable
+    `source_prd_id` does.
+
+    Every fixture here supplies enough table responses for BOTH source lookups to
+    succeed, so a silent-fallback implementation runs to completion. Without that,
+    a test would pass because the run ended for want of a query response rather
+    than because of the raise — passing under the very behaviour it exists to
+    reject.
+    """
+
+    def test_an_unresolvable_base_prototype_fails_the_job(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        _wire(mock_dynamodb, prd_pages=[{'Items': [PRD_OLD, PRD_NEW]}], prfaq_pages=[NO_DOCUMENTS], documents={})
+        mock_converse.return_value = HTML
+
+        with pytest.raises(Exception, match='Document generation failed'):
+            _run(
+                sample_job_event, lambda_context,
+                feedback='Make it admin-facing', base_prototype_id='proto_does_not_exist',
+            )
+
+        # No prompt built, no document saved: the build did not happen at all,
+        # rather than happening as a fresh generation mislabelled a revision.
+        mock_converse.assert_not_called()
+        mock_dynamodb['table'].put_item.assert_not_called()
+
+    def test_the_failure_names_the_field(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """Asserted on the message the job records, in the same shape
+        `_source_document` uses: without the field name, an operator reading a
+        failed job cannot tell WHICH of the three ids did not resolve."""
+        _wire(mock_dynamodb, prd_pages=[{'Items': [PRD_OLD, PRD_NEW]}], prfaq_pages=[NO_DOCUMENTS], documents={})
+        mock_converse.return_value = HTML
+
+        with pytest.raises(Exception, match='Document generation failed'):
+            _run(
+                sample_job_event, lambda_context,
+                feedback='Make it admin-facing', base_prototype_id='proto_does_not_exist',
+            )
+
+        recorded = str(mock_jobs_table.update_item.call_args_list)
+        assert 'base_prototype_id' in recorded
+        assert 'proto_does_not_exist' in recorded
+
+    def test_it_fails_even_when_no_feedback_was_sent(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The lookup does not hang off `feedback`: an id that is sent is claimed,
+        so it is resolved whenever it is supplied."""
+        _wire(mock_dynamodb, prd_pages=[{'Items': [PRD_OLD, PRD_NEW]}], prfaq_pages=[NO_DOCUMENTS], documents={})
+        mock_converse.return_value = HTML
+
+        with pytest.raises(Exception, match='Document generation failed'):
+            _run(sample_job_event, lambda_context, base_prototype_id='proto_does_not_exist')
+
+        mock_converse.assert_not_called()
+
+    def test_a_base_prototype_is_only_ever_read_under_this_project(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The ownership half, asserted on the key that is built: the supplied id
+        reaches `sk` only, under the `PROTOTYPE#` prefix, so neither another
+        project's prototype nor a PRD offered as one can resolve."""
+        _wire(mock_dynamodb, prd_pages=[{'Items': [PRD_NEW]}], prfaq_pages=[NO_DOCUMENTS], documents={})
+        mock_converse.return_value = HTML
+
+        with pytest.raises(Exception, match='Document generation failed'):
+            _run(
+                sample_job_event, lambda_context,
+                feedback='Make it admin-facing', base_prototype_id='../PROJECT#victim/proto_1',
+            )
+
+        keys = [call.kwargs.get('Key', {}) for call in mock_dynamodb['table'].get_item.call_args_list]
+        assert keys, 'expected at least one keyed read'
+        assert {k.get('pk') for k in keys} == {'PROJECT#proj_20250101120000'}
+        assert any(k.get('sk') == 'PROTOTYPE#../PROJECT#victim/proto_1' for k in keys)
+
+    def test_a_resolved_base_with_no_html_anywhere_still_builds(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """An empty prior-HTML string and an id that resolved to nothing are two
+        DIFFERENT conditions, and only the second is an error. Keying the raise on
+        empty HTML would break revising an older prototype whose stored content is
+        legitimately empty — which is exactly this item."""
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[NO_DOCUMENTS],
+            documents={'PROTOTYPE#proto_empty': {'document_id': 'proto_empty'}},
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context,
+            feedback='Make it admin-facing', base_prototype_id='proto_empty',
+        )
+
+        prompt = _prompt(mock_converse)
+        assert 'Make it admin-facing' in prompt          # the revision still runs
+        assert 'EXISTING PROTOTYPE' not in prompt        # with no prior-HTML block
+        assert _saved(mock_dynamodb)['revised_from_id'] == 'proto_empty'
+
+    def test_a_failed_s3_read_falls_back_to_the_inline_content(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """A failed S3 read is not an unresolvable id. The item resolved, so the
+        job keeps degrading to the pre-migration inline `content` rather than
+        failing."""
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[NO_DOCUMENTS],
+            documents={'PROTOTYPE#proto_1': {**PROTOTYPE_S3, 'content': 'INLINE prior prototype'}},
+        )
+        mock_s3.get_object.side_effect = RuntimeError('AccessDenied')
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context,
+            feedback='Make it admin-facing', base_prototype_id='proto_1',
+        )
+
+        assert 'INLINE prior prototype' in _prompt(mock_converse)
+        assert _saved(mock_dynamodb)['revised_from_id'] == 'proto_1'
+
+    @pytest.mark.parametrize('value', [
+        pytest.param(None, id='null'),
+        pytest.param('', id='blank'),
+        pytest.param('   ', id='whitespace'),
+    ])
+    def test_not_naming_a_base_prototype_still_builds(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context, value,
+    ):
+        """Not a revision, and it must stay buildable — no lookup, no raise."""
+        _wire(mock_dynamodb, prd_pages=[{'Items': [PRD_NEW]}], prfaq_pages=[NO_DOCUMENTS], documents={})
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, base_prototype_id=value)
+
+        assert 'NEW PRD body' in _prompt(mock_converse)
+        assert 'PROTOTYPE#' not in str([
+            call.kwargs.get('Key', {}) for call in mock_dynamodb['table'].get_item.call_args_list
+        ])


### PR DESCRIPTION
## Summary

`api_build_prototype` accepts three client-supplied document ids and validated two of them.
`source_prd_id` and `source_prfaq_id` go through `_validated_source_id`; `base_prototype_id` was copied
into `doc_config` straight from the request body. In the generator, an unresolvable base was fetched with a
single `get_item`, and when the key held nothing the prior-HTML variable stayed empty, the
`EXISTING PROTOTYPE (revise this)` block was dropped from the prompt, and the job completed as a **fresh
generation** — writing a document labelled a revision (it carries `revised_from_id`) that the model
produced without ever seeing the prototype it supposedly revises. The build succeeded, billed a
multi-minute Bedrock call, and nothing in the output revealed the base was missing.

One handler therefore failed loudly for one kind of missing source and degraded silently for another.

### Production changes (two files, ~40 lines)

- **`lambda/api/projects_handler.py`** — `base_prototype_id` now resolves through the existing
  `_validated_source_id` helper with the `PROTOTYPE#` prefix. An id naming no prototype in this project is
  a **404 naming the field**; a non-string or over-long value is a **400 naming the field**. Neither
  creates a job row or invokes the generator. The call sits in the same `doc_config` literal as the other
  two, so it runs **before** `create_job`, unconditionally — not gated on `feedback`.
- **`lambda/jobs/document_generator/handler.py`** — a new `_base_prototype` helper resolves the id and
  **raises** on an absent item, in the same shape `_source_document` already uses for the other two ids.
  It is called outside the `if feedback:` block, so an id that is sent is an id that is claimed.

The two checks are deliberately redundant, for the reason `_validated_source_id`'s own docstring already
gives: the boundary check is what keeps an unresolvable id from creating a job that bills a long Bedrock
call in order to fail, and the generator raise is what makes the failure loud if a job reaches the
generator by any other path.

### What deliberately did not change

- **A prototype that resolves but holds neither `prototype_url` nor `content`** builds with no prior-HTML
  block and does not raise. An empty prior-HTML string and an id that resolved to nothing are two different
  conditions, and only the second is an error — keying the raise on empty HTML would break revising an older
  prototype whose stored content is legitimately empty. The error condition is the **absent item**.
- **The S3-then-inline fallback**, including the `try`/`except` around the S3 read. A failed S3 read is not
  an unresolvable id and keeps degrading to the item's inline `content`.
- `_source_document`, `_document_by_id`, `_newest_document_id`, and the handling of `source_prd_id` /
  `source_prfaq_id` — already correct, untouched.
- `MAX_SOURCE_DOCUMENT_ID_LEN` keeps its value of 256.
- Absent, null and blank `base_prototype_id` all keep meaning "this build is not a revision".

## Tests

Extended the two existing files. Each new test's fixture is built so it is capable of failing:

**`lambda/api/test/test_build_prototype_sources.py`** (+11 tests, 15 → 26)

The shared `build_prototype` fixture now answers reads on the **whole composite key** rather than on `sk`
alone, and holds a prototype in a *second* project. Keyed on `sk` only, "belongs to another project" and
"does not exist" would be the same table, and the test could not tell a dropped partition key apart from a
working one.

- an unknown prototype → 404 **and `config is None`**. The `config is None` assertion is the load-bearing
  one: a check placed after `create_job` still returns 404 while having created the job row and, with it,
  the billable build the check exists to prevent.
- a prototype that exists in a *different* project → 404 (the fixture that fails if `pk` is dropped), also
  asserted on the keys actually built.
- a **PRD id** supplied as `base_prototype_id` → 404 (the fixture that fails if the `PROTOTYPE#` prefix is
  dropped).
- an unknown id → 404 **even with no `feedback` in the body**.
- non-string (list / object / number / bool) and over-long → 400 naming the field, no job, and the absurd id
  never reaches a key.
- absent / null / blank / whitespace → 200, `base_prototype_id is None`, generator invoked.

**`lambda/jobs/document_generator/test/test_prototype_sources.py`** (+9 tests, 11 → 20)

Every fixture in the new class supplies enough table responses for **both** source lookups to succeed, so a
silent-fallback implementation runs to completion. Without that, the test would pass because the run ended
for want of a query response rather than because of the raise — passing under exactly the behaviour it
exists to reject. (The file's existing `test_an_unresolvable_id_fails_instead_of_falling_back_to_the_newest`
documents getting this wrong once already.)

- a supplied id resolving to no item raises and the job fails; no prompt built, no `put_item`.
- the recorded failure message **names `base_prototype_id`** (and the id), asserted on what reaches the jobs
  table — without the field name an operator cannot tell which of the three ids did not resolve.
- it fails with no `feedback` sent.
- the id only ever reaches `sk`, under `PROTOTYPE#`, never `pk`.
- an item that resolves with **neither** `prototype_url` nor `content` completes, produces **no**
  `EXISTING PROTOTYPE` block, and still records `revised_from_id`.
- an item whose **S3 read raises** falls back to inline `content` and does not fail the job.
- null / blank / whitespace build normally and issue no `PROTOTYPE#` read at all.

### Revert check

With **both** production hunks reverted and the new tests kept:

- `test_build_prototype_sources.py` — **11 failed, 15 passed.** The failures are every test in
  `TestBasePrototypeIdIsCheckedLikeTheOtherTwo` except `test_a_named_prototype_reaches_the_generator`
  (an id that resolves is passed through either way) and the `absent`/`null` cases of
  `test_not_naming_a_base_prototype_still_builds` (`None` in, `None` out either way). Notably
  `test_not_naming_a_base_prototype_still_builds[blank]` and `[whitespace]` fail too, on
  `assert '   ' is None` — the un-normalised path forwarded the raw blank string.
- `test_prototype_sources.py` — **4 failed, 16 passed:**
  `test_an_unresolvable_base_prototype_fails_the_job`, `test_the_failure_names_the_field`,
  `test_it_fails_even_when_no_feedback_was_sent`, `test_a_base_prototype_is_only_ever_read_under_this_project`.
  The three "keeps its current behaviour" tests (empty-HTML item, failed S3 read, unnamed base) pass in both
  directions, which is the point of them.

Both hunks restored → all green.

## Build and test results

Commands run from `voc-datalake` with `.venv/bin/python -m pytest`, one directory at a time, each well under
the three-minute window:

| Command | Result |
|---|---|
| `mise run build` | **no such task** — `mise ERROR no tasks defined in <repo root>`. There is no mise task file in this repo; the setup notes flag the same thing and say build gating is inert. |
| `pytest lambda/api/test` | **540 passed** |
| `pytest lambda/jobs` | **95 passed** |
| `pytest lambda/api/test/test_build_prototype_sources.py` | **26 passed** (was 15) |
| `pytest lambda/jobs/document_generator/test/` | **93 passed**, incl. `test_prototype_sources.py` **20 passed** (was 11) |
| `ruff check` on the four touched files | **13 findings, byte-identical to the same command on `development`** — 9 `BLE001`, 3 `I001`, 1 `RUF100`, all pre-existing and none in the added lines. Compared before/after via `git stash`. |

Note on the environment: `voc-datalake/.venv` did not exist in the container, so I created it from
`requirements-dev.txt` plus the two layer requirements files (`lambda/layers/{ingestion,processing}-deps`)
as `requirements-dev.txt`'s header instructs — without the production deps every API test errors at import
on `Tracer()`. `.venv` is untracked and not part of this diff.

Frontend/vitest legs were **not** run: `npx vitest` in `voc-datalake/frontend` fails with
`npm error code ECOMPROMISED / Lock compromised` in this container. No frontend or locale file is touched by
this diff, so nothing here should affect them.

`lint:python` is already failing on `development` for reasons unrelated to this work, and is not addressed
here.

## Decisions made

- **A helper rather than an inline `if`.** The lookup moved into `_base_prototype` so it could be hoisted
  out of `if feedback:` without nesting, and so the "why" comment sits next to the raise the way
  `_source_document`'s does. It reads as the third member of that family.
- **`RuntimeError` with the message shape `field: no TYPE document "id" in this project.`** — copied from
  `_source_document` verbatim in shape so the two failures look identical in a job's error field.
- **`if base is not None:`** rather than `if base:` at the call site. An item that resolves but is falsy as a
  dict cannot occur (DynamoDB never returns an empty `Item`), but `is not None` states the intent — the
  distinction between "resolved" and "resolved to something empty" is the whole point of this change.

## Frontend observation (out of scope, not in this diff)

`RevisePrototypeForm` in `frontend/src/pages/ProjectDetail/DocumentsTab.tsx` awaits
`projectsApi.buildPrototype` and, on rejection, renders `e.message` inline and keeps the form open with the
typed feedback intact — so a 404 does surface to the user rather than being swallowed, and the retry does
not cost them retyping. But `fetchApi` in `frontend/src/api/client.ts` throws
`new Error('API Error: ' + response.status)`, discarding the response body — so the user sees
`API Error: 404`, not the server's `base_prototype_id: no such document in this project`. The reachable path
is narrow (the revision form sends the id of a prototype the user just clicked, so a 404 means it was
deleted between render and click), and a generic 404 arguably reads fine there. Surfacing the server's
message generally would be a change to `fetchApi` affecting every caller, which is why it is noted here
rather than done.

## Scope

Frontend and locale catalogues untouched, as specified.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

## Agent notes

**What went well.** The fix itself was small and the repo had already done the hard thinking: `_validated_source_id` and `_source_document` existed, their docstrings spell out *why* both a boundary check and a generator raise are needed, and the task was essentially "apply the pattern the module already documents to the one field that skipped it." Reusing the helper verbatim meant no new validation logic and no new error shape.

**What was difficult.**
- **Making the tests capable of failing.** Two fixtures needed deliberate construction rather than the obvious version. (a) The API fixture originally keyed reads on `sk` alone; with a single project in the table, "another project's prototype" and "no such prototype" are literally the same fixture, so the test could not detect a dropped `pk`. Rekeying on the composite `(pk, sk)` fixed that. (b) The generator fixture must supply enough `query` responses for *both* source lookups, or a silent-fallback implementation dies for want of a mock response and the test passes for the wrong reason. The existing file's docstrings warn about exactly this trap — they were worth reading before writing anything.
- **Verifying the revert check** rather than asserting it. Reverting both hunks and running the suites turned up two failures I had not predicted: the `blank` and `whitespace` cases of the "still builds" test fail on revert too, because the unchecked path forwarded `'   '` instead of normalising it to `None`. That is a real behaviour difference worth naming in the description, and I would have got it wrong from reasoning alone.
- **Environment setup.** `voc-datalake/.venv` did not exist, and creating it from `requirements-dev.txt` alone is not enough — every API test errors at import on Powertools `Tracer()` until the two layer requirements files are also installed. `requirements-dev.txt`'s header comment says so; worth reading first.

**Repo conventions discovered.**
- **Comments carry the reasoning, at length.** Production functions and test classes alike explain *why* a shape was chosen and *what breaks* if it is changed, often naming the review round or measurement that produced the decision ("0 of 6 when measured", "found in review round 2"). A terse patch would be stylistically out of place here. Test docstrings in particular explain which mutation each test is designed to catch.
- **Trust boundaries are enforced by the DynamoDB key, not by explicit checks.** `pk` is the project and `sk` is `{TYPE}#{id}`, so ownership and type isolation come free and are asserted *on the key that gets built* rather than on an outcome — because with one mocked table, an outcome-based assertion is a tautology. Several tests say so explicitly.
- **Redundant checks are intentional and documented as such**, with each layer's distinct job stated (boundary = don't bill for a failure; generator = don't fail silently).
- Python tests live in `test/` beside the code, `pytest.ini` at `voc-datalake/` sets `--cov`; `--no-cov` makes scoped runs fast. Commit messages are conventional-commit with a module scope, bodies explaining the failure mode in prose.

**Suggestions for future tasks here.**
1. **`mise run build` does not exist** — there is no mise task file at the repo root. The real gates are the per-leg npm scripts (`lint:python`, `test:backend`, `typecheck:*`). `npm run check` chains with `&&`, so the first failing leg hides the rest; run legs individually.
2. **`npx` is broken in this container** (`npm error code ECOMPROMISED / Lock compromised`), so vitest/tsc legs cannot be run. Any task touching `frontend/` or `lambda/stream/` will need that resolved, or will have to ship without frontend test evidence.
3. **`lint:python` fails on `development`** (9 `BLE001` blind-except findings in these two files alone, plus `I001`/`RUF100`). Comparing `ruff check --statistics` on the touched files before and after via `git stash` is the only way to show a change added nothing — worth doing routinely on this repo.
4. **A latent asymmetry remains nearby**: `revised_from_id` and `revision_feedback` are written only `if feedback:`, so a build that supplies `base_prototype_id` with no feedback now validates the id but records no revision relation. That is pre-existing and arguably correct ("no feedback means not a revision"), but it means `base_prototype_id` can be validated and then dropped on the floor. Worth an explicit product decision rather than leaving it implicit.
