### PR TITLE
feat(prototypes): let a build read product context and research

### DIFF
--- a/voc-datalake/frontend/public/locales/de/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/de/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "Dieses Projekt hat bereits einen Prototyp. Ein weiterer Build erstellt einen neuen und behält den vorhandenen. Fortfahren?",
       "downloadHtml": ".html herunterladen",
       "downloadJson": ".json herunterladen",
+      "extraSources": "Zusätzlich lesen (optional)",
       "feedbackBuilding": "Wird überarbeitet…",
       "feedbackButton": "Mit Feedback überarbeiten",
       "feedbackHeading": "Prototyp mit Feedback überarbeiten",
@@ -99,10 +100,13 @@
       "needsDocs": "Erstellen Sie zuerst ein PRD oder ein PR-FAQ, um die Prototyp-Erstellung zu aktivieren",
       "previewLabel": "Live-Vorschau",
       "rawLabel": "Rohausgabe (Parsen fehlgeschlagen — bitte neu generieren)",
+      "researchLimit": "Höchstens {{max}} Berichte pro Build",
       "sourceLatest": "neueste",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "Gestartet — Verfolgen Sie den Fortschritt unter Hintergrundaufgaben."
+      "started": "Gestartet — Verfolgen Sie den Fortschritt unter Hintergrundaufgaben.",
+      "useProductContext": "Produkt-/Servicebeschreibung",
+      "useResearch": "Rechercheberichte ({{total}})"
     },
     "revision": {
       "feedback": "Rückmeldung: {{feedback}}",
@@ -257,7 +261,7 @@
     "productDescription": "Produkt-/Service-Beschreibung",
     "productDescriptionDesc": "Beschreiben Sie das aktuelle Produkt. Fließt in die PRD- und PR/FAQ-Generierung ein.",
     "prototype": "Klickbarer Prototyp",
-    "prototypeDesc": "Erstellen Sie einen klickbaren HTML-Prototyp aus Ihrem PRD / PR-FAQ",
+    "prototypeDesc": "Erstellen Sie einen klickbaren HTML-Prototyp aus den Spezifikationen des Projekts und optional aus Produktbeschreibung und Recherche",
     "remixDocuments": "Dokumente remixen",
     "remixDocumentsDesc": "Dokumente kombinieren und überarbeiten",
     "runResearch": "Recherche starten",

--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "This project already has a prototype. Building again adds a new one and keeps the existing one. Continue?",
       "downloadHtml": "Download .html",
       "downloadJson": "Download .json",
+      "extraSources": "Also read (optional)",
       "feedbackBuilding": "Revising…",
       "feedbackButton": "Revise with feedback",
       "feedbackHeading": "Revise prototype with feedback",
@@ -99,10 +100,13 @@
       "needsDocs": "Create a PRD or a PR-FAQ first to enable prototype build",
       "previewLabel": "Live preview",
       "rawLabel": "Raw output (parse failed — please regenerate)",
+      "researchLimit": "At most {{max}} reports per build",
       "sourceLatest": "latest",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "Started — track it in Background Jobs."
+      "started": "Started — track it in Background Jobs.",
+      "useProductContext": "Product / service description",
+      "useResearch": "Research reports ({{total}})"
     },
     "revision": {
       "feedback": "Feedback: {{feedback}}",
@@ -257,7 +261,7 @@
     "productDescription": "Product / Service Description",
     "productDescriptionDesc": "Describe the current product. Feeds PRD and PR/FAQ generation.",
     "prototype": "Clickable Prototype",
-    "prototypeDesc": "Build a clickable HTML prototype from your PRD / PR-FAQ",
+    "prototypeDesc": "Build a clickable HTML prototype from your project's specs, and optionally its product description and research",
     "remixDocuments": "Remix Documents",
     "remixDocumentsDesc": "Combine and revise documents into new versions",
     "runResearch": "Run Research",

--- a/voc-datalake/frontend/public/locales/es/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/es/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "Este proyecto ya tiene un prototipo. Volver a compilar añade uno nuevo y conserva el existente. ¿Continuar?",
       "downloadHtml": "Descargar .html",
       "downloadJson": "Descargar .json",
+      "extraSources": "Leer también (opcional)",
       "feedbackBuilding": "Revisando…",
       "feedbackButton": "Revisar con feedback",
       "feedbackHeading": "Revisar el prototipo con feedback",
@@ -99,10 +100,13 @@
       "needsDocs": "Crea primero un PRD o un PR-FAQ para habilitar la creación del prototipo",
       "previewLabel": "Vista previa en vivo",
       "rawLabel": "Salida sin procesar (falló el análisis — regenera, por favor)",
+      "researchLimit": "Máximo {{max}} informes por compilación",
       "sourceLatest": "más reciente",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "Iniciado: síguelo en Tareas en segundo plano."
+      "started": "Iniciado: síguelo en Tareas en segundo plano.",
+      "useProductContext": "Descripción del producto o servicio",
+      "useResearch": "Informes de investigación ({{total}})"
     },
     "revision": {
       "feedback": "Comentarios: {{feedback}}",
@@ -260,7 +264,7 @@
     "productDescription": "Descripción del producto/servicio",
     "productDescriptionDesc": "Describe el producto actual. Alimenta la generación de PRD y PR/FAQ.",
     "prototype": "Prototipo interactivo",
-    "prototypeDesc": "Cree un prototipo HTML interactivo a partir de su PRD / PR-FAQ",
+    "prototypeDesc": "Cree un prototipo HTML interactivo a partir de las especificaciones del proyecto y, opcionalmente, de su descripción de producto e investigación",
     "remixDocuments": "Remezlar Documentos",
     "remixDocumentsDesc": "Combinar y revisar documentos en nuevas versiones",
     "runResearch": "Ejecutar Investigación",

--- a/voc-datalake/frontend/public/locales/fr/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/fr/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "Ce projet a déjà un prototype. Une nouvelle génération en ajoute un et conserve l’existant. Continuer ?",
       "downloadHtml": "Télécharger le .html",
       "downloadJson": "Télécharger le .json",
+      "extraSources": "Lire aussi (facultatif)",
       "feedbackBuilding": "Révision en cours…",
       "feedbackButton": "Réviser avec des retours",
       "feedbackHeading": "Réviser le prototype avec des retours",
@@ -99,10 +100,13 @@
       "needsDocs": "Créez d’abord un PRD ou un PR-FAQ pour activer la création de prototype",
       "previewLabel": "Aperçu en direct",
       "rawLabel": "Sortie brute (analyse échouée — veuillez régénérer)",
+      "researchLimit": "Au maximum {{max}} rapports par génération",
       "sourceLatest": "la plus récente",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "Lancé — suivez la progression dans Tâches en arrière-plan."
+      "started": "Lancé — suivez la progression dans Tâches en arrière-plan.",
+      "useProductContext": "Description du produit ou service",
+      "useResearch": "Rapports de recherche ({{total}})"
     },
     "revision": {
       "feedback": "Retour : {{feedback}}",
@@ -260,7 +264,7 @@
     "productDescription": "Description du produit/service",
     "productDescriptionDesc": "Décrivez le produit actuel. Alimente la génération de PRD et de PR/FAQ.",
     "prototype": "Prototype cliquable",
-    "prototypeDesc": "Créez un prototype HTML cliquable à partir de votre PRD / PR-FAQ",
+    "prototypeDesc": "Créez un prototype HTML cliquable à partir des spécifications du projet et, en option, de sa description produit et de ses recherches",
     "remixDocuments": "Remixer les documents",
     "remixDocumentsDesc": "Combiner et réviser les documents pour créer de nouvelles versions",
     "runResearch": "Lancer une recherche",

--- a/voc-datalake/frontend/public/locales/ja/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ja/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "このプロジェクトにはすでにプロトタイプがあります。再度ビルドすると既存のものを保持したまま新しいものが追加されます。続行しますか?",
       "downloadHtml": ".html をダウンロード",
       "downloadJson": ".json をダウンロード",
+      "extraSources": "追加で参照 (任意)",
       "feedbackBuilding": "修正中…",
       "feedbackButton": "フィードバックで修正",
       "feedbackHeading": "フィードバックでプロトタイプを修正",
@@ -99,10 +100,13 @@
       "needsDocs": "プロトタイプ作成を有効にするには、まず PRD または PR-FAQ を作成してください",
       "previewLabel": "ライブプレビュー",
       "rawLabel": "生の出力（解析失敗 — 再生成してください）",
+      "researchLimit": "1 回のビルドで最大 {{max}} 件のレポート",
       "sourceLatest": "最新",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "開始しました — バックグラウンドジョブで進行状況を確認できます。"
+      "started": "開始しました — バックグラウンドジョブで進行状況を確認できます。",
+      "useProductContext": "製品・サービスの説明",
+      "useResearch": "リサーチレポート ({{total}})"
     },
     "revision": {
       "feedback": "フィードバック: {{feedback}}",
@@ -257,7 +261,7 @@
     "productDescription": "製品／サービス説明",
     "productDescriptionDesc": "現在の製品を記述してください。PRD と PR/FAQ の生成に反映されます。",
     "prototype": "クリック可能なプロトタイプ",
-    "prototypeDesc": "PRD / PR-FAQ からクリック可能な HTML プロトタイプを作成します",
+    "prototypeDesc": "プロジェクトの仕様書から、必要に応じて製品説明やリサーチも参照して、クリック可能な HTML プロトタイプを作成します",
     "remixDocuments": "ドキュメントをリミックス",
     "remixDocumentsDesc": "ドキュメントを組み合わせて新しいバージョンに修正",
     "runResearch": "リサーチを実行",

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "이 프로젝트에는 이미 프로토타입이 있습니다. 다시 빌드하면 기존 항목을 유지한 채 새 항목이 추가됩니다. 계속하시겠습니까?",
       "downloadHtml": "HTML 다운로드",
       "downloadJson": "JSON 다운로드",
+      "extraSources": "추가로 참고 (선택)",
       "feedbackBuilding": "수정 중…",
       "feedbackButton": "피드백으로 수정",
       "feedbackHeading": "피드백으로 프로토타입 수정",
@@ -99,10 +100,13 @@
       "needsDocs": "프로토타입 생성은 PRD 또는 PR-FAQ가 있어야 활성화됩니다",
       "previewLabel": "미리보기",
       "rawLabel": "원본 출력 (파싱 실패 — 다시 생성해 주세요)",
+      "researchLimit": "한 번의 빌드에 최대 {{max}}개 보고서",
       "sourceLatest": "최신",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "시작했습니다 — 백그라운드 작업에서 진행 상황을 확인하세요."
+      "started": "시작했습니다 — 백그라운드 작업에서 진행 상황을 확인하세요.",
+      "useProductContext": "제품/서비스 설명",
+      "useResearch": "리서치 보고서 ({{total}}개)"
     },
     "revision": {
       "feedback": "피드백: {{feedback}}",
@@ -257,7 +261,7 @@
     "productDescription": "제품 / 서비스 설명",
     "productDescriptionDesc": "현재 제품을 설명합니다. PRD 및 PR/FAQ 생성에 사용됩니다.",
     "prototype": "클릭 가능한 프로토타입",
-    "prototypeDesc": "PRD / PR-FAQ에서 클릭 가능한 HTML 프로토타입을 만듭니다",
+    "prototypeDesc": "프로젝트 사양서를 바탕으로, 필요하면 제품 설명과 리서치까지 참고해 클릭 가능한 HTML 프로토타입을 만듭니다",
     "remixDocuments": "문서 리믹스",
     "remixDocumentsDesc": "문서를 결합하고 수정하여 새 버전 생성",
     "runResearch": "리서치 실행",

--- a/voc-datalake/frontend/public/locales/pt/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/pt/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "Este projeto já tem um protótipo. Criar novamente adiciona um novo e mantém o existente. Continuar?",
       "downloadHtml": "Baixar .html",
       "downloadJson": "Baixar .json",
+      "extraSources": "Ler também (opcional)",
       "feedbackBuilding": "Revisando…",
       "feedbackButton": "Revisar com feedback",
       "feedbackHeading": "Revisar o protótipo com feedback",
@@ -99,10 +100,13 @@
       "needsDocs": "Crie primeiro um PRD ou um PR-FAQ para habilitar a criação do protótipo",
       "previewLabel": "Prévia ao vivo",
       "rawLabel": "Saída bruta (falha na análise — regenere, por favor)",
+      "researchLimit": "No máximo {{max}} relatórios por build",
       "sourceLatest": "mais recente",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "Iniciado — acompanhe em Tarefas em Segundo Plano."
+      "started": "Iniciado — acompanhe em Tarefas em Segundo Plano.",
+      "useProductContext": "Descrição do produto ou serviço",
+      "useResearch": "Relatórios de pesquisa ({{total}})"
     },
     "revision": {
       "feedback": "Comentários: {{feedback}}",
@@ -260,7 +264,7 @@
     "productDescription": "Descrição do produto/serviço",
     "productDescriptionDesc": "Descreva o produto atual. Alimenta a geração de PRD e PR/FAQ.",
     "prototype": "Protótipo clicável",
-    "prototypeDesc": "Crie um protótipo HTML clicável a partir do seu PRD / PR-FAQ",
+    "prototypeDesc": "Crie um protótipo HTML clicável a partir das especificações do projeto e, opcionalmente, da descrição do produto e das pesquisas",
     "remixDocuments": "Remixar Documentos",
     "remixDocumentsDesc": "Combinar e revisar documentos em novas versões",
     "runResearch": "Executar Pesquisa",

--- a/voc-datalake/frontend/public/locales/zh/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/zh/projectDetail.json
@@ -88,6 +88,7 @@
       "confirmRebuild": "此项目已有原型。再次构建会新增一个并保留现有原型。是否继续？",
       "downloadHtml": "下载 .html",
       "downloadJson": "下载 .json",
+      "extraSources": "同时参考（可选）",
       "feedbackBuilding": "修订中…",
       "feedbackButton": "根据反馈修订",
       "feedbackHeading": "根据反馈修订原型",
@@ -99,10 +100,13 @@
       "needsDocs": "请先创建 PRD 或 PR-FAQ 以启用原型构建",
       "previewLabel": "实时预览",
       "rawLabel": "原始输出（解析失败 — 请重新生成）",
+      "researchLimit": "每次构建最多 {{max}} 份报告",
       "sourceLatest": "最新",
       "sourcePrd": "PRD",
       "sourcePrfaq": "PR/FAQ",
-      "started": "已开始 — 可在后台任务中查看进度。"
+      "started": "已开始 — 可在后台任务中查看进度。",
+      "useProductContext": "产品/服务说明",
+      "useResearch": "研究报告（{{total}}）"
     },
     "revision": {
       "feedback": "反馈：{{feedback}}",
@@ -257,7 +261,7 @@
     "productDescription": "产品/服务描述",
     "productDescriptionDesc": "描述当前产品。将用于 PRD 和 PR/FAQ 的生成。",
     "prototype": "可点击原型",
-    "prototypeDesc": "根据您的 PRD / PR-FAQ 创建可点击的 HTML 原型",
+    "prototypeDesc": "根据项目规格文档创建可点击的 HTML 原型，并可选择同时参考产品说明与研究报告",
     "remixDocuments": "重新混合文档",
     "remixDocumentsDesc": "合并和修订文档以创建新版本",
     "runResearch": "运行研究",

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -261,6 +261,17 @@ export const projectsApi = {
     // a document the user did not choose is invisible in the result.
     source_prd_id?: string;
     source_prfaq_id?: string;
+    // Optional extra grounding, chosen per build rather than remembered per
+    // project. Omitted means today's behaviour exactly: the generator adds a
+    // prompt section only for what is asked for.
+    use_product_context?: boolean;
+    // `selected_research_ids` is only read when `use_research` is true, and it is
+    // research-only on purpose — the shared reference-document path keeps just the
+    // first three of a selection, and research sorts last, so a general picker
+    // drops exactly the thing this field exists to include. Ids are validated
+    // against `RESEARCH#{id}` in this project; one that names nothing is a 4xx.
+    use_research?: boolean;
+    selected_research_ids?: string[];
   }) =>
     fetchApi<{
       success: boolean;

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.revisionExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.revisionExtraSources.test.tsx
@@ -18,6 +18,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DocumentsTab from './DocumentsTab'
+import { MAX_SELECTED_RESEARCH_IDS } from './overviewState'
 import type { DocumentDerivation } from '../../api/derivation'
 import type { Project, ProjectDocument } from '../../api/types'
 
@@ -185,6 +186,35 @@ describe('a revision keeps the inputs its base was built with', () => {
     // The rest of the inheritance survives one missing report.
     expect(body.use_product_context).toBe(true)
     expect(body.source_prd_id).toBe('prd_1')
+  })
+
+  it('still revises a base carrying more reports than the current bound allows', async () => {
+    // Today unreachable: the API capped the base build that recorded these, so an
+    // inherited list cannot exceed the bound. It becomes reachable the day the
+    // bound is LOWERED, and then every prototype built under the old one is
+    // un-revisable — a 400 naming a list length the user never chose and cannot
+    // shorten from this button. The fixture is built one over the live bound so it
+    // keeps testing that whatever the number becomes.
+    const extra = Array.from({ length: MAX_SELECTED_RESEARCH_IDS + 1 }, (_, i) => `research_over_${i}`)
+    const overBound = doc({
+      document_id: 'proto_over',
+      prototype_format: 'html',
+      derivation: derivation({
+        sources: extra.map((document_id) => ({ document_id, role: 'reference' as const })),
+        selected_document_count: extra.length,
+      }),
+    })
+    const reports = extra.map((id) => doc({
+      document_id: id, document_type: 'research', title: id, created_at: '2026-03-01T00:00:00Z',
+    }))
+    renderTab([overBound, PRD, ...reports], overBound)
+
+    const body = await revise()
+
+    // Sliced, not truncated arbitrarily: the first N in recorded order, which is
+    // the order the original build read them in.
+    expect(body.selected_research_ids).toEqual(extra.slice(0, MAX_SELECTED_RESEARCH_IDS))
+    expect(body.use_research).toBe(true)
   })
 
   it('inherits only research, never another document type recorded as a reference', async () => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.revisionExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.revisionExtraSources.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * A revision inherits the optional inputs its base prototype was built with.
+ *
+ * Same defect class as the `source_prd_id` inheritance bug found in #320: without
+ * inheritance the revision re-derives today's defaults, so a research report
+ * created between the build and the revision silently joins it, or the
+ * product-context flag is dropped — a revision that changes its inputs as well as
+ * its feedback, which is not what "revise this" means.
+ *
+ * Every fixture therefore adds research report **B** after the base was built
+ * with **A**. Only true inheritance sends A alone: re-deriving picks B (or both),
+ * and a fixture with a single report could not tell the two apart.
+ *
+ * What is inherited is read off the base's own recorded `derivation`, which is
+ * where the generator writes what it actually used.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DocumentsTab from './DocumentsTab'
+import type { DocumentDerivation } from '../../api/derivation'
+import type { Project, ProjectDocument } from '../../api/types'
+
+const mockBuildPrototype = vi.fn()
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    buildPrototype: (...args: unknown[]) => mockBuildPrototype(...args),
+  },
+}))
+
+const project: Project = {
+  project_id: 'proj_1',
+  name: 'Test project',
+  description: '',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  persona_count: 0,
+  document_count: 0,
+}
+
+function doc(overrides: Partial<ProjectDocument> & { document_id: string }): ProjectDocument {
+  return {
+    document_type: 'prototype',
+    title: 'Prototype',
+    content: '<!DOCTYPE html><html><body>x</body></html>',
+    created_at: '2026-07-10T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function derivation(overrides: Partial<DocumentDerivation>): DocumentDerivation {
+  return {
+    sources: [],
+    selected_document_count: 0,
+    feedback_count: 0,
+    persona_ids: [],
+    product_context_included: false,
+    ...overrides,
+  }
+}
+
+const RESEARCH_A = doc({
+  document_id: 'research_a', document_type: 'research', title: 'Churn interviews',
+  created_at: '2026-03-01T00:00:00Z',
+})
+/** Created AFTER the base was built. Re-deriving defaults picks this one. */
+const RESEARCH_B = doc({
+  document_id: 'research_b', document_type: 'research', title: 'Pricing survey',
+  created_at: '2026-09-01T00:00:00Z',
+})
+const PRD = doc({
+  document_id: 'prd_1', document_type: 'prd', title: 'Spec', created_at: '2026-01-01T00:00:00Z',
+})
+
+/** Built with product context ON and research A — and nothing else. */
+const BASE = doc({
+  document_id: 'proto_1',
+  title: 'First cut',
+  prototype_format: 'html',
+  source_prd_id: 'prd_1',
+  derivation: derivation({
+    sources: [
+      { document_id: 'prd_1', role: 'prototype_prd' },
+      { document_id: 'research_a', role: 'reference' },
+    ],
+    selected_document_count: 2,
+    product_context_included: true,
+  }),
+})
+
+function renderTab(documents: ProjectDocument[], selected: ProjectDocument) {
+  render(
+    <DocumentsTab
+      project={project}
+      documents={documents}
+      selectedDoc={selected}
+      onSelectDoc={vi.fn()}
+      onEditDoc={vi.fn()}
+      onDeleteDoc={vi.fn()}
+      onCreateDoc={vi.fn()}
+      isDeleting={false}
+    />,
+  )
+}
+
+async function revise() {
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: /revise with feedback/i }))
+  await user.type(screen.getByRole('textbox'), 'Show the admin view')
+  await user.click(screen.getByRole('button', { name: /^regenerate$/i }))
+  await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+  return mockBuildPrototype.mock.calls[0][1]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockBuildPrototype.mockResolvedValue({ job_id: 'job_1' })
+})
+
+describe('a revision keeps the inputs its base was built with', () => {
+  it('sends the base’s research report and not the one created since', async () => {
+    renderTab([BASE, PRD, RESEARCH_A, RESEARCH_B], BASE)
+
+    const body = await revise()
+
+    expect(body.use_research).toBe(true)
+    expect(body.selected_research_ids).toEqual(['research_a'])
+  })
+
+  it('sends the base’s product-context flag', async () => {
+    renderTab([BASE, PRD, RESEARCH_A, RESEARCH_B], BASE)
+
+    const body = await revise()
+
+    expect(body.use_product_context).toBe(true)
+  })
+
+  it('inherits nothing from a base that used neither', async () => {
+    // Research B exists and is the newest, so a re-derived default would pick it up
+    // and a hardcoded `true` flag would show here.
+    const plain = doc({
+      document_id: 'proto_plain',
+      prototype_format: 'html',
+      derivation: derivation({
+        sources: [{ document_id: 'prd_1', role: 'prototype_prd' }],
+        selected_document_count: 1,
+      }),
+    })
+    renderTab([plain, PRD, RESEARCH_A, RESEARCH_B], plain)
+
+    const body = await revise()
+
+    expect(body.use_product_context).toBe(false)
+    expect(body.use_research).toBe(false)
+    expect(body.selected_research_ids).toEqual([])
+  })
+
+  it('inherits nothing from a prototype built before the derivation existed', async () => {
+    // `resolveDerivation` reconstructs the two source ids for such a document from
+    // its legacy fields and records nothing else, so the revision behaves exactly
+    // as it did before this feature.
+    const legacy = doc({
+      document_id: 'proto_legacy', prototype_format: 'html', source_prd_id: 'prd_1',
+    })
+    renderTab([legacy, PRD, RESEARCH_A, RESEARCH_B], legacy)
+
+    const body = await revise()
+
+    expect(body.source_prd_id).toBe('prd_1')
+    expect(body.use_product_context).toBe(false)
+    expect(body.selected_research_ids).toEqual([])
+  })
+
+  it('drops an inherited report that has since been deleted', async () => {
+    // The API rejects an id it cannot resolve, so keeping it would turn someone
+    // else's deletion into this revision's 4xx and the prototype could never be
+    // revised again — the same fallback the source ids take, per slot.
+    renderTab([BASE, PRD, RESEARCH_B], BASE)
+
+    const body = await revise()
+
+    expect(body.selected_research_ids).toEqual([])
+    expect(body.use_research).toBe(false)
+    // The rest of the inheritance survives one missing report.
+    expect(body.use_product_context).toBe(true)
+    expect(body.source_prd_id).toBe('prd_1')
+  })
+
+  it('inherits only research, never another document type recorded as a reference', async () => {
+    // The scoping property, on the read side: a reference-role source that is not
+    // research must not be offered to a research-only field, which the API would
+    // reject under its `RESEARCH#` prefix. The base names a PRD as a reference,
+    // which is the only fixture that fails if the type filter is dropped.
+    const mixed = doc({
+      document_id: 'proto_mixed',
+      prototype_format: 'html',
+      derivation: derivation({
+        sources: [
+          { document_id: 'prd_1', role: 'reference' },
+          { document_id: 'research_a', role: 'reference' },
+        ],
+        selected_document_count: 2,
+      }),
+    })
+    renderTab([mixed, PRD, RESEARCH_A, RESEARCH_B], mixed)
+
+    const body = await revise()
+
+    expect(body.selected_research_ids).toEqual(['research_a'])
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
@@ -156,6 +156,9 @@ export default function DocumentsTab({
                   sourcePrdId={stillPresent(selectedDoc.source_prd_id, documents)}
                   sourcePrfaqId={stillPresent(selectedDoc.source_prfaq_id, documents)}
                   sourcesDropped={hasDroppedSource(selectedDoc, documents)}
+                  // The optional inputs the BASE was built with, not today's
+                  // defaults — see `inheritedExtraSources`.
+                  extraSources={inheritedExtraSources(selectedDoc, documents)}
                   onJobStarted={onJobStarted}
                 />
               ) : (
@@ -190,7 +193,8 @@ export default function DocumentsTab({
 type TFunc = (key: string, opts?: Record<string, unknown>) => string
 
 function PrototypeFeedbackButton({
-  projectId, basePrototypeId, title, sourcePrdId, sourcePrfaqId, sourcesDropped, onJobStarted, t,
+  projectId, basePrototypeId, title, sourcePrdId, sourcePrfaqId, sourcesDropped, extraSources,
+  onJobStarted, t,
 }: {
   readonly projectId: string
   readonly basePrototypeId: string
@@ -198,6 +202,8 @@ function PrototypeFeedbackButton({
   /** The base prototype's own sources, so a revision keeps the spec it revises. */
   readonly sourcePrdId: string
   readonly sourcePrfaqId: string
+  /** The base prototype's optional inputs, for the same reason. */
+  readonly extraSources: InheritedExtraSources
   /**
    * A source this prototype was built from has been deleted, so the revision will
    * read the latest of that type instead. Said out loud rather than left silent:
@@ -240,6 +246,14 @@ function PrototypeFeedbackButton({
         // falls back to today's behaviour.
         source_prd_id: sourcePrdId,
         source_prfaq_id: sourcePrfaqId,
+        // Inherited for the same reason as the two ids above, and it is the same
+        // defect class: re-deriving the defaults would ground the revision in
+        // whatever research exists NOW, so a report created between the build and
+        // the revision would silently join it — or the product-context flag would
+        // be dropped — while the user only asked to change the feedback.
+        use_product_context: extraSources.useProductContext,
+        use_research: extraSources.researchIds.length > 0,
+        selected_research_ids: [...extraSources.researchIds],
       })
       // The form closes but the text is kept: the revision can still fail
       // minutes later, in the jobs panel, and clearing it would mean retyping
@@ -252,7 +266,7 @@ function PrototypeFeedbackButton({
     } finally {
       setBusy(false)
     }
-  }, [feedback, projectId, basePrototypeId, title, sourcePrdId, sourcePrfaqId,
+  }, [feedback, projectId, basePrototypeId, title, sourcePrdId, sourcePrfaqId, extraSources,
       i18n.language, onJobStarted, started])
 
   if (!open) {
@@ -366,7 +380,7 @@ function LegacyHtmlActions({
 
 function PrototypeView({
   projectId, documentId, html, url, title, prototypeFormat, sourcePrdId, sourcePrfaqId,
-  sourcesDropped, onJobStarted,
+  sourcesDropped, extraSources, onJobStarted,
 }: {
   readonly projectId: string
   readonly documentId: string
@@ -379,6 +393,8 @@ function PrototypeView({
   readonly sourcePrfaqId: string
   /** One of those sources has been deleted, so the revision cannot inherit it. */
   readonly sourcesDropped: boolean
+  /** The optional inputs the base was built with, passed through to a revision. */
+  readonly extraSources: InheritedExtraSources
   readonly onJobStarted?: () => void
 }) {
   const { t } = useTranslation('projectDetail')
@@ -420,6 +436,7 @@ function PrototypeView({
               sourcePrdId={sourcePrdId}
               sourcePrfaqId={sourcePrfaqId}
               sourcesDropped={sourcesDropped}
+              extraSources={extraSources}
               onJobStarted={onJobStarted}
               t={t}
             />
@@ -642,6 +659,48 @@ function hasDroppedSource(
   return ([doc.source_prd_id, doc.source_prfaq_id]).some(
     (id) => id != null && id !== '' && stillPresent(id, documents) === '',
   )
+}
+
+/** The optional inputs a revision inherits from the prototype it revises. */
+export interface InheritedExtraSources {
+  readonly useProductContext: boolean
+  readonly researchIds: ReadonlyArray<string>
+}
+
+/**
+ * What the base prototype was actually built with, read off its own recorded
+ * derivation.
+ *
+ * Inherited rather than re-derived, and for the same reason the source ids are:
+ * re-deriving would ground the revision in whatever exists NOW, so a research
+ * report created between the build and the revision would silently join it, or the
+ * product-context flag would be lost — a revision that changes its inputs as well
+ * as its feedback, which is not what "revise this" means.
+ *
+ * Read through `resolveDerivation`, which is total: a prototype built before this
+ * feature (or one whose derivation is malformed) yields no flag and no reports, so
+ * its revision behaves exactly as it does today.
+ *
+ * Filtered to `document_type === 'research'` — the resolver only knows a type for a
+ * source it FOUND among the project's documents, so this drops both a
+ * reference-role source that is not research and a report that has since been
+ * deleted. Dropping the deleted one is required, not cosmetic: the API rejects an
+ * id it cannot resolve, so keeping it would turn someone else's deletion into this
+ * revision's 4xx. It is dropped without a note, unlike a dropped PRD — the
+ * `feedbackRebased` note says the latest of that type will be used instead, which
+ * would be untrue here: nothing substitutes for a missing research report.
+ */
+function inheritedExtraSources(
+  doc: ProjectDocument,
+  documents: readonly ProjectDocument[],
+): InheritedExtraSources {
+  const derivation = resolveDerivation(doc, documents)
+  return {
+    useProductContext: derivation.product_context_included,
+    researchIds: derivation.sources
+      .filter((source) => source.role === 'reference' && source.document_type === 'research')
+      .map((source) => source.document_id),
+  }
 }
 
 // ── Succession: what this document replaces ──────────────────────────────────

--- a/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/DocumentsTab.tsx
@@ -13,6 +13,7 @@ import remarkGfm from 'remark-gfm'
 import { projectsApi } from '../../api/projectsApi'
 import { resolveDerivation, type DerivationRole, type DerivationSource } from '../../api/derivation'
 import { ordinalByType, resolveRevision, type DocumentOrdinal } from '../../api/documentLineage'
+import { MAX_SELECTED_RESEARCH_IDS } from './overviewState'
 import { useTransientFlag } from './useTransientFlag'
 import DocumentExportMenu from '../../components/DocumentExportMenu'
 import PrototypeLinkActions, { PrototypeLinkLifetimeNote } from '../../components/PrototypeLinkActions'
@@ -251,9 +252,14 @@ function PrototypeFeedbackButton({
         // whatever research exists NOW, so a report created between the build and
         // the revision would silently join it — or the product-context flag would
         // be dropped — while the user only asked to change the feedback.
+        //
+        // The flag-and-ids pair, in the shape `usePrototypeBuild` sends it: the
+        // flag is the switch and the ids are gated on it. One rule for one API
+        // field — deriving the flag here instead was a second rule for the same
+        // field, and the two could have drifted apart.
         use_product_context: extraSources.useProductContext,
-        use_research: extraSources.researchIds.length > 0,
-        selected_research_ids: [...extraSources.researchIds],
+        use_research: extraSources.useResearch,
+        selected_research_ids: extraSources.useResearch ? [...extraSources.researchIds] : [],
       })
       // The form closes but the text is kept: the revision can still fail
       // minutes later, in the jobs panel, and clearing it would mean retyping
@@ -664,6 +670,15 @@ function hasDroppedSource(
 /** The optional inputs a revision inherits from the prototype it revises. */
 export interface InheritedExtraSources {
   readonly useProductContext: boolean
+  /**
+   * The flag-and-ids pair, in the same shape `usePrototypeBuild` sends: the flag
+   * is the switch and the ids are gated on it, so both paths have ONE rule for
+   * one API field. Derived here rather than at the send site — a revision has no
+   * recorded `use_research` boolean to inherit (the derivation records the reports
+   * it used, not the tick-box), so the flag has to come from the ids, and doing
+   * that at the call site is what made the two paths differ.
+   */
+  readonly useResearch: boolean
   readonly researchIds: ReadonlyArray<string>
 }
 
@@ -695,11 +710,23 @@ function inheritedExtraSources(
   documents: readonly ProjectDocument[],
 ): InheritedExtraSources {
   const derivation = resolveDerivation(doc, documents)
+  const researchIds = derivation.sources
+    .filter((source) => source.role === 'reference' && source.document_type === 'research')
+    .map((source) => source.document_id)
+    // Sliced to the bound the API enforces, exactly as the build path slices the
+    // reports it pre-selects. Today the list cannot exceed it — the API capped the
+    // base build that recorded it — so this is a bound on a bound. It earns its
+    // line for the day the number is LOWERED: without it every prototype built
+    // under the old bound becomes un-revisable, with a 400 naming a list length
+    // the user never chose and cannot shorten from this button.
+    .slice(0, MAX_SELECTED_RESEARCH_IDS)
   return {
     useProductContext: derivation.product_context_included,
-    researchIds: derivation.sources
-      .filter((source) => source.role === 'reference' && source.document_type === 'research')
-      .map((source) => source.document_id),
+    // Inherited research means research: no reports, no flag. Deriving the flag
+    // from the ids here — after the filter that drops deleted reports and after
+    // the slice — is what keeps it true of the list actually being sent.
+    useResearch: researchIds.length > 0,
+    researchIds,
   }
 }
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
@@ -205,6 +205,48 @@ describe('which research reports the build reads', () => {
   })
 })
 
+describe('a card that cannot act offers no choices', () => {
+  it('renders no tick-boxes on a project with no PRD and no PR-FAQ', () => {
+    // The fixture the rest of this suite never had: research and a filled product
+    // context, so there IS something to offer, and no PRD or PR-FAQ, so the card is
+    // disabled and nothing can be built. Choices above a dead button read as an
+    // offer — the user ticks them, then reads that they must create a document
+    // first. Every other fixture here passes whether or not the gate exists.
+    renderTab([RESEARCH_A], FILLED_CONTEXT)
+
+    expect(buildButton()).toBeDisabled()
+    expect(screen.getByText(en.documents.prototype.needsDocs)).toBeInTheDocument()
+    expect(screen.queryByTestId('prototype-extra-sources')).not.toBeInTheDocument()
+    // Asserted on the roles too, not just the container: a gate that kept the
+    // wrapper and hid its contents would leave the box focusable.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
+  })
+
+  it('offers them again as soon as one document exists', () => {
+    // The other half, from the same fixture one document later: the gate must be
+    // the disabled state and not something that hides the controls outright.
+    renderTab([PRD, RESEARCH_A], FILLED_CONTEXT)
+
+    expect(buildButton()).toBeEnabled()
+    expect(screen.getByTestId('prototype-extra-sources')).toBeInTheDocument()
+  })
+})
+
+describe('two similarly-named reports are distinguishable', () => {
+  it('gives each report title a tooltip carrying the full string', async () => {
+    // The titles are `truncate`d in a narrow column, so two reports named
+    // "Churn interviews Q1"/"Q2" render as the same visible string. A screen
+    // reader gets the full label either way; a sighted mouse user has only this.
+    const user = userEvent.setup()
+    renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+
+    await user.click(researchBox())
+
+    expect(screen.getByTitle('Churn interviews')).toBeInTheDocument()
+    expect(screen.getByTitle('Pricing survey')).toBeInTheDocument()
+  })
+})
+
 describe('the card no longer presents PRD/PR-FAQ as the whole input list', () => {
   it('states the optional inputs on an enabled card for a project that has them', () => {
     // The fixture matters twice over: with no research there would be nothing to

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * The prototype card's two optional inputs: the project's product description
+ * and its research reports.
+ *
+ * Where the controls live is the property under test, not a detail.
+ * `confirmKeyFor` in `usePrototypeBuild` deliberately opens NO dialog for a
+ * project with one PRD, one PR-FAQ and no prototype — the build starts on the
+ * first click — and the source picker lives inside that dialog. So the fixture
+ * that matters here is precisely that project: a control placed in the dialog is
+ * unreachable for it, and no other fixture shows that.
+ *
+ * `t()` resolves against the real en catalogue (src/test/setup.ts), so a key that
+ * is missing or has moved renders its raw path and these matchers fail.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import OverviewTab from './OverviewTab'
+import { emptyProductContext } from './productContextFields'
+// All eight catalogues, imported statically so a locale cannot be skipped the way
+// a dynamic path could — same shape as components/DataSourceWizard/localization.test.tsx.
+import de from '../../../public/locales/de/projectDetail.json'
+import en from '../../../public/locales/en/projectDetail.json'
+import es from '../../../public/locales/es/projectDetail.json'
+import fr from '../../../public/locales/fr/projectDetail.json'
+import ja from '../../../public/locales/ja/projectDetail.json'
+import ko from '../../../public/locales/ko/projectDetail.json'
+import pt from '../../../public/locales/pt/projectDetail.json'
+import zh from '../../../public/locales/zh/projectDetail.json'
+import type { Project, ProductContext, ProjectDocument } from '../../api/types'
+
+const mockBuildPrototype = vi.fn()
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    buildPrototype: (...args: unknown[]) => mockBuildPrototype(...args),
+  },
+}))
+
+const project: Project = {
+  project_id: 'proj_1',
+  name: 'Test project',
+  description: '',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  persona_count: 0,
+  document_count: 0,
+}
+
+function doc(
+  documentType: ProjectDocument['document_type'],
+  id: string,
+  title: string,
+  createdAt: string,
+): ProjectDocument {
+  return { document_id: id, document_type: documentType, title, content: 'x', created_at: createdAt }
+}
+
+const PRD = doc('prd', 'prd_1', 'Delivery spec', '2026-01-01T00:00:00Z')
+const PRFAQ = doc('prfaq', 'prfaq_1', 'Launch note', '2026-02-01T00:00:00Z')
+const RESEARCH_A = doc('research', 'research_a', 'Churn interviews', '2026-03-01T00:00:00Z')
+const RESEARCH_B = doc('research', 'research_b', 'Pricing survey', '2026-04-01T00:00:00Z')
+
+/** Exactly one filled field — enough to be non-empty, few enough to stay honest. */
+const FILLED_CONTEXT: ProductContext = { ...emptyProductContext(), one_liner: 'A console for wombats' }
+
+function tab(documents: ProjectDocument[], productContext?: ProductContext) {
+  return (
+    <OverviewTab
+      project={project}
+      personas={[]}
+      documents={documents}
+      productContext={productContext}
+      onGeneratePersonas={vi.fn()}
+      onGenerateDoc={vi.fn()}
+      onRunResearch={vi.fn()}
+      onRemixDocuments={vi.fn()}
+      onOpenProductTool={vi.fn()}
+      onJobStarted={vi.fn()}
+    />
+  )
+}
+
+function renderTab(documents: ProjectDocument[], productContext?: ProductContext) {
+  return render(tab(documents, productContext))
+}
+
+const buildButton = () => screen.getByRole('button', { name: /build prototype/i })
+const productContextBox = () => screen.getByRole('checkbox', { name: /product \/ service description/i })
+const researchBox = () => screen.getByRole('checkbox', { name: /research reports/i })
+const sentBody = () => mockBuildPrototype.mock.calls[0][1]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockBuildPrototype.mockResolvedValue({ job_id: 'job_1' })
+})
+
+describe('the controls are reachable without a dialog', () => {
+  it('offers both tick-boxes on a project with one PRD, one PR-FAQ and no prototype', async () => {
+    // The one project that opens no confirm dialog at all. A control placed inside
+    // ConfirmModal is invisible here, and every other fixture in this suite would
+    // still pass.
+    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+
+    expect(screen.getByTestId('prototype-extra-sources')).toBeInTheDocument()
+    expect(productContextBox()).toBeInTheDocument()
+    expect(researchBox()).toBeInTheDocument()
+    // No dialog was needed to get here.
+    expect(screen.queryByTestId('prototype-source-picker')).not.toBeInTheDocument()
+  })
+
+  it('sends what was ticked on that same one-click project', async () => {
+    const user = userEvent.setup()
+    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+
+    await user.click(productContextBox())
+    await user.click(buildButton())
+
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(sentBody().use_product_context).toBe(true)
+  })
+
+  it('sends both flags off when nothing is ticked', async () => {
+    // The request every existing caller makes. Off must stay off, or the feature
+    // changes builds nobody asked it to.
+    const user = userEvent.setup()
+    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+
+    await user.click(buildButton())
+
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(sentBody().use_product_context).toBe(false)
+    expect(sentBody().use_research).toBe(false)
+    expect(sentBody().selected_research_ids).toEqual([])
+  })
+
+  it('offers no research box when the project has no research', () => {
+    // A box whose only possible contribution is an empty section is an invitation
+    // to a no-op — the same reason `SourceRow` renders nothing for a type the
+    // project has none of.
+    renderTab([PRD, PRFAQ], FILLED_CONTEXT)
+
+    expect(screen.queryByRole('checkbox', { name: /research reports/i })).not.toBeInTheDocument()
+    expect(productContextBox()).toBeInTheDocument()
+  })
+})
+
+describe('which research reports the build reads', () => {
+  it('ticking research selects every report on offer', async () => {
+    const user = userEvent.setup()
+    renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+
+    await user.click(researchBox())
+    await user.click(buildButton())
+
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(sentBody().use_research).toBe(true)
+    // Newest first, matching the order `overviewState` derives and the backend's
+    // own newest-of-type rule.
+    expect(sentBody().selected_research_ids).toEqual(['research_b', 'research_a'])
+  })
+
+  it('sends only the reports left ticked', async () => {
+    // The feature: choose the research, rather than take all of it. Nothing else
+    // here fails if the per-report boxes are ignored.
+    const user = userEvent.setup()
+    renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+
+    await user.click(researchBox())
+    await user.click(screen.getByRole('checkbox', { name: 'Pricing survey' }))
+    await user.click(buildButton())
+
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(sentBody().selected_research_ids).toEqual(['research_a'])
+  })
+
+  it('drops a report that is deleted between the tick and the click', async () => {
+    // The document list refetches whenever a job completes, so a report can
+    // disappear under an open card. Sending its id would be a 4xx — someone else's
+    // deletion becoming this build's failure. Found by mutation: without a
+    // re-render in the fixture, the filter that prevents it has no test at all.
+    const user = userEvent.setup()
+    const { rerender } = renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+
+    await user.click(researchBox())
+    rerender(tab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT))
+    await user.click(buildButton())
+
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(sentBody().selected_research_ids).toEqual(['research_a'])
+  })
+
+  it('unticking research sends no ids at all', async () => {
+    const user = userEvent.setup()
+    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+
+    await user.click(researchBox())
+    await user.click(researchBox())
+    await user.click(buildButton())
+
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(sentBody().use_research).toBe(false)
+    expect(sentBody().selected_research_ids).toEqual([])
+    expect(screen.queryByTestId('prototype-research-list')).not.toBeInTheDocument()
+  })
+})
+
+describe('the card no longer presents PRD/PR-FAQ as the whole input list', () => {
+  it('states the optional inputs on an enabled card for a project that has them', () => {
+    // The fixture matters twice over: with no research there would be nothing to
+    // omit, so "states the omission" would be indistinguishable from "there was
+    // nothing to omit" — and a DISABLED card renders
+    // `documents.prototype.needsDocs` instead of this description, so the
+    // assertion would pass for the wrong reason.
+    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+
+    expect(buildButton()).toBeEnabled()
+    expect(screen.getByText(en.overview.prototypeDesc)).toBeInTheDocument()
+    expect(en.overview.prototypeDesc).toMatch(/product description/i)
+    expect(en.overview.prototypeDesc).toMatch(/research/i)
+  })
+
+  it.each([
+    ['de', de], ['en', en], ['es', es], ['fr', fr],
+    ['ja', ja], ['ko', ko], ['pt', pt], ['zh', zh],
+  ])('names no document type as the exhaustive input list in %s', (_locale, catalogue) => {
+    // Language-independent on purpose: every catalogue kept the Latin "PRD /
+    // PR-FAQ" verbatim in the old sentence, so naming either is the tell that a
+    // catalogue was left behind — and it is the one assertion that works for all
+    // eight without asserting on a translation's wording.
+    expect(catalogue.overview.prototypeDesc).not.toMatch(/PRD|PR.?FAQ/i)
+    expect(catalogue.overview.prototypeDesc).not.toBe('')
+  })
+
+  it.each([
+    ['de', de], ['en', en], ['es', es], ['fr', fr],
+    ['ja', ja], ['ko', ko], ['pt', pt], ['zh', zh],
+  ])('carries the new control labels in %s', (_locale, catalogue) => {
+    // A catalogue missing one of these renders the raw key path in that language —
+    // visible to a user of that locale, and to nobody running the tests under `en`.
+    const prototype = catalogue.documents.prototype
+    expect(prototype.extraSources).toBeTruthy()
+    expect(prototype.useProductContext).toBeTruthy()
+    expect(prototype.useResearch).toContain('{{total}}')
+    expect(prototype.researchLimit).toContain('{{max}}')
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
@@ -408,8 +408,17 @@ function ActionCard({
       )}
       {/* Above the button, because they change what the button does. Rendered raw
           like `statusLine`: only the caller knows what the choices are, and a
-          wrapper here would put an empty box on the five cards that have none. */}
-      {controls}
+          wrapper here would put an empty box on the five cards that have none.
+
+          Not rendered at all on a disabled card: choices for an action that cannot
+          be taken read as an offer, and a project with no PRD and no PR/FAQ showed
+          tick-boxes stacked above a dead button and the "create a document first"
+          message. That also hides them while `busy` — the prototype card's second
+          disabled reason — which is correct rather than merely tolerable: nothing
+          ticked during the start request can affect the build already in flight,
+          and the window closes when the request returns, not when the build
+          finishes. */}
+      {disabled === true ? null : controls}
       <button
         onClick={onClick}
         disabled={disabled}
@@ -605,8 +614,8 @@ function PrototypeExtraSources({
   )
 }
 
-/** One tick-box with a real label, so the whole row is a hit target and an
-    accessible name exists without a `title` or an aria-label. */
+/** One tick-box with a real label, so the whole row is a hit target and the
+    accessible name comes from the label rather than from an aria-label. */
 function SourceCheckbox({
   label, checked, disabled, onChange,
 }: {
@@ -630,7 +639,13 @@ function SourceCheckbox({
         onChange={(e) => onChange(e.target.checked)}
         className="rounded border-gray-300"
       />
-      <span className="truncate">{label}</span>
+      {/* `title` because of `truncate`, not for the accessible name — that already
+          comes from the label. Report titles are user-supplied and this column is
+          narrow, so two reports named "Churn interviews Q1" and "Churn interviews
+          Q2" render as the same visible string; the tooltip is the only way to tell
+          which box is which. Sighted mouse users are exactly who needs it: a screen
+          reader reads the full label regardless of the CSS clip. */}
+      <span className="truncate" title={label}>{label}</span>
     </label>
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
@@ -76,6 +76,7 @@ export default function OverviewTab({
     hasExistingPrototype: steps.prototype.hasOutput,
     prdOptions: prototypeSources.prdOptions,
     prfaqOptions: prototypeSources.prfaqOptions,
+    researchOptions: prototypeSources.researchOptions,
     onJobStarted,
   })
 
@@ -204,6 +205,12 @@ export default function OverviewTab({
           // START (everything after that belongs to the jobs panel) and a brief
           // acknowledgement covering the gap before that panel refetches.
           statusLine={prototypeStatusLine(prototypeBuild, t)}
+          // On the card, NOT in the confirm dialog: `confirmKeyFor` deliberately
+          // opens no dialog for a project with one PRD, one PR-FAQ and no
+          // prototype, so a control placed there would be unreachable for exactly
+          // the simplest project — and moving that project behind a fourth confirm
+          // reason would cost the deliberate one-click path.
+          controls={<PrototypeExtraSources extras={prototypeBuild.extras} t={t} />}
         />
         <ActionCard
           state={steps.remix}
@@ -323,6 +330,12 @@ interface ActionCardProps {
    * others leave this unset.
    */
   readonly statusLine?: ReactNode
+  /**
+   * Choices this card's own action reads, rendered above its button. Only the
+   * prototype card has any: the other five open a wizard that asks for its
+   * configuration, so a control here would duplicate the first wizard step.
+   */
+  readonly controls?: ReactNode
   readonly buttonColor: string
   readonly buttonIcon: ReactNode
   readonly buttonLabel: string
@@ -346,6 +359,7 @@ function ActionCard({
   stateLabel,
   hint,
   statusLine,
+  controls,
   buttonColor,
   buttonIcon,
   buttonLabel,
@@ -392,6 +406,10 @@ function ActionCard({
         // "None yet" is information, not decoration, so it has to be readable.
         <p className={`text-xs mb-3 ${state.hasOutput ? 'text-green-700' : 'text-gray-500'}`}>{stateLabel}</p>
       )}
+      {/* Above the button, because they change what the button does. Rendered raw
+          like `statusLine`: only the caller knows what the choices are, and a
+          wrapper here would put an empty box on the five cards that have none. */}
+      {controls}
       <button
         onClick={onClick}
         disabled={disabled}
@@ -511,5 +529,108 @@ function SourceRow({
         ))}
       </select>
     </div>
+  )
+}
+
+/**
+ * The two optional inputs a prototype build can be told to read: the project's
+ * product context, and specific research reports.
+ *
+ * On the card rather than inside `ConfirmModal`, and that placement is the whole
+ * design decision: `confirmKeyFor` returns null — no dialog at all — for a project
+ * with one PRD, one PR-FAQ and no prototype, deliberately, so that the build starts
+ * on the first click. A control living in the dialog would be unreachable for
+ * exactly that project.
+ *
+ * Checkboxes rather than the `select` the source picker uses, because these are
+ * independent on/off choices rather than one-of-many, and because the research list
+ * is a multi-selection: the same shape `DataSourceSteps` uses, which is also why the
+ * research ids stay a separate field from the document ids.
+ */
+function PrototypeExtraSources({
+  extras, t,
+}: {
+  readonly extras: PrototypeBuildControl['extras']
+  readonly t: TFunction<'projectDetail'>
+}) {
+  return (
+    <div data-testid="prototype-extra-sources" className="mb-3 space-y-1.5 rounded-lg bg-gray-50 p-2.5">
+      <p className="text-xs font-medium text-gray-600">{t('documents.prototype.extraSources')}</p>
+      <SourceCheckbox
+        label={t('documents.prototype.useProductContext')}
+        checked={extras.useProductContext}
+        onChange={extras.onToggleProductContext}
+      />
+      {/* Nothing to offer, nothing to show — the same reason `SourceRow` renders
+          null for a type the project has none of. A checkbox that can only ever
+          contribute an empty section is an invitation to a no-op. */}
+      {extras.researchOptions.length === 0 ? null : (
+        <>
+          <SourceCheckbox
+            // `total`, not `count`: `count` makes i18next resolve plural
+            // suffixes, which would mean two more keys per catalogue for a
+            // number that is only ever shown in parentheses. `overview.state.research`
+            // already interpolates `total` the same way.
+            label={t('documents.prototype.useResearch', { total: extras.researchOptions.length })}
+            checked={extras.useResearch}
+            onChange={extras.onToggleResearch}
+          />
+          {extras.useResearch ? (
+            <div data-testid="prototype-research-list" className="ml-5 space-y-1 border-l pl-2">
+              {extras.researchOptions.map((option) => {
+                const checked = extras.selectedResearchIds.includes(option.document_id)
+                return (
+                  <SourceCheckbox
+                    key={option.document_id}
+                    label={option.title}
+                    checked={checked}
+                    // At the bound, the unticked boxes stop accepting: the API
+                    // rejects a longer list, and a 400 after the choice is made
+                    // says nothing about which report to give up.
+                    disabled={!checked && extras.researchLimitReached}
+                    onChange={() => extras.onToggleResearchId(option.document_id)}
+                  />
+                )
+              })}
+              {extras.researchLimitReached ? (
+                <p className="text-xs text-amber-700">
+                  {t('documents.prototype.researchLimit', { max: extras.maxResearchIds })}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  )
+}
+
+/** One tick-box with a real label, so the whole row is a hit target and an
+    accessible name exists without a `title` or an aria-label. */
+function SourceCheckbox({
+  label, checked, disabled, onChange,
+}: {
+  readonly label: string
+  readonly checked: boolean
+  readonly disabled?: boolean
+  readonly onChange: (next: boolean) => void
+}) {
+  return (
+    <label className={clsx(
+      'flex items-center gap-2 text-xs',
+      // gray-500, not gray-400: #6b7280 clears 4.5:1 on white where #9ca3af does
+      // not, and the disabled rows are the ones a user most needs to read to
+      // understand why they cannot tick them.
+      disabled === true ? 'text-gray-500' : 'text-gray-700',
+    )}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="rounded border-gray-300"
+      />
+      <span className="truncate">{label}</span>
+    </label>
   )
 }

--- a/voc-datalake/frontend/src/pages/ProjectDetail/overviewState.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/overviewState.ts
@@ -32,6 +32,23 @@ export type OverviewStep = 'product' | 'personas' | 'research' | 'documents' | '
 /** Remix needs two documents to combine; below that its card stays disabled. */
 export const REMIX_MIN_DOCUMENTS = 2
 
+/**
+ * How many research reports one prototype build may name.
+ *
+ * The same number as `MAX_SELECTED_RESEARCH_IDS` in
+ * `lambda/api/projects_handler.py`, which enforces it — each id costs one keyed
+ * read there, so an unbounded list turns one request into N of them. Kept in
+ * lockstep by `lambda/api/test/test_research_selection_bound_lockstep.py`: a UI
+ * that lets a user pick more than the API accepts fails on submit, after the
+ * choice was made and with nothing said about which report to give up.
+ *
+ * Here rather than beside the request type in `projectsApi.ts` for a mundane
+ * reason worth writing down: that module is mocked with explicit partial objects
+ * by a dozen test files, so a new named export on it makes every one of them
+ * throw. This module is where the option lists are derived and is mocked nowhere.
+ */
+export const MAX_SELECTED_RESEARCH_IDS = 10
+
 export interface OverviewStepState {
   /** Position in the sequence, 1-based, as shown on the card. */
   readonly position: number
@@ -91,6 +108,17 @@ export interface PrototypeSources {
   readonly hasPrfaq: boolean
   readonly prdOptions: ReadonlyArray<PrototypeSourceOption>
   readonly prfaqOptions: ReadonlyArray<PrototypeSourceOption>
+  /**
+   * The research reports the build can additionally be told to read, newest
+   * first — the optional third input, alongside the two required ones.
+   *
+   * A separate list rather than entries in a combined document selection: the
+   * shared reference-document path keeps only the first three of a selection and
+   * research sorts last, so a general picker drops exactly what this list exists
+   * to offer. Kept distinct here for the same reason `DataSourceSteps` keeps
+   * `selectedResearchIds` apart from `selectedDocumentIds`.
+   */
+  readonly researchOptions: ReadonlyArray<PrototypeSourceOption>
 }
 
 export interface OverviewState {
@@ -120,7 +148,8 @@ export function deriveOverviewState({
   personas, documents, productContext,
 }: DeriveInput): OverviewState {
   const filled = productContext == null ? undefined : countFilledProductContextFields(productContext)
-  const researchCount = documents.filter((d) => d.document_type === 'research').length
+  const researchOptions = sourceOptions(documents, 'research')
+  const researchCount = researchOptions.length
   const prdOptions = sourceOptions(documents, 'prd')
   const prfaqOptions = sourceOptions(documents, 'prfaq')
   const prdCount = prdOptions.length
@@ -182,6 +211,7 @@ export function deriveOverviewState({
       hasPrfaq: prfaqCount > 0,
       prdOptions,
       prfaqOptions,
+      researchOptions,
     },
   }
 }
@@ -230,7 +260,7 @@ function pickNextStep(
  */
 function sourceOptions(
   documents: ReadonlyArray<ProjectDocument>,
-  documentType: 'prd' | 'prfaq',
+  documentType: 'prd' | 'prfaq' | 'research',
 ): ReadonlyArray<PrototypeSourceOption> {
   return documents
     .filter((d) => d.document_type === documentType)

--- a/voc-datalake/frontend/src/pages/ProjectDetail/overviewState.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/overviewState.ts
@@ -42,6 +42,14 @@ export const REMIX_MIN_DOCUMENTS = 2
  * that lets a user pick more than the API accepts fails on submit, after the
  * choice was made and with nothing said about which report to give up.
  *
+ * That test reads THIS LINE as source text, matching `^export const
+ * MAX_SELECTED_RESEARCH_IDS = <digits>` — it does not import the module, so that
+ * it needs neither a bundler nor the Python import graph. So the declaration has
+ * to stay one line starting at column 0 with a bare integer literal: fold it into
+ * an object, compute it, or add a second assignment, and the test fails loudly
+ * (it asserts exactly one match) rather than passing vacuously. Changing the
+ * shape here means updating the regex there.
+ *
  * Here rather than beside the request type in `projectsApi.ts` for a mundane
  * reason worth writing down: that module is mocked with explicit partial objects
  * by a dozen test files, so a new named export on it makes every one of them

--- a/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
@@ -23,9 +23,10 @@
  * exist, otherwise whichever one does. So one document is enough to build, and
  * when only one is present the user is told which before it runs.
  */
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { projectsApi } from '../../api/projectsApi'
+import { MAX_SELECTED_RESEARCH_IDS } from './overviewState'
 import { useTransientFlag } from './useTransientFlag'
 import type { PrototypeSourceOption } from './overviewState'
 
@@ -120,10 +121,38 @@ export interface PrototypeBuildControl {
     readonly onSelectPrd: (documentId: string) => void
     readonly onSelectPrfaq: (documentId: string) => void
   }
+  /**
+   * The two optional inputs, off by default so a build that touches nothing here
+   * sends the request it always did.
+   *
+   * These live on the card rather than in the confirm dialog, and that is a
+   * requirement rather than a preference: `confirmKeyFor` deliberately returns
+   * null for a project with one PRD, one PR-FAQ and no prototype, so a control
+   * placed in the dialog is unreachable for exactly the simplest project.
+   */
+  readonly extras: {
+    readonly useProductContext: boolean
+    readonly onToggleProductContext: (next: boolean) => void
+    readonly useResearch: boolean
+    readonly onToggleResearch: (next: boolean) => void
+    /** Newest first, as `overviewState` derives them. Empty means nothing to offer. */
+    readonly researchOptions: ReadonlyArray<PrototypeSourceOption>
+    /** Only ids still on offer — a report deleted under the card is never sent. */
+    readonly selectedResearchIds: ReadonlyArray<string>
+    readonly onToggleResearchId: (documentId: string) => void
+    /**
+     * True when no further report can be added. The API rejects an over-long
+     * list, so the control refuses at the bound instead of letting the build fail
+     * on submit.
+     */
+    readonly researchLimitReached: boolean
+    readonly maxResearchIds: number
+  }
 }
 
 export function usePrototypeBuild({
-  projectId, hasPrd, hasPrfaq, hasExistingPrototype, prdOptions = [], prfaqOptions = [], onJobStarted,
+  projectId, hasPrd, hasPrfaq, hasExistingPrototype, prdOptions = [], prfaqOptions = [],
+  researchOptions = [], onJobStarted,
 }: {
   readonly projectId: string
   readonly hasPrd: boolean
@@ -139,6 +168,12 @@ export function usePrototypeBuild({
    */
   readonly prdOptions?: ReadonlyArray<PrototypeSourceOption>
   readonly prfaqOptions?: ReadonlyArray<PrototypeSourceOption>
+  /**
+   * The project's research reports, newest first. Optional and empty-defaulted:
+   * a caller that offers no research selection sends no research ids, and the
+   * build reads none — today's behaviour.
+   */
+  readonly researchOptions?: ReadonlyArray<PrototypeSourceOption>
   /**
    * The project already has a prototype, so this build makes an additional one.
    *
@@ -159,6 +194,16 @@ export function usePrototypeBuild({
   // default rather than leaving the card aimed at yesterday's newest.
   const [chosenPrdId, setChosenPrdId] = useState('')
   const [chosenPrfaqId, setChosenPrfaqId] = useState('')
+  // The two optional inputs, per build. Not persisted and not remembered per
+  // project — the same answer #320 took for the source ids, and answering it
+  // differently for the two halves of one control would be worse than either.
+  const [useProductContext, setUseProductContext] = useState(false)
+  const [useResearch, setUseResearch] = useState(false)
+  // The reports the user has ticked. Filtered against the live options below
+  // rather than pruned on change, for the same reason `effectiveSourceId` falls
+  // back: the document list refetches when a job completes, so a chosen report
+  // can be deleted under an open card, and an id the API cannot resolve is a 4xx.
+  const [chosenResearchIds, setChosenResearchIds] = useState<ReadonlyArray<string>>([])
   const [busy, setBusy] = useState(false)
   // Lowers itself: the panel takes over, so the line must not outlive the gap.
   const started = useTransientFlag()
@@ -171,6 +216,37 @@ export function usePrototypeBuild({
   // silently reverts to the default rather than sending an id the API would reject.
   const prdId = effectiveSourceId(prdOptions, chosenPrdId)
   const prfaqId = effectiveSourceId(prfaqOptions, chosenPrfaqId)
+
+  // Only reports still on offer. A stale id would be rejected by the API, which
+  // would turn someone else's deletion into this build's failure.
+  const selectedResearchIds = useMemo(
+    () => chosenResearchIds.filter(
+      (id) => researchOptions.some((option) => option.document_id === id),
+    ),
+    [chosenResearchIds, researchOptions],
+  )
+
+  const onToggleResearch = useCallback((next: boolean) => {
+    setUseResearch(next)
+    // Ticking pre-selects the reports on offer, newest first, up to the bound the
+    // API enforces; unticking clears them rather than remembering a selection the
+    // build will not use. Same shape as `DataSourceSteps`, which sets
+    // `selectedResearchIds: checked ? … : []` on the same toggle.
+    setChosenResearchIds(next
+      ? researchOptions.slice(0, MAX_SELECTED_RESEARCH_IDS).map((option) => option.document_id)
+      : [])
+  }, [researchOptions])
+
+  const onToggleResearchId = useCallback((documentId: string) => {
+    setChosenResearchIds((current) => {
+      if (current.includes(documentId)) return current.filter((id) => id !== documentId)
+      // Refuse at the bound rather than send a list the API rejects: a 400 arrives
+      // after the user has already chosen, and says nothing about which report to
+      // drop.
+      if (current.length >= MAX_SELECTED_RESEARCH_IDS) return current
+      return [...current, documentId]
+    })
+  }, [])
 
   // THREE reasons to stop and ask, through the ConfirmModal pattern every other
   // guarded action uses (this began as a window.confirm, which cannot be styled):
@@ -211,6 +287,13 @@ export function usePrototypeBuild({
         response_language: i18n.language,
         source_prd_id: prdId,
         source_prfaq_id: prfaqId,
+        // The optional inputs, as the card is showing them. Both false and an
+        // empty list is the request this hook sent before they existed.
+        use_product_context: useProductContext,
+        use_research: useResearch,
+        // Never sent while the box is unticked: ids left behind by a box the user
+        // turned off are not a selection.
+        selected_research_ids: useResearch ? [...selectedResearchIds] : [],
       })
       started.set()
       onJobStarted?.()
@@ -219,7 +302,8 @@ export function usePrototypeBuild({
     } finally {
       setBusy(false)
     }
-  }, [projectId, hasPrd, hasPrfaq, prdId, prfaqId, i18n.language, onJobStarted, started])
+  }, [projectId, hasPrd, hasPrfaq, prdId, prfaqId, useProductContext, useResearch,
+      selectedResearchIds, i18n.language, onJobStarted, started])
 
   const onClick = useCallback(() => {
     if (confirmKey != null) {
@@ -260,6 +344,17 @@ export function usePrototypeBuild({
       prfaqId,
       onSelectPrd: setChosenPrdId,
       onSelectPrfaq: setChosenPrfaqId,
+    },
+    extras: {
+      useProductContext,
+      onToggleProductContext: setUseProductContext,
+      useResearch,
+      onToggleResearch,
+      researchOptions,
+      selectedResearchIds,
+      onToggleResearchId,
+      researchLimitReached: selectedResearchIds.length >= MAX_SELECTED_RESEARCH_IDS,
+      maxResearchIds: MAX_SELECTED_RESEARCH_IDS,
     },
   }
 }

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -608,6 +608,53 @@ def _validated_source_id(project_id: str, sk_prefix: str, raw: Any, field: str) 
     return document_id
 
 
+# One request must not become an unbounded number of keyed reads. `_validated_source_id`
+# needs no such bound — it checks one id — but a list does, and without it a 200-entry
+# array is 200 round trips paid for by a single unauthenticated-cost request.
+# Ten is well above any real selection (the whole point of the picker is choosing a
+# few reports) and far below a list worth paginating.
+MAX_SELECTED_RESEARCH_IDS = 10
+
+
+def _validated_research_ids(project_id: str, raw: Any, field: str) -> list[str]:
+    """
+    Check that every client-supplied research id names a research report in THIS
+    project, and return them in the order they were sent. Absent or empty means
+    "read no research" and is valid.
+
+    Each id goes through `_validated_source_id` under the `RESEARCH#` prefix, so
+    ownership, type and the length bound are all decided exactly as they are for
+    `source_prd_id` — an id from another project, or a PRD id offered as research,
+    does not resolve. Same trust boundary, same reason: the named document's text
+    goes straight into a Bedrock prompt.
+
+    Scoped to `RESEARCH#` on purpose rather than folded into a general document
+    selection. The prototype build already reads a PRD and a PR/FAQ, and the shared
+    reference-document path keeps only the first three of a selection — so research,
+    which sorts last, is exactly what a general picker would drop. A research-only
+    field cannot be capped out because nothing of another type is in its candidate
+    set.
+
+    The arity bound is checked BEFORE the first read, so an over-long list costs
+    one 400 rather than N reads and then a 400. Duplicates are collapsed: a
+    repeated id would otherwise be read twice and injected into the prompt twice.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValidationError(f'{field} must be a list of document ids')
+    if len(raw) > MAX_SELECTED_RESEARCH_IDS:
+        raise ValidationError(
+            f'{field} names more than {MAX_SELECTED_RESEARCH_IDS} documents'
+        )
+    document_ids: list[str] = []
+    for entry in raw:
+        document_id = _validated_source_id(project_id, 'RESEARCH#', entry, field)
+        if document_id and document_id not in document_ids:
+            document_ids.append(document_id)
+    return document_ids
+
+
 @app.post("/projects/<project_id>/build-prototype")
 @tracer.capture_method
 def api_build_prototype(project_id: str):
@@ -646,6 +693,17 @@ def api_build_prototype(project_id: str):
         ),
         'source_prfaq_id': _validated_source_id(
             project_id, 'PRFAQ#', body.get('source_prfaq_id'), 'source_prfaq_id',
+        ),
+        # Optional extra grounding, chosen per build rather than remembered per
+        # project (the same answer #320 took for the source ids). All three absent
+        # means the prompt this endpoint has always produced: the generator adds a
+        # section only for what is asked for, so False/[] changes nothing.
+        'use_product_context': bool(body.get('use_product_context')),
+        'use_research': bool(body.get('use_research')),
+        # Validated whenever ids are sent, regardless of `use_research` — an id
+        # that is sent is an id that is claimed, as with `base_prototype_id`.
+        'selected_research_ids': _validated_research_ids(
+            project_id, body.get('selected_research_ids'), 'selected_research_ids',
         ),
     }
     job_id, _ = create_job(project_id, 'build_prototype', 'doc_config', doc_config, status='pending')

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -622,6 +622,10 @@ def _validated_research_ids(project_id: str, raw: Any, field: str) -> list[str]:
     project, and return them in the order they were sent. Absent or empty means
     "read no research" and is valid.
 
+    Reached only when `use_research` is on. A list sent with the switch off is
+    ignored without a read and never stored — see the call site for why that is
+    the honest reading rather than a rejection.
+
     Each id goes through `_validated_source_id` under the `RESEARCH#` prefix, so
     ownership, type and the length bound are all decided exactly as they are for
     `source_prd_id` — an id from another project, or a PRD id offered as research,
@@ -667,6 +671,9 @@ def api_build_prototype(project_id: str):
     parent-page access).
     """
     body = app.current_event.json_body or {}
+    # Read once: it is both a stored field and the switch deciding whether the id
+    # list is looked at at all — see `selected_research_ids` below.
+    use_research = bool(body.get('use_research'))
     doc_config = {
         'doc_type': 'build_prototype',
         'title': body.get('title') or 'Prototype',
@@ -699,12 +706,26 @@ def api_build_prototype(project_id: str):
         # means the prompt this endpoint has always produced: the generator adds a
         # section only for what is asked for, so False/[] changes nothing.
         'use_product_context': bool(body.get('use_product_context')),
-        'use_research': bool(body.get('use_research')),
-        # Validated whenever ids are sent, regardless of `use_research` — an id
-        # that is sent is an id that is claimed, as with `base_prototype_id`.
+        'use_research': use_research,
+        # Ids sent with the switch OFF are ignored, not rejected — a deliberate
+        # choice, and the opposite of `base_prototype_id`, which is checked whether
+        # or not `feedback` came with it. The difference is what the field can
+        # still reach: an unchecked `base_prototype_id` reaches `doc_config` and
+        # produces a document labelled a revision, whereas `use_research` is the
+        # only thing the generator reads before it opens this list, so a list sent
+        # beside a false flag names nothing any build will look at. There is no
+        # claim to check, and a 4xx over a field the build ignores would fail a
+        # request for a reason the user cannot see. Ignoring it also drops the N
+        # keyed reads that validating it unconditionally spent on a result nothing
+        # used.
+        #
+        # DROPPED rather than passed through, which is the half that has to be
+        # deliberate: every id in the stored config resolved under this project's
+        # `RESEARCH#` prefix, so a replay of the job cannot reach an unvalidated
+        # id if the switch is ever read differently.
         'selected_research_ids': _validated_research_ids(
             project_id, body.get('selected_research_ids'), 'selected_research_ids',
-        ),
+        ) if use_research else [],
     }
     job_id, _ = create_job(project_id, 'build_prototype', 'doc_config', doc_config, status='pending')
     invoke_lambda_async(DOCUMENT_GENERATOR_FUNCTION, {

--- a/voc-datalake/lambda/api/test/test_build_prototype_sources.py
+++ b/voc-datalake/lambda/api/test/test_build_prototype_sources.py
@@ -38,6 +38,8 @@ def build_prototype(api_gateway_event, lambda_context):
     doc_config handed to the generator, or None when no job was created.
     """
     def _call(body):
+        from projects_handler import MAX_SELECTED_RESEARCH_IDS
+
         table = MagicMock()
         documents = {
             (f'PROJECT#{PROJECT}', 'PRD#prd_1'): {'document_id': 'prd_1'},
@@ -45,6 +47,15 @@ def build_prototype(api_gateway_event, lambda_context):
             (f'PROJECT#{PROJECT}', 'PROTOTYPE#proto_1'): {'document_id': 'proto_1'},
             (f'PROJECT#{PROJECT}', 'RESEARCH#research_a'): {'document_id': 'research_a'},
             (f'PROJECT#{PROJECT}', 'RESEARCH#research_b'): {'document_id': 'research_b'},
+            # Enough DISTINCT research reports to fill a selection at the bound.
+            # `['research_a'] * 10` dedupes to one, so a fixture at the bound built
+            # from repeats would pass against an implementation that never accepted
+            # more than a single id. `research_gone` stays absent from this dict on
+            # purpose — it is the unresolvable fixture.
+            **{
+                (f'PROJECT#{PROJECT}', f'RESEARCH#research_{i}'): {'document_id': f'research_{i}'}
+                for i in range(MAX_SELECTED_RESEARCH_IDS)
+            },
             # Real prototype, wrong project. Only reachable by a lookup that
             # dropped `pk`.
             (f'PROJECT#{OTHER_PROJECT}', 'PROTOTYPE#proto_other'): {'document_id': 'proto_other'},
@@ -395,20 +406,55 @@ class TestOptionalExtraSources:
         invoke.assert_not_called()
         table.get_item.assert_not_called()
 
-    def test_a_list_at_the_bound_is_accepted(self, build_prototype):
-        """The bound is a maximum, not a strict limit — a fixture only at 200
-        would pass against an off-by-one that rejected legitimate selections."""
+    def test_a_list_of_distinct_ids_at_the_bound_is_accepted(self, build_prototype):
+        """The bound is a maximum, not a strict limit — a fixture only at 200 would
+        pass against an off-by-one that rejected legitimate selections.
+
+        Ten DISTINCT ids, which is the whole point: the same id repeated ten times
+        collapses to one, so a fixture built from repeats passes against an
+        implementation that accepts only a single id and against one whose bound is
+        really 1. All ten must survive, in the order they were sent.
+        """
         from projects_handler import MAX_SELECTED_RESEARCH_IDS
 
+        ids = [f'research_{i}' for i in range(MAX_SELECTED_RESEARCH_IDS)]
         response, config, _table, _invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ids,
+        })
+
+        assert response['statusCode'] == 200
+        assert config['selected_research_ids'] == ids
+
+    def test_duplicates_count_toward_the_bound_and_then_collapse(self, build_prototype):
+        """Both halves of a deliberate asymmetry that looks like an inconsistency.
+
+        The arity check runs on the RAW list, before the first read, so eleven
+        entries that dedupe to one are still a 400. That is intended: the bound
+        exists to cap how many keyed reads one request can buy, and how many
+        entries survive deduplication is not known until they have been read.
+        Collapsing happens after, so the same report named ten times is one
+        document to read and one prompt section rather than ten copies of it.
+        """
+        from projects_handler import MAX_SELECTED_RESEARCH_IDS
+
+        at_bound, config, _table, _invoke = build_prototype({
             'use_research': True,
             'selected_research_ids': ['research_a'] * MAX_SELECTED_RESEARCH_IDS,
         })
 
-        assert response['statusCode'] == 200
-        # Collapsed: the same report named ten times is one document to read, and
-        # one prompt section rather than ten copies of it.
+        assert at_bound['statusCode'] == 200
         assert config['selected_research_ids'] == ['research_a']
+
+        over, over_config, table, invoke = build_prototype({
+            'use_research': True,
+            'selected_research_ids': ['research_a'] * (MAX_SELECTED_RESEARCH_IDS + 1),
+        })
+
+        assert over['statusCode'] == 400
+        assert over_config is None
+        invoke.assert_not_called()
+        # Before the first read, so the cost of an over-long list is one 400.
+        table.get_item.assert_not_called()
 
     @pytest.mark.parametrize('value', [
         pytest.param('research_a', id='bare-string'),
@@ -453,6 +499,46 @@ class TestOptionalExtraSources:
             'x' * 5000 in str(call.kwargs.get('Key', {}))
             for call in table.get_item.call_args_list
         )
+
+    @pytest.mark.parametrize('value', [
+        # Resolvable, so this is the one that fails if the reads are still made:
+        # nothing about the ids themselves would stop them.
+        pytest.param(['research_a', 'research_b'], id='resolvable'),
+        # Each of these would be a 4xx if the list were validated regardless of the
+        # switch. They are the assertion that "ignored" means ignored, and not
+        # "validated a bit more cheaply".
+        pytest.param(['research_gone'], id='unresolvable'),
+        pytest.param(['research_other'], id='another-projects'),
+        pytest.param([f'research_{i}' for i in range(200)], id='over-long'),
+        pytest.param('research_a', id='not-a-list'),
+    ])
+    def test_ids_sent_with_the_switch_off_are_ignored_and_cost_no_reads(
+        self, build_prototype, value,
+    ):
+        """The decision, stated: a list sent with `use_research` off is IGNORED,
+        not rejected. `use_research` is the only thing the generator reads before it
+        opens the list, so ids beside a false flag name nothing any build will look
+        at — there is no claim to check, and a 4xx over a field the build ignores
+        would fail a request for a reason the user cannot see.
+
+        Two halves are asserted. No keyed read under `RESEARCH#`: validating
+        regardless spent one read per id on a result nothing used. And `[]` in the
+        stored config rather than the raw list: every id that reaches `doc_config`
+        resolved under this project's prefix, so a replayed job cannot reach an
+        unvalidated id even if the switch is read differently later.
+        """
+        response, config, table, invoke = build_prototype({
+            'selected_research_ids': value,
+        })
+
+        assert response['statusCode'] == 200
+        assert config['use_research'] is False
+        assert config['selected_research_ids'] == []
+        invoke.assert_called_once()
+        assert not [
+            call.kwargs.get('Key', {}) for call in table.get_item.call_args_list
+            if str(call.kwargs.get('Key', {}).get('sk', '')).startswith('RESEARCH#')
+        ]
 
     @pytest.mark.parametrize('value', [
         pytest.param([], id='empty'),

--- a/voc-datalake/lambda/api/test/test_build_prototype_sources.py
+++ b/voc-datalake/lambda/api/test/test_build_prototype_sources.py
@@ -43,9 +43,14 @@ def build_prototype(api_gateway_event, lambda_context):
             (f'PROJECT#{PROJECT}', 'PRD#prd_1'): {'document_id': 'prd_1'},
             (f'PROJECT#{PROJECT}', 'PRFAQ#prfaq_1'): {'document_id': 'prfaq_1'},
             (f'PROJECT#{PROJECT}', 'PROTOTYPE#proto_1'): {'document_id': 'proto_1'},
+            (f'PROJECT#{PROJECT}', 'RESEARCH#research_a'): {'document_id': 'research_a'},
+            (f'PROJECT#{PROJECT}', 'RESEARCH#research_b'): {'document_id': 'research_b'},
             # Real prototype, wrong project. Only reachable by a lookup that
             # dropped `pk`.
             (f'PROJECT#{OTHER_PROJECT}', 'PROTOTYPE#proto_other'): {'document_id': 'proto_other'},
+            # Same, for research: "belongs to another project" is a different
+            # fixture from "does not exist" only while `pk` is part of the key.
+            (f'PROJECT#{OTHER_PROJECT}', 'RESEARCH#research_other'): {'document_id': 'research_other'},
         }
 
         def get_item(Key=None, **kwargs):
@@ -281,4 +286,186 @@ class TestBasePrototypeIdIsCheckedLikeTheOtherTwo:
 
         assert response['statusCode'] == 200, label
         assert config['base_prototype_id'] is None
+        invoke.assert_called_once()
+
+
+class TestOptionalExtraSources:
+    """
+    `use_product_context`, `use_research` and `selected_research_ids` — the
+    per-build tick-boxes.
+
+    The id list is the same trust boundary as the three ids above (its documents'
+    text goes into a Bedrock prompt), with one thing they do not need: a bounded
+    arity. One id is one keyed read; an unbounded list is N reads bought with a
+    single request.
+    """
+
+    def test_all_three_absent_leaves_the_build_unaimed(self, build_prototype):
+        """The pre-existing request shape, which every caller before this feature
+        sends. It must reach the generator as "asked for nothing" — that is what
+        makes the generated prompt identical to the one it produced before."""
+        response, config, _table, _invoke = build_prototype({'title': 'Prototype'})
+
+        assert response['statusCode'] == 200
+        assert config['use_product_context'] is False
+        assert config['use_research'] is False
+        assert config['selected_research_ids'] == []
+
+    def test_the_ticked_sources_reach_the_generator(self, build_prototype):
+        response, config, _table, invoke = build_prototype({
+            'use_product_context': True,
+            'use_research': True,
+            'selected_research_ids': ['research_a', 'research_b'],
+        })
+
+        assert response['statusCode'] == 200
+        assert config['use_product_context'] is True
+        assert config['selected_research_ids'] == ['research_a', 'research_b']
+        # The job row and the generator invocation must say the same thing.
+        assert invoke.call_args.args[1]['doc_config']['selected_research_ids'] == [
+            'research_a', 'research_b',
+        ]
+
+    def test_research_ids_are_read_under_this_project_as_research_only(self, build_prototype):
+        """Ownership and type both come from the key: the supplied string reaches
+        `sk` under the `RESEARCH#` prefix and never touches `pk`."""
+        _response, _config, table, _invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ['research_a'],
+        })
+
+        keys = [call.kwargs.get('Key', {}) for call in table.get_item.call_args_list]
+        assert {'pk': f'PROJECT#{PROJECT}', 'sk': 'RESEARCH#research_a'} in keys
+        assert {k.get('pk') for k in keys} == {f'PROJECT#{PROJECT}'}
+
+    def test_a_research_id_naming_nothing_in_this_project_is_a_404_before_any_job(
+        self, build_prototype,
+    ):
+        """The criterion this endpoint exists to satisfy, and `config is None` is
+        the load-bearing half of it: the table answers every read from a dict, so
+        an implementation that skipped the unresolvable id — or validated after
+        `create_job` — would run to completion and start a billable build. The
+        assertion is that no job was created at all, not merely that the status
+        code is a 4xx.
+        """
+        response, config, _table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ['research_a', 'research_gone'],
+        })
+
+        assert response['statusCode'] == 404
+        assert 'selected_research_ids' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_another_projects_research_is_a_404(self, build_prototype):
+        """`research_other` is a real research report, in `proj_2`. This is the
+        fixture that fails the moment `pk` is dropped from the lookup."""
+        response, config, _table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ['research_other'],
+        })
+
+        assert response['statusCode'] == 404
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_a_prd_id_offered_as_research_is_a_404(self, build_prototype):
+        """`prd_1` is a real document in this project, just not research."""
+        response, config, _table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ['prd_1'],
+        })
+
+        assert response['statusCode'] == 404
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_an_over_long_research_id_list_is_a_400_naming_the_field(self, build_prototype):
+        """The bound `_validated_source_id` has no equivalent of. Without it a
+        single request becomes one keyed read per entry, so the list length is
+        checked BEFORE the first read — asserted here on `get_item` never having
+        been called, which is what separates "rejected the list" from "read all
+        200 of them and then rejected".
+        """
+        response, config, table, invoke = build_prototype({
+            'use_research': True,
+            'selected_research_ids': [f'research_{i}' for i in range(200)],
+        })
+
+        assert response['statusCode'] == 400
+        assert 'selected_research_ids' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+        table.get_item.assert_not_called()
+
+    def test_a_list_at_the_bound_is_accepted(self, build_prototype):
+        """The bound is a maximum, not a strict limit — a fixture only at 200
+        would pass against an off-by-one that rejected legitimate selections."""
+        from projects_handler import MAX_SELECTED_RESEARCH_IDS
+
+        response, config, _table, _invoke = build_prototype({
+            'use_research': True,
+            'selected_research_ids': ['research_a'] * MAX_SELECTED_RESEARCH_IDS,
+        })
+
+        assert response['statusCode'] == 200
+        # Collapsed: the same report named ten times is one document to read, and
+        # one prompt section rather than ten copies of it.
+        assert config['selected_research_ids'] == ['research_a']
+
+    @pytest.mark.parametrize('value', [
+        pytest.param('research_a', id='bare-string'),
+        pytest.param({'id': 'research_a'}, id='object'),
+        pytest.param(7, id='number'),
+    ])
+    def test_a_non_list_selection_is_a_400(self, build_prototype, value):
+        """A bare string is the dangerous one: it is iterable, so an
+        implementation that skipped the type check would read one key per
+        CHARACTER."""
+        response, config, _table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': value,
+        })
+
+        assert response['statusCode'] == 400
+        assert 'selected_research_ids' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_a_non_string_entry_is_a_400(self, build_prototype):
+        response, config, _table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ['research_a', 7],
+        })
+
+        assert response['statusCode'] == 400
+        assert 'selected_research_ids' in json.loads(response['body'])['error']
+        assert config is None
+        invoke.assert_not_called()
+
+    def test_an_absurdly_long_research_id_is_a_400_not_a_500(self, build_prototype):
+        """Per-entry length bound, inherited from `_validated_source_id`: a sort
+        key is capped at 1024 bytes, so unbounded this is a DynamoDB
+        ValidationException surfacing as a 500."""
+        response, config, table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': ['x' * 5000],
+        })
+
+        assert response['statusCode'] == 400
+        assert config is None
+        invoke.assert_not_called()
+        assert not any(
+            'x' * 5000 in str(call.kwargs.get('Key', {}))
+            for call in table.get_item.call_args_list
+        )
+
+    @pytest.mark.parametrize('value', [
+        pytest.param([], id='empty'),
+        pytest.param(None, id='null'),
+        pytest.param(['', '   '], id='blank-entries'),
+    ])
+    def test_naming_no_research_is_valid(self, build_prototype, value):
+        """A ticked box with nothing chosen, and a cleared picker, both mean "read
+        no research" rather than "document ''"."""
+        response, config, _table, invoke = build_prototype({
+            'use_research': True, 'selected_research_ids': value,
+        })
+
+        assert response['statusCode'] == 200
+        assert config['selected_research_ids'] == []
         invoke.assert_called_once()

--- a/voc-datalake/lambda/api/test/test_research_selection_bound_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_research_selection_bound_lockstep.py
@@ -1,0 +1,79 @@
+"""Lockstep test: how many research reports a prototype build may name is one
+number in two files.
+
+`MAX_SELECTED_RESEARCH_IDS` in lambda/api/projects_handler.py is the enforcing
+copy — an over-long `selected_research_ids` is a 400 there, because each id costs
+one keyed read. The frontend holds the same number in
+frontend/src/pages/ProjectDetail/overviewState.ts, where it decides when the
+research tick-boxes stop accepting.
+
+The failure mode is one-sided and quiet: raise the frontend's copy and the picker
+happily offers a selection the API rejects, so the build fails on submit, after
+the user has chosen, with nothing said about which report to give up. Lower it and
+some reports simply become unpickable for no visible reason. Neither shows up in
+either file's own tests.
+
+Both literals are read as SOURCE TEXT rather than imported, so the assertion
+cannot be satisfied by whatever either module resolves at import time, and it
+needs neither the AWS-shaped Python import graph nor a bundler.
+
+Pattern follows test_product_context_placeholder_lockstep.py (same directory).
+"""
+import re
+from pathlib import Path
+
+PYTHON_SOURCE = 'lambda/api/projects_handler.py'
+FRONTEND_SOURCE = 'frontend/src/pages/ProjectDetail/overviewState.ts'
+
+
+def _read(relative: str) -> str:
+    # lambda/api/test/ -> voc-datalake/
+    path = Path(__file__).resolve().parents[3] / relative
+    assert path.is_file(), (
+        f'{relative} not found — did the file move? '
+        f'If so, update the path constant in this test file.'
+    )
+    return path.read_text(encoding='utf-8')
+
+
+def _single_int(source: str, pattern: str, where: str) -> int:
+    matches = re.findall(pattern, source, re.MULTILINE)
+    assert len(matches) == 1, (
+        f'Expected exactly one MAX_SELECTED_RESEARCH_IDS assignment in {where}; '
+        f'found {len(matches)}. A second copy is the drift this test exists to '
+        f'prevent — if the declaration was restructured, update this helper.'
+    )
+    return int(matches[0])
+
+
+def test_the_research_selection_bound_is_the_same_number_in_both_files():
+    python_value = _single_int(
+        _read(PYTHON_SOURCE),
+        r'^MAX_SELECTED_RESEARCH_IDS\s*=\s*(\d+)',
+        PYTHON_SOURCE,
+    )
+    frontend_value = _single_int(
+        _read(FRONTEND_SOURCE),
+        r'^export const MAX_SELECTED_RESEARCH_IDS\s*=\s*(\d+)',
+        FRONTEND_SOURCE,
+    )
+
+    assert python_value == frontend_value, (
+        f'{PYTHON_SOURCE} allows {python_value} research ids but '
+        f'{FRONTEND_SOURCE} offers {frontend_value}. The API is the enforcing '
+        f'side: whichever is wrong, the two must agree or the picker and the '
+        f'validator disagree in front of the user.'
+    )
+
+
+def test_the_bound_is_a_plausible_selection_size():
+    """A bound that is 0 or 1 would make the feature useless while keeping the
+    lockstep test green, and an enormous one would defeat its purpose — the whole
+    reason it exists is that each id is a read."""
+    value = _single_int(
+        _read(PYTHON_SOURCE),
+        r'^MAX_SELECTED_RESEARCH_IDS\s*=\s*(\d+)',
+        PYTHON_SOURCE,
+    )
+
+    assert 2 <= value <= 50

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -549,10 +549,36 @@ RESEARCH_PER_DOC_CAP = 3000
 #: The per-report cap alone was not a bound on the section: RESEARCH_PER_DOC_CAP
 #: x MAX_SELECTED_RESEARCH_IDS is 30000, more than the PRD and PR/FAQ combined,
 #: so a ten-report selection could crowd out the spec the prototype is supposed
-#: to implement. It stays the cap for a small selection (12000 // 4 == 3000, so
-#: anything up to four reports is unaffected); this is what makes ten of them
-#: bounded too.
+#: to implement. It stays the cap for a small selection (12000 // 3 is already
+#: over it, so one to three reports are unaffected); this is what makes ten of
+#: them bounded too.
+#:
+#: Four used to be unaffected as well, before the share started paying for the
+#: heading it carries (RESEARCH_TITLE_CAP below): 12000 // 4 == 3000 was the
+#: per-report cap exactly, which left nothing for four headings and put the
+#: assembled body 58 characters past this ceiling — taken off the last report.
 RESEARCH_TOTAL_CAP = 12000
+
+#: Cap on a report's `title` where it is used as the block's heading.
+#:
+#: A title is a label for the block, not content, so it is sized against the
+#: titles this system writes rather than against the content caps: every research
+#: report created on this path gets `f'Research: {research_question[:50]}'` (see
+#: `projects.py` and `research_step_handler.py`) — about 60 characters. 120 leaves
+#: that much room again for a hand-edited title while keeping a heading a heading.
+#:
+#: Needed because the title is otherwise bounded NOWHERE on this path: it comes
+#: back from DynamoDB as stored, and ten 1000-character titles cost more of the
+#: budget than the reports they label.
+RESEARCH_TITLE_CAP = 120
+
+#: What one block costs on top of its content: `'### '` + a capped title + `'\n'`,
+#: plus the `'\n\n'` the blocks are joined with.
+#:
+#: Charged to every block including the last, which is one separator more than is
+#: actually written — deliberately, so the arithmetic needs no special case and the
+#: assembled body lands two characters UNDER the total rather than one over.
+_RESEARCH_BLOCK_OVERHEAD = len('### ') + RESEARCH_TITLE_CAP + len('\n') + len('\n\n')
 
 
 def _research_section(documents: list[dict]) -> str:
@@ -560,25 +586,42 @@ def _research_section(documents: list[dict]) -> str:
     The research block for the reports a build read, or '' when it read none.
 
     Two bounds, because one of them does not hold on its own. Each report is
-    sliced to an equal share of RESEARCH_TOTAL_CAP, never more than
-    RESEARCH_PER_DOC_CAP — so one to four reports are sliced exactly as before
-    and ten get 1200 characters each instead of 3000.
+    sliced to an equal share of RESEARCH_TOTAL_CAP *minus what its heading and
+    separator cost*, never more than RESEARCH_PER_DOC_CAP — so one to three
+    reports are sliced exactly as before, four get 2873 characters instead of
+    3000, and ten get 1073 each.
 
     Shared equally rather than spent front-to-back: a running budget would drop
     the last reports of a long selection entirely, and every named report is
     recorded in the document's `derivation` as having been used, so a report that
     reached none of the prompt would make that record a lie.
 
-    The assembled body is then hard-capped at RESEARCH_TOTAL_CAP as well, because
-    each block carries the report's `title`, which is user-supplied and bounded
-    nowhere in this path — without it the ceiling would be "the budget, plus
-    however long ten titles happen to be".
+    Charging the overhead is what makes that hold. Dividing RESEARCH_TOTAL_CAP
+    alone and then hard-slicing the assembled body re-introduced exactly the
+    front-to-back spending this shares to avoid: with the heading unpaid for, the
+    body overran the cap and the slice took the overrun off the END — ~120
+    characters at eight reports with short titles, but whole reports once titles
+    are long, which is the same lie by a different route.
+
+    The assembled body is still hard-capped at RESEARCH_TOTAL_CAP, and that cap is
+    now belt-and-braces: with the title capped and the overhead paid, the body is
+    within the total by construction (n x (overhead + share) <= total). It only
+    binds where the headings alone exceed the budget — above ~94 reports the share
+    clamps to zero — which the API's MAX_SELECTED_RESEARCH_IDS bound of ten keeps
+    out of reach, so it is a guard rather than the thing doing the work.
     """
     if not documents:
         return ''
-    per_doc = min(RESEARCH_PER_DOC_CAP, RESEARCH_TOTAL_CAP // len(documents))
+    per_doc = min(
+        RESEARCH_PER_DOC_CAP,
+        # max(): a selection long enough for the headings to eat the whole budget
+        # would otherwise make this negative, and `content[:-n]` silently keeps
+        # everything BUT the last n characters instead of nothing.
+        max(0, RESEARCH_TOTAL_CAP // len(documents) - _RESEARCH_BLOCK_OVERHEAD),
+    )
     body = '\n\n'.join(
-        f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:per_doc]}"
+        f"### {str(d.get('title') or 'Untitled')[:RESEARCH_TITLE_CAP]}\n"
+        f"{d.get('content', '')[:per_doc]}"
         for d in documents
     )
     return '\n\nRESEARCH FINDINGS:\n' + body[:RESEARCH_TOTAL_CAP]

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -538,6 +538,51 @@ def _source_document(
 #: (`MAX_SELECTED_RESEARCH_IDS`), so this bounds the other dimension.
 RESEARCH_PER_DOC_CAP = 3000
 
+#: Ceiling on the whole research section, however many reports were named.
+#:
+#: Sized against the other caps in `_generate_prototype` rather than picked: the
+#: PRD, the PR/FAQ and the product-context block each get PER_DOC_CAP (12000),
+#: and a revision's prior prototype HTML gets PRIOR_CAP (24000). Research is
+#: corroborating evidence, not the thing being built, so the whole selection is
+#: allowed no more than a single spec document gets — one PER_DOC_CAP.
+#:
+#: The per-report cap alone was not a bound on the section: RESEARCH_PER_DOC_CAP
+#: x MAX_SELECTED_RESEARCH_IDS is 30000, more than the PRD and PR/FAQ combined,
+#: so a ten-report selection could crowd out the spec the prototype is supposed
+#: to implement. It stays the cap for a small selection (12000 // 4 == 3000, so
+#: anything up to four reports is unaffected); this is what makes ten of them
+#: bounded too.
+RESEARCH_TOTAL_CAP = 12000
+
+
+def _research_section(documents: list[dict]) -> str:
+    """
+    The research block for the reports a build read, or '' when it read none.
+
+    Two bounds, because one of them does not hold on its own. Each report is
+    sliced to an equal share of RESEARCH_TOTAL_CAP, never more than
+    RESEARCH_PER_DOC_CAP — so one to four reports are sliced exactly as before
+    and ten get 1200 characters each instead of 3000.
+
+    Shared equally rather than spent front-to-back: a running budget would drop
+    the last reports of a long selection entirely, and every named report is
+    recorded in the document's `derivation` as having been used, so a report that
+    reached none of the prompt would make that record a lie.
+
+    The assembled body is then hard-capped at RESEARCH_TOTAL_CAP as well, because
+    each block carries the report's `title`, which is user-supplied and bounded
+    nowhere in this path — without it the ceiling would be "the budget, plus
+    however long ten titles happen to be".
+    """
+    if not documents:
+        return ''
+    per_doc = min(RESEARCH_PER_DOC_CAP, RESEARCH_TOTAL_CAP // len(documents))
+    body = '\n\n'.join(
+        f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:per_doc]}"
+        for d in documents
+    )
+    return '\n\nRESEARCH FINDINGS:\n' + body[:RESEARCH_TOTAL_CAP]
+
 
 def _research_documents(projects_table, project_id: str, research_ids) -> list[dict]:
     """
@@ -688,12 +733,9 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
         _research_documents(projects_table, project_id, doc_config.get('selected_research_ids'))
         if doc_config.get('use_research') else []
     )
-    research_section = ''
-    if research_docs:
-        research_section = '\n\nRESEARCH FINDINGS:\n' + '\n\n'.join(
-            f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:RESEARCH_PER_DOC_CAP]}"
-            for d in research_docs
-        )
+    # Bounded per report AND in total — see `_research_section`. The per-report cap
+    # alone let ten reports contribute more than the PRD and PR/FAQ combined.
+    research_section = _research_section(research_docs)
 
     # Optional feedback-driven regeneration: when the user gives feedback on an
     # existing prototype, we re-generate CENTERED on that feedback while still
@@ -802,8 +844,15 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
         # derivation_source drops the None that `(prd or {}).get(...)` yields.
         DERIVATION_FIELD: build_derivation(
             sources=[
-                derivation_source((prd or {}).get('document_id'), ROLE_PROTOTYPE_PRD),
-                derivation_source((prfaq or {}).get('document_id'), ROLE_PROTOTYPE_PRFAQ),
+                # `_document_id_of` for all three, rather than `.get('document_id')`
+                # for two of them and the helper for the third: one idiom per call
+                # site. It reads the same id and then falls back to the sort key, so
+                # an absent document still yields '' and `derivation_source` drops it
+                # exactly as it dropped the None before. The two `source_*_id`
+                # attributes above keep `.get`, deliberately — a stored None and a
+                # stored '' are different values to their existing readers.
+                derivation_source(_document_id_of(prd or {}), ROLE_PROTOTYPE_PRD),
+                derivation_source(_document_id_of(prfaq or {}), ROLE_PROTOTYPE_PRFAQ),
                 # The research reports that reached the prompt, in the reference
                 # role the shared vocabulary already has for "selected and fed to
                 # the model". Recorded from the documents themselves rather than

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -341,7 +341,7 @@ Produce a polished, tap-through prototype. Remember: ONE HTML document, output n
 PROTOTYPE_HTML_USER_TEMPLATE = """Build a clickable HTML prototype for the product/feature below. Output ONE complete HTML document only — no prose, no code fences.
 
 PROJECT: {project_name}
-{brand_section}{prd_section}{prfaq_section}
+{brand_section}{product_context_section}{prd_section}{prfaq_section}{research_section}
 
 Requirements:
 - Single self-contained HTML file (inline CSS + vanilla JS), offline-first, no external resources.
@@ -533,6 +533,50 @@ def _source_document(
     return doc
 
 
+#: Per-research-report slice of the prompt, matching the reference-document cap
+#: `_gather_context` applies. The arity is bounded by the API
+#: (`MAX_SELECTED_RESEARCH_IDS`), so this bounds the other dimension.
+RESEARCH_PER_DOC_CAP = 3000
+
+
+def _research_documents(projects_table, project_id: str, research_ids) -> list[dict]:
+    """
+    The research reports a build was told to read, in the order they were asked
+    for, or [] when it named none.
+
+    A narrow reader on purpose, and NOT `_gather_context`: every branch in that
+    function is gated on a `data_sources` map a prototype's `doc_config` does not
+    carry (so it would return nothing), it re-queries feedback, and its progress
+    callbacks overwrite this build's own 40 → 80 → 90 narrative.
+
+    Keyed reads only — one `get_item` per id under `RESEARCH#`, so ownership and
+    document type come from the key exactly as in `_document_by_id`, and no id can
+    address another project's partition. There is no "read all the research"
+    fallback: an empty list means nothing to read, so the callers stay one keyed
+    read per named report rather than a project-wide query, and the recorded
+    provenance is exactly what was asked for.
+
+    An id that does not resolve RAISES, for the same reason `_source_document`
+    does: the alternative is a prototype the user believes was grounded in a
+    report the model never saw, with nothing in the output saying otherwise. The
+    API rejects such an id before a job exists; this is the second line, and it is
+    what keeps the failure loud if a job is ever replayed after the document was
+    deleted.
+    """
+    documents: list[dict] = []
+    for research_id in research_ids or []:
+        document_id = str(research_id or '').strip()
+        if not document_id:
+            continue
+        doc = _document_by_id(projects_table, project_id, 'RESEARCH#', document_id)
+        if not doc:
+            raise RuntimeError(
+                f'selected_research_ids: no RESEARCH document "{document_id}" in this project.'
+            )
+        documents.append(doc)
+    return documents
+
+
 def _base_prototype(projects_table, project_id: str, base_prototype_id: str) -> dict | None:
     """
     The prototype a revision is built on: the one the request named, or None when
@@ -570,6 +614,12 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
     PR/FAQ for this project, save it as a ProjectDocument of type 'prototype' with
     prototype_format='html'. The frontend renders the HTML in a sandboxed
     <iframe srcdoc> so inline CSS/JS run in isolation. Opus 5 builds the HTML.
+
+    Two further inputs are read only when the request asks for them:
+    `use_product_context` adds the project's product-context block, and
+    `use_research` + `selected_research_ids` add named research reports. Both
+    absent — every caller before they existed — produces the same prompt this
+    function always produced.
     """
     from shared.converse import converse
 
@@ -607,6 +657,43 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
     # absent, the system prompt's neutral defaults apply.
     brand = (doc_config.get('brand') or '').strip()
     brand_section = f'BRAND: {brand}\n' if brand else ''
+
+    # Optional extra grounding, ticked per build on the prototype card. Both
+    # default off, so a request that asks for neither produces the prompt this
+    # path has always produced, byte for byte.
+    #
+    # The section is added only when the block carries something. `_product_context`
+    # returns its placeholder both for "the project described nothing" and for a
+    # failed read, and a prompt section whose body says "(No product context
+    # provided.)" is worse than no section: it spends budget telling the model
+    # nothing. The flag it returns is the same one the derivation records, so what
+    # reached the prompt and what the document claims cannot disagree.
+    product_context_section = ''
+    product_context_included = False
+    if doc_config.get('use_product_context'):
+        product_context_block, product_context_included = _product_context(project_id)
+        if product_context_included:
+            # Capped like every other injected block here (PER_DOC_CAP, PRIOR_CAP).
+            # `build_product_context_block` budgets uploaded document text at
+            # 50k chars, which unbounded would crowd out the PRD this prompt is
+            # actually built from.
+            product_context_section = (
+                f'\n\nPRODUCT CONTEXT (what this product is, who it is for):\n'
+                f'{product_context_block[:PER_DOC_CAP]}'
+            )
+
+    # Research reports, scoped to RESEARCH# only — see `_research_documents` for
+    # why this is not the shared document picker.
+    research_docs = (
+        _research_documents(projects_table, project_id, doc_config.get('selected_research_ids'))
+        if doc_config.get('use_research') else []
+    )
+    research_section = ''
+    if research_docs:
+        research_section = '\n\nRESEARCH FINDINGS:\n' + '\n\n'.join(
+            f"### {d.get('title', 'Untitled')}\n{d.get('content', '')[:RESEARCH_PER_DOC_CAP]}"
+            for d in research_docs
+        )
 
     # Optional feedback-driven regeneration: when the user gives feedback on an
     # existing prototype, we re-generate CENTERED on that feedback while still
@@ -650,8 +737,10 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
     user_prompt = PROTOTYPE_HTML_USER_TEMPLATE.format(
         project_name=project_name,
         brand_section=brand_section,
+        product_context_section=product_context_section,
         prd_section=prd_section,
         prfaq_section=prfaq_section,
+        research_section=research_section,
         lang_hint=lang_hint,
     ) + feedback_section
 
@@ -715,8 +804,19 @@ def _generate_prototype(ctx, projects_table, project_id: str, job_id: str, doc_c
             sources=[
                 derivation_source((prd or {}).get('document_id'), ROLE_PROTOTYPE_PRD),
                 derivation_source((prfaq or {}).get('document_id'), ROLE_PROTOTYPE_PRFAQ),
+                # The research reports that reached the prompt, in the reference
+                # role the shared vocabulary already has for "selected and fed to
+                # the model". Recorded from the documents themselves rather than
+                # from the requested ids, so this stays "what was used" — and
+                # `_research_documents` raises rather than dropping, so the two
+                # cannot silently differ.
+                *(derivation_source(_document_id_of(d), ROLE_REFERENCE) for d in research_docs),
             ],
-            selected_document_count=len([d for d in (prd, prfaq) if d]),
+            selected_document_count=len([d for d in (prd, prfaq) if d]) + len(research_docs),
+            # Whether the product-context block actually carried anything, not
+            # whether it was asked for: a build that ticked the box on a project
+            # that describes nothing must not claim it was grounded.
+            product_context_included=product_context_included,
         ),
         'created_at': now,
     }

--- a/voc-datalake/lambda/jobs/document_generator/test/golden/prototype_prompt_baseline.txt
+++ b/voc-datalake/lambda/jobs/document_generator/test/golden/prototype_prompt_baseline.txt
@@ -1,0 +1,16 @@
+Build a clickable HTML prototype for the product/feature below. Output ONE complete HTML document only — no prose, no code fences.
+
+PROJECT: Golden Project
+
+
+PRD:
+PRD body for the golden prompt
+
+PR/FAQ:
+PRFAQ body for the golden prompt
+
+Requirements:
+- Single self-contained HTML file (inline CSS + vanilla JS), offline-first, no external resources.
+- 3-6 clickable screens toggled by inline JS, with a navigation bar.
+- Realistic placeholder content from the brief above.
+- Match the language of the brief.

--- a/voc-datalake/lambda/jobs/document_generator/test/test_prototype_context_sources.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_prototype_context_sources.py
@@ -361,6 +361,16 @@ class TestTheResearchSectionIsBoundedInTotal:
     REPORT_BODY = 2450
     REPORT_COUNT = 8
 
+    #: The other dimension of the same overrun: a block costs its heading too, and
+    #: a `title` is bounded nowhere between the UI that writes it and the prompt.
+    #: Ten of these headings cost 10130 characters — five sixths of the budget —
+    #: so unpaid-for they push the body past 22000 and the hard slice drops the
+    #: last five reports ENTIRELY, which is the failure the shared budget exists
+    #: to prevent rather than the harmless tail-trim eight short titles cause.
+    LONG_TITLE_PAD = 1000
+    #: MAX_SELECTED_RESEARCH_IDS — the most the API will pass through.
+    LONG_TITLE_COUNT = 10
+
     @classmethod
     def _reports(cls):
         """Eight reports, each carrying a marker at the START and END of its body,
@@ -416,12 +426,21 @@ class TestTheResearchSectionIsBoundedInTotal:
             selected_research_ids=[f'research_{i}' for i in range(self.REPORT_COUNT)],
         )
 
-        block = self._research_block(_prompt(mock_converse))
+        prompt = _prompt(mock_converse)
+        block = self._research_block(prompt)
         assert len(block) <= RESEARCH_TOTAL_CAP + len('RESEARCH FINDINGS:\n')
+        # A length assertion is satisfied by a body that was truncated INTO the
+        # bound as well as by one that fit, and the two are not the same outcome:
+        # the hard slice takes the overrun off the end, so the last report is what
+        # goes missing. This passed while ~120 characters of report 7 were being
+        # dropped. Assert the last report survived, so a truncation regression is
+        # visible from here and not only from the long-title fixture below.
+        last = self.REPORT_COUNT - 1
+        assert f'HEAD{last}' in prompt, f'report {last} was truncated away to fit'
         # The spec is still there — bounding research must not be achieved by
         # bounding the thing research is supposed to support.
-        assert 'NEW PRD body' in _prompt(mock_converse)
-        assert 'PRFAQ body' in _prompt(mock_converse)
+        assert 'NEW PRD body' in prompt
+        assert 'PRFAQ body' in prompt
 
     def test_every_named_report_still_reaches_the_prompt_truncated(
         self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
@@ -450,6 +469,137 @@ class TestTheResearchSectionIsBoundedInTotal:
             assert f'TAIL{i}' not in prompt, f'report {i} was not truncated'
         # And all eight are still claimed as used, because all eight were.
         assert _saved(mock_dynamodb)['derivation']['selected_document_count'] == 2 + self.REPORT_COUNT
+
+    @classmethod
+    def _long_titles(cls):
+        """Ten titles too long to be headings, each still identifiable by prefix."""
+        return [
+            f'LONGTITLE{i} ' + ('T' * cls.LONG_TITLE_PAD)
+            for i in range(cls.LONG_TITLE_COUNT)
+        ]
+
+    @classmethod
+    def _long_title_reports(cls):
+        """The eight-report fixture's bodies under ten unbounded titles: each body
+        still fits the per-report cap comfortably, so anything that goes missing
+        went missing to the SECTION's bound and not to its own."""
+        return {
+            f'RESEARCH#research_{i}': {
+                'document_id': f'research_{i}',
+                'title': title,
+                'content': f'HEAD{i} ' + ('n' * cls.REPORT_BODY) + f' TAIL{i}',
+            }
+            for i, title in enumerate(cls._long_titles())
+        }
+
+    def test_the_long_title_fixture_would_lose_whole_reports_unpaid_for(self):
+        """Guards the test below from going vacuous, and states what "unpaid for"
+        costs. Dividing the budget without charging each block for its own heading
+        leaves a body whose whole blocks do not fit — so the hard slice is not
+        trimming a tail, it is deleting reports."""
+        from jobs.document_generator.handler import (
+            RESEARCH_PER_DOC_CAP,
+            RESEARCH_TITLE_CAP,
+            RESEARCH_TOTAL_CAP,
+        )
+
+        title = self._long_titles()[0]
+        assert self.REPORT_BODY < RESEARCH_PER_DOC_CAP, 'each body must fit on its own'
+        assert len(title) > RESEARCH_TITLE_CAP, 'the title cap must actually bite'
+
+        unpaid_share = min(RESEARCH_PER_DOC_CAP, RESEARCH_TOTAL_CAP // self.LONG_TITLE_COUNT)
+        stride = len(f'### {title}\n') + unpaid_share + len('\n\n')
+        assert RESEARCH_TOTAL_CAP // stride < self.LONG_TITLE_COUNT - 1, (
+            'the unpaid-for body must overrun by more than one report, or this '
+            'fixture is testing the same harmless tail-trim as the short titles'
+        )
+
+    def test_ten_long_titled_reports_still_all_reach_the_prompt(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The falsifier for the heading arithmetic. Titles are user-supplied and
+        bounded nowhere on this path, so a block's cost is not its content: unpaid
+        for, ten of these overrun the budget by 10000 characters and the hard slice
+        drops the last five reports outright — each of them still recorded in the
+        derivation as having been used.
+
+        The LAST report's marker is the assertion that matters; the others would
+        survive front-to-back spending too."""
+        from jobs.document_generator.handler import (
+            RESEARCH_TITLE_CAP,
+            RESEARCH_TOTAL_CAP,
+        )
+
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents=self._long_title_reports(),
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context, use_research=True,
+            selected_research_ids=[f'research_{i}' for i in range(self.LONG_TITLE_COUNT)],
+        )
+
+        prompt = _prompt(mock_converse)
+        last = self.LONG_TITLE_COUNT - 1
+        assert f'HEAD{last}' in prompt, f'report {last} reached none of the prompt'
+        for i in range(self.LONG_TITLE_COUNT):
+            assert f'HEAD{i}' in prompt, f'report {i} contributed nothing'
+            assert f'TAIL{i}' not in prompt, f'report {i} was not truncated'
+        # The title is a label, and it is capped. Pinned from BOTH sides, so a cap
+        # one character either way is visible rather than merely "short enough".
+        title = self._long_titles()[last]
+        assert title[:RESEARCH_TITLE_CAP] in prompt, 'title cut before the cap'
+        assert title[:RESEARCH_TITLE_CAP + 1] not in prompt, 'title cut past the cap'
+        assert len(self._research_block(prompt)) <= RESEARCH_TOTAL_CAP + len('RESEARCH FINDINGS:\n')
+        assert (
+            _saved(mock_dynamodb)['derivation']['selected_document_count']
+            == 2 + self.LONG_TITLE_COUNT
+        )
+
+    def test_a_ten_report_share_pays_for_its_own_heading(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """Where the equal share binds, it is the budget's share MINUS what the
+        block costs around the content, pinned from both sides at the cut.
+
+        Without this the overhead subtraction is only observable through whether
+        reports survive, which a share one character out in either direction does
+        not change — the same gap the small-selection test closed for the
+        per-report cap."""
+        from jobs.document_generator.handler import (
+            _RESEARCH_BLOCK_OVERHEAD,
+            RESEARCH_TOTAL_CAP,
+        )
+
+        share = RESEARCH_TOTAL_CAP // self.LONG_TITLE_COUNT - _RESEARCH_BLOCK_OVERHEAD
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents={
+                f'RESEARCH#research_{i}': {
+                    'document_id': f'research_{i}',
+                    'title': f'Report {i}',
+                    'content': ('z' * (share - 1)) + 'CUT_HERE' + ('z' * 500),
+                }
+                for i in range(self.LONG_TITLE_COUNT)
+            },
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context, use_research=True,
+            selected_research_ids=[f'research_{i}' for i in range(self.LONG_TITLE_COUNT)],
+        )
+
+        prompt = _prompt(mock_converse)
+        assert 'z' * (share - 1) + 'C' in prompt, 'cut before the share'
+        assert 'z' * (share - 1) + 'CU' not in prompt, 'cut past the share'
+        assert 'CUT_HERE' not in prompt
 
     def test_a_small_selection_is_sliced_exactly_as_before(
         self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
@@ -482,6 +632,56 @@ class TestTheResearchSectionIsBoundedInTotal:
         assert 'z' * (RESEARCH_PER_DOC_CAP - 1) + 'C' in prompt, 'cut before the cap'
         assert 'z' * (RESEARCH_PER_DOC_CAP - 1) + 'CU' not in prompt, 'cut past the cap'
         assert 'CUT_HERE' not in prompt
+
+
+class TestTheHardCeilingIsStillAGuard:
+    """
+    `body[:RESEARCH_TOTAL_CAP]` no longer bounds the section — the shares pay for
+    their own headings, so at every arity the API can reach (ten) the slice is a
+    no-op. Which would leave it untested, so this is where it is exercised.
+
+    The by-construction argument has a floor: the share is
+    `RESEARCH_TOTAL_CAP // n - overhead`, which reaches zero at about 94 reports,
+    and past that the HEADINGS ALONE exceed the budget however little content each
+    block carries. `_research_section` is called directly because that arity cannot
+    be reached through the route — the guard is what is under test, not the path.
+    """
+
+    ARITY = 200
+
+    @staticmethod
+    def _documents(count):
+        return [
+            {'document_id': f'research_{i}', 'title': 'T' * 200, 'content': 'x' * 500}
+            for i in range(count)
+        ]
+
+    def test_headings_alone_cannot_take_the_section_past_the_total(self):
+        from jobs.document_generator.handler import (
+            RESEARCH_TITLE_CAP,
+            RESEARCH_TOTAL_CAP,
+            _research_section,
+        )
+
+        # Vacuity guard: at this arity the headings must exceed the budget on their
+        # own, or the slice is a no-op here too and this asserts nothing.
+        heading = len('### ') + RESEARCH_TITLE_CAP + len('\n')
+        assert self.ARITY * heading > RESEARCH_TOTAL_CAP
+
+        section = _research_section(self._documents(self.ARITY))
+
+        assert len(section) == len('\n\nRESEARCH FINDINGS:\n') + RESEARCH_TOTAL_CAP
+
+    def test_a_share_that_goes_negative_takes_no_content_rather_than_all_of_it(self):
+        """The share is a subtraction, so at this arity it goes negative, and
+        `content[:-67]` keeps everything BUT the last 67 characters — the opposite
+        of a cap. Clamping at zero is what makes "no room left for content" mean
+        no content."""
+        from jobs.document_generator.handler import _research_section
+
+        section = _research_section(self._documents(self.ARITY))
+
+        assert 'x' not in section, 'content reached the prompt through a negative slice'
 
 
 class TestTheDerivationReportsWhatWasUsed:

--- a/voc-datalake/lambda/jobs/document_generator/test/test_prototype_context_sources.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_prototype_context_sources.py
@@ -342,6 +342,148 @@ class TestResearchIsScopedToResearchDocuments:
         assert _saved(mock_dynamodb)['derivation']['selected_document_count'] == 2
 
 
+class TestTheResearchSectionIsBoundedInTotal:
+    """
+    The research section has TWO bounds, and the per-report one is not a bound on
+    the section: `RESEARCH_PER_DOC_CAP` x `MAX_SELECTED_RESEARCH_IDS` is 30000
+    characters, more than the PRD and PR/FAQ combined (12000 each), on top of the
+    product-context block and — on a revision — 24000 of prior prototype HTML. The
+    worst case could crowd out the spec the prototype is supposed to implement.
+
+    Every fixture here is therefore built so that each report fits the per-report
+    cap COMFORTABLY and the reports only exceed the budget together. That is what
+    makes these tests fail against a per-report cap alone: a fixture with one
+    oversized report would pass either way.
+    """
+
+    #: Under RESEARCH_PER_DOC_CAP (3000) individually, over RESEARCH_TOTAL_CAP
+    #: (12000) at eight of them: 8 x 2450 = 19600.
+    REPORT_BODY = 2450
+    REPORT_COUNT = 8
+
+    @classmethod
+    def _reports(cls):
+        """Eight reports, each carrying a marker at the START and END of its body,
+        so "reached the prompt" and "was truncated" are separately observable."""
+        return {
+            f'RESEARCH#research_{i}': {
+                'document_id': f'research_{i}',
+                'title': f'Report {i}',
+                'content': f'HEAD{i} ' + ('n' * cls.REPORT_BODY) + f' TAIL{i}',
+            }
+            for i in range(cls.REPORT_COUNT)
+        }
+
+    @staticmethod
+    def _research_block(prompt: str) -> str:
+        """The research section as it appears in the prompt.
+
+        Sliced out on the template's own boundaries rather than measured on the
+        whole prompt, so the assertion is about the section's size and not about
+        the PRD's. `index` raises if either marker moves, which is the loud
+        failure to want here.
+        """
+        start = prompt.index('RESEARCH FINDINGS:')
+        return prompt[start:prompt.index('\n\nRequirements:', start)]
+
+    def test_the_fixture_would_exceed_the_budget_under_the_per_report_cap_alone(self):
+        """Guards the two tests below from going vacuous. If either cap is ever
+        retuned so that eight of these reports fit anyway, the fixture stops
+        exercising an aggregate bound and this says so instead of passing."""
+        from jobs.document_generator.handler import (
+            RESEARCH_PER_DOC_CAP,
+            RESEARCH_TOTAL_CAP,
+        )
+
+        assert self.REPORT_BODY < RESEARCH_PER_DOC_CAP
+        assert self.REPORT_COUNT * self.REPORT_BODY > RESEARCH_TOTAL_CAP
+
+    def test_eight_reports_that_each_fit_are_bounded_together(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        from jobs.document_generator.handler import RESEARCH_TOTAL_CAP
+
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents=self._reports(),
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context, use_research=True,
+            selected_research_ids=[f'research_{i}' for i in range(self.REPORT_COUNT)],
+        )
+
+        block = self._research_block(_prompt(mock_converse))
+        assert len(block) <= RESEARCH_TOTAL_CAP + len('RESEARCH FINDINGS:\n')
+        # The spec is still there — bounding research must not be achieved by
+        # bounding the thing research is supposed to support.
+        assert 'NEW PRD body' in _prompt(mock_converse)
+        assert 'PRFAQ body' in _prompt(mock_converse)
+
+    def test_every_named_report_still_reaches_the_prompt_truncated(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The budget is SHARED, not spent front-to-back. A running budget would
+        satisfy the bound above by dropping the last reports entirely — and each
+        one is recorded in the derivation as having been used, so a report that
+        reached none of the prompt would make that record a lie."""
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents=self._reports(),
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context, use_research=True,
+            selected_research_ids=[f'research_{i}' for i in range(self.REPORT_COUNT)],
+        )
+
+        prompt = _prompt(mock_converse)
+        for i in range(self.REPORT_COUNT):
+            assert f'Report {i}' in prompt, f'report {i} lost its heading'
+            assert f'HEAD{i}' in prompt, f'report {i} contributed nothing'
+            assert f'TAIL{i}' not in prompt, f'report {i} was not truncated'
+        # And all eight are still claimed as used, because all eight were.
+        assert _saved(mock_dynamodb)['derivation']['selected_document_count'] == 2 + self.REPORT_COUNT
+
+    def test_a_small_selection_is_sliced_exactly_as_before(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The aggregate bound must not quietly tighten the common case. At four
+        reports the equal share is 12000 // 4 == 3000, which IS the per-report cap,
+        so nothing up to four is affected — asserted by giving one report a body
+        longer than the per-report cap and seeing it cut at exactly that cap."""
+        from jobs.document_generator.handler import RESEARCH_PER_DOC_CAP
+
+        long_report = {
+            'document_id': 'research_long', 'title': 'Long report',
+            'content': ('z' * (RESEARCH_PER_DOC_CAP - 1)) + 'CUT_HERE' + ('z' * 500),
+        }
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents={'RESEARCH#research_long': long_report},
+        )
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, use_research=True,
+             selected_research_ids=['research_long'])
+
+        prompt = _prompt(mock_converse)
+        # Pinned from BOTH sides, so the cut lands on exactly RESEARCH_PER_DOC_CAP.
+        # `in prompt` alone was satisfied by any cut at or past the cap, which let a
+        # share one character tighter than the cap pass — found by mutation.
+        assert 'z' * (RESEARCH_PER_DOC_CAP - 1) + 'C' in prompt, 'cut before the cap'
+        assert 'z' * (RESEARCH_PER_DOC_CAP - 1) + 'CU' not in prompt, 'cut past the cap'
+        assert 'CUT_HERE' not in prompt
+
+
 class TestTheDerivationReportsWhatWasUsed:
     """
     The real `_product_context` and the real `build_product_context_block`, over a

--- a/voc-datalake/lambda/jobs/document_generator/test/test_prototype_context_sources.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_prototype_context_sources.py
@@ -1,0 +1,420 @@
+"""
+The two extra sources a prototype build can be told to read: the project's
+product context, and specific research reports.
+
+Both are opt-in per build (`use_product_context`, `use_research` +
+`selected_research_ids` in `doc_config`). Three properties:
+
+1. **Ticked reaches the prompt, unticked does not**, and the document's
+   `derivation` says which of the two happened. A build that claims grounding it
+   did not get is the failure this whole feature exists to avoid.
+
+2. **Research is scoped to `RESEARCH#` only.** It is read by keyed lookups per
+   named id, never through `_gather_context` (inert here — every branch of it is
+   gated on a `data_sources` map a prototype's `doc_config` does not carry) and
+   never through the shared reference-document path, which keeps only the first
+   three of a selection and so drops research whenever a PRD and a PR/FAQ are
+   also selected. Hence the fixture below holds TWO PRDs, ONE PR/FAQ and TWO
+   research reports: with fewer non-research documents, "scoped to research"
+   and "reused the general picker" would be the same test.
+
+3. **Asking for neither leaves the prompt byte-identical to what this path
+   produced before the feature existed.** Pinned against a golden file captured
+   on the pre-change tree (`golden/prototype_prompt_baseline.txt`), because a
+   substring assertion cannot see an added blank line or a reordered section.
+
+Every fixture supplies enough table responses for a build to COMPLETE, so a
+test that expects a failure fails for the reason it names rather than because
+the mock ran out of answers.
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HTML = '<!DOCTYPE html><html><body><h1>Demo</h1></body></html>'
+
+# A block that could not be mistaken for the placeholder `_product_context`
+# returns when a project describes nothing. Asserting on the placeholder would
+# be vacuous: it appears in the prompt in exactly the same way whether the
+# section was injected or omitted, because it is absent from both.
+DISTINCTIVE_CONTEXT = '### Structured product context\n**Product**: Wombat Telemetry Console'
+
+PRD_OLD = {'document_id': 'zz_prd_old', 'content': 'OLD PRD body', 'created_at': '2026-01-01T00:00:00Z'}
+PRD_NEW = {'document_id': 'aa_prd_new', 'content': 'NEW PRD body', 'created_at': '2026-06-01T00:00:00Z'}
+PRFAQ = {'document_id': 'prfaq_1', 'content': 'PRFAQ body', 'created_at': '2026-02-01T00:00:00Z'}
+RESEARCH_A = {'document_id': 'research_a', 'title': 'Churn interviews', 'content': 'RESEARCH A findings'}
+RESEARCH_B = {'document_id': 'research_b', 'title': 'Pricing survey', 'content': 'RESEARCH B findings'}
+
+GOLDEN_PROMPT = Path(__file__).parent / 'golden' / 'prototype_prompt_baseline.txt'
+
+
+def _wire(mock_dynamodb, *, prd_pages=(), prfaq_pages=(), documents=None, project_name='My Project'):
+    """
+    Wire the projects table: newest-of-type query pages per type, plus items
+    reachable by key.
+
+    Same shape as `test_prototype_sources._wire` — kept local rather than
+    imported so this file's fixtures can be read without opening another, and so
+    a change there cannot silently retune the golden test here.
+    """
+    table = mock_dynamodb['table']
+    table.query.side_effect = [*prd_pages, *prfaq_pages]
+
+    by_sk = {}
+    for prefix, pages in (('PRD#', prd_pages), ('PRFAQ#', prfaq_pages)):
+        for page in pages:
+            for item in page.get('Items') or []:
+                document_id = item.get('document_id')
+                if document_id:
+                    by_sk[f'{prefix}{document_id}'] = item
+    by_sk.update(documents or {})
+
+    def get_item(Key=None, **kwargs):
+        sk = (Key or {}).get('sk', '')
+        if sk == 'META':
+            return {'Item': {'name': project_name}}
+        item = by_sk.get(sk)
+        return {'Item': item} if item else {}
+
+    table.get_item.side_effect = get_item
+    return table
+
+
+def _wire_one_of_each(mock_dynamodb, **kwargs):
+    """The simplest buildable project: one PRD, one PR/FAQ, plus both research reports."""
+    return _wire(
+        mock_dynamodb,
+        prd_pages=[{'Items': [PRD_NEW]}],
+        prfaq_pages=[{'Items': [PRFAQ]}],
+        documents={'RESEARCH#research_a': RESEARCH_A, 'RESEARCH#research_b': RESEARCH_B},
+        **kwargs,
+    )
+
+
+def _run(sample_job_event, lambda_context, **config):
+    from jobs.document_generator.handler import lambda_handler
+    return lambda_handler({
+        **sample_job_event,
+        'doc_config': {'doc_type': 'build_prototype', 'title': 'Test Prototype', **config},
+    }, lambda_context)
+
+
+def _prompt(mock_converse):
+    return mock_converse.call_args.kwargs['prompt']
+
+
+def _saved(mock_dynamodb):
+    return mock_dynamodb['table'].put_item.call_args.kwargs['Item']
+
+
+def _keys(mock_dynamodb):
+    return [call.kwargs.get('Key', {}) for call in mock_dynamodb['table'].get_item.call_args_list]
+
+
+@pytest.fixture
+def stub_product_context():
+    """`_product_context` answering with a distinctive block, as if the project
+    described itself. The real helper is exercised separately (see
+    `TestTheDerivationReportsWhatWasUsed`) — here the point is what the caller
+    does with an answer, so the answer is fixed."""
+    with patch(
+        'jobs.document_generator.handler._product_context',
+        return_value=(DISTINCTIVE_CONTEXT, True),
+    ) as stub:
+        yield stub
+
+
+class TestProductContextIsOptIn:
+    def test_ticking_product_context_puts_the_block_in_the_prompt(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event,
+        lambda_context, stub_product_context,
+    ):
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, use_product_context=True)
+
+        assert DISTINCTIVE_CONTEXT in _prompt(mock_converse)
+        assert _saved(mock_dynamodb)['derivation']['product_context_included'] is True
+
+    def test_not_ticking_product_context_keeps_the_block_out(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event,
+        lambda_context, stub_product_context,
+    ):
+        """The helper is stubbed to succeed, so the only thing keeping the block
+        out of the prompt is the flag. It must also not be READ: a build that
+        pays for the lookup and discards it is the same defect one step earlier."""
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context)
+
+        assert DISTINCTIVE_CONTEXT not in _prompt(mock_converse)
+        assert _saved(mock_dynamodb)['derivation']['product_context_included'] is False
+        stub_product_context.assert_not_called()
+
+    def test_a_failure_to_build_the_product_context_does_not_fail_the_build(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The raise is planted INSIDE `build_product_context_block`, which is
+        where a real failure happens (a DynamoDB read, an S3 read of extracted
+        text). `_product_context` is what swallows it, so stubbing that instead
+        would test the stub. The prototype is the artifact the user asked for;
+        losing it because an optional section could not be assembled would be a
+        worse outcome than building without the section."""
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        with patch(
+            'api.product_context.build_product_context_block',
+            side_effect=RuntimeError('DynamoDB is having a day'),
+        ):
+            _run(sample_job_event, lambda_context, use_product_context=True)
+
+        item = _saved(mock_dynamodb)
+        assert item['document_type'] == 'prototype'
+        assert item['derivation']['product_context_included'] is False
+
+
+class TestResearchIsScopedToResearchDocuments:
+    """
+    Fixture throughout: two PRDs, one PR/FAQ, two research reports. The three
+    non-research documents are what make a general-picker implementation
+    observable — its `[:3]` cap keeps PRD/PR-FAQ and drops research.
+    """
+
+    def test_both_selected_research_reports_reach_the_prompt(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_OLD, PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents={'RESEARCH#research_a': RESEARCH_A, 'RESEARCH#research_b': RESEARCH_B},
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context,
+            use_research=True, selected_research_ids=['research_a', 'research_b'],
+        )
+
+        prompt = _prompt(mock_converse)
+        assert 'RESEARCH A findings' in prompt
+        assert 'RESEARCH B findings' in prompt
+        # And the documents the build already read are still there — the research
+        # section is additive, not a replacement for the spec.
+        assert 'NEW PRD body' in prompt
+        assert 'PRFAQ body' in prompt
+
+    def test_the_derivation_records_every_research_report_used(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_OLD, PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents={'RESEARCH#research_a': RESEARCH_A, 'RESEARCH#research_b': RESEARCH_B},
+        )
+        mock_converse.return_value = HTML
+
+        _run(
+            sample_job_event, lambda_context,
+            use_research=True, selected_research_ids=['research_a', 'research_b'],
+        )
+
+        derivation = _saved(mock_dynamodb)['derivation']
+        assert derivation['sources'] == [
+            {'document_id': 'aa_prd_new', 'role': 'prototype_prd'},
+            {'document_id': 'prfaq_1', 'role': 'prototype_prfaq'},
+            {'document_id': 'research_a', 'role': 'reference'},
+            {'document_id': 'research_b', 'role': 'reference'},
+        ]
+        # Nothing was capped, so used and selected agree. They are separate
+        # numbers precisely so a future cap would show up as a difference.
+        assert derivation['selected_document_count'] == 4
+
+    def test_research_is_read_by_key_under_this_project_only(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The ownership and type halves of the trust boundary, asserted on the
+        keys that are built rather than on an outcome — one mocked table has no
+        other project to reach, so an outcome assertion would be a tautology.
+
+        Also pins that the research read is KEYED: a `RESEARCH#` prefix appearing
+        in a `query` here would mean the reader scans the project instead, which
+        is how the reference-document cap gets inherited.
+        """
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents={'RESEARCH#research_a': RESEARCH_A},
+        )
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, use_research=True, selected_research_ids=['research_a'])
+
+        research_keys = [k for k in _keys(mock_dynamodb) if str(k.get('sk', '')).startswith('RESEARCH#')]
+        assert research_keys == [{'pk': 'PROJECT#proj_20250101120000', 'sk': 'RESEARCH#research_a'}]
+        assert 'RESEARCH#' not in str(mock_dynamodb['table'].query.call_args_list)
+
+    def test_an_unresolvable_research_id_fails_the_build_and_saves_nothing(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """A named report that resolves to nothing must not be quietly skipped:
+        the prototype would look grounded in research the model never saw. The
+        fixture is wired so a build that skipped it would COMPLETE — both source
+        lookups have answers — so this fails for the raise, not for a starved mock.
+        """
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [PRD_NEW]}],
+            prfaq_pages=[{'Items': [PRFAQ]}],
+            documents={'RESEARCH#research_a': RESEARCH_A},
+        )
+        mock_converse.return_value = HTML
+
+        with pytest.raises(Exception, match='Document generation failed'):
+            _run(
+                sample_job_event, lambda_context,
+                use_research=True, selected_research_ids=['research_a', 'research_gone'],
+            )
+
+        mock_converse.assert_not_called()
+        mock_dynamodb['table'].put_item.assert_not_called()
+        recorded = str(mock_jobs_table.update_item.call_args_list)
+        assert 'selected_research_ids' in recorded
+        assert 'research_gone' in recorded
+
+    def test_a_prd_id_offered_as_research_does_not_resolve(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """Type isolation comes from the `sk` prefix, so this is the fixture that
+        fails if `RESEARCH#` is ever dropped from the lookup: `aa_prd_new` is a
+        real document in this project, just not research."""
+        _wire(mock_dynamodb, prd_pages=[{'Items': [PRD_NEW]}], prfaq_pages=[{'Items': [PRFAQ]}])
+        mock_converse.return_value = HTML
+
+        with pytest.raises(Exception, match='Document generation failed'):
+            _run(sample_job_event, lambda_context, use_research=True, selected_research_ids=['aa_prd_new'])
+
+        mock_converse.assert_not_called()
+
+    @pytest.mark.parametrize('switch', [
+        pytest.param({}, id='absent'),
+        # What the API actually sends. `bool(body.get(...))` means the key is
+        # always present and explicitly False for a build that did not ask —
+        # so a switch tested only for absence is a switch tested on a shape
+        # production never produces. Found by mutation: reading the switch as
+        # "is not None" passes the absent case and turns every real request into
+        # a research-reading one.
+        pytest.param({'use_research': False}, id='explicit-false'),
+        pytest.param({'use_research': None}, id='null'),
+    ])
+    def test_ids_sent_without_the_research_box_are_not_read(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event,
+        lambda_context, switch,
+    ):
+        """`use_research` is the switch. Ids left behind by an unticked box must
+        cost neither a read nor a prompt section."""
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, selected_research_ids=['research_a'], **switch)
+
+        assert 'RESEARCH A findings' not in _prompt(mock_converse)
+        assert not [k for k in _keys(mock_dynamodb) if str(k.get('sk', '')).startswith('RESEARCH#')]
+
+    def test_ticking_research_with_no_ids_reads_nothing(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """An empty selection is not "all of it". The reader is keyed reads per
+        named id by design, so there is no project-wide query to fall back to —
+        the frontend always names the reports it is showing."""
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, use_research=True, selected_research_ids=[])
+
+        assert 'RESEARCH FINDINGS' not in _prompt(mock_converse)
+        assert _saved(mock_dynamodb)['derivation']['selected_document_count'] == 2
+
+
+class TestTheDerivationReportsWhatWasUsed:
+    """
+    The real `_product_context` and the real `build_product_context_block`, over a
+    project with EXACTLY ONE filled field.
+
+    One field is the discriminating fixture: a fully-filled context cannot tell a
+    computed flag from a hardcoded `True`, and an empty one cannot tell it from a
+    hardcoded `False`. Both directions are asserted here, from the same shape of
+    fixture, so neither constant survives.
+    """
+
+    @staticmethod
+    def _context(**fields):
+        base = {
+            'product_name': '', 'one_liner': '', 'current_state': '', 'target_users': '',
+            'problem_solved': '', 'key_features': '', 'differentiators': '',
+            'known_limitations': '', 'non_goals': '', 'success_metrics': '', 'free_form_notes': '',
+        }
+        return {'context': {**base, **fields}}
+
+    def test_one_filled_field_is_reported_as_grounding(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        with patch('api.product_context.get_context', return_value=self._context(one_liner='A console for wombats')), \
+                patch('api.product_context._list_doc_items', return_value=[]):
+            _run(sample_job_event, lambda_context, use_product_context=True)
+
+        assert 'A console for wombats' in _prompt(mock_converse)
+        assert _saved(mock_dynamodb)['derivation']['product_context_included'] is True
+
+    def test_an_empty_product_context_is_not_reported_as_grounding(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """The box was ticked and the read succeeded, but there was nothing to
+        say. The placeholder must not reach the prompt (it spends budget telling
+        the model nothing) and the document must not claim it was grounded."""
+        _wire_one_of_each(mock_dynamodb)
+        mock_converse.return_value = HTML
+
+        with patch('api.product_context.get_context', return_value=self._context()), \
+                patch('api.product_context._list_doc_items', return_value=[]):
+            _run(sample_job_event, lambda_context, use_product_context=True)
+
+        assert 'No product context provided' not in _prompt(mock_converse)
+        assert _saved(mock_dynamodb)['derivation']['product_context_included'] is False
+
+
+class TestAskingForNeitherChangesNothing:
+    def test_the_prompt_is_byte_identical_to_the_pre_feature_prompt(
+        self, mock_dynamodb, mock_jobs_table, mock_converse, mock_s3, sample_job_event, lambda_context,
+    ):
+        """Golden file, captured by running this exact fixture on the tree before
+        the two sections existed. A substring assertion would not notice an extra
+        blank line where an empty section sits, or two sections swapping places —
+        and every existing caller sends neither flag, so this prompt is what the
+        feature must leave alone.
+
+        Regenerating the golden file to make this pass is only correct if the
+        prompt change is intended for builds that ask for NOTHING, which is
+        exactly the promise being made.
+        """
+        _wire(
+            mock_dynamodb,
+            prd_pages=[{'Items': [{**PRD_NEW, 'document_id': 'prd_1',
+                                   'content': 'PRD body for the golden prompt'}]}],
+            prfaq_pages=[{'Items': [{**PRFAQ, 'content': 'PRFAQ body for the golden prompt'}]}],
+            project_name='Golden Project',
+        )
+        mock_converse.return_value = HTML
+
+        _run(sample_job_event, lambda_context, title='Golden Prototype')
+
+        assert _prompt(mock_converse) == GOLDEN_PROMPT.read_text(encoding='utf-8')


### PR DESCRIPTION
Rung 1 of the prototype visual-grounding ladder (`analysis/FEATURE-prototype-visual-grounding-GITHUB-ISSUE.md`, not yet filed). Closes U25's last open acceptance criterion, which the product owner answered **yes to both, by tick-box**.

Built on top of #321 (both change `api_build_prototype` and `_generate_prototype`), and rebased onto `development` once #321 merged as `5f2172e` — so this is a single commit and the diff is rung 1 alone. Gates re-run after the rebase, unchanged.

## What changes

A prototype build read the PRD and PR/FAQ and nothing else. The project's product context and its research reports reached every other generation path and never reached this one — so the artifact stakeholders actually look at was grounded in the least. Both are now optional inputs, ticked per build on the prototype card.

Three new optional request fields. **All absent reproduces today's prompt byte for byte**, so no existing caller changes behaviour.

## Three decisions that had a plausible alternative

**Controls on the card, not in the confirm dialog.** This is a requirement, not a preference: `confirmKeyFor` deliberately returns no dialog for a project with one PRD, one PR/FAQ and no prototype, so controls placed in the dialog are unreachable for exactly the simplest project. The card also preserves the one-click build.

**Per build, not remembered per project** — the same answer #320 took for the source ids. Answering it differently for two halves of one control would be worse than either answer.

**Research is scoped to `RESEARCH#` with its own field.** It does not reuse the shared document picker and does not join `selected_document_ids`. The shared reference path keeps only the first three of a selection and research sorts last, so a general picker drops precisely the report the user asked for. A research-only field cannot be capped out — nothing of another type is in its candidate set. The cap itself stays a separate issue.

## Trust boundary

The named document's text goes straight into a Bedrock prompt, so every id resolves through the existing `_validated_source_id` under the `RESEARCH#` prefix — `pk` is the project, `sk` is the type, so ownership and document type come from the key rather than a separate check. Two things a single-id check did not need: the **arity bound is checked before the first read**, so an over-long list costs one 400 rather than N reads and then a 400; and **duplicates collapse**, because a repeated id would be read twice and injected twice.

## Revisions inherit rather than re-derive

A revision reads what its base was built with off the base's own recorded derivation. Re-deriving would ground the revision in whatever research exists *now*, so a report created between build and revision would silently join it while the user only asked to change the feedback. `resolveDerivation` is total, so a prototype built before this feature yields no flag and no reports and its revision behaves exactly as today.

## Verification — by delta against a baseline on the untouched tree, not against green

| gate | before | after |
|---|---|---|
| `pytest lambda/jobs/document_generator/test` | 67 | **82** |
| `pytest lambda/api/test` | 540 | **558** |
| `vitest src/pages/ProjectDetail` | 364 | **395** |
| full `vitest run` | — | 2394 passed, 163 files |
| `tsc -b` | clean | clean |
| `eslint src --max-warnings 0` | — | clean |
| `ruff` on the two edited files | 177 / 136 lines | **177 / 136, unchanged** |
| `npm run i18n:check` | **already red**, 2 unrelated causes | red, output **byte-identical** to the pre-change capture |

The two ruff numbers are pre-existing. The bar was "does not grow", not "reaches zero", and no pre-existing failure was opportunistically fixed in here.

**26 mutation probes, 26 caught.** Two survived first and both were real test defects, both worth knowing:

- A test for "unticked research is not read" only covered the key being **absent**. The API always sends `use_research: false` explicitly, so the shape production actually produces was untested — reading the switch as `is not None` passed. Now parametrised over absent / explicit false / null.
- Nothing exercised the hook filtering a selection against the live options, which is what stops a report deleted under an open card being sent to an API that would reject it. Catching it needed a **re-render with the report removed**, which no existing test did.

## Two things I'd flag to a reviewer

**`MAX_SELECTED_RESEARCH_IDS` lives beside `overviewState`, not the request type.** Putting it with the request type broke four unrelated suites: they mock the api module with explicit partial objects, so any new named export there makes every consumer throw. Patching a dozen mocks was the larger diff. A lockstep test reads both copies as source text and asserts exactly one match per file, so a restructure fails loudly rather than vacuously, plus a plausibility bound so a value of 0 or 1 cannot keep it green. The drift it guards is one-sided and quiet: raise the frontend copy and the picker offers a selection the API rejects, after the user has chosen, with nothing said about which report to drop.

**The card description no longer names PRD or PR-FAQ at all**, where it could have kept the names and added the optional inputs. That was done so one regex asserts across all eight catalogues — every locale kept the Latin "PRD / PR-FAQ" verbatim, so a missed catalogue fails language-independently. It is the test shaping the copy, and a reviewer may reasonably want the names back with a per-language assertion instead.

## Known gap, tested and deliberately not papered over

When a revision's inherited research report has since been deleted, it is dropped silently. The existing rebased-feedback note says "the latest of that type will be used instead", which would be untrue here — nothing substitutes for a missing research report. Saying it properly needs a ninth string in eight catalogues, outside this change's criteria.

## Not verified

**No browser has rendered these controls.** The tests render them in jsdom and assert reachability and behaviour, which is not the same thing. Live verification is owed before this is called done.
