### PR TITLE
fix(prototype): configure a build in a wizard, not on the card face

### DIFF
--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
@@ -95,7 +95,7 @@ function renderCard(props: { hasPrd: boolean; hasPrfaq: boolean; hasPrototype?: 
 
 /** The build trigger, not the modal's confirm button. */
 function buildButton() {
-  return screen.getByRole('button', { name: /build prototype/i })
+  return screen.getByRole('button', { name: /configure & build prototype/i })
 }
 
 /**
@@ -103,7 +103,7 @@ function buildButton() {
  * before the panel is opened.
  */
 function confirmButton() {
-  return screen.queryByRole('button', { name: /build anyway/i })
+  return screen.queryByRole('button', { name: /^build prototype$/i })
 }
 
 /**
@@ -116,7 +116,7 @@ function confirmButton() {
  */
 async function startBuildVia(user: ReturnType<typeof userEvent.setup>) {
   await user.click(buildButton())
-  await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /build anyway/i }))
+  await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^build prototype$/i }))
 }
 
 describe('prototype card confirm gate (U12)', () => {
@@ -151,7 +151,7 @@ describe('prototype card confirm gate (U12)', () => {
     renderCard({ hasPrd: true, hasPrfaq: false })
     await user.click(buildButton())
 
-    await user.click(screen.getByRole('button', { name: /build anyway/i }))
+    await user.click(screen.getByRole('button', { name: /^build prototype$/i }))
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(mockBuildPrototype).toHaveBeenCalledWith('proj_1', expect.anything())
@@ -188,7 +188,7 @@ describe('prototype card confirm gate (U12)', () => {
     expect(screen.queryByText(/already has a prototype/i)).not.toBeInTheDocument()
 
     // ...and it builds once asked.
-    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /build anyway/i }))
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^build prototype$/i }))
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
   })
 
@@ -264,7 +264,7 @@ describe('prototype card rebuild guard', () => {
     renderCard({ hasPrd: true, hasPrfaq: true, hasPrototype: true })
     await user.click(buildButton())
 
-    await user.click(screen.getByRole('button', { name: /build anyway/i }))
+    await user.click(screen.getByRole('button', { name: /^build prototype$/i }))
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
   })
@@ -320,6 +320,25 @@ describe('prototype card rebuild guard', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
     expect(mockBuildPrototype).not.toHaveBeenCalled()
+  })
+
+  it('announces the escalated caution, not only renders it', async () => {
+    // The caution can appear or change while the panel is open, so a sighted user
+    // sees the amber block move and a screen-reader user must be told. Asserted on
+    // the live region CONTAINING the new text, because a region that is only mounted
+    // once there is something to say cannot announce its own arrival.
+    const user = userEvent.setup()
+    const { rerender } = renderCard({ hasPrd: true, hasPrfaq: true })
+
+    await user.click(buildButton())
+    const region = within(screen.getByRole('dialog')).getByRole('status')
+    expect(region).toHaveAttribute('aria-live', 'polite')
+    expect(region).toBeEmptyDOMElement()
+
+    rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1'), doc('prototype', 'proto_1')]))
+
+    expect(within(screen.getByRole('dialog')).getByRole('status'))
+      .toHaveTextContent(/already has a prototype/i)
   })
 
   it('escalates the caution to the rebuild warning when a prototype arrives mid-interaction', async () => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
@@ -24,7 +24,7 @@
  * assistive tech because both the code and its test agreed on a missing key.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import OverviewTab from './OverviewTab'
 import type { Project, ProjectDocument } from '../../api/types'
@@ -99,12 +99,24 @@ function buildButton() {
 }
 
 /**
- * The modal's confirm action, queried rather than got: the tests below assert on
- * its ABSENCE, which is the load-bearing half of a dialog that must not be
- * clickable once its question no longer applies.
+ * The wizard's submit, queried rather than got, so its ABSENCE can be asserted
+ * before the panel is opened.
  */
 function confirmButton() {
   return screen.queryByRole('button', { name: /build anyway/i })
+}
+
+/**
+ * Open the wizard and start the build — two clicks, because the card's button no
+ * longer spends money.
+ *
+ * Every test that wants a build to actually run goes through here, so the two-step
+ * shape is stated once. A test that only wants the panel open uses `buildButton()`
+ * alone, and one that asserts nothing was spent asserts it after that first click.
+ */
+async function startBuildVia(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(buildButton())
+  await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /build anyway/i }))
 }
 
 describe('prototype card confirm gate (U12)', () => {
@@ -156,15 +168,28 @@ describe('prototype card confirm gate (U12)', () => {
     expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
   })
 
-  it('builds immediately without a confirmation when both documents exist', async () => {
+  // This replaces "builds immediately without a confirmation when both documents
+  // exist". That one-click path was traded away deliberately when the build moved
+  // into a wizard: it is what made the card unpredictable, since a project with two
+  // PRDs opened a dialog and this one did not. The successor property is that the
+  // panel opens with NO warning and still spends nothing until its own button.
+  it('opens the wizard with no warning, and spends nothing, when both documents exist', async () => {
     const user = userEvent.setup()
     renderCard({ hasPrd: true, hasPrfaq: true })
 
     await user.click(buildButton())
 
-    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
+    // Nothing to caution about on this project, so no caution is shown — an
+    // always-rendered warning block would be an empty amber panel here.
     expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/No PRD yet/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/already has a prototype/i)).not.toBeInTheDocument()
+
+    // ...and it builds once asked.
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: /build anyway/i }))
+    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
   })
 
   it('does not build when neither document exists', async () => {
@@ -198,7 +223,7 @@ describe('prototype card confirm gate (U12)', () => {
     }))
     renderCard({ hasPrd: true, hasPrfaq: true })
 
-    await user.click(buildButton())
+    await startBuildVia(user)
 
     // The label becomes "Building…" while in flight, so the trigger has to be found
     // by that name — the disabled state is real, and the point is what it *says*.
@@ -273,34 +298,40 @@ describe('prototype card rebuild guard', () => {
     expect(screen.getByText('Prototypes built: 1')).toBeInTheDocument()
   })
 
-  it('closes the confirm rather than emptying it when the reason to ask disappears', async () => {
-    // The confirm reason is derived from live data, and this page refetches
-    // documents whenever a job completes. So a PR-FAQ generation finishing while
-    // the single-document dialog is open removes the thing being confirmed — and
-    // gating the dialog on its own open flag alone left it up with no message.
+  // The three tests that used to live here pinned the #294/#296 behaviour: a confirm
+  // dialog CLOSED itself when the reason it was raised for went stale. That is
+  // deliberately inverted now — the panel holds the user's selections, and closing on
+  // a data change would discard them in response to something the user did not do.
+  //
+  // The danger those tests guarded against has not gone away, it changed shape, so
+  // the replacements below assert the new form rather than delete the concern:
+  // the panel stays open, the caution FOLLOWS the documents, and nothing is spent
+  // until the user presses the wizard's own button.
+  it('keeps the panel open and clears the caution when the reason for it disappears', async () => {
     const user = userEvent.setup()
     const { rerender } = renderCard({ hasPrd: true, hasPrfaq: false })
 
     await user.click(buildButton())
     expect(screen.getByText(/No PR-FAQ yet/i)).toBeInTheDocument()
 
+    // A PR-FAQ generation completes and the page refetches documents.
     rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1')]))
 
-    // The role, the question and the action, so this cannot go vacuous if the
-    // shell's ARIA role ever changes: the bug being pinned was a dialog that was
-    // still THERE and still clickable, just with nothing written in it.
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
-    expect(confirmButton()).not.toBeInTheDocument()
     expect(mockBuildPrototype).not.toHaveBeenCalled()
   })
 
-  it('closes the confirm rather than swapping its question for a costlier one', async () => {
-    // Same refetch, a different outcome: a prototype arriving while the
-    // single-document confirm is open changes what "Build anyway" MEANS — from
-    // "build from the PRD alone" to "build a second prototype and keep the first".
-    // Rewriting the message under an open dialog would have the button answer a
-    // question the user never read, so the dialog closes and the next click asks.
+  it('escalates the caution to the rebuild warning when a prototype arrives mid-interaction', async () => {
+    // The residual risk of a live-derived caution, asserted rather than assumed. A
+    // prototype arriving while the panel is open changes what pressing Build COSTS:
+    // from "build from the PRD alone" to "build a second one and keep the first".
+    //
+    // Materially weaker than the #296 defect it replaces — there the dialog was
+    // already open with a stale message and one click from spending, whereas here
+    // the caution is rendered into the panel the user is looking at and they must
+    // still press Build. What must not happen is the panel showing the OLD caution,
+    // or none, while the cost has changed.
     const user = userEvent.setup()
     const { rerender } = renderCard({ hasPrd: true, hasPrfaq: false })
 
@@ -309,32 +340,26 @@ describe('prototype card rebuild guard', () => {
 
     rerender(overviewTab([doc('prd', 'prd_1'), doc('prototype', 'proto_1')]))
 
-    expect(screen.queryByText(/already has a prototype/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/already has a prototype/i)).toBeInTheDocument()
     expect(screen.queryByText(/No PR-FAQ yet/i)).not.toBeInTheDocument()
     expect(mockBuildPrototype).not.toHaveBeenCalled()
   })
 
-  it('does not re-open the confirm when a later reason to ask arrives', async () => {
-    // An open flag outlives the question it was raised for: once the reason
-    // disappeared the flag stayed set, so the NEXT reason to ask put a modal back
-    // on screen that the user never asked for — one reflexive click from a
-    // multi-minute billable build. Tracking which question was asked is what makes
-    // this unreachable.
-    const user = userEvent.setup()
+  it('never opens the panel on its own, whatever the documents do', async () => {
+    // The half of the old open-flag bug that still applies: a panel appearing
+    // unasked is one reflexive click from a multi-minute billable build. With
+    // visibility owned rather than derived, no document change can produce it.
     const { rerender } = renderCard({ hasPrd: true, hasPrfaq: false })
 
-    await user.click(buildButton())
-    expect(screen.getByText(/No PR-FAQ yet/i)).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    // The reason to ask disappears: the PR-FAQ generation completes.
+    // A PR-FAQ appears, then a prototype — each of which used to be "a reason to ask".
     rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1')]))
-    expect(confirmButton()).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    // A later job produces a prototype, which is a new reason to ask.
     rerender(overviewTab([doc('prd', 'prd_1'), doc('prfaq', 'prfaq_1'), doc('prototype', 'proto_1')]))
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-    expect(screen.queryByText(/already has a prototype/i)).not.toBeInTheDocument()
     expect(confirmButton()).not.toBeInTheDocument()
     expect(mockBuildPrototype).not.toHaveBeenCalled()
   })
@@ -350,7 +375,7 @@ describe('prototype card handover to the jobs panel (U9)', () => {
     const user = userEvent.setup()
     renderCard({ hasPrd: true, hasPrfaq: true })
 
-    await user.click(buildButton())
+    await startBuildVia(user)
 
     await waitFor(() => expect(mockJobStarted).toHaveBeenCalledTimes(1))
   })
@@ -360,7 +385,7 @@ describe('prototype card handover to the jobs panel (U9)', () => {
     mockBuildPrototype.mockRejectedValue(new Error('Bedrock unavailable'))
     renderCard({ hasPrd: true, hasPrfaq: true })
 
-    await user.click(buildButton())
+    await startBuildVia(user)
 
     await waitFor(() => expect(screen.getByText(/Bedrock unavailable/)).toBeInTheDocument())
     expect(mockJobStarted).not.toHaveBeenCalled()
@@ -371,7 +396,7 @@ describe('prototype card handover to the jobs panel (U9)', () => {
     mockBuildPrototype.mockRejectedValue(new Error('Bedrock unavailable'))
     renderCard({ hasPrd: true, hasPrfaq: true })
 
-    await user.click(buildButton())
+    await startBuildVia(user)
 
     // A build that failed to start has not started. The card has one status line,
     // so an error that lost to the acknowledgement would be invisible.
@@ -389,7 +414,7 @@ describe('prototype card handover to the jobs panel (U9)', () => {
     }))
     renderCard({ hasPrd: true, hasPrfaq: true })
 
-    await user.click(buildButton())
+    await startBuildVia(user)
     expect(await screen.findByText(/building…/i)).toBeInTheDocument()
 
     releaseRequest()
@@ -402,7 +427,7 @@ describe('prototype card handover to the jobs panel (U9)', () => {
     const user = userEvent.setup()
     renderCard({ hasPrd: true, hasPrfaq: true })
 
-    await user.click(buildButton())
+    await startBuildVia(user)
 
     expect(await screen.findByText(/track it in background jobs/i)).toBeInTheDocument()
   })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeCard.test.tsx
@@ -435,6 +435,14 @@ describe('prototype card handover to the jobs panel (U9)', () => {
 
     await startBuildVia(user)
     expect(await screen.findByText(/building…/i)).toBeInTheDocument()
+    // On the FULL accessible name, not a substring: `ActionCard` concatenates the
+    // "Configure & " prefix with this label, and the busy label is a sentence rather
+    // than a verb, so an unconditional prefix reads "Configure & Building…". A
+    // substring match on /building…/i passes either way, which is exactly why the
+    // regression needs the whole name.
+    // Anchored, so a surviving prefix ("Configure & Building…") fails this. Verified
+    // by mutation: restoring the unconditional prefix fails exactly this assertion.
+    expect(screen.getByRole('button', { name: /^building…$/i })).toBeInTheDocument()
 
     releaseRequest()
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
@@ -13,7 +13,7 @@
  * is missing or has moved renders its raw path and these matchers fail.
  */
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import i18n from 'i18next'
 import OverviewTab from './OverviewTab'
@@ -88,12 +88,38 @@ function tab(
   )
 }
 
-function renderTab(
+/** The card only — for the two assertions that are about the card, not the panel. */
+function renderCard(
   documents: ProjectDocument[],
   productContext?: ProductContext,
   productDocs?: ProductDoc[],
 ) {
   return render(tab(documents, productContext, productDocs))
+}
+
+/**
+ * The card, with the build wizard opened — where these controls now live.
+ *
+ * `fireEvent` rather than `userEvent` for this one click, deliberately: it is
+ * synchronous, so every test below keeps the signature it had when the controls
+ * were on the card face. `userEvent.click` returns a promise, and a test that
+ * forgot to await it would assert against a panel that had not opened yet — a
+ * failure mode that looks like the feature being broken.
+ */
+function renderWizard(
+  documents: ProjectDocument[],
+  productContext?: ProductContext,
+  productDocs?: ProductDoc[],
+) {
+  const result = render(tab(documents, productContext, productDocs))
+  // Resolved through i18n rather than hardcoded English: one test in this file
+  // switches the catalogue to German, and a hardcoded name would fail there with
+  // "cannot find the button" — a message that points at the card rather than at the
+  // query.
+  fireEvent.click(screen.getByRole('button', {
+    name: i18n.t('documents.prototype.button', { ns: 'projectDetail' }),
+  }))
+  return result
 }
 
 /**
@@ -148,7 +174,16 @@ const noteStem = (key: 'visualsNotReady' | 'visualsFailed') =>
 /** Everything the visual group says, as one string. */
 const visualNotes = () => screen.getByTestId('prototype-visual-sources').textContent ?? ''
 
+/** The card's button. It opens the wizard; it no longer starts anything. */
 const buildButton = () => screen.getByRole('button', { name: /build prototype/i })
+/**
+ * The wizard's own submit — the only control that spends money.
+ *
+ * Scoped to the dialog rather than matched by label alone, so this cannot silently
+ * start resolving to the card's button if either label changes.
+ */
+const startBuild = () => within(screen.getByRole('dialog'))
+  .getByRole('button', { name: en.documents.prototype.confirmBuild })
 const productContextBox = () => screen.getByRole('checkbox', { name: /product \/ service description/i })
 const researchBox = () => screen.getByRole('checkbox', { name: /research reports/i })
 const sentBody = () => mockBuildPrototype.mock.calls[0][1]
@@ -158,26 +193,32 @@ beforeEach(() => {
   mockBuildPrototype.mockResolvedValue({ job_id: 'job_1' })
 })
 
-describe('the controls are reachable without a dialog', () => {
+/**
+ * This block used to be called "the controls are reachable without a dialog", and
+ * that property is deliberately gone — the configuration moved into the wizard, and
+ * its replacement ("reachable for EVERY project, including the one that previously
+ * opened nothing") lives in `OverviewTab.prototypeWizard.test.tsx`, which is where
+ * the placement is now pinned. What stays here is what the controls DO.
+ */
+describe('what the optional inputs send', () => {
   it('offers both tick-boxes on a project with one PRD, one PR-FAQ and no prototype', async () => {
-    // The one project that opens no confirm dialog at all. A control placed inside
-    // ConfirmModal is invisible here, and every other fixture in this suite would
-    // still pass.
-    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+    // Still the fixture worth naming: this is the project that used to open no
+    // dialog at all, so it is the one a placement regression would strand.
+    renderWizard([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
 
     expect(screen.getByTestId('prototype-extra-sources')).toBeInTheDocument()
     expect(productContextBox()).toBeInTheDocument()
     expect(researchBox()).toBeInTheDocument()
-    // No dialog was needed to get here.
-    expect(screen.queryByTestId('prototype-source-picker')).not.toBeInTheDocument()
+    // And the pickers are its neighbours now, not a separate dialog's content.
+    expect(screen.getByTestId('prototype-source-picker')).toBeInTheDocument()
   })
 
-  it('sends what was ticked on that same one-click project', async () => {
+  it('sends what was ticked on that same project', async () => {
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
 
     await user.click(productContextBox())
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().use_product_context).toBe(true)
@@ -187,9 +228,9 @@ describe('the controls are reachable without a dialog', () => {
     // The request every existing caller makes. Off must stay off, or the feature
     // changes builds nobody asked it to.
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
 
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().use_product_context).toBe(false)
@@ -201,7 +242,7 @@ describe('the controls are reachable without a dialog', () => {
     // A box whose only possible contribution is an empty section is an invitation
     // to a no-op — the same reason `SourceRow` renders nothing for a type the
     // project has none of.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT)
 
     expect(screen.queryByRole('checkbox', { name: /research reports/i })).not.toBeInTheDocument()
     expect(productContextBox()).toBeInTheDocument()
@@ -211,10 +252,10 @@ describe('the controls are reachable without a dialog', () => {
 describe('which research reports the build reads', () => {
   it('ticking research selects every report on offer', async () => {
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
 
     await user.click(researchBox())
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().use_research).toBe(true)
@@ -227,11 +268,11 @@ describe('which research reports the build reads', () => {
     // The feature: choose the research, rather than take all of it. Nothing else
     // here fails if the per-report boxes are ignored.
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
 
     await user.click(researchBox())
     await user.click(screen.getByRole('checkbox', { name: 'Pricing survey' }))
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_research_ids).toEqual(['research_a'])
@@ -243,11 +284,11 @@ describe('which research reports the build reads', () => {
     // deletion becoming this build's failure. Found by mutation: without a
     // re-render in the fixture, the filter that prevents it has no test at all.
     const user = userEvent.setup()
-    const { rerender } = renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+    const { rerender } = renderWizard([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
 
     await user.click(researchBox())
     rerender(tab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT))
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_research_ids).toEqual(['research_a'])
@@ -255,11 +296,11 @@ describe('which research reports the build reads', () => {
 
   it('unticking research sends no ids at all', async () => {
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
 
     await user.click(researchBox())
     await user.click(researchBox())
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().use_research).toBe(false)
@@ -281,7 +322,7 @@ describe('which uploaded visuals the build reads', () => {
     // nothing to send it to — and a collapsed group would hide ticked ids that are
     // still being sent. The list is therefore open from the start, which is what
     // this asserts: no click, and the rows are already there.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
 
     expect(screen.getByText(label('visuals', 2))).toBeInTheDocument()
     expect(screen.getByTestId('prototype-visual-list')).toBeInTheDocument()
@@ -293,11 +334,11 @@ describe('which uploaded visuals the build reads', () => {
     // Order is precedence: the generator's prompt prefers the first visual where
     // two disagree, so B-then-A must arrive as B, A and not in option order.
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
 
     await user.click(screen.getByRole('checkbox', { name: 'settings-screen.png' }))
     await user.click(screen.getByRole('checkbox', { name: 'home-screen.png' }))
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_product_doc_ids).toEqual(['pd_b', 'pd_a'])
@@ -308,9 +349,9 @@ describe('which uploaded visuals the build reads', () => {
     // indistinguishable from "always sends every visual", and the request every
     // existing caller makes would be free to change.
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
 
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_product_doc_ids).toEqual([])
@@ -322,7 +363,7 @@ describe('which uploaded visuals the build reads', () => {
     // product-context box — so it is absent without comment. An image that is
     // still extracting has no description yet, so it cannot be ticked, but it
     // WAS uploaded: silence there reads as a lost file.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [
       VISUAL_A,
       productDoc({ doc_id: 'pd_text', filename: 'notes.md', content_type: 'text/markdown' }),
       VISUAL_EXTRACTING,
@@ -340,7 +381,7 @@ describe('which uploaded visuals the build reads', () => {
     // A text-only upload must not produce an empty visuals section: a group whose
     // only possible contribution is nothing is an invitation to a no-op, the same
     // rule the research box follows.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [
       productDoc({ doc_id: 'pd_text', filename: 'notes.md', content_type: 'text/markdown' }),
     ])
 
@@ -356,7 +397,7 @@ describe('which uploaded visuals the build reads', () => {
       { length: MAX_SELECTED_PRODUCT_DOC_IDS + 1 },
       (_, i) => productDoc({ doc_id: `pd_${i}`, filename: `screen-${i}.png` }),
     )
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, many)
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, many)
 
     for (const option of many.slice(0, MAX_SELECTED_PRODUCT_DOC_IDS)) {
       await user.click(screen.getByRole('checkbox', { name: option.filename }))
@@ -365,7 +406,7 @@ describe('which uploaded visuals the build reads', () => {
     expect(overBound).toBeDisabled()
     expect(screen.getByText(label('visualsLimit', MAX_SELECTED_PRODUCT_DOC_IDS))).toBeInTheDocument()
 
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_product_doc_ids).toHaveLength(MAX_SELECTED_PRODUCT_DOC_IDS)
@@ -385,7 +426,7 @@ describe('which uploaded visuals the build reads', () => {
       { length: MAX_SELECTED_PRODUCT_DOC_IDS + 1 },
       (_, i) => productDoc({ doc_id: `pd_${i}`, filename: `screen-${i}.png` }),
     )
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, many)
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, many)
 
     for (const option of many.slice(0, MAX_SELECTED_PRODUCT_DOC_IDS)) {
       await user.click(screen.getByRole('checkbox', { name: option.filename }))
@@ -395,7 +436,7 @@ describe('which uploaded visuals the build reads', () => {
       screen.getByRole('checkbox', { name: `screen-${MAX_SELECTED_PRODUCT_DOC_IDS}.png` }),
       { target: { checked: true } },
     )
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_product_doc_ids).toHaveLength(MAX_SELECTED_PRODUCT_DOC_IDS)
@@ -418,7 +459,7 @@ describe('which uploaded visuals the build reads', () => {
     )
     const atBound = all.slice(0, MAX_SELECTED_PRODUCT_DOC_IDS)
     const spare = all[MAX_SELECTED_PRODUCT_DOC_IDS]
-    const { rerender } = renderTab([PRD, PRFAQ], FILLED_CONTEXT, all)
+    const { rerender } = renderWizard([PRD, PRFAQ], FILLED_CONTEXT, all)
 
     for (const option of atBound) {
       await user.click(screen.getByRole('checkbox', { name: option.filename }))
@@ -429,7 +470,7 @@ describe('which uploaded visuals the build reads', () => {
     const spareBox = screen.getByRole('checkbox', { name: spare.filename })
     expect(spareBox).toBeEnabled()
     await user.click(spareBox)
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     const sent = sentBody().selected_product_doc_ids
@@ -454,7 +495,7 @@ describe('which uploaded visuals the build reads', () => {
     )
     const atBound = all.slice(0, MAX_SELECTED_PRODUCT_DOC_IDS)
     const spare = all[MAX_SELECTED_PRODUCT_DOC_IDS]
-    const { rerender } = renderTab([PRD, PRFAQ], FILLED_CONTEXT, all)
+    const { rerender } = renderWizard([PRD, PRFAQ], FILLED_CONTEXT, all)
 
     for (const option of atBound) {
       await user.click(screen.getByRole('checkbox', { name: option.filename }))
@@ -466,7 +507,7 @@ describe('which uploaded visuals the build reads', () => {
     await user.click(screen.getByRole('checkbox', { name: spare.filename }))
     // ...and then extraction finishes, so it is offered again.
     rerender(tab([PRD, PRFAQ], FILLED_CONTEXT, all))
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     const sent = sentBody().selected_product_doc_ids
@@ -484,12 +525,12 @@ describe('which uploaded visuals the build reads', () => {
     // assertion alone would pass without the filter, so the surviving id is
     // asserted too.
     const user = userEvent.setup()
-    const { rerender } = renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
+    const { rerender } = renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
 
     await user.click(screen.getByRole('checkbox', { name: 'settings-screen.png' }))
     await user.click(screen.getByRole('checkbox', { name: 'home-screen.png' }))
     rerender(tab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A]))
-    await user.click(buildButton())
+    await user.click(startBuild())
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().selected_product_doc_ids).toEqual(['pd_a'])
@@ -507,7 +548,7 @@ describe('which uploaded visuals the build reads', () => {
  */
 describe('an image that cannot be offered says which kind of wait it is', () => {
   it('reports an extracting image as in flight, not as failed', () => {
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_EXTRACTING])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_EXTRACTING])
 
     expect(screen.getByText(label('visualsNotReady', 1))).toBeInTheDocument()
     expect(visualNotes()).not.toContain(noteStem('visualsFailed'))
@@ -517,7 +558,7 @@ describe('an image that cannot be offered says which kind of wait it is', () => 
     // THE discriminating case. Under the old single count this line read "1 still
     // being processed" — advice to wait for an extraction that has already given
     // up, with no mention that uploading the file again is the way out.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_FAILED])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_FAILED])
 
     expect(screen.getByText(label('visualsFailed', 1))).toBeInTheDocument()
     expect(visualNotes()).not.toContain(noteStem('visualsNotReady'))
@@ -526,7 +567,7 @@ describe('an image that cannot be offered says which kind of wait it is', () => 
   it('reports both counts when one image is extracting and another failed', () => {
     // Independent lines, not a winner: the user has one file to wait for and a
     // different one to re-upload, and either note alone hides half of that.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_EXTRACTING, VISUAL_FAILED])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_EXTRACTING, VISUAL_FAILED])
 
     expect(screen.getByText(label('visualsNotReady', 1))).toBeInTheDocument()
     expect(screen.getByText(label('visualsFailed', 1))).toBeInTheDocument()
@@ -535,7 +576,7 @@ describe('an image that cannot be offered says which kind of wait it is', () => 
   it('reports neither line when every uploaded image is ready', () => {
     // The positive control: without it, "reports the failed ones" is
     // indistinguishable from "always shows both lines".
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
 
     expect(visualNotes()).not.toContain(noteStem('visualsNotReady'))
     expect(visualNotes()).not.toContain(noteStem('visualsFailed'))
@@ -545,7 +586,7 @@ describe('an image that cannot be offered says which kind of wait it is', () => 
     // Counting them must not have made them tickable: neither has an extracted
     // description, so `build_visual_brief_block` would ignore either one — a box
     // that contributes nothing to the build it appears to configure.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_EXTRACTING, VISUAL_FAILED])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_EXTRACTING, VISUAL_FAILED])
 
     expect(screen.getByRole('checkbox', { name: 'home-screen.png' })).toBeInTheDocument()
     expect(screen.queryByRole('checkbox', { name: 'wip.png' })).not.toBeInTheDocument()
@@ -562,7 +603,7 @@ describe('the visual tick-boxes are a named group', () => {
     // from its master checkbox and this list has no master by design, so without
     // an explicit group the rows announce as loose checkboxes carrying filenames
     // and nothing says what ticking one does.
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_B])
 
     const group = screen.getByRole('group', { name: label('visuals', 2) })
     expect(group).toContainElement(screen.getByRole('checkbox', { name: 'home-screen.png' }))
@@ -571,28 +612,36 @@ describe('the visual tick-boxes are a named group', () => {
 })
 
 describe('a card that cannot act offers no choices', () => {
-  it('renders no tick-boxes on a project with no PRD and no PR-FAQ', () => {
-    // The fixture the rest of this suite never had: research and a filled product
-    // context, so there IS something to offer, and no PRD or PR-FAQ, so the card is
-    // disabled and nothing can be built. Choices above a dead button read as an
-    // offer — the user ticks them, then reads that they must create a document
-    // first. Every other fixture here passes whether or not the gate exists.
-    renderTab([RESEARCH_A], FILLED_CONTEXT)
+  // The property is unchanged — choices for an action that cannot be taken read as
+  // an offer — but the controls moved into the wizard, so it is now enforced one
+  // step earlier: the card's button is what refuses, and the panel is never
+  // reachable. Asserting the absence of tick-boxes alone would be WEAKER than the
+  // old test, because they are absent on every unopened card, so the assertion that
+  // carries the property is that the button does not open anything.
+  it('cannot open the wizard on a project with no PRD and no PR-FAQ', () => {
+    // Research and a filled product context, so there IS something to offer, and no
+    // PRD or PR-FAQ, so nothing can be built.
+    renderCard([RESEARCH_A], FILLED_CONTEXT)
 
     expect(buildButton()).toBeDisabled()
     expect(screen.getByText(en.documents.prototype.needsDocs)).toBeInTheDocument()
-    expect(screen.queryByTestId('prototype-extra-sources')).not.toBeInTheDocument()
-    // Asserted on the roles too, not just the container: a gate that kept the
-    // wrapper and hid its contents would leave the box focusable.
+
+    // A disabled button swallows the click, so the panel never opens and no control
+    // inside it is reachable or focusable.
+    fireEvent.click(buildButton())
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
   })
 
-  it('offers them again as soon as one document exists', () => {
-    // The other half, from the same fixture one document later: the gate must be
-    // the disabled state and not something that hides the controls outright.
-    renderTab([PRD, RESEARCH_A], FILLED_CONTEXT)
-
+  it('opens with the choices as soon as one document exists', () => {
+    // The other half, from the same fixture one document later: the gate must be the
+    // button's disabled state and nothing else.
+    renderCard([PRD, RESEARCH_A], FILLED_CONTEXT)
     expect(buildButton()).toBeEnabled()
+
+    fireEvent.click(buildButton())
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByTestId('prototype-extra-sources')).toBeInTheDocument()
   })
 })
@@ -603,7 +652,7 @@ describe('two similarly-named reports are distinguishable', () => {
     // "Churn interviews Q1"/"Q2" render as the same visible string. A screen
     // reader gets the full label either way; a sighted mouse user has only this.
     const user = userEvent.setup()
-    renderTab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], FILLED_CONTEXT)
 
     await user.click(researchBox())
 
@@ -619,7 +668,7 @@ describe('the card no longer presents PRD/PR-FAQ as the whole input list', () =>
     // nothing to omit" — and a DISABLED card renders
     // `documents.prototype.needsDocs` instead of this description, so the
     // assertion would pass for the wrong reason.
-    renderTab([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
+    renderWizard([PRD, PRFAQ, RESEARCH_A], FILLED_CONTEXT)
 
     expect(buildButton()).toBeEnabled()
     expect(screen.getByText(en.overview.prototypeDesc)).toBeInTheDocument()
@@ -693,7 +742,7 @@ describe('the failed note renders from a non-English catalogue', () => {
   })
 
   it('renders the German wording, not the key path or the English string', () => {
-    renderTab([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_FAILED])
+    renderWizard([PRD, PRFAQ], FILLED_CONTEXT, [VISUAL_A, VISUAL_FAILED])
 
     expect(screen.getByText(
       de.documents.prototype.visualsFailed.replace('{{total}}', '1'),

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
@@ -3,7 +3,7 @@
  * research reports, and the uploaded visuals a build takes its palette from.
  *
  * Where the controls live is the property under test, not a detail.
- * `confirmKeyFor` in `usePrototypeBuild` deliberately opens NO dialog for a
+ * `warningKeyFor` in `usePrototypeBuild` deliberately opens NO dialog for a
  * project with one PRD, one PR-FAQ and no prototype — the build starts on the
  * first click — and the source picker lives inside that dialog. So the fixture
  * that matters here is precisely that project: a control placed in the dialog is
@@ -116,8 +116,13 @@ function renderWizard(
   // switches the catalogue to German, and a hardcoded name would fail there with
   // "cannot find the button" — a message that points at the card rather than at the
   // query.
+  // Matched as a SUBSTRING of the accessible name, not equal to it: the card carries
+  // the "Configure & " prefix its five siblings have, and the panel's own submit is
+  // the bare verb. Anchoring here would break on the prefix; using the bare verb
+  // keeps this locale-independent, and the card is the only match while the panel is
+  // still closed.
   fireEvent.click(screen.getByRole('button', {
-    name: i18n.t('documents.prototype.button', { ns: 'projectDetail' }),
+    name: new RegExp(i18n.t('documents.prototype.button', { ns: 'projectDetail' }), 'i'),
   }))
   return result
 }
@@ -175,7 +180,7 @@ const noteStem = (key: 'visualsNotReady' | 'visualsFailed') =>
 const visualNotes = () => screen.getByTestId('prototype-visual-sources').textContent ?? ''
 
 /** The card's button. It opens the wizard; it no longer starts anything. */
-const buildButton = () => screen.getByRole('button', { name: /build prototype/i })
+const buildButton = () => screen.getByRole('button', { name: /configure & build prototype/i })
 /**
  * The wizard's own submit — the only control that spends money.
  *
@@ -183,7 +188,7 @@ const buildButton = () => screen.getByRole('button', { name: /build prototype/i 
  * start resolving to the card's button if either label changes.
  */
 const startBuild = () => within(screen.getByRole('dialog'))
-  .getByRole('button', { name: en.documents.prototype.confirmBuild })
+  .getByRole('button', { name: en.documents.prototype.button })
 const productContextBox = () => screen.getByRole('checkbox', { name: /product \/ service description/i })
 const researchBox = () => screen.getByRole('checkbox', { name: /research reports/i })
 const sentBody = () => mockBuildPrototype.mock.calls[0][1]

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeExtraSources.test.tsx
@@ -2,12 +2,15 @@
  * The prototype card's optional inputs: the project's product description, its
  * research reports, and the uploaded visuals a build takes its palette from.
  *
- * Where the controls live is the property under test, not a detail.
- * `warningKeyFor` in `usePrototypeBuild` deliberately opens NO dialog for a
- * project with one PRD, one PR-FAQ and no prototype — the build starts on the
- * first click — and the source picker lives inside that dialog. So the fixture
- * that matters here is precisely that project: a control placed in the dialog is
- * unreachable for it, and no other fixture shows that.
+ * What these controls DO is the property under test. WHERE they live is pinned
+ * separately, in `OverviewTab.prototypeWizard.test.tsx` — they sit in the build
+ * wizard now, so every test here opens it first via `renderWizard`.
+ *
+ * The one-PRD/one-PR-FAQ/no-prototype fixture is still the one worth naming, and
+ * still for the same reason: `warningKeyFor` returns null for it, so under the old
+ * placement it was the project that opened no dialog at all and would have been
+ * stranded by a control living in one. It is now the project a placement regression
+ * would strand first.
  *
  * `t()` resolves against the real en catalogue (src/test/setup.ts), so a key that
  * is missing or has moved renders its raw path and these matchers fail.
@@ -116,14 +119,13 @@ function renderWizard(
   // switches the catalogue to German, and a hardcoded name would fail there with
   // "cannot find the button" — a message that points at the card rather than at the
   // query.
-  // Matched as a SUBSTRING of the accessible name, not equal to it: the card carries
-  // the "Configure & " prefix its five siblings have, and the panel's own submit is
-  // the bare verb. Anchoring here would break on the prefix; using the bare verb
-  // keeps this locale-independent, and the card is the only match while the panel is
-  // still closed.
-  fireEvent.click(screen.getByRole('button', {
-    name: new RegExp(i18n.t('documents.prototype.button', { ns: 'projectDetail' }), 'i'),
-  }))
+  // A FUNCTION matcher, not a regex built from a translated string: the card carries
+  // the "Configure & " prefix its five siblings have, so the name must be matched as
+  // a substring rather than equal — but a catalogue label containing a regex
+  // metacharacter would silently change what a constructed pattern means. `includes`
+  // has no such failure mode and needs no escaping.
+  const verb = i18n.t('documents.prototype.button', { ns: 'projectDetail' })
+  fireEvent.click(screen.getByRole('button', { name: (name) => name.includes(verb) }))
   return result
 }
 

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeSources.test.tsx
@@ -67,8 +67,8 @@ function renderTab(documents: ProjectDocument[]) {
   )
 }
 
-const buildButton = () => screen.getByRole('button', { name: /build prototype/i })
-const confirmButton = () => screen.getByRole('button', { name: /build anyway/i })
+const buildButton = () => screen.getByRole('button', { name: /configure & build prototype/i })
+const confirmButton = () => screen.getByRole('button', { name: /^build prototype$/i })
 const sentBody = () => mockBuildPrototype.mock.calls[0][1]
 
 beforeEach(() => {
@@ -160,7 +160,7 @@ describe('the build reads the documents the dialog named', () => {
   })
 
   it('names the documents even when there is nothing to choose', async () => {
-    // With one of each there is no dialog, but the ids are still sent. Without
+    // With one of each there is nothing to choose, but the ids are still sent. Without
     // them the backend re-resolves "the newest" at build time, so a document
     // saved between render and click would be used instead of the one shown.
     const user = userEvent.setup()
@@ -168,7 +168,7 @@ describe('the build reads the documents the dialog named', () => {
 
     await user.click(buildButton())
     await user.click(within(screen.getByRole('dialog'))
-      .getByRole('button', { name: /build anyway/i }))
+      .getByRole('button', { name: /^build prototype$/i }))
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().source_prd_id).toBe('aa_prd_new')

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeSources.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeSources.test.tsx
@@ -13,7 +13,7 @@
  * moved echoes its raw path and these matchers fail.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import OverviewTab from './OverviewTab'
 import type { Project, ProjectDocument } from '../../api/types'
@@ -89,16 +89,21 @@ describe('the source picker appears only when there is a choice', () => {
     expect(screen.getByTestId('prototype-source-picker')).toBeInTheDocument()
   })
 
-  it('does not ask when there is exactly one of each', async () => {
-    // Preserved deliberately: a dialog offering a choice with one possible answer
-    // is friction, and this build has started on the first click since it shipped.
+  // This replaces "does not ask when there is exactly one of each". That test
+  // asserted the build started on the first click and no picker was rendered — the
+  // one-click path, traded away when the build moved into a wizard. What survives
+  // is the reason it existed: a choice with one possible answer must not be
+  // presented AS a choice. So the picker is there, and it offers no select.
+  it('presents the sources without a select when there is exactly one of each', async () => {
     const user = userEvent.setup()
     renderTab([PRD_NEW, PRFAQ])
 
     await user.click(buildButton())
 
-    await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
-    expect(screen.queryByTestId('prototype-source-picker')).not.toBeInTheDocument()
+    expect(screen.getByTestId('prototype-source-picker')).toBeInTheDocument()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    // And opening it is still not a build.
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
   })
 
   it('offers a select for the type with several and a plain line for the type with one', async () => {
@@ -154,7 +159,7 @@ describe('the build reads the documents the dialog named', () => {
     expect(sentBody().source_prd_id).toBe('zz_prd_old')
   })
 
-  it('names the documents even when it does not stop to ask', async () => {
+  it('names the documents even when there is nothing to choose', async () => {
     // With one of each there is no dialog, but the ids are still sent. Without
     // them the backend re-resolves "the newest" at build time, so a document
     // saved between render and click would be used instead of the one shown.
@@ -162,6 +167,8 @@ describe('the build reads the documents the dialog named', () => {
     renderTab([PRD_NEW, PRFAQ])
 
     await user.click(buildButton())
+    await user.click(within(screen.getByRole('dialog'))
+      .getByRole('button', { name: /build anyway/i }))
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     expect(sentBody().source_prd_id).toBe('aa_prd_new')

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeWizard.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Where the prototype build is configured, and for which projects it is reachable.
+ *
+ * This suite replaces `OverviewTab.prototypeExtraSources.test.tsx`'s opening
+ * property, "the controls are reachable without a dialog". That property was true
+ * of the old placement and is deliberately abandoned: the configuration moves into
+ * a wizard, so the card matches its five siblings. The invariant it has to be
+ * traded for is stated once, here:
+ *
+ *   > The build configuration is reachable for EVERY project — including one with
+ *   > exactly one PRD, one PR-FAQ and no prototype, the case that previously opened
+ *   > no dialog at all.
+ *
+ * That case is the whole reason the controls sat on the card face, so it is the
+ * regression test for the placement change and it is parametrised below rather
+ * than asserted once.
+ *
+ * ⚠️ A bare `getByRole('dialog')` would be VACUOUS here: three project shapes
+ * already open a `ConfirmModal` today, so "a dialog appears" passes on unchanged
+ * code for those. The wizard is identified by carrying the configuration —
+ * `prototype-extra-sources` (today on the card, outside any dialog) together with
+ * `prototype-source-picker` — which no current code path puts in one container.
+ *
+ * `t()` resolves against the real en catalogue (src/test/setup.ts), so a key that
+ * is missing or has moved renders its raw path and these matchers fail.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import OverviewTab from './OverviewTab'
+import { emptyProductContext } from './productContextFields'
+import type { Project, ProductContext, ProductDoc, ProjectDocument } from '../../api/types'
+
+const mockBuildPrototype = vi.fn()
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    buildPrototype: (...args: unknown[]) => mockBuildPrototype(...args),
+  },
+}))
+
+const project: Project = {
+  project_id: 'proj_1',
+  name: 'Test project',
+  description: '',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  persona_count: 0,
+  document_count: 0,
+}
+
+function doc(
+  documentType: ProjectDocument['document_type'],
+  id: string,
+  title: string,
+  createdAt: string,
+): ProjectDocument {
+  return { document_id: id, document_type: documentType, title, content: 'x', created_at: createdAt }
+}
+
+const PRD = doc('prd', 'prd_1', 'Delivery spec', '2026-01-01T00:00:00Z')
+const PRD_2 = doc('prd', 'prd_2', 'Delivery spec v2', '2026-01-15T00:00:00Z')
+const PRFAQ = doc('prfaq', 'prfaq_1', 'Launch note', '2026-02-01T00:00:00Z')
+const RESEARCH_A = doc('research', 'research_a', 'Churn interviews', '2026-03-01T00:00:00Z')
+const RESEARCH_B = doc('research', 'research_b', 'Pricing survey', '2026-04-01T00:00:00Z')
+const PROTOTYPE = doc('prototype', 'proto_1', 'First cut', '2026-05-01T00:00:00Z')
+
+const FILLED_CONTEXT: ProductContext = { ...emptyProductContext(), one_liner: 'A console for wombats' }
+
+const VISUAL_A: ProductDoc = {
+  doc_id: 'pd_a',
+  filename: 'home-screen.png',
+  content_type: 'image/png',
+  size_bytes: 1024,
+  status: 'ready',
+  error: null,
+  extracted_chars: 400,
+  created_at: '2026-05-01T00:00:00Z',
+}
+
+function tab(documents: ProjectDocument[], productDocs?: ProductDoc[]) {
+  return (
+    <OverviewTab
+      project={project}
+      personas={[]}
+      documents={documents}
+      productContext={FILLED_CONTEXT}
+      productDocs={productDocs}
+      onGeneratePersonas={vi.fn()}
+      onGenerateDoc={vi.fn()}
+      onRunResearch={vi.fn()}
+      onRemixDocuments={vi.fn()}
+      onOpenProductTool={vi.fn()}
+      onJobStarted={vi.fn()}
+    />
+  )
+}
+
+const buildButton = () => screen.getByRole('button', { name: /build prototype/i })
+/**
+ * The panel, found the way assistive tech finds it. `ModalShell` owns
+ * `role="dialog"`, the accessible name and the focus trap, so asserting those
+ * attributes here would only re-test the shell — what this suite has to pin is
+ * that the build configuration is INSIDE the dialog, which the content assertions
+ * do.
+ */
+const wizard = () => screen.getByRole('dialog')
+const maybeWizard = () => screen.queryByRole('dialog')
+
+/**
+ * The five project shapes that used to behave differently. Only the first opened no
+ * dialog; the other four raised one of the three `confirmKeyFor` reasons. After the
+ * move they must all do the same thing, which is what makes the card predictable.
+ */
+const SHAPES: ReadonlyArray<{ name: string; documents: ProjectDocument[] }> = [
+  { name: 'one PRD, one PR-FAQ, no prototype (previously NO dialog)', documents: [PRD, PRFAQ, RESEARCH_A] },
+  { name: 'a PRD only (previously the single-document note)', documents: [PRD, RESEARCH_A] },
+  { name: 'a PR-FAQ only (previously the single-document note)', documents: [PRFAQ, RESEARCH_A] },
+  { name: 'an existing prototype (previously the rebuild warning)', documents: [PRD, PRFAQ, PROTOTYPE] },
+  { name: 'two PRDs (previously the choose-sources note)', documents: [PRD, PRD_2, PRFAQ] },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockBuildPrototype.mockResolvedValue({ job_id: 'job_1' })
+})
+
+describe('the build configuration is reachable for every project', () => {
+  it.each(SHAPES)('opens the wizard on $name', async ({ documents }) => {
+    render(tab(documents, [VISUAL_A]))
+
+    await userEvent.click(buildButton())
+
+    // Identified by what it CONTAINS, not merely by being a dialog: four of these
+    // shapes already open a ConfirmModal, so a role-only assertion would pass on
+    // unchanged code for them.
+    const panel = wizard()
+    expect(within(panel).getByTestId('prototype-extra-sources')).toBeInTheDocument()
+    expect(within(panel).getByTestId('prototype-source-picker')).toBeInTheDocument()
+    // The body is the wizard's own, not a confirm dialog that happens to be open.
+    expect(within(panel).getByTestId('prototype-build-wizard')).toBeInTheDocument()
+  })
+
+  it('does not put the configuration on the card face any more', () => {
+    render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
+
+    // Before the click there is no wizard, and the card must not be carrying the
+    // controls either — that is the placement half of the change.
+    expect(maybeWizard()).not.toBeInTheDocument()
+    expect(screen.queryByTestId('prototype-extra-sources')).not.toBeInTheDocument()
+  })
+})
+
+describe('opening the wizard is not itself a build', () => {
+  it('starts no build when the card button only opens the wizard', async () => {
+    render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
+
+    await userEvent.click(buildButton())
+
+    expect(wizard()).toBeInTheDocument()
+    // The endpoint is billable and has no existing-prototype check of its own, so
+    // reaching the configuration must never be what spends the money.
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
+  })
+})
+
+describe('the wizard owns its own open state', () => {
+  it('keeps the panel open and the selection intact when the documents change underneath', async () => {
+    // §5b: the confirm dialog it replaces derived its visibility from live document
+    // data, and the page refetches documents whenever a job completes. Hosting user
+    // input in something with that property discards the input mid-interaction.
+    const { rerender } = render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
+    await userEvent.click(buildButton())
+
+    const researchBox = within(wizard()).getByRole('checkbox', { name: /research reports/i })
+    await userEvent.click(researchBox)
+    expect(researchBox).toBeChecked()
+
+    // An unrelated job finishing: the same project, one more document.
+    rerender(tab([PRD, PRFAQ, RESEARCH_A, RESEARCH_B], [VISUAL_A]))
+
+    expect(maybeWizard()).toBeInTheDocument()
+    // Asserted as a DOM property, not as rendered text — `checked` is invisible to a
+    // textContent read, which is how a working checkbox once got reported broken.
+    expect(within(wizard()).getByRole('checkbox', { name: /research reports/i })).toBeChecked()
+  })
+
+  it('closes on an explicit cancel', async () => {
+    render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
+    await userEvent.click(buildButton())
+    expect(wizard()).toBeInTheDocument()
+
+    await userEvent.click(within(wizard()).getByRole('button', { name: /^cancel$/i }))
+
+    expect(maybeWizard()).not.toBeInTheDocument()
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
+  })
+})

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeWizard.test.tsx
@@ -29,6 +29,9 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import OverviewTab from './OverviewTab'
 import { emptyProductContext } from './productContextFields'
+// The real en catalogue, so the dialog's expected accessible name is the shipped
+// string rather than a copy of it that can drift.
+import en from '../../../public/locales/en/projectDetail.json'
 import type { Project, ProductContext, ProductDoc, ProjectDocument } from '../../api/types'
 
 const mockBuildPrototype = vi.fn()
@@ -140,6 +143,10 @@ describe('the build configuration is reachable for every project', () => {
     expect(within(panel).getByTestId('prototype-source-picker')).toBeInTheDocument()
     // The body is the wizard's own, not a confirm dialog that happens to be open.
     expect(within(panel).getByTestId('prototype-build-wizard')).toBeInTheDocument()
+    // Named, and named by the heading it renders. Querying by role alone cannot see
+    // an unnamed dialog, so without this the switch from `ariaLabel` to
+    // `ariaLabelledBy` could silently produce one and every test here would pass.
+    expect(panel).toHaveAccessibleName(en.documents.prototype.button)
   })
 
   it('does not put the configuration on the card face any more', () => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeWizard.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.prototypeWizard.test.tsx
@@ -96,7 +96,7 @@ function tab(documents: ProjectDocument[], productDocs?: ProductDoc[]) {
   )
 }
 
-const buildButton = () => screen.getByRole('button', { name: /build prototype/i })
+const buildButton = () => screen.getByRole('button', { name: /configure & build prototype/i })
 /**
  * The panel, found the way assistive tech finds it. `ModalShell` owns
  * `role="dialog"`, the accessible name and the focus trap, so asserting those
@@ -109,7 +109,7 @@ const maybeWizard = () => screen.queryByRole('dialog')
 
 /**
  * The five project shapes that used to behave differently. Only the first opened no
- * dialog; the other four raised one of the three `confirmKeyFor` reasons. After the
+ * dialog; the other four raised one of the three `warningKeyFor` reasons. After the
  * move they must all do the same thing, which is what makes the card predictable.
  */
 const SHAPES: ReadonlyArray<{ name: string; documents: ProjectDocument[] }> = [
@@ -127,9 +127,10 @@ beforeEach(() => {
 
 describe('the build configuration is reachable for every project', () => {
   it.each(SHAPES)('opens the wizard on $name', async ({ documents }) => {
+    const user = userEvent.setup()
     render(tab(documents, [VISUAL_A]))
 
-    await userEvent.click(buildButton())
+    await user.click(buildButton())
 
     // Identified by what it CONTAINS, not merely by being a dialog: four of these
     // shapes already open a ConfirmModal, so a role-only assertion would pass on
@@ -153,9 +154,10 @@ describe('the build configuration is reachable for every project', () => {
 
 describe('opening the wizard is not itself a build', () => {
   it('starts no build when the card button only opens the wizard', async () => {
+    const user = userEvent.setup()
     render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
 
-    await userEvent.click(buildButton())
+    await user.click(buildButton())
 
     expect(wizard()).toBeInTheDocument()
     // The endpoint is billable and has no existing-prototype check of its own, so
@@ -166,14 +168,15 @@ describe('opening the wizard is not itself a build', () => {
 
 describe('the wizard owns its own open state', () => {
   it('keeps the panel open and the selection intact when the documents change underneath', async () => {
+    const user = userEvent.setup()
     // §5b: the confirm dialog it replaces derived its visibility from live document
     // data, and the page refetches documents whenever a job completes. Hosting user
     // input in something with that property discards the input mid-interaction.
     const { rerender } = render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
-    await userEvent.click(buildButton())
+    await user.click(buildButton())
 
     const researchBox = within(wizard()).getByRole('checkbox', { name: /research reports/i })
-    await userEvent.click(researchBox)
+    await user.click(researchBox)
     expect(researchBox).toBeChecked()
 
     // An unrelated job finishing: the same project, one more document.
@@ -185,12 +188,33 @@ describe('the wizard owns its own open state', () => {
     expect(within(wizard()).getByRole('checkbox', { name: /research reports/i })).toBeChecked()
   })
 
-  it('closes on an explicit cancel', async () => {
-    render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
-    await userEvent.click(buildButton())
+  it('refuses to build once the documents that enabled the card are gone', async () => {
+    // Owned visibility has a consequence the old gate did not: an open panel can
+    // OUTLIVE the state that enabled the card button. The card's `disabled` cannot
+    // help here — it is behind the modal and the panel is already up — so the hook's
+    // own guard is the last thing between the user and a billable call with nothing
+    // to build from. Nothing else in this suite exercises that guard from the wizard
+    // path, which is what makes this the regression test for it.
+    const user = userEvent.setup()
+    const { rerender } = render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
+    await user.click(buildButton())
     expect(wizard()).toBeInTheDocument()
 
-    await userEvent.click(within(wizard()).getByRole('button', { name: /^cancel$/i }))
+    // Both source documents deleted from another surface while the panel is open.
+    rerender(tab([RESEARCH_A], [VISUAL_A]))
+
+    await user.click(within(wizard()).getByRole('button', { name: /^build prototype$/i }))
+
+    expect(mockBuildPrototype).not.toHaveBeenCalled()
+  })
+
+  it('closes on an explicit cancel', async () => {
+    const user = userEvent.setup()
+    render(tab([PRD, PRFAQ, RESEARCH_A], [VISUAL_A]))
+    await user.click(buildButton())
+    expect(wizard()).toBeInTheDocument()
+
+    await user.click(within(wizard()).getByRole('button', { name: /^cancel$/i }))
 
     expect(maybeWizard()).not.toBeInTheDocument()
     expect(mockBuildPrototype).not.toHaveBeenCalled()

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
@@ -19,10 +19,11 @@ import clsx from 'clsx'
 import { format } from 'date-fns'
 import {
   Users, FileText, Search, Sparkles, Shuffle, Package, Wand2, AlertCircle, Loader2,
+  AlertTriangle,
 } from 'lucide-react'
 import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
-import ConfirmModal from '../../components/ConfirmModal'
+import ModalShell from '../../components/ModalShell'
 import {
   deriveOverviewState, type OverviewStep, type OverviewStepState,
 } from './overviewState'
@@ -219,12 +220,6 @@ export default function OverviewTab({
           // START (everything after that belongs to the jobs panel) and a brief
           // acknowledgement covering the gap before that panel refetches.
           statusLine={prototypeStatusLine(prototypeBuild, t)}
-          // On the card, NOT in the confirm dialog: `confirmKeyFor` deliberately
-          // opens no dialog for a project with one PRD, one PR-FAQ and no
-          // prototype, so a control placed there would be unreachable for exactly
-          // the simplest project — and moving that project behind a fourth confirm
-          // reason would cost the deliberate one-click path.
-          controls={<PrototypeExtraSources extras={prototypeBuild.extras} t={t} />}
         />
         <ActionCard
           state={steps.remix}
@@ -245,23 +240,12 @@ export default function OverviewTab({
         />
       </div>
 
-      {/* Only reachable from the prototype card, and only when the build needs
-          something said first: one of PRD/PR-FAQ missing, a prototype already
-          present, or several documents of a type to choose between. The build is
-          billable, so which documents it will read is stated before it runs
-          rather than after. */}
-      <ConfirmModal
-        isOpen={prototypeBuild.confirm.isOpen}
-        title={t('documents.prototype.button')}
-        message={prototypeBuild.confirm.message}
-        confirmLabel={t('documents.prototype.confirmBuild')}
-        cancelLabel={t('documents.prototype.cancel')}
-        variant="warning"
-        onConfirm={prototypeBuild.confirm.onConfirm}
-        onCancel={prototypeBuild.confirm.onCancel}
-      >
-        <PrototypeSourcePicker sources={prototypeBuild.sources} t={t} />
-      </ConfirmModal>
+      {/* Reachable from the prototype card for EVERY project, which is the whole
+          point of it being a wizard rather than the confirm dialog it replaces:
+          the build is configured here, so a project that needs no warning still
+          needs a way in. The build is billable, so nothing here starts one until
+          its own button is pressed. */}
+      <PrototypeBuildWizard build={prototypeBuild} t={t} />
     </div>
   )
 }
@@ -344,12 +328,6 @@ interface ActionCardProps {
    * others leave this unset.
    */
   readonly statusLine?: ReactNode
-  /**
-   * Choices this card's own action reads, rendered above its button. Only the
-   * prototype card has any: the other five open a wizard that asks for its
-   * configuration, so a control here would duplicate the first wizard step.
-   */
-  readonly controls?: ReactNode
   readonly buttonColor: string
   readonly buttonIcon: ReactNode
   readonly buttonLabel: string
@@ -373,7 +351,6 @@ function ActionCard({
   stateLabel,
   hint,
   statusLine,
-  controls,
   buttonColor,
   buttonIcon,
   buttonLabel,
@@ -420,19 +397,6 @@ function ActionCard({
         // "None yet" is information, not decoration, so it has to be readable.
         <p className={`text-xs mb-3 ${state.hasOutput ? 'text-green-700' : 'text-gray-500'}`}>{stateLabel}</p>
       )}
-      {/* Above the button, because they change what the button does. Rendered raw
-          like `statusLine`: only the caller knows what the choices are, and a
-          wrapper here would put an empty box on the five cards that have none.
-
-          Not rendered at all on a disabled card: choices for an action that cannot
-          be taken read as an offer, and a project with no PRD and no PR/FAQ showed
-          tick-boxes stacked above a dead button and the "create a document first"
-          message. That also hides them while `busy` — the prototype card's second
-          disabled reason — which is correct rather than merely tolerable: nothing
-          ticked during the start request can affect the build already in flight,
-          and the window closes when the request returns, not when the build
-          finishes. */}
-      {disabled === true ? null : controls}
       <button
         onClick={onClick}
         disabled={disabled}
@@ -454,6 +418,74 @@ function ActionCard({
           hard to read. */}
       {disabled === true && disabledMessage != null && disabledMessage !== '' ? <p className="text-xs text-gray-500 mt-2 text-center">{disabledMessage}</p> : null}
     </div>
+  )
+}
+
+/**
+ * Where a prototype build is configured and started.
+ *
+ * One panel for the whole "what should this build read?" question: which PRD and
+ * PR/FAQ, plus the optional product context, research reports and uploaded
+ * visuals. It replaces a confirm dialog that opened for only some projects, and
+ * that is the behaviour change — the card now always opens this, so the
+ * configuration is reachable for every project rather than for the awkward ones.
+ *
+ * `ModalShell` rather than a hand-rolled overlay, and rather than `ConfirmModal`:
+ * the shell owns `role="dialog"`, the accessible name, the focus trap and Escape
+ * (issue #283 found 23 overlays of which 2 declared a role), while `ConfirmModal`
+ * requires a `message` — correct for something whose whole content is a question,
+ * wrong here, where the question is optional and the content is a form.
+ *
+ * The warning, when there is one, is stated FIRST and styled as a caution: it is
+ * the only thing on this panel that can save money, since the build endpoint has
+ * no existing-prototype check of its own.
+ */
+function PrototypeBuildWizard({
+  build, t,
+}: {
+  readonly build: PrototypeBuildControl
+  readonly t: TFunction<'projectDetail'>
+}) {
+  return (
+    <ModalShell
+      isOpen={build.wizard.isOpen}
+      onClose={build.wizard.onCancel}
+      ariaLabel={t('documents.prototype.button')}
+      panelClassName="max-w-lg"
+    >
+      <div data-testid="prototype-build-wizard" className="p-4 sm:p-6">
+        <h3 className="text-base sm:text-lg font-semibold text-gray-900">
+          {t('documents.prototype.button')}
+        </h3>
+        {/* Empty exactly when this build needs no caution, so it is asked about
+            rather than assumed — an always-rendered block would leave an amber
+            panel with nothing in it on the common path. */}
+        {build.wizard.warning === '' ? null : (
+          <p className="mt-2 flex items-start gap-2 rounded-lg bg-amber-50 p-2.5 text-sm text-amber-800">
+            <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
+            <span>{build.wizard.warning}</span>
+          </p>
+        )}
+        <PrototypeSourcePicker sources={build.sources} t={t} />
+        <PrototypeExtraSources extras={build.extras} t={t} />
+        <div className="mt-5 sm:mt-6 flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3">
+          <button
+            onClick={build.wizard.onCancel}
+            className="w-full sm:w-auto px-4 py-2.5 sm:py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
+          >
+            {t('documents.prototype.cancel')}
+          </button>
+          <button
+            onClick={build.wizard.onConfirm}
+            disabled={build.busy}
+            className="w-full sm:w-auto px-4 py-2.5 sm:py-2 text-sm font-medium rounded-lg bg-orange-500 hover:bg-orange-600 text-white disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            {build.busy ? <Loader2 size={16} className="animate-spin" /> : null}
+            {t('documents.prototype.confirmBuild')}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
   )
 }
 
@@ -481,9 +513,10 @@ function PrototypeSourcePicker({
   if (sources.prdOptions.length === 0 && sources.prfaqOptions.length === 0) return null
 
   return (
-    // `mt-3` lives here rather than on a wrapper in ConfirmModal: this component
+    // `mt-3` lives here rather than on a wrapper in the wizard: this component
     // returns null when there is nothing to choose, and a wrapper's margin would
-    // leave a gap the modal cannot detect.
+    // leave a gap the panel cannot detect (a React element that renders nothing is
+    // still a non-null child).
     <div data-testid="prototype-source-picker" className="mt-3 space-y-2 rounded-lg bg-gray-50 p-3">
       <SourceRow
         label={t('documents.prototype.sourcePrd')}
@@ -560,11 +593,16 @@ function SourceRow({
  * product context, specific research reports, and uploaded visuals to take the
  * palette and layout from.
  *
- * On the card rather than inside `ConfirmModal`, and that placement is the whole
- * design decision: `confirmKeyFor` returns null — no dialog at all — for a project
- * with one PRD, one PR-FAQ and no prototype, deliberately, so that the build starts
- * on the first click. A control living in the dialog would be unreachable for
- * exactly that project.
+ * Rendered inside `PrototypeBuildWizard`, beside the PRD/PR-FAQ pickers, so one
+ * panel answers the whole "what should this build read?" question.
+ *
+ * These sat on the card face until the wizard existed, and the reason is worth
+ * keeping because it constrains any future move: the confirm dialog they would
+ * otherwise have lived in opened for only SOME projects — `confirmKeyFor` returned
+ * null for one PRD, one PR-FAQ and no prototype — so a control inside it was
+ * unreachable for the simplest project. The wizard opens for every project, which
+ * is what makes this placement safe and what
+ * `OverviewTab.prototypeWizard.test.tsx` pins.
  *
  * Checkboxes rather than the `select` the source picker uses, because these are
  * independent on/off choices rather than one-of-many, and because the research list

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
@@ -198,9 +198,14 @@ export default function OverviewTab({
           buttonLabel={prototypeBuild.busy
             ? t('documents.prototype.building')
             : t('documents.prototype.button')}
-          // No `configureLabel`: the other cards open a wizard to configure first,
-          // this one starts the build (or a confirm) directly, so "Configure and"
-          // would promise a step that does not exist.
+          // The prefix the other five wizard-opening cards carry. It was absent
+          // while this card started work directly — "Configure and" would have
+          // promised a step that did not exist — and it is correct now for the same
+          // reason it is correct on them: the button opens a panel and spends
+          // nothing. It is also what frees the plain verb for the panel's own submit
+          // button, which had been left reading "Build anyway" on projects with
+          // nothing to build anyway despite.
+          configureLabel={t('overview.configureAnd')}
           onClick={prototypeBuild.onClick}
           // Like remix, `missingUpstream` is a hard block here rather than a hint.
           // This is the *user-facing* authority — one derived condition, shared
@@ -446,42 +451,63 @@ function PrototypeBuildWizard({
   readonly build: PrototypeBuildControl
   readonly t: TFunction<'projectDetail'>
 }) {
+  // `aria-labelledby` rather than `ariaLabel`, pointing at the heading this panel
+  // already renders: one string on screen and in the accessible name, so the two
+  // cannot drift apart, and no second translated value to keep in step.
+  const headingId = useId()
+
   return (
     <ModalShell
       isOpen={build.wizard.isOpen}
       onClose={build.wizard.onCancel}
-      ariaLabel={t('documents.prototype.button')}
+      ariaLabelledBy={headingId}
       panelClassName="max-w-lg"
     >
       <div data-testid="prototype-build-wizard" className="p-4 sm:p-6">
-        <h3 className="text-base sm:text-lg font-semibold text-gray-900">
+        <h3 id={headingId} className="text-base sm:text-lg font-semibold text-gray-900">
           {t('documents.prototype.button')}
         </h3>
-        {/* Empty exactly when this build needs no caution, so it is asked about
-            rather than assumed — an always-rendered block would leave an amber
-            panel with nothing in it on the common path. */}
-        {build.wizard.warning === '' ? null : (
-          <p className="mt-2 flex items-start gap-2 rounded-lg bg-amber-50 p-2.5 text-sm text-amber-800">
-            <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
-            <span>{build.wizard.warning}</span>
-          </p>
-        )}
+        {/* A LIVE REGION, and that is the point rather than decoration: `warning` is
+            derived from documents that refetch whenever a job completes, so it can
+            APPEAR or ESCALATE while this panel is open — a prototype arriving turns
+            the submit from "build from the PRD alone" into "build a second and keep
+            the first". A sighted user sees the amber block change; without a live
+            region a screen-reader user who opened with no warning is told nothing,
+            and the submit quietly costs more than when they opened it.
+
+            The region wraps the CONDITION, not just the text: an element that only
+            exists once there is something to say cannot announce its own arrival, so
+            the container is always mounted and only its contents change. */}
+        <div role="status" aria-live="polite">
+          {build.wizard.warning === '' ? null : (
+            <p className="mt-2 flex items-start gap-2 rounded-lg bg-amber-50 p-2.5 text-sm text-amber-800">
+              <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
+              <span>{build.wizard.warning}</span>
+            </p>
+          )}
+        </div>
         <PrototypeSourcePicker sources={build.sources} t={t} />
         <PrototypeExtraSources extras={build.extras} t={t} />
         <div className="mt-5 sm:mt-6 flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3">
           <button
+            type="button"
             onClick={build.wizard.onCancel}
             className="w-full sm:w-auto px-4 py-2.5 sm:py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
           >
             {t('documents.prototype.cancel')}
           </button>
+          {/* No busy state here, deliberately: `onConfirm` closes the panel before
+              starting the request, so this button cannot be on screen while a start
+              is in flight. The busy label and any failure to start belong to the
+              card's own status line, which is where the user is looking once this
+              closes — and which already has tests for both. A spinner here would be
+              protection that never runs. */}
           <button
+            type="button"
             onClick={build.wizard.onConfirm}
-            disabled={build.busy}
-            className="w-full sm:w-auto px-4 py-2.5 sm:py-2 text-sm font-medium rounded-lg bg-orange-500 hover:bg-orange-600 text-white disabled:opacity-50 flex items-center justify-center gap-2"
+            className="w-full sm:w-auto px-4 py-2.5 sm:py-2 text-sm font-medium rounded-lg bg-orange-500 hover:bg-orange-600 text-white"
           >
-            {build.busy ? <Loader2 size={16} className="animate-spin" /> : null}
-            {t('documents.prototype.confirmBuild')}
+            {t('documents.prototype.button')}
           </button>
         </div>
       </div>
@@ -598,7 +624,7 @@ function SourceRow({
  *
  * These sat on the card face until the wizard existed, and the reason is worth
  * keeping because it constrains any future move: the confirm dialog they would
- * otherwise have lived in opened for only SOME projects — `confirmKeyFor` returned
+ * otherwise have lived in opened for only SOME projects — `warningKeyFor` returned
  * null for one PRD, one PR-FAQ and no prototype — so a control inside it was
  * unreachable for the simplest project. The wizard opens for every project, which
  * is what makes this placement safe and what

--- a/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/OverviewTab.tsx
@@ -205,7 +205,9 @@ export default function OverviewTab({
           // nothing. It is also what frees the plain verb for the panel's own submit
           // button, which had been left reading "Build anyway" on projects with
           // nothing to build anyway despite.
-          configureLabel={t('overview.configureAnd')}
+          //
+          // Absent while busy, and that is not cosmetic — see `configurePrefix`.
+          configureLabel={configurePrefix(prototypeBuild, t)}
           onClick={prototypeBuild.onClick}
           // Like remix, `missingUpstream` is a hard block here rather than a hint.
           // This is the *user-facing* authority — one derived condition, shared
@@ -314,6 +316,26 @@ function productContextStateLabel(state: OverviewStepState, t: TFunction): strin
     filled: state.filled,
     total: state.total,
   })
+}
+
+/**
+ * The "Configure & " prefix for the prototype card, or nothing while a build is
+ * starting.
+ *
+ * `ActionCard` CONCATENATES this with `buttonLabel`, and the prototype card is the
+ * only one whose label changes: idle it is a verb ("Build Prototype"), in flight it
+ * is a whole sentence ("Building…"). Passing the prefix unconditionally therefore
+ * reads "Configure & Building…" for the duration of every start request. The five
+ * sibling cards never hit this because none of them has a busy label.
+ *
+ * A module-level function rather than a ternary at the call site, so `OverviewTab`
+ * stays under the complexity ceiling — the inline form put it at 13 of 12. It takes
+ * the build control rather than a boolean, matching `prototypeStatusLine` below: a
+ * bare boolean parameter is a behaviour selector, which the lint rules reject and
+ * which reads worse at the call site anyway.
+ */
+function configurePrefix(build: PrototypeBuildControl, t: TFunction): string | undefined {
+  return build.busy ? undefined : t('overview.configureAnd')
 }
 
 interface ActionCardProps {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.jobHandover.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.jobHandover.test.tsx
@@ -14,7 +14,7 @@
  * this proves ProjectDetail actually wires that prop to the query.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
@@ -105,6 +105,8 @@ describe('ProjectDetail job handover (U9)', () => {
     const callsBeforeBuild = mockGetJobs.mock.calls.length
 
     await user.click(buildButton)
+    await user.click(within(screen.getByRole('dialog'))
+      .getByRole('button', { name: /build anyway/i }))
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     // Without the handover this stays at 1 forever: refetchInterval is 0 while
@@ -145,6 +147,8 @@ describe('ProjectDetail job handover (U9)', () => {
     const callsBeforeBuild = mockGetJobs.mock.calls.length
 
     await user.click(buildButton)
+    await user.click(within(screen.getByRole('dialog'))
+      .getByRole('button', { name: /build anyway/i }))
 
     // The start failed, so there is no job to show; the error belongs inline.
     await waitFor(() => expect(screen.getByText(/Bedrock unavailable/)).toBeInTheDocument())

--- a/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.jobHandover.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/ProjectDetail.jobHandover.test.tsx
@@ -100,13 +100,13 @@ describe('ProjectDetail job handover (U9)', () => {
     const user = userEvent.setup()
     renderProjectDetail()
 
-    const buildButton = await screen.findByRole('button', { name: /build prototype/i })
+    const buildButton = await screen.findByRole('button', { name: /configure & build prototype/i })
     await waitFor(() => expect(mockGetJobs).toHaveBeenCalled())
     const callsBeforeBuild = mockGetJobs.mock.calls.length
 
     await user.click(buildButton)
     await user.click(within(screen.getByRole('dialog'))
-      .getByRole('button', { name: /build anyway/i }))
+      .getByRole('button', { name: /^build prototype$/i }))
 
     await waitFor(() => expect(mockBuildPrototype).toHaveBeenCalledTimes(1))
     // Without the handover this stays at 1 forever: refetchInterval is 0 while
@@ -142,13 +142,13 @@ describe('ProjectDetail job handover (U9)', () => {
     mockBuildPrototype.mockRejectedValue(new Error('Bedrock unavailable'))
     renderProjectDetail()
 
-    const buildButton = await screen.findByRole('button', { name: /build prototype/i })
+    const buildButton = await screen.findByRole('button', { name: /configure & build prototype/i })
     await waitFor(() => expect(mockGetJobs).toHaveBeenCalled())
     const callsBeforeBuild = mockGetJobs.mock.calls.length
 
     await user.click(buildButton)
     await user.click(within(screen.getByRole('dialog'))
-      .getByRole('button', { name: /build anyway/i }))
+      .getByRole('button', { name: /^build prototype$/i }))
 
     // The start failed, so there is no job to show; the error belongs inline.
     await waitFor(() => expect(screen.getByText(/Bedrock unavailable/)).toBeInTheDocument())

--- a/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
@@ -46,22 +46,22 @@ function hasOnlyOneDoc(hasPrd: boolean, hasPrfaq: boolean): boolean {
  * duplicate is the more consequential surprise of the two.
  */
 /** One of the three confirm keys — not `string`, so a typo cannot compile. */
-type ConfirmKey = (typeof CONFIRM_MESSAGE)[keyof typeof CONFIRM_MESSAGE]
+type WarningKey = (typeof WARNING_MESSAGE)[keyof typeof WARNING_MESSAGE]
 
-function confirmKeyFor(
+function warningKeyFor(
   hasPrd: boolean,
   hasPrfaq: boolean,
   hasExistingPrototype: boolean,
   hasChoice: boolean,
-): ConfirmKey | null {
-  if (hasExistingPrototype) return CONFIRM_MESSAGE.rebuild
-  if (hasOnlyOneDoc(hasPrd, hasPrfaq)) return CONFIRM_MESSAGE[hasPrd ? 'prd' : 'prfaq']
+): WarningKey | null {
+  if (hasExistingPrototype) return WARNING_MESSAGE.rebuild
+  if (hasOnlyOneDoc(hasPrd, hasPrfaq)) return WARNING_MESSAGE[hasPrd ? 'prd' : 'prfaq']
   // More than one document of a type exists, so "the latest" is a decision rather
   // than the only option — stop and name what will be read. Deliberately NOT
   // raised when there is exactly one of each: the dialog would present a choice
   // that has one possible answer, and the build has always started on the first
   // click in that case.
-  if (hasChoice) return CONFIRM_MESSAGE.choose
+  if (hasChoice) return WARNING_MESSAGE.choose
   return null
 }
 
@@ -73,7 +73,7 @@ function confirmKeyFor(
 // real `en` catalogue, so a key that is missing or has moved renders its raw path
 // and fails a test. A `defaultValue` hides exactly that, which is how buttons once
 // shipped announcing `editForm` to assistive tech.
-const CONFIRM_MESSAGE = {
+const WARNING_MESSAGE = {
   prd: 'documents.prototype.confirmPrdOnly',
   prfaq: 'documents.prototype.confirmPrfaqOnly',
   // A prototype already exists. This is the one that costs money to get wrong: the
@@ -372,7 +372,7 @@ export function usePrototypeBuild({
   // that raised no warning used to get no way in. Keeping the two jobs separate is
   // the point: the warning may follow live data, the wizard's visibility may not.
   const hasChoice = prdOptions.length > 1 || prfaqOptions.length > 1
-  const warningKey = confirmKeyFor(hasPrd, hasPrfaq, hasExistingPrototype, hasChoice)
+  const warningKey = warningKeyFor(hasPrd, hasPrfaq, hasExistingPrototype, hasChoice)
 
   // Only the *start* call is reported here.
   const runBuild = useCallback(async () => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/usePrototypeBuild.ts
@@ -97,13 +97,17 @@ export interface PrototypeBuildControl {
   /** True briefly after a successful start, covering the gap before the panel refetches. */
   readonly started: boolean
   /**
-   * State for the confirm dialog. Open only while the reason it was opened for is
-   * still the reason that applies, so `message` is empty exactly when `isOpen` is
-   * false rather than needing its own check at the call site.
+   * State for the build wizard — where this build is configured and started.
+   *
+   * `isOpen` is owned by the hook and changes only on an explicit user action, so
+   * the selections inside survive a document refetch. `warning` is independent of
+   * it: live-derived, and empty when nothing needs saying, which is why a caller
+   * renders it conditionally rather than assuming an open panel has a warning.
    */
-  readonly confirm: {
+  readonly wizard: {
     readonly isOpen: boolean
-    readonly message: string
+    /** '' when this build needs no caution. Never gates the panel. */
+    readonly warning: string
     readonly onConfirm: () => void
     readonly onCancel: () => void
   }
@@ -127,10 +131,14 @@ export interface PrototypeBuildControl {
    * flag-and-list pair, and the visual list (which has no flag — see
    * `selectedVisualIds`).
    *
-   * These live on the card rather than in the confirm dialog, and that is a
-   * requirement rather than a preference: `confirmKeyFor` deliberately returns
-   * null for a project with one PRD, one PR-FAQ and no prototype, so a control
-   * placed in the dialog is unreachable for exactly the simplest project.
+   * These live in the build wizard, beside the PRD/PR-FAQ pickers, so one panel
+   * answers the whole "what should this build read?" question and the card keeps
+   * the single button its five siblings have.
+   *
+   * They used to sit on the card face, because the dialog that existed then opened
+   * for only some projects and a control inside it was unreachable for the rest.
+   * That constraint is gone: the wizard opens for every project, which is the
+   * property `OverviewTab.prototypeWizard.test.tsx` exists to hold.
    */
   readonly extras: {
     readonly useProductContext: boolean
@@ -275,8 +283,9 @@ export function usePrototypeBuild({
   // Lowers itself: the panel takes over, so the line must not outlive the gap.
   const started = useTransientFlag()
   const [error, setError] = useState<string | null>(null)
-  // The question that was asked, not a bare "a dialog is open" flag — see `openKey`.
-  const [askedKey, setAskedKey] = useState<ConfirmKey | null>(null)
+  // Whether the build wizard is on screen. A bare boolean is correct here, unlike
+  // in the dialog this replaces — the reasoning is at the `wizard` return value.
+  const [isOpen, setIsOpen] = useState(false)
 
   // The effective choice: what the user picked if that document is still offered,
   // otherwise the newest of the type. A selection whose document has been deleted
@@ -354,18 +363,16 @@ export function usePrototypeBuild({
     ))
   }, [visualOptions])
 
-  // THREE reasons to stop and ask, through the ConfirmModal pattern every other
-  // guarded action uses (this began as a window.confirm, which cannot be styled):
-  // only one of PRD/PR-FAQ exists, a prototype already does, or a type has several
-  // documents so "the latest" is a decision. Null means none applies and the build
-  // starts on the first click, as it always has for one-of-each.
+  // THREE things worth saying before a build runs: only one of PRD/PR-FAQ exists, a
+  // prototype already does (so this one costs money for a duplicate), or a type has
+  // several documents so "the latest" is a decision. Null means none applies.
   //
-  // Derived from the option COUNTS, never from the selection: a key derived from
-  // what the user picked would change the moment they picked it, and `openKey`
-  // below closes a dialog whose reason no longer applies — so choosing a document
-  // would dismiss the dialog you chose it in.
+  // This SELECTS A WARNING. It no longer decides whether anything opens — the
+  // wizard always opens, because it is where the build is configured and a project
+  // that raised no warning used to get no way in. Keeping the two jobs separate is
+  // the point: the warning may follow live data, the wizard's visibility may not.
   const hasChoice = prdOptions.length > 1 || prfaqOptions.length > 1
-  const confirmKey = confirmKeyFor(hasPrd, hasPrfaq, hasExistingPrototype, hasChoice)
+  const warningKey = confirmKeyFor(hasPrd, hasPrfaq, hasExistingPrototype, hasChoice)
 
   // Only the *start* call is reported here.
   const runBuild = useCallback(async () => {
@@ -416,35 +423,38 @@ export function usePrototypeBuild({
   }, [projectId, hasPrd, hasPrfaq, prdId, prfaqId, useProductContext, useResearch,
       selectedResearchIds, selectedVisualIds, i18n.language, onJobStarted, started])
 
-  const onClick = useCallback(() => {
-    if (confirmKey != null) {
-      setAskedKey(confirmKey)
-      return
-    }
-    void runBuild()
-  }, [confirmKey, runBuild])
+  // Opening is now the card's whole job: no build starts from the card, so this
+  // never spends money.
+  const onClick = useCallback(() => setIsOpen(true), [])
 
   const onConfirm = useCallback(() => {
-    setAskedKey(null)
+    setIsOpen(false)
     void runBuild()
   }, [runBuild])
 
-  const onCancel = useCallback(() => setAskedKey(null), [])
-
-  // The question on screen: the one the click raised, and only while it still
-  // applies. `confirmKey` is derived from live data that changes under an open dialog
-  // (documents refetch when a job completes), so a boolean open-flag beside it could
-  // disagree with the message — leaving it blank, rewritten, or re-raised unasked.
-  const openKey = askedKey != null && askedKey === confirmKey ? askedKey : null
+  const onCancel = useCallback(() => setIsOpen(false), [])
 
   return {
     onClick,
     busy,
     error,
     started: started.isSet,
-    confirm: {
-      isOpen: openKey != null,
-      message: openKey == null ? '' : t(openKey),
+    wizard: {
+      // 🔑 A PLAIN BOOLEAN, deliberately, and this is the one place where copying
+      // the old `openKey` comparison would be a bug rather than a safeguard.
+      //
+      // That comparison existed to close a dialog whose *reason* had gone stale —
+      // correct for something that only asked a question, because the question was
+      // the whole content. This panel holds the user's SELECTIONS, and `warningKey`
+      // is derived from documents that refetch whenever a job completes. Closing on
+      // a reason change would therefore discard ticked research and visuals
+      // mid-interaction, in response to something the user did not do.
+      //
+      // So visibility is owned here and changes only on an explicit onClick,
+      // onConfirm or onCancel. The WARNING still follows live data, which is what
+      // #294/#296 actually required: the text may never contradict the documents.
+      isOpen,
+      warning: warningKey == null ? '' : t(warningKey),
       onConfirm,
       onCancel,
     },


### PR DESCRIPTION
## What this changes

Project Overview step 5 carried about a dozen build-configuration tick-boxes on the card surface, while its five siblings each have a single button. They were there by elimination rather than by design: the confirm dialog they would otherwise have lived in opened for only *some* projects, so a control inside it would have been unreachable for the simplest one — a project with one PRD, one PR/FAQ and no prototype.

That is an argument against **that dialog**, not for the card face. The card now opens a wizard, which is where the build is configured and started.

It also fixes something adjacent that was not raised: **pressing Build was unpredictable**. Because the confirm fired on three conditions, a project with two PRDs opened a dialog and a project with one of each immediately started a billable multi-minute build. A user could not tell which they would get. Now it always opens the wizard, and nothing is spent until the wizard's own button.

## The gate had to go with the move, not after it

`confirmKeyFor` decided whether anything opened at all, so the controls could not become reachable for every project while it remained. Sequencing them separately would leave the configuration in two places at once, which is worse than either end state.

- `usePrototypeBuild` owns a plain `isOpen`. `confirmKeyFor` is demoted from a gate to a **warning selector**, so the panel always opens and the caution still follows live documents.
- **This is the one place where copying the old `askedKey`/`openKey` comparison would be a bug.** That comparison closed a dialog whose *reason* had gone stale — correct for something whose whole content is a question, wrong for something holding the user's selections, because documents refetch whenever a job completes and the ticks would be discarded by an unrelated job finishing. Visibility is now owned; the warning stays derived.
- `PrototypeBuildWizard` is built on `ModalShell`, which already owns the dialog role, the accessible name, the focus trap, Escape and correct nesting. Not `ConfirmModal`, which requires a `message` — right for a question, wrong for a form.
- `ActionCard` loses `controls`, a prop only one of six cards passed.

Both existing guards on the billable endpoint are kept, and opening the wizard starts no build.

## Tests: what was retired, and what it was traded for

`OverviewTab.prototypeWizard.test.tsx` replaces the old "controls are reachable without a dialog" property with the one it is traded for: **the configuration is reachable for every project, including the case that previously opened nothing.** Parametrised over all five project shapes.

The panel is identified by what it *contains* rather than by role, because four of the five shapes already opened a dialog and a role-only assertion would pass on unchanged code.

Four suites asserted the old placement. Most of that was mechanical, but these assertions were about properties deliberately gone, and each is rewritten rather than deleted because each protected something that still matters:

| Retired | Replaced by |
|---|---|
| builds immediately without a confirmation when both documents exist | opens with **no warning** and spends nothing until the wizard's button |
| does not ask when there is exactly one of each | the picker is shown and offers **no select** — a one-answer choice must not be presented as a choice |
| closes the confirm when its reason disappears | panel **stays open**, caution **clears** |
| closes the confirm rather than swapping its question for a costlier one | panel stays open, caution **escalates** to the rebuild warning |
| does not re-open the confirm when a later reason arrives | kept in substance: **never opens on its own**, whatever the documents do |
| a disabled card renders no tick-boxes | a disabled button **cannot open the panel** — absence of tick-boxes alone would be *weaker*, since they are absent on every unopened card |

### One residual risk, named rather than hidden

Because the caution is derived from live documents, it can now **escalate under an open panel**: a prototype arriving mid-interaction changes what pressing Build costs, from "build from the PRD alone" to "build a second and keep the first". This is materially weaker than the #296 defect it replaces — there a stale message sat one click from spending, whereas here the caution renders into the panel the user is looking at and they must still press Build — but it is not nothing, so there is a test for it.

### Eight tests had started passing for the wrong reason

They assert "asks for confirmation instead of building". The wizard always asks, so the assertion became true for every project and the suite would be green whichever way the code went — their discriminator ceased to exist. Found by auditing the passes I could not account for, not the failures. Renamed and re-pointed at what they can still tell apart.

## Verification

- frontend vitest **2622 / 2622** (174 files); 2613 baseline + 9 new reconciles exactly
- `tsc` 0 errors; eslint 0 on the changed files
- **i18n gate byte-identical to `development`**, measured against the base directly rather than assumed — no catalogue was touched and no key added

## Deliberately not in this PR

1. **A second entry point from the Documents tab.** The issue proposes one wizard invoked from both the card and the prototype pane, which satisfies U23's "open the surface, not a dialog" principle without making the card useless. It needs a decision on U24's larger question first.
2. **The submit label.** It still reads "Build anyway", which is odd with no warning to build anyway *despite*. The clean fix adds no keys — submit reuses `documents.prototype.button` and the card takes the `overview.configureAnd` prefix its five siblings already carry — but it is a wording decision rather than a refactor.
3. `ActionCard.statusLine` remains prototype-only, the last single-call-site prop.

Refs `analysis/UI-prototype-build-configuration-GITHUB-ISSUE.md`, which records the two corrections this work forced on its own plan.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).
