### PR TITLE
test(i18n): gate the init options, above all the namespace list

### DIFF
--- a/voc-datalake/frontend/scripts/fix-i18n.mjs
+++ b/voc-datalake/frontend/scripts/fix-i18n.mjs
@@ -12,8 +12,12 @@ import { execFileSync } from 'node:child_process'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const LOCALES_DIR = resolve(__dirname, '..', 'public', 'locales')
+// Must match the shipped catalogues in public/locales/<lang>/ — `src/i18n/options.test.ts`
+// compares this list, i18n-check.mjs's copy, src/i18n/options.ts and src/test/setup.ts
+// against the files on disk. `feedback` was listed here with no catalogue in any
+// locale, so every run tried to load a namespace that does not exist.
 const NAMESPACES = ['categories', 'chat', 'common', 'components', 'dashboard',
-  'dataExplorer', 'feedback', 'feedbackDetail', 'feedbackForms', 'login',
+  'dataExplorer', 'feedbackDetail', 'feedbackForms', 'login',
   'prioritization', 'problemAnalysis', 'projectDetail', 'projects', 'scrapers', 'settings']
 const LANGUAGES = ['es', 'fr', 'de', 'ko', 'pt', 'ja', 'zh']
 const LANG_NAMES = {

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -1,101 +1,220 @@
 /**
- * @fileoverview Gates on the i18n init options.
+ * @fileoverview Gates on the i18n init options, and on the namespace list in
+ * particular.
  *
  * These exist because the options moved out of `config.ts` into `options.ts` and
  * NOTHING imports `config.ts` in a test — it runs `init()` with an HTTP backend at
- * module scope. So every option in it was, and would remain, untested: drop
+ * module scope. So every option in it was, and would have remained, untested: drop
  * `supportedLngs` and the app still boots, just without the guard that rejects a
  * stale cached locale.
  *
  * The load-bearing one is the namespace list. A page that calls
  * `useTranslation('somewhere')` for a namespace absent from `ns` does not throw —
  * i18next resolves nothing and the page renders raw key paths. That is the same
- * failure this module's own history is made of (a relative key read through the
- * wrong namespace, and a data-held key invisible to the i18n gate), and
- * `scripts/i18n-check.mjs` cannot catch it: its own `NAMESPACES` array is a
- * separate hardcoded copy, so it validates keys against the namespaces IT knows,
- * never against the ones the app registers.
+ * failure this module's history is made of, and `scripts/i18n-check.mjs` cannot
+ * catch it: its own `NAMESPACES` array is a separate hardcoded copy, so it
+ * validates keys against the namespaces IT knows, never against the ones the app
+ * registers.
+ *
+ * The reference for "which namespaces exist" is the shipped catalogue files, not
+ * any of the four hardcoded lists — a namespace IS a catalogue.
  */
 import { describe, it, expect } from 'vitest'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { join, extname } from 'node:path'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, extname, basename } from 'node:path'
+import i18n from 'i18next'
 import { I18N_INIT_OPTIONS } from './options'
 
 const SRC = join(__dirname, '..')
+const FRONTEND = join(SRC, '..')
+const LOCALES_EN = join(FRONTEND, 'public', 'locales', 'en')
+const SCRIPTS = join(FRONTEND, 'scripts')
+
+/** The namespaces actually shipped: one catalogue file each. */
+function shippedNamespaces(): string[] {
+  return readdirSync(LOCALES_EN)
+    .filter((f) => extname(f) === '.json')
+    .map((f) => basename(f, '.json'))
+    .sort()
+}
+
+/**
+ * Parse a `const NAME = ['a', 'b']` array literal out of a script.
+ *
+ * Throws rather than returning empty on a miss: an unparsed list would make every
+ * comparison below trivially pass.
+ */
+function arrayLiteral(file: string, variable: string): string[] {
+  const text = readFileSync(file, 'utf-8')
+  const match = new RegExp(`${variable}\\s*=\\s*\\[([^\\]]*)\\]`, 's').exec(text)
+  if (!match) throw new Error(`${basename(file)}: could not find the ${variable} array`)
+  const items = [...match[1].matchAll(/['"](\w+)['"]/g)].map((m) => m[1])
+  if (items.length === 0) throw new Error(`${basename(file)}: ${variable} parsed as empty`)
+  return items.sort()
+}
 
 /**
  * Drop comments before scanning.
  *
- * Not fussiness: this file's own docblocks discuss the shape of a translation key
- * (`xKey: 'ns:key'`), and a naive scan reads that prose as a namespace called `ns`
- * and reports the app as broken. `scripts/i18n-check.mjs` has the same blind spot
- * and warns about that exact comment.
+ * Not fussiness: a docblock in `ValidationLinkPicker.tsx` discusses the shape of a
+ * translation key (`xKey: 'ns:key'`), and a naive scan reads that prose as a
+ * namespace called `ns` and reports the app as broken. It did, on the first run.
+ * `scripts/i18n-check.mjs` has the same blind spot and warns about that comment.
  *
- * Block comments and whole-line comments only — a `//` inside a string literal (a
- * URL) is left alone, so no line of real code is truncated.
+ * Block comments are stripped only where `/*` opens the line, so a `/*` inside a
+ * string or regex literal cannot pair with a later `*␘/` and delete real code
+ * between them — that would be a false negative, the worse direction for a gate.
  */
 function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .split('\n')
-    .filter((line) => {
-      const t = line.trim()
-      return !t.startsWith('//') && !t.startsWith('*')
-    })
-    .join('\n')
+  const lines = source.split('\n')
+  const kept: string[] = []
+  let inBlock = false
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (inBlock) {
+      if (trimmed.includes('*/')) inBlock = false
+      continue
+    }
+    if (trimmed.startsWith('/*')) {
+      if (!trimmed.includes('*/')) inBlock = true
+      continue
+    }
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue
+    kept.push(line)
+  }
+  return kept.join('\n')
 }
 
-/** Every namespace the source asks `useTranslation` for, or addresses as `ns:key`. */
-function namespacesReferencedInSource(): Set<string> {
-  const found = new Set<string>()
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir)) {
-      if (entry === 'node_modules' || entry === 'test') continue
-      const full = join(dir, entry)
-      if (statSync(full).isDirectory()) {
-        walk(full)
-        continue
-      }
-      if (!['.ts', '.tsx'].includes(extname(entry))) continue
-      // Test files are excluded deliberately: they address namespaces directly
-      // (`t('feedbackForms:...')`) for assertions, which is not the app asking
-      // i18next to load one.
-      if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) continue
-      const source = stripComments(readFileSync(full, 'utf-8'))
-      for (const [, ns] of source.matchAll(/useTranslation\(\s*['"](\w+)['"]/g)) found.add(ns)
-      for (const [, ns] of source.matchAll(/\bt\(\s*['"](\w+):/g)) found.add(ns)
-      // Namespace-qualified keys held in data and passed to t() indirectly — the
-      // shape SCORABLE_TYPE_META uses. Same extraction rule as i18n-check.mjs.
-      for (const [, ns] of source.matchAll(/\b\w*[Kk]ey:\s*['"](\w+):[\w.]+['"]/g)) found.add(ns)
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'test' || entry.name === '__tests__') continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      sourceFiles(full, acc)
+      continue
+    }
+    if (!['.ts', '.tsx'].includes(extname(entry.name))) continue
+    // Tests address namespaces directly for their assertions, which is not the app
+    // asking i18next to load one.
+    if (/\.(test|spec)\.tsx?$/.test(entry.name)) continue
+    acc.push(full)
+  }
+  return acc
+}
+
+/**
+ * Every namespace the app asks i18next for, and how many files were read to find
+ * them (returned so a broken walk cannot look like a clean result).
+ *
+ * Forms understood:
+ *   useTranslation('ns')            — single string
+ *   useTranslation(['a', 'b'])      — array, which IS used (Categories/FeedbackResults)
+ *   t('ns:key')                     — qualified key
+ *   somethingKey: 'ns:key'          — namespace-qualified key held in data
+ *
+ *   tr('ns:key')                    — where `t` was renamed (`{ t: tr }`), which
+ *                                     Chat.tsx does; the alias is resolved per file
+ *                                     rather than banned, since a bare key through a
+ *                                     renamed `t` is perfectly correct
+ *
+ * The one form that cannot be resolved statically — a namespace passed as a variable
+ * or template literal — is asserted absent by a test below rather than left as a
+ * silent blind spot.
+ */
+function scanSource(): { namespaces: Set<string>; filesScanned: number } {
+  const namespaces = new Set<string>()
+  const files = sourceFiles(SRC)
+  for (const file of files) {
+    const source = stripComments(readFileSync(file, 'utf-8'))
+    for (const [, ns] of source.matchAll(/useTranslation\(\s*['"](\w+)['"]/g)) namespaces.add(ns)
+    for (const [, list] of source.matchAll(/useTranslation\(\s*\[([^\]]*)\]/g)) {
+      for (const [, ns] of list.matchAll(/['"](\w+)['"]/g)) namespaces.add(ns)
+    }
+    for (const [, ns] of source.matchAll(/\b\w*[Kk]ey:\s*['"](\w+):[\w.]+['"]/g)) namespaces.add(ns)
+
+    // `t` plus every name `t` was renamed to in this file, so a qualified key
+    // reached through an alias is not invisible.
+    const callers = new Set(['t'])
+    for (const [, alias] of source.matchAll(/\bt\s*:\s*(\w+)/g)) callers.add(alias)
+    for (const caller of callers) {
+      const qualified = new RegExp(`\\b${caller}\\(\\s*['"](\\w+):`, 'g')
+      for (const [, ns] of source.matchAll(qualified)) namespaces.add(ns)
     }
   }
-  walk(SRC)
-  return found
+  return { namespaces, filesScanned: files.length }
 }
 
 describe('I18N_INIT_OPTIONS', () => {
   it('registers every namespace the app actually asks for', () => {
     const registered = new Set(I18N_INIT_OPTIONS.ns as string[])
-    const referenced = namespacesReferencedInSource()
+    const { namespaces, filesScanned } = scanSource()
 
-    // Guard against the scan silently finding nothing — a broken walk would make
-    // the assertion below pass over an empty set.
-    expect(referenced.size, 'the source scan found no namespaces at all')
-      .toBeGreaterThan(5)
-    expect(referenced.has('feedbackForms'), 'scan missed a known namespace').toBe(true)
-    expect(referenced.has('prioritization'), 'scan missed the data-held namespace').toBe(true)
+    // Liveness, structural rather than by name: a walk that silently returns
+    // nothing would make the assertion below pass over an empty set. Names are
+    // deliberately not pinned here — a legitimately renamed namespace should not
+    // fail as though the app were broken.
+    expect(filesScanned, 'the source walk found almost no files').toBeGreaterThan(100)
+    const shipped = shippedNamespaces()
+    expect(
+      [...namespaces].filter((ns) => shipped.includes(ns)).length,
+      'the scan matched no shipped namespace at all — it is not reading source',
+    ).toBeGreaterThan(3)
 
-    const unregistered = [...referenced].filter((ns) => !registered.has(ns))
+    const unregistered = [...namespaces].filter((ns) => !registered.has(ns))
     expect(
       unregistered,
-      'these namespaces are used in source but not in I18N_INIT_OPTIONS.ns — '
-      + 'i18next will resolve nothing for them and the UI renders raw key paths',
+      'used in source but absent from I18N_INIT_OPTIONS.ns — i18next resolves '
+      + 'nothing for these and the UI renders raw key paths',
     ).toEqual([])
   })
 
+  it('sees every form the source uses to name a namespace', () => {
+    // The gate's own fidelity, asserted rather than assumed: a scan that silently
+    // under-matches reads green on exactly the defect it exists to catch.
+    //
+    // Only one form is unresolvable by any static scan — a namespace that is not a
+    // literal. The renamed-`t` and array forms are both IN USE (Chat.tsx,
+    // Categories/FeedbackResults.tsx) and `scanSource` handles them, so banning
+    // them would fail on correct code.
+    const offenders: string[] = []
+    for (const file of sourceFiles(SRC)) {
+      const source = stripComments(readFileSync(file, 'utf-8'))
+      for (const match of source.matchAll(/useTranslation\(\s*([^)]{0,40})/g)) {
+        const arg = match[1].trim()
+        if (arg === '' || arg.startsWith(')')) continue      // useTranslation()
+        if (/^['"[]/.test(arg)) continue                     // literal or array
+        offenders.push(`${file}: useTranslation(${arg.slice(0, 24)}…)`)
+      }
+    }
+    expect(
+      offenders,
+      'a namespace passed as a variable or template literal cannot be resolved '
+      + 'statically, so the gate above would silently stop covering it',
+    ).toEqual([])
+  })
+
+  it('keeps all four copies of the namespace list in step with the shipped catalogues', () => {
+    // The root cause the previous test only mitigates: the list is duplicated four
+    // times. The shipped catalogue files are the reference — a namespace IS a
+    // catalogue — so each copy is compared against them rather than against each
+    // other, which would let all four drift together.
+    const shipped = shippedNamespaces()
+    expect(shipped.length, 'no catalogues found — wrong locales path').toBeGreaterThan(5)
+
+    expect([...(I18N_INIT_OPTIONS.ns as string[])].sort(), 'src/i18n/options.ts').toEqual(shipped)
+    expect(arrayLiteral(join(SCRIPTS, 'i18n-check.mjs'), 'NAMESPACES'), 'scripts/i18n-check.mjs')
+      .toEqual(shipped)
+    expect(arrayLiteral(join(SCRIPTS, 'fix-i18n.mjs'), 'NAMESPACES'), 'scripts/fix-i18n.mjs')
+      .toEqual(shipped)
+    // The fourth copy is src/test/setup.ts's `namespaceResources`; the harness has
+    // already initialised i18next from it, so read the live value instead of
+    // re-parsing the file.
+    expect([...(i18n.options.ns as string[])].sort(), 'src/test/setup.ts').toEqual(shipped)
+  })
+
   it('keeps the options that are load-bearing rather than cosmetic', () => {
-    // One assertion per behaviour, with the behaviour named: a bare snapshot of
-    // this object would fail on any edit without saying what broke.
+    // One assertion per behaviour, with the behaviour named: a snapshot of this
+    // object would fail on any edit without saying what broke.
     expect(I18N_INIT_OPTIONS.fallbackLng, 'first visit must land on English').toBe('en')
     expect(
       I18N_INIT_OPTIONS.nonExplicitSupportedLngs,

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -20,7 +20,7 @@
  * any of the four hardcoded lists — a namespace IS a catalogue.
  */
 import { describe, it, expect } from 'vitest'
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join, extname, basename } from 'node:path'
 import i18n from 'i18next'
 import { I18N_INIT_OPTIONS } from './options'
@@ -44,12 +44,16 @@ function shippedNamespaces(): string[] {
   return cataloguesIn(LOCALES_EN)
 }
 
-/** Every locale directory, `en` included. */
-function localeDirs(): string[] {
-  return readdirSync(LOCALES, { withFileTypes: true })
-    .filter((e) => e.isDirectory())
-    .map((e) => e.name)
-    .sort()
+/**
+ * The locales to check: the ones the app declares support for, not every directory
+ * under `public/locales`.
+ *
+ * Reading the filesystem would make an unrelated subdirectory (`_templates/`) fail
+ * the parity test with a message about catalogues. `supportedLngs` is also the more
+ * meaningful set — it is what the language detector will accept.
+ */
+function supportedLocales(): string[] {
+  return [...(I18N_INIT_OPTIONS.supportedLngs as string[])].sort()
 }
 
 /**
@@ -149,11 +153,18 @@ function scanSource(): { namespaces: Set<string>; filesScanned: number } {
     // `t` plus every name `t` was renamed to in this file, so a qualified key
     // reached through an alias is not invisible.
     //
-    // Scoped to a destructuring pattern on purpose: a bare `/\bt\s*:\s*(\w+)/`
-    // also matches type annotations and parameters (`{ t: TFunction }`,
-    // `(t: number)`), which would add meaningless names to the caller set. The
-    // negated class spans newlines, so a multi-line destructuring still matches —
-    // which it must, because Chat.tsx's rename is in one.
+    // Brace-scoped, which drops bare `(t: number)` parameters. It does NOT
+    // distinguish a destructuring from a type literal — `{ t: TFunction }` still
+    // contributes `TFunction` — and that is fine rather than fixed, because the
+    // two directions are not symmetric: an extra caller name matches no call site
+    // and changes nothing, while a MISSED alias is the silent blind spot this
+    // whole scan exists to avoid. So the regex is deliberately generous.
+    //
+    // Caveat worth knowing: `[^{}]*` cannot cross a nested object, so a future
+    // `const { data: { x }, t: tr }` would drop out of the caller set. Unused today.
+    //
+    // The negated class spans newlines, which it must — Chat.tsx's rename is in a
+    // multi-line destructuring.
     const callers = new Set(['t'])
     for (const [, alias] of source.matchAll(/\{[^{}]*\bt\s*:\s*(\w+)/g)) callers.add(alias)
     for (const caller of callers) {
@@ -242,12 +253,18 @@ describe('I18N_INIT_OPTIONS', () => {
     // would skip that file forever. The reverse, a locale missing a catalogue `en`
     // ships, means that whole page falls back to English with no other signal.
     const shipped = shippedNamespaces()
-    const locales = localeDirs()
-    expect(locales, 'no locale directories found — wrong path').toContain('en')
-    expect(locales.length, 'only one locale found; parity across locales is untested')
+    const locales = supportedLocales()
+    expect(locales, 'supportedLngs must include the reference locale').toContain('en')
+    expect(locales.length, 'only one locale supported; parity across locales is untested')
       .toBeGreaterThan(1)
 
     for (const locale of locales) {
+      // A declared locale with no directory at all is the sharper failure, so name it
+      // rather than letting readdirSync throw ENOENT.
+      expect(
+        existsSync(join(LOCALES, locale)),
+        `${locale} is in supportedLngs but ships no catalogue directory`,
+      ).toBe(true)
       expect(cataloguesIn(join(LOCALES, locale)), `locale ${locale}`).toEqual(shipped)
     }
   })

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -276,9 +276,10 @@ describe('I18N_INIT_OPTIONS', () => {
     // would reduce coverage instead of failing. Set equality first, then iterate.
     expect(
       localeDirsOnDisk(),
-      'catalogue directories and supportedLngs must be the same set — a directory '
-      + 'missing here ships translations nothing can select; one missing there is a '
-      + 'locale the detector accepts with no catalogues to load',
+      'locale directories on disk (received) must equal supportedLngs (expected). '
+      + 'Extra on disk = translations shipped that the detector will never select. '
+      + 'Extra in supportedLngs = a locale the detector accepts with no catalogues '
+      + 'to load.',
     ).toEqual(locales)
 
     for (const locale of locales) {

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -20,7 +20,7 @@
  * any of the four hardcoded lists — a namespace IS a catalogue.
  */
 import { describe, it, expect } from 'vitest'
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join, extname, basename } from 'node:path'
 import i18n from 'i18next'
 import { I18N_INIT_OPTIONS } from './options'
@@ -44,16 +44,28 @@ function shippedNamespaces(): string[] {
   return cataloguesIn(LOCALES_EN)
 }
 
-/**
- * The locales to check: the ones the app declares support for, not every directory
- * under `public/locales`.
- *
- * Reading the filesystem would make an unrelated subdirectory (`_templates/`) fail
- * the parity test with a message about catalogues. `supportedLngs` is also the more
- * meaningful set — it is what the language detector will accept.
- */
+/** The locales the app declares support for — what the detector will accept. */
 function supportedLocales(): string[] {
   return [...(I18N_INIT_OPTIONS.supportedLngs as string[])].sort()
+}
+
+/**
+ * Directories under `public/locales` that are not locales.
+ *
+ * A convention rather than a name list: anything starting with `_` or `.` is
+ * infrastructure (templates, tooling, dotfiles). Without this, such a directory
+ * fails the parity test with a message about missing catalogues.
+ */
+function isIgnoredLocaleDir(name: string): boolean {
+  return name.startsWith('_') || name.startsWith('.')
+}
+
+/** Locale directories present on disk, ignoring non-locale infrastructure. */
+function localeDirsOnDisk(): string[] {
+  return readdirSync(LOCALES, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !isIgnoredLocaleDir(e.name))
+    .map((e) => e.name)
+    .sort()
 }
 
 /**
@@ -258,13 +270,18 @@ describe('I18N_INIT_OPTIONS', () => {
     expect(locales.length, 'only one locale supported; parity across locales is untested')
       .toBeGreaterThan(1)
 
+    // Both directions, because deriving the loop from `supportedLngs` alone would
+    // quietly shrink this gate: a shipped directory absent from `supportedLngs`
+    // would never be visited, and pruning an entry while its catalogues stay on disk
+    // would reduce coverage instead of failing. Set equality first, then iterate.
+    expect(
+      localeDirsOnDisk(),
+      'catalogue directories and supportedLngs must be the same set — a directory '
+      + 'missing here ships translations nothing can select; one missing there is a '
+      + 'locale the detector accepts with no catalogues to load',
+    ).toEqual(locales)
+
     for (const locale of locales) {
-      // A declared locale with no directory at all is the sharper failure, so name it
-      // rather than letting readdirSync throw ENOENT.
-      expect(
-        existsSync(join(LOCALES, locale)),
-        `${locale} is in supportedLngs but ships no catalogue directory`,
-      ).toBe(true)
       expect(cataloguesIn(join(LOCALES, locale)), `locale ${locale}`).toEqual(shipped)
     }
   })

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview Gates on the i18n init options.
+ *
+ * These exist because the options moved out of `config.ts` into `options.ts` and
+ * NOTHING imports `config.ts` in a test — it runs `init()` with an HTTP backend at
+ * module scope. So every option in it was, and would remain, untested: drop
+ * `supportedLngs` and the app still boots, just without the guard that rejects a
+ * stale cached locale.
+ *
+ * The load-bearing one is the namespace list. A page that calls
+ * `useTranslation('somewhere')` for a namespace absent from `ns` does not throw —
+ * i18next resolves nothing and the page renders raw key paths. That is the same
+ * failure this module's own history is made of (a relative key read through the
+ * wrong namespace, and a data-held key invisible to the i18n gate), and
+ * `scripts/i18n-check.mjs` cannot catch it: its own `NAMESPACES` array is a
+ * separate hardcoded copy, so it validates keys against the namespaces IT knows,
+ * never against the ones the app registers.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, extname } from 'node:path'
+import { I18N_INIT_OPTIONS } from './options'
+
+const SRC = join(__dirname, '..')
+
+/**
+ * Drop comments before scanning.
+ *
+ * Not fussiness: this file's own docblocks discuss the shape of a translation key
+ * (`xKey: 'ns:key'`), and a naive scan reads that prose as a namespace called `ns`
+ * and reports the app as broken. `scripts/i18n-check.mjs` has the same blind spot
+ * and warns about that exact comment.
+ *
+ * Block comments and whole-line comments only — a `//` inside a string literal (a
+ * URL) is left alone, so no line of real code is truncated.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim()
+      return !t.startsWith('//') && !t.startsWith('*')
+    })
+    .join('\n')
+}
+
+/** Every namespace the source asks `useTranslation` for, or addresses as `ns:key`. */
+function namespacesReferencedInSource(): Set<string> {
+  const found = new Set<string>()
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry === 'test') continue
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        walk(full)
+        continue
+      }
+      if (!['.ts', '.tsx'].includes(extname(entry))) continue
+      // Test files are excluded deliberately: they address namespaces directly
+      // (`t('feedbackForms:...')`) for assertions, which is not the app asking
+      // i18next to load one.
+      if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) continue
+      const source = stripComments(readFileSync(full, 'utf-8'))
+      for (const [, ns] of source.matchAll(/useTranslation\(\s*['"](\w+)['"]/g)) found.add(ns)
+      for (const [, ns] of source.matchAll(/\bt\(\s*['"](\w+):/g)) found.add(ns)
+      // Namespace-qualified keys held in data and passed to t() indirectly — the
+      // shape SCORABLE_TYPE_META uses. Same extraction rule as i18n-check.mjs.
+      for (const [, ns] of source.matchAll(/\b\w*[Kk]ey:\s*['"](\w+):[\w.]+['"]/g)) found.add(ns)
+    }
+  }
+  walk(SRC)
+  return found
+}
+
+describe('I18N_INIT_OPTIONS', () => {
+  it('registers every namespace the app actually asks for', () => {
+    const registered = new Set(I18N_INIT_OPTIONS.ns as string[])
+    const referenced = namespacesReferencedInSource()
+
+    // Guard against the scan silently finding nothing — a broken walk would make
+    // the assertion below pass over an empty set.
+    expect(referenced.size, 'the source scan found no namespaces at all')
+      .toBeGreaterThan(5)
+    expect(referenced.has('feedbackForms'), 'scan missed a known namespace').toBe(true)
+    expect(referenced.has('prioritization'), 'scan missed the data-held namespace').toBe(true)
+
+    const unregistered = [...referenced].filter((ns) => !registered.has(ns))
+    expect(
+      unregistered,
+      'these namespaces are used in source but not in I18N_INIT_OPTIONS.ns — '
+      + 'i18next will resolve nothing for them and the UI renders raw key paths',
+    ).toEqual([])
+  })
+
+  it('keeps the options that are load-bearing rather than cosmetic', () => {
+    // One assertion per behaviour, with the behaviour named: a bare snapshot of
+    // this object would fail on any edit without saying what broke.
+    expect(I18N_INIT_OPTIONS.fallbackLng, 'first visit must land on English').toBe('en')
+    expect(
+      I18N_INIT_OPTIONS.nonExplicitSupportedLngs,
+      'must stay false, or a regional variant we do not ship can be selected',
+    ).toBe(false)
+    expect(
+      (I18N_INIT_OPTIONS.supportedLngs as string[] | undefined)?.length,
+      'without supportedLngs a stale localStorage value selects an unshipped locale',
+    ).toBeGreaterThan(1)
+    expect(
+      I18N_INIT_OPTIONS.detection?.order,
+      "detection must read ONLY the user's stored choice — 'navigator' is "
+      + 'deliberately absent so a non-English browser still gets English',
+    ).toEqual(['localStorage'])
+    expect(I18N_INIT_OPTIONS.detection?.lookupLocalStorage).toBe('voc-language')
+    expect(
+      I18N_INIT_OPTIONS.interpolation?.escapeValue,
+      'React escapes already; true would double-escape every interpolated value',
+    ).toBe(false)
+  })
+})

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -27,14 +27,28 @@ import { I18N_INIT_OPTIONS } from './options'
 
 const SRC = join(__dirname, '..')
 const FRONTEND = join(SRC, '..')
-const LOCALES_EN = join(FRONTEND, 'public', 'locales', 'en')
+const LOCALES = join(FRONTEND, 'public', 'locales')
+const LOCALES_EN = join(LOCALES, 'en')
 const SCRIPTS = join(FRONTEND, 'scripts')
 
-/** The namespaces actually shipped: one catalogue file each. */
-function shippedNamespaces(): string[] {
-  return readdirSync(LOCALES_EN)
+/** Catalogue names in one locale directory. */
+function cataloguesIn(dir: string): string[] {
+  return readdirSync(dir)
     .filter((f) => extname(f) === '.json')
     .map((f) => basename(f, '.json'))
+    .sort()
+}
+
+/** The namespaces actually shipped: one catalogue file each, per `en`. */
+function shippedNamespaces(): string[] {
+  return cataloguesIn(LOCALES_EN)
+}
+
+/** Every locale directory, `en` included. */
+function localeDirs(): string[] {
+  return readdirSync(LOCALES, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
     .sort()
 }
 
@@ -134,8 +148,14 @@ function scanSource(): { namespaces: Set<string>; filesScanned: number } {
 
     // `t` plus every name `t` was renamed to in this file, so a qualified key
     // reached through an alias is not invisible.
+    //
+    // Scoped to a destructuring pattern on purpose: a bare `/\bt\s*:\s*(\w+)/`
+    // also matches type annotations and parameters (`{ t: TFunction }`,
+    // `(t: number)`), which would add meaningless names to the caller set. The
+    // negated class spans newlines, so a multi-line destructuring still matches —
+    // which it must, because Chat.tsx's rename is in one.
     const callers = new Set(['t'])
-    for (const [, alias] of source.matchAll(/\bt\s*:\s*(\w+)/g)) callers.add(alias)
+    for (const [, alias] of source.matchAll(/\{[^{}]*\bt\s*:\s*(\w+)/g)) callers.add(alias)
     for (const caller of callers) {
       const qualified = new RegExp(`\\b${caller}\\(\\s*['"](\\w+):`, 'g')
       for (const [, ns] of source.matchAll(qualified)) namespaces.add(ns)
@@ -153,7 +173,10 @@ describe('I18N_INIT_OPTIONS', () => {
     // nothing would make the assertion below pass over an empty set. Names are
     // deliberately not pinned here — a legitimately renamed namespace should not
     // fail as though the app were broken.
-    expect(filesScanned, 'the source walk found almost no files').toBeGreaterThan(100)
+    // A floor that says "the walk ran", not an assertion about how much code exists:
+    // a high threshold would fail on a legitimate large deletion. A broken walk
+    // returns 0 or a handful.
+    expect(filesScanned, 'the source walk found almost no files').toBeGreaterThan(20)
     const shipped = shippedNamespaces()
     expect(
       [...namespaces].filter((ns) => shipped.includes(ns)).length,
@@ -181,7 +204,7 @@ describe('I18N_INIT_OPTIONS', () => {
       const source = stripComments(readFileSync(file, 'utf-8'))
       for (const match of source.matchAll(/useTranslation\(\s*([^)]{0,40})/g)) {
         const arg = match[1].trim()
-        if (arg === '' || arg.startsWith(')')) continue      // useTranslation()
+        if (arg === '') continue                             // useTranslation()
         if (/^['"[]/.test(arg)) continue                     // literal or array
         offenders.push(`${file}: useTranslation(${arg.slice(0, 24)}…)`)
       }
@@ -210,6 +233,23 @@ describe('I18N_INIT_OPTIONS', () => {
     // already initialised i18next from it, so read the live value instead of
     // re-parsing the file.
     expect([...(i18n.options.ns as string[])].sort(), 'src/test/setup.ts').toEqual(shipped)
+  })
+
+  it('ships the same catalogue set in every locale', () => {
+    // Because the check above uses `en` as the reference, an orphan catalogue in
+    // another locale (`fr/feedback.json`) would satisfy every list while belonging
+    // to no namespace — and now that `fix-i18n.mjs` iterates the registered list, it
+    // would skip that file forever. The reverse, a locale missing a catalogue `en`
+    // ships, means that whole page falls back to English with no other signal.
+    const shipped = shippedNamespaces()
+    const locales = localeDirs()
+    expect(locales, 'no locale directories found — wrong path').toContain('en')
+    expect(locales.length, 'only one locale found; parity across locales is untested')
+      .toBeGreaterThan(1)
+
+    for (const locale of locales) {
+      expect(cataloguesIn(join(LOCALES, locale)), `locale ${locale}`).toEqual(shipped)
+    }
   })
 
   it('keeps the options that are load-bearing rather than cosmetic', () => {

--- a/voc-datalake/frontend/src/i18n/options.test.ts
+++ b/voc-datalake/frontend/src/i18n/options.test.ts
@@ -91,9 +91,10 @@ function arrayLiteral(file: string, variable: string): string[] {
  * namespace called `ns` and reports the app as broken. It did, on the first run.
  * `scripts/i18n-check.mjs` has the same blind spot and warns about that comment.
  *
- * Block comments are stripped only where `/*` opens the line, so a `/*` inside a
- * string or regex literal cannot pair with a later `*␘/` and delete real code
- * between them — that would be a false negative, the worse direction for a gate.
+ * Block comments are stripped only where a line OPENS one, so an inline block-comment
+ * marker inside a string or regex literal cannot pair with a later terminator and
+ * delete the real code between them. That direction is a false negative, which is the
+ * worse one for a gate: it would read green while covering less.
  */
 function stripComments(source: string): string {
   const lines = source.split('\n')


### PR DESCRIPTION
## Summary

Follow-up to #324, which merged while this was being written.

#324 moved the i18next init options out of `src/i18n/config.ts` into a side-effect-free `src/i18n/options.ts`, so a test could assert the app's real `nsSeparator` instead of the test harness's. It stopped one step short: **the options became importable but nothing asserted anything about them.** No test imports `config.ts` — it runs `i18n.use(HttpBackend).use(LanguageDetector).init(...)` at module scope — so every option in that literal was untested before the move and stayed untested after. Drop `supportedLngs` and the app still boots, just without the guard that rejects a stale cached locale.

> **Scope note (corrected):** this started as test-only and is no longer. Review round 1 asked for a parity assertion across the four copies of the namespace list, and **that assertion failed on arrival** — so this PR also changes one line of production tooling, `scripts/fix-i18n.mjs`. Details below.

## The gap that matters: the namespace list

A page calling `useTranslation('somewhere')` for a namespace absent from `init({ ns })` **does not throw**. i18next resolves nothing and the page renders raw key paths — the same failure class #324 fixed twice.

`scripts/i18n-check.mjs` structurally cannot catch this: its own `NAMESPACES` array is a separate hardcoded copy, so it validates keys against the namespaces *it* knows, never against the ones the app registers.

`src/i18n/options.test.ts` adds five gates:

| gate | what it prevents |
|---|---|
| every namespace used in source is registered | a page rendering raw key paths |
| the scan sees every form the source uses | the gate above silently under-matching |
| four copies of the list agree with the shipped catalogues | drift between app, test harness and two scripts |
| every locale ships the same catalogue set | an orphan catalogue belonging to no namespace |
| the load-bearing options keep their values | a silent loss of the locale/detection guards |

The scan understands `useTranslation('ns')`, `useTranslation(['a','b'])`, `t('ns:key')`, a `t` renamed on destructuring, and namespace-qualified keys held in data. The one form no static scan can resolve — a namespace passed as a variable or template literal — is asserted absent rather than left as a blind spot.

## The bug the parity gate found

**`scripts/fix-i18n.mjs` listed a 16th namespace, `feedback`, with no catalogue in any locale.** Every run of that script tried to load `locales/<lang>/feedback.json`, which does not exist. Removing that one entry is the production change in this PR; the four copies now agree with the 15 shipped catalogues.

Related, and why the per-locale gate exists: parity against `en` alone would let an orphan like `fr/feedback.json` satisfy every list while belonging to no namespace — and since `fix-i18n.mjs` iterates the registered list, it would skip that file forever. No orphans today (all 8 locales ship exactly 15 catalogues), and now that cannot start silently.

## Two notes from writing it

- **A comment created a false positive.** The scan's first run reported a namespace called `ns` and declared the app broken. The source was a docblock in `ValidationLinkPicker.tsx` discussing the shape `xKey: 'ns:key'` — prose, not code. `i18n-check.mjs` shares the blind spot and warns about that same comment. Comments are stripped before scanning, block comments only where `/*` opens the line so a `/*` inside a string cannot pair with a later `*/` and delete real code.
- **#324's extraction was lossless**, confirmed by diffing the option keys `config.ts` passed inline at the branch point against the new module, positive-controlled. `defaultNS` was a shorthand property before (`defaultNS,`) and so is invisible to a `key:` regex — it reads as newly added when it was there all along.

## Testing

- **2464/2464** tests, `tsc --noEmit` and eslint clean over `src/` and `scripts/`, on top of the post-merge `development` tip.
- `i18n-check.mjs` output **byte-identical** to that tip, measured by stashing this PR's files and re-running. The pre-existing ja/zh/ko `extra: 4` in `categories.json` is not from here.
- **Eleven mutations, each caught by the intended test and the file restored**, with a green baseline asserted first. Including: an unregistered namespace via the single-string form and via the **array** form; a qualified key through the **renamed** `t`; a non-literal namespace; the stale `feedback` entry put back; an **orphan** `fr/feedback.json`; a locale **missing** a catalogue.
- One **negative control**: planting a type annotation shaped like a rename (`{ t: GhostType }`) must *not* be treated as a caller, and the gate correctly stays green — the alias regex is scoped to destructuring precisely so type annotations and parameters don't join the caller set.
