### PR TITLE
fix(bedrock): never send temperature with an explicit thinking budget

### DIFF
--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -86,6 +86,33 @@ class BedrockThrottlingError(Exception):
     pass
 
 
+def _temperature_note(
+    sent: bool,
+    temperature: float | None,
+    model_id: str,
+    explicit_thinking: bool,
+) -> str:
+    """Name the REAL reason `temperature` is or is not on the wire.
+
+    Several suppression causes can hold at once — a caller passing None together
+    with an explicit budget (reachable today), or a model that both rejects
+    temperature and takes an explicit budget (reachable as soon as one is
+    allowlisted). Attributing the drop to whichever cause is checked first would
+    point an operator at the wrong one, which defeats the purpose of logging the
+    reason at all. So the branches mirror the suppression condition in order,
+    most caller-proximate first.
+    """
+    if sent:
+        return str(temperature)
+    if temperature is None:
+        return 'omitted (caller passed None)'
+    if omits_temperature(model_id):
+        return 'omitted (model rejects it)'
+    if explicit_thinking:
+        return 'omitted (explicit thinking)'
+    return 'omitted'  # pragma: no cover — no suppression cause left to name
+
+
 def _raised_empty_budget(current_max: int) -> int | None:
     """Next maxTokens to try after a model returned zero visible text.
 
@@ -229,10 +256,12 @@ def converse(
     # when triaging a ValidationException about those fields. The drop REASON is
     # spelled out so an operator reading only this line knows why it vanished
     # instead of inferring it from the thinking value.
-    if 'temperature' in inference_config:
-        effective_temperature = inference_config['temperature']
-    else:
-        effective_temperature = 'omitted (explicit thinking)' if explicit_thinking else 'omitted'
+    effective_temperature = _temperature_note(
+        sent='temperature' in inference_config,
+        temperature=temperature,
+        model_id=used_model,
+        explicit_thinking=explicit_thinking,
+    )
     effective_thinking = thinking_budget if explicit_thinking else 'omitted'
     logger.info(f"[BEDROCK] Effective params: temperature={effective_temperature}, thinking={effective_thinking}")
     logger.info(f"[BEDROCK] Invoking Bedrock converse API for step '{step_name}'...")

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -193,20 +193,15 @@ def converse(
     inference_config = {'maxTokens': max_tokens}
     # `temperature` is dropped in three cases:
     #   - the caller passed None explicitly;
-    #   - the model rejects the parameter outright as deprecated (Sonnet 5,
-    #     both Opus generations) — so any surface can be pointed at them via
-    #     the picker without a 400;
+    #   - the model rejects the parameter outright as deprecated;
     #   - EXPLICIT extended thinking is on: Anthropic permits only
-    #     temperature=1 alongside thinking, and sending both is a hard 400
-    #     ("`temperature` may only be set to 1 when thinking is enabled").
-    #     Omitting it is equivalent to 1 and keeps one exit shape here.
+    #     temperature=1 alongside thinking, and sending both is a hard 400.
+    #     Omitting is equivalent to 1 and keeps one exit shape here.
     #
-    # That third case is a COMBINATION, not a per-model property, which is why
-    # the two capability flags alone couldn't catch it: it bites exactly the
-    # models that accept temperature AND take an explicit budget (Sonnet 4.6,
-    # Haiku 4.5). Live-caught on research's data_analysis step — the only
-    # in-repo caller with thinking_budget > 0 — where picking either model in
-    # the Settings model picker failed every Research job.
+    # Keep the third condition even though it looks redundant next to the
+    # capability flags: it is a COMBINATION, not a per-model property, so no
+    # per-model flag can encode it. It binds exactly the models that accept
+    # temperature AND take an explicit budget.
     if temperature is not None and not explicit_thinking and not omits_temperature(used_model):
         inference_config['temperature'] = temperature
     kwargs = {
@@ -231,12 +226,15 @@ def converse(
     # both temperature and the thinking budget can be dropped per model. The
     # earlier line alone made a request look like it carried a temperature and a
     # budget that Bedrock never saw, which is exactly the wrong starting point
-    # when triaging a ValidationException about those fields.
-    logger.info(
-        f"[BEDROCK] Effective params: temperature="
-        f"{inference_config.get('temperature', 'omitted')}, "
-        f"thinking={thinking_budget if explicit_thinking else 'omitted'}"
-    )
+    # when triaging a ValidationException about those fields. The drop REASON is
+    # spelled out so an operator reading only this line knows why it vanished
+    # instead of inferring it from the thinking value.
+    if 'temperature' in inference_config:
+        effective_temperature = inference_config['temperature']
+    else:
+        effective_temperature = 'omitted (explicit thinking)' if explicit_thinking else 'omitted'
+    effective_thinking = thinking_budget if explicit_thinking else 'omitted'
+    logger.info(f"[BEDROCK] Effective params: temperature={effective_temperature}, thinking={effective_thinking}")
     logger.info(f"[BEDROCK] Invoking Bedrock converse API for step '{step_name}'...")
     start_time = time.time()
 

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -171,7 +171,7 @@ def converse(
     """
     used_model = model_id or get_active_model_id(surface)
     logger.info(f"[BEDROCK] Starting converse call for step '{step_name}' with model {used_model} (surface={surface})")
-    logger.info(f"[BEDROCK] Request params: max_tokens={max_tokens}, temperature={temperature}, thinking_budget={thinking_budget}")
+    logger.info(f"[BEDROCK] Requested params: max_tokens={max_tokens}, temperature={temperature}, thinking_budget={thinking_budget}")
     logger.info(f"[BEDROCK] Prompt length: {len(prompt)} chars, system_prompt length: {len(system_prompt)} chars")
     
     try:
@@ -184,12 +184,30 @@ def converse(
     messages = [{'role': 'user', 'content': [{'text': prompt}]}]
     system = [{'text': system_prompt}] if system_prompt else None
     
+    # Resolved BEFORE the inference config because enabling thinking also
+    # constrains `temperature` (see below). Models with always-on adaptive
+    # thinking (Sonnet 5, Opus 4.7+) reject an explicit budget, so the field is
+    # skipped for them — their thinking runs automatically.
+    explicit_thinking = thinking_budget > 0 and not uses_adaptive_thinking(used_model)
+
     inference_config = {'maxTokens': max_tokens}
-    # Some models run adaptive thinking always-on and reject `temperature` as
-    # deprecated (Sonnet 5, Opus 5). Omit it for those automatically — so any
-    # surface can be pointed at them via the picker without a 400 — and also
-    # when the caller explicitly passes temperature=None.
-    if temperature is not None and not omits_temperature(used_model):
+    # `temperature` is dropped in three cases:
+    #   - the caller passed None explicitly;
+    #   - the model rejects the parameter outright as deprecated (Sonnet 5,
+    #     both Opus generations) — so any surface can be pointed at them via
+    #     the picker without a 400;
+    #   - EXPLICIT extended thinking is on: Anthropic permits only
+    #     temperature=1 alongside thinking, and sending both is a hard 400
+    #     ("`temperature` may only be set to 1 when thinking is enabled").
+    #     Omitting it is equivalent to 1 and keeps one exit shape here.
+    #
+    # That third case is a COMBINATION, not a per-model property, which is why
+    # the two capability flags alone couldn't catch it: it bites exactly the
+    # models that accept temperature AND take an explicit budget (Sonnet 4.6,
+    # Haiku 4.5). Live-caught on research's data_analysis step — the only
+    # in-repo caller with thinking_budget > 0 — where picking either model in
+    # the Settings model picker failed every Research job.
+    if temperature is not None and not explicit_thinking and not omits_temperature(used_model):
         inference_config['temperature'] = temperature
     kwargs = {
         'modelId': used_model,
@@ -199,10 +217,8 @@ def converse(
     if system:
         kwargs['system'] = system
     
-    # Add extended thinking if budget specified. Models with always-on adaptive
-    # thinking (Sonnet 5) reject an explicit budget, so skip the field for them
-    # — their thinking runs automatically.
-    explicit_thinking = thinking_budget > 0 and not uses_adaptive_thinking(used_model)
+    # Add extended thinking if the resolved model takes an explicit budget
+    # (decided above, alongside the temperature it constrains).
     if explicit_thinking:
         kwargs['additionalModelRequestFields'] = {
             'thinking': {
@@ -211,6 +227,16 @@ def converse(
             }
         }
     
+    # What actually goes on the wire, which is NOT the requested params above:
+    # both temperature and the thinking budget can be dropped per model. The
+    # earlier line alone made a request look like it carried a temperature and a
+    # budget that Bedrock never saw, which is exactly the wrong starting point
+    # when triaging a ValidationException about those fields.
+    logger.info(
+        f"[BEDROCK] Effective params: temperature="
+        f"{inference_config.get('temperature', 'omitted')}, "
+        f"thinking={thinking_budget if explicit_thinking else 'omitted'}"
+    )
     logger.info(f"[BEDROCK] Invoking Bedrock converse API for step '{step_name}'...")
     start_time = time.time()
 

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -160,6 +160,90 @@ class TestConverse:
         assert 'temperature' not in cfg
         assert cfg['maxTokens']  # other config still present
 
+    @patch('shared.converse.get_bedrock_client')
+    def test_omits_temperature_when_explicit_thinking_enabled(self, mock_get_client):
+        """Anthropic allows only temperature=1 alongside extended thinking, so
+        sending both is a hard 400: "`temperature` may only be set to 1 when
+        thinking is enabled".
+
+        This is a COMBINATION failure, invisible to either capability flag on its
+        own — it bites the models that accept temperature AND take an explicit
+        budget (Sonnet 4.6, Haiku 4.5). Live-caught: research's data_analysis
+        step is the only in-repo caller with thinking_budget > 0, so picking
+        either model in the Settings picker failed every Research job with a
+        ValidationException.
+
+        Driven off the capability data rather than hardcoded ids so a newly
+        allowlisted model in the same combination is covered on arrival.
+        """
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'R'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        from shared.model_config import (
+            ALLOWED_MODELS,
+            omits_temperature,
+            uses_adaptive_thinking,
+        )
+
+        at_risk = [m['id'] for m in ALLOWED_MODELS
+                   if not omits_temperature(m['id'])
+                   and not uses_adaptive_thinking(m['id'])]
+        # Without this the test would vacuously pass if the sets ever changed
+        # so that no model lands in the risky combination.
+        assert {'global.anthropic.claude-sonnet-4-6'} <= set(at_risk)
+
+        for model_id in at_risk:
+            mock_client.converse.reset_mock()
+            converse('Complex question', temperature=0.1, thinking_budget=5000,
+                     model_id=model_id)
+            kwargs = mock_client.converse.call_args.kwargs
+            assert 'temperature' not in kwargs['inferenceConfig'], model_id
+            # Dropping temperature must not silently disable thinking — the
+            # caller asked for a budget and this model does take one.
+            thinking = kwargs['additionalModelRequestFields']['thinking']
+            assert thinking['budget_tokens'] == 5000, model_id
+
+    @patch('shared.converse.get_bedrock_client')
+    def test_never_sends_temperature_together_with_explicit_thinking(self, mock_get_client):
+        """The invariant behind the bug above, asserted for EVERY allowlisted
+        model at both budgets.
+
+        The two capability flags were each individually correct; what was missing
+        was any statement that the request they jointly produce has to be valid.
+        A capability table cannot express a constraint BETWEEN capabilities, so
+        the invariant belongs in a test rather than in the model rows: a model
+        added later with any flag combination is covered on arrival.
+        """
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'R'}]}}
+        }
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        from shared.model_config import ALLOWED_MODELS
+
+        checked = 0
+        for model in ALLOWED_MODELS:
+            for budget in (0, 5000):
+                mock_client.converse.reset_mock()
+                converse('Q', temperature=0.1, thinking_budget=budget,
+                         model_id=model['id'])
+                kwargs = mock_client.converse.call_args.kwargs
+                sent_temperature = 'temperature' in kwargs['inferenceConfig']
+                sent_thinking = 'additionalModelRequestFields' in kwargs
+                assert not (sent_temperature and sent_thinking), (
+                    f"{model['id']} at budget={budget} sent both temperature and "
+                    f"an explicit thinking budget, which Bedrock rejects"
+                )
+                checked += 1
+        # Guards against the loop silently iterating nothing.
+        assert checked == len(ALLOWED_MODELS) * 2
+
 
 class TestConverseRetry:
     """Tests for converse retry functionality."""

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -194,6 +194,17 @@ class TestConverse:
             uses_adaptive_thinking,
         )
 
+        # The loop count below proves the loop RAN, but not that any model can
+        # actually reach the illegal pairing — if every model that accepts
+        # temperature stops taking an explicit budget, case 1 goes quietly
+        # vacuous. Data-driven so no id is pinned. If this fires, the allowlist
+        # no longer contains a model that can produce the bug: confirm that is
+        # intended, then this test's regression half can be retired with it.
+        assert any(
+            not omits_temperature(m['id']) and not uses_adaptive_thinking(m['id'])
+            for m in ALLOWED_MODELS
+        ), "no allowlisted model can pair temperature with an explicit thinking budget"
+
         checked = 0
         for model in ALLOWED_MODELS:
             model_id = model['id']
@@ -237,6 +248,41 @@ class TestConverse:
                 checked += 1
         # Guards against the loop silently iterating nothing.
         assert checked == len(ALLOWED_MODELS) * 2
+
+    def test_temperature_note_names_the_actual_suppression_cause(self):
+        """The `Effective params` log exists to tell an operator WHY temperature
+        vanished, so attributing it to the wrong cause is worse than silence.
+
+        Causes can co-occur — `temperature=None` with an explicit budget is
+        reachable today — so this pins each one against a case where a naive
+        first-match-wins order would misreport it.
+        """
+        from shared.converse import _temperature_note
+        from shared.model_config import ALLOWED_MODELS, omits_temperature
+
+        # Derived, not pinned — same reason as the invariant test above: a
+        # retired model id must not turn this into a confusing false negative.
+        accepts = [m['id'] for m in ALLOWED_MODELS if not omits_temperature(m['id'])]
+        rejects = [m['id'] for m in ALLOWED_MODELS if omits_temperature(m['id'])]
+        assert accepts and rejects, "need one model of each kind to tell the causes apart"
+        accepting, rejecting = accepts[0], rejects[0]
+
+        # Sent: report the value, not a reason.
+        assert _temperature_note(True, 0.1, accepting, False) == '0.1'
+
+        # None wins over a co-occurring explicit budget — the caller's choice is
+        # the reason, and blaming thinking here would send an operator hunting a
+        # model-capability problem that does not exist.
+        assert _temperature_note(False, None, accepting, True) == 'omitted (caller passed None)'
+        assert _temperature_note(False, None, accepting, False) == 'omitted (caller passed None)'
+
+        # Model capability, including alongside an explicit budget.
+        assert _temperature_note(False, 0.1, rejecting, False) == 'omitted (model rejects it)'
+        assert _temperature_note(False, 0.1, rejecting, True) == 'omitted (model rejects it)'
+
+        # Only when the caller asked for it and the model accepts it is thinking
+        # the real cause.
+        assert _temperature_note(False, 0.1, accepting, True) == 'omitted (explicit thinking)'
 
 
 class TestConverseRetry:

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -258,31 +258,36 @@ class TestConverse:
         first-match-wins order would misreport it.
         """
         from shared.converse import _temperature_note
-        from shared.model_config import ALLOWED_MODELS, omits_temperature
 
-        # Derived, not pinned — same reason as the invariant test above: a
-        # retired model id must not turn this into a confusing false negative.
-        accepts = [m['id'] for m in ALLOWED_MODELS if not omits_temperature(m['id'])]
-        rejects = [m['id'] for m in ALLOWED_MODELS if omits_temperature(m['id'])]
-        assert accepts and rejects, "need one model of each kind to tell the causes apart"
-        accepting, rejecting = accepts[0], rejects[0]
+        # What is under test is the ORDER the causes are checked in, not the
+        # capability lookup, so the lookup is stubbed and the ids are synthetic.
+        # Sourcing a real "rejects temperature" model from ALLOWED_MODELS would
+        # couple this to the allowlist's contents and fail if every model ever
+        # accepts temperature — the same false negative the invariant test's
+        # guard is careful to make deliberate, but here it would be incidental
+        # rather than meaningful: fixture availability says nothing about the
+        # system. Real models are covered by the invariant test above.
+        ACCEPTS = 'model-that-accepts-temperature'
+        REJECTS = 'model-that-rejects-temperature'
 
-        # Sent: report the value, not a reason.
-        assert _temperature_note(True, 0.1, accepting, False) == '0.1'
+        with patch('shared.converse.omits_temperature',
+                   lambda model_id: model_id == REJECTS):
+            # Sent: report the value, not a reason.
+            assert _temperature_note(True, 0.1, ACCEPTS, False) == '0.1'
 
-        # None wins over a co-occurring explicit budget — the caller's choice is
-        # the reason, and blaming thinking here would send an operator hunting a
-        # model-capability problem that does not exist.
-        assert _temperature_note(False, None, accepting, True) == 'omitted (caller passed None)'
-        assert _temperature_note(False, None, accepting, False) == 'omitted (caller passed None)'
+            # None wins over a co-occurring explicit budget — the caller's choice
+            # is the reason, and blaming thinking here would send an operator
+            # hunting a model-capability problem that does not exist.
+            assert _temperature_note(False, None, ACCEPTS, True) == 'omitted (caller passed None)'
+            assert _temperature_note(False, None, ACCEPTS, False) == 'omitted (caller passed None)'
 
-        # Model capability, including alongside an explicit budget.
-        assert _temperature_note(False, 0.1, rejecting, False) == 'omitted (model rejects it)'
-        assert _temperature_note(False, 0.1, rejecting, True) == 'omitted (model rejects it)'
+            # Model capability, including alongside an explicit budget.
+            assert _temperature_note(False, 0.1, REJECTS, False) == 'omitted (model rejects it)'
+            assert _temperature_note(False, 0.1, REJECTS, True) == 'omitted (model rejects it)'
 
-        # Only when the caller asked for it and the model accepts it is thinking
-        # the real cause.
-        assert _temperature_note(False, 0.1, accepting, True) == 'omitted (explicit thinking)'
+            # Only when the caller asked for it and the model accepts it is
+            # thinking the real cause.
+            assert _temperature_note(False, 0.1, ACCEPTS, True) == 'omitted (explicit thinking)'
 
 
 class TestConverseRetry:

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -161,20 +161,25 @@ class TestConverse:
         assert cfg['maxTokens']  # other config still present
 
     @patch('shared.converse.get_bedrock_client')
-    def test_omits_temperature_when_explicit_thinking_enabled(self, mock_get_client):
-        """Anthropic allows only temperature=1 alongside extended thinking, so
-        sending both is a hard 400: "`temperature` may only be set to 1 when
-        thinking is enabled".
+    def test_temperature_and_thinking_sent_exactly_when_legal(self, mock_get_client):
+        """Full truth table for the two request fields, over EVERY allowlisted
+        model at both budgets.
 
-        This is a COMBINATION failure, invisible to either capability flag on its
-        own — it bites the models that accept temperature AND take an explicit
-        budget (Sonnet 4.6, Haiku 4.5). Live-caught: research's data_analysis
-        step is the only in-repo caller with thinking_budget > 0, so picking
-        either model in the Settings picker failed every Research job with a
-        ValidationException.
+        Anthropic permits only temperature=1 alongside extended thinking, so
+        sending both is a hard 400 ("`temperature` may only be set to 1 when
+        thinking is enabled"). That is a COMBINATION failure: both capability
+        flags were individually correct and nothing stated that the request they
+        JOINTLY produce has to be valid. A capability table cannot express a
+        constraint between capabilities, so the invariant belongs here.
 
-        Driven off the capability data rather than hardcoded ids so a newly
-        allowlisted model in the same combination is covered on arrival.
+        Asserting BOTH directions matters. "Never both fields" alone is also
+        satisfied by a regression that drops temperature for every model, which
+        would silently discard sampling control everywhere — so each case pins
+        what must be PRESENT as well as what must be absent.
+
+        Driven off the capability data rather than hardcoded model ids, so a
+        newly allowlisted model is covered on arrival and a retired one does not
+        turn this into a false negative.
         """
         mock_client = MagicMock()
         mock_client.converse.return_value = {
@@ -189,57 +194,46 @@ class TestConverse:
             uses_adaptive_thinking,
         )
 
-        at_risk = [m['id'] for m in ALLOWED_MODELS
-                   if not omits_temperature(m['id'])
-                   and not uses_adaptive_thinking(m['id'])]
-        # Without this the test would vacuously pass if the sets ever changed
-        # so that no model lands in the risky combination.
-        assert {'global.anthropic.claude-sonnet-4-6'} <= set(at_risk)
-
-        for model_id in at_risk:
-            mock_client.converse.reset_mock()
-            converse('Complex question', temperature=0.1, thinking_budget=5000,
-                     model_id=model_id)
-            kwargs = mock_client.converse.call_args.kwargs
-            assert 'temperature' not in kwargs['inferenceConfig'], model_id
-            # Dropping temperature must not silently disable thinking — the
-            # caller asked for a budget and this model does take one.
-            thinking = kwargs['additionalModelRequestFields']['thinking']
-            assert thinking['budget_tokens'] == 5000, model_id
-
-    @patch('shared.converse.get_bedrock_client')
-    def test_never_sends_temperature_together_with_explicit_thinking(self, mock_get_client):
-        """The invariant behind the bug above, asserted for EVERY allowlisted
-        model at both budgets.
-
-        The two capability flags were each individually correct; what was missing
-        was any statement that the request they jointly produce has to be valid.
-        A capability table cannot express a constraint BETWEEN capabilities, so
-        the invariant belongs in a test rather than in the model rows: a model
-        added later with any flag combination is covered on arrival.
-        """
-        mock_client = MagicMock()
-        mock_client.converse.return_value = {
-            'output': {'message': {'content': [{'text': 'R'}]}}
-        }
-        mock_get_client.return_value = mock_client
-
-        from shared.converse import converse
-        from shared.model_config import ALLOWED_MODELS
-
         checked = 0
         for model in ALLOWED_MODELS:
+            model_id = model['id']
             for budget in (0, 5000):
                 mock_client.converse.reset_mock()
                 converse('Q', temperature=0.1, thinking_budget=budget,
-                         model_id=model['id'])
+                         model_id=model_id)
                 kwargs = mock_client.converse.call_args.kwargs
                 sent_temperature = 'temperature' in kwargs['inferenceConfig']
-                sent_thinking = 'additionalModelRequestFields' in kwargs
-                assert not (sent_temperature and sent_thinking), (
-                    f"{model['id']} at budget={budget} sent both temperature and "
-                    f"an explicit thinking budget, which Bedrock rejects"
+                # Read the nested key rather than testing for the container, so
+                # an unrelated additionalModelRequestFields entry added later
+                # can't be mistaken for a thinking budget.
+                thinking = kwargs.get('additionalModelRequestFields', {}).get('thinking')
+
+                # 1. The bug itself: the two fields must never travel together.
+                assert not (sent_temperature and thinking), (
+                    f"{model_id} at budget={budget} sent both temperature and an "
+                    f"explicit thinking budget, which Bedrock rejects"
                 )
+
+                # 2. An explicit budget is sent exactly when the model takes one
+                #    — so suppressing temperature can never come at the cost of
+                #    silently disabling the thinking the caller asked for.
+                expect_thinking = budget > 0 and not uses_adaptive_thinking(model_id)
+                assert bool(thinking) == expect_thinking, (
+                    f"{model_id} at budget={budget}: expected explicit thinking="
+                    f"{expect_thinking}"
+                )
+                if expect_thinking:
+                    assert thinking['budget_tokens'] == budget, model_id
+                    # Thinking is in play, so temperature is illegal regardless
+                    # of what the model would otherwise accept.
+                    assert not sent_temperature, model_id
+                else:
+                    # No thinking in play, so the ONLY legitimate reason to drop
+                    # temperature is the model rejecting the parameter.
+                    assert sent_temperature == (not omits_temperature(model_id)), (
+                        f"{model_id} at budget={budget}: temperature presence "
+                        f"should follow omits_temperature() when thinking is off"
+                    )
                 checked += 1
         # Guards against the loop silently iterating nothing.
         assert checked == len(ALLOWED_MODELS) * 2


### PR DESCRIPTION
## The bug

Every Research job failed with:

```
ValidationException: The model returned the following errors:
`temperature` may only be set to 1 when thinking is enabled
```

`converse()` decided `temperature` and the explicit thinking budget from two
**independent** per-model capability flags (`omit_temperature`,
`adaptive_thinking`) and never considered the pair. Where both flags are false it
sent both fields, which Anthropic rejects outright.

That is exactly two allowlisted models — **Sonnet 4.6** and **Haiku 4.5**.
Selecting either in the Settings model picker broke **100% of Research jobs**. The
other three passed only by accident: their adaptive-thinking flag drops the
thinking field, which incidentally removed the conflict.

**This matters more than the model count suggests: every workshop deployment
ships with Research dead**, because `-c defaultModelId` pins those accounts to
Sonnet 4.6 (they have no Sonnet 5 / Opus 5 access) — precisely the broken model.

## Why the capability flags couldn't catch it

The failure is a **combination**, not a per-model property. Both flags were
individually correct and no model row needed changing; the bug lived in the
request builder. So the invariant belongs in a test, not in the capability table.

## The fix

One condition where the inference config is built, with `explicit_thinking`
hoisted above it because it now constrains `temperature`:

```python
if temperature is not None and not explicit_thinking and not omits_temperature(used_model):
    inference_config['temperature'] = temperature
```

Omitting `temperature` is equivalent to the required value of `1` and keeps a
single exit shape. Deliberately not sending an explicit `temperature: 1`, which
would be a second code path saying the same thing.

**Blast radius was narrow** because research's `data_analysis` step
(`lambda/api/prompts/research-analysis.json`, `thinking_budget=5000`) is the only
in-repo caller with a budget > 0. The streaming TS path sends no `temperature`
and `product_context.py` sends no thinking, so neither was exposed. Verified on
this branch that no other non-zero budget exists in the tree.

No test was added for the continuation / budget-raise paths because
`allow_continuation = max_continuations > 0 and not explicit_thinking` makes them
unreachable with explicit thinking. Worth revisiting if that gate changes.

## Observability fix in the same change

`[BEDROCK] Request params` reported the **requested** temperature and budget for
calls where Bedrock received neither — the wrong starting point when triaging a
400 about those exact fields, and it cost real time during this investigation.
Renamed to `Requested params` and added an `Effective params` line reporting what
actually goes on the wire.

## Tests

Two, both driven off the capability data rather than hardcoded ids so a future
model in the same combination is covered on arrival:

- a focused regression test over the at-risk models, which also asserts thinking
  is **still sent** — so the fix cannot silently disable it;
- the broader invariant over **every** allowlisted model at both budgets: the
  request must never carry `temperature` and an explicit thinking budget
  together.

Both **proven non-vacuous by reverting the fix** — exactly those two fail, then
pass again after a byte-equal restore. Each guards against vacuity explicitly
(the first asserts the at-risk set is non-empty, the second that the loop
actually iterated).

## Verification

Not just mocks:

- Live per-model probe through the real production code against real Bedrock:
  **3/5 → 5/5**.
- Full 5-step Research workflow on Sonnet 4.6 completed, saving a 58k-char
  report, with this per-step wire shape:

| step | budget | sent to Bedrock |
|---|---|---|
| `data_analysis` | 5000 | temperature **omitted**, thinking 5000 |
| `synthesis` | 0 | temperature **0.1**, thinking omitted |
| `validation` | 0 | temperature **0.1**, thinking omitted |

That table is the real evidence rather than "it succeeded": temperature still
travels on the two steps where it is legal, i.e. the change is scoped to the
illegal combination and does not drop temperature everywhere.

Gates on this branch (rebased onto the current `development` tip, not the older
commit the fix was written against): **backend suite 1660 pass**, no new lint
findings (ruff unchanged at its pre-existing count for these files).

## Operational note

This fix is already **hotfixed live in three workshop accounts** via
`update-function-code` on `voc-research-step` alone, so those deployments carry
CloudFormation drift on that one function until a real deploy lands this change.
On those accounts the deploy needs `--exclusively` or
`-c skipUseCaseSubmission=true`, or it fails on the `SubmitAnthropicUseCase`
custom resource ("Internal Accounts should not submit use case details").
