### PR TITLE
fix(api): stop logging raw request payloads

### DIFF
--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -272,7 +272,6 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
     
     logger.info(f"[PERSONA] ========== STARTING PERSONA GENERATION ==========")
     logger.info(f"[PERSONA] Project: {project_id}")
-    logger.info(f"[PERSONA] Filters: {filters}")
     overall_start = time.time()
     
     def update_progress(progress: int, step: str):

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -13,7 +13,7 @@ from shared.logging import logger, tracer
 from shared.aws import (
     get_dynamodb_resource, get_bedrock_client, invoke_self_async, BEDROCK_MODEL_ID
 )
-from shared.api import create_api_resolver, validate_days, validate_int, api_handler, DecimalEncoder
+from shared.api import create_api_resolver, validate_days, validate_int, api_handler
 from shared.converse import converse
 from shared.tables import get_jobs_table, get_aggregates_table
 from shared.jobs import create_job, update_job_status
@@ -765,8 +765,20 @@ def lambda_handler(event: dict, context: Any) -> dict:
             return handle_import_persona_job(event)
         
         # Normal API Gateway request
+        request_context = event.get('requestContext') or {}
+        logger.info(
+            'Request received',
+            extra={
+                'method': event.get('httpMethod'),
+                'resource': event.get('resource'),
+                'request_id': request_context.get('requestId'),
+            },
+        )
         result = app.resolve(event, context)
-        logger.info(f"Returning result: {json.dumps(result, cls=DecimalEncoder)}")
+        logger.info(
+            'Request completed',
+            extra={'status_code': result.get('statusCode')},
+        )
         return result
         
     except Exception as e:

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -349,7 +349,6 @@ def handle_generate_personas_job(event: dict) -> dict:
     import time
     
     logger.info(f"[JOB] ========== ASYNC PERSONA JOB STARTED ==========")
-    logger.info(f"[JOB] Event: {event}")
     job_start = time.time()
     
     project_id = event['project_id']
@@ -357,7 +356,6 @@ def handle_generate_personas_job(event: dict) -> dict:
     filters = event['filters']
     
     logger.info(f"[JOB] Project: {project_id}, Job: {job_id}")
-    logger.info(f"[JOB] Filters: {filters}")
     
     def progress_callback(progress: int, step: str):
         logger.info(f"[JOB] Progress callback: {progress}% - {step}")
@@ -755,8 +753,6 @@ CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
 def lambda_handler(event: dict, context: Any) -> dict:
     """Main Lambda handler for projects API."""
     try:
-        logger.info(f"Received event: {json.dumps(event)}")
-        
         # Route async job invocations
         job_type = event.get('job_type')
         if job_type == 'generate_personas':

--- a/voc-datalake/lambda/api/test/test_projects_handler.py
+++ b/voc-datalake/lambda/api/test/test_projects_handler.py
@@ -3,7 +3,7 @@ Tests for projects_handler.py - /projects/* endpoints.
 """
 import json
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import DEFAULT, MagicMock, patch
 from datetime import datetime, timezone
 
 
@@ -369,39 +369,76 @@ class TestDocumentCRUDEndpoints:
 class TestSensitiveEventLogging:
     """Tests that request and job payloads are not written to logs."""
 
-    @patch('projects_handler.logger.info')
-    def test_api_gateway_event_is_not_logged(
-        self, mock_log_info, api_gateway_event, lambda_context
-    ):
-        """Credentials and request bodies must not appear in info logs."""
-        from projects_handler import lambda_handler
+    LOG_METHODS = ('debug', 'info', 'warning', 'error', 'exception', 'critical')
 
-        secret = 'v37-sensitive-api-payload'
+    @staticmethod
+    def _render_log_calls(log_methods):
+        return str(
+            [
+                call
+                for method in TestSensitiveEventLogging.LOG_METHODS
+                for call in log_methods[method].call_args_list
+            ]
+        )
+
+    @patch('projects_handler.create_project')
+    def test_api_gateway_event_is_not_logged(
+        self, mock_create_project, api_gateway_event, lambda_context
+    ):
+        """Credentials and request bodies must not appear at any log level."""
+        from projects_handler import lambda_handler, logger
+
+        secrets = {
+            'authorization': 'v37-sensitive-authorization',
+            'cookie': 'v37-sensitive-cookie',
+            'body': 'v37-sensitive-request-body',
+        }
+        mock_create_project.return_value = {
+            'success': True,
+            'project': {'description': secrets['body']},
+        }
         event = api_gateway_event(
-            method='GET',
-            path='/projects/config',
+            method='POST',
+            path='/projects',
+            body={'name': 'Test', 'description': secrets['body']},
             headers={
-                'Authorization': f'Bearer {secret}',
-                'Cookie': f'session={secret}',
+                'Authorization': f"Bearer {secrets['authorization']}",
+                'Cookie': f"session={secrets['cookie']}",
             },
         )
 
-        response = lambda_handler(event, lambda_context)
+        with patch.multiple(
+            logger,
+            **{method: DEFAULT for method in self.LOG_METHODS},
+        ) as log_methods:
+            response = lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 200
-        assert secret not in str(mock_log_info.call_args_list)
+        logged_calls = self._render_log_calls(log_methods)
+        assert all(secret not in logged_calls for secret in secrets.values())
+        log_methods['info'].assert_any_call(
+            'Request received',
+            extra={
+                'method': 'POST',
+                'resource': '/projects',
+                'request_id': 'test-request-id',
+            },
+        )
+        log_methods['info'].assert_any_call(
+            'Request completed',
+            extra={'status_code': 200},
+        )
 
-    @patch('projects_handler.logger.info')
-    @patch('projects_handler.generate_personas')
+    @patch('projects.projects_table', None)
     @patch('projects_handler.update_job_status')
     def test_async_job_payload_is_not_logged(
-        self, mock_update_job_status, mock_generate_personas, mock_log_info
+        self, mock_update_job_status
     ):
-        """Job filters can contain customer input and must not be logged raw."""
-        from projects_handler import handle_generate_personas_job
+        """Job filters must remain protected across the downstream call path."""
+        from projects_handler import handle_generate_personas_job, logger
+        from shared.exceptions import ServiceError
 
         secret = 'v37-sensitive-job-payload'
-        mock_generate_personas.return_value = {'success': True}
         event = {
             'job_type': 'generate_personas',
             'project_id': 'project-1',
@@ -409,9 +446,15 @@ class TestSensitiveEventLogging:
             'filters': {'custom_instructions': secret},
         }
 
-        result = handle_generate_personas_job(event)
+        with patch.multiple(
+            logger,
+            **{method: DEFAULT for method in self.LOG_METHODS},
+        ) as log_methods:
+            with pytest.raises(ServiceError):
+                handle_generate_personas_job(event)
 
-        assert result == {'success': True}
-        assert secret not in str(mock_log_info.call_args_list)
-
-
+        assert secret not in self._render_log_calls(log_methods)
+        log_methods['info'].assert_any_call(
+            '[JOB] Project: project-1, Job: job-1'
+        )
+        log_methods['info'].assert_any_call('[PERSONA] Project: project-1')

--- a/voc-datalake/lambda/api/test/test_projects_handler.py
+++ b/voc-datalake/lambda/api/test/test_projects_handler.py
@@ -366,4 +366,52 @@ class TestDocumentCRUDEndpoints:
         assert body['success'] is True
 
 
+class TestSensitiveEventLogging:
+    """Tests that request and job payloads are not written to logs."""
+
+    @patch('projects_handler.logger.info')
+    def test_api_gateway_event_is_not_logged(
+        self, mock_log_info, api_gateway_event, lambda_context
+    ):
+        """Credentials and request bodies must not appear in info logs."""
+        from projects_handler import lambda_handler
+
+        secret = 'v37-sensitive-api-payload'
+        event = api_gateway_event(
+            method='GET',
+            path='/projects/config',
+            headers={
+                'Authorization': f'Bearer {secret}',
+                'Cookie': f'session={secret}',
+            },
+        )
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert secret not in str(mock_log_info.call_args_list)
+
+    @patch('projects_handler.logger.info')
+    @patch('projects_handler.generate_personas')
+    @patch('projects_handler.update_job_status')
+    def test_async_job_payload_is_not_logged(
+        self, mock_update_job_status, mock_generate_personas, mock_log_info
+    ):
+        """Job filters can contain customer input and must not be logged raw."""
+        from projects_handler import handle_generate_personas_job
+
+        secret = 'v37-sensitive-job-payload'
+        mock_generate_personas.return_value = {'success': True}
+        event = {
+            'job_type': 'generate_personas',
+            'project_id': 'project-1',
+            'job_id': 'job-1',
+            'filters': {'custom_instructions': secret},
+        }
+
+        result = handle_generate_personas_job(event)
+
+        assert result == {'success': True}
+        assert secret not in str(mock_log_info.call_args_list)
+
 

--- a/voc-datalake/lambda/shared/api.py
+++ b/voc-datalake/lambda/shared/api.py
@@ -228,7 +228,7 @@ def api_handler(func):
         def lambda_handler(event, context):
             return app.resolve(event, context)
     """
-    @logger.inject_lambda_context
+    @logger.inject_lambda_context(log_event=False)
     @tracer.capture_lambda_handler
     @metrics.log_metrics(capture_cold_start_metric=True)
     @functools.wraps(func)

--- a/voc-datalake/lambda/shared/test/test_api.py
+++ b/voc-datalake/lambda/shared/test/test_api.py
@@ -528,7 +528,12 @@ class TestApiHandlerDecorator:
     def test_calls_wrapped_function(self, mock_logger, mock_tracer, mock_metrics):
         """Calls the wrapped function with event and context."""
         # Setup mocks to pass through
-        mock_logger.inject_lambda_context = lambda f: f
+        def passthrough_decorator(func=None, **kwargs):
+            if func is not None:
+                return func
+            return lambda wrapped: wrapped
+
+        mock_logger.inject_lambda_context.side_effect = passthrough_decorator
         mock_tracer.capture_lambda_handler = lambda f: f
         mock_metrics.log_metrics = lambda **kwargs: lambda f: f
         
@@ -548,3 +553,4 @@ class TestApiHandlerDecorator:
         
         assert len(call_tracker) == 1
         assert call_tracker[0][0] == event
+        mock_logger.inject_lambda_context.assert_called_once_with(log_event=False)


### PR DESCRIPTION
## Summary

- stop the projects Lambda handler from logging the complete API Gateway event
- stop async persona generation from logging the complete job event and filter payload
- add regressions proving request credentials and customer-supplied job input do not reach info logs

## Why

`projects_handler` wrote the complete API Gateway event to CloudWatch. That event can contain `Authorization`, `Cookie`, and request-body data. The async persona path also repeated the job event and its filters, including customer-supplied instructions.

The handler already logs bounded project/job identity and completion state, so removing the raw payload logs preserves operational progress without retaining credentials or customer content.

Fixes #245.

## Verification

- red-first regressions: 2 failures before the production change
- focused sensitive-event regressions: 2 passed
- projects handler suite: 18 passed
- complete Lambda suite: 528 passed
- Python compile check for both changed files
- raw-event logging pattern audit
- `git diff --check`

The tests capture info-log calls and use sentinel values in API Gateway credentials and persona-job input. No deployed CloudWatch log group or existing retained log data was inspected or changed.

## AI assistance

OpenAI Codex assisted with investigation, implementation, regression tests, and verification. I reviewed the complete submitted diff and remain responsible for the contribution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of the project license.