### PR TITLE
fix(stream): read the category taxonomy from the key and field Python owns

### DIFF
--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -502,13 +502,30 @@ class TestCounterSortKeyShapeLockstep:
     def test_every_aggregate_counter_is_written_under_a_bare_date_sort_key(self):
         source = _read(AGGREGATOR_SOURCE)
         calls = re.findall(AGGREGATOR_COUNTER_CALL_PATTERN, source)
-        # The denominator first: a pattern that matched nothing would satisfy the
-        # real assertion below for the wrong reason.
+        # Two denominators, because they fail for different reasons and only the
+        # second one notices a call site the pattern cannot see.
+        #
+        # The floor catches the pattern breaking entirely — a rename, a
+        # restructure — which would otherwise satisfy the real assertion below by
+        # finding nothing at all.
         assert len(calls) >= 8, (
             f'Found only {len(calls)} counter writes in {AGGREGATOR_SOURCE}; this '
             f'module writes at least eight. The pattern in this test file has '
             f'stopped matching the call sites, so the assertion below proves '
             f'nothing — fix the pattern rather than the count.'
+        )
+        # The equality catches the subtler half: ONE newly added call site the
+        # pattern cannot match — a multi-line form, a keyword-argument call — while
+        # the other eight still match, so the floor holds and the new site's sort
+        # key goes unpinned. Every textual invocation must therefore be accounted
+        # for by a matched call site.
+        invocations = len(re.findall(r'(?<!def )update_(?:counter|average)\(', source))
+        assert invocations == len(calls), (
+            f'{AGGREGATOR_SOURCE} invokes a counter writer {invocations} times but '
+            f'this test can only read the arguments of {len(calls)} of them. The '
+            f'unmatched call site is UNPINNED: its sort key could be composite and '
+            f'the assertion below would still pass. Widen the pattern in this file '
+            f'to cover the new call shape.'
         )
         composite = sorted({sk.strip() for _, sk in calls if sk.strip() != 'date'})
         assert not composite, (

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -45,8 +45,12 @@ Both sides are read as SOURCE TEXT with a regular expression rather than
 imported, so the assertions need neither a bundler for the TypeScript nor the
 AWS-shaped import graph for the Python.
 
-Pattern follows test_visual_selection_bound_lockstep.py (same directory).
+Pattern follows test_visual_selection_bound_lockstep.py (same directory). The one
+place a parser is used instead of a pattern is the aggregator's counter calls,
+following test_product_context_placeholder_lockstep.py — see
+_aggregator_counter_writes for why a regular expression is the wrong tool there.
 """
+import ast
 import re
 from pathlib import Path
 
@@ -73,12 +77,8 @@ PYTHON_READER_KEY_PATTERN = (
 PYTHON_WRITER_PK_PATTERN = rf'^CATEGORIES_PK = {_Q}([^\'"]+){_Q}'
 PYTHON_WRITER_SK_PATTERN = rf'^CATEGORIES_SK = {_Q}([^\'"]+){_Q}'
 
-# Every counter write in the aggregator, as (pk expression, sk expression). The
-# `def ` lookbehind keeps the two function DEFINITIONS out of the call list; no
-# call site's pk or sk expression contains a comma, so stopping each group at one
-# is safe, and the call count is asserted so a pattern that stopped matching
-# cannot pass by finding nothing.
-AGGREGATOR_COUNTER_CALL_PATTERN = r'(?<!def )update_(?:counter|average)\(\s*([^,]+),\s*([^,]+),'
+# The counter writers whose sort key the streaming window predicate depends on.
+AGGREGATOR_COUNTER_WRITERS = ('update_counter', 'update_average')
 
 # The never-written key streaming chat used to ask for, assembled rather than
 # written out so that a repository-wide search for it keeps returning nothing
@@ -296,6 +296,49 @@ def _required_zod_properties(object_literal: str) -> set[str]:
     return required
 
 
+def _aggregator_counter_writes() -> list[tuple[str, str]]:
+    """Every counter write in the aggregator, as (pk source, sk source).
+
+    Parsed with `ast`, not matched with a regular expression, following
+    test_product_context_placeholder_lockstep.py. The rest of this file reads
+    source text because one side is TypeScript, where a parser is not available
+    without a bundler — but this side is Python, and here a pattern is simply the
+    wrong tool. It removes two opposite failure modes at once:
+
+      * A pattern cannot tell a call from a MENTION of one, so an occurrence in a
+        comment, a docstring or an f-string would be counted as a call site — a
+        doc comment reading `update_counter(pk, sk, ...)` would fail a correct
+        aggregator, which is the one thing a lockstep must never do.
+      * A pattern reads only the call shapes it anticipated, so a keyword-argument
+        call, a multi-line call or a pk expression containing a comma would go
+        UNREAD while the others still matched — leaving that call site's sort key
+        unpinned with every assertion still green.
+
+    `ast` has neither problem: it sees exactly the calls, with their arguments
+    where they belong, whatever their shape. It also excludes the two function
+    DEFINITIONS for free, since a `def` is not a Call. No module is imported —
+    ast.parse reads the same text every other helper here reads.
+    """
+    writes: list[tuple[str, str]] = []
+    for node in ast.walk(ast.parse(_read(AGGREGATOR_SOURCE))):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, 'attr', '')
+        if name not in AGGREGATOR_COUNTER_WRITERS:
+            continue
+        keywords = {kw.arg: kw.value for kw in node.keywords}
+        pk = node.args[0] if node.args else keywords.get('pk')
+        sk = node.args[1] if len(node.args) > 1 else keywords.get('sk')
+        # '<missing>' rather than a skip: a call this helper cannot read the sort
+        # key of must FAIL the assertion below, not quietly leave it unpinned.
+        writes.append((
+            ast.unparse(pk) if pk is not None else '<missing>',
+            ast.unparse(sk) if sk is not None else '<missing>',
+        ))
+    return writes
+
+
 def _processor_default_categories() -> list[str]:
     """The default taxonomy as the ENRICHMENT PROMPT spells it: one pipe-delimited
     string, not a list.
@@ -500,34 +543,18 @@ class TestCounterSortKeyShapeLockstep:
     """
 
     def test_every_aggregate_counter_is_written_under_a_bare_date_sort_key(self):
-        source = _read(AGGREGATOR_SOURCE)
-        calls = re.findall(AGGREGATOR_COUNTER_CALL_PATTERN, source)
-        # Two denominators, because they fail for different reasons and only the
-        # second one notices a call site the pattern cannot see.
-        #
-        # The floor catches the pattern breaking entirely — a rename, a
-        # restructure — which would otherwise satisfy the real assertion below by
-        # finding nothing at all.
-        assert len(calls) >= 8, (
-            f'Found only {len(calls)} counter writes in {AGGREGATOR_SOURCE}; this '
-            f'module writes at least eight. The pattern in this test file has '
-            f'stopped matching the call sites, so the assertion below proves '
-            f'nothing — fix the pattern rather than the count.'
+        writes = _aggregator_counter_writes()
+        # The denominator first: a helper that found nothing would satisfy the real
+        # assertion below for the wrong reason. This is the only guard the parsed
+        # form needs — unlike a pattern, it cannot read SOME of the call sites, so
+        # there is no partial-blindness case left to count against.
+        assert len(writes) >= 8, (
+            f'Found only {len(writes)} counter writes in {AGGREGATOR_SOURCE}; this '
+            f'module writes at least eight. If the writers were renamed, update '
+            f'AGGREGATOR_COUNTER_WRITERS in this file — do not lower the floor, '
+            f'because the assertion below proves nothing without it.'
         )
-        # The equality catches the subtler half: ONE newly added call site the
-        # pattern cannot match — a multi-line form, a keyword-argument call — while
-        # the other eight still match, so the floor holds and the new site's sort
-        # key goes unpinned. Every textual invocation must therefore be accounted
-        # for by a matched call site.
-        invocations = len(re.findall(r'(?<!def )update_(?:counter|average)\(', source))
-        assert invocations == len(calls), (
-            f'{AGGREGATOR_SOURCE} invokes a counter writer {invocations} times but '
-            f'this test can only read the arguments of {len(calls)} of them. The '
-            f'unmatched call site is UNPINNED: its sort key could be composite and '
-            f'the assertion below would still pass. Widen the pattern in this file '
-            f'to cover the new call shape.'
-        )
-        composite = sorted({sk.strip() for _, sk in calls if sk.strip() != 'date'})
+        composite = sorted({sk for _, sk in writes if sk != 'date'})
         assert not composite, (
             f'{AGGREGATOR_SOURCE} keys a counter by {composite} rather than by '
             f'the bare `date`. {STREAM_SOURCE} sums these partitions with '

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -226,6 +226,22 @@ def _stream_default_categories() -> list[str]:
     return re.findall(r"'([^']+)'", match.group(1))
 
 
+def _required_zod_properties(object_literal: str) -> set[str]:
+    """The property names a Zod object literal REQUIRES.
+
+    Every declared property is required unless its chain ends in `.optional()` or
+    `.nullish()`. Reading only the first key was how a second required property
+    could hide: `z.object({ name: z.string(), id: z.string() })` looks right to a
+    pattern anchored on the leading key while dropping every stored category the
+    writer never gave an `id`.
+    """
+    required = set()
+    for name, chain in re.findall(r'(\w+)\s*:\s*(z\.[^,}]+)', object_literal):
+        if '.optional()' not in chain and '.nullish()' not in chain:
+            required.add(name)
+    return required
+
+
 def _processor_default_categories() -> list[str]:
     """The default taxonomy as the ENRICHMENT PROMPT spells it: one pipe-delimited
     string, not a list.
@@ -318,10 +334,19 @@ class TestCategoryNameFieldLockstep:
         """The Zod object at the top of the module decides which configured
         categories survive the parse. Requiring `id` while reading `name` drops
         every category that carries no `id` — silently, because safeParse
-        failures are filtered out."""
+        failures are filtered out.
+
+        EVERY property is inspected, not just the first. Capturing only the
+        leading key let `z.object({ name: z.string(), id: z.string() })` satisfy
+        this pin while reinstating the exact defect the test is named for: the
+        frontend's own normalizer has to DERIVE ids from names
+        (frontend/src/components/CategoriesManager/categoriesSchema.ts), so
+        id-less rows are what real and legacy data looks like, and a schema
+        requiring one drops them."""
         source = _read(STREAM_SOURCE)
         match = re.search(
-            r'^const categoryItemSchema = z\.object\(\{\s*(\w+):', source, re.MULTILINE,
+            r'^const categoryItemSchema = z\.object\((\{.*?\})\)', source,
+            re.MULTILINE | re.DOTALL,
         )
         assert match, (
             f'categoryItemSchema not found in {STREAM_SOURCE}, or its shape '
@@ -329,11 +354,21 @@ class TestCategoryNameFieldLockstep:
             f'does not permit a type assertion here — so update this pattern '
             f'rather than removing the schema.'
         )
-        assert match.group(1) == 'name', (
-            f'categoryItemSchema requires `{match.group(1)}` but the read takes '
+        literal = match.group(1)
+        required = _required_zod_properties(literal)
+        assert 'name' in required, (
+            f'categoryItemSchema requires {sorted(required)} but the read takes '
             f'`name`. The key, the field, and the schema must describe one '
-            f'contract, or a configured category without an internal identifier '
-            f'is dropped before it can be counted.'
+            f'contract, or the parse rejects the very categories it is meant to '
+            f'admit.'
+        )
+        assert required == {'name'}, (
+            f'categoryItemSchema requires {sorted(required)}; only `name` may be '
+            f'required. Any other required property — `id` above all — drops '
+            f'every configured category the writer stored without one, silently, '
+            f'because safeParse failures become an empty string and are removed '
+            f'by filter(Boolean) rather than reported. Make the extra property '
+            f'.optional() if the reader really needs to see it.'
         )
 
 

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -53,6 +53,7 @@ from pathlib import Path
 PYTHON_READER_SOURCE = 'lambda/shared/api.py'
 PYTHON_WRITER_SOURCE = 'lambda/api/settings_handler.py'
 PROCESSOR_SOURCE = 'lambda/processor/handler.py'
+AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
 STREAM_SOURCE = 'lambda/stream/src/context/voc-context.ts'
 
 # Quoting is not part of the contract, so no pattern here insists on it: these
@@ -71,6 +72,13 @@ PYTHON_READER_KEY_PATTERN = (
 # The key as the writer declares it, as two module constants.
 PYTHON_WRITER_PK_PATTERN = rf'^CATEGORIES_PK = {_Q}([^\'"]+){_Q}'
 PYTHON_WRITER_SK_PATTERN = rf'^CATEGORIES_SK = {_Q}([^\'"]+){_Q}'
+
+# Every counter write in the aggregator, as (pk expression, sk expression). The
+# `def ` lookbehind keeps the two function DEFINITIONS out of the call list; no
+# call site's pk or sk expression contains a comma, so stopping each group at one
+# is safe, and the call count is asserted so a pattern that stopped matching
+# cannot pass by finding nothing.
+AGGREGATOR_COUNTER_CALL_PATTERN = r'(?<!def )update_(?:counter|average)\(\s*([^,]+),\s*([^,]+),'
 
 # The never-written key streaming chat used to ask for, assembled rather than
 # written out so that a repository-wide search for it keeps returning nothing
@@ -226,19 +234,65 @@ def _stream_default_categories() -> list[str]:
     return re.findall(r"'([^']+)'", match.group(1))
 
 
+def _split_object_properties(object_literal: str) -> list[str]:
+    """One fragment per property of an object literal, split on TOP-LEVEL commas.
+
+    Bracket depth is tracked, and characters inside quotes are skipped, so
+    neither a nested `z.object({ ... })` nor a validator message containing a
+    comma or a bracket can split one property into two.
+    """
+    fragments: list[str] = []
+    depth = 0
+    quote = ''
+    start = 0
+    for index, char in enumerate(object_literal):
+        if quote:
+            if char == quote:
+                quote = ''
+        elif char in '\'"`':
+            quote = char
+        elif char in '([{':
+            depth += 1
+        elif char in ')]}':
+            depth -= 1
+        elif char == ',' and depth == 1:
+            fragments.append(object_literal[start:index])
+            start = index + 1
+    fragments.append(object_literal[start:])
+    return fragments
+
+
 def _required_zod_properties(object_literal: str) -> set[str]:
     """The property names a Zod object literal REQUIRES.
 
-    Every declared property is required unless its chain ends in `.optional()` or
+    Every declared property is required unless its chain carries `.optional()` or
     `.nullish()`. Reading only the first key was how a second required property
     could hide: `z.object({ name: z.string(), id: z.string() })` looks right to a
     pattern anchored on the leading key while dropping every stored category the
     writer never gave an `id`.
+
+    Properties are split on top-level commas rather than on every comma because a
+    validator may take a message: `id: z.string().min(1, 'x').optional()` is ONE
+    property whose chain ends in `.optional()`, and reading it only as far as the
+    first comma reports it as REQUIRED — failing a correct schema with a message
+    telling the author to make the property optional, which is what they did.
+    TestTheZodPropertyHelperItself pins that case directly.
+
+    Two limits, both of which fail loudly rather than passing silently: an
+    object-level `.partial()` after `z.object({...})` makes every property
+    optional and is invisible here, so a schema restructured that way must update
+    this test; and a validator message containing an escaped copy of its own
+    quote character would mis-split, which surfaces as a missing property name
+    (a failed assertion), never as a pass.
     """
     required = set()
-    for name, chain in re.findall(r'(\w+)\s*:\s*(z\.[^,}]+)', object_literal):
+    for fragment in _split_object_properties(object_literal):
+        text = fragment.strip().lstrip('{').rstrip('}').strip()
+        name, separator, chain = text.partition(':')
+        if not separator:
+            continue
         if '.optional()' not in chain and '.nullish()' not in chain:
-            required.add(name)
+            required.add(name.strip())
     return required
 
 
@@ -252,7 +306,7 @@ def _processor_default_categories() -> list[str]:
     """
     source = _read(PROCESSOR_SOURCE)
     literal = _single(
-        source, r'^DEFAULT_CATEGORIES = "([^"]+)"', PROCESSOR_SOURCE,
+        source, rf'^DEFAULT_CATEGORIES = {_Q}([^\'"]+){_Q}', PROCESSOR_SOURCE,
         'DEFAULT_CATEGORIES string literal',
     )[0]
     return literal.split('|')
@@ -372,6 +426,101 @@ class TestCategoryNameFieldLockstep:
         )
 
 
+class TestTheZodPropertyHelperItself:
+    """The helper decides whether the schema pin above passes, so its own failure
+    modes matter as much as the pin's.
+
+    A lockstep whose failures are sometimes WRONG is worse than none: the pin's
+    message offers an escape hatch — make the extra property `.optional()` — and
+    a helper that reads a chain only as far as its first comma does not honour it
+    for any property whose validator also carries a message. The author would be
+    told to do the thing they had already done.
+    """
+
+    def test_a_bare_property_is_required(self):
+        assert _required_zod_properties('{ name: z.string() }') == {'name'}
+
+    def test_every_declared_property_is_read_not_just_the_first(self):
+        literal = '{ name: z.string(), id: z.string() }'
+        assert _required_zod_properties(literal) == {'name', 'id'}, (
+            'A second required property must be visible — reading only the '
+            'leading key is how a required `id` hid from this pin.'
+        )
+
+    def test_an_optional_property_is_not_required(self):
+        assert _required_zod_properties('{ name: z.string(), id: z.string().optional() }') == {
+            'name',
+        }
+
+    def test_a_nullish_property_is_not_required(self):
+        assert _required_zod_properties('{ name: z.string(), id: z.string().nullish() }') == {
+            'name',
+        }
+
+    def test_a_validator_message_does_not_hide_the_optional_marker(self):
+        # The regression this class exists for. `.min(1, 'x')` puts a comma inside
+        # the chain, which used to truncate it before `.optional()` was seen — so
+        # a correct schema failed the pin, with a message telling its author to
+        # make the property optional.
+        literal = "{ name: z.string(), id: z.string().min(1, 'x').optional() }"
+        assert _required_zod_properties(literal) == {'name'}, (
+            'A property is optional if its chain says so, wherever the commas '
+            'fall inside its validators.'
+        )
+
+    def test_a_message_containing_a_comma_is_not_a_second_property(self):
+        literal = "{ name: z.string().min(1, 'set a name, please') }"
+        assert _required_zod_properties(literal) == {'name'}
+
+    def test_a_nested_object_does_not_contribute_its_own_properties(self):
+        # The inner comma sits at bracket depth 3, so it must not split the outer
+        # literal — otherwise `a` and `b` would be reported as top-level
+        # properties of a schema that does not declare them.
+        literal = '{ name: z.string(), meta: z.object({ a: z.string(), b: z.string() }) }'
+        assert _required_zod_properties(literal) == {'name', 'meta'}
+
+
+class TestCounterSortKeyShapeLockstep:
+    """The streaming reader sums a window with `sk BETWEEN :oldest AND :newest`,
+    which is only equivalent to "these dates" while every sort key under those
+    partitions is a bare `YYYY-MM-DD`.
+
+    A composite sort key sorts INSIDE the window it looks unrelated to:
+    '2026-03-03#proj_1' is greater than '2026-03-02' and less than '2026-03-04',
+    so it would be summed and the section would silently OVER-report. Nothing on
+    the reading side can detect that — which is why this is pinned against the
+    writer rather than with a reader fixture asserting such a row is skipped. Such
+    a fixture would be asserting a falsehood: the range predicate does match it.
+
+    The guarantee is therefore the aggregator's, and it is one line per call site:
+    every counter is keyed by the item's date, with nothing appended. What remains
+    assumed, and is not pinnable here, is the shape of that `date` FIELD itself —
+    an ingestion path that wrote a composite value into `date` would defeat this
+    from the other end.
+    """
+
+    def test_every_aggregate_counter_is_written_under_a_bare_date_sort_key(self):
+        source = _read(AGGREGATOR_SOURCE)
+        calls = re.findall(AGGREGATOR_COUNTER_CALL_PATTERN, source)
+        # The denominator first: a pattern that matched nothing would satisfy the
+        # real assertion below for the wrong reason.
+        assert len(calls) >= 8, (
+            f'Found only {len(calls)} counter writes in {AGGREGATOR_SOURCE}; this '
+            f'module writes at least eight. The pattern in this test file has '
+            f'stopped matching the call sites, so the assertion below proves '
+            f'nothing — fix the pattern rather than the count.'
+        )
+        composite = sorted({sk.strip() for _, sk in calls if sk.strip() != 'date'})
+        assert not composite, (
+            f'{AGGREGATOR_SOURCE} keys a counter by {composite} rather than by '
+            f'the bare `date`. {STREAM_SOURCE} sums these partitions with '
+            f'`sk BETWEEN :oldest AND :newest`, and a composite sort key sorts '
+            f'inside a date window — so streaming chat would silently count rows '
+            f'that are not days. If a composite sort key is really wanted here, '
+            f'the streaming reader needs a different predicate, not a wider one.'
+        )
+
+
 class TestNotConfiguredFallbackLockstep:
     """Both surfaces answer the same way when nothing is configured.
 
@@ -427,19 +576,28 @@ class TestNotConfiguredFallbackLockstep:
         written under names neither reader ever asks for — so the Top Categories
         section is empty again while both readers agree with each other, and
         every other assertion in this file stays green."""
-        processor_defaults = _processor_default_categories()
-        assert processor_defaults == _python_default_categories(), (
+        # Compared as MEMBERSHIP, not as sequence. What has to hold is that the
+        # names match: the counters are written under whichever name the model
+        # emits, and a reader asks for all of its names regardless of their order.
+        # Order IS pinned between the two readers' list literals above, where they
+        # are hand-maintained mirrors of each other and a divergence is worth
+        # seeing — but this copy is a pipe-delimited prompt string, where insisting
+        # on the same sequence would fail a harmless reordering and say the
+        # counters are wrong. Sorted rather than set-compared so a duplicated name
+        # still shows up.
+        processor_defaults = sorted(_processor_default_categories())
+        assert processor_defaults == sorted(_python_default_categories()), (
             f'{PROCESSOR_SOURCE} lets the enrichment model emit '
             f'{processor_defaults} but {PYTHON_READER_SOURCE} falls back to '
-            f'{_python_default_categories()}. The counters are written under the '
-            f'names the model emits, so the readers would ask for partitions that '
-            f'are never written.'
+            f'{sorted(_python_default_categories())}. The counters are written '
+            f'under the names the model emits, so the readers would ask for '
+            f'partitions that are never written.'
         )
-        assert processor_defaults == _stream_default_categories(), (
+        assert processor_defaults == sorted(_stream_default_categories()), (
             f'{PROCESSOR_SOURCE} lets the enrichment model emit '
             f'{processor_defaults} but {STREAM_SOURCE} falls back to '
-            f'{_stream_default_categories()}. Streaming chat would ask for '
-            f'counter partitions the enrichment output never names.'
+            f'{sorted(_stream_default_categories())}. Streaming chat would ask '
+            f'for counter partitions the enrichment output never names.'
         )
 
     def test_the_default_list_is_not_empty(self):

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -1,0 +1,290 @@
+"""Lockstep test: the configured category taxonomy is one DynamoDB key, one
+field, and one fallback in two languages.
+
+The aggregates item that holds the taxonomy is written in exactly one place —
+the PUT /settings/categories handler in lambda/api/settings_handler.py, which
+spells the key out as CATEGORIES_PK/CATEGORIES_SK. Python reads it back in
+lambda/shared/api.py (`get_raw_categories_config`), maps each object to its
+`name`, and falls back to DEFAULT_CATEGORIES when the item is absent. Streaming
+chat needs the SAME names, because it uses them to build the daily counter
+partitions `METRIC#daily_category#<name>` that the aggregator writes — and its
+copy of the reader lives in lambda/stream/src/context/voc-context.ts.
+
+The failure mode is silent and total, which is why this test exists. Streaming
+chat used to query a `CONFIG#`-prefixed partition with the sort key `CURRENT` —
+a key nothing in the repository has ever written, whose only occurrence anywhere
+was that read, which is why it is not spelled out here either — and to map each
+category object to `id` rather than to the taxonomy name. Either
+defect alone empties the Top Categories section of every single chat turn: a
+wrong key returns no item, and a wrong field names counter partitions that are
+never written. The section still renders, just with nothing under it, so the
+model answers "which categories dominate" from an empty list while the metrics
+page for the same window shows counts. Nothing failed, nobody was told, and the
+local mock server hid it by serving category payloads that carry BOTH `id` and
+`name`.
+
+Three things therefore have to agree across the boundary, and this file pins
+each of them:
+
+  * the item key (pk and sk),
+  * the field read off each category object (`name`, because the counter
+    partitions are named after the enrichment output),
+  * the not-configured fallback (DEFAULT_CATEGORIES, so the two surfaces report
+    the same categories for the same table rather than one reporting nothing).
+
+The Zod schema at the top of voc-context.ts is part of the same contract: if it
+requires `id` while the read takes `name`, a configured category that carries no
+`id` is dropped by the parse instead of counted. So the schema's required
+property is pinned to the field that is read.
+
+Both sides are read as SOURCE TEXT with a regular expression rather than
+imported, so the assertions need neither a bundler for the TypeScript nor the
+AWS-shaped import graph for the Python.
+
+Pattern follows test_visual_selection_bound_lockstep.py (same directory).
+"""
+import re
+from pathlib import Path
+
+PYTHON_READER_SOURCE = 'lambda/shared/api.py'
+PYTHON_WRITER_SOURCE = 'lambda/api/settings_handler.py'
+STREAM_SOURCE = 'lambda/stream/src/context/voc-context.ts'
+
+# The key as the streaming reader declares it, as two module constants.
+STREAM_PK_PATTERN = r"^const CATEGORY_SETTINGS_PK = '([^']+)';"
+STREAM_SK_PATTERN = r"^const CATEGORY_SETTINGS_SK = '([^']+)';"
+# The key as the Python reader spends it, inline in the get_item call.
+PYTHON_READER_KEY_PATTERN = (
+    r"get_item\(Key=\{'pk':\s*'([^']+)',\s*'sk':\s*'([^']+)'\}\)"
+)
+# The key as the writer declares it, as two module constants.
+PYTHON_WRITER_PK_PATTERN = r'^CATEGORIES_PK = "([^"]+)"'
+PYTHON_WRITER_SK_PATTERN = r'^CATEGORIES_SK = "([^"]+)"'
+
+# The never-written partition streaming chat used to ask for, assembled rather
+# than written out so that a repository-wide search for it keeps returning
+# nothing outside build artifacts — which is itself part of the fix.
+ABANDONED_PK = 'CONFIG' + '#categories'
+
+
+def _read(relative: str) -> str:
+    # lambda/api/test/ -> voc-datalake/
+    path = Path(__file__).resolve().parents[3] / relative
+    assert path.is_file(), (
+        f'{relative} not found — did the file move? '
+        f'If so, update the path constant in this test file.'
+    )
+    return path.read_text(encoding='utf-8')
+
+
+def _single(source: str, pattern: str, where: str, what: str) -> tuple[str, ...]:
+    matches = re.findall(pattern, source, re.MULTILINE)
+    assert len(matches) == 1, (
+        f'Expected exactly one {what} in {where}; found {len(matches)}. A second '
+        f'copy is the drift this test exists to prevent — if the declaration was '
+        f'restructured, update the pattern in this file.'
+    )
+    match = matches[0]
+    return match if isinstance(match, tuple) else (match,)
+
+
+def _stream_key() -> tuple[str, str]:
+    source = _read(STREAM_SOURCE)
+    pk = _single(source, STREAM_PK_PATTERN, STREAM_SOURCE, 'CATEGORY_SETTINGS_PK')[0]
+    sk = _single(source, STREAM_SK_PATTERN, STREAM_SOURCE, 'CATEGORY_SETTINGS_SK')[0]
+    return pk, sk
+
+
+def _stream_reader_body() -> str:
+    """The body of getConfiguredCategories in the streaming module.
+
+    Scoped so another function's return cannot answer for this one. The body ends
+    at the next top-level declaration, which in this module is always a `function`
+    or `async function` at column 0.
+    """
+    source = _read(STREAM_SOURCE)
+    marker = 'async function getConfiguredCategories('
+    start = source.find(marker)
+    assert start != -1, (
+        f'{marker} not found in {STREAM_SOURCE} — if the reader was renamed, '
+        f'update this helper.'
+    )
+    rest = source[start + len(marker):]
+    next_decl = re.search(r'^(async )?function ', rest, re.MULTILINE)
+    return rest[:next_decl.start()] if next_decl else rest
+
+
+def _python_reader_key() -> tuple[str, str]:
+    """The pk/sk of the categories get_item in shared/api.py.
+
+    Scoped to `get_raw_categories_config` so another reader in the module cannot
+    satisfy this test. The function body ends at the next top-level `def`.
+    """
+    source = _read(PYTHON_READER_SOURCE)
+    marker = 'def get_raw_categories_config('
+    start = source.find(marker)
+    assert start != -1, f'{marker} not found in {PYTHON_READER_SOURCE}'
+    next_def = re.search(r'^def ', source[start + len(marker):], re.MULTILINE)
+    end = start + len(marker) + (next_def.start() if next_def else len(source))
+    pk, sk = _single(
+        source[start:end], PYTHON_READER_KEY_PATTERN,
+        f'{PYTHON_READER_SOURCE}::get_raw_categories_config', 'categories get_item Key',
+    )
+    return pk, sk
+
+
+def _python_writer_key() -> tuple[str, str]:
+    source = _read(PYTHON_WRITER_SOURCE)
+    pk = _single(source, PYTHON_WRITER_PK_PATTERN, PYTHON_WRITER_SOURCE, 'CATEGORIES_PK')[0]
+    sk = _single(source, PYTHON_WRITER_SK_PATTERN, PYTHON_WRITER_SOURCE, 'CATEGORIES_SK')[0]
+    return pk, sk
+
+
+def _python_default_categories() -> list[str]:
+    source = _read(PYTHON_READER_SOURCE)
+    match = re.search(r'^DEFAULT_CATEGORIES = \[(.*?)\]', source, re.MULTILINE | re.DOTALL)
+    assert match, f'DEFAULT_CATEGORIES list literal not found in {PYTHON_READER_SOURCE}'
+    return re.findall(r"'([^']+)'", match.group(1))
+
+
+def _stream_default_categories() -> list[str]:
+    source = _read(STREAM_SOURCE)
+    match = re.search(
+        r'^const DEFAULT_CATEGORIES = \[(.*?)\] as const;', source, re.MULTILINE | re.DOTALL,
+    )
+    assert match, (
+        f'DEFAULT_CATEGORIES array literal not found in {STREAM_SOURCE}. Streaming '
+        f'chat must fall back to the same list Python does, or an unconfigured '
+        f'table gives the two surfaces different answers.'
+    )
+    return re.findall(r"'([^']+)'", match.group(1))
+
+
+class TestCategorySettingsKeyLockstep:
+    def test_the_streaming_reader_asks_for_the_key_the_writer_writes(self):
+        assert _stream_key() == _python_writer_key(), (
+            f'{STREAM_SOURCE} queries {_stream_key()} but '
+            f'{PYTHON_WRITER_SOURCE} writes the item at {_python_writer_key()}. A '
+            f'streaming read of a key nobody writes returns no item, so the Top '
+            f'Categories section is empty on every turn and nothing fails.'
+        )
+
+    def test_the_streaming_reader_asks_for_the_key_the_python_reader_asks_for(self):
+        assert _stream_key() == _python_reader_key(), (
+            f'{STREAM_SOURCE} queries {_stream_key()} but '
+            f'{PYTHON_READER_SOURCE}::get_raw_categories_config reads '
+            f'{_python_reader_key()}. The two surfaces must describe the same '
+            f'configuration or they report different categories for one table.'
+        )
+
+    def test_the_abandoned_streaming_key_is_gone(self):
+        source = _read(STREAM_SOURCE)
+        assert ABANDONED_PK not in source, (
+            f"{STREAM_SOURCE} still mentions '{ABANDONED_PK}', a partition key "
+            f'nothing in this repository writes. Its only occurrence used to be '
+            f'this module\'s own read.'
+        )
+
+
+class TestCategoryNameFieldLockstep:
+    """The field read must be the taxonomy NAME on both sides.
+
+    `METRIC#daily_category#<category>` partitions are keyed by the enrichment
+    output, which is the category name. Reading any other field yields
+    partitions that are never written even once the item key is right — which is
+    why fixing only the key is not a fix.
+    """
+
+    def test_the_python_reader_maps_categories_to_their_name(self):
+        source = _read(PYTHON_READER_SOURCE)
+        assert re.search(r"cat\.get\('name'\)", source), (
+            f'{PYTHON_READER_SOURCE}::get_configured_categories no longer maps '
+            f'each category to its `name`. If the owning side changed field, the '
+            f'streaming mirror and the aggregator partitions must change with it.'
+        )
+
+    def test_the_streaming_reader_maps_categories_to_their_name(self):
+        source = _read(STREAM_SOURCE)
+        assert 'parsed.data.name' in source, (
+            f'{STREAM_SOURCE} no longer reads `name` off each parsed category. '
+            f'The counter partitions are named after the category name, so any '
+            f'other field sums partitions that do not exist.'
+        )
+        assert 'parsed.data.id' not in source, (
+            f'{STREAM_SOURCE} reads an internal identifier instead of the '
+            f'taxonomy name. That names counter partitions the aggregator never '
+            f'writes, so the section is empty however right the item key is.'
+        )
+
+    def test_the_streaming_schema_requires_the_field_that_is_read(self):
+        """The Zod object at the top of the module decides which configured
+        categories survive the parse. Requiring `id` while reading `name` drops
+        every category that carries no `id` — silently, because safeParse
+        failures are filtered out."""
+        source = _read(STREAM_SOURCE)
+        match = re.search(
+            r'^const categoryItemSchema = z\.object\(\{\s*(\w+):', source, re.MULTILINE,
+        )
+        assert match, (
+            f'categoryItemSchema not found in {STREAM_SOURCE}, or its shape '
+            f'changed. It must keep validating at this boundary — this repository '
+            f'does not permit a type assertion here — so update this pattern '
+            f'rather than removing the schema.'
+        )
+        assert match.group(1) == 'name', (
+            f'categoryItemSchema requires `{match.group(1)}` but the read takes '
+            f'`name`. The key, the field, and the schema must describe one '
+            f'contract, or a configured category without an internal identifier '
+            f'is dropped before it can be counted.'
+        )
+
+
+class TestNotConfiguredFallbackLockstep:
+    """Both surfaces answer the same way when nothing is configured.
+
+    Python falls back to DEFAULT_CATEGORIES; streaming used to fall back to an
+    empty array, and that silent difference is how these two copies drifted this
+    far. The default list wins because the enrichment prompt labels feedback with
+    those same names when no taxonomy is configured, so the counters exist under
+    them — an empty fallback reports nothing where the metrics surface reports
+    counts.
+    """
+
+    def test_both_sides_fall_back_to_the_same_default_list(self):
+        python_defaults = _python_default_categories()
+        stream_defaults = _stream_default_categories()
+        assert stream_defaults == python_defaults, (
+            f'{STREAM_SOURCE} falls back to {stream_defaults} but '
+            f'{PYTHON_READER_SOURCE} falls back to {python_defaults}. An '
+            f'unconfigured table must look the same to streaming chat as it does '
+            f'to the metrics surface.'
+        )
+
+    def test_the_streaming_reader_actually_returns_its_default_list(self):
+        """Declaring the list is not the same as spending it. A reader that keeps
+        DEFAULT_CATEGORIES for documentation and still returns `[]` on the
+        unconfigured path keeps the comparison above green while the section
+        stays empty — the exact shape of the original bug."""
+        reader = _stream_reader_body()
+        assert 'DEFAULT_CATEGORIES' in reader, (
+            f'{STREAM_SOURCE}::getConfiguredCategories no longer returns '
+            f'DEFAULT_CATEGORIES from its not-configured path. Python returns the '
+            f'default list there, so returning an empty array makes streaming chat '
+            f'report no categories for a table the metrics surface reports counts '
+            f'for.'
+        )
+        assert 'return [];' not in reader, (
+            f'{STREAM_SOURCE}::getConfiguredCategories still returns an empty '
+            f'array on some path. That is the fallback difference this contract '
+            f'removed.'
+        )
+
+    def test_the_default_list_is_not_empty(self):
+        """An empty list on both sides would keep the comparison above green
+        while restoring the very bug this file pins: no categories asked for,
+        so no counts reported."""
+        assert _python_default_categories(), (
+            f'{PYTHON_READER_SOURCE}::DEFAULT_CATEGORIES is empty. If the default '
+            f'taxonomy really was dropped, this whole fallback contract needs '
+            f'rethinking on both sides rather than silently agreeing on nothing.'
+        )

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -30,7 +30,11 @@ each of them:
   * the field read off each category object (`name`, because the counter
     partitions are named after the enrichment output),
   * the not-configured fallback (DEFAULT_CATEGORIES, so the two surfaces report
-    the same categories for the same table rather than one reporting nothing).
+    the same categories for the same table rather than one reporting nothing) —
+    at all THREE of its copies, including the pipe-delimited string in
+    lambda/processor/handler.py, which is the copy that decides which names the
+    enrichment model may emit and therefore the only reason falling back to that
+    list is right rather than arbitrary.
 
 The Zod schema at the top of voc-context.ts is part of the same contract: if it
 requires `id` while the read takes `name`, a configured category that carries no
@@ -48,23 +52,31 @@ from pathlib import Path
 
 PYTHON_READER_SOURCE = 'lambda/shared/api.py'
 PYTHON_WRITER_SOURCE = 'lambda/api/settings_handler.py'
+PROCESSOR_SOURCE = 'lambda/processor/handler.py'
 STREAM_SOURCE = 'lambda/stream/src/context/voc-context.ts'
 
+# Quoting is not part of the contract, so no pattern here insists on it: these
+# three modules already use different conventions, and a reformat must not fail a
+# pin whose subject is the key's VALUE.
+_Q = r"""['"]"""
+
 # The key as the streaming reader declares it, as two module constants.
-STREAM_PK_PATTERN = r"^const CATEGORY_SETTINGS_PK = '([^']+)';"
-STREAM_SK_PATTERN = r"^const CATEGORY_SETTINGS_SK = '([^']+)';"
+STREAM_PK_PATTERN = rf'^const CATEGORY_SETTINGS_PK = {_Q}([^\'"]+){_Q};'
+STREAM_SK_PATTERN = rf'^const CATEGORY_SETTINGS_SK = {_Q}([^\'"]+){_Q};'
 # The key as the Python reader spends it, inline in the get_item call.
 PYTHON_READER_KEY_PATTERN = (
-    r"get_item\(Key=\{'pk':\s*'([^']+)',\s*'sk':\s*'([^']+)'\}\)"
+    rf'get_item\(\s*Key=\{{\s*{_Q}pk{_Q}:\s*{_Q}([^\'"]+){_Q},'
+    rf'\s*{_Q}sk{_Q}:\s*{_Q}([^\'"]+){_Q},?\s*\}}\s*\)'
 )
 # The key as the writer declares it, as two module constants.
-PYTHON_WRITER_PK_PATTERN = r'^CATEGORIES_PK = "([^"]+)"'
-PYTHON_WRITER_SK_PATTERN = r'^CATEGORIES_SK = "([^"]+)"'
+PYTHON_WRITER_PK_PATTERN = rf'^CATEGORIES_PK = {_Q}([^\'"]+){_Q}'
+PYTHON_WRITER_SK_PATTERN = rf'^CATEGORIES_SK = {_Q}([^\'"]+){_Q}'
 
-# The never-written partition streaming chat used to ask for, assembled rather
-# than written out so that a repository-wide search for it keeps returning
-# nothing outside build artifacts — which is itself part of the fix.
+# The never-written key streaming chat used to ask for, assembled rather than
+# written out so that a repository-wide search for it keeps returning nothing
+# outside build artifacts — which is itself part of the fix.
 ABANDONED_PK = 'CONFIG' + '#categories'
+ABANDONED_SK = 'CURR' + 'ENT'
 
 
 def _read(relative: str) -> str:
@@ -95,39 +107,93 @@ def _stream_key() -> tuple[str, str]:
     return pk, sk
 
 
-def _stream_reader_body() -> str:
-    """The body of getConfiguredCategories in the streaming module.
+def _stream_function_body(marker: str) -> str:
+    """The body of one function in the streaming module.
 
-    Scoped so another function's return cannot answer for this one. The body ends
-    at the next top-level declaration, which in this module is always a `function`
-    or `async function` at column 0.
+    Scoped so another function cannot answer for this one — every field and
+    fallback assertion in this file reads a body, never the whole file, because a
+    comment or an unrelated helper elsewhere in the module must not be able to
+    satisfy a pin whose whole purpose is to fail when this reader drifts. The
+    body ends at the next top-level declaration, which in this module is always a
+    `function`, `async function` or exported form at column 0.
     """
     source = _read(STREAM_SOURCE)
-    marker = 'async function getConfiguredCategories('
     start = source.find(marker)
     assert start != -1, (
-        f'{marker} not found in {STREAM_SOURCE} — if the reader was renamed, '
+        f'{marker} not found in {STREAM_SOURCE} — if the function was renamed, '
         f'update this helper.'
     )
     rest = source[start + len(marker):]
-    next_decl = re.search(r'^(async )?function ', rest, re.MULTILINE)
-    return rest[:next_decl.start()] if next_decl else rest
+    next_decl = re.search(r'^(export )?(async )?function ', rest, re.MULTILINE)
+    assert next_decl, (
+        f'No declaration follows {marker} in {STREAM_SOURCE}, so this helper can '
+        f'no longer tell where the body ends and would scope the assertion to the '
+        f'rest of the file — which would let unrelated code satisfy it. If the '
+        f'function is now the last declaration in the module, give this helper an '
+        f'explicit end marker rather than letting it over-scope.'
+    )
+    return rest[:next_decl.start()]
+
+
+def _stream_reader_body() -> str:
+    """The body of getConfiguredCategories's read in the streaming module.
+
+    The reader was split so the cache wraps it: `readConfiguredCategories` is
+    the part that spends the key, maps the field and chooses the fallback, so
+    that is the body these assertions scope to.
+    """
+    return _stream_function_body('async function readConfiguredCategories(')
+
+
+def _stream_not_configured_path() -> str:
+    """The reader's not-configured path only: everything before its `catch`.
+
+    The distinction is load-bearing. A read that THREW and a table with nothing
+    configured are different situations that happen to share an answer, and each
+    has its own return. Pinning the fallback against the whole body would let the
+    not-configured path return `[]` — the original bug, for the overwhelmingly
+    common case — while the error path alone keeps returning the defaults and the
+    assertion stays green.
+    """
+    body = _stream_reader_body()
+    catch = re.search(r'\}\s*catch\b', body)
+    assert catch, (
+        f'{STREAM_SOURCE}::readConfiguredCategories no longer has a `catch`, so '
+        f'this helper cannot separate its not-configured path from its error '
+        f'path. The settings read must not be able to break a chat turn — if the '
+        f'error handling moved, move this helper with it rather than widening it '
+        f'to the whole body.'
+    )
+    return body[:catch.start()]
+
+
+def _python_function_body(source: str, marker: str, where: str) -> str:
+    """The body of one top-level function in a Python module.
+
+    Scoped so another function in the same module cannot satisfy an assertion
+    about this one. The body ends at the next top-level `def`.
+    """
+    start = source.find(marker)
+    assert start != -1, (
+        f'{marker} not found in {where} — if the function was renamed, update the '
+        f'marker in this test file.'
+    )
+    rest = source[start + len(marker):]
+    next_def = re.search(r'^def ', rest, re.MULTILINE)
+    return rest[:next_def.start()] if next_def else rest
 
 
 def _python_reader_key() -> tuple[str, str]:
     """The pk/sk of the categories get_item in shared/api.py.
 
     Scoped to `get_raw_categories_config` so another reader in the module cannot
-    satisfy this test. The function body ends at the next top-level `def`.
+    satisfy this test.
     """
-    source = _read(PYTHON_READER_SOURCE)
-    marker = 'def get_raw_categories_config('
-    start = source.find(marker)
-    assert start != -1, f'{marker} not found in {PYTHON_READER_SOURCE}'
-    next_def = re.search(r'^def ', source[start + len(marker):], re.MULTILINE)
-    end = start + len(marker) + (next_def.start() if next_def else len(source))
+    body = _python_function_body(
+        _read(PYTHON_READER_SOURCE), 'def get_raw_categories_config(', PYTHON_READER_SOURCE,
+    )
     pk, sk = _single(
-        source[start:end], PYTHON_READER_KEY_PATTERN,
+        body, PYTHON_READER_KEY_PATTERN,
         f'{PYTHON_READER_SOURCE}::get_raw_categories_config', 'categories get_item Key',
     )
     return pk, sk
@@ -160,6 +226,22 @@ def _stream_default_categories() -> list[str]:
     return re.findall(r"'([^']+)'", match.group(1))
 
 
+def _processor_default_categories() -> list[str]:
+    """The default taxonomy as the ENRICHMENT PROMPT spells it: one pipe-delimited
+    string, not a list.
+
+    This is the third copy, and the one that decides which category names the
+    model may emit — so it is the copy the other two's fallback depends on for
+    being true rather than merely self-consistent.
+    """
+    source = _read(PROCESSOR_SOURCE)
+    literal = _single(
+        source, r'^DEFAULT_CATEGORIES = "([^"]+)"', PROCESSOR_SOURCE,
+        'DEFAULT_CATEGORIES string literal',
+    )[0]
+    return literal.split('|')
+
+
 class TestCategorySettingsKeyLockstep:
     def test_the_streaming_reader_asks_for_the_key_the_writer_writes(self):
         assert _stream_key() == _python_writer_key(), (
@@ -184,6 +266,14 @@ class TestCategorySettingsKeyLockstep:
             f'nothing in this repository writes. Its only occurrence used to be '
             f'this module\'s own read.'
         )
+        # Both halves, not just the partition: the sort key is equally
+        # never-written, and a reader that got the partition right and this wrong
+        # still reads no item and still empties the section.
+        assert ABANDONED_SK not in source, (
+            f"{STREAM_SOURCE} still mentions the sort key '{ABANDONED_SK}'. The "
+            f'settings item is written under a different sort key, so this one '
+            f'returns no item however right the partition is.'
+        )
 
 
 class TestCategoryNameFieldLockstep:
@@ -196,21 +286,29 @@ class TestCategoryNameFieldLockstep:
     """
 
     def test_the_python_reader_maps_categories_to_their_name(self):
-        source = _read(PYTHON_READER_SOURCE)
-        assert re.search(r"cat\.get\('name'\)", source), (
+        # Scoped to the mapping function: a `cat.get('name')` in some other
+        # helper elsewhere in this module must not be able to satisfy a pin on
+        # what THIS function maps to.
+        body = _python_function_body(
+            _read(PYTHON_READER_SOURCE), 'def get_configured_categories(', PYTHON_READER_SOURCE,
+        )
+        assert re.search(r"cat\.get\('name'\)", body), (
             f'{PYTHON_READER_SOURCE}::get_configured_categories no longer maps '
             f'each category to its `name`. If the owning side changed field, the '
             f'streaming mirror and the aggregator partitions must change with it.'
         )
 
     def test_the_streaming_reader_maps_categories_to_their_name(self):
-        source = _read(STREAM_SOURCE)
-        assert 'parsed.data.name' in source, (
+        # Scoped to the mapping function for the same reason, and because the
+        # negative assertion below would otherwise fire on a mere mention of the
+        # field in a comment anywhere in the module.
+        body = _stream_function_body('function namesFromStoredList(')
+        assert 'parsed.data.name' in body, (
             f'{STREAM_SOURCE} no longer reads `name` off each parsed category. '
             f'The counter partitions are named after the category name, so any '
             f'other field sums partitions that do not exist.'
         )
-        assert 'parsed.data.id' not in source, (
+        assert 'parsed.data.id' not in body, (
             f'{STREAM_SOURCE} reads an internal identifier instead of the '
             f'taxonomy name. That names counter partitions the aggregator never '
             f'writes, so the section is empty however right the item key is.'
@@ -264,19 +362,49 @@ class TestNotConfiguredFallbackLockstep:
         """Declaring the list is not the same as spending it. A reader that keeps
         DEFAULT_CATEGORIES for documentation and still returns `[]` on the
         unconfigured path keeps the comparison above green while the section
-        stays empty — the exact shape of the original bug."""
-        reader = _stream_reader_body()
-        assert 'DEFAULT_CATEGORIES' in reader, (
-            f'{STREAM_SOURCE}::getConfiguredCategories no longer returns '
-            f'DEFAULT_CATEGORIES from its not-configured path. Python returns the '
-            f'default list there, so returning an empty array makes streaming chat '
-            f'report no categories for a table the metrics surface reports counts '
-            f'for.'
+        stays empty — the exact shape of the original bug.
+
+        Pinned as a positive match on the RETURN, not as a ban on the text
+        `return []`: Python really does answer `[]` for a configured-but-nameless
+        list, so a reader that spells that outcome out explicitly is correct and
+        must not fail here.
+
+        Scoped to the not-configured path rather than the whole body, so that
+        returning the defaults from the error path alone cannot answer for it."""
+        reader = _stream_not_configured_path()
+        assert re.search(r'\[\s*\.\.\.\s*DEFAULT_CATEGORIES\s*\]', reader), (
+            f'{STREAM_SOURCE}::readConfiguredCategories no longer returns a copy '
+            f'of DEFAULT_CATEGORIES from its not-configured path. Python returns '
+            f'the default list there, so returning an empty array makes streaming '
+            f'chat report no categories for a table the metrics surface reports '
+            f'counts for. Declaring the list without returning it keeps the '
+            f'sibling comparison green while the section stays empty.'
         )
-        assert 'return [];' not in reader, (
-            f'{STREAM_SOURCE}::getConfiguredCategories still returns an empty '
-            f'array on some path. That is the fallback difference this contract '
-            f'removed.'
+
+    def test_the_enrichment_prompt_offers_the_same_default_list(self):
+        """The third copy, and the one the other two depend on.
+
+        lambda/processor/handler.py decides which category names the enrichment
+        model may emit when no taxonomy is configured. That is the only reason
+        falling back to the default list is right rather than arbitrary: the
+        `METRIC#daily_category#<name>` counters exist under exactly those names.
+        If this copy disagrees with the readers' fallback, the counters are
+        written under names neither reader ever asks for — so the Top Categories
+        section is empty again while both readers agree with each other, and
+        every other assertion in this file stays green."""
+        processor_defaults = _processor_default_categories()
+        assert processor_defaults == _python_default_categories(), (
+            f'{PROCESSOR_SOURCE} lets the enrichment model emit '
+            f'{processor_defaults} but {PYTHON_READER_SOURCE} falls back to '
+            f'{_python_default_categories()}. The counters are written under the '
+            f'names the model emits, so the readers would ask for partitions that '
+            f'are never written.'
+        )
+        assert processor_defaults == _stream_default_categories(), (
+            f'{PROCESSOR_SOURCE} lets the enrichment model emit '
+            f'{processor_defaults} but {STREAM_SOURCE} falls back to '
+            f'{_stream_default_categories()}. Streaming chat would ask for '
+            f'counter partitions the enrichment output never names.'
         )
 
     def test_the_default_list_is_not_empty(self):

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -296,6 +296,39 @@ def _required_zod_properties(object_literal: str) -> set[str]:
     return required
 
 
+def _aggregator_counter_parameters(tree: ast.Module) -> dict[str, tuple[str, str]]:
+    """Each counter writer's own first two parameter names, from its `def`.
+
+    A keyword call has to be looked up under the name the WRITER declares, and
+    this file must not guess that name. Hardcoding `sk` would mean that renaming
+    the writer's parameter turns a correct keyword call into an unreadable one, so
+    a correct aggregator would fail — the residual form of the hazard this file
+    exists to avoid rather than to reproduce.
+
+    Read per function rather than as one shared pair, so the two writers are free
+    to name their parameters differently without either becoming unreadable.
+    """
+    parameters: dict[str, tuple[str, str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name not in AGGREGATOR_COUNTER_WRITERS:
+            continue
+        positional = [arg.arg for arg in node.args.args]
+        assert len(positional) >= 2, (
+            f'{AGGREGATOR_SOURCE}::{node.name} takes fewer than two positional '
+            f'parameters, so this helper cannot tell which one is the sort key. '
+            f'If the signature changed shape, update this file rather than '
+            f'loosening the assertion that depends on it.'
+        )
+        parameters[node.name] = (positional[0], positional[1])
+    assert set(parameters) == set(AGGREGATOR_COUNTER_WRITERS), (
+        f'Expected {AGGREGATOR_SOURCE} to define {sorted(AGGREGATOR_COUNTER_WRITERS)}; '
+        f'found {sorted(parameters)}. A writer that moved to another module cannot '
+        f'have its parameter names read here, so its keyword calls would look '
+        f'unreadable — follow it, or pin it where it now lives.'
+    )
+    return parameters
+
+
 def _aggregator_counter_writes() -> list[tuple[str, str]]:
     """Every counter write in the aggregator, as (pk source, sk source).
 
@@ -318,18 +351,28 @@ def _aggregator_counter_writes() -> list[tuple[str, str]]:
     where they belong, whatever their shape. It also excludes the two function
     DEFINITIONS for free, since a `def` is not a Call. No module is imported —
     ast.parse reads the same text every other helper here reads.
+
+    Keyword arguments are resolved through the writers' own signatures
+    (_aggregator_counter_parameters) rather than through the names this file
+    expects, so the last way a correct aggregator could fail here — a renamed
+    parameter — is closed too.
     """
+    tree = ast.parse(_read(AGGREGATOR_SOURCE))
+    parameters = _aggregator_counter_parameters(tree)
     writes: list[tuple[str, str]] = []
-    for node in ast.walk(ast.parse(_read(AGGREGATOR_SOURCE))):
+    for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
         name = func.id if isinstance(func, ast.Name) else getattr(func, 'attr', '')
         if name not in AGGREGATOR_COUNTER_WRITERS:
             continue
+        # Keyword lookups use the writer's OWN parameter names, so a rename cannot
+        # turn a correct keyword call into an unreadable one.
+        pk_name, sk_name = parameters[name]
         keywords = {kw.arg: kw.value for kw in node.keywords}
-        pk = node.args[0] if node.args else keywords.get('pk')
-        sk = node.args[1] if len(node.args) > 1 else keywords.get('sk')
+        pk = node.args[0] if node.args else keywords.get(pk_name)
+        sk = node.args[1] if len(node.args) > 1 else keywords.get(sk_name)
         # '<missing>' rather than a skip: a call this helper cannot read the sort
         # key of must FAIL the assertion below, not quietly leave it unpinned.
         writes.append((

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -310,9 +310,17 @@ def _aggregator_counter_parameters(tree: ast.Module) -> dict[str, tuple[str, str
     """
     parameters: dict[str, tuple[str, str]] = {}
     for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef) or node.name not in AGGREGATOR_COUNTER_WRITERS:
+        # `async def` is an AsyncFunctionDef, not a FunctionDef, and matching only
+        # the latter would report a converted writer as ABSENT — a correct
+        # aggregator failing with a message about a module that did not move.
+        # test_product_context_placeholder_lockstep.py takes both for the same
+        # reason. Positional-only parameters come first in a `/` signature, so they
+        # are read first or the first two names would be the wrong two.
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        positional = [arg.arg for arg in node.args.args]
+        if node.name not in AGGREGATOR_COUNTER_WRITERS:
+            continue
+        positional = [arg.arg for arg in [*node.args.posonlyargs, *node.args.args]]
         assert len(positional) >= 2, (
             f'{AGGREGATOR_SOURCE}::{node.name} takes fewer than two positional '
             f'parameters, so this helper cannot tell which one is the sort key. '

--- a/voc-datalake/lambda/stream/src/context/query-errors.ts
+++ b/voc-datalake/lambda/stream/src/context/query-errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Query-error vocabulary shared by the context builders.
+ *
+ * Neither builder owns this judgement. Both fan out over many partitions of one
+ * table or index, and both have to decide the same thing: whether a failure is
+ * one partition's bad luck or the whole read failing sixteen times over. Keeping
+ * the set here rather than in whichever builder happened to need it first
+ * follows src/indexes.ts, the existing home for vocabulary that is shared rather
+ * than one module's business.
+ */
+
+// Error names that fail identically for every partition of the same table or
+// index — a missing grant, an absent table, a malformed request. Retrying the
+// remaining partitions just repeats the failure N times, and reporting it N
+// times says nothing the first line did. Two consequences follow for any
+// consumer: report one of these ONCE for the turn, and treat the numbers it
+// leaves behind as unmeasured rather than as zero.
+export const PERSISTENT_QUERY_ERRORS = new Set([
+  'AccessDeniedException',
+  'ResourceNotFoundException',
+  'ValidationException',
+]);

--- a/voc-datalake/lambda/stream/src/context/recent-feedback.ts
+++ b/voc-datalake/lambda/stream/src/context/recent-feedback.ts
@@ -43,7 +43,11 @@ const DAY_QUERY_BATCH_SIZE = 7;
 // Error names that will fail identically for every partition of the same
 // index — retrying the remaining days would just repeat the failure 30x
 // and silently reproduce the empty-section symptom this fix removes.
-const PERSISTENT_QUERY_ERRORS = new Set([
+// Exported because voc-context.ts fans out over metric partitions and needs the
+// same judgement: one of these names means every sibling read is failing for the
+// same reason, so it must be reported once for the turn rather than once per
+// partition, and the numbers it leaves behind are not measured facts.
+export const PERSISTENT_QUERY_ERRORS = new Set([
   'AccessDeniedException',
   'ResourceNotFoundException',
   'ValidationException',

--- a/voc-datalake/lambda/stream/src/context/recent-feedback.ts
+++ b/voc-datalake/lambda/stream/src/context/recent-feedback.ts
@@ -10,6 +10,7 @@
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { FEEDBACK_BY_DATE_INDEX } from '../indexes.js';
+import { PERSISTENT_QUERY_ERRORS } from './query-errors.js';
 
 export interface FeedbackSummary {
   count: number;
@@ -39,19 +40,6 @@ const RECENT_FEEDBACK_PROMPT_LINES = 15;
 // little read amplification to bound latency. Don't "optimize" this back to
 // sequential-with-early-exit without re-reading the round-trip math above.
 const DAY_QUERY_BATCH_SIZE = 7;
-
-// Error names that will fail identically for every partition of the same
-// index — retrying the remaining days would just repeat the failure 30x
-// and silently reproduce the empty-section symptom this fix removes.
-// Exported because voc-context.ts fans out over metric partitions and needs the
-// same judgement: one of these names means every sibling read is failing for the
-// same reason, so it must be reported once for the turn rather than once per
-// partition, and the numbers it leaves behind are not measured facts.
-export const PERSISTENT_QUERY_ERRORS = new Set([
-  'AccessDeniedException',
-  'ResourceNotFoundException',
-  'ValidationException',
-]);
 
 /** Parse and append one page of rows, capped at the collection target.
  * Per-row safeParse: one malformed item must not discard the rest. Note this

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -350,6 +350,62 @@ describe('buildVocChatContext Top Categories', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('settings read failed'));
   });
 
+  it('tells the model the figures are incomplete when the taxonomy read fails', async () => {
+    // The operator log was only half of it. A failed settings read is the FOURTH
+    // way this turn hands the model something that was not measured, and the worst
+    // of the four: the other three make a number short, this one swaps the whole
+    // taxonomy, so a tenant who configured `delivery_ops`/`kyc`/`fees` gets counts
+    // for ten partitions that are not theirs — plausibly all zero — and the
+    // section still renders as authoritative.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') {
+          return Promise.reject(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+        }
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 1 });
+
+    expect(ctx.userMessage).toContain('the figures below are incomplete');
+    // The name is operator detail and belongs in the log only: it tells whoever
+    // reads the answer that this Lambda's role is missing a grant, which is not
+    // theirs to act on, and this is the one sentence the model is told to relay.
+    expect(ctx.userMessage).not.toContain('AccessDeniedException');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('AccessDeniedException'));
+  });
+
+  it('still reports degraded on a turn served from the cached fallback', async () => {
+    // The failure is cached WITH the names for CATEGORY_ERROR_CACHE_TTL_MS. A turn
+    // inside that window is describing the tenant with a taxonomy it never
+    // configured exactly as much as the turn that did the failed read, so caching
+    // the names while dropping the reason would make that window read as healthy.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') return Promise.reject(new Error('throttled'));
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'first', days: 1 });
+    warnSpy.mockClear();
+    const second = await buildVocChatContext(docClient, TABLE_NAME, { message: 'second', days: 1 });
+
+    // Served from the cache: no second settings read, and no second warning...
+    const settingsReads = vi.mocked(docClient.send).mock.calls.filter((call) => {
+      const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
+        .input.ExpressionAttributeValues;
+      return values[':pk'] === 'SETTINGS#categories';
+    });
+    expect(settingsReads).toHaveLength(1);
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('settings read failed'));
+    // ...but the prompt still says the figures are not to be trusted as complete.
+    expect(second.userMessage).toContain('the figures below are incomplete');
+  });
+
   it('falls back to the default taxonomy when the stored list is empty', async () => {
     // `item.get('categories')` is falsy for [] in Python, so an empty stored
     // list is one of the three shapes its reader treats as not configured —
@@ -673,13 +729,21 @@ describe('buildVocChatContext category read amplification', () => {
   // otherwise parse as a MEASURED zero — the one thing this module exists to stop.
   // 'n/a' is the contrast case and belongs here: it is caught by `.finite()`
   // rather than by the union, so the test covers both gates.
+  // `true` is the one of these that would not read as a zero but as a COUNT:
+  // Number(true) is 1, so under a bare coercion a boolean row would add one item
+  // of feedback nobody ever recorded. It is rejected by the union in front of the
+  // coercion, so it belongs here beside the shapes Number() flattens to 0.
+  // Infinity covers the far end, where `.finite()` rather than the union is the
+  // gate that stops `Infinity` rendering in the prompt.
   it.each([
     ['null', null],
     ['an empty string', ''],
     ['a whitespace string', '   '],
     ['false', false],
+    ['true', true],
+    ['a value too large to be finite', 1e999],
     ['a non-numeric string', 'n/a'],
-  ])('treats %s in a counter as unreadable rather than as a measured zero', async (_label, bad) => {
+  ])('treats %s in a counter as unreadable rather than as a measured count', async (_label, bad) => {
     const docClient = createKeyedDocClient({
       [`METRIC#daily_total|${TODAY_UTC}`]: [{ count: 7 }],
       [`METRIC#daily_total|${utcDaysAgo(1)}`]: [{ count: bad }],

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -607,6 +607,10 @@ describe('buildVocChatContext category read amplification', () => {
 
     expect(ctx.userMessage).toContain('- delivery: 2');
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('paging hit its bound'));
+    // An unread remainder is a partial window, so it takes the same path as a
+    // failed read: the model is told the figures are short rather than being
+    // handed a number that looks measured.
+    expect(ctx.userMessage).toContain('the figures below are incomplete');
     // The log has to be actionable: which window, and what it came to, or it
     // cannot be correlated with the number the model was handed — the same
     // payload lambda/api/metrics_handler.py::_query_metric_window carries.
@@ -658,6 +662,10 @@ describe('buildVocChatContext category read amplification', () => {
     expect(ctx.userMessage).not.toContain('NaN');
     // Dropping a row must not be silent: the window under-reports by that much.
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unreadable counter row'));
+    // Silent in the LOG was only half of it. The number handed to the model is
+    // short by the dropped row, so the prompt has to say so — a dropped row used
+    // to render `- delivery: 5` with nothing to suggest 5 was not the whole count.
+    expect(ctx.userMessage).toContain('the figures below are incomplete');
   });
 
   it('never hands the model NaN for the headline numbers', async () => {
@@ -702,13 +710,24 @@ describe('buildVocChatContext category read amplification', () => {
       days: 3,
     });
 
+    // Each of these is an EXACT total over a window with rows on both sides of
+    // both bounds, which pins the bound in both directions: a bound too wide
+    // admits the out-of-window row (6 would read 56, 2 would read 11), and one
+    // too narrow drops an in-window row (6 would read 2 or 4).
+    //
+    // What was here before was a scan of the whole prompt for the out-of-window
+    // VALUES ('50', '9', '70', '80'). It caught nothing these exact assertions do
+    // not — a leaked row changes the totals, and 6+50 does not contain '50'
+    // anyway — while '9' is a single digit against a message that legitimately
+    // contains any digit through `pct()`'s toFixed(1) (an in-window total of 7
+    // with 3 positive renders `- Positive: 3 (42.9%)`). It could therefore fail
+    // on correct code, which is the failure mode this file argues against.
     expect(ctx.metadata.total_feedback).toBe(6);
     expect(ctx.metadata.urgent_count).toBe(2);
+    expect(ctx.userMessage).toContain('**Total Feedback Items:** 6');
+    expect(ctx.userMessage).toContain('**Urgent Issues:** 2');
     expect(ctx.userMessage).toContain('- Positive: 5');
     expect(ctx.userMessage).toContain('- Negative: 1');
-    for (const outOfWindow of ['50', '9', '70', '80']) {
-      expect(ctx.userMessage).not.toContain(outOfWindow);
-    }
   });
 
   it('reports a table-wide read failure once for the turn, not once per partition', async () => {
@@ -737,6 +756,56 @@ describe('buildVocChatContext category read amplification', () => {
     // And the zeros left behind are not presented as measured facts: the whole
     // point of the section is that the model must not answer confidently from
     // data nobody could read.
+    expect(ctx.userMessage).toContain('the figures below are incomplete');
+    // The CAUSE stays in the log. An AWS exception name is infrastructure detail
+    // — this one says the Lambda's IAM role is missing a grant — and the note is
+    // the one sentence in the section the model is told to relay, so a name
+    // interpolated into it is a name offered to an end user who can do nothing
+    // with it. The operator keeps it, with the window bounds attached.
+    expect(ctx.userMessage).not.toContain('AccessDeniedException');
+    expect(failureWarnings[0][0]).toContain('AccessDeniedException');
+  });
+
+  it('reports unreadable counter rows once for the turn, not once per partition', async () => {
+    // A cause that makes rows unparseable — a migration that wrote strings into
+    // `count`, a hand-edit — hits every partition of the table identically, so
+    // the ninth warning says nothing the first did. That is the same fan-out the
+    // read-failure report above exists to prevent, reached through a different
+    // cause, and it is why the count is aggregated by the caller rather than
+    // warned about inside the per-page read.
+    //
+    // Three configured names rather than the default ten, so this fixture does
+    // not restate DEFAULT_CATEGORIES: 3 categories + total + urgent + 4
+    // sentiments = 9 windows, every one of them holding a bad row.
+    const configured = ['delivery', 'billing', 'app'];
+    const table: Record<string, Record<string, unknown>[]> = {
+      [CATEGORY_SETTINGS_KEY]: [{ categories: configured.map((name) => ({ name })) }],
+    };
+    const partitions = [
+      'METRIC#daily_total',
+      'METRIC#urgent',
+      ...['positive', 'negative', 'neutral', 'mixed'].map((s) => `METRIC#daily_sentiment#${s}`),
+      ...configured.map((cat) => `METRIC#daily_category#${cat}`),
+    ];
+    for (const pk of partitions) {
+      table[`${pk}|${TODAY_UTC}`] = [{ count: 4 }, { count: 'n/a' }];
+    }
+
+    const ctx = await buildVocChatContext(createKeyedDocClient(table), TABLE_NAME, {
+      message: 'hi',
+      days: 1,
+    });
+
+    const skipWarnings = warnSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('unreadable counter row'),
+    );
+    expect(skipWarnings).toHaveLength(1);
+    // One line is only as useful as sixteen if it carries the scale and the
+    // windows, so it is those the assertion pins, not just the phrasing.
+    expect(String(skipWarnings[0][0])).toContain(`${partitions.length} metric window(s)`);
+    expect(String(skipWarnings[0][0])).toContain('METRIC#daily_total');
+    // The readable rows still count, and the prompt says the total is short.
+    expect(ctx.userMessage).toContain('**Total Feedback Items:** 4');
     expect(ctx.userMessage).toContain('the figures below are incomplete');
   });
 

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -668,21 +668,44 @@ describe('buildVocChatContext category read amplification', () => {
     expect(ctx.userMessage).toContain('the figures below are incomplete');
   });
 
-  it('treats a null counter as unreadable rather than as a measured zero', async () => {
-    // `z.coerce.number()` runs Number() first, and Number(null) is 0, so a row
-    // storing a literal null would pass the parse and be counted as a measured
-    // zero. Nobody knows what that row held, so it belongs in the skipped count:
-    // the total is short by an unknown amount, and the turn has to say so.
+  // Every value Number() turns into a plausible-looking 0 while holding no count
+  // at all. `z.coerce` runs Number() before validating, so each of these would
+  // otherwise parse as a MEASURED zero — the one thing this module exists to stop.
+  // 'n/a' is the contrast case and belongs here: it is caught by `.finite()`
+  // rather than by the union, so the test covers both gates.
+  it.each([
+    ['null', null],
+    ['an empty string', ''],
+    ['a whitespace string', '   '],
+    ['false', false],
+    ['a non-numeric string', 'n/a'],
+  ])('treats %s in a counter as unreadable rather than as a measured zero', async (_label, bad) => {
     const docClient = createKeyedDocClient({
       [`METRIC#daily_total|${TODAY_UTC}`]: [{ count: 7 }],
-      [`METRIC#daily_total|${utcDaysAgo(1)}`]: [{ count: null }],
+      [`METRIC#daily_total|${utcDaysAgo(1)}`]: [{ count: bad }],
     });
 
     const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 3 });
 
+    // 7, not 7 + 0: the readable row is kept and the unreadable one is reported,
+    // so the number is short by an unknown amount and the prompt says so.
     expect(ctx.metadata.total_feedback).toBe(7);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unreadable counter row'));
     expect(ctx.userMessage).toContain('the figures below are incomplete');
+  });
+
+  it('still reads a counter stored as a padded numeric string', async () => {
+    // The other side of the union: DynamoDB stores what it was given, and a
+    // number can arrive as a string depending on path. Rejecting the empty string
+    // must not become rejecting strings.
+    const docClient = createKeyedDocClient({
+      [`METRIC#daily_total|${TODAY_UTC}`]: [{ count: ' 5 ' }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 1 });
+
+    expect(ctx.metadata.total_feedback).toBe(5);
+    expect(ctx.userMessage).not.toContain('the figures below are incomplete');
   });
 
   it('keeps the window well formed for a days value below the floor', async () => {

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -668,6 +668,53 @@ describe('buildVocChatContext category read amplification', () => {
     expect(ctx.userMessage).toContain('the figures below are incomplete');
   });
 
+  it('treats a null counter as unreadable rather than as a measured zero', async () => {
+    // `z.coerce.number()` runs Number() first, and Number(null) is 0, so a row
+    // storing a literal null would pass the parse and be counted as a measured
+    // zero. Nobody knows what that row held, so it belongs in the skipped count:
+    // the total is short by an unknown amount, and the turn has to say so.
+    const docClient = createKeyedDocClient({
+      [`METRIC#daily_total|${TODAY_UTC}`]: [{ count: 7 }],
+      [`METRIC#daily_total|${utcDaysAgo(1)}`]: [{ count: null }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 3 });
+
+    expect(ctx.metadata.total_feedback).toBe(7);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unreadable counter row'));
+    expect(ctx.userMessage).toContain('the figures below are incomplete');
+  });
+
+  it('keeps the window well formed for a days value below the floor', async () => {
+    // `days` reaches this module already bounded — schema.ts declares
+    // `z.number().int().min(1).max(365)` — and buildVocChatContext clamps again on
+    // top of that. The clamp is what stops `days - 1` from running backwards and
+    // asking DynamoDB for `oldest > newest`, which is a ValidationException for
+    // every partition of the turn: sixteen failed reads and a prompt that says its
+    // own figures are incomplete. Pinned as an INVARIANT on what is sent, so
+    // removing the clamp fails here rather than in production.
+    const docClient = createKeyedDocClient({
+      [`METRIC#daily_total|${TODAY_UTC}`]: [{ count: 3 }],
+    });
+
+    for (const days of [0, -5]) {
+      const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days });
+
+      expect(ctx.metadata.days_analyzed).toBe(1);
+      expect(ctx.userMessage).not.toContain('the figures below are incomplete');
+      expect(ctx.metadata.total_feedback).toBe(3);
+    }
+
+    const ranges = (docClient.send as unknown as { mock: { calls: { input: Record<string, unknown> }[][] } })
+      .mock.calls
+      .map(([command]) => (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>)
+      .filter((values) => values[':oldest'] !== undefined);
+    expect(ranges.length).toBeGreaterThan(0);
+    for (const values of ranges) {
+      expect(values[':oldest'] <= values[':newest']).toBe(true);
+    }
+  });
+
   it('never hands the model NaN for the headline numbers', async () => {
     // A malformed METRIC#daily_total row used to render, verbatim,
     // `**Total Feedback Items:** NaN` and `- Positive: 0 (NaN%)` for all four

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -494,6 +494,36 @@ describe('buildVocChatContext category read amplification', () => {
     expect(settingsReads).toHaveLength(1);
   });
 
+  it('caches the taxonomy per table rather than once for the container', async () => {
+    // `aggregatesTable` is a parameter of every read here, so nothing in the
+    // types says it cannot vary. A single global entry would answer a second
+    // table with the first one's taxonomy — describing one deployment with
+    // another's categories is the same class of silent disagreement as the bug
+    // this module was fixed for.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] !== 'SETTINGS#categories') return Promise.resolve({ Items: [] });
+        const name = command.input.TableName === TABLE_NAME ? 'delivery' : 'billing';
+        return Promise.resolve({ Items: [{ categories: [{ name }] }] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'first', days: 1 });
+    await buildVocChatContext(docClient, 'other-table', { message: 'second', days: 1 });
+
+    const categoryPartitions = vi.mocked(docClient.send).mock.calls
+      .map((call) => {
+        const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
+          .input.ExpressionAttributeValues;
+        return values[':pk'];
+      })
+      .filter((pk) => pk.startsWith('METRIC#daily_category#'));
+
+    expect(categoryPartitions).toContain('METRIC#daily_category#delivery');
+    expect(categoryPartitions).toContain('METRIC#daily_category#billing');
+  });
+
   it('re-reads the taxonomy once its cache entry has expired', async () => {
     // Cached, not frozen: an admin who edits the taxonomy must see chat follow
     // within the same TTL Python uses, or the two surfaces disagree again.
@@ -577,5 +607,167 @@ describe('buildVocChatContext category read amplification', () => {
 
     expect(ctx.userMessage).toContain('- delivery: 2');
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('paging hit its bound'));
+    // The log has to be actionable: which window, and what it came to, or it
+    // cannot be correlated with the number the model was handed — the same
+    // payload lambda/api/metrics_handler.py::_query_metric_window carries.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`${utcDaysAgo(1)}..${TODAY_UTC}`),
+    );
+  });
+
+  it('keeps the pages it already read when a later page fails', async () => {
+    // The paging follow must not be all-or-nothing. Discarding the pages already
+    // read turns a partial window into a confident zero — and a zero category is
+    // filtered out entirely, so the section renders with nothing under it: the
+    // exact symptom this module exists to remove, reached through its own
+    // pagination. The per-day shape this replaced degraded gracefully (one
+    // failing day cost one day), so losing that would be a regression.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') {
+          return Promise.resolve({ Items: [{ categories: [{ name: 'delivery' }] }] });
+        }
+        if (values[':pk'] !== 'METRIC#daily_category#delivery') return Promise.resolve({ Items: [] });
+        return command.input.ExclusiveStartKey === undefined
+          ? Promise.resolve({ Items: [{ count: 400 }], LastEvaluatedKey: { pk: 'x', sk: 'y' } })
+          : Promise.reject(new Error('page two is gone'));
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 3 });
+
+    expect(ctx.userMessage).toContain('- delivery: 400');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('the data summary is incomplete'));
+  });
+
+  it('keeps a category whose window holds one unreadable counter row', async () => {
+    // Nothing between the admin UI and this read enforces a counter's shape, and
+    // `Number('n/a')` is NaN — which is contagious under `+`, so coercing the
+    // page as a whole would make the whole window NaN. `NaN > 0` is false, so the
+    // category would vanish from the prompt despite having real feedback.
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'delivery' }] }],
+      [`METRIC#daily_category#delivery|${TODAY_UTC}`]: [{ count: 5 }],
+      [`METRIC#daily_category#delivery|${utcDaysAgo(1)}`]: [{ count: 'n/a' }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 3 });
+
+    expect(ctx.userMessage).toContain('- delivery: 5');
+    expect(ctx.userMessage).not.toContain('NaN');
+    // Dropping a row must not be silent: the window under-reports by that much.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unreadable counter row'));
+  });
+
+  it('never hands the model NaN for the headline numbers', async () => {
+    // A malformed METRIC#daily_total row used to render, verbatim,
+    // `**Total Feedback Items:** NaN` and `- Positive: 0 (NaN%)` for all four
+    // sentiments, and the model was then asked to reason about "NaN" items.
+    const docClient = createKeyedDocClient({
+      [`METRIC#daily_total|${TODAY_UTC}`]: [{ count: 'not-a-number' }],
+      [`METRIC#daily_total|${utcDaysAgo(1)}`]: [{ count: 3 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 3 });
+
+    expect(ctx.userMessage).not.toContain('NaN');
+    expect(ctx.userMessage).toContain('**Total Feedback Items:** 3');
+    expect(ctx.metadata.total_feedback).toBe(3);
+  });
+
+  it('sums the headline metrics over the whole requested window', async () => {
+    // These went through the same per-day-to-BETWEEN rewrite as the category
+    // sums, but every other keyed test drives category partitions only — so a
+    // wrong window bound for the totals, urgency and sentiment passed the whole
+    // suite while chat reported one day of data under a "Last 3 days" heading.
+    const outside = utcDaysAgo(3);
+    const table: Record<string, Record<string, unknown>[]> = {};
+    for (const offset of [0, 1, 2]) {
+      table[`METRIC#daily_total|${utcDaysAgo(offset)}`] = [{ count: 2 }];
+    }
+    table[`METRIC#daily_total|${outside}`] = [{ count: 50 }];
+    for (const offset of [0, 1]) {
+      table[`METRIC#urgent|${utcDaysAgo(offset)}`] = [{ count: 1 }];
+    }
+    table[`METRIC#urgent|${outside}`] = [{ count: 9 }];
+    table[`METRIC#daily_sentiment#positive|${TODAY_UTC}`] = [{ count: 4 }];
+    table[`METRIC#daily_sentiment#positive|${utcDaysAgo(2)}`] = [{ count: 1 }];
+    table[`METRIC#daily_sentiment#positive|${outside}`] = [{ count: 70 }];
+    table[`METRIC#daily_sentiment#negative|${utcDaysAgo(1)}`] = [{ count: 1 }];
+    table[`METRIC#daily_sentiment#negative|${outside}`] = [{ count: 80 }];
+
+    const ctx = await buildVocChatContext(createKeyedDocClient(table), TABLE_NAME, {
+      message: 'hi',
+      days: 3,
+    });
+
+    expect(ctx.metadata.total_feedback).toBe(6);
+    expect(ctx.metadata.urgent_count).toBe(2);
+    expect(ctx.userMessage).toContain('- Positive: 5');
+    expect(ctx.userMessage).toContain('- Negative: 1');
+    for (const outOfWindow of ['50', '9', '70', '80']) {
+      expect(ctx.userMessage).not.toContain(outOfWindow);
+    }
+  });
+
+  it('reports a table-wide read failure once for the turn, not once per partition', async () => {
+    // An AccessDeniedException fails identically for every partition of the same
+    // table, so sixteen warnings say nothing the first one did. The names are
+    // shared with src/context/recent-feedback.ts, which reached the same
+    // conclusion for its own fan-out.
+    const denied = new Error('no');
+    denied.name = 'AccessDeniedException';
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') {
+          return Promise.resolve({ Items: [{ categories: [{ name: 'delivery' }] }] });
+        }
+        return Promise.reject(denied);
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 7 });
+
+    const failureWarnings = warnSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('AccessDeniedException'),
+    );
+    expect(failureWarnings).toHaveLength(1);
+    // And the zeros left behind are not presented as measured facts: the whole
+    // point of the section is that the model must not answer confidently from
+    // data nobody could read.
+    expect(ctx.userMessage).toContain('the figures below are incomplete');
+  });
+
+  it('keeps at most one batch of category reads in flight at once', async () => {
+    // The taxonomy is operator-supplied and uncapped — save_categories_config
+    // validates neither length nor shape — so an unbounded fan-out means one
+    // query per configured name, simultaneously, in front of the first streamed
+    // token. src/context/recent-feedback.ts made the same call for its day
+    // queries: concurrent, but batched.
+    const names = Array.from({ length: 25 }, (_, index) => `cat-${index}`);
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const docClient = {
+      send: vi.fn().mockImplementation(async (command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        const pk = values[':pk'];
+        if (pk === 'SETTINGS#categories') {
+          return { Items: [{ categories: names.map((name) => ({ name })) }] };
+        }
+        if (!pk.startsWith('METRIC#daily_category#')) return { Items: [] };
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await Promise.resolve();
+        inFlight -= 1;
+        return { Items: [{ count: 1 }] };
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 1 });
+
+    expect(peakInFlight).toBeGreaterThan(1);
+    expect(peakInFlight).toBeLessThanOrEqual(10);
   });
 });

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -16,6 +16,31 @@ function createMockDocClient(responses: Record<string, unknown>[][] = []) {
   } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
 }
 
+/**
+ * A doc client that answers each query by its key, the way DynamoDB does,
+ * rather than by call order. The context builder fires its metric reads through
+ * Promise.all, so call order is not something a test may depend on — and the
+ * bug this fixture exists for was precisely a read of the WRONG key, which an
+ * order-indexed fixture answers as happily as the right one.
+ */
+function createKeyedDocClient(table: Record<string, Record<string, unknown>[]>) {
+  return {
+    send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+      const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+      const items = table[`${values[':pk']}|${values[':sk']}`] ?? [];
+      return Promise.resolve({ Items: items });
+    }),
+  } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+}
+
+/** The single item key the settings PUT handler writes the taxonomy under. */
+const CATEGORY_SETTINGS_KEY = 'SETTINGS#categories|config';
+
+/** Today in UTC, the first day the builder sums over. */
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 describe('buildVocChatContext', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -127,5 +152,191 @@ describe('buildVocChatContext', () => {
     expect(ctx.systemPrompt).not.toContain('it-XX');
     expect(ctx.systemPrompt).not.toContain('undefined');
     expect(ctx.systemPrompt).not.toContain('MUST respond entirely in');
+  });
+});
+
+describe('buildVocChatContext Top Categories', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the configured names when the settings item exists', async () => {
+    const today = todayUtc();
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{
+        categories: [
+          { name: 'delivery', description: 'shipping' },
+          { name: 'billing', description: 'invoices' },
+        ],
+      }],
+      [`METRIC#daily_category#delivery|${today}`]: [{ count: 12 }],
+      [`METRIC#daily_category#billing|${today}`]: [{ count: 30 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+      message: 'which categories dominate?',
+      days: 1,
+    });
+
+    // The regression this guards: the section rendered with nothing under it,
+    // because the reader asked for a key nobody writes and then read the wrong
+    // field off each category.
+    expect(ctx.userMessage).toContain('**Top Categories:**\n- billing: 30\n- delivery: 12');
+  });
+
+  it('counts a configured category that carries no internal id', async () => {
+    // The settings PUT handler stores whatever the admin UI sends, and does not
+    // guarantee an `id`. A schema requiring one would drop this category
+    // silently, since parse failures are filtered out rather than reported.
+    const today = todayUtc();
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'returns' }] }],
+      [`METRIC#daily_category#returns|${today}`]: [{ count: 7 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('- returns: 7');
+  });
+
+  it('reads the taxonomy from the key the settings handler writes', async () => {
+    // Named explicitly, because a reader that asks for any other key gets no
+    // item and empties the section on every turn without failing anything.
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'app' }] }],
+    });
+
+    await buildVocChatContext(docClient, 'agg-table', { message: 'hi', days: 1 });
+
+    const keys = vi.mocked(docClient.send).mock.calls.map((call) => {
+      const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
+        .input.ExpressionAttributeValues;
+      return `${values[':pk']}|${values[':sk']}`;
+    });
+
+    expect(keys).toContain(CATEGORY_SETTINGS_KEY);
+    // Every non-metric read must be that one key: the abandoned reader asked a
+    // partition nothing writes, which returns no item and fails nothing.
+    const settingsReads = keys.filter((key) => !key.startsWith('METRIC#'));
+    expect(settingsReads).toStrictEqual([CATEGORY_SETTINGS_KEY]);
+  });
+
+  it('sums each category over the whole requested window', async () => {
+    // The counts must match what the metrics surface reports for the same
+    // window, and the metrics surface sums one partition per day.
+    const now = new Date();
+    const dates = [0, 1, 2].map((offset) => {
+      const d = new Date(now);
+      d.setUTCDate(d.getUTCDate() - offset);
+      return d.toISOString().slice(0, 10);
+    });
+    const table: Record<string, Record<string, unknown>[]> = {
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'pricing' }] }],
+    };
+    for (const date of dates) {
+      table[`METRIC#daily_category#pricing|${date}`] = [{ count: 5 }];
+    }
+
+    const ctx = await buildVocChatContext(createKeyedDocClient(table), 'agg-table', {
+      message: 'hi',
+      days: 3,
+    });
+
+    expect(ctx.userMessage).toContain('- pricing: 15');
+  });
+
+  it('reports the top five categories, busiest first', async () => {
+    const today = todayUtc();
+    const names = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const table: Record<string, Record<string, unknown>[]> = {
+      [CATEGORY_SETTINGS_KEY]: [{ categories: names.map((name) => ({ name })) }],
+    };
+    names.forEach((name, index) => {
+      table[`METRIC#daily_category#${name}|${today}`] = [{ count: index + 1 }];
+    });
+
+    const ctx = await buildVocChatContext(createKeyedDocClient(table), 'agg-table', {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('**Top Categories:**\n- f: 6\n- e: 5\n- d: 4\n- c: 3\n- b: 2\n');
+    expect(ctx.userMessage).not.toContain('- a: 1');
+  });
+
+  it('falls back to the default taxonomy when no settings item exists', async () => {
+    // Matches lambda/shared/api.py::get_configured_categories, which falls back
+    // to DEFAULT_CATEGORIES. An empty fallback here would report no categories
+    // where the metrics surface reports counts for the same table.
+    const today = todayUtc();
+    const docClient = createKeyedDocClient({
+      [`METRIC#daily_category#product_quality|${today}`]: [{ count: 4 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('- product_quality: 4');
+  });
+
+  it('falls back to the default taxonomy when the settings lookup throws', async () => {
+    const today = todayUtc();
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') {
+          return Promise.reject(new Error('throttled'));
+        }
+        if (values[':pk'] === 'METRIC#daily_category#other' && values[':sk'] === today) {
+          return Promise.resolve({ Items: [{ count: 3 }] });
+        }
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('- other: 3');
+  });
+
+  it('omits categories with no feedback in the window', async () => {
+    const today = todayUtc();
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'website' }, { name: 'app' }] }],
+      [`METRIC#daily_category#website|${today}`]: [{ count: 2 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('- website: 2');
+    expect(ctx.userMessage).not.toContain('- app:');
+  });
+
+  it('ignores a configured entry that carries no name', async () => {
+    // Mirrors the Python reader, which filters on a truthy `name`. An entry
+    // without one would otherwise sum the partition `METRIC#daily_category#`.
+    const today = todayUtc();
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ id: 'cat-1' }, { name: 'delivery' }] }],
+      [`METRIC#daily_category#delivery|${today}`]: [{ count: 9 }],
+      [`METRIC#daily_category#|${today}`]: [{ count: 99 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('- delivery: 9');
+    expect(ctx.userMessage).not.toContain('99');
   });
 });

--- a/voc-datalake/lambda/stream/src/context/voc-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for VoC Chat context builder.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildVocChatContext } from './voc-context.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildVocChatContext, clearCategoryCache } from './voc-context.js';
 import { chatRequestSchema } from '../schema.js';
 
 function createMockDocClient(responses: Record<string, unknown>[][] = []) {
@@ -16,18 +16,35 @@ function createMockDocClient(responses: Record<string, unknown>[][] = []) {
   } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
 }
 
+const TABLE_NAME = 'agg-table';
+
 /**
  * A doc client that answers each query by its key, the way DynamoDB does,
  * rather than by call order. The context builder fires its metric reads through
  * Promise.all, so call order is not something a test may depend on — and the
  * bug this fixture exists for was precisely a read of the WRONG key, which an
  * order-indexed fixture answers as happily as the right one.
+ *
+ * Two shapes are served, matching the two the module issues: the settings item
+ * is an `sk = :sk` equality read, and a metric window is an `sk BETWEEN :oldest
+ * AND :newest` range read, so a fixture row is returned only when its date
+ * falls inside the requested window. A read against another table answers
+ * nothing, since the fixture stands in for one table only.
  */
 function createKeyedDocClient(table: Record<string, Record<string, unknown>[]>) {
   return {
     send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
       const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
-      const items = table[`${values[':pk']}|${values[':sk']}`] ?? [];
+      if (command.input.TableName !== TABLE_NAME) return Promise.resolve({ Items: [] });
+      const rangeRead = values[':oldest'] !== undefined;
+      const items = rangeRead
+        ? Object.entries(table).flatMap(([key, rows]) => {
+          const [pk, sk] = key.split('|');
+          const inWindow = pk === values[':pk']
+            && sk >= values[':oldest'] && sk <= values[':newest'];
+          return inWindow ? rows : [];
+        })
+        : table[`${values[':pk']}|${values[':sk']}`] ?? [];
       return Promise.resolve({ Items: items });
     }),
   } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
@@ -36,13 +53,26 @@ function createKeyedDocClient(table: Record<string, Record<string, unknown>[]>) 
 /** The single item key the settings PUT handler writes the taxonomy under. */
 const CATEGORY_SETTINGS_KEY = 'SETTINGS#categories|config';
 
-/** Today in UTC, the first day the builder sums over. */
-function todayUtc(): string {
-  return new Date().toISOString().slice(0, 10);
+// The clock is pinned for the category suite: the module samples it separately
+// from the fixture (`new Date()` inside sumDailyMetric), so a run straddling
+// UTC midnight would ask for a window the fixture keys nothing under. Same
+// convention as src/context/project-context.test.ts.
+const FIXED_NOW = new Date('2026-03-04T12:00:00.000Z');
+const TODAY_UTC = '2026-03-04';
+
+/** A UTC date `daysAgo` before the pinned instant, as 'YYYY-MM-DD'. */
+function utcDaysAgo(daysAgo: number): string {
+  const d = new Date(FIXED_NOW);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().slice(0, 10);
 }
 
 describe('buildVocChatContext', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The taxonomy is cached per container, so it must not leak between tests.
+    clearCategoryCache();
+  });
 
   it('returns system prompt, user message, and metadata', async () => {
     const docClient = createMockDocClient();
@@ -156,10 +186,23 @@ describe('buildVocChatContext', () => {
 });
 
 describe('buildVocChatContext Top Categories', () => {
-  beforeEach(() => vi.clearAllMocks());
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    clearCategoryCache();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
 
   it('returns the configured names when the settings item exists', async () => {
-    const today = todayUtc();
+    const today = TODAY_UTC;
     const docClient = createKeyedDocClient({
       [CATEGORY_SETTINGS_KEY]: [{
         categories: [
@@ -171,7 +214,7 @@ describe('buildVocChatContext Top Categories', () => {
       [`METRIC#daily_category#billing|${today}`]: [{ count: 30 }],
     });
 
-    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
       message: 'which categories dominate?',
       days: 1,
     });
@@ -186,13 +229,13 @@ describe('buildVocChatContext Top Categories', () => {
     // The settings PUT handler stores whatever the admin UI sends, and does not
     // guarantee an `id`. A schema requiring one would drop this category
     // silently, since parse failures are filtered out rather than reported.
-    const today = todayUtc();
+    const today = TODAY_UTC;
     const docClient = createKeyedDocClient({
       [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'returns' }] }],
       [`METRIC#daily_category#returns|${today}`]: [{ count: 7 }],
     });
 
-    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
       message: 'hi',
       days: 1,
     });
@@ -207,7 +250,7 @@ describe('buildVocChatContext Top Categories', () => {
       [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'app' }] }],
     });
 
-    await buildVocChatContext(docClient, 'agg-table', { message: 'hi', days: 1 });
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 1 });
 
     const keys = vi.mocked(docClient.send).mock.calls.map((call) => {
       const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
@@ -224,21 +267,18 @@ describe('buildVocChatContext Top Categories', () => {
 
   it('sums each category over the whole requested window', async () => {
     // The counts must match what the metrics surface reports for the same
-    // window, and the metrics surface sums one partition per day.
-    const now = new Date();
-    const dates = [0, 1, 2].map((offset) => {
-      const d = new Date(now);
-      d.setUTCDate(d.getUTCDate() - offset);
-      return d.toISOString().slice(0, 10);
-    });
+    // window, so every date inside it must be summed — and only those dates.
     const table: Record<string, Record<string, unknown>[]> = {
       [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'pricing' }] }],
     };
-    for (const date of dates) {
-      table[`METRIC#daily_category#pricing|${date}`] = [{ count: 5 }];
+    for (const offset of [0, 1, 2]) {
+      table[`METRIC#daily_category#pricing|${utcDaysAgo(offset)}`] = [{ count: 5 }];
     }
+    // Just outside a three-day window: counted would mean the window's oldest
+    // bound is wrong, which would silently disagree with the metrics surface.
+    table[`METRIC#daily_category#pricing|${utcDaysAgo(3)}`] = [{ count: 100 }];
 
-    const ctx = await buildVocChatContext(createKeyedDocClient(table), 'agg-table', {
+    const ctx = await buildVocChatContext(createKeyedDocClient(table), TABLE_NAME, {
       message: 'hi',
       days: 3,
     });
@@ -247,7 +287,7 @@ describe('buildVocChatContext Top Categories', () => {
   });
 
   it('reports the top five categories, busiest first', async () => {
-    const today = todayUtc();
+    const today = TODAY_UTC;
     const names = ['a', 'b', 'c', 'd', 'e', 'f'];
     const table: Record<string, Record<string, unknown>[]> = {
       [CATEGORY_SETTINGS_KEY]: [{ categories: names.map((name) => ({ name })) }],
@@ -256,7 +296,7 @@ describe('buildVocChatContext Top Categories', () => {
       table[`METRIC#daily_category#${name}|${today}`] = [{ count: index + 1 }];
     });
 
-    const ctx = await buildVocChatContext(createKeyedDocClient(table), 'agg-table', {
+    const ctx = await buildVocChatContext(createKeyedDocClient(table), TABLE_NAME, {
       message: 'hi',
       days: 1,
     });
@@ -269,12 +309,12 @@ describe('buildVocChatContext Top Categories', () => {
     // Matches lambda/shared/api.py::get_configured_categories, which falls back
     // to DEFAULT_CATEGORIES. An empty fallback here would report no categories
     // where the metrics surface reports counts for the same table.
-    const today = todayUtc();
+    const today = TODAY_UTC;
     const docClient = createKeyedDocClient({
       [`METRIC#daily_category#product_quality|${today}`]: [{ count: 4 }],
     });
 
-    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
       message: 'hi',
       days: 1,
     });
@@ -283,36 +323,59 @@ describe('buildVocChatContext Top Categories', () => {
   });
 
   it('falls back to the default taxonomy when the settings lookup throws', async () => {
-    const today = todayUtc();
+    // A failed read is not the same as "nothing configured", but Python's reader
+    // makes the same trade (log, then fall through to the fallback), so the two
+    // surfaces still agree rather than one reporting nothing.
     const docClient = {
       send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
         const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
         if (values[':pk'] === 'SETTINGS#categories') {
           return Promise.reject(new Error('throttled'));
         }
-        if (values[':pk'] === 'METRIC#daily_category#other' && values[':sk'] === today) {
+        if (values[':pk'] === 'METRIC#daily_category#other') {
           return Promise.resolve({ Items: [{ count: 3 }] });
         }
         return Promise.resolve({ Items: [] });
       }),
     } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
 
-    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
       message: 'hi',
       days: 1,
     });
 
     expect(ctx.userMessage).toContain('- other: 3');
+    // The original bug's worst property was silence: a failed read that quietly
+    // substitutes a taxonomy the tenant never configured must at least say so.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('settings read failed'));
+  });
+
+  it('falls back to the default taxonomy when the stored list is empty', async () => {
+    // `item.get('categories')` is falsy for [] in Python, so an empty stored
+    // list is one of the three shapes its reader treats as not configured —
+    // alongside an absent item and a missing `categories` attribute.
+    const today = TODAY_UTC;
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [] }],
+      [`METRIC#daily_category#billing|${today}`]: [{ count: 6 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
+      message: 'hi',
+      days: 1,
+    });
+
+    expect(ctx.userMessage).toContain('- billing: 6');
   });
 
   it('omits categories with no feedback in the window', async () => {
-    const today = todayUtc();
+    const today = TODAY_UTC;
     const docClient = createKeyedDocClient({
       [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'website' }, { name: 'app' }] }],
       [`METRIC#daily_category#website|${today}`]: [{ count: 2 }],
     });
 
-    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
       message: 'hi',
       days: 1,
     });
@@ -324,19 +387,195 @@ describe('buildVocChatContext Top Categories', () => {
   it('ignores a configured entry that carries no name', async () => {
     // Mirrors the Python reader, which filters on a truthy `name`. An entry
     // without one would otherwise sum the partition `METRIC#daily_category#`.
-    const today = todayUtc();
+    const today = TODAY_UTC;
     const docClient = createKeyedDocClient({
       [CATEGORY_SETTINGS_KEY]: [{ categories: [{ id: 'cat-1' }, { name: 'delivery' }] }],
       [`METRIC#daily_category#delivery|${today}`]: [{ count: 9 }],
       [`METRIC#daily_category#|${today}`]: [{ count: 99 }],
     });
 
-    const ctx = await buildVocChatContext(docClient, 'agg-table', {
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, {
       message: 'hi',
       days: 1,
     });
 
     expect(ctx.userMessage).toContain('- delivery: 9');
     expect(ctx.userMessage).not.toContain('99');
+  });
+});
+
+describe('buildVocChatContext category read amplification', () => {
+  // The non-empty fallback means an UNCONFIGURED deployment now asks for ten
+  // category partitions on every turn, where it used to ask for none. That sum
+  // sits in front of time-to-first-token, so its cost has to stay bounded:
+  // one request per partition per window, all partitions concurrent, and the
+  // taxonomy itself read once per container rather than once per turn.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    clearCategoryCache();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  it('bounds a long window to one read per partition instead of one per day', async () => {
+    // The per-day shape issued `days` queries per category: at the permitted
+    // ceiling of 365 days that is 3,650 reads for the default taxonomy alone.
+    // ISO dates sort lexicographically, so BETWEEN bounds the window
+    // server-side, exactly as metrics_handler.py::_query_metric_window does.
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'delivery' }] }],
+      [`METRIC#daily_category#delivery|${TODAY_UTC}`]: [{ count: 11 }],
+    });
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 365 });
+
+    expect(ctx.userMessage).toContain('- delivery: 11');
+    // 1 settings read + 1 per metric partition: daily_total, urgent, four
+    // sentiments, and the single configured category.
+    expect(vi.mocked(docClient.send).mock.calls).toHaveLength(8);
+  });
+
+  it('reads every category partition concurrently, not one after another', async () => {
+    // Ten serial round trips in front of the first streamed token is what the
+    // non-empty fallback would otherwise have introduced on the unconfigured
+    // path. Each send is held open until all of them have been issued: if the
+    // reads were serialised, the first would never resolve and this would time
+    // out rather than fail on a count.
+    const names = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+    const categoryReads: (() => void)[] = [];
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        const pk = values[':pk'];
+        if (pk === 'SETTINGS#categories') {
+          return Promise.resolve({ Items: [{ categories: names.map((name) => ({ name })) }] });
+        }
+        if (!pk.startsWith('METRIC#daily_category#')) return Promise.resolve({ Items: [] });
+        return new Promise((resolve) => {
+          categoryReads.push(() => resolve({ Items: [{ count: 1 }] }));
+          if (categoryReads.length === names.length) {
+            for (const release of categoryReads) release();
+          }
+        });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 1 });
+
+    expect(categoryReads).toHaveLength(names.length);
+    expect(ctx.userMessage).toContain('**Top Categories:**');
+  });
+
+  it('reads the taxonomy once per container, not once per turn', async () => {
+    // The taxonomy changes at human speed. lambda/shared/api.py memoizes it for
+    // CATEGORIES_CACHE_TTL = 300s per container; re-reading it on every turn
+    // spends a round trip in front of the first token for nothing.
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'delivery' }] }],
+      [`METRIC#daily_category#delivery|${TODAY_UTC}`]: [{ count: 2 }],
+    });
+
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'first', days: 1 });
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'second', days: 1 });
+
+    const settingsReads = vi.mocked(docClient.send).mock.calls.filter((call) => {
+      const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
+        .input.ExpressionAttributeValues;
+      return values[':pk'] === 'SETTINGS#categories';
+    });
+    expect(settingsReads).toHaveLength(1);
+  });
+
+  it('re-reads the taxonomy once its cache entry has expired', async () => {
+    // Cached, not frozen: an admin who edits the taxonomy must see chat follow
+    // within the same TTL Python uses, or the two surfaces disagree again.
+    const docClient = createKeyedDocClient({
+      [CATEGORY_SETTINGS_KEY]: [{ categories: [{ name: 'delivery' }] }],
+      [`METRIC#daily_category#delivery|${TODAY_UTC}`]: [{ count: 2 }],
+    });
+
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'first', days: 1 });
+    vi.setSystemTime(new Date(FIXED_NOW.getTime() + 300_001));
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'second', days: 1 });
+
+    const settingsReads = vi.mocked(docClient.send).mock.calls.filter((call) => {
+      const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
+        .input.ExpressionAttributeValues;
+      return values[':pk'] === 'SETTINGS#categories';
+    });
+    expect(settingsReads).toHaveLength(2);
+  });
+
+  it('retries a failed taxonomy read sooner than a successful one', async () => {
+    // A throttling blip must not pin streaming chat to the default taxonomy for
+    // a full five minutes when the tenant has configured one.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') return Promise.reject(new Error('throttled'));
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'first', days: 1 });
+    vi.setSystemTime(new Date(FIXED_NOW.getTime() + 10_001));
+    await buildVocChatContext(docClient, TABLE_NAME, { message: 'second', days: 1 });
+
+    const settingsReads = vi.mocked(docClient.send).mock.calls.filter((call) => {
+      const values = (call[0] as unknown as { input: { ExpressionAttributeValues: Record<string, string> } })
+        .input.ExpressionAttributeValues;
+      return values[':pk'] === 'SETTINGS#categories';
+    });
+    expect(settingsReads).toHaveLength(2);
+  });
+
+  it('follows the cursor when a metric window spans more than one page', async () => {
+    // A bounded follow, so a window wider than one 1 MB page is summed in full
+    // rather than silently short.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') {
+          return Promise.resolve({ Items: [{ categories: [{ name: 'delivery' }] }] });
+        }
+        if (values[':pk'] !== 'METRIC#daily_category#delivery') return Promise.resolve({ Items: [] });
+        return command.input.ExclusiveStartKey === undefined
+          ? Promise.resolve({ Items: [{ count: 4 }], LastEvaluatedKey: { pk: 'x', sk: 'y' } })
+          : Promise.resolve({ Items: [{ count: 5 }] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 3 });
+
+    expect(ctx.userMessage).toContain('- delivery: 9');
+  });
+
+  it('reports a partial window rather than returning a quietly short count', async () => {
+    // One date yields at most one item and an unfiltered page yields at least
+    // one, so a window of `days` dates cannot span more than `days` pages.
+    // Exhausting that bound means the invariant no longer holds.
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        if (values[':pk'] === 'SETTINGS#categories') {
+          return Promise.resolve({ Items: [{ categories: [{ name: 'delivery' }] }] });
+        }
+        if (values[':pk'] !== 'METRIC#daily_category#delivery') return Promise.resolve({ Items: [] });
+        return Promise.resolve({ Items: [{ count: 1 }], LastEvaluatedKey: { pk: 'x', sk: 'y' } });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const ctx = await buildVocChatContext(docClient, TABLE_NAME, { message: 'hi', days: 2 });
+
+    expect(ctx.userMessage).toContain('- delivery: 2');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('paging hit its bound'));
   });
 });

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -552,7 +552,10 @@ function buildDataContext(
   // response_language, so the model relays this fact in the user's language —
   // translating the prompt would change nothing the user reads.
   const degradedNote = degraded
-    ? '\n**NOTE:** Some metric reads did not complete, so the figures below are incomplete and may under-report. Say so rather than presenting them as complete.\n'
+    // "reads", not "metric reads": four causes feed this note and one of them is
+    // the SETTINGS read, where every metric window succeeded and the taxonomy
+    // they were counted under is not the tenant's.
+    ? '\n**NOTE:** Some reads did not complete, so the figures below are incomplete and may under-report. Say so rather than presenting them as complete.\n'
     : '';
 
   const context = `## Current Data Summary (Last ${days} days)
@@ -620,9 +623,11 @@ export async function buildVocChatContext(
   const urgentCount = urgentRead.total;
   // A failed TAXONOMY read degrades the turn too, and it is not a MetricRead: it
   // substitutes the default names for the tenant's own, so the counts under Top
-  // Categories are for partitions that may not be theirs. reportMetricFailures
-  // has already logged its own warning (with the error name, which stays out of
-  // the prompt), so only the flag is ORed in here.
+  // Categories are for partitions that may not be theirs. Only the flag is ORed
+  // in here because the error name has its own operator channel:
+  // readConfiguredCategories logs it — NOT reportMetricFailures, which never sees
+  // this failure — and on a turn served from the error cache entry nothing is
+  // logged at all, since no read happened. The flag is what carries that turn.
   const degraded = reportMetricFailures([
     totalRead, urgentRead, ...sentimentReads, ...categories.reads,
   ]) || categories.taxonomyErrorName !== undefined;

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -27,13 +27,33 @@ const categoryItemSchema = z.object({ name: z.string() }).passthrough();
 
 // Mirrors lambda/shared/api.py::DEFAULT_CATEGORIES. When nothing is configured,
 // get_configured_categories() falls back to this list, and the enrichment
-// prompt uses the same names, so the counters exist under these names. Falling
-// back to an empty array here would report an empty section where the metrics
-// surface reports counts.
+// prompt uses the same names (lambda/processor/handler.py::DEFAULT_CATEGORIES),
+// so the counters exist under these names. Falling back to an empty array here
+// would report an empty section where the metrics surface reports counts.
+// Note the admin UI's own GET /settings/categories still answers `[]` for an
+// unconfigured deployment (lambda/api/settings_handler.py::get_categories_config);
+// aligning that third surface is deliberately out of this module's scope.
 const DEFAULT_CATEGORIES = [
   'delivery', 'customer_support', 'product_quality', 'pricing',
   'website', 'app', 'billing', 'returns', 'communication', 'other',
 ] as const;
+
+// The taxonomy changes at human speed, so re-reading it on every chat turn buys
+// nothing and sits in front of time-to-first-token. 300s matches
+// CATEGORIES_CACHE_TTL in lambda/shared/api.py, whose reader this one mirrors.
+// A failed read caches for much less, so a throttling blip cannot pin streaming
+// chat to the default taxonomy for a full five minutes (the shape used by
+// src/bedrock/model-override.ts).
+const CATEGORY_CACHE_TTL_MS = 300_000;
+const CATEGORY_ERROR_CACHE_TTL_MS = 10_000;
+
+const categoryCache: { names: string[] | null; expires: number } = { names: null, expires: 0 };
+
+/** Reset the container-level taxonomy cache (tests). */
+export function clearCategoryCache(): void {
+  categoryCache.names = null;
+  categoryCache.expires = 0;
+}
 
 interface VocChatContext {
   systemPrompt: string;
@@ -66,6 +86,63 @@ function parseContextFilters(contextHint: string): Record<string, string> {
   return filters;
 }
 
+function utcDateString(now: Date, daysAgo: number): string {
+  const d = new Date(now);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * One metric partition's trailing window, summed, newest date inclusive.
+ *
+ * `sk` is 'YYYY-MM-DD' and ISO dates sort lexicographically, so a window is a
+ * contiguous sort-key range that BETWEEN bounds server-side: a fixed number of
+ * requests regardless of `days`, not one query per day. This mirrors
+ * lambda/api/metrics_handler.py::_query_metric_window, which was deliberately
+ * moved off per-day reads for exactly that reason — and it matters most here,
+ * because this sum sits in front of the first streamed token.
+ *
+ * Paging is bounded rather than `while (true)`: one date yields at most one item
+ * and an unfiltered page yields at least one, so a window of `days` dates cannot
+ * span more than `days` pages. Exhausting the bound means that invariant no
+ * longer holds, so the window really is partial — log it instead of returning a
+ * quietly short answer.
+ */
+async function sumMetricWindow(
+  docClient: DynamoDBDocumentClient,
+  aggregatesTable: string,
+  metricKey: string,
+  bounds: { oldest: string; newest: string },
+  pagesLeft: number,
+  startKey?: Record<string, unknown>,
+): Promise<number> {
+  const resp = await docClient.send(
+    new QueryCommand({
+      TableName: aggregatesTable,
+      KeyConditionExpression: 'pk = :pk AND sk BETWEEN :oldest AND :newest',
+      ExpressionAttributeValues: {
+        ':pk': metricKey,
+        ':oldest': bounds.oldest,
+        ':newest': bounds.newest,
+      },
+      ExclusiveStartKey: startKey,
+    }),
+  );
+  const total = (resp.Items ?? []).reduce(
+    (sum: number, item) => sum + Number(item.count ?? item.value ?? 0),
+    0,
+  );
+  const lastKey = resp.LastEvaluatedKey;
+  if (!lastKey) return total;
+  if (pagesLeft <= 1) {
+    console.warn(`sumMetricWindow: paging hit its bound for ${metricKey}; window is partial`);
+    return total;
+  }
+  return total + (await sumMetricWindow(
+    docClient, aggregatesTable, metricKey, bounds, pagesLeft - 1, lastKey,
+  ));
+}
+
 async function sumDailyMetric(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
@@ -73,39 +150,48 @@ async function sumDailyMetric(
   days: number,
 ): Promise<number> {
   const now = new Date();
-  const totals = await Promise.all(
-    Array.from({ length: days }, (_, i) => {
-      const d = new Date(now);
-      d.setUTCDate(d.getUTCDate() - i);
-      return d.toISOString().slice(0, 10);
-    }).map(async (dateStr) => {
-      try {
-        const resp = await docClient.send(
-          new QueryCommand({
-            TableName: aggregatesTable,
-            KeyConditionExpression: 'pk = :pk AND sk = :sk',
-            ExpressionAttributeValues: { ':pk': metricKey, ':sk': dateStr },
-          }),
-        );
-        const items = resp.Items ?? [];
-        return items.length > 0 ? Number(items[0].count ?? items[0].value ?? 0) : 0;
-      } catch {
-        return 0;
-      }
-    }),
-  );
-  return totals.reduce((sum, v) => sum + v, 0);
+  const bounds = { oldest: utcDateString(now, days - 1), newest: utcDateString(now, 0) };
+  try {
+    return await sumMetricWindow(docClient, aggregatesTable, metricKey, bounds, days);
+  } catch (error) {
+    console.warn(
+      `sumMetricWindow: read failed for ${metricKey}: ${error instanceof Error ? error.name : 'UnknownError'}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * The names in a stored `categories` list, or the empty array when the stored
+ * list is present but names nothing.
+ *
+ * A configured-but-nameless list yields [] rather than the defaults, exactly as
+ * Python does: `get_raw_categories_config` returns the raw list, and
+ * `get_configured_categories` sees a truthy list so never reaches its fallback,
+ * leaving the name filter to produce [].
+ */
+function namesFromStoredList(cats: unknown[]): string[] {
+  return cats
+    .map((c: unknown) => {
+      const parsed = categoryItemSchema.safeParse(c);
+      return parsed.success ? parsed.data.name : '';
+    })
+    .filter(Boolean);
 }
 
 /**
  * The configured category names, matching lambda/shared/api.py
  * (`get_raw_categories_config` + `get_configured_categories`) item-for-item:
  * one key, the `name` field, and DEFAULT_CATEGORIES when nothing is configured.
+ *
+ * The three stored shapes Python treats as "not configured" — item absent,
+ * `categories` missing, `categories: []` — all fall through to the defaults
+ * here too, because `item.get('categories')` is falsy for an empty list.
  */
-async function getConfiguredCategories(
+async function readConfiguredCategories(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
-): Promise<string[]> {
+): Promise<{ names: string[]; ttl: number }> {
   try {
     const resp = await docClient.send(
       new QueryCommand({
@@ -115,24 +201,37 @@ async function getConfiguredCategories(
       }),
     );
     const items = resp.Items ?? [];
-    if (items.length > 0) {
-      const firstItem: Record<string, unknown> = items[0];
-      const cats = firstItem.categories;
-      if (Array.isArray(cats) && cats.length > 0) {
-        // A configured-but-nameless list yields [] here, exactly as the Python
-        // reader does — it only falls back when the item itself is absent.
-        return cats
-          .map((c: unknown) => {
-            const parsed = categoryItemSchema.safeParse(c);
-            return parsed.success ? parsed.data.name : '';
-          })
-          .filter(Boolean);
-      }
+    const firstItem: Record<string, unknown> = items.length > 0 ? items[0] : {};
+    const cats: unknown = firstItem.categories;
+    if (Array.isArray(cats) && cats.length > 0) {
+      return { names: namesFromStoredList(cats), ttl: CATEGORY_CACHE_TTL_MS };
     }
+    return { names: [...DEFAULT_CATEGORIES], ttl: CATEGORY_CACHE_TTL_MS };
   } catch (error) {
-    console.warn('Could not fetch categories from settings; using defaults:', error);
+    // A failed read is NOT the same as "nothing configured": a tenant that has
+    // configured a taxonomy is briefly described by the default one instead.
+    // Python's reader makes the same trade (it logs and falls through to the
+    // fallback), so the two surfaces still agree; the short error TTL keeps the
+    // window small rather than caching a wrong answer for five minutes.
+    console.warn(
+      `getConfiguredCategories: settings read failed (${error instanceof Error ? error.name : 'UnknownError'}); using the default taxonomy`,
+    );
+    return { names: [...DEFAULT_CATEGORIES], ttl: CATEGORY_ERROR_CACHE_TTL_MS };
   }
-  return [...DEFAULT_CATEGORIES];
+}
+
+async function getConfiguredCategories(
+  docClient: DynamoDBDocumentClient,
+  aggregatesTable: string,
+): Promise<string[]> {
+  const now = Date.now();
+  if (categoryCache.names !== null && now < categoryCache.expires) {
+    return categoryCache.names;
+  }
+  const { names, ttl } = await readConfiguredCategories(docClient, aggregatesTable);
+  categoryCache.names = names;
+  categoryCache.expires = now + ttl;
+  return names;
 }
 
 async function fetchCategoryCounts(
@@ -141,13 +240,19 @@ async function fetchCategoryCounts(
   days: number,
 ): Promise<[string, number][]> {
   const categories = await getConfiguredCategories(docClient, aggregatesTable);
-  const counts: [string, number][] = [];
-  for (const cat of categories) {
-    const count = await sumDailyMetric(docClient, aggregatesTable, `METRIC#daily_category#${cat}`, days);
-    if (count > 0) counts.push([cat, count]);
-  }
-  counts.sort((a, b) => b[1] - a[1]);
-  return counts.slice(0, 5);
+  // Concurrent, not serial: the taxonomy has ten names by default, and awaiting
+  // each sum in turn put ten sequential round trips in front of the first
+  // streamed token.
+  const counts = await Promise.all(
+    categories.map(async (cat): Promise<[string, number]> => [
+      cat,
+      await sumDailyMetric(docClient, aggregatesTable, `METRIC#daily_category#${cat}`, days),
+    ]),
+  );
+  return counts
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
 }
 
 function buildSystemPrompt(responseLanguage?: SupportedLanguage): string {

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -44,6 +44,18 @@ const categoryItemSchema = z.object({ name: z.string() }).passthrough();
 // makes the turn say the figures are incomplete instead of quietly reading zero.
 // (`.trim()` before `.min(1)` is what rejects ' ' as well as ''; a padded numeric
 // string like ' 5 ' still parses, since DynamoDB stores what it was given.)
+//
+// Booleans are rejected by the UNION, not by the coercion, and the distinction
+// matters to anyone tempted to simplify this to `z.coerce.number().finite()` on
+// the grounds that the coercion handles everything: a boolean is not a number in
+// JavaScript, so `z.number()` rejects it here — but `Number(false)` is 0 and
+// `Number(true)` is 1, so under a bare coercion a `count: true` row would be
+// counted as one item of feedback that nobody ever recorded. Simplifying this
+// away reinstates exactly the class of defect the whole schema exists for.
+//
+// `.finite()` is the last gate, and it covers the other end: a stored 1e999
+// parses as Infinity, which would render in the prompt as `Infinity` (and make
+// every sentiment percentage 0.0%). It lands in `skippedRows` instead.
 const counterValue = z.union([z.number(), z.string().trim().min(1)])
   .pipe(z.coerce.number().finite());
 
@@ -85,7 +97,15 @@ const CATEGORY_QUERY_BATCH_SIZE = 10;
 // types says it cannot vary, and keying the entry makes a mismatch impossible
 // rather than merely unlikely. It also stops clearCategoryCache() from being the
 // thing that keeps the invariant true.
-const categoryCache = new Map<string, { names: string[]; expires: number }>();
+// `errorName` is cached WITH the entry, not recomputed per turn. A turn served
+// from the short error entry is describing the tenant with a taxonomy it never
+// configured just as much as the turn that did the failed read, so it has to
+// report the same thing — caching the names while dropping the reason would make
+// the CATEGORY_ERROR_CACHE_TTL_MS window read as healthy.
+const categoryCache = new Map<
+  string,
+  { names: string[]; expires: number; errorName?: string }
+>();
 
 /** Reset the container-level taxonomy cache (tests). */
 export function clearCategoryCache(): void {
@@ -382,11 +402,20 @@ function namesFromStoredList(cats: unknown[]): string[] {
  * already streaming — and it is the same trade the catch below makes. It is not
  * a shape either side should be relied on to normalise: the fix for a malformed
  * item is to fix the item.
+ *
+ * A read that FAILED is reported on the returned value (`errorName`) rather than
+ * only logged, because it is the fourth way this turn can hand the model
+ * something that was not measured — and the most consequential one. The other
+ * three make a number short; this one substitutes the whole taxonomy, so a
+ * tenant who configured `delivery_ops`, `kyc`, `fees` gets counts for ten
+ * partitions that are not theirs, plausibly all zero, and the section still
+ * renders as authoritative. It therefore feeds the same degraded note the metric
+ * shortfalls do.
  */
 async function readConfiguredCategories(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
-): Promise<{ names: string[]; ttl: number }> {
+): Promise<{ names: string[]; ttl: number; errorName?: string }> {
   try {
     const resp = await docClient.send(
       new QueryCommand({
@@ -408,33 +437,36 @@ async function readConfiguredCategories(
     // Python's reader makes the same trade (it logs and falls through to the
     // fallback), so the two surfaces still agree; the short error TTL keeps the
     // window small rather than caching a wrong answer for five minutes.
+    const errorName = error instanceof Error ? error.name : 'UnknownError';
     console.warn(
-      `readConfiguredCategories: settings read failed (${error instanceof Error ? error.name : 'UnknownError'}); using the default taxonomy`,
+      `readConfiguredCategories: settings read failed (${errorName}); using the default taxonomy`,
     );
-    return { names: [...DEFAULT_CATEGORIES], ttl: CATEGORY_ERROR_CACHE_TTL_MS };
+    return { names: [...DEFAULT_CATEGORIES], ttl: CATEGORY_ERROR_CACHE_TTL_MS, errorName };
   }
 }
 
 async function getConfiguredCategories(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
-): Promise<string[]> {
+): Promise<{ names: string[]; errorName?: string }> {
   const now = Date.now();
   const cached = categoryCache.get(aggregatesTable);
   if (cached && now < cached.expires) {
-    return cached.names;
+    return { names: cached.names, errorName: cached.errorName };
   }
-  const { names, ttl } = await readConfiguredCategories(docClient, aggregatesTable);
-  categoryCache.set(aggregatesTable, { names, expires: now + ttl });
-  return names;
+  const { names, ttl, errorName } = await readConfiguredCategories(docClient, aggregatesTable);
+  categoryCache.set(aggregatesTable, { names, expires: now + ttl, errorName });
+  return { names, errorName };
 }
 
 async function fetchCategoryCounts(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
   days: number,
-): Promise<{ top: [string, number][]; reads: MetricRead[] }> {
-  const categories = await getConfiguredCategories(docClient, aggregatesTable);
+): Promise<{ top: [string, number][]; reads: MetricRead[]; taxonomyErrorName?: string }> {
+  const { names: categories, errorName: taxonomyErrorName } = await getConfiguredCategories(
+    docClient, aggregatesTable,
+  );
   // Concurrent but bounded, the same trade src/context/recent-feedback.ts makes
   // for its day queries (DAY_QUERY_BATCH_SIZE): awaiting each sum in turn put
   // one round trip per category in front of the first streamed token, and an
@@ -463,7 +495,7 @@ async function fetchCategoryCounts(
     .filter(([, count]) => count > 0)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5);
-  return { top, reads: counted.map(([, read]) => read) };
+  return { top, reads: counted.map(([, read]) => read), taxonomyErrorName };
 }
 
 function buildSystemPrompt(responseLanguage?: SupportedLanguage): string {
@@ -586,9 +618,14 @@ export async function buildVocChatContext(
 
   const totalFeedback = totalRead.total;
   const urgentCount = urgentRead.total;
+  // A failed TAXONOMY read degrades the turn too, and it is not a MetricRead: it
+  // substitutes the default names for the tenant's own, so the counts under Top
+  // Categories are for partitions that may not be theirs. reportMetricFailures
+  // has already logged its own warning (with the error name, which stays out of
+  // the prompt), so only the flag is ORed in here.
   const degraded = reportMetricFailures([
     totalRead, urgentRead, ...sentimentReads, ...categories.reads,
-  ]);
+  ]) || categories.taxonomyErrorName !== undefined;
 
   const systemPrompt = buildSystemPrompt(body.response_language);
   const dataContext = buildDataContext(

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -6,7 +6,7 @@ import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { getLanguageInstruction } from './language.js';
 import type { SupportedLanguage } from './language.js';
-import { PERSISTENT_QUERY_ERRORS } from './recent-feedback.js';
+import { PERSISTENT_QUERY_ERRORS } from './query-errors.js';
 
 const SENTIMENT_LABELS = ['positive', 'negative', 'neutral', 'mixed'] as const;
 
@@ -116,41 +116,51 @@ function utcDateString(now: Date, daysAgo: number): string {
 }
 
 /**
- * What one metric partition's window came to, and whether reading it failed.
+ * What one metric partition's window came to, and every way it may be short.
  *
- * The error name travels with the total rather than being logged where it
- * happens, for two reasons: a persistent failure hits every partition of the
- * table identically, so the turn must report it ONCE instead of sixteen times;
- * and a zero that came from a failed read is not a measured zero, so the prompt
- * has to be able to say the summary is incomplete rather than presenting it as
- * fact.
+ * There are exactly three ways: the read failed, some rows would not parse, or
+ * paging hit its bound. All three travel with the total rather than being logged
+ * where they happen, for two reasons. A systemic cause — a denied table, a
+ * migration that wrote strings, a fan-out wider than the bound — hits every
+ * partition identically, so the turn must report it ONCE instead of sixteen
+ * times; and a number that is short is not a measured number, so the prompt has
+ * to be able to say the summary is incomplete rather than presenting it as fact.
+ * Only the caller sees the whole turn, so only the caller can do either.
  */
 interface MetricRead {
+  /** What the readable rows of the pages that were read came to. */
   total: number;
+  /** Which window this is, so one warning per cause can name the reads it covers. */
+  window: string;
+  /** Set when a page read failed; `total` is then only what earlier pages held. */
   errorName?: string;
-  /** Which window came back short, for the one warning the caller logs. */
-  partial?: string;
+  /** How many rows would not parse, so `total` is short by their counts. */
+  skippedRows: number;
+  /** Set when paging hit its bound, so an unread remainder is missing. */
+  boundExhausted?: boolean;
 }
 
-/** The readable counter rows of one page, summed. */
+/**
+ * The readable counter rows of one page, summed, and how many were not readable.
+ *
+ * The count is returned rather than warned about here: this runs once per page
+ * per partition, and a systemic cause makes every one of those pages fail the
+ * same way. Reporting is the caller's job for that reason.
+ */
 function sumMetricItems(
   items: Record<string, unknown>[] | undefined,
-  metricKey: string,
-): number {
+): { total: number; skipped: number } {
   // Per-row, so one unreadable row costs one row. Coercing the page as a whole
   // would make the window NaN, which drops a category that has real feedback
   // (`NaN > 0` is false) and reaches the prompt as `Total Feedback Items: NaN`.
   const rows = (items ?? []).map((item) => metricItemSchema.safeParse(item));
-  const skipped = rows.filter((row) => !row.success).length;
-  if (skipped > 0) {
-    console.warn(
-      `sumMetricWindow: skipped ${skipped} unreadable counter row(s) in ${metricKey}; the window under-reports by that much`,
-    );
-  }
-  return rows.reduce(
-    (sum, row) => sum + (row.success ? row.data.count ?? row.data.value ?? 0 : 0),
-    0,
-  );
+  return {
+    total: rows.reduce(
+      (sum, row) => sum + (row.success ? row.data.count ?? row.data.value ?? 0 : 0),
+      0,
+    ),
+    skipped: rows.filter((row) => !row.success).length,
+  };
 }
 
 /**
@@ -170,7 +180,12 @@ async function readMetricPage(
   metricKey: string,
   bounds: { oldest: string; newest: string },
   startKey?: Record<string, unknown>,
-): Promise<{ total: number; lastKey?: Record<string, unknown>; errorName?: string }> {
+): Promise<{
+  total: number;
+  skipped: number;
+  lastKey?: Record<string, unknown>;
+  errorName?: string;
+}> {
   try {
     const resp = await docClient.send(
       new QueryCommand({
@@ -184,9 +199,13 @@ async function readMetricPage(
         ExclusiveStartKey: startKey,
       }),
     );
-    return { total: sumMetricItems(resp.Items, metricKey), lastKey: resp.LastEvaluatedKey };
+    return { ...sumMetricItems(resp.Items), lastKey: resp.LastEvaluatedKey };
   } catch (error) {
-    return { total: 0, errorName: error instanceof Error ? error.name : 'UnknownError' };
+    return {
+      total: 0,
+      skipped: 0,
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+    };
   }
 }
 
@@ -203,10 +222,14 @@ async function readMetricPage(
  * Paging is bounded rather than `while (true)`: one date yields at most one item
  * and an unfiltered page yields at least one, so a window of `days` dates cannot
  * span more than `days` pages. Exhausting the bound means that invariant no
- * longer holds, so the window really is partial — log it instead of returning a
- * quietly short answer. A page that FAILS is the same situation and takes the
- * same path: readMetricPage returns rather than throws, so the pages already
- * summed survive and only the unread remainder is missing.
+ * longer holds, so the window really is partial — say so on the returned value
+ * instead of returning a quietly short answer. A page that FAILS is the same
+ * situation and takes the same path: readMetricPage returns rather than throws,
+ * so the pages already summed survive and only the unread remainder is missing.
+ *
+ * Every shortfall is reported by the CALLER, once per cause for the whole turn.
+ * Warning here instead was the mistake this shape replaces: this function runs
+ * once per partition, and a systemic cause makes all sixteen say the same thing.
  */
 async function sumMetricWindow(
   docClient: DynamoDBDocumentClient,
@@ -216,30 +239,34 @@ async function sumMetricWindow(
   pagesLeft: number,
   startKey?: Record<string, unknown>,
 ): Promise<MetricRead> {
+  // Named on every return, not just the short ones, so the caller's one warning
+  // per cause can say WHICH reads came back short — the payload
+  // metrics_handler.py::_query_metric_window carries, for the same reason:
+  // nothing in the returned number can express that it is partial.
+  const window = `${metricKey} over ${bounds.oldest}..${bounds.newest}`;
   const page = await readMetricPage(docClient, aggregatesTable, metricKey, bounds, startKey);
   if (page.errorName) {
     // Whatever earlier pages counted is already in the caller's accumulator, and
-    // this page's own rows are lost rather than the whole partition. The window
-    // is named so the caller's single warning can say WHICH read came back short
-    // — the payload metrics_handler.py::_query_metric_window carries, for the
-    // same reason: nothing in the returned number can express that it is partial.
+    // this page's own rows are lost rather than the whole partition.
     return {
-      total: page.total,
-      errorName: page.errorName,
-      partial: `${metricKey} over ${bounds.oldest}..${bounds.newest}`,
+      total: page.total, window, skippedRows: page.skipped, errorName: page.errorName,
     };
   }
-  if (!page.lastKey) return { total: page.total };
+  if (!page.lastKey) return { total: page.total, window, skippedRows: page.skipped };
   if (pagesLeft <= 1) {
-    console.warn(
-      `sumMetricWindow: paging hit its bound for ${metricKey} over ${bounds.oldest}..${bounds.newest}; window is partial at ${page.total}`,
-    );
-    return { total: page.total };
+    return {
+      total: page.total, window, skippedRows: page.skipped, boundExhausted: true,
+    };
   }
   const rest = await sumMetricWindow(
     docClient, aggregatesTable, metricKey, bounds, pagesLeft - 1, page.lastKey,
   );
-  return { ...rest, total: page.total + rest.total };
+  return {
+    ...rest,
+    window,
+    total: page.total + rest.total,
+    skippedRows: page.skipped + rest.skippedRows,
+  };
 }
 
 async function sumDailyMetric(
@@ -254,19 +281,28 @@ async function sumDailyMetric(
 }
 
 /**
- * Report each distinct read failure once for the turn, not once per partition,
- * and say whether the summary is degraded.
+ * Report each way this turn's windows came back short ONCE, and answer whether
+ * the summary is degraded.
  *
- * A systemic failure — the names in PERSISTENT_QUERY_ERRORS, shared with
- * src/context/recent-feedback.ts — fails identically for every partition of the
- * same table, so sixteen warnings say nothing the first one did not.
+ * Three causes, one report each. A read that failed, rows that would not parse
+ * and paging that hit its bound all leave a total lower than the truth, and each
+ * has a systemic form that hits every partition of the table identically — the
+ * names in PERSISTENT_QUERY_ERRORS (src/context/query-errors.ts, shared with
+ * recent-feedback.ts, which reached the same conclusion for its own fan-out), a
+ * migration that wrote strings into `count`, a taxonomy wider than the page
+ * bound. Sixteen warnings say nothing the first one did, so the aggregation
+ * happens here, where the whole turn is visible, and not in the per-page read.
+ *
+ * The returned flag is the other half, and the more important one: a total that
+ * is short must not be rendered as a measured fact. All three causes feed it, so
+ * "the figures are incomplete" means one thing.
  */
-function reportMetricFailures(reads: MetricRead[]): string[] {
+function reportMetricFailures(reads: MetricRead[]): boolean {
   const failures = new Map<string, string[]>();
   for (const read of reads) {
     if (!read.errorName) continue;
     const windows = failures.get(read.errorName) ?? [];
-    windows.push(read.partial ?? 'unknown window');
+    windows.push(read.window);
     failures.set(read.errorName, windows);
   }
   for (const [errorName, windows] of failures) {
@@ -277,7 +313,23 @@ function reportMetricFailures(reads: MetricRead[]): string[] {
       `buildVocChatContext: ${windows.length} metric window read(s) failed with ${errorName}${systemic}; the data summary is incomplete. Partial: ${windows.join('; ')}`,
     );
   }
-  return [...failures.keys()];
+
+  const withSkips = reads.filter((read) => read.skippedRows > 0);
+  if (withSkips.length > 0) {
+    const rows = withSkips.reduce((sum, read) => sum + read.skippedRows, 0);
+    console.warn(
+      `buildVocChatContext: skipped ${rows} unreadable counter row(s) across ${withSkips.length} metric window(s); those windows under-report by that much. Partial: ${withSkips.map((read) => read.window).join('; ')}`,
+    );
+  }
+
+  const exhausted = reads.filter((read) => read.boundExhausted);
+  if (exhausted.length > 0) {
+    console.warn(
+      `buildVocChatContext: paging hit its bound for ${exhausted.length} metric window(s), so an unread remainder is missing. Partial: ${exhausted.map((read) => read.window).join('; ')}`,
+    );
+  }
+
+  return failures.size > 0 || withSkips.length > 0 || exhausted.length > 0;
 }
 
 /**
@@ -427,24 +479,38 @@ Format your responses clearly with bullet points or numbered lists when appropri
 
 function buildDataContext(
   days: number,
-  totals: { totalFeedback: number; urgentCount: number; failedReads: string[] },
+  totals: { totalFeedback: number; urgentCount: number; degraded: boolean },
   sentimentMap: Record<string, number>,
   topCategories: [string, number][],
   filters: { source?: string; category?: string; sentiment?: string },
 ): string {
-  const { totalFeedback, urgentCount, failedReads } = totals;
+  const { totalFeedback, urgentCount, degraded } = totals;
   const pct = (n: number) => ((n / Math.max(totalFeedback, 1)) * 100).toFixed(1);
   const topCatLines = topCategories.map(([cat, count]) => `- ${cat}: ${count}`).join('\n');
-  // A zero that came from a failed read is not a measured zero. Saying so is the
+  // A number that came back short is not a measured number. Saying so is the
   // difference between the model reporting "no urgent issues" and reporting that
   // it could not tell — the same silent-confidence failure this module's history
   // is made of.
-  const degraded = failedReads.length > 0
-    ? `\n**NOTE:** Some metric reads failed (${failedReads.join(', ')}), so the figures below are incomplete and may under-report. Say so rather than presenting them as complete.\n`
+  //
+  // What this sentence must NOT carry is the CAUSE. `error.name` is
+  // infrastructure detail: AccessDeniedException tells whoever reads the answer
+  // that this Lambda's IAM role is missing a grant, ResourceNotFoundException
+  // that a table is absent or misnamed. Neither is actionable for them, and this
+  // is the one sentence in the section the model is explicitly told to relay, so
+  // interpolating the name is inviting it out to an end user. The operator
+  // channel for it already exists and is strictly better: reportMetricFailures
+  // logs the name together with the window bounds it applies to.
+  //
+  // English is deliberate, as it is for the field labels below: this is prompt
+  // text, not UI copy. buildSystemPrompt instructs the model to answer in
+  // response_language, so the model relays this fact in the user's language —
+  // translating the prompt would change nothing the user reads.
+  const degradedNote = degraded
+    ? '\n**NOTE:** Some metric reads did not complete, so the figures below are incomplete and may under-report. Say so rather than presenting them as complete.\n'
     : '';
 
   const context = `## Current Data Summary (Last ${days} days)
-${degraded}
+${degradedNote}
 **Total Feedback Items:** ${totalFeedback}
 **Urgent Issues:** ${urgentCount}
 
@@ -506,14 +572,14 @@ export async function buildVocChatContext(
 
   const totalFeedback = totalRead.total;
   const urgentCount = urgentRead.total;
-  const failedReads = reportMetricFailures([
+  const degraded = reportMetricFailures([
     totalRead, urgentRead, ...sentimentReads, ...categories.reads,
   ]);
 
   const systemPrompt = buildSystemPrompt(body.response_language);
   const dataContext = buildDataContext(
     days,
-    { totalFeedback, urgentCount, failedReads },
+    { totalFeedback, urgentCount, degraded },
     sentimentMap,
     categories.top,
     { source: sourceFilter, category: categoryFilter, sentiment: sentimentFilter },

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -9,7 +9,31 @@ import type { SupportedLanguage } from './language.js';
 
 const SENTIMENT_LABELS = ['positive', 'negative', 'neutral', 'mixed'] as const;
 
-const categoryItemSchema = z.object({ id: z.string() }).passthrough();
+// The configured category taxonomy lives in the aggregates table under ONE key,
+// written by the PUT /settings/categories handler (lambda/api/settings_handler.py,
+// CATEGORIES_PK/CATEGORIES_SK) and read by the Python owner of this contract
+// (lambda/shared/api.py::get_raw_categories_config). Any other key is never
+// written, so reading it empties the Top Categories section on every turn.
+// Pinned from Python by lambda/api/test/test_streaming_categories_lockstep.py.
+const CATEGORY_SETTINGS_PK = 'SETTINGS#categories';
+const CATEGORY_SETTINGS_SK = 'config';
+
+// The daily counter partitions are named after the ENRICHMENT OUTPUT, which is
+// the category NAME (see lambda/aggregator/handler.py) — hence `name` here, not
+// any internal identifier. `name` is the only required property: a configured
+// category that carries no `id` must survive the parse, because the writer does
+// not guarantee one.
+const categoryItemSchema = z.object({ name: z.string() }).passthrough();
+
+// Mirrors lambda/shared/api.py::DEFAULT_CATEGORIES. When nothing is configured,
+// get_configured_categories() falls back to this list, and the enrichment
+// prompt uses the same names, so the counters exist under these names. Falling
+// back to an empty array here would report an empty section where the metrics
+// surface reports counts.
+const DEFAULT_CATEGORIES = [
+  'delivery', 'customer_support', 'product_quality', 'pricing',
+  'website', 'app', 'billing', 'returns', 'communication', 'other',
+] as const;
 
 interface VocChatContext {
   systemPrompt: string;
@@ -73,6 +97,11 @@ async function sumDailyMetric(
   return totals.reduce((sum, v) => sum + v, 0);
 }
 
+/**
+ * The configured category names, matching lambda/shared/api.py
+ * (`get_raw_categories_config` + `get_configured_categories`) item-for-item:
+ * one key, the `name` field, and DEFAULT_CATEGORIES when nothing is configured.
+ */
 async function getConfiguredCategories(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
@@ -82,26 +111,28 @@ async function getConfiguredCategories(
       new QueryCommand({
         TableName: aggregatesTable,
         KeyConditionExpression: 'pk = :pk AND sk = :sk',
-        ExpressionAttributeValues: { ':pk': 'CONFIG#categories', ':sk': 'CURRENT' },
+        ExpressionAttributeValues: { ':pk': CATEGORY_SETTINGS_PK, ':sk': CATEGORY_SETTINGS_SK },
       }),
     );
     const items = resp.Items ?? [];
     if (items.length > 0) {
       const firstItem: Record<string, unknown> = items[0];
       const cats = firstItem.categories;
-      if (Array.isArray(cats)) {
+      if (Array.isArray(cats) && cats.length > 0) {
+        // A configured-but-nameless list yields [] here, exactly as the Python
+        // reader does — it only falls back when the item itself is absent.
         return cats
           .map((c: unknown) => {
             const parsed = categoryItemSchema.safeParse(c);
-            return parsed.success ? parsed.data.id : '';
+            return parsed.success ? parsed.data.name : '';
           })
           .filter(Boolean);
       }
     }
-  } catch {
-    // fallback
+  } catch (error) {
+    console.warn('Could not fetch categories from settings; using defaults:', error);
   }
-  return [];
+  return [...DEFAULT_CATEGORIES];
 }
 
 async function fetchCategoryCounts(

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -33,9 +33,19 @@ const categoryItemSchema = z.object({ name: z.string() }).passthrough();
 // a category that has real feedback (`NaN > 0` is false) and handing the model a
 // literal `Total Feedback Items: NaN`. A row that fails this parse contributes
 // nothing and is reported, rather than poisoning its siblings.
+//
+// The union in front of the coercion is the decision about `null`, and it is a
+// decision rather than an accident: `z.coerce` runs Number() first, and
+// Number(null) is 0, so a row storing a literal null would be counted as a
+// MEASURED zero. It is not one — nobody knows what that row's count was — so the
+// union rejects anything that is not already a number or a numeric string, which
+// puts such a row in `skippedRows` and makes the turn say the figures are
+// incomplete. Same for `count: true`, which used to count as 1.
+const counterValue = z.union([z.number(), z.string()]).pipe(z.coerce.number().finite());
+
 const metricItemSchema = z.object({
-  count: z.coerce.number().finite().optional(),
-  value: z.coerce.number().finite().optional(),
+  count: counterValue.optional(),
+  value: counterValue.optional(),
 }).passthrough();
 
 // Mirrors lambda/shared/api.py::DEFAULT_CATEGORIES. When nothing is configured,

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -34,14 +34,18 @@ const categoryItemSchema = z.object({ name: z.string() }).passthrough();
 // literal `Total Feedback Items: NaN`. A row that fails this parse contributes
 // nothing and is reported, rather than poisoning its siblings.
 //
-// The union in front of the coercion is the decision about `null`, and it is a
-// decision rather than an accident: `z.coerce` runs Number() first, and
-// Number(null) is 0, so a row storing a literal null would be counted as a
-// MEASURED zero. It is not one — nobody knows what that row's count was — so the
-// union rejects anything that is not already a number or a numeric string, which
-// puts such a row in `skippedRows` and makes the turn say the figures are
-// incomplete. Same for `count: true`, which used to count as 1.
-const counterValue = z.union([z.number(), z.string()]).pipe(z.coerce.number().finite());
+// The union in front of the coercion is a decision about what is NOT a count,
+// and it is a decision rather than an accident. `z.coerce` runs Number() first,
+// and Number() answers 0 for several things that hold no count at all: null, an
+// empty string, a whitespace string, false. Each would then be counted as a
+// MEASURED zero, and none of them is one — nobody knows what that row held. So
+// the value must already be a number, or a string with something in it, and the
+// coercion only ever sees those; everything else lands in `skippedRows`, where it
+// makes the turn say the figures are incomplete instead of quietly reading zero.
+// (`.trim()` before `.min(1)` is what rejects ' ' as well as ''; a padded numeric
+// string like ' 5 ' still parses, since DynamoDB stores what it was given.)
+const counterValue = z.union([z.number(), z.string().trim().min(1)])
+  .pipe(z.coerce.number().finite());
 
 const metricItemSchema = z.object({
   count: counterValue.optional(),

--- a/voc-datalake/lambda/stream/src/context/voc-context.ts
+++ b/voc-datalake/lambda/stream/src/context/voc-context.ts
@@ -6,6 +6,7 @@ import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { getLanguageInstruction } from './language.js';
 import type { SupportedLanguage } from './language.js';
+import { PERSISTENT_QUERY_ERRORS } from './recent-feedback.js';
 
 const SENTIMENT_LABELS = ['positive', 'negative', 'neutral', 'mixed'] as const;
 
@@ -24,6 +25,18 @@ const CATEGORY_SETTINGS_SK = 'config';
 // category that carries no `id` must survive the parse, because the writer does
 // not guarantee one.
 const categoryItemSchema = z.object({ name: z.string() }).passthrough();
+
+// The counters are validated at this boundary for the same reason the categories
+// are: nothing between the admin UI and this read enforces a shape. `Number()`
+// on a hand-edited or migrated `count: 'n/a'` yields NaN, and NaN is contagious
+// under `+`, so one malformed row would take the whole window with it — dropping
+// a category that has real feedback (`NaN > 0` is false) and handing the model a
+// literal `Total Feedback Items: NaN`. A row that fails this parse contributes
+// nothing and is reported, rather than poisoning its siblings.
+const metricItemSchema = z.object({
+  count: z.coerce.number().finite().optional(),
+  value: z.coerce.number().finite().optional(),
+}).passthrough();
 
 // Mirrors lambda/shared/api.py::DEFAULT_CATEGORIES. When nothing is configured,
 // get_configured_categories() falls back to this list, and the enrichment
@@ -47,12 +60,22 @@ const DEFAULT_CATEGORIES = [
 const CATEGORY_CACHE_TTL_MS = 300_000;
 const CATEGORY_ERROR_CACHE_TTL_MS = 10_000;
 
-const categoryCache: { names: string[] | null; expires: number } = { names: null, expires: 0 };
+// How many category partitions may be in flight at once. See fetchCategoryCounts
+// for why this is neither serial nor unbounded; the ten-name default taxonomy is
+// exactly one round either way.
+const CATEGORY_QUERY_BATCH_SIZE = 10;
+
+// Keyed by table, not one global entry. A container reads a single
+// AGGREGATES_TABLE today (handler.ts), so the distinction is theoretical — but
+// `aggregatesTable` is a parameter of every function here, so nothing in the
+// types says it cannot vary, and keying the entry makes a mismatch impossible
+// rather than merely unlikely. It also stops clearCategoryCache() from being the
+// thing that keeps the invariant true.
+const categoryCache = new Map<string, { names: string[]; expires: number }>();
 
 /** Reset the container-level taxonomy cache (tests). */
 export function clearCategoryCache(): void {
-  categoryCache.names = null;
-  categoryCache.expires = 0;
+  categoryCache.clear();
 }
 
 interface VocChatContext {
@@ -93,6 +116,81 @@ function utcDateString(now: Date, daysAgo: number): string {
 }
 
 /**
+ * What one metric partition's window came to, and whether reading it failed.
+ *
+ * The error name travels with the total rather than being logged where it
+ * happens, for two reasons: a persistent failure hits every partition of the
+ * table identically, so the turn must report it ONCE instead of sixteen times;
+ * and a zero that came from a failed read is not a measured zero, so the prompt
+ * has to be able to say the summary is incomplete rather than presenting it as
+ * fact.
+ */
+interface MetricRead {
+  total: number;
+  errorName?: string;
+  /** Which window came back short, for the one warning the caller logs. */
+  partial?: string;
+}
+
+/** The readable counter rows of one page, summed. */
+function sumMetricItems(
+  items: Record<string, unknown>[] | undefined,
+  metricKey: string,
+): number {
+  // Per-row, so one unreadable row costs one row. Coercing the page as a whole
+  // would make the window NaN, which drops a category that has real feedback
+  // (`NaN > 0` is false) and reaches the prompt as `Total Feedback Items: NaN`.
+  const rows = (items ?? []).map((item) => metricItemSchema.safeParse(item));
+  const skipped = rows.filter((row) => !row.success).length;
+  if (skipped > 0) {
+    console.warn(
+      `sumMetricWindow: skipped ${skipped} unreadable counter row(s) in ${metricKey}; the window under-reports by that much`,
+    );
+  }
+  return rows.reduce(
+    (sum, row) => sum + (row.success ? row.data.count ?? row.data.value ?? 0 : 0),
+    0,
+  );
+}
+
+/**
+ * One page of a metric window.
+ *
+ * The failure is returned rather than thrown so that the pages already read are
+ * kept: a partition whose second page fails must report what its first page
+ * measured. Throwing from inside the follow discarded all of it, which turned a
+ * partial window into a confident zero — and a zero category is filtered out
+ * entirely, so the Top Categories section rendered with nothing under it. The
+ * per-day shape this replaced degraded gracefully (one failing day cost one
+ * day), and losing that would be a regression.
+ */
+async function readMetricPage(
+  docClient: DynamoDBDocumentClient,
+  aggregatesTable: string,
+  metricKey: string,
+  bounds: { oldest: string; newest: string },
+  startKey?: Record<string, unknown>,
+): Promise<{ total: number; lastKey?: Record<string, unknown>; errorName?: string }> {
+  try {
+    const resp = await docClient.send(
+      new QueryCommand({
+        TableName: aggregatesTable,
+        KeyConditionExpression: 'pk = :pk AND sk BETWEEN :oldest AND :newest',
+        ExpressionAttributeValues: {
+          ':pk': metricKey,
+          ':oldest': bounds.oldest,
+          ':newest': bounds.newest,
+        },
+        ExclusiveStartKey: startKey,
+      }),
+    );
+    return { total: sumMetricItems(resp.Items, metricKey), lastKey: resp.LastEvaluatedKey };
+  } catch (error) {
+    return { total: 0, errorName: error instanceof Error ? error.name : 'UnknownError' };
+  }
+}
+
+/**
  * One metric partition's trailing window, summed, newest date inclusive.
  *
  * `sk` is 'YYYY-MM-DD' and ISO dates sort lexicographically, so a window is a
@@ -106,7 +204,9 @@ function utcDateString(now: Date, daysAgo: number): string {
  * and an unfiltered page yields at least one, so a window of `days` dates cannot
  * span more than `days` pages. Exhausting the bound means that invariant no
  * longer holds, so the window really is partial — log it instead of returning a
- * quietly short answer.
+ * quietly short answer. A page that FAILS is the same situation and takes the
+ * same path: readMetricPage returns rather than throws, so the pages already
+ * summed survive and only the unread remainder is missing.
  */
 async function sumMetricWindow(
   docClient: DynamoDBDocumentClient,
@@ -115,32 +215,31 @@ async function sumMetricWindow(
   bounds: { oldest: string; newest: string },
   pagesLeft: number,
   startKey?: Record<string, unknown>,
-): Promise<number> {
-  const resp = await docClient.send(
-    new QueryCommand({
-      TableName: aggregatesTable,
-      KeyConditionExpression: 'pk = :pk AND sk BETWEEN :oldest AND :newest',
-      ExpressionAttributeValues: {
-        ':pk': metricKey,
-        ':oldest': bounds.oldest,
-        ':newest': bounds.newest,
-      },
-      ExclusiveStartKey: startKey,
-    }),
-  );
-  const total = (resp.Items ?? []).reduce(
-    (sum: number, item) => sum + Number(item.count ?? item.value ?? 0),
-    0,
-  );
-  const lastKey = resp.LastEvaluatedKey;
-  if (!lastKey) return total;
-  if (pagesLeft <= 1) {
-    console.warn(`sumMetricWindow: paging hit its bound for ${metricKey}; window is partial`);
-    return total;
+): Promise<MetricRead> {
+  const page = await readMetricPage(docClient, aggregatesTable, metricKey, bounds, startKey);
+  if (page.errorName) {
+    // Whatever earlier pages counted is already in the caller's accumulator, and
+    // this page's own rows are lost rather than the whole partition. The window
+    // is named so the caller's single warning can say WHICH read came back short
+    // — the payload metrics_handler.py::_query_metric_window carries, for the
+    // same reason: nothing in the returned number can express that it is partial.
+    return {
+      total: page.total,
+      errorName: page.errorName,
+      partial: `${metricKey} over ${bounds.oldest}..${bounds.newest}`,
+    };
   }
-  return total + (await sumMetricWindow(
-    docClient, aggregatesTable, metricKey, bounds, pagesLeft - 1, lastKey,
-  ));
+  if (!page.lastKey) return { total: page.total };
+  if (pagesLeft <= 1) {
+    console.warn(
+      `sumMetricWindow: paging hit its bound for ${metricKey} over ${bounds.oldest}..${bounds.newest}; window is partial at ${page.total}`,
+    );
+    return { total: page.total };
+  }
+  const rest = await sumMetricWindow(
+    docClient, aggregatesTable, metricKey, bounds, pagesLeft - 1, page.lastKey,
+  );
+  return { ...rest, total: page.total + rest.total };
 }
 
 async function sumDailyMetric(
@@ -148,17 +247,37 @@ async function sumDailyMetric(
   aggregatesTable: string,
   metricKey: string,
   days: number,
-): Promise<number> {
+): Promise<MetricRead> {
   const now = new Date();
   const bounds = { oldest: utcDateString(now, days - 1), newest: utcDateString(now, 0) };
-  try {
-    return await sumMetricWindow(docClient, aggregatesTable, metricKey, bounds, days);
-  } catch (error) {
-    console.warn(
-      `sumMetricWindow: read failed for ${metricKey}: ${error instanceof Error ? error.name : 'UnknownError'}`,
-    );
-    return 0;
+  return sumMetricWindow(docClient, aggregatesTable, metricKey, bounds, days);
+}
+
+/**
+ * Report each distinct read failure once for the turn, not once per partition,
+ * and say whether the summary is degraded.
+ *
+ * A systemic failure — the names in PERSISTENT_QUERY_ERRORS, shared with
+ * src/context/recent-feedback.ts — fails identically for every partition of the
+ * same table, so sixteen warnings say nothing the first one did not.
+ */
+function reportMetricFailures(reads: MetricRead[]): string[] {
+  const failures = new Map<string, string[]>();
+  for (const read of reads) {
+    if (!read.errorName) continue;
+    const windows = failures.get(read.errorName) ?? [];
+    windows.push(read.partial ?? 'unknown window');
+    failures.set(read.errorName, windows);
   }
+  for (const [errorName, windows] of failures) {
+    const systemic = PERSISTENT_QUERY_ERRORS.has(errorName)
+      ? ' — this name fails identically for every partition of the table'
+      : '';
+    console.warn(
+      `buildVocChatContext: ${windows.length} metric window read(s) failed with ${errorName}${systemic}; the data summary is incomplete. Partial: ${windows.join('; ')}`,
+    );
+  }
+  return [...failures.keys()];
 }
 
 /**
@@ -187,6 +306,16 @@ function namesFromStoredList(cats: unknown[]): string[] {
  * The three stored shapes Python treats as "not configured" — item absent,
  * `categories` missing, `categories: []` — all fall through to the defaults
  * here too, because `item.get('categories')` is falsy for an empty list.
+ *
+ * There is a FOURTH shape where the two sides deliberately differ: a stored
+ * `categories` that is not a list at all (a dict, say, from a hand-edit or a
+ * future writer). Python's `get_configured_categories` raises AttributeError on
+ * it, so the metrics endpoint 500s; the Array.isArray guard below treats it as
+ * not-configured instead. That is the deliberate choice for this surface — a
+ * wrong-typed settings item must not be able to break a chat turn that is
+ * already streaming — and it is the same trade the catch below makes. It is not
+ * a shape either side should be relied on to normalise: the fix for a malformed
+ * item is to fix the item.
  */
 async function readConfiguredCategories(
   docClient: DynamoDBDocumentClient,
@@ -214,7 +343,7 @@ async function readConfiguredCategories(
     // fallback), so the two surfaces still agree; the short error TTL keeps the
     // window small rather than caching a wrong answer for five minutes.
     console.warn(
-      `getConfiguredCategories: settings read failed (${error instanceof Error ? error.name : 'UnknownError'}); using the default taxonomy`,
+      `readConfiguredCategories: settings read failed (${error instanceof Error ? error.name : 'UnknownError'}); using the default taxonomy`,
     );
     return { names: [...DEFAULT_CATEGORIES], ttl: CATEGORY_ERROR_CACHE_TTL_MS };
   }
@@ -225,12 +354,12 @@ async function getConfiguredCategories(
   aggregatesTable: string,
 ): Promise<string[]> {
   const now = Date.now();
-  if (categoryCache.names !== null && now < categoryCache.expires) {
-    return categoryCache.names;
+  const cached = categoryCache.get(aggregatesTable);
+  if (cached && now < cached.expires) {
+    return cached.names;
   }
   const { names, ttl } = await readConfiguredCategories(docClient, aggregatesTable);
-  categoryCache.names = names;
-  categoryCache.expires = now + ttl;
+  categoryCache.set(aggregatesTable, { names, expires: now + ttl });
   return names;
 }
 
@@ -238,21 +367,37 @@ async function fetchCategoryCounts(
   docClient: DynamoDBDocumentClient,
   aggregatesTable: string,
   days: number,
-): Promise<[string, number][]> {
+): Promise<{ top: [string, number][]; reads: MetricRead[] }> {
   const categories = await getConfiguredCategories(docClient, aggregatesTable);
-  // Concurrent, not serial: the taxonomy has ten names by default, and awaiting
-  // each sum in turn put ten sequential round trips in front of the first
-  // streamed token.
-  const counts = await Promise.all(
-    categories.map(async (cat): Promise<[string, number]> => [
-      cat,
-      await sumDailyMetric(docClient, aggregatesTable, `METRIC#daily_category#${cat}`, days),
-    ]),
+  // Concurrent but bounded, the same trade src/context/recent-feedback.ts makes
+  // for its day queries (DAY_QUERY_BATCH_SIZE): awaiting each sum in turn put
+  // one round trip per category in front of the first streamed token, and an
+  // unbounded fan-out is no better — the taxonomy is operator-supplied and
+  // uncapped (lambda/api/settings_handler.py::save_categories_config validates
+  // neither its length nor its shape), so 200 configured names would mean 200
+  // simultaneous queries from one invocation. A batch width of 10 keeps the
+  // ten-name default at exactly one round while bounding the worst case.
+  const batchStarts = Array.from(
+    { length: Math.ceil(categories.length / CATEGORY_QUERY_BATCH_SIZE) },
+    (_, index) => index * CATEGORY_QUERY_BATCH_SIZE,
   );
-  return counts
+  const counted: [string, MetricRead][] = [];
+  for (const start of batchStarts) {
+    const batch = categories.slice(start, start + CATEGORY_QUERY_BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (cat): Promise<[string, MetricRead]> => [
+        cat,
+        await sumDailyMetric(docClient, aggregatesTable, `METRIC#daily_category#${cat}`, days),
+      ]),
+    );
+    counted.push(...results);
+  }
+  const top = counted
+    .map(([cat, read]): [string, number] => [cat, read.total])
     .filter(([, count]) => count > 0)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5);
+  return { top, reads: counted.map(([, read]) => read) };
 }
 
 function buildSystemPrompt(responseLanguage?: SupportedLanguage): string {
@@ -282,19 +427,24 @@ Format your responses clearly with bullet points or numbered lists when appropri
 
 function buildDataContext(
   days: number,
-  totalFeedback: number,
-  urgentCount: number,
+  totals: { totalFeedback: number; urgentCount: number; failedReads: string[] },
   sentimentMap: Record<string, number>,
   topCategories: [string, number][],
-  sourceFilter?: string,
-  categoryFilter?: string,
-  sentimentFilter?: string,
+  filters: { source?: string; category?: string; sentiment?: string },
 ): string {
+  const { totalFeedback, urgentCount, failedReads } = totals;
   const pct = (n: number) => ((n / Math.max(totalFeedback, 1)) * 100).toFixed(1);
   const topCatLines = topCategories.map(([cat, count]) => `- ${cat}: ${count}`).join('\n');
+  // A zero that came from a failed read is not a measured zero. Saying so is the
+  // difference between the model reporting "no urgent issues" and reporting that
+  // it could not tell — the same silent-confidence failure this module's history
+  // is made of.
+  const degraded = failedReads.length > 0
+    ? `\n**NOTE:** Some metric reads failed (${failedReads.join(', ')}), so the figures below are incomplete and may under-report. Say so rather than presenting them as complete.\n`
+    : '';
 
   const context = `## Current Data Summary (Last ${days} days)
-
+${degraded}
 **Total Feedback Items:** ${totalFeedback}
 **Urgent Issues:** ${urgentCount}
 
@@ -309,9 +459,9 @@ ${topCatLines}
 `;
 
   const activeFilters: string[] = [];
-  if (sourceFilter) activeFilters.push(`Source: ${sourceFilter}`);
-  if (categoryFilter) activeFilters.push(`Category: ${categoryFilter}`);
-  if (sentimentFilter) activeFilters.push(`Sentiment: ${sentimentFilter}`);
+  if (filters.source) activeFilters.push(`Source: ${filters.source}`);
+  if (filters.category) activeFilters.push(`Category: ${filters.category}`);
+  if (filters.sentiment) activeFilters.push(`Sentiment: ${filters.sentiment}`);
   if (activeFilters.length > 0) {
     return `${context}\n## Active Filters: ${activeFilters.join(', ')}\nWhen using the search_feedback tool, apply these filters.\n`;
   }
@@ -339,7 +489,7 @@ export async function buildVocChatContext(
   const sentimentFilter = parsed.sentiment;
 
   // Fetch metrics in parallel
-  const [totalFeedback, urgentCount, ...sentimentCounts] = await Promise.all([
+  const [totalRead, urgentRead, ...sentimentReads] = await Promise.all([
     sumDailyMetric(docClient, aggregatesTable, 'METRIC#daily_total', days),
     sumDailyMetric(docClient, aggregatesTable, 'METRIC#urgent', days),
     ...SENTIMENT_LABELS.map((s) =>
@@ -349,15 +499,24 @@ export async function buildVocChatContext(
 
   const sentimentMap: Record<string, number> = {};
   for (const [i, label] of SENTIMENT_LABELS.entries()) {
-    sentimentMap[label] = sentimentCounts[i];
+    sentimentMap[label] = sentimentReads[i].total;
   }
 
-  const topCategories = await fetchCategoryCounts(docClient, aggregatesTable, days);
+  const categories = await fetchCategoryCounts(docClient, aggregatesTable, days);
+
+  const totalFeedback = totalRead.total;
+  const urgentCount = urgentRead.total;
+  const failedReads = reportMetricFailures([
+    totalRead, urgentRead, ...sentimentReads, ...categories.reads,
+  ]);
 
   const systemPrompt = buildSystemPrompt(body.response_language);
   const dataContext = buildDataContext(
-    days, totalFeedback, urgentCount, sentimentMap, topCategories,
-    sourceFilter, categoryFilter, sentimentFilter,
+    days,
+    { totalFeedback, urgentCount, failedReads },
+    sentimentMap,
+    categories.top,
+    { source: sourceFilter, category: categoryFilter, sentiment: sentimentFilter },
   );
   const userMessage = `${dataContext}\n\n---\n\nUser Question: ${message}`;
 


### PR DESCRIPTION
## Summary

Streaming chat sent the model an **empty Top Categories section on every turn**, and the model answered "which categories dominate" from that empty list while the metrics page showed real counts for the same window. Nothing failed and nobody was told.

Two independent defects in `voc-datalake/lambda/stream/src/context/voc-context.ts`, either sufficient alone:

1. **Wrong item key.** The reader queried `CONFIG#categories` / `CURRENT`. Nothing in this repository has ever written that key — its only occurrence in the tree was that read. The authoritative key is `SETTINGS#categories` / `config`, written by `lambda/api/settings_handler.py` (`CATEGORIES_PK`/`CATEGORIES_SK`) and read by `lambda/shared/api.py::get_raw_categories_config`.
2. **Wrong field.** Each category object was mapped to `id`. The daily counter partitions are `METRIC#daily_category#<category>` where `<category>` is the *enrichment output*, i.e. the taxonomy **name** (`lambda/aggregator/handler.py`). Reading `id` names partitions the aggregator never writes, so fixing only the key would still have produced an empty section.

The local mock server hid this: it serves category payloads carrying **both** `id` and `name`.

## What changed

The fix itself is four lines of contract. Everything after it exists because making the section non-empty made an unconfigured deployment read ten category partitions per turn, in front of time-to-first-token — and because three review rounds found real defects in that new machinery. Grouped by concern:

**The contract (the fix).** The item key, the field read, the Zod schema's required property and the not-configured fallback now describe one thing. The schema requires `name` (not `id`) with `.passthrough()`, because a configured category carrying no `id` must survive the parse — the frontend's own normalizer *derives* ids from names, so id-less rows are what real data looks like.

**Read cost.** The window is now one `sk BETWEEN :oldest AND :newest` range read per partition instead of one query per day (365 days × 10 categories was 3,650 reads), mirroring `metrics_handler.py::_query_metric_window`. Paging is bounded by `days` rather than `while (true)`. Category partitions are read concurrently in batches of 10, matching `recent-feedback.ts`'s `DAY_QUERY_BATCH_SIZE` — the taxonomy is operator-supplied and uncapped, so an unbounded fan-out means one simultaneous query per configured name. The taxonomy itself is cached per container per table for 300s (matching `CATEGORIES_CACHE_TTL` in `shared/api.py`), with a 10s TTL on a failed read so a throttling blip cannot pin chat to the default taxonomy for five minutes.

**Never hand the model a confident wrong number.** This is the same class as the original bug, and three things can make a window short: the read fails, rows will not parse, or paging hits its bound. All three now return rather than throw, keep the pages already read, and are carried on `MetricRead` (`errorName`, `skippedRows`, `boundExhausted`, plus the `window` they apply to). A **fourth** cause joins them from outside `MetricRead`: a failed *settings* read, which does not merely shorten a number but substitutes the whole taxonomy, so a tenant with its own category names gets counts for partitions that are not theirs. Its `errorName` is cached with the taxonomy entry, so the turns served from the short error TTL report degraded too rather than reading as healthy. Counters go through Zod at the boundary (`metricItemSchema`) because `Number('n/a')` is NaN and NaN is contagious under `+` — one malformed row used to render `**Total Feedback Items:** NaN` and drop every category with real feedback (`NaN > 0` is false).

**Report once per turn, not once per partition.** `reportMetricFailures` emits one warning per *cause* for the whole turn — a systemic cause (a denied table, a migration that wrote strings) hits all sixteen partitions identically, so the sixteenth line says nothing the first did. It returns one `degraded` flag that all three causes feed, and the prompt renders an incomplete-figures note from it. That note deliberately carries **no AWS exception name**: it is the one sentence the model is told to relay, and `AccessDeniedException` tells an end user only that this Lambda's IAM role is missing a grant. The name stays in the operator log, with the window bounds attached.

## Decisions worth disagreeing with

**The unconfigured fallback is the default list, not an empty array.** Python (`get_configured_categories`) falls back to `DEFAULT_CATEGORIES`; streaming fell back to `[]`. Streaming now matches Python, because the default list is not decorative: when no taxonomy is configured the enrichment prompt (`processor/handler.py`) labels feedback with exactly those names, so the `METRIC#daily_category#<name>` counters *do* exist under them. Falling back to `[]` reports "no categories" for a table the metrics surface reports counts for — the same silent disagreement as the original bug. A *configured but empty/nameless* list still yields `[]`, exactly as Python does.

**A wrong-typed settings item is treated as not-configured.** Python's reader raises `AttributeError` on a `categories` that is not a list (the metrics endpoint 500s); the `Array.isArray` guard here treats it as unconfigured instead. A malformed settings item must not break a chat turn that is already streaming. Documented at the reader rather than silently differing.

**The prompt's degraded note is English.** It is prompt text, not UI copy — the system prompt already tells the model to answer in `response_language`, so the model relays the fact in the user's language.

## Tests

**`lambda/api/test/test_streaming_categories_lockstep.py` — 18 tests, new file.** Follows `test_visual_selection_bound_lockstep.py`: reads both languages as *source text* with regular expressions rather than importing them, so it needs neither a bundler nor the AWS-shaped Python import graph. Asserts each file exists before matching, scopes every assertion to a specific function body so an unrelated occurrence cannot satisfy it, and explains in each docstring what breaks if the two sides disagree. It pins the item key (against the writer's constants *and* the Python reader's `get_item`), the abandoned key's absence, the field read on both sides, the schema's required property, the fallback list at all three copies plus that the streaming reader actually *returns* it, and — added in the last round — that every counter in `aggregator/handler.py` is written under a bare `date` sort key, which is what makes the widened `BETWEEN` predicate safe. The Zod-property helper that decides the schema pin has its own 7 tests, because a lockstep whose failures are sometimes wrong is worse than none.

**`voc-context.test.ts` — 33 tests (8 pre-existing, 25 added).** A new key-addressed mock doc client answers each query by its pk/sk the way DynamoDB does; the file's original fixture answers by *call order*, which would have answered a wrong-key read as happily as a right-key one, and the builder fires its reads through `Promise.all` anyway. Covers the configured names, a category with no internal id, the key the settings handler writes, both fallback paths, the window sums for the headline metrics, the read bound, cache keying and both TTLs, batch width, cursor following, a page that fails mid-window, an unreadable counter row, and the one-warning-per-turn behaviour of all three shortfall causes.

**Every behavioural claim was mutation-verified, not asserted.** Two harnesses that refuse to report unless the unmutated suite is green first: 7 TypeScript mutations (error name back in the prompt, per-partition warnings, each degrade signal dropped, window bound too narrow, too wide, aggregate count dropped) and 5 Python cases including two that must *stay* green or red for opposite reasons (a reordered processor list must stay green; a renamed entry must go red). 12/12 behaved as specified.

| Command | Result |
| --- | --- |
| `npx vitest run` (`lambda/stream`) | **PASS** — 22 files, 339 tests |
| `npx tsc --noEmit` (`lambda/stream`) | **PASS** |
| `npx eslint src/` (`lambda/stream`) | **PASS** — 0 errors, 1 warning (pre-existing, `src/indexes.test.ts`) |
| `pytest lambda/api/test` | **PASS** — 902 tests |
| `pytest lambda/shared/test` | **PASS** — 470 tests |
| `ruff check` on the new lockstep file | **PASS** |

`mise run build` does not exist in this repository (`mise ERROR no tasks defined`, at the root and under `voc-datalake/`); the equivalent legs above were run individually.

## Scope

Five files, all of them the reader or its tests:

- `voc-datalake/lambda/stream/src/context/voc-context.ts` — the fix and the machinery above
- `voc-datalake/lambda/stream/src/context/voc-context.test.ts` — behavioural coverage
- `voc-datalake/lambda/stream/src/context/query-errors.ts` — **new**; the shared error-name set, so the two context builders no longer import from each other
- `voc-datalake/lambda/stream/src/context/recent-feedback.ts` — imports that set instead of owning it
- `voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py` — **new**

`shared/api.py`, `chat_handler.py`, `settings_handler.py`, `projects_handler.py`, `aggregator/handler.py` and `processor/handler.py` are **read only** — their constants and behaviour are read by the lockstep test, never edited. A repository-wide search for the abandoned key returns nothing outside build artifacts; the test assembles that string from fragments precisely so it stays that way.

**Pre-existing and not touched:** `lint:python` (`ruff check lambda plugins`) is red on the base branch with an identical error count with these changes stashed and unstashed; the two new/changed files pass ruff on their own. `i18n:check` was reported red on the base branch; no frontend or locale file is touched here.

**Deliberately not attempted:** whether the default list should exist at all; the wider disagreement of category counts between pages; any change to metrics or aggregation paths; and introducing a structured logger to `lambda/stream` (there is none today — all eight non-test modules use `console.*`, and adding one is a package-wide change with its own review).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

