### PR TITLE
fix(feedback-forms): honest submission counts, one partition per form

### DIFF
--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -80,6 +80,16 @@ DEFAULT_FORM_CONFIG = {
 }
 
 # Fields that can be updated via PUT
+#
+# `brand_name` is deliberately absent, and that is a decision rather than an
+# omission: it is the form's partition key input (see _form_source_pk), so
+# editing it moves where this form's stats read looks WITHOUT moving the
+# submissions already stored under the old value — the exact stranding this
+# module's write/read agreement exists to prevent, only triggered by hand. A
+# form's brand is therefore set once (build_form_item, or _anchor_form_brand for
+# a record created without one) and then fixed for the life of the form. If a
+# brand ever genuinely needs correcting, it needs a migration that rewrites the
+# feedback records' partition too, not a PUT.
 UPDATABLE_FIELDS = [
     'name', 'enabled', 'title', 'description', 'question', 'placeholder',
     'rating_enabled', 'rating_type', 'rating_max', 'submit_button_text',
@@ -145,24 +155,61 @@ def _anchor_form_brand(form_id: str, effective_brand: str) -> None:
     and that value stands, which is the outcome we want either way. Best effort:
     the submission itself must not fail because the anchor did not stick, since
     the record being enqueued already carries the same brand.
+
+    Writes updated_at as well, because brand_name is not an internal detail: it
+    is published by item_to_form AND by the public item_to_widget_config, and
+    every other write path here maintains updated_at (build_form_item sets it,
+    update_form always appends it). A published field that changes with no trace
+    of when is harder to explain later than the split this prevents.
     """
     try:
         aggregates_table.update_item(
             Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
-            UpdateExpression='SET brand_name = :brand',
+            UpdateExpression='SET brand_name = :brand, updated_at = :now',
+            # attribute_exists(sk) leads, because UpdateItem is an UPSERT and
+            # attribute_not_exists(brand_name) is SATISFIED by a missing item: a
+            # form deleted between submit_form_feedback's get_item and this write
+            # (a widget on a customer's site racing DELETE /feedback-forms/<id>)
+            # would otherwise be written back as a bare {pk, sk, brand_name}
+            # stub — a nameless row in list_forms whose own form_id is '', and a
+            # deleted form answering 200 with total_submissions 0 again on the
+            # very route this change made honest. Existence-first turns that into
+            # a ConditionalCheckFailedException, i.e. nothing.
+            #
+            # The parentheses are load-bearing: `A AND B OR C` would let
+            # brand_name = '' satisfy the condition on its own and reopen it.
             ConditionExpression=(
-                'attribute_not_exists(brand_name) OR brand_name = :empty'
+                'attribute_exists(sk) AND '
+                '(attribute_not_exists(brand_name) OR brand_name = :empty)'
             ),
-            ExpressionAttributeValues={':brand': effective_brand, ':empty': ''},
+            ExpressionAttributeValues={
+                ':brand': effective_brand,
+                ':empty': '',
+                ':now': datetime.now(timezone.utc).isoformat(),
+            },
         )
         logger.info(f"Anchored form {form_id} to brand '{effective_brand}'")
-    except ClientError as e:
-        if e.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
-            # The form already carries a brand — already anchored, nothing to do.
+    except Exception as e:  # noqa: BLE001 - see below; a submission outlives it
+        # One handler, so there is exactly one place this can be logged from.
+        # Deliberately blind: an anchor is a convenience for future reads, and no
+        # failure of it — throttling, a denied grant, a bug in this function — is
+        # worth dropping a customer's feedback for. The record already on its way
+        # to the queue carries the same brand either way.
+        if _is_conditional_check_failure(e):
+            # The condition did its job: the form already carries a brand, or the
+            # record no longer exists. The stored state wins; nothing to do.
             return
         logger.warning(f"Could not anchor brand_name for form {form_id}: {e}")
-    except Exception as e:
-        logger.warning(f"Could not anchor brand_name for form {form_id}: {e}")
+
+
+def _is_conditional_check_failure(error: Exception) -> bool:
+    """Was this DynamoDB refusing a write because its condition did not hold?"""
+    if not isinstance(error, ClientError):
+        return False
+    return (
+        error.response.get('Error', {}).get('Code')
+        == 'ConditionalCheckFailedException'
+    )
 
 
 def build_form_item(body: dict, form_id: str | None = None) -> dict:
@@ -693,8 +740,13 @@ def get_form_submissions(form_id: str):
             'submissions': items[:limit]
         }
     except ApiError:
-        # A typed exception already carries its own status; re-raised so the
-        # blanket handler below cannot downgrade a 404 or a 400 to a 500.
+        # Precautionary, not currently reachable: the only typed raise on this
+        # route (_load_form_for_query) happens ABOVE the try, and nothing inside
+        # it raises an ApiError today. It is here so that when something in this
+        # block eventually does — a validation of a page of items, a helper that
+        # 404s — its status survives instead of being flattened to a 500 by the
+        # handler below. Pinned by a test that raises a typed exception from
+        # feedback_table.query; without this clause that test gets a 500.
         raise
     except Exception as e:
         logger.error(f"Error fetching submissions: {e}")
@@ -762,8 +814,11 @@ def get_form_stats(form_id: str):
             }
         }
     except ApiError:
-        # See get_form_submissions: a typed exception keeps its own status rather
-        # than being reported as a server fault by the handler below.
+        # See get_form_submissions: precautionary. No statement in this block
+        # raises a typed exception today (the form load, which does, is above the
+        # try), but a future one would otherwise be reported as a server fault —
+        # and would take the FeedbackFormStatsReadFailed metric with it, which is
+        # meant to count read failures rather than every 4xx-shaped cause.
         raise
     except Exception as e:
         # This read failure was previously reported as a zero count and so was

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -12,12 +12,19 @@ from pathlib import Path
 from aws_lambda_powertools.event_handler import Response
 
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 
 # Shared module imports
-from shared.logging import logger, tracer
+from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, get_sqs_client
 from shared.api import create_api_resolver, api_handler, validate_limit
-from shared.exceptions import ConfigurationError, ValidationError, NotFoundError, ServiceError
+from shared.exceptions import (
+    ApiError,
+    ConfigurationError,
+    ValidationError,
+    NotFoundError,
+    ServiceError,
+)
 
 # AWS Clients
 dynamodb = get_dynamodb_resource()
@@ -114,6 +121,48 @@ def validate_link_fields(body: dict) -> None:
             raise ValidationError(
                 f'{field} must be at most {LINK_FIELD_MAX_LENGTH} characters'
             )
+
+
+def _anchor_form_brand(form_id: str, effective_brand: str) -> None:
+    """Pin a form with no stored brand to the brand its submissions are going to.
+
+    build_form_item writes 'brand_name': BRAND_NAME, so a form created while
+    BRAND_NAME was unset is stored with ''. For those records BOTH sides of the
+    partition fall through to the live environment variable — the write's
+    `form.get('brand_name') or BRAND_NAME` and _form_source_pk's identical
+    fallback. They agree at any instant, so nothing looks wrong, but the
+    agreement is only as stable as the environment: rename the deployment and
+    every submission collected before the rename becomes unreachable to the
+    form's own stats read. That is exactly the stranding the write-site fix was
+    chosen to avoid.
+
+    Writing the resolved brand back onto the form record removes the dependence
+    on the environment for good: from here on both sides read a stored value the
+    next deployment cannot move.
+
+    Conditional so it is idempotent and can never overwrite a real brand — if a
+    concurrent submission (or an admin edit) got there first, the condition fails
+    and that value stands, which is the outcome we want either way. Best effort:
+    the submission itself must not fail because the anchor did not stick, since
+    the record being enqueued already carries the same brand.
+    """
+    try:
+        aggregates_table.update_item(
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+            UpdateExpression='SET brand_name = :brand',
+            ConditionExpression=(
+                'attribute_not_exists(brand_name) OR brand_name = :empty'
+            ),
+            ExpressionAttributeValues={':brand': effective_brand, ':empty': ''},
+        )
+        logger.info(f"Anchored form {form_id} to brand '{effective_brand}'")
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+            # The form already carries a brand — already anchored, nothing to do.
+            return
+        logger.warning(f"Could not anchor brand_name for form {form_id}: {e}")
+    except Exception as e:
+        logger.warning(f"Could not anchor brand_name for form {form_id}: {e}")
 
 
 def build_form_item(body: dict, form_id: str | None = None) -> dict:
@@ -423,9 +472,20 @@ def submit_form_feedback(form_id: str):
         logger.error(f"Error fetching form: {e}")
         raise ServiceError('Failed to load form configuration')
     
+    # The FORM's brand, not the deployment's: the stats read builds its partition
+    # from the form's stored brand_name (_form_source_pk), so stamping BRAND_NAME
+    # here would split a form's submissions across two partitions the day the
+    # deployment is renamed. `or` rather than a get() default because a stored ''
+    # must take the fallback too — that is how the read side treats it.
+    effective_brand = form.get('brand_name') or BRAND_NAME
+    if not form.get('brand_name') and effective_brand:
+        # Store it, so this form stops depending on the environment variable —
+        # see _anchor_form_brand.
+        _anchor_form_brand(form_id, effective_brand)
+
     now = datetime.now(timezone.utc)
     feedback_id = str(uuid.uuid4())
-    
+
     # Build normalized record with category routing
     metadata = {
         'form_id': form_id,
@@ -447,14 +507,10 @@ def submit_form_feedback(form_id: str):
         'rating': body.get('rating'),
         'created_at': now.isoformat(),
         'ingested_at': now.isoformat(),
-        # The FORM's brand, not the deployment's: _get_form_source_pk builds the
-        # stats partition from the form's stored brand_name, so stamping the
-        # environment variable here would split a form's submissions across two
-        # partitions the day the deployment's brand name changes — new ones under
-        # the new brand, the stats read still querying the old. Falls back to
-        # BRAND_NAME for a form recorded without one. The form record is already
-        # loaded above for the enabled check, so this costs no extra read.
-        'brand_name': form.get('brand_name') or BRAND_NAME,
+        # Resolved above, from the form record already loaded for the enabled
+        # check: the form's own brand, so this submission lands in the partition
+        # _form_source_pk queries for the whole life of the form.
+        'brand_name': effective_brand,
         'url': body.get('page_url'),
         'preset_category': form.get('category', ''),
         'preset_subcategory': form.get('subcategory', ''),
@@ -519,20 +575,56 @@ def get_form_iframe(form_id: str):
 # Form Stats & Submissions
 # ============================================
 
-def _get_form_source_pk(form_id: str) -> str:
-    """Get the source pk for querying feedback by form."""
+def _form_source_pk(form: dict) -> str:
+    """The feedback partition this form's submissions live in.
+
+    Pure: derived from the form record the caller already holds, never from a
+    read of its own. A partition GUESSED from a failed form read is the whole
+    problem — it resolves to BRAND_NAME, which after a rename is a partition the
+    form's submissions were never written to, so the query finds nothing and the
+    route reports 0 submissions for a form that has them (issue #312's false zero
+    arriving by another door). Callers get the record from _load_form_for_query,
+    which fails loudly instead.
+
+    Mirrors submit_form_feedback's write side: the form's own brand, the
+    deployment's only for a form recorded without one, and `or` rather than a
+    get() default so a stored '' takes the fallback on both sides alike.
+    """
+    effective_brand = form.get('brand_name') or BRAND_NAME
+    return f"SOURCE#{effective_brand}" if effective_brand else 'SOURCE#feedback_form'
+
+
+def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
+    """Load a form record for a stats/submissions query, failing loudly.
+
+    One get_item answers both questions those routes need, so neither has to be
+    guessed:
+
+    - Does this form exist? A form id that was deleted (or never existed) must be
+      a 404, not a 200 with a measured-looking 0 — LinkedFormEvidence renders
+      that zero as evidence against a work item and has an `evidence.unavailable`
+      branch waiting for the error.
+    - Which feedback partition are its submissions in? See _form_source_pk: a
+      degraded fallback here queries the wrong partition after a brand rename.
+
+    Both failure modes previously produced HTTP 200 with total_submissions: 0 on
+    the stats route, which is the exact defect issue #312 is about.
+    """
     try:
-        form_response = aggregates_table.get_item(
+        response = aggregates_table.get_item(
             Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
         )
-        form = form_response.get('Item')
-        form_brand_name = form.get('brand_name', '') if form else ''
     except Exception as e:
-        logger.warning(f"Could not fetch form brand_name: {e}")
-        form_brand_name = ''
-    
-    effective_brand = form_brand_name or BRAND_NAME
-    return f"SOURCE#{effective_brand}" if effective_brand else 'SOURCE#feedback_form'
+        # Surfaced as a metric because this failure used to be invisible: it was
+        # reported to the caller as a zero count and to operations as nothing.
+        metrics.add_metric(name='FeedbackFormReadFailed', unit='Count', value=1)
+        logger.error(f"Error fetching form {form_id}: {e}")
+        raise ServiceError(read_failure_message) from e
+
+    form = response.get('Item')
+    if not form:
+        raise NotFoundError('Form not found')
+    return form
 
 
 @app.get("/feedback-forms/<form_id>/submissions")
@@ -544,23 +636,15 @@ def get_form_submissions(form_id: str):
     
     if not feedback_table:
         raise ConfigurationError('Feedback table not configured')
-    
-    # Verify form exists
-    try:
-        response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
-        )
-        if not response.get('Item'):
-            raise NotFoundError('Form not found')
-    except NotFoundError:
-        raise
-    except Exception as e:
-        logger.error(f"Error fetching form: {e}")
-        raise ServiceError('Failed to fetch form')
-    
+
+    # One read answers both the 404 and the partition, where this route used to
+    # do its own existence check and then have _get_form_source_pk re-read the
+    # same record (and swallow a failure of it).
+    form = _load_form_for_query(form_id, 'Failed to fetch form')
+
     source_channel = f'form_{form_id}'
-    source_pk = _get_form_source_pk(form_id)
-    
+    source_pk = _form_source_pk(form)
+
     try:
         items = []
         total_rating = 0
@@ -608,9 +692,13 @@ def get_form_submissions(form_id: str):
             },
             'submissions': items[:limit]
         }
+    except ApiError:
+        # A typed exception already carries its own status; re-raised so the
+        # blanket handler below cannot downgrade a 404 or a 400 to a 500.
+        raise
     except Exception as e:
         logger.error(f"Error fetching submissions: {e}")
-        raise ServiceError('Failed to fetch submissions')
+        raise ServiceError('Failed to fetch submissions') from e
 
 
 @app.get("/feedback-forms/<form_id>/stats")
@@ -622,13 +710,21 @@ def get_form_stats(form_id: str):
     rendered next to a prioritization score, so "0 submissions" is a claim about
     the product, not a placeholder: a read that could not be completed must not
     be reported as a form nobody answered.
+
+    That applies to EVERY read this route makes, not just the feedback query: an
+    unconfigured table, a failed form lookup, a form that no longer exists and a
+    failed feedback query all used to arrive as total_submissions: 0.
     """
     if not feedback_table:
         raise ConfigurationError('Feedback table not configured')
 
+    # 404 for a deleted form, and the partition its submissions are in, from the
+    # one read — never a partition guessed from a read that failed.
+    form = _load_form_for_query(form_id, 'Failed to fetch form stats')
+
     source_channel = f'form_{form_id}'
-    source_pk = _get_form_source_pk(form_id)
-    
+    source_pk = _form_source_pk(form)
+
     try:
         total_rating = 0
         rating_count = 0
@@ -665,9 +761,16 @@ def get_form_stats(form_id: str):
                 'rating_count': rating_count,
             }
         }
+    except ApiError:
+        # See get_form_submissions: a typed exception keeps its own status rather
+        # than being reported as a server fault by the handler below.
+        raise
     except Exception as e:
+        # This read failure was previously reported as a zero count and so was
+        # invisible in dashboards; the metric is what makes it observable.
+        metrics.add_metric(name='FeedbackFormStatsReadFailed', unit='Count', value=1)
         logger.error(f"Error fetching form stats: {e}")
-        raise ServiceError('Failed to fetch form stats')
+        raise ServiceError('Failed to fetch form stats') from e
 
 
 # ============================================

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -90,6 +90,20 @@ DEFAULT_FORM_CONFIG = {
 # a record created without one) and then fixed for the life of the form. If a
 # brand ever genuinely needs correcting, it needs a migration that rewrites the
 # feedback records' partition too, not a PUT.
+#
+# The case that migration is the ONLY remedy for, spelled out because it exists
+# in deployed data rather than in theory: a form whose submissions predate its
+# anchor can have them spread over two SOURCE# partitions already — before the
+# brand was resolved onto the record, a submission was stamped from the live
+# BRAND_NAME, so any deployment renamed (or given a brand for the first time)
+# while a brandless form was collecting has some submissions under the old value
+# and some under the new. The anchor pins the form to one of them, and the stats
+# read reports only that half. This is not a regression — that form reported the
+# same half before — but the anchor makes it durable where a further rename used
+# to flip it, and no PUT can move it. Accepted deliberately: the alternative is
+# recording the pre-anchor brand and querying both partitions, which doubles the
+# reads on a route that already reads a whole partition (see get_form_stats).
+# Recovering the other half means rewriting those feedback records' pk.
 UPDATABLE_FIELDS = [
     'name', 'enabled', 'title', 'description', 'question', 'placeholder',
     'rating_enabled', 'rating_type', 'rating_max', 'submit_button_text',
@@ -527,22 +541,17 @@ def submit_form_feedback(form_id: str):
     
     # The FORM's brand, not the deployment's: the stats read builds its partition
     # from the form's stored brand_name (_form_source_pk), so stamping BRAND_NAME
-    # here would split a form's submissions across two partitions the day the
+    # here splits a form's submissions across two partitions the day the
     # deployment is renamed. `or` rather than a get() default because a stored ''
-    # must take the fallback too — that is how the read side treats it.
+    # must take the fallback too — that is how the read side treats it. The
+    # consequence, chosen rather than incidental, is that a pre-rename form keeps
+    # writing under its OLD brand; _anchor_form_brand's docstring is the canonical
+    # explanation of why that beats the alternative.
     #
-    # The trade-off, stated because it is chosen rather than incidental: after a
-    # rename, a pre-rename form keeps writing under its OLD brand, so its
-    # submissions carry a brand the deployment no longer uses. That is deliberate
-    # — the alternative strands every submission the form already collected. It
-    # costs nothing in the read paths as they stand: the processor derives the
-    # pk from this value (source_display = brand_name or source_platform), and
-    # every other reader is scoped by source_platform, not by brand —
-    # metrics_handler queries the DATE# GSI filtering source_platform, and
-    # data_explorer_handler builds SOURCE#<source_platform>. No aggregate is
-    # scoped by BRAND_NAME, so there is nothing for a pre-rename form to fall out
-    # of. A future brand-scoped view would have to reckon with this and should
-    # read the form's brand rather than the environment's.
+    # _form_source_pk, in this module, is the one brand-scoped read of the
+    # feedback partition; every other reader scopes by source_platform. That is a
+    # claim about other modules, so it is asserted by a test rather than trusted
+    # here — see test_no_other_module_derives_a_feedback_partition_from_the_brand.
     effective_brand = form.get('brand_name') or BRAND_NAME
     if not form.get('brand_name') and effective_brand:
         # Store it, so this form stops depending on the environment variable —
@@ -785,6 +794,17 @@ def get_form_stats(form_id: str):
     That applies to EVERY read this route makes, not just the feedback query: an
     unconfigured table, a failed form lookup, a form that no longer exists and a
     failed feedback query all used to arrive as total_submissions: 0.
+
+    Cost, noted next to the loudness because the two interact: the query below
+    pages a whole SOURCE# partition with no Limit and filters source_channel
+    server-side but AFTER the partition is read. That partition is the BRAND's,
+    not the form's — plugin ingestion stamps brand_name from the same BRAND_NAME —
+    so the work scales with total brand feedback volume rather than with this
+    form's own submissions, against a 30s Lambda timeout. Failing loudly turns
+    exceeding that from a silent zero into a user-visible error, and because the
+    partition is shared it would surface for every form in the deployment at once.
+    Reading it honestly is still right; bounding it needs an index on the
+    submission-to-form link, which is deliberately not done here.
     """
     if not feedback_table:
         raise ConfigurationError('Feedback table not configured')

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -176,8 +176,14 @@ def _anchor_form_brand(form_id: str, effective_brand: str) -> None:
             # very route this change made honest. Existence-first turns that into
             # a ConditionalCheckFailedException, i.e. nothing.
             #
-            # The parentheses are load-bearing: `A AND B OR C` would let
-            # brand_name = '' satisfy the condition on its own and reopen it.
+            # The parentheses are for readability only, NOT for correctness:
+            # DynamoDB binds AND tighter than OR, and a comparison against an
+            # absent attribute evaluates false rather than erroring, so the
+            # unparenthesised spelling rejects a missing item identically
+            # (verified against a real table). attribute_exists(sk) is the whole
+            # of the guard — said explicitly so nobody re-derives a precedence
+            # rule that does not exist and then "protects" the brackets instead
+            # of the conjunct that matters.
             ConditionExpression=(
                 'attribute_exists(sk) AND '
                 '(attribute_not_exists(brand_name) OR brand_name = :empty)'

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -524,6 +524,19 @@ def submit_form_feedback(form_id: str):
     # here would split a form's submissions across two partitions the day the
     # deployment is renamed. `or` rather than a get() default because a stored ''
     # must take the fallback too — that is how the read side treats it.
+    #
+    # The trade-off, stated because it is chosen rather than incidental: after a
+    # rename, a pre-rename form keeps writing under its OLD brand, so its
+    # submissions carry a brand the deployment no longer uses. That is deliberate
+    # — the alternative strands every submission the form already collected. It
+    # costs nothing in the read paths as they stand: the processor derives the
+    # pk from this value (source_display = brand_name or source_platform), and
+    # every other reader is scoped by source_platform, not by brand —
+    # metrics_handler queries the DATE# GSI filtering source_platform, and
+    # data_explorer_handler builds SOURCE#<source_platform>. No aggregate is
+    # scoped by BRAND_NAME, so there is nothing for a pre-rename form to fall out
+    # of. A future brand-scoped view would have to reckon with this and should
+    # read the form's brand rather than the environment's.
     effective_brand = form.get('brand_name') or BRAND_NAME
     if not form.get('brand_name') and effective_brand:
         # Store it, so this form stops depending on the environment variable —

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -447,7 +447,14 @@ def submit_form_feedback(form_id: str):
         'rating': body.get('rating'),
         'created_at': now.isoformat(),
         'ingested_at': now.isoformat(),
-        'brand_name': BRAND_NAME,
+        # The FORM's brand, not the deployment's: _get_form_source_pk builds the
+        # stats partition from the form's stored brand_name, so stamping the
+        # environment variable here would split a form's submissions across two
+        # partitions the day the deployment's brand name changes — new ones under
+        # the new brand, the stats read still querying the old. Falls back to
+        # BRAND_NAME for a form recorded without one. The form record is already
+        # loaded above for the enabled check, so this costs no extra read.
+        'brand_name': form.get('brand_name') or BRAND_NAME,
         'url': body.get('page_url'),
         'preset_category': form.get('category', ''),
         'preset_subcategory': form.get('subcategory', ''),
@@ -609,10 +616,16 @@ def get_form_submissions(form_id: str):
 @app.get("/feedback-forms/<form_id>/stats")
 @tracer.capture_method
 def get_form_stats(form_id: str):
-    """Get quick stats for a form (lightweight endpoint for card display)."""
+    """Get quick stats for a form (lightweight endpoint for card display).
+
+    Fails loudly, like get_form_submissions above. The count this returns is
+    rendered next to a prioritization score, so "0 submissions" is a claim about
+    the product, not a placeholder: a read that could not be completed must not
+    be reported as a form nobody answered.
+    """
     if not feedback_table:
-        return {'success': True, 'stats': {'total_submissions': 0, 'avg_rating': None}}
-    
+        raise ConfigurationError('Feedback table not configured')
+
     source_channel = f'form_{form_id}'
     source_pk = _get_form_source_pk(form_id)
     
@@ -654,7 +667,7 @@ def get_form_stats(form_id: str):
         }
     except Exception as e:
         logger.error(f"Error fetching form stats: {e}")
-        return {'success': True, 'stats': {'total_submissions': 0, 'avg_rating': None}}
+        raise ServiceError('Failed to fetch form stats')
 
 
 # ============================================

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -143,6 +143,35 @@ def _form_with_legacy_brand(brand_name: str = 'Acme Classic') -> dict:
     }
 
 
+def _emitted_metrics(capsys, metric_name: str) -> list[dict]:
+    """The EMF blobs naming `metric_name` that this request actually flushed.
+
+    `metrics.add_metric` only BUFFERS; nothing reaches CloudWatch unless the
+    handler is wrapped in `metrics.log_metrics`, which `api_handler` does. So a
+    metric is only worth trusting if it is asserted all the way out, and this
+    reads the flushed blobs rather than a mock's call list.
+
+    Note this depends on powertools writing EMF to stdout with `print()`, which
+    is what makes it visible to capsys — if a powertools upgrade changes that,
+    every caller fails together and the cause is this helper, not a metric that
+    stopped being emitted.
+    """
+    return [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if metric_name in line and '_aws' in line
+    ]
+
+
+def _namespaces_of(emitted: list[dict]) -> set[str]:
+    """The CloudWatch namespaces a set of EMF blobs was published under."""
+    return {
+        directive['Namespace']
+        for blob in emitted
+        for directive in blob['_aws']['CloudWatchMetrics']
+    }
+
+
 def _queried_partition(query_kwargs: dict) -> str:
     """The pk a stats/submissions query was aimed at.
 
@@ -1058,7 +1087,6 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
         assert 'stats' not in body
         assert 'total_submissions' not in response['body']
 
-    @patch.dict('os.environ', {}, clear=False)
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')
     def test_a_read_failure_reaches_cloudwatch_and_not_just_the_caller(
@@ -1068,19 +1096,20 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
         """A metric is only worth adding if it is actually emitted.
 
         `metrics.add_metric` BUFFERS: nothing leaves the function unless the
-        handler is wrapped in `metrics.log_metrics`, which `api_handler` does —
-        and a flush with no namespace raises SchemaValidationError, which on this
-        path would replace the read failure with a metrics bug. So this asserts
-        the whole way out: an EMF blob on stdout, naming this metric, under the
-        namespace shared/logging pins on the Metrics singleton ('VoC', a default
-        that does not depend on POWERTOOLS_METRICS_NAMESPACE being deployed).
+        handler is wrapped in `metrics.log_metrics`, which `api_handler` does. So
+        this asserts the whole way out — an EMF blob flushed to stdout naming this
+        metric — rather than that add_metric was called.
 
-        Without it, "the failure is now visible to operations" — the answer given
-        to the review question about a silent DynamoDB fault — is unverified.
+        The namespace is compared against the Metrics singleton rather than a
+        literal, so it cannot drift from shared/logging.py; the test does not
+        control it and does not claim to. (POWERTOOLS_METRICS_NAMESPACE plays no
+        part: powertools resolves the namespace when Metrics(namespace="VoC") is
+        constructed at import time, so the env var never participates.)
+
+        Without this, "the failure is now visible to operations" — the answer
+        given to the review question about a silent DynamoDB fault — is
+        unverified.
         """
-        import os
-
-        os.environ.pop('POWERTOOLS_METRICS_NAMESPACE', None)
         mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
         mock_feedback.query.side_effect = Exception('ProvisionedThroughputExceeded')
 
@@ -1093,23 +1122,14 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
         response = feedback_form_handler.lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 500
-        emitted = [
-            json.loads(line)
-            for line in capsys.readouterr().out.splitlines()
-            if 'FeedbackFormStatsReadFailed' in line and '_aws' in line
-        ]
+        emitted = _emitted_metrics(capsys, 'FeedbackFormStatsReadFailed')
         assert emitted, (
             'the read failure emitted no CloudWatch metric — add_metric only '
             'buffers, so this is invisible to operations unless api_handler '
             'flushes it'
         )
-        namespaces = {
-            directive['Namespace']
-            for blob in emitted
-            for directive in blob['_aws']['CloudWatchMetrics']
-        }
-        assert namespaces == {'VoC'}, (
-            f'metric emitted under {namespaces}, not the namespace '
+        assert _namespaces_of(emitted) == {feedback_form_handler.metrics.namespace}, (
+            f'metric emitted under {_namespaces_of(emitted)}, not the namespace '
             'shared/logging sets on the Metrics singleton'
         )
 
@@ -1202,15 +1222,20 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')
     def test_a_failed_form_lookup_is_an_error_not_a_zero_count(
-        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
-        feedback_form_handler
+        self, mock_aggregates, mock_feedback, capsys, api_gateway_event,
+        lambda_context, feedback_form_handler
     ):
         """The other read on this route. The FORM lookup used to be swallowed and
         degraded to BRAND_NAME, which after a rename is a partition this form's
         submissions were never written to: the feedback query then succeeds
         against the wrong partition, finds nothing, and the route answers 200 with
         total_submissions 0 — issue #312's false zero arriving through the door
-        the earlier fix left open."""
+        the earlier fix left open.
+
+        Asserts the metric too, to the same standard as the stats one: this is the
+        BROADER of the two, since _load_form_for_query is shared by the stats and
+        submissions routes, so it is the one whose absence would leave the most
+        failures invisible to operations."""
         mock_aggregates.get_item.side_effect = Exception(
             'ProvisionedThroughputExceededException'
         )
@@ -1231,6 +1256,17 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
         assert body['success'] is False
         assert 'stats' not in body
         assert 'total_submissions' not in body
+
+        emitted = _emitted_metrics(capsys, 'FeedbackFormReadFailed')
+        assert emitted, (
+            'the form read failed and emitted no CloudWatch metric — the caller '
+            'sees a 500 but operations sees nothing, which is half of the defect '
+            'this route was fixed for'
+        )
+        assert _namespaces_of(emitted) == {feedback_form_handler.metrics.namespace}, (
+            f'metric emitted under {_namespaces_of(emitted)}, not the namespace '
+            'shared/logging sets on the Metrics singleton'
+        )
 
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')
@@ -1623,13 +1659,13 @@ class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
         # satisfied by a MISSING item, so existence has to be required
         # separately or this write recreates a form someone just deleted.
         assert 'attribute_exists(sk)' in kwargs['ConditionExpression']
-        # And the parentheses are part of the guard, not formatting: without them
-        # `attribute_exists(sk) AND attribute_not_exists(brand_name) OR
-        # brand_name = :empty` is satisfied by brand_name = '' alone, on a
-        # non-existent item, which is exactly the case being excluded.
-        assert '(attribute_not_exists(brand_name) OR brand_name = :empty)' in (
-            kwargs['ConditionExpression']
-        )
+        # Nothing is asserted about the parentheses around the OR: DynamoDB binds
+        # AND tighter than OR and an absent attribute compares false, so both
+        # spellings behave identically and an assertion on the brackets could
+        # only ever fail for reformatting. attribute_exists(sk) is the conjunct
+        # that excludes a missing item, and that exclusion is proved against a
+        # real table in TestTheAnchorCanOnlyEverUpdateAFormThatExists rather than
+        # by matching a string here.
 
     @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
     @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
@@ -1664,7 +1700,7 @@ class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
         # assertion above.
         datetime.fromisoformat(kwargs['ExpressionAttributeValues'][':now'])
 
-    def test_the_brand_is_not_editable_through_the_public_form_api(
+    def test_the_brand_is_not_in_the_put_allowlist(
         self, feedback_form_handler
     ):
         """A deliberate decision, recorded as a test because the anchor makes the
@@ -1673,7 +1709,13 @@ class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
         moves where this form's stats read looks WITHOUT moving the submissions
         already written under the old value — the stranding this module's
         write/read agreement exists to prevent, triggered by hand. Correcting a
-        brand needs a migration that rewrites the feedback partition too."""
+        brand needs a migration that rewrites the feedback partition too.
+
+        UPDATABLE_FIELDS gates `PUT /feedback-forms/<id>`, which is Cognito
+        AUTHENTICATED (lib/stacks/api-stack.ts passes authMethodOptions); the
+        unauthenticated routes are config, submit and iframe. So this is not a
+        leak test against the widget surface — brand_name IS published by
+        item_to_widget_config and nothing here guards that."""
         assert 'brand_name' not in feedback_form_handler.UPDATABLE_FIELDS
 
     @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -4,7 +4,7 @@ Tests for feedback_form_handler.py - /feedback-forms/* endpoints.
 import json
 import re
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -120,6 +120,51 @@ def _fields_the_widget_reads() -> set[str]:
     fields = set(_WIDGET_CONFIG_READ.findall(source))
     assert fields, f'found no config reads in {WIDGET_SOURCE.name} — did it move?'
     return fields
+
+
+# An enabled form recorded under the brand the deployment carried when it was
+# created — the pre-rename half of the partition-split cases below.
+_FORM_WITH_LEGACY_BRAND = {
+    'form_id': 'form-123',
+    'name': 'Product Form',
+    'enabled': True,
+    'brand_name': 'Acme Classic',
+}
+
+
+def _queried_partition(query_kwargs: dict) -> str:
+    """The pk a stats/submissions query was aimed at.
+
+    Read off the KeyConditionExpression the handler actually passed rather than
+    reconstructed from the brand under test, so the assertion still means
+    something if the handler starts building the partition differently.
+    """
+    return query_kwargs['KeyConditionExpression'].get_expression()['values'][1]
+
+
+def _fake_feedback_table(items_by_pk: dict[str, list[dict]]):
+    """A feedback table that answers a query from the partition it was asked for.
+
+    The point of the brand tests below is that a write and a read must agree on
+    ONE partition, which a mock returning the same Items for every pk cannot
+    show. This one returns nothing for a partition it was never given items for
+    — exactly how a real rename-split reads — and applies the handler's
+    source_channel filter, so a submission is only "found" if both the partition
+    and the channel line up.
+    """
+    table = MagicMock()
+
+    def query(**kwargs):
+        pk = _queried_partition(kwargs)
+        channel = kwargs.get('ExpressionAttributeValues', {}).get(':sc')
+        items = [
+            item for item in items_by_pk.get(pk, [])
+            if channel is None or item.get('source_channel') == channel
+        ]
+        return {'Items': items}
+
+    table.query.side_effect = query
+    return table
 
 
 class TestListForms:
@@ -944,4 +989,253 @@ class TestValidationLinkBoundary:
             f'{sorted(writable_identifiers - link_fields)} can be written by a '
             'PUT but is absent from LINK_FIELDS, so validate_link_fields never '
             'sees it.'
+        )
+
+
+class TestFormStatsNeverReportsAZeroItDidNotMeasure:
+    """GET /feedback-forms/<id>/stats must fail loudly rather than answer 0.
+
+    The count this route returns is rendered next to a prioritization score, so
+    'total_submissions: 0' is read as "customers were asked and did not answer" —
+    evidence that lowers a score. A DynamoDB failure, or a Lambda deployed
+    without FEEDBACK_TABLE, must therefore be reported as a failure and not be
+    indistinguishable from an unanswered form (issue #312). get_form_submissions
+    on the same table has always done this; stats now matches it.
+    """
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_failed_stats_read_is_an_error_not_a_zero_count(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """A query that raises returns 500, and no count at all."""
+        mock_aggregates.get_item.return_value = {
+            'Item': {'form_id': 'form-123', 'brand_name': 'Acme'}
+        }
+        mock_feedback.query.side_effect = Exception('ProvisionedThroughputExceeded')
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 500
+        assert body['success'] is False
+        assert 'error' in body
+        # The specific regression: a zero must not be reported for a read that
+        # never completed, under any key.
+        assert 'stats' not in body
+        assert 'total_submissions' not in response['body']
+
+    @patch('feedback_form_handler.feedback_table', None)
+    @patch('feedback_form_handler.aggregates_table')
+    def test_an_unconfigured_feedback_table_is_a_configuration_error(
+        self, mock_aggregates, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """No table configured is a deployment fault, not an empty form."""
+        mock_aggregates.get_item.return_value = {
+            'Item': {'form_id': 'form-123', 'brand_name': 'Acme'}
+        }
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 500
+        assert body['success'] is False
+        assert 'not configured' in body['error'].lower()
+        assert 'stats' not in body
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_successful_stats_read_still_reports_the_counts(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The happy path is unchanged — including a genuine, measured zero."""
+        mock_aggregates.get_item.return_value = {
+            'Item': {'form_id': 'form-123', 'brand_name': 'Acme'}
+        }
+        mock_feedback.query.return_value = {
+            'Items': [
+                {'feedback_id': 'fb-1', 'rating': 5},
+                {'feedback_id': 'fb-2', 'rating': 4},
+                {'feedback_id': 'fb-3'},
+            ]
+        }
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['success'] is True
+        assert body['form_id'] == 'form-123'
+        assert body['stats']['total_submissions'] == 3
+        assert body['stats']['avg_rating'] == 4.5
+        assert body['stats']['rating_count'] == 2
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_form_with_no_submissions_still_reports_a_measured_zero(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """Failing loudly must not have turned "nobody answered" into an error:
+        an empty partition is a legitimate 200 with a zero count."""
+        mock_aggregates.get_item.return_value = {
+            'Item': {'form_id': 'form-123', 'brand_name': 'Acme'}
+        }
+        mock_feedback.query.return_value = {'Items': []}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['stats']['total_submissions'] == 0
+        assert body['stats']['avg_rating'] is None
+
+
+class TestSubmissionsStayInThePartitionTheStatsReadQueries:
+    """A submission must land where that form's stats read looks for it.
+
+    _get_form_source_pk builds the partition from the FORM's stored brand_name,
+    falling back to the environment only when the form has none. So the write has
+    to stamp the form's brand too: stamping the deployment's BRAND_NAME splits a
+    form's submissions across two partitions the moment the deployment is renamed
+    — new submissions under the new brand, the stats read still querying the old,
+    and the form reporting 0 with the data sitting intact elsewhere.
+
+    Fixed at the write site deliberately. Making the READ prefer the environment
+    would instead strand every submission collected before the rename.
+    """
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_submission_is_stamped_with_the_forms_brand_not_the_environments(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The enqueued record carries the form's stored brand after a rename."""
+        mock_aggregates.get_item.return_value = {'Item': dict(_FORM_WITH_LEGACY_BRAND)}
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Still a great product', 'rating': 5},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        enqueued = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        assert enqueued['brand_name'] == 'Acme Classic'
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_submission_after_a_rename_is_found_by_that_forms_stats_read(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """End to end over the split: submit under the renamed deployment, then
+        read the stats, with the feedback table only answering the partition the
+        record was actually written to."""
+        mock_aggregates.get_item.return_value = {'Item': dict(_FORM_WITH_LEGACY_BRAND)}
+
+        submit_event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Still a great product', 'rating': 4},
+        )
+        submit_response = feedback_form_handler.lambda_handler(
+            submit_event, lambda_context
+        )
+        assert submit_response['statusCode'] == 200
+
+        enqueued = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        # The processor writes pk = SOURCE#<brand_name> (lambda/processor/handler.py).
+        stored = {
+            'feedback_id': enqueued['id'],
+            'rating': enqueued['rating'],
+            'source_channel': enqueued['source_channel'],
+        }
+        partition = f"SOURCE#{enqueued['brand_name']}"
+
+        stats_event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+        with patch(
+            'feedback_form_handler.feedback_table',
+            _fake_feedback_table({partition: [stored]}),
+        ):
+            stats_response = feedback_form_handler.lambda_handler(
+                stats_event, lambda_context
+            )
+
+        body = json.loads(stats_response['body'])
+        assert stats_response['statusCode'] == 200
+        assert body['stats']['total_submissions'] == 1, (
+            'the submission landed in a partition this form\'s stats read does '
+            'not query — the brand-rename split is back'
+        )
+        assert body['stats']['avg_rating'] == 4.0
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_form_stored_without_a_brand_falls_back_to_the_environment(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The read's own fallback, mirrored on the write: a legacy form record
+        with no brand_name must still agree with _get_form_source_pk."""
+        mock_aggregates.get_item.return_value = {
+            'Item': {'form_id': 'form-123', 'name': 'Legacy Form', 'enabled': True}
+        }
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Legacy submission'},
+        )
+
+        feedback_form_handler.lambda_handler(event, lambda_context)
+
+        enqueued = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        assert enqueued['brand_name'] == 'Acme Rebranded'
+        assert (
+            f"SOURCE#{enqueued['brand_name']}"
+            == feedback_form_handler._get_form_source_pk('form-123')
         )

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -1540,6 +1540,47 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
             == feedback_form_handler._form_source_pk(form)
         )
 
+    def test_no_other_module_derives_a_feedback_partition_from_the_brand(self):
+        """_form_source_pk must stay the ONLY brand-scoped read of SOURCE#.
+
+        The write side keeps a pre-rename form writing under its old brand, which
+        is safe precisely because no other reader is scoped by brand: every other
+        SOURCE# partition under lambda/ is built from source_platform. That is a
+        claim about other modules, and the write site used to assert it in a
+        comment nothing could falsify — so it is asserted here instead, and a
+        future brand-scoped read fails this test rather than quietly inheriting a
+        trade-off that was reasoned about without it.
+
+        Deliberately syntactic: it reads the source rather than importing, because
+        the point is to catch a NEW construction site, and an f-string's inputs are
+        visible in the text. A reader landing here from a failure should decide
+        whether the new read wants the form's brand (see _form_source_pk) or the
+        environment's, not silence the test.
+        """
+        lambda_root = Path(__file__).resolve().parents[2]
+        this_module = lambda_root / 'api' / 'feedback_form_handler.py'
+
+        offenders = []
+        for path in sorted(lambda_root.rglob('*.py')):
+            if path == this_module or 'test' in path.parts:
+                continue
+            for lineno, line in enumerate(
+                path.read_text(encoding='utf-8').splitlines(), start=1
+            ):
+                if 'SOURCE#' in line and 'BRAND_NAME' in line:
+                    rel = path.relative_to(lambda_root)
+                    offenders.append(f'{rel}:{lineno}: {line.strip()}')
+
+        assert not offenders, (
+            'a SOURCE# partition is now derived from BRAND_NAME outside '
+            'feedback_form_handler._form_source_pk:\n  '
+            + '\n  '.join(offenders)
+            + '\nThe write site in submit_form_feedback reasons that a pre-rename '
+            'form is safe to leave on its old brand BECAUSE no other reader is '
+            'brand-scoped. That reasoning now needs revisiting rather than this '
+            'assertion relaxing.'
+        )
+
 
 class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
     """A form with no stored brand must not be left depending on the env var.
@@ -1990,3 +2031,83 @@ class TestTheAnchorCanOnlyEverUpdateAFormThatExists:
         assert item['name'] == 'Product Form'
         assert item['enabled'] is True
         datetime.fromisoformat(item['updated_at'])
+
+    @mock_aws
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.sqs')
+    def test_a_form_whose_history_predates_its_anchor_reports_only_the_anchored_half(
+        self, mock_sqs, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The accepted limit of the fix, pinned so it is a decision and not a
+        surprise.
+
+        A form that was already collecting before its brand was resolved onto the
+        record can have submissions in TWO SOURCE# partitions: the pre-fix write
+        stamped the live BRAND_NAME, so a deployment renamed (or given a brand for
+        the first time) mid-collection split them. The anchor pins the form to the
+        brand live when it next receives a submission, and the stats read reports
+        that partition only — the other half needs a migration that rewrites those
+        records' pk, which is why UPDATABLE_FIELDS says so.
+
+        This is NOT a regression: the same form reported the same half before this
+        change. What the anchor adds is permanence, and permanence is the reason to
+        assert the number rather than leave it incidental — if someone later
+        teaches the read to cover the pre-anchor partition, this test is where the
+        expected count changes, deliberately.
+        """
+        table = self._table_with_a_brandless_form()
+
+        submit_event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'The submission that anchors the form', 'rating': 5},
+        )
+        with patch('feedback_form_handler.aggregates_table', table):
+            submit_response = feedback_form_handler.lambda_handler(
+                submit_event, lambda_context
+            )
+        assert submit_response['statusCode'] == 200
+
+        anchored_brand = table.get_item(
+            Key={'pk': 'FEEDBACK_FORM', 'sk': 'FORM#form-123'}
+        )['Item']['brand_name']
+        assert anchored_brand == 'Acme Rebranded'
+
+        # The history: 7 submissions collected under the old brand, 2 under the
+        # new one, all stamped by the pre-fix write from whatever BRAND_NAME held
+        # at the time. Nine are stored; the form can only reach the anchored half.
+        channel = 'form_form-123'
+        history = {
+            'SOURCE#Acme Classic': [
+                {'feedback_id': f'old-{n}', 'rating': 4, 'source_channel': channel}
+                for n in range(7)
+            ],
+            f'SOURCE#{anchored_brand}': [
+                {'feedback_id': f'new-{n}', 'rating': 5, 'source_channel': channel}
+                for n in range(2)
+            ],
+        }
+
+        stats_event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+        with patch('feedback_form_handler.aggregates_table', table), patch(
+            'feedback_form_handler.feedback_table', _fake_feedback_table(history)
+        ):
+            stats_response = feedback_form_handler.lambda_handler(
+                stats_event, lambda_context
+            )
+
+        body = json.loads(stats_response['body'])
+        assert stats_response['statusCode'] == 200
+        assert body['stats']['total_submissions'] == 2, (
+            'the stats read reports the anchored partition only — 2 of the 9 '
+            'stored. Accepted deliberately (see the UPDATABLE_FIELDS comment): '
+            'covering the pre-anchor partition means recording the prior brand '
+            'and doubling the reads on a route that already pages a whole '
+            'partition. If that changed, this expectation changes with it.'
+        )

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -122,14 +122,22 @@ def _fields_the_widget_reads() -> set[str]:
     return fields
 
 
-# An enabled form recorded under the brand the deployment carried when it was
-# created — the pre-rename half of the partition-split cases below.
-_FORM_WITH_LEGACY_BRAND = {
-    'form_id': 'form-123',
-    'name': 'Product Form',
-    'enabled': True,
-    'brand_name': 'Acme Classic',
-}
+def _form_with_legacy_brand(brand_name: str = 'Acme Classic') -> dict:
+    """An enabled form recorded under the brand its deployment carried then.
+
+    A factory rather than a shared dict so each test gets its own mutable copy —
+    these are handed to a mock as a DynamoDB Item and a handler is free to read
+    or reshape one.
+
+    `brand_name=''` is the form created while BRAND_NAME was unset (that is what
+    build_form_item stores), i.e. the record with no anchor of its own.
+    """
+    return {
+        'form_id': 'form-123',
+        'name': 'Product Form',
+        'enabled': True,
+        'brand_name': brand_name,
+    }
 
 
 def _queried_partition(query_kwargs: dict) -> str:
@@ -138,8 +146,23 @@ def _queried_partition(query_kwargs: dict) -> str:
     Read off the KeyConditionExpression the handler actually passed rather than
     reconstructed from the brand under test, so the assertion still means
     something if the handler starts building the partition differently.
+
+    That means reaching into a boto3 condition object's internal shape, so the
+    shape is asserted first: if boto3 changes it, this fails as a broken HELPER
+    naming itself rather than as a mystery KeyError inside a test whose subject
+    is brands.
     """
-    return query_kwargs['KeyConditionExpression'].get_expression()['values'][1]
+    expression = query_kwargs['KeyConditionExpression'].get_expression()
+    assert expression['operator'] == '=', (
+        '_queried_partition expected an equality condition on the key; boto3 '
+        f"gave operator {expression['operator']!r} — the helper needs updating, "
+        'this is not a finding about partitions.'
+    )
+    assert expression['values'][0].name == 'pk', (
+        '_queried_partition expected the key condition to be on pk; boto3 gave '
+        f"{expression['values'][0]!r} — helper needs updating."
+    )
+    return expression['values'][1]
 
 
 def _fake_feedback_table(items_by_pk: dict[str, list[dict]]):
@@ -1117,11 +1140,157 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
         assert body['stats']['total_submissions'] == 0
         assert body['stats']['avg_rating'] is None
 
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_failed_form_lookup_is_an_error_not_a_zero_count(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The other read on this route. The FORM lookup used to be swallowed and
+        degraded to BRAND_NAME, which after a rename is a partition this form's
+        submissions were never written to: the feedback query then succeeds
+        against the wrong partition, finds nothing, and the route answers 200 with
+        total_submissions 0 — issue #312's false zero arriving through the door
+        the earlier fix left open."""
+        mock_aggregates.get_item.side_effect = Exception(
+            'ProvisionedThroughputExceededException'
+        )
+        # The data is intact, in the partition the form's real brand names. A
+        # degraded read queries somewhere else and this is never consulted.
+        mock_feedback.query.return_value = {'Items': []}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 500
+        assert body['success'] is False
+        assert 'stats' not in body
+        assert 'total_submissions' not in body
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_form_that_does_not_exist_is_a_404_not_a_zero_count(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """A deleted form must present as a deleted form. get_form_submissions
+        over the same table has always answered 404 here; stats answered 200 with
+        a measured-looking 0, which LinkedFormEvidence renders as evidence
+        against a work item. Its error branch already has an
+        `evidence.unavailable` string waiting for the 404."""
+        mock_aggregates.get_item.return_value = {}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/does-not-exist/stats',
+            path_params={'form_id': 'does-not-exist'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 404
+        assert body['success'] is False
+        assert 'stats' not in body
+        assert 'total_submissions' not in body
+        # A 404 is about the form, so the feedback partition is never read.
+        mock_feedback.query.assert_not_called()
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_missing_form_is_reported_as_missing_not_as_a_server_fault(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The blanket `except Exception` must not downgrade a typed exception.
+        NotFoundError raised inside the route carries 404; swallowing it into
+        ServiceError would report a client's bad form id as a server outage and
+        make it invisible in error triage."""
+        mock_aggregates.get_item.return_value = {}
+        mock_feedback.query.side_effect = AssertionError('should not be reached')
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/does-not-exist/stats',
+            path_params={'form_id': 'does-not-exist'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404, (
+            'a typed exception was converted to a 500 by the blanket handler'
+        )
+
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_stats_read_queries_the_forms_own_partition(
+        self, mock_aggregates, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The partition comes from the form record this route loaded, not from
+        the deployment's brand — the read half of the one-partition invariant, now
+        that the form is loaded here rather than inside a helper that re-read it
+        and tolerated failure."""
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
+        fake_table = _fake_feedback_table({
+            'SOURCE#Acme Classic': [
+                {'feedback_id': 'fb-1', 'rating': 3, 'source_channel': 'form_form-123'}
+            ]
+        })
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        with patch('feedback_form_handler.feedback_table', fake_table):
+            response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        body = json.loads(response['body'])
+        assert response['statusCode'] == 200
+        assert body['stats']['total_submissions'] == 1
+        assert (
+            _queried_partition(fake_table.query.call_args.kwargs)
+            == 'SOURCE#Acme Classic'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_form_is_read_once_per_stats_request(
+        self, mock_aggregates, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """One get_item, where this route used to make none of its own and let a
+        helper read the record separately. Pinned because the 404 check and the
+        partition are answered from the same record on purpose — the existence
+        check must not have added a read."""
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        with patch(
+            'feedback_form_handler.feedback_table', _fake_feedback_table({})
+        ):
+            feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert mock_aggregates.get_item.call_count == 1
+
 
 class TestSubmissionsStayInThePartitionTheStatsReadQueries:
     """A submission must land where that form's stats read looks for it.
 
-    _get_form_source_pk builds the partition from the FORM's stored brand_name,
+    _form_source_pk builds the partition from the FORM's stored brand_name,
     falling back to the environment only when the form has none. So the write has
     to stamp the form's brand too: stamping the deployment's BRAND_NAME splits a
     form's submissions across two partitions the moment the deployment is renamed
@@ -1141,7 +1310,7 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
         feedback_form_handler
     ):
         """The enqueued record carries the form's stored brand after a rename."""
-        mock_aggregates.get_item.return_value = {'Item': dict(_FORM_WITH_LEGACY_BRAND)}
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
 
         event = api_gateway_event(
             method='POST',
@@ -1167,7 +1336,7 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
         """End to end over the split: submit under the renamed deployment, then
         read the stats, with the feedback table only answering the partition the
         record was actually written to."""
-        mock_aggregates.get_item.return_value = {'Item': dict(_FORM_WITH_LEGACY_BRAND)}
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
 
         submit_event = api_gateway_event(
             method='POST',
@@ -1219,10 +1388,9 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
         feedback_form_handler
     ):
         """The read's own fallback, mirrored on the write: a legacy form record
-        with no brand_name must still agree with _get_form_source_pk."""
-        mock_aggregates.get_item.return_value = {
-            'Item': {'form_id': 'form-123', 'name': 'Legacy Form', 'enabled': True}
-        }
+        with no brand_name must still agree with _form_source_pk."""
+        form = {'form_id': 'form-123', 'name': 'Legacy Form', 'enabled': True}
+        mock_aggregates.get_item.return_value = {'Item': dict(form)}
 
         event = api_gateway_event(
             method='POST',
@@ -1237,5 +1405,212 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
         assert enqueued['brand_name'] == 'Acme Rebranded'
         assert (
             f"SOURCE#{enqueued['brand_name']}"
-            == feedback_form_handler._get_form_source_pk('form-123')
+            == feedback_form_handler._form_source_pk(form)
+        )
+
+
+class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
+    """A form with no stored brand must not be left depending on the env var.
+
+    build_form_item writes 'brand_name': BRAND_NAME, so a form created while
+    BRAND_NAME was unset is stored with ''. For that record BOTH sides of the
+    partition — submit_form_feedback's `form.get('brand_name') or BRAND_NAME` and
+    _form_source_pk's identical fallback — resolve through the live environment
+    variable. They agree at any instant, so a same-instant test passes either
+    way; what does not hold is the property the fix claims, that a submission
+    stays in the partition the read queries for the WHOLE LIFE of the form.
+    Rename the deployment and the pre-rename submissions are unreachable, which
+    is exactly the stranding the write-site fix was chosen over.
+
+    So the resolved brand is written back onto the form record once, and every
+    read and write afterwards is anchored to a stored value.
+    """
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_submission_survives_a_rename_that_happens_after_it(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The case a same-instant test cannot see: submit against a form stored
+        with brand_name '', THEN rename the deployment, then read the stats. The
+        submission must still be found, which is only true if the form record was
+        anchored to the brand the submission was written under."""
+        stored_form = _form_with_legacy_brand(brand_name='')
+        mock_aggregates.get_item.return_value = {'Item': dict(stored_form)}
+
+        # The anchor is a real conditional write, so let it mutate the record the
+        # subsequent read returns — that is the whole mechanism under test.
+        def update_item(**kwargs):
+            stored_form['brand_name'] = kwargs['ExpressionAttributeValues'][':brand']
+            mock_aggregates.get_item.return_value = {'Item': dict(stored_form)}
+            return {}
+
+        mock_aggregates.update_item.side_effect = update_item
+
+        submit_event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Collected before the rename', 'rating': 5},
+        )
+        submit_response = feedback_form_handler.lambda_handler(
+            submit_event, lambda_context
+        )
+        assert submit_response['statusCode'] == 200
+
+        enqueued = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        assert enqueued['brand_name'] == 'Acme Original'
+        # The processor writes pk = SOURCE#<brand_name> (lambda/processor/handler.py).
+        partition = f"SOURCE#{enqueued['brand_name']}"
+        stored_submission = {
+            'feedback_id': enqueued['id'],
+            'rating': enqueued['rating'],
+            'source_channel': enqueued['source_channel'],
+        }
+
+        stats_event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+        # The rename: nothing about the form or the stored feedback changes, only
+        # the deployment's environment.
+        with patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded'), patch(
+            'feedback_form_handler.feedback_table',
+            _fake_feedback_table({partition: [stored_submission]}),
+        ):
+            stats_response = feedback_form_handler.lambda_handler(
+                stats_event, lambda_context
+            )
+
+        body = json.loads(stats_response['body'])
+        assert stats_response['statusCode'] == 200
+        assert body['stats']['total_submissions'] == 1, (
+            'a submission collected before the rename is unreachable to the '
+            "form's own stats read — the form was never anchored to a brand, so "
+            'both sides followed the environment variable when it moved'
+        )
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_anchor_write_cannot_overwrite_a_brand_already_stored(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """Guarded by a condition, so a concurrent submission or an admin edit
+        that got there first wins. Without the condition this backfill would be a
+        blind write that could move a form's partition — the defect it exists to
+        prevent."""
+        mock_aggregates.get_item.return_value = {
+            'Item': _form_with_legacy_brand(brand_name='')
+        }
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Anything'},
+        )
+
+        feedback_form_handler.lambda_handler(event, lambda_context)
+
+        kwargs = mock_aggregates.update_item.call_args.kwargs
+        assert 'attribute_not_exists(brand_name)' in kwargs['ConditionExpression']
+        assert kwargs['ExpressionAttributeValues'][':empty'] == ''
+        assert kwargs['ExpressionAttributeValues'][':brand'] == 'Acme Original'
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_form_that_already_has_a_brand_is_not_rewritten(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """No write for a form that is already anchored: the backfill must not add
+        a DynamoDB write to every submission on every form."""
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Anything'},
+        )
+
+        feedback_form_handler.lambda_handler(event, lambda_context)
+
+        mock_aggregates.update_item.assert_not_called()
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_failed_anchor_does_not_fail_the_submission(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """Best effort by design. The anchor makes future reads durable; the
+        record being enqueued already carries the right brand either way, so
+        losing a customer's feedback over it would be the worse outcome."""
+        mock_aggregates.get_item.return_value = {
+            'Item': _form_with_legacy_brand(brand_name='')
+        }
+        mock_aggregates.update_item.side_effect = Exception('Throttled')
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Feedback that must not be dropped'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        enqueued = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        assert enqueued['brand_name'] == 'Acme Original'
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', '')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_no_brand_anywhere_is_left_alone_and_still_agrees(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """Neither the form nor the deployment has a brand: there is nothing to
+        anchor TO, so no write is made and both sides fall through to the
+        processor's own default partition (SOURCE#feedback_form, from
+        source_platform). Pinned because writing '' would be a pointless write,
+        and because this is the one case where the partition comes from neither
+        brand."""
+        form = _form_with_legacy_brand(brand_name='')
+        mock_aggregates.get_item.return_value = {'Item': dict(form)}
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Unbranded deployment'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        mock_aggregates.update_item.assert_not_called()
+
+        enqueued = json.loads(mock_sqs.send_message.call_args.kwargs['MessageBody'])
+        assert enqueued['brand_name'] == ''
+        # The processor falls back to source_platform for an empty brand_name
+        # (lambda/processor/handler.py: source_display = brand_name or
+        # source_platform), which is the partition the read builds too.
+        assert (
+            f"SOURCE#{enqueued['source_platform']}"
+            == feedback_form_handler._form_source_pk(form)
         )

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -1545,7 +1545,8 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
 
         The write side keeps a pre-rename form writing under its old brand, which
         is safe precisely because no other reader is scoped by brand: every other
-        SOURCE# partition under lambda/ is built from source_platform. That is a
+        SOURCE# partition under lambda/ and plugins/ is built from
+        source_platform. That is a
         claim about other modules, and the write site used to assert it in a
         comment nothing could falsify — so it is asserted here instead, and a
         future brand-scoped read fails this test rather than quietly inheriting a
@@ -1556,20 +1557,52 @@ class TestSubmissionsStayInThePartitionTheStatsReadQueries:
         visible in the text. A reader landing here from a failure should decide
         whether the new read wants the form's brand (see _form_source_pk) or the
         environment's, not silence the test.
+
+        The guarantee is therefore precise and worth stating so nobody reads it as
+        broader: a new SAME-LINE construction under lambda/ or plugins/. A
+        deliberately split one — `brand = BRAND_NAME` then f"SOURCE#{brand}" on the
+        next line — is NOT caught, and neither is a partition assembled at
+        runtime. Catching those needs dataflow analysis; the value here is
+        catching the copy-paste of _form_source_pk, which is how a second
+        brand-scoped read would realistically arrive.
+
+        lambda/layers/ is excluded for the same reason pytest.ini
+        (--ignore=lambda/layers, norecursedirs) and ruff.toml (extend-exclude)
+        exclude it: it is vendored third-party build output from
+        scripts/build-layers.sh, absent from git but expected to exist locally, so
+        a match there is someone else's prose and not a finding about this repo.
         """
-        lambda_root = Path(__file__).resolve().parents[2]
-        this_module = lambda_root / 'api' / 'feedback_form_handler.py'
+        repo_root = Path(__file__).resolve().parents[3]
+        this_module = repo_root / 'lambda' / 'api' / 'feedback_form_handler.py'
+
+        def is_first_party_source(path: Path) -> bool:
+            return not (
+                path == this_module
+                # Vendored: see the docstring. Matches pytest.ini and ruff.toml.
+                or 'layers' in path.parts
+                # Exact-segment, so it skips a test/ package but not a stray
+                # tests/; the name check below covers plugins', which sit beside
+                # the code they exercise rather than in a test/ directory.
+                or 'test' in path.parts
+                or path.name.startswith('test_')
+                or path.name == 'conftest.py'
+            )
 
         offenders = []
-        for path in sorted(lambda_root.rglob('*.py')):
-            if path == this_module or 'test' in path.parts:
-                continue
-            for lineno, line in enumerate(
-                path.read_text(encoding='utf-8').splitlines(), start=1
-            ):
-                if 'SOURCE#' in line and 'BRAND_NAME' in line:
-                    rel = path.relative_to(lambda_root)
-                    offenders.append(f'{rel}:{lineno}: {line.strip()}')
+        for tree in ('lambda', 'plugins'):
+            for path in sorted((repo_root / tree).rglob('*.py')):
+                if not is_first_party_source(path):
+                    continue
+                # errors='replace' so one non-UTF-8 vendored fixture cannot abort
+                # the run with a UnicodeDecodeError that names neither the file
+                # nor this invariant. A mojibake byte cannot spell either token.
+                for lineno, line in enumerate(
+                    path.read_text(encoding='utf-8', errors='replace').splitlines(),
+                    start=1,
+                ):
+                    if 'SOURCE#' in line and 'BRAND_NAME' in line:
+                        rel = path.relative_to(repo_root)
+                        offenders.append(f'{rel}:{lineno}: {line.strip()}')
 
         assert not offenders, (
             'a SOURCE# partition is now derived from BRAND_NAME outside '

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -1058,6 +1058,61 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
         assert 'stats' not in body
         assert 'total_submissions' not in response['body']
 
+    @patch.dict('os.environ', {}, clear=False)
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_read_failure_reaches_cloudwatch_and_not_just_the_caller(
+        self, mock_aggregates, mock_feedback, capsys, api_gateway_event,
+        lambda_context, feedback_form_handler
+    ):
+        """A metric is only worth adding if it is actually emitted.
+
+        `metrics.add_metric` BUFFERS: nothing leaves the function unless the
+        handler is wrapped in `metrics.log_metrics`, which `api_handler` does —
+        and a flush with no namespace raises SchemaValidationError, which on this
+        path would replace the read failure with a metrics bug. So this asserts
+        the whole way out: an EMF blob on stdout, naming this metric, under the
+        namespace shared/logging pins on the Metrics singleton ('VoC', a default
+        that does not depend on POWERTOOLS_METRICS_NAMESPACE being deployed).
+
+        Without it, "the failure is now visible to operations" — the answer given
+        to the review question about a silent DynamoDB fault — is unverified.
+        """
+        import os
+
+        os.environ.pop('POWERTOOLS_METRICS_NAMESPACE', None)
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
+        mock_feedback.query.side_effect = Exception('ProvisionedThroughputExceeded')
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 500
+        emitted = [
+            json.loads(line)
+            for line in capsys.readouterr().out.splitlines()
+            if 'FeedbackFormStatsReadFailed' in line and '_aws' in line
+        ]
+        assert emitted, (
+            'the read failure emitted no CloudWatch metric — add_metric only '
+            'buffers, so this is invisible to operations unless api_handler '
+            'flushes it'
+        )
+        namespaces = {
+            directive['Namespace']
+            for blob in emitted
+            for directive in blob['_aws']['CloudWatchMetrics']
+        }
+        assert namespaces == {'VoC'}, (
+            f'metric emitted under {namespaces}, not the namespace '
+            'shared/logging sets on the Metrics singleton'
+        )
+
     @patch('feedback_form_handler.feedback_table', None)
     @patch('feedback_form_handler.aggregates_table')
     def test_an_unconfigured_feedback_table_is_a_configuration_error(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3,10 +3,13 @@ Tests for feedback_form_handler.py - /feedback-forms/* endpoints.
 """
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import boto3
 import pytest
+from moto import mock_aws
 
 WIDGET_SOURCE = Path(__file__).resolve().parents[1] / 'static' / 'feedback-widget.js'
 
@@ -1205,27 +1208,65 @@ class TestFormStatsNeverReportsAZeroItDidNotMeasure:
 
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')
-    def test_a_missing_form_is_reported_as_missing_not_as_a_server_fault(
+    def test_a_typed_failure_inside_the_stats_query_keeps_its_own_status(
         self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
         feedback_form_handler
     ):
         """The blanket `except Exception` must not downgrade a typed exception.
-        NotFoundError raised inside the route carries 404; swallowing it into
-        ServiceError would report a client's bad form id as a server outage and
-        make it invisible in error triage."""
-        mock_aggregates.get_item.return_value = {}
-        mock_feedback.query.side_effect = AssertionError('should not be reached')
+
+        This raises the typed exception from INSIDE the try block, which is what
+        makes it a test of the `except ApiError: raise` guard. The obvious
+        spelling — a missing form, which raises NotFoundError — proves nothing
+        about the guard: that raise happens in _load_form_for_query, above the
+        try, so it reaches the caller whether the guard exists or not (this test
+        used to be written that way and passed with both guards deleted).
+
+        Currently no statement inside the try raises an ApiError, so the guard is
+        precautionary; the mock stands in for the future one that does. Delete
+        the guard and this is a 500.
+        """
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
+        mock_feedback.query.side_effect = feedback_form_handler.NotFoundError(
+            'Form not found'
+        )
 
         event = api_gateway_event(
             method='GET',
-            path='/feedback-forms/does-not-exist/stats',
-            path_params={'form_id': 'does-not-exist'},
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
         )
 
         response = feedback_form_handler.lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 404, (
-            'a typed exception was converted to a 500 by the blanket handler'
+            'a typed exception raised inside the try was converted to a 500 by '
+            'the blanket handler'
+        )
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_typed_failure_inside_the_submissions_query_keeps_its_own_status(
+        self, mock_aggregates, mock_feedback, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The same guard on the sibling route, which has the same shape and so
+        the same way of being silently correct-for-the-wrong-reason."""
+        mock_aggregates.get_item.return_value = {'Item': _form_with_legacy_brand()}
+        mock_feedback.query.side_effect = feedback_form_handler.ValidationError(
+            'limit must be a number'
+        )
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/submissions',
+            path_params={'form_id': 'form-123'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400, (
+            'a typed exception raised inside the try was converted to a 500 by '
+            'the blanket handler'
         )
 
     @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
@@ -1523,6 +1564,62 @@ class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
         assert 'attribute_not_exists(brand_name)' in kwargs['ConditionExpression']
         assert kwargs['ExpressionAttributeValues'][':empty'] == ''
         assert kwargs['ExpressionAttributeValues'][':brand'] == 'Acme Original'
+        # UpdateItem is an upsert and attribute_not_exists(brand_name) is
+        # satisfied by a MISSING item, so existence has to be required
+        # separately or this write recreates a form someone just deleted.
+        assert 'attribute_exists(sk)' in kwargs['ConditionExpression']
+        # And the parentheses are part of the guard, not formatting: without them
+        # `attribute_exists(sk) AND attribute_not_exists(brand_name) OR
+        # brand_name = :empty` is satisfied by brand_name = '' alone, on a
+        # non-existent item, which is exactly the case being excluded.
+        assert '(attribute_not_exists(brand_name) OR brand_name = :empty)' in (
+            kwargs['ConditionExpression']
+        )
+
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_anchor_records_when_it_changed_the_form(
+        self, mock_aggregates, mock_sqs, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """brand_name is published by item_to_form and by the PUBLIC widget
+        config, so the anchor changes what the management UI and the widget on a
+        customer's site report. Every other write path here maintains updated_at
+        (build_form_item sets it, update_form always appends it); a published
+        field that moves with no timestamp is the kind of change nobody can
+        account for six months later."""
+        mock_aggregates.get_item.return_value = {
+            'Item': _form_with_legacy_brand(brand_name='')
+        }
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'Anything'},
+        )
+
+        feedback_form_handler.lambda_handler(event, lambda_context)
+
+        kwargs = mock_aggregates.update_item.call_args.kwargs
+        assert 'updated_at' in kwargs['UpdateExpression']
+        # A real ISO-8601 instant, not a placeholder that only satisfies the
+        # assertion above.
+        datetime.fromisoformat(kwargs['ExpressionAttributeValues'][':now'])
+
+    def test_the_brand_is_not_editable_through_the_public_form_api(
+        self, feedback_form_handler
+    ):
+        """A deliberate decision, recorded as a test because the anchor makes the
+        stored brand permanent and an obvious "fix" for that is to let PUT change
+        it. It must not: brand_name is the input to _form_source_pk, so editing it
+        moves where this form's stats read looks WITHOUT moving the submissions
+        already written under the old value — the stranding this module's
+        write/read agreement exists to prevent, triggered by hand. Correcting a
+        brand needs a migration that rewrites the feedback partition too."""
+        assert 'brand_name' not in feedback_form_handler.UPDATABLE_FIELDS
 
     @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
     @patch('feedback_form_handler.BRAND_NAME', 'Acme Rebranded')
@@ -1614,3 +1711,185 @@ class TestABrandlessFormIsAnchoredSoARenameCannotStrandIt:
             f"SOURCE#{enqueued['source_platform']}"
             == feedback_form_handler._form_source_pk(form)
         )
+
+
+class TestTheAnchorCanOnlyEverUpdateAFormThatExists:
+    """The backfill must not be able to bring a deleted form back.
+
+    DynamoDB's UpdateItem is an UPSERT, and `attribute_not_exists(brand_name)` is
+    SATISFIED by an item that is not there at all — so a condition written only
+    about brand_name lets the anchor CREATE the record it meant to amend. The
+    window is real: `POST /feedback-forms/<id>/submit` is public and
+    unauthenticated, so a widget on a customer's site can be mid-submission when
+    an operator deletes the form, between this route's get_item and its anchor
+    write. The role has UpdateItem on the aggregates table
+    (`aggregatesTable.grantReadWriteData` in api-stack.ts), so nothing else stops
+    it.
+
+    What a resurrected record would cost is worse than the split the anchor
+    prevents: it is a bare {pk, sk, brand_name, updated_at} stub, which
+    list_forms renders as a nameless row whose own form_id is '' (so its delete
+    and edit actions cannot address it), and — on the very route this change made
+    honest — a deleted form goes back to answering 200 with total_submissions 0,
+    because _load_form_for_query now finds an Item.
+
+    Backed by a real (moto) table rather than a mock, because "UpdateItem creates
+    the item" is DynamoDB's behaviour, not the handler's: asserting the condition
+    string is what the sibling class does, and it cannot show that the string
+    actually excludes this.
+    """
+
+    @staticmethod
+    def _aggregates_table_that_loses_the_form_mid_request(table):
+        """The real table, with the form deleted the instant it is read.
+
+        Stands in for the race: get_item answers with the record submit_form_feedback
+        is about to trust, and by the time the anchor writes, the DELETE has landed.
+        Every call goes to the real table, so the condition is evaluated by
+        DynamoDB and not by this test's idea of it.
+        """
+        racing = MagicMock()
+
+        def get_item(**kwargs):
+            response = table.get_item(**kwargs)
+            table.delete_item(Key=kwargs['Key'])
+            return response
+
+        racing.get_item.side_effect = get_item
+        racing.update_item.side_effect = table.update_item
+        return racing
+
+    @staticmethod
+    def _table_with_a_brandless_form():
+        table = boto3.resource('dynamodb', region_name='us-east-1').create_table(
+            TableName='test-aggregates-anchor',
+            KeySchema=[
+                {'AttributeName': 'pk', 'KeyType': 'HASH'},
+                {'AttributeName': 'sk', 'KeyType': 'RANGE'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'pk', 'AttributeType': 'S'},
+                {'AttributeName': 'sk', 'AttributeType': 'S'},
+            ],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        # A form created while BRAND_NAME was unset: build_form_item stores ''.
+        table.put_item(Item={
+            'pk': 'FEEDBACK_FORM',
+            'sk': 'FORM#form-123',
+            'form_id': 'form-123',
+            'name': 'Product Form',
+            'enabled': True,
+            'brand_name': '',
+        })
+        return table
+
+    @mock_aws
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    def test_a_form_deleted_mid_submission_is_not_written_back(
+        self, mock_sqs, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The delete wins, and the anchor is a no-op rather than a resurrection."""
+        table = self._table_with_a_brandless_form()
+        racing = self._aggregates_table_that_loses_the_form_mid_request(table)
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'In flight when the form was deleted', 'rating': 5},
+        )
+
+        with patch('feedback_form_handler.aggregates_table', racing):
+            response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        # The submission itself still succeeds: it was accepted before the delete
+        # and its record already carries the brand, so dropping it would be the
+        # worse outcome — the anchor has always been best effort.
+        assert response['statusCode'] == 200
+        assert mock_sqs.send_message.called
+
+        assert 'Item' not in table.get_item(
+            Key={'pk': 'FEEDBACK_FORM', 'sk': 'FORM#form-123'}
+        ), (
+            'the anchor upserted a deleted form back into existence — '
+            'attribute_not_exists(brand_name) is satisfied by a missing item, so '
+            'the condition has to require the item to exist as well'
+        )
+
+    @mock_aws
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    def test_the_stats_route_still_reports_that_form_as_gone(
+        self, mock_sqs, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The consequence that matters to this change: a phantom record makes
+        _load_form_for_query find an Item, so /stats answers 200 with
+        total_submissions 0 for a deleted form — reopening the false zero this PR
+        closed, for exactly the ids most likely to be read just after a delete."""
+        table = self._table_with_a_brandless_form()
+        racing = self._aggregates_table_that_loses_the_form_mid_request(table)
+
+        submit_event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'In flight when the form was deleted'},
+        )
+        with patch('feedback_form_handler.aggregates_table', racing):
+            feedback_form_handler.lambda_handler(submit_event, lambda_context)
+
+        stats_event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/form-123/stats',
+            path_params={'form_id': 'form-123'},
+        )
+        with patch('feedback_form_handler.aggregates_table', table), patch(
+            'feedback_form_handler.feedback_table', _fake_feedback_table({})
+        ):
+            stats_response = feedback_form_handler.lambda_handler(
+                stats_event, lambda_context
+            )
+
+        body = json.loads(stats_response['body'])
+        assert stats_response['statusCode'] == 404, (
+            'a deleted form is answering the stats route again, which means the '
+            'anchor recreated it'
+        )
+        assert 'total_submissions' not in body
+
+    @mock_aws
+    @patch('feedback_form_handler.PROCESSING_QUEUE_URL', 'https://sqs.example.com/queue')
+    @patch('feedback_form_handler.BRAND_NAME', 'Acme Original')
+    @patch('feedback_form_handler.sqs')
+    def test_a_form_that_is_still_there_is_anchored_as_before(
+        self, mock_sqs, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The boundary the existence check must not have crossed: requiring the
+        item to exist is only correct if it still lets the ordinary brandless form
+        be anchored. Over-tighten the condition and the backfill quietly stops
+        working, which the failure it tolerates would hide."""
+        table = self._table_with_a_brandless_form()
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/form-123/submit',
+            path_params={'form_id': 'form-123'},
+            body={'text': 'An ordinary submission', 'rating': 4},
+        )
+
+        with patch('feedback_form_handler.aggregates_table', table):
+            response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        item = table.get_item(
+            Key={'pk': 'FEEDBACK_FORM', 'sk': 'FORM#form-123'}
+        )['Item']
+        assert item['brand_name'] == 'Acme Original'
+        # And the rest of the record is intact — an update, never a replacement.
+        assert item['name'] == 'Product Form'
+        assert item['enabled'] is True
+        datetime.fromisoformat(item['updated_at'])


### PR DESCRIPTION
## Summary

Two defects in `voc-datalake/lambda/api/feedback_form_handler.py` corrupted the submission count and average rating a form reports. That number is rendered next to a prioritization score, so a wrong value silently changes a product decision. Python backend only — no frontend, CDK, or locale file is touched.

**Invariant 1 — a failed stats read must not report zero.** `get_form_stats` returned HTTP 200 with `{'success': True, 'stats': {'total_submissions': 0, 'avg_rating': None}}` from both its `except Exception` handler and its "table not configured" branch, so a DynamoDB failure or a Lambda deployed without `FEEDBACK_TABLE` was indistinguishable from a form nobody had answered. It now raises `ServiceError` on an unexpected read failure and `ConfigurationError` when the table is not configured — exactly what `get_form_submissions`, over the same table, has always done. Closes #312.

**Invariant 2 — a brand rename must not split the partition the stats read queries.** `submit_form_feedback` stamped the enqueued record's `brand_name` from the module-level `BRAND_NAME` environment variable, while `_get_form_source_pk` builds the query partition from the FORM's stored `brand_name` and only falls back to the environment. Once a deployment's brand name changed, new submissions landed under the new brand while the stats read still queried the old one, and the form reported 0 submissions with the data sitting intact elsewhere. Fixed at the WRITE site: the record now carries `form.get('brand_name') or BRAND_NAME`. The form record is already loaded a few lines above for the `enabled` check, so this costs no extra read, and every submission stays in the partition the read queries for the whole life of the form.

**Correction to an earlier claim in this description.** This originally said the fix "needs no data migration". That is no longer true and the review was right to call it out. A form created while `BRAND_NAME` was unset is stored with `brand_name: ''`, and for those records *both* sides fall through to the live environment variable — so they agree at any instant but a rename still strands the pre-rename submissions. Closing that required making the resolved brand durable on the record, so the diff now includes a **one-time, conditional, best-effort in-band backfill** of `brand_name` (`_anchor_form_brand`), reachable from the public `POST /feedback-forms/<id>/submit` path. It is guarded so that it can only ever move `''` to a real brand, never brand to brand, and only on a record that still exists (`attribute_exists(sk) AND (attribute_not_exists(brand_name) OR brand_name = :empty)`) — because `UpdateItem` is an upsert and a condition written only about `brand_name` would recreate a form deleted mid-submission. A failed backfill never fails the submission. Still Python-only: no frontend, CDK or locale file is touched.

Deliberately **not** the alternative fix of making `_get_form_source_pk` prefer the environment variable — that would strand every submission collected before the rename.

### Tests

Seven cases added to `voc-datalake/lambda/api/test/test_feedback_form_handler.py`, following the conventions already in that file (AWS mocked at the import boundary via `@patch('feedback_form_handler.…')`, the `feedback_form_handler` conftest fixture, outcome-named tests):

- `TestFormStatsNeverReportsAZeroItDidNotMeasure`
  - a stats read that raises returns 500 with no count at all (asserts `total_submissions` appears nowhere in the body, not merely that the status changed)
  - an unconfigured feedback table returns a configuration error rather than a zero count
  - a successful stats read is unchanged (3 submissions, avg 4.5, rating_count 2)
  - an empty partition still returns a 200 with a *measured* zero — failing loudly must not have turned "nobody answered" into an error
- `TestSubmissionsStayInThePartitionTheStatsReadQueries`
  - a submission on a form whose stored brand differs from the environment brand is enqueued with the FORM's brand
  - end-to-end over the split: submit under the renamed deployment, then read the stats through a fake feedback table that only answers the partition the record was actually written to, and the stats read finds it. A mock returning the same `Items` for every `pk` cannot demonstrate this invariant, so the helper reads the `pk` off the `KeyConditionExpression` the handler passed and applies the handler's own `source_channel` filter.
  - a legacy form record with no `brand_name` falls back to the environment, and the resulting partition is asserted equal to `_get_form_source_pk`'s output

Each new test was confirmed to actually catch its defect: with the handler change stashed and only the tests applied, 4 of the new cases fail (`4 failed, 33 passed`); with the fix applied, `37 passed`.

## Build and test results

- `mise run build` → `mise ERROR no tasks defined in …` — this repo defines no mise tasks, matching the note that build gating is inert here. There is no Python build step; the npm `build` script only builds the frontend, which is out of scope and whose `node_modules` are not installed in this container.
- Test environment: the repo's `voc-datalake/.venv` was absent, so it was created from `requirements-dev.txt` (plus `aws-xray-sdk` and `pydantic`, which `aws-lambda-powertools` needs at import time and which come from the Lambda layer requirements in a real install).
- `.venv/bin/python -m pytest lambda/api/test/test_feedback_form_handler.py` → **37 passed** (30 before, 7 added).
- `.venv/bin/python -m pytest lambda/api` → **891 passed**, no failures.
- `.venv/bin/python -m pytest lambda` → **1816 passed, 14 failed**. All 14 failures are in `lambda/shared/test/test_http.py` (`AttributeError: module 'shared' has no attribute 'http_utils'`), are pre-existing, and are untouched by this change. `plugins/` cannot be collected at all in this container (`tenacity`, `bs4`, `app_store_web_scraper` missing), also pre-existing.
- `.venv/bin/python -m ruff check lambda/api/feedback_form_handler.py lambda/api/test/test_feedback_form_handler.py` → 28 findings, byte-for-byte the same count and the same two categories (`I001` unsorted-imports ×16, `BLE001` blind-except ×12) as on the unmodified files. No new lint finding was introduced, and none of the pre-existing ones were "fixed" to make anything green. `git diff --check` is clean.

## Decisions made

- **`form.get('brand_name') or BRAND_NAME`** rather than `form.get('brand_name', BRAND_NAME)`: a form record with `brand_name: ''` (which `build_form_item` writes whenever `BRAND_NAME` is unset) must take the fallback too, and the read side's `form_brand_name or BRAND_NAME` already treats empty exactly this way. The two sides now agree on empty as well as on absent.
- **`ServiceError('Failed to fetch form stats')`** — the message follows the `Failed to …` phrasing every other handler in this file uses, and `ConfigurationError('Feedback table not configured')` is the same string `get_form_submissions` raises, so the two routes report the same fault identically.
- **A fourth, unasked-for stats test** (a genuine empty partition still returns 200 with 0) was added because the obvious way to over-apply invariant 1 is to make an empty result an error too, which would break both frontend consumers. It pins the boundary.
- The module-level `_FORM_WITH_LEGACY_BRAND` constant is a module constant rather than a class attribute solely because `ruff` flags a mutable class attribute (`RUF012`); keeping the new code lint-clean mattered more than the nesting.
- Out of scope and untouched, as specified: everything under `voc-datalake/frontend/` (`LinkedFormEvidence`'s `evidence.unavailable` branch and `FormCard`'s em dash already handle a failed query — making the endpoint honest is what activates them), `get_form_stats`'s query shape and its full-partition read cost, every other handler, `voc-datalake/lib/`, and all locale files.

## Agent notes

**What went well.** The task named both defects precisely, including the fix site for the second one and the alternative to avoid, so no interpretation was needed. The repo made both fixes easy to justify: `get_form_submissions` sits directly above `get_form_stats` and already raised the two exceptions, both were already imported, and `_get_form_source_pk`'s `form_brand_name or BRAND_NAME` spelled out precisely what the write side had to mirror.

**What was difficult.**
- The container had no `voc-datalake/.venv`, which every backend npm script hardcodes, so the suite could not run until it was built. Three dependencies were needed beyond `requirements-dev.txt` before any handler could even be imported: `aws-xray-sdk` (imported by `powertools`' `Tracer()` at module scope in `shared/logging.py`) and `pydantic` (imported by `create_api_resolver`'s `enable_validation=True`). Both ship via the Lambda layer requirements, which `requirements-dev.txt` mentions in a comment but does not install. Worth noting for anyone else touching Python here.
- The end-to-end brand test needed real thought. A `MagicMock` whose `query` returns fixed `Items` passes whether or not the partitions agree, i.e. it would not have caught the bug. Reading the queried `pk` off the `KeyConditionExpression` object (`.get_expression()['values'][1]`) and answering only from that partition is what makes the assertion mean something.

**Patterns and conventions discovered.**
- `shared/exceptions.py` + the handlers registered in `shared/api.py` are the error contract: raise a typed exception, get `{'success': False, 'error': …}` at the right status. Handlers should never hand-build an error payload.
- Tests mock AWS at the import boundary (`@patch('feedback_form_handler.aggregates_table')`), never boto3 itself. Newer tests take the module from the `feedback_form_handler` conftest fixture; older ones do an inline `sys.path.insert` + import. The fixture is clearly the current direction, so the new tests use it.
- Test and comment style in this file is unusually explanatory: docstrings state *why* a guard exists and which direction a wrong assertion fails in. The new tests match that register.
- The feedback partition key is `SOURCE#<brand_name>`, minted in `lambda/processor/handler.py` (`source_display = brand_name if brand_name else source_platform`). Any API code that constructs that `pk` is coupled to the processor, and the test comment says so.

**Suggestions for future tasks.**
- `pytest` cannot run out of the box here. Adding the two import-time dependencies to `requirements-dev.txt`, or a documented bootstrap script, would remove a recurring first-ten-minutes cost.
- The 14 pre-existing `lambda/shared/test/test_http.py` failures (`module 'shared' has no attribute 'http_utils'`) look like a stale patch target after a rename and are a small, self-contained fix.
- `get_form_stats` still reads a whole `SOURCE#<brand>` partition and filters `source_channel` client-side, with no index on the submission-to-form link. Explicitly out of scope here, but it is a real cost issue that grows with total feedback volume rather than with the form's own submissions, and it now sits behind a route that raises instead of silently degrading.
- The write/read agreement fixed here is enforced only by the new test, not by shared code. If a third site ever needs this partition, extracting one helper used by both the write and the read would make the invariant structural.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).
