### PR TITLE
feat(feedback-forms): show the document type in the validation link picker

### DIFF
--- a/voc-datalake/frontend/public/locales/de/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/de/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "Erfassen Sie optional, zu welchem Projekt — und zu welchem PRD oder PR/FAQ — dieses Formular Feedback sammelt. Die erfassten Bewertungen erscheinen dann neben diesem Dokument auf der Priorisierungsseite. Lassen Sie beide Felder leer für ein eigenständiges Formular, etwa eine Website-Umfrage.",
     "validationDocumentHint": "Belassen Sie es beim gesamten Projekt, damit die Verknüpfung erhalten bleibt, wenn ein Dokument neu erzeugt wird.",
     "validationDocumentLabel": "Dokument (optional)",
+    "validationDocumentOption": "{{title}} ({{type}})",
     "validationLoadingLink": "Verknüpfung wird geladen …",
     "validationNoProject": "-- Nicht verknüpft --",
     "validationProjectHint": "Wird das Projekt geleert, ist dieses Formular nicht mehr verknüpft.",

--- a/voc-datalake/frontend/public/locales/en/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/en/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "Optionally record which project — and which PRD or PR/FAQ — this form collects feedback about. The ratings it gathers then appear next to that document on the Prioritization page. Leave both empty for a standalone form such as a website survey.",
     "validationDocumentHint": "Leave on the whole project to keep the link when a document is regenerated.",
     "validationDocumentLabel": "Document (Optional)",
+    "validationDocumentOption": "{{title}} ({{type}})",
     "validationLoadingLink": "Loading link…",
     "validationNoProject": "-- Not linked --",
     "validationProjectHint": "Clearing the project unlinks this form.",

--- a/voc-datalake/frontend/public/locales/es/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/es/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "Opcionalmente registre a qué proyecto — y a qué PRD o PR/FAQ — se refieren los comentarios de este formulario. Las valoraciones recopiladas aparecerán junto a ese documento en la página de Priorización. Deje ambos vacíos para un formulario independiente, como una encuesta del sitio web.",
     "validationDocumentHint": "Déjelo en el proyecto completo para mantener el vínculo cuando se regenere un documento.",
     "validationDocumentLabel": "Documento (opcional)",
+    "validationDocumentOption": "{{title}} ({{type}})",
     "validationLoadingLink": "Cargando el vínculo…",
     "validationNoProject": "-- Sin vincular --",
     "validationProjectHint": "Borrar el proyecto desvincula este formulario.",

--- a/voc-datalake/frontend/public/locales/fr/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/fr/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "Indiquez éventuellement à quel projet — et à quel PRD ou PR/FAQ — se rapportent les retours de ce formulaire. Les notes recueillies apparaîtront alors à côté de ce document sur la page Priorisation. Laissez les deux champs vides pour un formulaire autonome, comme une enquête sur un site web.",
     "validationDocumentHint": "Laissez sur l'ensemble du projet pour conserver le lien lorsqu'un document est régénéré.",
     "validationDocumentLabel": "Document (facultatif)",
+    "validationDocumentOption": "{{title}} ({{type}})",
     "validationLoadingLink": "Chargement du lien…",
     "validationNoProject": "-- Non lié --",
     "validationProjectHint": "Effacer le projet délie ce formulaire.",

--- a/voc-datalake/frontend/public/locales/ja/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ja/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "このフォームがどのプロジェクトの、どのPRDまたはPR/FAQについてフィードバックを集めるのかを任意で記録できます。収集した評価は優先順位付けページの該当ドキュメントの横に表示されます。ウェブサイトのアンケートなど単独のフォームでは両方を空のままにしてください。",
     "validationDocumentHint": "プロジェクト全体のままにすると、ドキュメントを再生成してもリンクが維持されます。",
     "validationDocumentLabel": "ドキュメント（任意）",
+    "validationDocumentOption": "{{title}}（{{type}}）",
     "validationLoadingLink": "リンクを読み込み中…",
     "validationNoProject": "-- リンクなし --",
     "validationProjectHint": "プロジェクトを空にするとこのフォームのリンクが解除されます。",

--- a/voc-datalake/frontend/public/locales/ko/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/ko/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "이 양식이 어떤 프로젝트의, 어떤 PRD 또는 PR/FAQ에 대한 피드백을 수집하는지 선택적으로 기록할 수 있습니다. 수집된 평점은 우선순위 지정 페이지의 해당 문서 옆에 표시됩니다. 웹사이트 설문처럼 독립적인 양식이라면 두 항목을 비워 두세요.",
     "validationDocumentHint": "프로젝트 전체로 두면 문서를 다시 생성해도 연결이 유지됩니다.",
     "validationDocumentLabel": "문서(선택 사항)",
+    "validationDocumentOption": "{{title}}({{type}})",
     "validationLoadingLink": "연결 정보를 불러오는 중…",
     "validationNoProject": "-- 연결되지 않음 --",
     "validationProjectHint": "프로젝트를 비우면 이 양식의 연결이 해제됩니다.",

--- a/voc-datalake/frontend/public/locales/pt/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/pt/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "Opcionalmente registre sobre qual projeto — e qual PRD ou PR/FAQ — este formulário coleta feedback. As avaliações reunidas aparecerão ao lado desse documento na página de Priorização. Deixe ambos vazios para um formulário independente, como uma pesquisa de site.",
     "validationDocumentHint": "Mantenha no projeto inteiro para preservar o vínculo quando um documento for regerado.",
     "validationDocumentLabel": "Documento (Opcional)",
+    "validationDocumentOption": "{{title}} ({{type}})",
     "validationLoadingLink": "Carregando o vínculo…",
     "validationNoProject": "-- Não vinculado --",
     "validationProjectHint": "Limpar o projeto desvincula este formulário.",

--- a/voc-datalake/frontend/public/locales/zh/feedbackForms.json
+++ b/voc-datalake/frontend/public/locales/zh/feedbackForms.json
@@ -75,6 +75,7 @@
     "validationDescription": "可选择记录此表单收集的反馈针对哪个项目，以及哪个 PRD 或 PR/FAQ。收集到的评分随后会显示在优先级排序页面上该文档的旁边。对于网站调查等独立表单，请将两项留空。",
     "validationDocumentHint": "保留为整个项目，可在文档重新生成后仍保持关联。",
     "validationDocumentLabel": "文档（可选）",
+    "validationDocumentOption": "{{title}}（{{type}}）",
     "validationLoadingLink": "正在加载关联信息…",
     "validationNoProject": "-- 未关联 --",
     "validationProjectHint": "清空项目将解除此表单的关联。",

--- a/voc-datalake/frontend/src/i18n/config.ts
+++ b/voc-datalake/frontend/src/i18n/config.ts
@@ -11,8 +11,7 @@ import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
-import { LOCALE_LOAD_PATH } from './loadPath'
-import { supportedLanguages } from './languages'
+import { I18N_INIT_OPTIONS } from './options'
 
 // Language constants and the change helper live in ./languages (side-effect
 // free) so UI components can import them without triggering this module's
@@ -20,44 +19,14 @@ import { supportedLanguages } from './languages'
 export { supportedLanguages, languageNames, changeLanguage } from './languages'
 export type { SupportedLanguage } from './languages'
 
-const defaultNS = 'common'
-const namespaces = ['common', 'dashboard', 'dataExplorer', 'feedbackDetail', 'chat', 'login', 'settings', 'components', 'scrapers', 'feedbackForms', 'projects', 'categories', 'prioritization', 'problemAnalysis', 'projectDetail'] as const
-
+// The init options live in ./options for that same reason: a test can then assert
+// on the REAL config — that `nsSeparator` is still ':', which every
+// namespace-qualified key depends on — without executing this module's init.
 void i18n
   .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
-  .init({
-    // No `lng` pin: the language switcher (UserProfileModal) now drives the
-    // active language via localStorage('voc-language'), read by the detector
-    // below. First visit (no cached choice) falls back to English.
-    fallbackLng: 'en',
-    // Reject unsupported cached values (e.g. a stale regional variant) so a
-    // bad localStorage entry can't select a locale we don't ship.
-    supportedLngs: [...supportedLanguages],
-    nonExplicitSupportedLngs: false,
-    defaultNS,
-    ns: [...namespaces],
-
-    // Version-stamped path — see i18n/loadPath.ts for the cache-busting
-    // rationale (issue #191).
-    backend: { loadPath: LOCALE_LOAD_PATH },
-
-    detection: {
-      // 'navigator' is intentionally omitted: the user's explicit choice
-      // (persisted to localStorage by the switcher via caches below) is the
-      // only signal, so a non-English browser still gets English until the
-      // user opts in to another language.
-      order: ['localStorage'],
-      lookupLocalStorage: 'voc-language',
-      caches: ['localStorage'],
-    },
-
-    // React already escapes
-    interpolation: { escapeValue: false },
-
-    react: { useSuspense: true },
-  })
+  .init(I18N_INIT_OPTIONS)
   .then(() => {
     // Initial sync once detection has resolved (index.html defaults to "en").
     document.documentElement.lang = i18n.resolvedLanguage ?? 'en'

--- a/voc-datalake/frontend/src/i18n/config.ts
+++ b/voc-datalake/frontend/src/i18n/config.ts
@@ -22,11 +22,16 @@ export type { SupportedLanguage } from './languages'
 // The init options live in ./options for that same reason: a test can then assert
 // on the REAL config — that `nsSeparator` is still ':', which every
 // namespace-qualified key depends on — without executing this module's init.
+//
+// Spread, not the object itself: the test's assertions are only about the declared
+// config, so init() must not be able to write back into it. Shallow, which covers
+// every top-level option (`nsSeparator` among them); the nested `backend`,
+// `detection`, `interpolation` and `react` objects are still shared.
 void i18n
   .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
-  .init(I18N_INIT_OPTIONS)
+  .init({ ...I18N_INIT_OPTIONS })
   .then(() => {
     // Initial sync once detection has resolved (index.html defaults to "en").
     document.documentElement.lang = i18n.resolvedLanguage ?? 'en'

--- a/voc-datalake/frontend/src/i18n/options.ts
+++ b/voc-datalake/frontend/src/i18n/options.ts
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview The options object passed to `i18n.init()`, split out so it can be
+ * READ without running init.
+ *
+ * Same reason `./languages` is a separate module: importing `./config` executes
+ * `i18n.use(HttpBackend).use(LanguageDetector).init(...)` at module scope, which a
+ * test cannot do without a network backend and a browser language detector. The
+ * options themselves are plain data, so they can live here and be asserted on.
+ *
+ * What that buys, concretely: `nsSeparator` is not set, so it is i18next's default
+ * `':'`, and namespace-qualified keys like `prioritization:docType.prd` resolve
+ * from a `t` bound to any namespace. `SCORABLE_TYPE_META` depends on that — set
+ * `nsSeparator: false` here (a common workaround for keys that contain colons) and
+ * the Prioritization badge and the Feedback Forms document picker would both
+ * render the raw key path. `prioritizationUtils.test.ts` asserts against THIS
+ * object, so that change fails a test instead of shipping.
+ *
+ * @module i18n/options
+ */
+import type { InitOptions } from 'i18next'
+import { LOCALE_LOAD_PATH } from './loadPath'
+import { supportedLanguages } from './languages'
+
+export const DEFAULT_NS = 'common'
+
+export const NAMESPACES = ['common', 'dashboard', 'dataExplorer', 'feedbackDetail', 'chat', 'login', 'settings', 'components', 'scrapers', 'feedbackForms', 'projects', 'categories', 'prioritization', 'problemAnalysis', 'projectDetail'] as const
+
+export const I18N_INIT_OPTIONS: InitOptions = {
+  // No `lng` pin: the language switcher (UserProfileModal) now drives the
+  // active language via localStorage('voc-language'), read by the detector
+  // below. First visit (no cached choice) falls back to English.
+  fallbackLng: 'en',
+  // Reject unsupported cached values (e.g. a stale regional variant) so a
+  // bad localStorage entry can't select a locale we don't ship.
+  supportedLngs: [...supportedLanguages],
+  nonExplicitSupportedLngs: false,
+  defaultNS: DEFAULT_NS,
+  ns: [...NAMESPACES],
+  // Version-stamped path — see i18n/loadPath.ts for the cache-busting
+  // rationale (issue #191).
+  backend: { loadPath: LOCALE_LOAD_PATH },
+  detection: {
+    // 'navigator' is intentionally omitted: the user's explicit choice
+    // (persisted to localStorage by the switcher via caches below) is the
+    // only signal, so a non-English browser still gets English until the
+    // user opts in to another language.
+    order: ['localStorage'],
+    lookupLocalStorage: 'voc-language',
+    caches: ['localStorage'],
+  },
+  // React already escapes
+  interpolation: { escapeValue: false },
+  react: { useSuspense: true },
+}

--- a/voc-datalake/frontend/src/i18n/options.ts
+++ b/voc-datalake/frontend/src/i18n/options.ts
@@ -21,9 +21,14 @@ import type { InitOptions } from 'i18next'
 import { LOCALE_LOAD_PATH } from './loadPath'
 import { supportedLanguages } from './languages'
 
-export const DEFAULT_NS = 'common'
+// Module-private, as they were in config.ts: I18N_INIT_OPTIONS is the only thing
+// worth importing, and exporting these would add public surface nothing reads.
+// Note this is NOT the only copy of the namespace list — src/test/setup.ts,
+// scripts/i18n-check.mjs and scripts/fix-i18n.mjs each keep their own, as they did
+// before this move. Consolidating them is a separate change.
+const DEFAULT_NS = 'common'
 
-export const NAMESPACES = ['common', 'dashboard', 'dataExplorer', 'feedbackDetail', 'chat', 'login', 'settings', 'components', 'scrapers', 'feedbackForms', 'projects', 'categories', 'prioritization', 'problemAnalysis', 'projectDetail'] as const
+const NAMESPACES = ['common', 'dashboard', 'dataExplorer', 'feedbackDetail', 'chat', 'login', 'settings', 'components', 'scrapers', 'feedbackForms', 'projects', 'categories', 'prioritization', 'problemAnalysis', 'projectDetail'] as const
 
 export const I18N_INIT_OPTIONS: InitOptions = {
   // No `lng` pin: the language switcher (UserProfileModal) now drives the

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -105,6 +105,15 @@ async function openValidationTab(formName: string) {
 const projectSelect = () => screen.getByLabelText(t('feedbackForms:editor.validationProjectLabel'))
 const documentSelect = () => screen.getByLabelText(t('feedbackForms:editor.validationDocumentLabel'))
 
+/**
+ * The full option text for the `doc_prfaq` fixture: title, then its type.
+ *
+ * Spelled out as a literal rather than composed from `documentOptionLabel` — a
+ * test that builds the expected string the way the component does passes for any
+ * format, including one that drops the type entirely.
+ */
+const PRFAQ_OPTION_LABEL = 'Feature A PR/FAQ (PR/FAQ)'
+
 describe('validation link in the form editor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -182,7 +191,7 @@ describe('validation link in the form editor', () => {
     })
     await user.selectOptions(projectSelect(), 'p1')
     await waitFor(() => {
-      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+      expect(screen.getByText(PRFAQ_OPTION_LABEL)).toBeInTheDocument()
     })
     await user.selectOptions(documentSelect(), 'doc_prfaq')
     await user.click(screen.getByText('Save Changes'))
@@ -217,9 +226,11 @@ describe('validation link in the form editor', () => {
     await openValidationTab('PR/FAQ concept test')
 
     await waitFor(() => {
-      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+      expect(screen.getByText(PRFAQ_OPTION_LABEL)).toBeInTheDocument()
     })
-    expect(screen.queryByText('Research Notes')).not.toBeInTheDocument()
+    // Substring, not the full option text: what must not be offered is that
+    // document, under any label this picker might give it.
+    expect(screen.queryByText(/Research Notes/)).not.toBeInTheDocument()
   })
 
   it('keeps a link whose document no longer exists rather than silently clearing it', async () => {
@@ -279,7 +290,7 @@ describe('validation link in the form editor', () => {
     // Once it lands, the real title replaces the placeholder and no "missing"
     // label ever appeared.
     await waitFor(() => {
-      expect(screen.getByText('Feature A PR/FAQ')).toBeInTheDocument()
+      expect(screen.getByText(PRFAQ_OPTION_LABEL)).toBeInTheDocument()
     })
     expect(
       screen.queryByText(t('feedbackForms:editor.validationLoadingLink')),
@@ -379,14 +390,44 @@ describe('validation link in the form editor', () => {
     await openValidationTab('PR/FAQ concept test')
 
     await waitFor(() => {
-      expect(screen.getByText(`Doc ${scorableTypes[0]}`)).toBeInTheDocument()
+      expect(documentSelect().querySelectorAll('option').length).toBeGreaterThan(1)
     })
+    // Matched on the option's VALUE, not its text: the text now carries a
+    // per-type label this test deliberately knows nothing about — it asserts
+    // only that every scorable type is offered.
+    const optionValues = [...documentSelect().querySelectorAll('option')].map((o) => o.value)
     for (const type of scorableTypes) {
       expect(
-        screen.getByText(`Doc ${type}`),
+        optionValues,
         `${type} is scorable on Prioritization but the picker will not link to it`,
-      ).toBeInTheDocument()
+      ).toContain(`doc_${type}`)
     }
+  })
+
+  it('labels every option with the document type, not the title alone', async () => {
+    // The reason this matters: a project's PRD and PR/FAQ come from the same
+    // feature idea and routinely carry the SAME title, so a list of names cannot
+    // be used to pick between them — and they are separate rows on the
+    // Prioritization page, where this form's ratings then appear.
+    mockGetProject.mockResolvedValue({
+      project_id: 'p1',
+      documents: [
+        { document_id: 'doc_prd', document_type: 'prd', title: 'Instant payouts', content: '', created_at: '' },
+        { document_id: 'doc_prfaq', document_type: 'prfaq', title: 'Instant payouts', content: '', created_at: '' },
+      ],
+    })
+
+    await openValidationTab('PR/FAQ concept test')
+
+    // Full option text, spelled out: the two same-titled documents are now
+    // distinguishable, and each says which one it is.
+    await waitFor(() => {
+      expect(screen.getByText('Instant payouts (PRD)')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Instant payouts (PR/FAQ)')).toBeInTheDocument()
+    // And the bare title is no longer any option's text — if it were, the two
+    // would still be indistinguishable.
+    expect(screen.queryByText('Instant payouts')).not.toBeInTheDocument()
   })
 
   it('does not claim to be loading when the project list request fails', async () => {

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -229,8 +229,10 @@ describe('validation link in the form editor', () => {
       expect(screen.getByText(PRFAQ_OPTION_LABEL)).toBeInTheDocument()
     })
     // Substring, not the full option text: what must not be offered is that
-    // document, under any label this picker might give it.
-    expect(screen.queryByText(/Research Notes/)).not.toBeInTheDocument()
+    // document, under any label this picker might give it. queryAll, because
+    // queryBy throws on multiple matches — the failure would then read "found
+    // multiple elements" instead of naming the leak.
+    expect(screen.queryAllByText(/Research Notes/)).toHaveLength(0)
   })
 
   it('keeps a link whose document no longer exists rather than silently clearing it', async () => {

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.test.tsx
@@ -430,6 +430,28 @@ describe('validation link in the form editor', () => {
     expect(screen.queryByText('Instant payouts')).not.toBeInTheDocument()
   })
 
+  it('falls back to the document id when a record has no title', async () => {
+    // `ProjectDocument.title` is declared `string` but projectsApi has no schema
+    // at its boundary, so a legacy record without one reaches this render. Before
+    // the type label, `{doc.title}` rendered an empty option for it; interpolating
+    // it into a template would print the literal "undefined" to the admin.
+    mockGetProject.mockResolvedValue({
+      project_id: 'p1',
+      documents: [
+        { document_id: 'doc_untitled', document_type: 'prd', content: '', created_at: '' },
+        { document_id: 'doc_blank', document_type: 'prfaq', title: '   ', content: '', created_at: '' },
+      ],
+    })
+
+    await openValidationTab('PR/FAQ concept test')
+
+    await waitFor(() => {
+      expect(screen.getByText('doc_untitled (PRD)')).toBeInTheDocument()
+    })
+    expect(screen.getByText('doc_blank (PR/FAQ)')).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument()
+  })
+
   it('does not claim to be loading when the project list request fails', async () => {
     // A rejected query is not "loading" and it is not "no longer available"
     // either — nobody managed to look. Saying either is a false statement next

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -113,7 +113,14 @@ function storedOptionLabel(
  */
 function documentOptionLabel(doc: ProjectDocument, t: (key: string) => string): string {
   const typeMeta = SCORABLE_TYPE_META[doc.document_type]
-  return `${doc.title} (${typeMeta ? t(typeMeta.i18nKey) : doc.document_type})`
+  const typeLabel = typeMeta ? t(typeMeta.i18nKey) : doc.document_type
+  // `title` is declared `string` and `projectsApi` has no schema at its boundary,
+  // so nothing enforces that. It matters here and not before this change: `{title}`
+  // rendered an empty option for a missing title, while interpolating it prints the
+  // literal "undefined". Falling back to the id, the way DocumentsTab labels a
+  // revision with no title — an opaque id at least identifies the record.
+  const name = typeof doc.title === 'string' && doc.title.trim() !== '' ? doc.title : doc.document_id
+  return `${name} (${typeLabel})`
 }
 
 export default function ValidationLinkPicker({

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -100,18 +100,26 @@ function storedOptionLabel(
  * admin to link a form to a proposal they cannot tell apart — and the two are
  * separate rows on the Prioritization page, where the ratings then show up.
  *
- * `(TYPE)` after the name rather than before it, following `CheckboxItem` in
- * `pages/ProjectDetail/PickerComponents` — the repo's other picker that shows a
- * document's type inline — so the two read the same way.
+ * The COMPOSITION is a translation key, not a template literal in code: this
+ * catalogue's own CJK labels use full-width parentheses (`ドキュメント（任意）`,
+ * `文档（可选）`) while Korean uses half-width with no space, so building
+ * `name (type)` here would print the wrong punctuation into three locales. The
+ * key also lets a locale reorder the two parts. Name after type follows
+ * `CheckboxItem` in `pages/ProjectDetail/PickerComponents`, the repo's other
+ * picker that shows a document's type inline.
  *
- * The label comes from `SCORABLE_TYPE_META`, the same source as the badge on the
- * Prioritization row this link feeds, so the type is named identically in both
- * places. The raw `document_type` is the fallback: a type made scorable without
- * display metadata then reads as its own slug rather than as empty parentheses.
- * Unreachable today — the list is filtered by `isScorable`, which reads the very
- * table the label comes from — and kept because that coupling is not enforced.
+ * The type label comes from `SCORABLE_TYPE_META`, the same source as the badge on
+ * the Prioritization row this link feeds, so the type is named identically in
+ * both places. The raw `document_type` is the fallback: a type made scorable
+ * without display metadata then reads as its own slug rather than as an empty
+ * pair of parentheses. Unreachable today — the list is filtered by `isScorable`,
+ * which reads the very table the label comes from — and kept because that
+ * coupling is not enforced.
  */
-function documentOptionLabel(doc: ProjectDocument, t: (key: string) => string): string {
+function documentOptionLabel(
+  doc: ProjectDocument,
+  t: (key: string, options?: Record<string, string>) => string,
+): string {
   const typeMeta = SCORABLE_TYPE_META[doc.document_type]
   const typeLabel = typeMeta ? t(typeMeta.i18nKey) : doc.document_type
   // `title` is declared `string` and `projectsApi` has no schema at its boundary,
@@ -120,7 +128,7 @@ function documentOptionLabel(doc: ProjectDocument, t: (key: string) => string): 
   // literal "undefined". Falling back to the id, the way DocumentsTab labels a
   // revision with no title — an opaque id at least identifies the record.
   const name = typeof doc.title === 'string' && doc.title.trim() !== '' ? doc.title : doc.document_id
-  return `${name} (${typeLabel})`
+  return t('editor.validationDocumentOption', { title: name, type: typeLabel })
 }
 
 export default function ValidationLinkPicker({

--- a/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackForms/ValidationLinkPicker.tsx
@@ -17,8 +17,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { projectKey, projectsKey } from '../../api/projectQueryKeys'
 import { projectsApi } from '../../api/projectsApi'
-import { isScorable } from '../Prioritization/prioritizationUtils'
-import type { Project } from '../../api/types'
+import { isScorable, SCORABLE_TYPE_META } from '../Prioritization/prioritizationUtils'
+import type { Project, ProjectDocument } from '../../api/types'
 import type { ReactElement } from 'react'
 
 /** The link, as the editor holds it. '' on either field means "not set". */
@@ -89,6 +89,31 @@ function storedOptionLabel(
   return state === 'missing'
     ? t('editor.validationUnknownDocument')
     : t('editor.validationUnverifiedDocument')
+}
+
+/**
+ * One document's option text: its title, plus the type it is.
+ *
+ * The type is here because the title alone does not identify the document. A
+ * project's PRD and its PR/FAQ are generated from the same feature idea and
+ * routinely carry the same or near-identical titles, so a list of names asks the
+ * admin to link a form to a proposal they cannot tell apart — and the two are
+ * separate rows on the Prioritization page, where the ratings then show up.
+ *
+ * `(TYPE)` after the name rather than before it, following `CheckboxItem` in
+ * `pages/ProjectDetail/PickerComponents` — the repo's other picker that shows a
+ * document's type inline — so the two read the same way.
+ *
+ * The label comes from `SCORABLE_TYPE_META`, the same source as the badge on the
+ * Prioritization row this link feeds, so the type is named identically in both
+ * places. The raw `document_type` is the fallback: a type made scorable without
+ * display metadata then reads as its own slug rather than as empty parentheses.
+ * Unreachable today — the list is filtered by `isScorable`, which reads the very
+ * table the label comes from — and kept because that coupling is not enforced.
+ */
+function documentOptionLabel(doc: ProjectDocument, t: (key: string) => string): string {
+  const typeMeta = SCORABLE_TYPE_META[doc.document_type]
+  return `${doc.title} (${typeMeta ? t(typeMeta.i18nKey) : doc.document_type})`
 }
 
 export default function ValidationLinkPicker({
@@ -202,7 +227,9 @@ export default function ValidationLinkPicker({
               </option>
             )}
             {documents.map((doc) => (
-              <option key={doc.document_id} value={doc.document_id}>{doc.title}</option>
+              <option key={doc.document_id} value={doc.document_id}>
+                {documentOptionLabel(doc, t)}
+              </option>
             ))}
           </select>
           <p className="text-xs text-gray-500 mt-1">{t('editor.validationDocumentHint')}</p>

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -2,8 +2,10 @@
  * @fileoverview Tests for prioritizationUtils — safe score access and calculations.
  */
 import { describe, it, expect } from 'vitest'
+import i18n from 'i18next'
 import {
   getScore, calculatePriorityScore, collectPRFAQs, comparePRFAQs, DEFAULT_SCORE, isScorable,
+  SCORABLE_TYPE_META,
 } from './prioritizationUtils'
 import type { PrioritizationScore, ProjectDocument } from '../../api/types'
 
@@ -216,5 +218,42 @@ describe('StatsCards regression: scores with missing document_id', () => {
     const score = getScore(scores, 'missing')
     expect(() => calculatePriorityScore(score)).not.toThrow()
     expect(calculatePriorityScore(score)).toBeCloseTo(0.9)
+  })
+})
+
+describe('SCORABLE_TYPE_META display labels', () => {
+  // Bound to feedbackForms ON PURPOSE, not to prioritization: these keys are read
+  // from two namespaces — the badge in PRFAQRow (prioritization) and the document
+  // select in FeedbackForms/ValidationLinkPicker (feedbackForms) — and only the
+  // foreign binding can fail. A relative key resolves fine in its own namespace,
+  // so a test using `prioritization` passes with or without the prefix and proves
+  // nothing. This is the gate the badge itself never had: no Prioritization test
+  // asserts the badge text, so un-qualifying these keys left that suite green.
+  const t = i18n.getFixedT(null, 'feedbackForms')
+
+  it('resolve to real text, not the raw key path, from another namespace', () => {
+    const entries = Object.entries(SCORABLE_TYPE_META)
+    expect(entries.length, 'nothing is scorable — the constant is empty').toBeGreaterThan(0)
+
+    for (const [type, meta] of entries) {
+      if (!meta) throw new Error(`${type} has no display metadata`)
+      const label = t(meta.i18nKey)
+      expect(label, `${type}: '${meta.i18nKey}' does not resolve — the badge and the
+        document picker would both render this raw key path to users`)
+        .not.toBe(meta.i18nKey)
+      expect(label.trim(), `${type} resolves to an empty label`).not.toBe('')
+    }
+  })
+
+  it('name the scorable types PRD and PR/FAQ', () => {
+    // Pinned literals, not the catalogue value looked up the same way the code
+    // does: this is what a user reads on the Prioritization badge and in the
+    // document select, and it is the assertion that fails if a rename lands in
+    // one place only.
+    const { prd, prfaq } = SCORABLE_TYPE_META
+    if (!prd || !prfaq) throw new Error('prd/prfaq are no longer scorable — update this test')
+
+    expect(t(prd.i18nKey)).toBe('PRD')
+    expect(t(prfaq.i18nKey)).toBe('PR/FAQ')
   })
 })

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import i18n from 'i18next'
+import { I18N_INIT_OPTIONS } from '../../i18n/options'
 import {
   getScore, calculatePriorityScore, collectPRFAQs, comparePRFAQs, DEFAULT_SCORE, isScorable,
   SCORABLE_TYPE_META,
@@ -230,6 +231,23 @@ describe('SCORABLE_TYPE_META display labels', () => {
   // nothing. This is the gate the badge itself never had: no Prioritization test
   // asserts the badge text, so un-qualifying these keys left that suite green.
   const t = i18n.getFixedT(null, 'feedbackForms')
+
+  it("keep working only while the app's nsSeparator is ':' — assert the real config", () => {
+    // The resolution test below runs against the TEST i18n instance (src/test/setup.ts),
+    // so it would stay green if the APP disabled the namespace separator — a common
+    // workaround for keys that contain colons. I18N_INIT_OPTIONS is the object
+    // src/i18n/config.ts hands to init(), imported from a side-effect-free module so
+    // reading it here does not start the HTTP backend.
+    expect(
+      I18N_INIT_OPTIONS.nsSeparator ?? ':',
+      'the app disabled/changed nsSeparator — every `prioritization:docType.*` read '
+      + '(the Prioritization badge, the Feedback Forms document picker) now renders '
+      + 'the raw key path',
+    ).toBe(':')
+    // And the test instance must agree, or the assertion below tests a different
+    // resolver than the app ships.
+    expect(i18n.options.nsSeparator ?? ':').toBe(':')
+  })
 
   it('resolve to real text, not the raw key path, from another namespace', () => {
     const entries = Object.entries(SCORABLE_TYPE_META)

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -85,10 +85,17 @@ export function getScore(scores: Record<string, PrioritizationScore>, docId: str
  * when they carry a namespace (see `extractDataHeldKeys`), so without the prefix
  * these two are reported unused and become deletion candidates in a cleanup
  * pass, leaving the badge and the select rendering `docType.prd`.
+ *
+ * The prefix is in the TYPE, not only in the values: as a plain `string` field,
+ * dropping it was a valid compile and only a test stood between that and raw key
+ * paths in the UI. `tsc` now rejects it at the definition, and the resolution
+ * gate in `prioritizationUtils.test.ts` remains the runtime check — vitest runs
+ * through esbuild and does not typecheck, so the type alone would not have
+ * failed a suite.
  */
 export const SCORABLE_TYPE_META: Partial<Record<ProjectDocument['document_type'], {
   readonly badgeColor: string
-  readonly i18nKey: string
+  readonly i18nKey: `prioritization:${string}`
 }>> = {
   prd: { badgeColor: 'bg-blue-100 text-blue-700', i18nKey: 'prioritization:docType.prd' },
   prfaq: { badgeColor: 'bg-purple-100 text-purple-700', i18nKey: 'prioritization:docType.prfaq' },

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -74,14 +74,24 @@ export function getScore(scores: Record<string, PrioritizationScore>, docId: str
  * This is the single source of truth for which document types are scorable.
  * Keys are constrained to `ProjectDocument['document_type']`, so a typo or
  * stale entry is a compile error. Adding a new scorable type here automatically
- * propagates to `isScorable` and to the `DocumentTypeBadge` in `PRFAQRow`.
+ * propagates to `isScorable`, to the `DocumentTypeBadge` in `PRFAQRow`, and to
+ * the document select in `pages/FeedbackForms/ValidationLinkPicker`.
+ *
+ * `i18nKey` is namespace-QUALIFIED (`prioritization:…`) rather than relative,
+ * for two reasons. It is read through a `t` bound to another namespace — the
+ * validation-link picker's is `feedbackForms` — and a relative key would resolve
+ * against that namespace and render the raw path. And a bare `'docType.prd'` is
+ * invisible to `scripts/i18n-check.mjs`: keys held in data are only collected
+ * when they carry a namespace (see `extractDataHeldKeys`), so without the prefix
+ * these two are reported unused and become deletion candidates in a cleanup
+ * pass, leaving the badge and the select rendering `docType.prd`.
  */
 export const SCORABLE_TYPE_META: Partial<Record<ProjectDocument['document_type'], {
   readonly badgeColor: string
   readonly i18nKey: string
 }>> = {
-  prd: { badgeColor: 'bg-blue-100 text-blue-700', i18nKey: 'docType.prd' },
-  prfaq: { badgeColor: 'bg-purple-100 text-purple-700', i18nKey: 'docType.prfaq' },
+  prd: { badgeColor: 'bg-blue-100 text-blue-700', i18nKey: 'prioritization:docType.prd' },
+  prfaq: { badgeColor: 'bg-purple-100 text-purple-700', i18nKey: 'prioritization:docType.prfaq' },
 }
 
 export function isScorable(doc: ProjectDocument): boolean {


### PR DESCRIPTION
## Summary

The document `<select>` on the Feedback Forms editor's **Validates** tab listed titles only. A project's PRD and its PR/FAQ are generated from the same feature idea and routinely carry the same title, so an admin had to choose between two indistinguishable names — for a link that decides which **Prioritization** row that form's ratings show up on.

Each option now reads `Title (TYPE)`, e.g. `Instant payouts (PRD)` / `Instant payouts (PR/FAQ)`.

`(TYPE)` after the name, following `CheckboxItem` in `pages/ProjectDetail/PickerComponents` — the repo's other picker that shows a document's type inline — so the two read the same way. This was the only document picker that did not show the type; the DataSourceWizard, the prototype source picker and the Documents list cards already did.

## Changes

- **`ValidationLinkPicker.tsx`** — `documentOptionLabel()` composes the option text. The type label resolves from `SCORABLE_TYPE_META`, the same source as the badge on the Prioritization row this link feeds, so the two cannot disagree.
- **`prioritizationUtils.ts`** — `SCORABLE_TYPE_META`'s `i18nKey` is now namespace-qualified (`prioritization:docType.prd`). Two reasons, both load-bearing:
  - It is read here through a `t` bound to `feedbackForms`. A relative key resolves against *that* namespace and renders the raw key path to the user.
  - `scripts/i18n-check.mjs` only collects data-held keys that carry a namespace (`extractDataHeldKeys`). Both keys were on the "not directly referenced" list and were therefore deletion candidates in a cleanup pass. That list drops 635 → 633.
- **Missing-title guard** — `projectsApi` has no schema at its boundary, so `ProjectDocument.title` being declared `string` enforces nothing. `{doc.title}` rendered an empty option for a legacy record without one; interpolating it into a template prints the literal `undefined`. Falls back to the document id, as `DocumentsTab` does for a revision with no title.

## Testing

- **2458/2458** frontend tests, `tsc --noEmit` and eslint clean.
- `i18n-check.mjs` output identical to baseline apart from the two keys becoming referenced.
- New tests: option labelling with two **same-titled** documents (the motivating case, asserting the bare title is no longer any option's text); the titleless/blank-title fallback; and a resolution gate over every `SCORABLE_TYPE_META` entry.
- **The label gate binds `t` to a foreign namespace on purpose.** No Prioritization test asserts the badge text, so un-qualifying the keys left that entire suite green — a `prioritization`-bound test would pass with or without the prefix and prove nothing.
- **4 mutations run, each caught, file restored after**: drop the type from the label; drop the namespace prefix (twice — once against the picker's suite, once against the new gate in isolation); delete the missing-title guard. Every run asserted a green baseline first, so the failures mean something.

## Not covered

No live browser check at PR time — the assertions are jsdom, which covers the option text but not how a native `select` popup renders at narrow widths.
