### PR TITLE
fix(prioritization): honest partial ballots (#342, #343)

### DIFF
--- a/voc-datalake/frontend/public/locales/de/prioritization.json
+++ b/voc-datalake/frontend/public/locales/de/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "Auswirkung",
     "impactDescription": "Geschäftswert und Kundennutzen",
     "low": "Niedrig",
+    "notScored": "Nicht bewertet",
     "slow": "Langsam",
     "strategicFit": "Strategische Passung",
     "strategicFitDescription": "Übereinstimmung mit Unternehmenszielen",

--- a/voc-datalake/frontend/public/locales/en/prioritization.json
+++ b/voc-datalake/frontend/public/locales/en/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "Impact",
     "impactDescription": "Business value and customer benefit",
     "low": "Low",
+    "notScored": "Not scored",
     "slow": "Slow",
     "strategicFit": "Strategic Fit",
     "strategicFitDescription": "Alignment with company goals",

--- a/voc-datalake/frontend/public/locales/es/prioritization.json
+++ b/voc-datalake/frontend/public/locales/es/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "Impacto",
     "impactDescription": "Valor comercial y beneficio para el cliente",
     "low": "Bajo",
+    "notScored": "Sin puntuar",
     "slow": "Lento",
     "strategicFit": "Ajuste estratégico",
     "strategicFitDescription": "Alineación con los objetivos de la empresa",

--- a/voc-datalake/frontend/public/locales/fr/prioritization.json
+++ b/voc-datalake/frontend/public/locales/fr/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "Portée",
     "impactDescription": "Valeur commerciale et bénéfice client",
     "low": "Faible",
+    "notScored": "Non noté",
     "slow": "Lent",
     "strategicFit": "Adéquation stratégique",
     "strategicFitDescription": "Alignement avec les objectifs de l'entreprise",

--- a/voc-datalake/frontend/public/locales/ja/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ja/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "インパクト",
     "impactDescription": "ビジネス価値と顧客メリット",
     "low": "低",
+    "notScored": "未採点",
     "slow": "遅い",
     "strategicFit": "戦略的適合性",
     "strategicFitDescription": "会社の目標との整合性",

--- a/voc-datalake/frontend/public/locales/ko/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ko/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "영향도",
     "impactDescription": "비즈니스 가치 및 고객 이점",
     "low": "낮음",
+    "notScored": "미채점",
     "slow": "느림",
     "strategicFit": "전략적 부합도",
     "strategicFitDescription": "회사 목표와의 부합도",

--- a/voc-datalake/frontend/public/locales/pt/prioritization.json
+++ b/voc-datalake/frontend/public/locales/pt/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "Impacto",
     "impactDescription": "Valor comercial e benefício ao cliente",
     "low": "Baixo",
+    "notScored": "Sem pontuação",
     "slow": "Lento",
     "strategicFit": "Alinhamento Estratégico",
     "strategicFitDescription": "Alinhamento com objetivos da empresa",

--- a/voc-datalake/frontend/public/locales/zh/prioritization.json
+++ b/voc-datalake/frontend/public/locales/zh/prioritization.json
@@ -129,6 +129,7 @@
     "impact": "影响力",
     "impactDescription": "业务价值和客户收益",
     "low": "低",
+    "notScored": "未评分",
     "slow": "缓慢",
     "strategicFit": "战略契合度",
     "strategicFitDescription": "与公司目标的一致性",

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -55,6 +55,30 @@ function unscoredLabel(kind: TeamView['kind'], t: TFunction): string {
 }
 
 /**
+ * One team number as the row prints it: the value to one decimal, or the dash
+ * for an axis nobody scored (`null`). One renderer, because the three chips
+ * printing independently is how a dash and a `0.0` could otherwise coexist for
+ * the same absence. The dash itself is decorative (the treatment every dash on
+ * this page gets); the state is carried by visually-hidden text using the same
+ * catalogue key the slider's `aria-valuetext` uses, so a screen reader hears
+ * "not scored" where a sighted reader sees the dash — not silence.
+ */
+function TeamNumber({ value, notScoredLabel }: {
+  readonly value: number | null
+  readonly notScoredLabel: string
+}): ReactElement {
+  if (value === null) {
+    return (
+      <>
+        <span aria-hidden="true" className="text-gray-300">—</span>
+        <span className="sr-only">{notScoredLabel}</span>
+      </>
+    )
+  }
+  return <>{value.toFixed(1)}</>
+}
+
+/**
  * The resting row's numbers: what the TEAM said about this document.
  *
  * Not the caller's own ballot, which used to be here and now lives behind the
@@ -83,19 +107,6 @@ function unscoredLabel(kind: TeamView['kind'], t: TFunction): string {
  * ballot produces a mean equal to that ballot and a spread of zero: without the
  * count, "one person looked" is indistinguishable from "we agree".
  */
-/**
- * One team number as the row prints it: the value to one decimal, or the
- * decorative dash for an axis nobody scored (`null`). One renderer, because the
- * three chips printing independently is how a dash and a `0.0` could otherwise
- * coexist for the same absence.
- */
-function TeamNumber({ value }: { readonly value: number | null }): ReactElement {
-  if (value === null) {
-    return <span aria-hidden="true" className="text-gray-300">—</span>
-  }
-  return <>{value.toFixed(1)}</>
-}
-
 function TeamScoreSummary({ team }: { readonly team: TeamView }): ReactElement {
   const { t } = useTranslation('prioritization')
   if (team.kind !== 'scored') {
@@ -129,11 +140,11 @@ function TeamScoreSummary({ team }: { readonly team: TeamView }): ReactElement {
           0.0 for it, and printing that ranked "nobody mentioned time to market"
           as "the team rated it worst" (#343). */}
       <div className="text-center">
-        <div className="text-base sm:text-lg font-bold text-blue-600"><TeamNumber value={scored.displayImpact} /></div>
+        <div className="text-base sm:text-lg font-bold text-blue-600"><TeamNumber value={scored.displayImpact} notScoredLabel={t('scores.notScored')} /></div>
         <div className="text-xs text-gray-500">{t('scores.impact')}</div>
       </div>
       <div className="text-center">
-        <div className="text-base sm:text-lg font-bold text-purple-600"><TeamNumber value={scored.displayTimeToMarket} /></div>
+        <div className="text-base sm:text-lg font-bold text-purple-600"><TeamNumber value={scored.displayTimeToMarket} notScoredLabel={t('scores.notScored')} /></div>
         <div className="text-xs text-gray-500">{t('sort.ttm')}</div>
       </div>
       <div className="text-center px-2 sm:px-3 py-1 bg-gray-50 rounded-lg">
@@ -142,7 +153,7 @@ function TeamScoreSummary({ team }: { readonly team: TeamView }): ReactElement {
             two roundings of it. Null — a ballot that expressed no axis at all,
             only a note — prints the dash, and the band beside the title reads
             "Not Scored" off the same null. */}
-        <div className="text-lg sm:text-xl font-bold text-green-600"><TeamNumber value={scored.displayComposite} /></div>
+        <div className="text-lg sm:text-xl font-bold text-green-600"><TeamNumber value={scored.displayComposite} notScoredLabel={t('scores.notScored')} /></div>
         {/* Labelled as the TEAM's score, not "Score": this number changed meaning
             from "my composite" to "the team's mean composite", and a row a reader
             cannot attribute is worse than either alone. */}

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -83,6 +83,19 @@ function unscoredLabel(kind: TeamView['kind'], t: TFunction): string {
  * ballot produces a mean equal to that ballot and a spread of zero: without the
  * count, "one person looked" is indistinguishable from "we agree".
  */
+/**
+ * One team number as the row prints it: the value to one decimal, or the
+ * decorative dash for an axis nobody scored (`null`). One renderer, because the
+ * three chips printing independently is how a dash and a `0.0` could otherwise
+ * coexist for the same absence.
+ */
+function TeamNumber({ value }: { readonly value: number | null }): ReactElement {
+  if (value === null) {
+    return <span aria-hidden="true" className="text-gray-300">—</span>
+  }
+  return <>{value.toFixed(1)}</>
+}
+
 function TeamScoreSummary({ team }: { readonly team: TeamView }): ReactElement {
   const { t } = useTranslation('prioritization')
   if (team.kind !== 'scored') {
@@ -111,19 +124,25 @@ function TeamScoreSummary({ team }: { readonly team: TeamView }): ReactElement {
           order two rows that show the same number. One rounding, shared — the rule
           `displayComposite` already follows. Captions are `text-gray-500` (4.63:1 on this
           white row) rather than `text-gray-400` (2.49:1), which is under AA at this size. */}
+      {/* An axis nobody scored is `null` and prints as the same decorative dash
+          the non-scored branch above uses — never a number. The backend reports
+          0.0 for it, and printing that ranked "nobody mentioned time to market"
+          as "the team rated it worst" (#343). */}
       <div className="text-center">
-        <div className="text-base sm:text-lg font-bold text-blue-600">{scored.displayImpact.toFixed(1)}</div>
+        <div className="text-base sm:text-lg font-bold text-blue-600"><TeamNumber value={scored.displayImpact} /></div>
         <div className="text-xs text-gray-500">{t('scores.impact')}</div>
       </div>
       <div className="text-center">
-        <div className="text-base sm:text-lg font-bold text-purple-600">{scored.displayTimeToMarket.toFixed(1)}</div>
+        <div className="text-base sm:text-lg font-bold text-purple-600"><TeamNumber value={scored.displayTimeToMarket} /></div>
         <div className="text-xs text-gray-500">{t('sort.ttm')}</div>
       </div>
       <div className="text-center px-2 sm:px-3 py-1 bg-gray-50 rounded-lg">
         {/* The same rounded value the priority band beside the title classifies, so
             the printed number and the label describing it are one value rather than
-            two roundings of it. */}
-        <div className="text-lg sm:text-xl font-bold text-green-600">{scored.displayComposite.toFixed(1)}</div>
+            two roundings of it. Null — a ballot that expressed no axis at all,
+            only a note — prints the dash, and the band beside the title reads
+            "Not Scored" off the same null. */}
+        <div className="text-lg sm:text-xl font-bold text-green-600"><TeamNumber value={scored.displayComposite} /></div>
         {/* Labelled as the TEAM's score, not "Score": this number changed meaning
             from "my composite" to "the team's mean composite", and a row a reader
             cannot attribute is worse than either alone. */}
@@ -326,8 +345,12 @@ function TeamScorePanel({ team }: { readonly team: TeamView }): ReactElement {
       {score ? (
         <>
           <p className="text-sm text-indigo-900 mt-1">
+            {/* A null composite — a ballot that expressed no axis, only a note —
+                interpolates the same dash the chips print, keeping one key in
+                eight catalogues rather than a second sentence for a state the
+                reviewer count beside it already explains. */}
             {t('team.summary', {
-              score: score.displayComposite.toFixed(1),
+              score: score.displayComposite === null ? '—' : score.displayComposite.toFixed(1),
               reviewers: score.reviewerCount,
             })}
           </p>
@@ -439,10 +462,16 @@ function PRFAQRowExpanded({
               </p>
             ) : null}
           </div>
-          <ScoreSlider label={t('scores.impact')} value={score.impact === 0 ? 3 : score.impact} onChange={(v) => onUpdateScore('impact', v)} description={t('scores.impactDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
-          <ScoreSlider label={t('scores.timeToMarket')} value={score.time_to_market === 0 ? 3 : score.time_to_market} onChange={(v) => onUpdateScore('time_to_market', v)} description={t('scores.timeToMarketDescription')} lowLabel={t('scores.slow')} highLabel={t('scores.fast')} />
-          <ScoreSlider label={t('scores.strategicFit')} value={score.strategic_fit === 0 ? 3 : score.strategic_fit} onChange={(v) => onUpdateScore('strategic_fit', v)} description={t('scores.strategicFitDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
-          <ScoreSlider label={t('scores.confidence')} value={score.confidence === 0 ? 3 : score.confidence} onChange={(v) => onUpdateScore('confidence', v)} description={t('scores.confidenceDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
+          {/* The stored value goes in RAW: 0 means unscored (the API's own
+              contract) and `ScoreSlider` renders it as such. The old
+              `=== 0 ? 3` coercion here painted a mid-range number the record
+              did not hold, indistinguishable from a stored 3 — so a reviewer
+              whose partial save recorded three axes as nothing could never
+              discover it on screen (#343). */}
+          <ScoreSlider label={t('scores.impact')} value={score.impact} onChange={(v) => onUpdateScore('impact', v)} description={t('scores.impactDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
+          <ScoreSlider label={t('scores.timeToMarket')} value={score.time_to_market} onChange={(v) => onUpdateScore('time_to_market', v)} description={t('scores.timeToMarketDescription')} lowLabel={t('scores.slow')} highLabel={t('scores.fast')} />
+          <ScoreSlider label={t('scores.strategicFit')} value={score.strategic_fit} onChange={(v) => onUpdateScore('strategic_fit', v)} description={t('scores.strategicFitDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
+          <ScoreSlider label={t('scores.confidence')} value={score.confidence} onChange={(v) => onUpdateScore('confidence', v)} description={t('scores.confidenceDescription')} lowLabel={t('scores.low')} highLabel={t('scores.high')} />
           <div>
             <label className="text-sm font-medium text-gray-700">{t('notes.label')}</label>
             {/* Bounded, because the API REFUSES a longer note rather than

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -625,6 +625,18 @@ describe('Prioritization', () => {
 
       expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
       expect(mockPatchPrioritizationScores).not.toHaveBeenCalled()
+
+      // The stuck-flag variant: a press that STARTS on the slider and ends
+      // elsewhere must not leave the guard armed — without clearing it on
+      // pointerleave, the NEXT unrelated release over the input casts the
+      // resting value, the exact stray vote the guard exists to prevent, one
+      // interaction later.
+      fireEvent.pointerDown(sliders[1])
+      fireEvent.pointerLeave(sliders[1])
+      fireEvent.pointerUp(sliders[1])
+
+      expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+      expect(mockPatchPrioritizationScores).not.toHaveBeenCalled()
     })
 
     it('says nobody has scored a document absent from the aggregate', async () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -625,14 +625,27 @@ describe('Prioritization', () => {
 
       expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
       expect(mockPatchPrioritizationScores).not.toHaveBeenCalled()
+    })
 
-      // The stuck-flag variant: a press that STARTS on the slider and ends
-      // elsewhere must not leave the guard armed — without clearing it on
-      // pointerleave, the NEXT unrelated release over the input casts the
-      // resting value, the exact stray vote the guard exists to prevent, one
-      // interaction later.
+    it('a press that starts on an unscored slider and ends elsewhere does not arm the next stray release', async () => {
+      // The stuck-flag case: without clearing the guard on pointerleave, a
+      // press that started on the slider and ended off it leaves the flag
+      // armed, and the NEXT unrelated release over the input casts the resting
+      // value — the exact stray vote the guard exists to prevent, one
+      // interaction later. Removing the clearing handlers fails this test.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '2025-01-01' },
+      ]))
+      mockGetPrioritizationScores.mockResolvedValue({ scores: {}, aggregates: {} })
+      const user = userEvent.setup()
+
+      renderPrioritization()
+      await user.click(await screen.findByText('Feature A PR/FAQ'))
+      const sliders = await screen.findAllByRole('slider')
+
       fireEvent.pointerDown(sliders[1])
       fireEvent.pointerLeave(sliders[1])
+      // The press ended elsewhere; this later release over the input is stray.
       fireEvent.pointerUp(sliders[1])
 
       expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -573,6 +573,60 @@ describe('Prioritization', () => {
       }
     })
 
+    it('releasing a press on an unscored slider commits the resting value, so exactly-3 is reachable by click', async () => {
+      // Clicking the track AT the resting position fires no `change` (the value
+      // did not move), so without this path a reviewer who wants exactly 3 has
+      // no way to say so short of wiggling the handle. The commit reads the
+      // value off the CONTROL at release — not this render's props — so a
+      // click-at-5 (whose `change` fires first) cannot be rewritten back to 3
+      // by a stale closure. Reverting the onPointerUp path fails this test:
+      // no change event fires, no edit is recorded, Save stays disabled.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '2025-01-01' },
+      ]))
+      mockGetPrioritizationScores.mockResolvedValue({ scores: {}, aggregates: {} })
+      const user = userEvent.setup()
+
+      renderPrioritization()
+      await user.click(await screen.findByText('Feature A PR/FAQ'))
+      const sliders = await screen.findAllByRole('slider')
+      expect(sliders[1]).toHaveAttribute('aria-valuetext', 'Not scored')
+
+      // A press that starts AND ends on the control, without moving: the
+      // click-at-the-resting-position case.
+      fireEvent.pointerDown(sliders[1])
+      fireEvent.pointerUp(sliders[1])
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+      })
+      await user.click(screen.getByRole('button', { name: /save/i }))
+      expect(mockPatchPrioritizationScores).toHaveBeenCalledWith({
+        [R.d1]: { row_id: R.d1, time_to_market: 3 },
+      })
+    })
+
+    it('a pointer released over an unscored slider after going down elsewhere casts nothing', async () => {
+      // `pointerup` fires on whatever the pointer is over when it is released,
+      // including a press that started on the row header and drifted. A stray
+      // release must not cast a vote nobody aimed at the control.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '2025-01-01' },
+      ]))
+      mockGetPrioritizationScores.mockResolvedValue({ scores: {}, aggregates: {} })
+      const user = userEvent.setup()
+
+      renderPrioritization()
+      await user.click(await screen.findByText('Feature A PR/FAQ'))
+      const sliders = await screen.findAllByRole('slider')
+
+      // Release over the control with NO pointerdown on it first.
+      fireEvent.pointerUp(sliders[1])
+
+      expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+      expect(mockPatchPrioritizationScores).not.toHaveBeenCalled()
+    })
+
     it('says nobody has scored a document absent from the aggregate', async () => {
       // The defect this closes: DEFAULT_SCORE has time_to_market 3 and the old
       // summary substituted 3 for an unset axis, so an untouched proposal

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -514,8 +514,9 @@ describe('Prioritization', () => {
       })
       await user.click(screen.getByText('Feature A PR/FAQ'))
       const sliders = await screen.findAllByRole('slider')
-      // Exactly one slider moves. The other three display 3 — the seeding that makes
-      // the control usable — and that display value must not become a vote.
+      // Exactly one slider moves. The other three read "Not scored" (#343 —
+      // the handle rests mid-track as presentation, but no number is asserted
+      // on screen), and an unscored axis must not become a vote.
       fireEvent.change(sliders[0], { target: { value: '5' } })
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
@@ -531,6 +532,44 @@ describe('Prioritization', () => {
       const body = mockPatchPrioritizationScores.mock.calls[0][0]
       for (const axis of ['time_to_market', 'confidence', 'strategic_fit', 'notes']) {
         expect(Object.hasOwn(body[R.d1], axis), axis).toBe(false)
+      }
+    })
+
+    it('shows a stored partial ballot as it is recorded: the scored axis a number, the rest not scored', async () => {
+      // The assertion nothing made before #343. The editor coerced a stored 0
+      // to a displayed 3 — purely for display, never written — so after a
+      // partial save the sliders read 4/3/3/3 against a record of 4/0/0/0,
+      // and the reviewer could never discover on screen that three quarters of
+      // their ballot was recorded as nothing. Reproduced on production before
+      // it was fixed; this pins that the editor and the record now agree.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '2025-01-01' },
+      ]))
+      mockGetPrioritizationScores.mockResolvedValue({
+        // Exactly what the API returns after `PATCH {impact: 4}` on a fresh
+        // row: the expressed axis, and 0.0 (the wire encoding of "absent") for
+        // the rest.
+        scores: {
+          [R.d1]: { row_id: R.d1, impact: 4, time_to_market: 0, confidence: 0, strategic_fit: 0, notes: '' },
+        },
+        aggregates: {
+          [R.d1]: { impact: 4, time_to_market: 0, confidence: 0, strategic_fit: 0, reviewer_count: 1, score_spread: 0 },
+        },
+      })
+      const user = userEvent.setup()
+
+      renderPrioritization()
+      await user.click(await screen.findByText('Feature A PR/FAQ'))
+      const sliders = await screen.findAllByRole('slider')
+
+      // The one scored axis reads as its number...
+      expect(sliders[0]).toHaveValue('4')
+      expect(sliders[0]).not.toHaveAttribute('aria-valuetext')
+      // ...and each unscored one says so where a screen reader listens. The
+      // handle may REST at mid-track (a range input cannot be valueless), but
+      // no number is presented as the axis's value.
+      for (const slider of sliders.slice(1)) {
+        expect(slider).toHaveAttribute('aria-valuetext', 'Not scored')
       }
     })
 

--- a/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
@@ -4,10 +4,21 @@
  */
 
 import clsx from 'clsx'
+import { useTranslation } from 'react-i18next'
 import { getScoreColor } from './prioritizationUtils'
+
+/**
+ * Where an unscored slider's handle rests. A range input must hold SOME
+ * position — `min={1}` cannot represent "no value" — so the handle sits in the
+ * middle while the badge and `aria-valuetext` say "not scored". The position is
+ * presentation only: it is never written anywhere until the reader drags, at
+ * which point `onChange` reports the dragged value and the axis becomes real.
+ */
+const UNSCORED_HANDLE_POSITION = 3
 
 interface ScoreSliderProps {
   readonly label: string
+  /** The stored axis value, where 0 means UNSCORED (the API's own contract). */
   readonly value: number
   readonly onChange: (v: number) => void
   readonly description?: string
@@ -16,19 +27,60 @@ interface ScoreSliderProps {
   readonly inverted?: boolean
 }
 
+/**
+ * One axis of the caller's own ballot.
+ *
+ * An axis nobody scored (value 0) renders as UNSCORED — a dash in the badge, a
+ * muted handle, and `aria-valuetext` saying so — rather than as a 3. Painting a
+ * 3 was #343: the editor asserted a mid-range value the record did not hold,
+ * indistinguishable from a stored 3, so a reviewer could never discover on
+ * screen that three quarters of their ballot was recorded as nothing. The dash
+ * cannot be misread as a score, which is the same rule the team summary's em
+ * dash follows one level up.
+ */
 export default function ScoreSlider({
   label, value, onChange, description, lowLabel = '1', highLabel = '5', inverted = false,
 }: ScoreSliderProps) {
+  const { t } = useTranslation('prioritization')
+  const unscored = value === 0
+  const position = unscored ? UNSCORED_HANDLE_POSITION : value
   return (
     <div className="space-y-2">
       <div className="flex justify-between items-center">
         <label className="text-sm font-medium text-gray-700">{label}</label>
-        <span className={clsx('text-sm font-bold px-2 py-0.5 rounded', getScoreColor(inverted ? 6 - value : value))}>{value}</span>
+        {unscored ? (
+          /* The dash is decorative (the same treatment as the team summary's);
+             the state itself is announced on the input via aria-valuetext, which
+             is where a screen reader is listening. */
+          <span className="text-sm font-bold px-2 py-0.5 rounded bg-gray-100 text-gray-600" aria-hidden="true">—</span>
+        ) : (
+          <span className={clsx('text-sm font-bold px-2 py-0.5 rounded', getScoreColor(inverted ? 6 - value : value))}>{value}</span>
+        )}
       </div>
       {description != null && description !== '' ? <p className="text-xs text-gray-500">{description}</p> : null}
       <div className="flex items-center gap-2">
         <span className="text-xs text-gray-400 w-16">{lowLabel}</span>
-        <input type="range" min={1} max={5} value={value} onChange={(e) => onChange(Number(e.target.value))} className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600" />
+        <input
+          type="range"
+          min={1}
+          max={5}
+          value={position}
+          aria-valuetext={unscored ? t('scores.notScored') : undefined}
+          onChange={(e) => onChange(Number(e.target.value))}
+          /* A reader who wants EXACTLY the resting position: clicking the track
+             at 3 leaves the value unchanged, so `onChange` never fires and the
+             axis would stay unscored with no way to say "3" short of wiggling.
+             Releasing the pointer on an unscored slider commits wherever it
+             rests — a deliberate press on the control, not a hover or a tab
+             past it, so it cannot cast a vote by accident. (Keyboard readers
+             are covered by onChange itself: the first arrow key changes the
+             value and scores the axis.) */
+          onPointerUp={unscored ? () => onChange(position) : undefined}
+          className={clsx(
+            'flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer',
+            unscored ? 'accent-gray-400' : 'accent-blue-600',
+          )}
+        />
         <span className="text-xs text-gray-400 w-16 text-right">{highLabel}</span>
       </div>
     </div>

--- a/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
@@ -4,6 +4,7 @@
  */
 
 import clsx from 'clsx'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getScoreColor } from './prioritizationUtils'
 
@@ -44,6 +45,11 @@ export default function ScoreSlider({
   const { t } = useTranslation('prioritization')
   const unscored = value === 0
   const position = unscored ? UNSCORED_HANDLE_POSITION : value
+  // Was the press that is now ending a press ON THIS CONTROL? `pointerup` also
+  // fires when a pointer that went down elsewhere is released over the input,
+  // and that stray release must not cast a vote. A ref, not state: it changes
+  // nothing on screen.
+  const pressedHere = useRef(false)
   return (
     <div className="space-y-2">
       <div className="flex justify-between items-center">
@@ -67,15 +73,23 @@ export default function ScoreSlider({
           value={position}
           aria-valuetext={unscored ? t('scores.notScored') : undefined}
           onChange={(e) => onChange(Number(e.target.value))}
+          onPointerDown={() => { pressedHere.current = true }}
           /* A reader who wants EXACTLY the resting position: clicking the track
              at 3 leaves the value unchanged, so `onChange` never fires and the
              axis would stay unscored with no way to say "3" short of wiggling.
-             Releasing the pointer on an unscored slider commits wherever it
-             rests — a deliberate press on the control, not a hover or a tab
-             past it, so it cannot cast a vote by accident. (Keyboard readers
-             are covered by onChange itself: the first arrow key changes the
-             value and scores the axis.) */
-          onPointerUp={unscored ? () => onChange(position) : undefined}
+             Releasing a press that STARTED on an unscored slider commits the
+             value the control holds at release — read off the DOM, not off this
+             render's props, because on a click-at-5 the `change` event fires
+             first and a stale closure would rewrite that deliberate 5 back to
+             the resting 3 if the re-render has not flushed. `pressedHere` keeps
+             a pointer that went down elsewhere and was released over the input
+             from casting a vote nobody aimed at it. (Keyboard readers are
+             covered by onChange itself: the first arrow key scores the axis.) */
+          onPointerUp={(e) => {
+            const pressed = pressedHere.current
+            pressedHere.current = false
+            if (unscored && pressed) onChange(Number(e.currentTarget.value))
+          }}
           className={clsx(
             'flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer',
             unscored ? 'accent-gray-400' : 'accent-blue-600',

--- a/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
@@ -48,8 +48,17 @@ export default function ScoreSlider({
   // Was the press that is now ending a press ON THIS CONTROL? `pointerup` also
   // fires when a pointer that went down elsewhere is released over the input,
   // and that stray release must not cast a vote. A ref, not state: it changes
-  // nothing on screen.
+  // nothing on screen. Cleared on EVERY way a press can stop mattering — up,
+  // leaving the control, cancel, lost capture — because a flag set on
+  // pointerdown and cleared only on pointerup-on-the-input sticks when the
+  // press ends elsewhere, and the NEXT unrelated release over the input would
+  // then cast the resting value: the exact stray vote the guard exists to
+  // prevent, one interaction later. (In real browsers a range input takes
+  // implicit pointer capture on press, so `pointerleave` does not fire during
+  // a legitimate drag that strays off the control and `pointerup` still
+  // arrives here — dragging off and releasing keeps working.)
   const pressedHere = useRef(false)
+  const releasePress = () => { pressedHere.current = false }
   return (
     <div className="space-y-2">
       <div className="flex justify-between items-center">
@@ -74,6 +83,9 @@ export default function ScoreSlider({
           aria-valuetext={unscored ? t('scores.notScored') : undefined}
           onChange={(e) => onChange(Number(e.target.value))}
           onPointerDown={() => { pressedHere.current = true }}
+          onPointerLeave={releasePress}
+          onPointerCancel={releasePress}
+          onLostPointerCapture={releasePress}
           /* A reader who wants EXACTLY the resting position: clicking the track
              at 3 leaves the value unchanged, so `onChange` never fires and the
              axis would stay unscored with no way to say "3" short of wiggling.

--- a/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/ScoreSlider.tsx
@@ -48,15 +48,22 @@ export default function ScoreSlider({
   // Was the press that is now ending a press ON THIS CONTROL? `pointerup` also
   // fires when a pointer that went down elsewhere is released over the input,
   // and that stray release must not cast a vote. A ref, not state: it changes
-  // nothing on screen. Cleared on EVERY way a press can stop mattering — up,
-  // leaving the control, cancel, lost capture — because a flag set on
-  // pointerdown and cleared only on pointerup-on-the-input sticks when the
-  // press ends elsewhere, and the NEXT unrelated release over the input would
-  // then cast the resting value: the exact stray vote the guard exists to
-  // prevent, one interaction later. (In real browsers a range input takes
-  // implicit pointer capture on press, so `pointerleave` does not fire during
-  // a legitimate drag that strays off the control and `pointerup` still
-  // arrives here — dragging off and releasing keeps working.)
+  // nothing on screen. Cleared on every way a press stops mattering — the up
+  // itself, leaving the control, cancel — because a flag cleared only on
+  // pointerup-on-the-input sticks when the press ends elsewhere, and the NEXT
+  // unrelated release over the input would then cast the resting value: the
+  // exact stray vote the guard exists to prevent, one interaction later.
+  //
+  // The three clears are ORDERING-SAFE by construction: `pointercancel` fires
+  // instead of an up, and a `pointerleave` after an up runs after the commit
+  // already happened. `lostpointercapture` is deliberately NOT used — per spec
+  // it follows the up (so it would add nothing), and an engine firing it early
+  // would break the click-at-the-resting-position commit on touch; a clear
+  // whose only distinctive ordering is the harmful one earns no place here.
+  // Browser-verified caveat: jsdom models no implicit pointer capture, so the
+  // drag-off-and-release path (capture keeps `pointerleave` from firing
+  // mid-drag and the up still lands here) holds in real browsers, not in the
+  // test harness — the tests pin the guard's logic, not the capture model.
   const pressedHere = useRef(false)
   const releasePress = () => { pressedHere.current = false }
   return (
@@ -85,7 +92,6 @@ export default function ScoreSlider({
           onPointerDown={() => { pressedHere.current = true }}
           onPointerLeave={releasePress}
           onPointerCancel={releasePress}
-          onLostPointerCapture={releasePress}
           /* A reader who wants EXACTLY the resting position: clicking the track
              at 3 leaves the value unchanged, so `onChange` never fires and the
              axis would stay unscored with no way to say "3" short of wiggling.

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -32,9 +32,14 @@ describe('getScore', () => {
 
     const result = getScore(scores, 'missing-id')
 
+    // 0 on EVERY axis, one shared unscored sentinel (#343). time_to_market
+    // used to default to 3 while its siblings defaulted to 0, so the number 3
+    // had two unrelated sources — a default here and a display coercion in the
+    // row — that agreed only by accident.
     expect(result.impact).toBe(0)
-    expect(result.time_to_market).toBe(3)
+    expect(result.time_to_market).toBe(0)
     expect(result.confidence).toBe(0)
+    expect(result.strategic_fit).toBe(0)
     expect(result.row_id).toBe('missing-id')
   })
 
@@ -49,8 +54,11 @@ describe('calculatePriorityScore', () => {
   it('returns 0 for default unscored item', () => {
     const score = { ...DEFAULT_SCORE, row_id: 'd1' }
 
-    // impact=0*0.4 + ttm=3*0.3 + strategic=0*0.2 + confidence=0*0.1 = 0.9
-    expect(calculatePriorityScore(score)).toBeCloseTo(0.9)
+    // The name finally tells the truth: with every axis at the unscored
+    // sentinel (0), the raw weighted sum is 0. It used to be 0.9 — the phantom
+    // composite of time_to_market's old default of 3 — which is what let an
+    // untouched proposal outrank one the team genuinely rated low.
+    expect(calculatePriorityScore(score)).toBe(0)
   })
 
   it('computes weighted score correctly', () => {
@@ -614,6 +622,67 @@ describe('the sort orders by the TEAM aggregate, not the caller own ballot', () 
 })
 
 describe('getTeamScore', () => {
+  // The #343 arithmetic: the composite covers what the team EXPRESSED, weights
+  // renormalised to the expressed axes, and an axis the backend reported as 0.0
+  // (its contract for "nobody scored this") is null — a dash, not a number.
+
+  it('renormalises a one-axis ballot to that axis rather than averaging in zeros', () => {
+    // Impact 4 alone. Weighing the three unexpressed axes as 0 composited this
+    // to 1.6 and banded it Low Priority — three zeros nobody entered outvoting
+    // the one number somebody did, which is the production defect (#343).
+    const team = getTeamScore({
+      d1: aggregate({ impact: 4, time_to_market: 0, strategic_fit: 0, confidence: 0, reviewer_count: 1 }),
+    }, 'd1')
+
+    expect(team?.displayComposite).toBe(4.0)
+    expect(team?.displayImpact).toBe(4.0)
+    expect(team?.reviewerCount).toBe(1)
+  })
+
+  it('reports an axis nobody scored as null, never as a number', () => {
+    const team = getTeamScore({
+      d1: aggregate({ impact: 4, time_to_market: 0, strategic_fit: 0, confidence: 0, reviewer_count: 1 }),
+    }, 'd1')
+
+    // 0.0 TTM on a ballot that never mentioned time to market was the chip
+    // that made the row read as rated-worst on an axis nobody rated.
+    expect(team?.displayTimeToMarket).toBeNull()
+  })
+
+  it('renormalises two expressed axes over their own weights', () => {
+    // impact 4 (weight .4) + confidence 2 (weight .1): (1.6 + 0.2) / 0.5 = 3.6.
+    const team = getTeamScore({
+      d1: aggregate({ impact: 4, time_to_market: 0, strategic_fit: 0, confidence: 2, reviewer_count: 2 }),
+    }, 'd1')
+
+    expect(team?.displayComposite).toBe(3.6)
+  })
+
+  it('a ballot that expressed no axis at all has no composite', () => {
+    // A notes-only ballot: the aggregate row exists (reviewer_count 1) and no
+    // axis was scored. There is no number to print, and inventing one is the
+    // defect this replaces. The band reads 'none' off the same null.
+    const team = getTeamScore({
+      d1: aggregate({ impact: 0, time_to_market: 0, strategic_fit: 0, confidence: 0, reviewer_count: 1 }),
+    }, 'd1')
+
+    expect(team?.displayComposite).toBeNull()
+    expect(team?.displayImpact).toBeNull()
+    expect(team?.displayTimeToMarket).toBeNull()
+    expect(team?.reviewerCount).toBe(1)
+  })
+
+  it('a fully-expressed aggregate composites exactly as before', () => {
+    // The regression guard for the renormalisation: when every axis is
+    // expressed, the expressed weights sum to 1 and dividing by them changes
+    // nothing — a full ballot's number is untouched by #343.
+    const team = getTeamScore({
+      d1: aggregate({ impact: 5, time_to_market: 4, strategic_fit: 2, confidence: 3, reviewer_count: 4 }),
+    }, 'd1')
+
+    expect(team?.displayComposite).toBe(3.9)
+  })
+
   it('composites the team means through the same weights the page sorts by', () => {
     // 5*0.4 + 4*0.3 + 2*0.2 + 3*0.1 = 3.9 — the calculatePriorityScore case above,
     // reached through the aggregate. The displayed number and the sort order are
@@ -716,6 +785,21 @@ describe('priorityBand', () => {
 
   it('names an unscored document, and ONLY an unscored one, as unbanded', () => {
     expect(priorityBand(getTeamView({}, 'd1'))).toBe('none')
+  })
+
+  it('bands a notes-only ballot as Not Scored rather than Low', () => {
+    // Somebody said something — the reviewer count is real — but nobody scored
+    // an axis, so there is no composite to band. 'low' would rank a comment as
+    // a verdict; before #343 the four zeros composited to 0 and did exactly
+    // that.
+    expect(bandOf({ ...uniform(0), reviewer_count: 1 })).toBe('none')
+  })
+
+  it('bands a one-axis ballot by that axis, not by the zeros beside it', () => {
+    // The production reproduction of #343: impact 4 alone banded 'low' off a
+    // 1.6 composite. Renormalised, the one expressed number is the composite.
+    expect(bandOf({ impact: 4, time_to_market: 0, confidence: 0, strategic_fit: 0, reviewer_count: 1 }))
+      .toBe('high')
   })
 
   it('names a document whose team view could not be READ as neither', () => {
@@ -1672,7 +1756,9 @@ describe('StatsCards regression: scores with missing document_id', () => {
 
     const score = getScore(scores, 'missing')
     expect(() => calculatePriorityScore(score)).not.toThrow()
-    expect(calculatePriorityScore(score)).toBeCloseTo(0.9)
+    // All-zero sentinel composites to 0 (#343) — see 'returns 0 for default
+    // unscored item' for why this stopped being 0.9.
+    expect(calculatePriorityScore(score)).toBe(0)
   })
 })
 

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -606,9 +606,12 @@ describe('the sort orders by the TEAM aggregate, not the caller own ballot', () 
     }
 
     for (const direction of ['asc', 'desc'] as const) {
-      const order = idsOf(sortRows([rowA, rowB, rowC], aggregates, 'time_to_market', direction))
-      expect(order.indexOf('b'), direction).toBe(0)
-      expect(order.indexOf('a'), direction).toBeGreaterThan(order.indexOf('b'))
+      // The ranked row first, then the number-less block IN ARRIVAL ORDER (`a`
+      // was supplied before `c`) in BOTH directions — the block neither ranks
+      // its members against each other nor flips with the toggle, which is the
+      // determinism this grouping exists for.
+      expect(idsOf(sortRows([rowA, rowB, rowC], aggregates, 'time_to_market', direction)), direction)
+        .toEqual(['b', 'a', 'c'])
     }
   })
 

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -590,6 +590,28 @@ describe('the sort orders by the TEAM aggregate, not the caller own ballot', () 
     }
   })
 
+  it('groups a row with no number in the sorted column with the number-less, in both directions', () => {
+    // Sorting by time to market: `a` never scored that axis (a partial ballot —
+    // its TTM prints a dash), `b` scored it. A dash cannot be ordered against a
+    // number, and letting the comparator tie it against every ranked row makes
+    // the final order depend on the engine's sort rather than on the data —
+    // null would tie both a 5 and a 1 that do not tie each other. So the dash
+    // row is GROUPED below the ranked rows, deterministically, where the
+    // number-less already live; its own label still says which state it is.
+    const rowC = rowView('c', 'Gamma', '2025-01-03')
+    const aggregates: Record<string, PrioritizationAggregate> = {
+      a: aggregate({ impact: 5, reviewer_count: 2 }), // TTM unexpressed: dash
+      b: aggregate({ impact: 1, time_to_market: 1, confidence: 1, strategic_fit: 1, reviewer_count: 2 }),
+      // c absent entirely: nobody voted.
+    }
+
+    for (const direction of ['asc', 'desc'] as const) {
+      const order = idsOf(sortRows([rowA, rowB, rowC], aggregates, 'time_to_market', direction))
+      expect(order.indexOf('b'), direction).toBe(0)
+      expect(order.indexOf('a'), direction).toBeGreaterThan(order.indexOf('b'))
+    }
+  })
+
   it('groups unscored documents rather than ordering them against each other', () => {
     // Two rows nobody has scored tie, in both directions, so they stay in the order
     // they arrived rather than being ranked by a number neither has.

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -857,17 +857,25 @@ const roundToDisplay = (composite: number): number => Math.round(composite * 10)
  * document.
  */
 /**
- * The weight one axis carries in the composite, read OFF the pinned formula.
+ * The weight each axis carries in the composite, read OFF the pinned formula.
  *
- * Derived by evaluating `calculatePriorityScore` on an indicator (this axis 1,
- * the rest 0) rather than declared as a second table of literals, so the
- * renormalisation below cannot drift from the formula the backend lockstep
- * test pins (`test_prioritization_weights_lockstep.py` parses that function's
- * source) — one set of weights, two readers, zero copies.
+ * Derived once, at module load, by evaluating `calculatePriorityScore` on an
+ * indicator per axis (this axis 1, the rest 0) rather than declared as a
+ * second table of literals — so the renormalisation below cannot drift from
+ * the formula the backend lockstep test pins
+ * (`test_prioritization_weights_lockstep.py` parses that function's source).
+ * One set of weights, two readers, zero copies.
  */
-const compositeWeightOf = (axis: keyof CompositeAxes): number => calculatePriorityScore({
+const COMPOSITE_AXES: readonly (keyof CompositeAxes)[] = ['impact', 'time_to_market', 'strategic_fit', 'confidence']
+const weightOf = (axis: keyof CompositeAxes): number => calculatePriorityScore({
   impact: 0, time_to_market: 0, strategic_fit: 0, confidence: 0, [axis]: 1,
 })
+const COMPOSITE_WEIGHT: Readonly<Record<keyof CompositeAxes, number>> = {
+  impact: weightOf('impact'),
+  time_to_market: weightOf('time_to_market'),
+  strategic_fit: weightOf('strategic_fit'),
+  confidence: weightOf('confidence'),
+}
 
 /**
  * A team mean as the row may print it: the number, or `null` for an axis the
@@ -885,11 +893,15 @@ const expressedMean = (mean: number): number | null => (mean === 0 ? null : mean
  * a reviewer count that keeps "one person said one thing" visible. `null` when
  * nothing was expressed at all (a notes-only ballot), because there is no
  * number to print and inventing one is the defect this replaces.
+ *
+ * The backend's spread stays comparable without renormalising: it composites
+ * only FULLY-scored ballots, where the expressed weights sum to 1 and this
+ * computation is the identity (`_composite` in projects_handler.py records
+ * the same argument from its side).
  */
 const expressedComposite = (aggregate: CompositeAxes): number | null => {
-  const axes: readonly (keyof CompositeAxes)[] = ['impact', 'time_to_market', 'strategic_fit', 'confidence']
-  const expressedWeight = axes.reduce(
-    (sum, axis) => sum + (expressedMean(aggregate[axis]) === null ? 0 : compositeWeightOf(axis)),
+  const expressedWeight = COMPOSITE_AXES.reduce(
+    (sum, axis) => sum + (expressedMean(aggregate[axis]) === null ? 0 : COMPOSITE_WEIGHT[axis]),
     0,
   )
   if (expressedWeight === 0) return null
@@ -1464,9 +1476,12 @@ function compareByTeamScore(
   const a = value(teamA)
   const b = value(teamB)
   // An axis nobody scored prints as a dash, and a dash cannot be ordered
-  // against a number — the same rule the signature already states for a whole
-  // missing TeamScore, one level further in. Treating null as 0 would rank
-  // "nobody mentioned time to market" below "the team rated it worst".
+  // against a number — treating null as 0 would rank "nobody mentioned time to
+  // market" below "the team rated it worst". Within `sortRows` this branch is
+  // unreachable: `blockOf` groups a dash-in-this-column row with the
+  // number-less block before any comparison, precisely because a null that
+  // ties both a 5 and a 1 makes the order engine-dependent. Kept for the
+  // direct caller, where a tie is the honest answer for one comparison.
   if (a === null || b === null) return 0
   return a - b
 }
@@ -1562,7 +1577,22 @@ export function sortRows(
   const blockOf = (row: PrioritizationRowView): number => {
     if (!ordersByTeamScore) return 0
     const view = views.get(row.row_id)
-    return view === undefined ? 0 : SORT_BLOCK[view.kind]
+    if (view === undefined) return 0
+    // A scored row with NO NUMBER IN THIS COLUMN — an axis nobody scored, or a
+    // notes-only composite — prints a dash there, and a dash sorts with the
+    // number-less rows rather than tying arbitrarily among the ranked ones: a
+    // null that ties both a 5 and a 1 (which do not tie each other) makes the
+    // final order depend on the engine's sort, not on the data. Grouped with
+    // the unscored block because that is what the reader sees — no value in
+    // the sorted column — while the row's own label still says which state it
+    // is. Deciding this here, per row, is also what keeps the comparator's
+    // null branch unreachable within the ranked block.
+    if (view.kind === 'scored'
+      && (sortField === 'priority_score' || sortField === 'impact' || sortField === 'time_to_market')
+      && TEAM_SORT_VALUE[sortField](view.team) === null) {
+      return SORT_BLOCK.unscored
+    }
+    return SORT_BLOCK[view.kind]
   }
   return [...rows].sort((a, b) => {
     const blockA = blockOf(a)

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -46,10 +46,23 @@ export interface PrioritizationRowView {
 export type SortField = 'priority_score' | 'impact' | 'time_to_market' | 'created_at' | 'title'
 export type SortDirection = 'asc' | 'desc'
 
+/**
+ * The score of a row with no stored ballot: every axis 0, and 0 MEANS UNSCORED.
+ *
+ * The backend reads an absent axis back as 0.0 and documents that "0.0 here
+ * means ABSENT" — this constant is the frontend adopting the same sentinel for
+ * all four axes rather than for three of them. `time_to_market` used to sit at
+ * 3 while its siblings sat at 0, so the number 3 had two unrelated sources (a
+ * default here, a display coercion in the row) that agreed only by accident,
+ * and an unreadable stored TTM degraded to "untouched" while an unreadable
+ * impact degraded to what the page then painted as 3 anyway (#343). One
+ * sentinel, and the sliders RENDER it as unscored (`ScoreSlider`) instead of
+ * borrowing a number from the middle of the range.
+ */
 export const DEFAULT_SCORE: PrioritizationScore = {
   row_id: '',
   impact: 0,
-  time_to_market: 3,
+  time_to_market: 0,
   confidence: 0,
   strategic_fit: 0,
   notes: '',
@@ -494,11 +507,14 @@ export function normalizeAggregates(
 /**
  * One axis of the CALLER'S OWN ballot: out of range clamps, unreadable degrades.
  *
- * The AXIS-level difference from `TEAM_AXIS`, which is the only difference left now that
- * both halves drop an unreadable row: `TEAM_AXIS` catches to 0, because 0 is a mean the
- * team could genuinely have, while this catches to the value an UNSET axis already shows
- * (`time_to_market` is 3, not 0). A slider that cannot be given the reviewer's stored
- * value should read as untouched rather than as a deliberate lowest score.
+ * Both catch to the axis's `DEFAULT_SCORE` value — 0, the shared unscored
+ * sentinel — so a slider that cannot be given the reviewer's stored value reads
+ * as UNSCORED rather than as a deliberate score. That used to differ per axis
+ * (`time_to_market` degraded to 3, its siblings to 0), which meant an
+ * unreadable TTM presented as a real mid-range vote; one sentinel ends the
+ * asymmetry (#343). `TEAM_AXIS` also catches to 0 and the row renders a 0 team
+ * mean as unscored, for the same reason: the backend reports 0.0 for an axis
+ * nobody scored, and a number nobody entered must not read as one they did.
  */
 const ownAxis = (fallback: number) => z.number()
   .transform((value) => Math.min(5, Math.max(0, value)))
@@ -775,8 +791,15 @@ export interface TeamScore {
    * which the row prints as `4.0` while an unrounded `>= 4` test calls it Medium.
    * Rounding once, here, is what makes the printed number and the band that
    * describes it agree by construction rather than by two matching literals.
+   *
+   * Composited over the axes the team EXPRESSED, with the weights renormalised
+   * to them (`getTeamScore`), and `null` when it expressed none — a notes-only
+   * ballot produces an aggregate row with a reviewer count and no scores.
+   * Weighing an unscored axis as 0 is what ranked a ballot of impact 4 alone at
+   * 1.6, Low Priority — three zeros nobody entered outvoting the one number
+   * somebody did (#343).
    */
-  readonly displayComposite: number
+  readonly displayComposite: number | null
   /**
    * The two sortable axes AS THE ROW PRINTS THEM, for the same reason
    * `displayComposite` exists — and for a reason that needs no floating-point dust.
@@ -793,9 +816,17 @@ export interface TeamScore {
    * unrounded copy of a value whose whole point is that everything reads one rounding is
    * exactly the drift this replaced. The unrounded means are still on the
    * `PrioritizationAggregate` for anything that genuinely needs them.
+   *
+   * `null` means NO REVIEWER SCORED THIS AXIS. The backend reports 0.0 for an
+   * axis nobody carried — its own docstring says 0.0 there means ABSENT — and
+   * painting that as a number is what put "0.0 TTM" on a row whose one ballot
+   * never mentioned time to market (#343). The row prints a dash for it and the
+   * sort treats it as unorderable rather than as lowest. A GENUINE zero mean
+   * cannot occur: the sliders put in 1–5, and the API's contract reads a stored
+   * 0 as absent.
    */
-  readonly displayImpact: number
-  readonly displayTimeToMarket: number
+  readonly displayImpact: number | null
+  readonly displayTimeToMarket: number | null
   readonly reviewerCount: number
   /**
    * The range of the composite across reviewers who scored every axis, or `null`
@@ -825,6 +856,46 @@ const roundToDisplay = (composite: number): number => Math.round(composite * 10)
  * on the lookup, so an inherited property name (`'toString'`) cannot answer for a
  * document.
  */
+/**
+ * The weight one axis carries in the composite, read OFF the pinned formula.
+ *
+ * Derived by evaluating `calculatePriorityScore` on an indicator (this axis 1,
+ * the rest 0) rather than declared as a second table of literals, so the
+ * renormalisation below cannot drift from the formula the backend lockstep
+ * test pins (`test_prioritization_weights_lockstep.py` parses that function's
+ * source) — one set of weights, two readers, zero copies.
+ */
+const compositeWeightOf = (axis: keyof CompositeAxes): number => calculatePriorityScore({
+  impact: 0, time_to_market: 0, strategic_fit: 0, confidence: 0, [axis]: 1,
+})
+
+/**
+ * A team mean as the row may print it: the number, or `null` for an axis the
+ * backend reported as 0.0 — its own contract for "no reviewer scored this".
+ */
+const expressedMean = (mean: number): number | null => (mean === 0 ? null : mean)
+
+/**
+ * The composite over the axes the team actually expressed, weights renormalised.
+ *
+ * Weighing an unexpressed axis as 0 is the arithmetic behind #343's ranking:
+ * one ballot of impact 4 composited to 1.6 and banded Low Priority, three
+ * zeros nobody entered outvoting the number somebody did. Renormalising says
+ * the composite of what the team HAS said — impact 4 alone reads 4.0 — beside
+ * a reviewer count that keeps "one person said one thing" visible. `null` when
+ * nothing was expressed at all (a notes-only ballot), because there is no
+ * number to print and inventing one is the defect this replaces.
+ */
+const expressedComposite = (aggregate: CompositeAxes): number | null => {
+  const axes: readonly (keyof CompositeAxes)[] = ['impact', 'time_to_market', 'strategic_fit', 'confidence']
+  const expressedWeight = axes.reduce(
+    (sum, axis) => sum + (expressedMean(aggregate[axis]) === null ? 0 : compositeWeightOf(axis)),
+    0,
+  )
+  if (expressedWeight === 0) return null
+  return calculatePriorityScore(aggregate) / expressedWeight
+}
+
 export function getTeamScore(
   aggregates: Record<string, TeamAggregateRow>,
   rowId: string,
@@ -835,10 +906,13 @@ export function getTeamScore(
   // `TeamScore`. `null` here would read as "nobody voted", which is why `getTeamView` asks
   // about `UNREADABLE_ROW` before it asks this — the two absences are not the same claim.
   if (aggregate === UNREADABLE_ROW) return null
+  const composite = expressedComposite(aggregate)
+  const impact = expressedMean(aggregate.impact)
+  const timeToMarket = expressedMean(aggregate.time_to_market)
   return {
-    displayComposite: roundToDisplay(calculatePriorityScore(aggregate)),
-    displayImpact: roundToDisplay(aggregate.impact),
-    displayTimeToMarket: roundToDisplay(aggregate.time_to_market),
+    displayComposite: composite === null ? null : roundToDisplay(composite),
+    displayImpact: impact === null ? null : roundToDisplay(impact),
+    displayTimeToMarket: timeToMarket === null ? null : roundToDisplay(timeToMarket),
     reviewerCount: aggregate.reviewer_count,
     spread: aggregate.reviewer_count > 1 ? aggregate.score_spread : null,
   }
@@ -993,6 +1067,11 @@ export const priorityBand = (view: TeamView): PriorityBand => {
   if (view.kind === 'unavailable') return 'unavailable'
   if (view.kind === 'loading') return 'loading'
   if (view.kind === 'unscored') return 'none'
+  // A scored view with no composite: somebody said something (the reviewer
+  // count is real) but nobody scored an axis — a notes-only ballot. There is
+  // no number to band, and 'low' would rank a comment as a verdict; 'none' is
+  // the honest label, and the row still shows the reviewer count beside it.
+  if (view.team.displayComposite === null) return 'none'
   if (view.team.displayComposite >= 4) return 'high'
   if (view.team.displayComposite >= 3) return 'medium'
   return 'low'
@@ -1333,7 +1412,7 @@ function byNewestFirst(a: ProjectDocument, b: ProjectDocument): number {
 }
 
 /** Which number on the team view each score sort field orders by. */
-const TEAM_SORT_VALUE: Record<'priority_score' | 'impact' | 'time_to_market', (team: TeamScore) => number> = {
+const TEAM_SORT_VALUE: Record<'priority_score' | 'impact' | 'time_to_market', (team: TeamScore) => number | null> = {
   // `displayComposite`, the value the row PRINTS, not the raw weighted sum — the rule
   // `displayComposite` was introduced for ("every classification reads this") applies
   // to the order as much as to the band. Rounding is monotonic, so raw never
@@ -1347,6 +1426,10 @@ const TEAM_SORT_VALUE: Record<'priority_score' | 'impact' | 'time_to_market', (t
   // while the raw values still order — and flip when the reader toggles the direction.
   // Reading the printed value ties them instead. These two tie most often of the three,
   // because a 0–5 mean is a coarse scale.
+  //
+  // `null` — an axis no reviewer scored, printed as a dash — reaches the
+  // comparator and ties there: a dash is not a lowest value, and ordering by a
+  // number the row does not show is the mismatch this table exists to prevent.
   impact: (team) => team.displayImpact,
   time_to_market: (team) => team.displayTimeToMarket,
 }
@@ -1378,7 +1461,14 @@ function compareByTeamScore(
 ): number {
   if (!teamA || !teamB) return 0
   const value = TEAM_SORT_VALUE[sortField]
-  return value(teamA) - value(teamB)
+  const a = value(teamA)
+  const b = value(teamB)
+  // An axis nobody scored prints as a dash, and a dash cannot be ordered
+  // against a number — the same rule the signature already states for a whole
+  // missing TeamScore, one level further in. Treating null as 0 would rank
+  // "nobody mentioned time to market" below "the team rated it worst".
+  if (a === null || b === null) return 0
+  return a - b
 }
 
 /** Does this sort field read a number only a scored ROW has? */

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -867,6 +867,10 @@ const roundToDisplay = (composite: number): number => Math.round(composite * 10)
  * One set of weights, two readers, zero copies.
  */
 const COMPOSITE_AXES: readonly (keyof CompositeAxes)[] = ['impact', 'time_to_market', 'strategic_fit', 'confidence']
+// Evaluated AT MODULE LOAD, and the file order is load-bearing:
+// `calculatePriorityScore` is a `const` arrow, so this block must stay BELOW
+// its declaration. Moving either past the other turns every import of this
+// module into a TDZ ReferenceError — a blank page, not a test failure.
 const weightOf = (axis: keyof CompositeAxes): number => calculatePriorityScore({
   impact: 0, time_to_market: 0, strategic_fit: 0, confidence: 0, [axis]: 1,
 })

--- a/voc-datalake/frontend/src/pages/Vote/BallotForm.tsx
+++ b/voc-datalake/frontend/src/pages/Vote/BallotForm.tsx
@@ -24,10 +24,12 @@ import type { ReactElement } from 'react'
  *
  * The MIDDLE of the range, deliberately, and every axis alike: a submitter is a
  * person in a room with no stored ballot to restore, so there is nothing to
- * default to except a neutral position. It matches the value the prioritization
- * page shows for an unset axis (`score.impact === 0 ? 3 : …`), so a ballot cast
- * here without touching a slider reads the same as the signed-in page's own
- * untouched row rather than as an emphatic zero.
+ * default to except a neutral position. This is a REAL 3 that the submit sends
+ * — every axis goes in the body, so an unmoved slider casts a genuine neutral
+ * vote — which is different from the signed-in page's unscored state, where a
+ * slider showing no value sends nothing and the axis stays unrecorded
+ * (`ScoreSlider`, #343). A room glancing at a phone gets a position to accept
+ * or move; a reviewer at a desk gets an honest "you have not scored this".
  */
 const NEUTRAL = 3
 

--- a/voc-datalake/lambda/api/ballots_handler.py
+++ b/voc-datalake/lambda/api/ballots_handler.py
@@ -432,16 +432,20 @@ def _row_exists(row_id: str) -> bool:
     that collects unrepeatable votes the page will discard (#342). The same
     direction the signed-in save path fails in, for the same reason.
     """
+    table = _table()  # its ConfigurationError is not this read's failure
     try:
-        item = _table().get_item(
-            Key={'pk': PRIORITIZATION_PK, 'sk': f'{ROW_SK_PREFIX}{row_id}'}
-        ).get('Item')
-    except ApiError:
-        raise
+        # Strongly consistent, because this read GATES the write that opens a
+        # public window: the facilitator's flow is create-row-then-open-vote,
+        # and an eventually-consistent read can miss a row created moments ago
+        # — refusing a legitimate session with 404 in front of a room.
+        response = table.get_item(
+            Key={'pk': PRIORITIZATION_PK, 'sk': f'{ROW_SK_PREFIX}{row_id}'},
+            ConsistentRead=True,
+        )
     except Exception as e:
         logger.exception(f'Failed to read a prioritization row before opening a session: {e}')
         raise ServiceError('Failed to open the voting session') from e
-    return isinstance(item, dict)
+    return isinstance(response.get('Item'), dict)
 
 
 def _sanitized_text(raw: Any, max_length: int) -> str:

--- a/voc-datalake/lambda/api/ballots_handler.py
+++ b/voc-datalake/lambda/api/ballots_handler.py
@@ -173,6 +173,10 @@ MAX_BALLOT_CAP = 200
 # that a room scores the whole proposal rather than one of its documents.
 PRIORITIZATION_PK = 'PRIORITIZATION'
 BALLOT_SK_PREFIX = 'BALLOT#'
+# The row-record prefix `projects_handler.ROW_SK_PREFIX` writes. Read here for one
+# purpose only: to check, at session creation, that the row the facilitator names
+# exists (`_row_exists`). This module still never composes or interprets a row.
+ROW_SK_PREFIX = 'ROW#'
 REVIEWER_KIND_ANON = 'anon'
 
 # Minted here, never accepted from a caller — see `_minted_ballot_id`.
@@ -395,12 +399,17 @@ def _validated_row_id(raw: Any) -> str:
     than a DynamoDB ValidationException surfacing as a 500. Neither message echoes
     the value, which is unbounded caller input.
 
-    NOT a check that the row EXISTS: this Lambda's role grants it one item read at
-    a time on one table and it deliberately knows nothing about row records, so the
-    only thing it can honestly check is the shape of the key it is about to write.
-    A session opened for a row that does not resolve collects ballots the page
-    ignores on read — the same outcome as the signed-in save path, whose reasoning
-    `_validated_ballot_row_id` records.
+    The SHAPE only; existence is the route's check (`_row_exists`), because this
+    function has one key in hand and no table. The route CAN check existence
+    honestly — one `get_item` on the aggregates table, which is exactly the
+    read this Lambda's role already grants — and it must (#342): a session
+    opened for a row that does not resolve collects a room's ballots that the
+    page then discards on read, and a room's votes are unrepeatable. The check
+    is at session CREATION and not at submit, deliberately: submit takes the
+    row id from the stored session, never from the body, so a session that
+    named a real row cannot start naming a phantom one (nothing deletes rows
+    today — phase 2's delete path owes the write-time condition), and the
+    public submit path stays at its current cost.
     """
     if not isinstance(raw, str) or not raw.strip():
         raise ValidationError('row_id is required')
@@ -412,6 +421,27 @@ def _validated_row_id(raw: Any) -> str:
             f'row_id must be at most {MAX_KEY_SEGMENT_ID_LEN} characters'
         )
     return row_id
+
+
+def _row_exists(row_id: str) -> bool:
+    """Does a row record exist for this id — the check a session must pass to open.
+
+    One `get_item`, the read this role already grants. A FAILED read raises
+    rather than answering either way: "missing" refuses a facilitator standing
+    in front of a room over a transient throttle, and "present" opens a window
+    that collects unrepeatable votes the page will discard (#342). The same
+    direction the signed-in save path fails in, for the same reason.
+    """
+    try:
+        item = _table().get_item(
+            Key={'pk': PRIORITIZATION_PK, 'sk': f'{ROW_SK_PREFIX}{row_id}'}
+        ).get('Item')
+    except ApiError:
+        raise
+    except Exception as e:
+        logger.exception(f'Failed to read a prioritization row before opening a session: {e}')
+        raise ServiceError('Failed to open the voting session') from e
+    return isinstance(item, dict)
 
 
 def _sanitized_text(raw: Any, max_length: int) -> str:
@@ -647,11 +677,24 @@ def create_voting_session():
     it is this one, and what changed is a single slot in the key.
 
     The row is named, not composed, here: this Lambda has no access to the projects
-    table by design and never reads a row record. `row_title` is copied onto the
-    session so the public page can say what is being scored without either.
+    table by design and never interprets a row record. It does now check that one
+    EXISTS (`_row_exists`, #342): a session is a public write window onto that row,
+    and one opened for a row nothing describes collects a room's ballots that the
+    page then discards — votes that cannot be recast. `row_title` is still copied
+    onto the session so the public page can say what is being scored without
+    reading anything.
     """
     body = _json_object_body()
     row_id = _validated_row_id(body.get('row_id'))
+    if not _row_exists(row_id):
+        # 404 about the world, not 400 about the request: the id is well-formed
+        # and the page sent one it was shown — a row created moments ago in
+        # another tab, or a stale tab after this deployment re-keyed rows. The
+        # id is not echoed (unbounded caller input, the module's standing rule).
+        raise NotFoundError(
+            'that prioritization row does not exist; reload the page and '
+            'reopen the vote'
+        )
     row_title = _sanitized_text(body.get('row_title'), MAX_ROW_TITLE_LEN)
     ballot_cap = validate_int(
         body.get('ballot_cap'),

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -756,7 +756,7 @@ def _validated_ballot_row_id(raw: Any) -> str:
     `validate_bool` in shared/api.py records).
 
     WHAT THIS CHECKS IS THE SHAPE, not the existence. Existence is checked by the
-    ROUTE, against the table, once per save (`_missing_ballot_rows`) — it cannot
+    ROUTE, against the table, once per save (`_fetched_ballot_rows`) — it cannot
     live here because this function sees one key at a time with no table in hand.
     The two checks answer differently on purpose: a malformed key is a 400 about
     the request, a well-formed key naming no row is a 404 about the world.
@@ -1045,15 +1045,18 @@ def _composite(entry: Any) -> float:
     than a fully-scored one carrying the same number.
 
     That floor is why `score_spread` compares only fully-scored ballots rather
-    than every voting one (see `_aggregate_scores`). Renormalising the weights
-    over the present axes would be the other way to make partial ballots
-    comparable, and is deliberately NOT done: renormalised weights no longer sum
-    to 1.0 against the four-axis 0-5 scale, so the composite — and therefore the
-    spread — would silently leave the unit the page's own column sorts by, for
-    some ballots and not others. That scale is what
-    `test_prioritization_weights_lockstep.py` exists to protect. Restricting
-    WHICH ballots are compared keeps every composite on the scale; changing how
-    one is computed would not.
+    than every voting one (see `_aggregate_scores`) — and restricting WHICH
+    ballots are compared is what keeps this function and the page agreeing.
+    Since #343 the page's TEAM composite renormalises its weights over the axes
+    the team expressed (so a one-axis ballot is not ranked on three zeros
+    nobody entered); on a fully-scored input the expressed weights sum to 1.0
+    and renormalisation is the identity, and fully-scored inputs are the only
+    ones this composite is ever compared across. So the spread stays in the
+    unit the page's column sorts by without this function renormalising —
+    which it deliberately does not, because for PARTIAL inputs the two
+    computations answer different questions (completeness versus disagreement)
+    and the spread must never mix them. The shared scale is what
+    `test_prioritization_weights_lockstep.py` exists to protect.
     """
     return sum(_axis_value(entry, axis) * weight for axis, weight in COMPOSITE_WEIGHTS.items())
 
@@ -1434,7 +1437,7 @@ class _LegacyScores:
         """
         return not self._held()
 
-    def drop_for_row(self, row_id: str) -> None:
+    def drop_for_row(self, row: Any) -> None:
         """Retire the pre-ballot value of every document the saved row holds.
 
         The translation the write side owes the read side: the legacy map is keyed
@@ -1442,8 +1445,11 @@ class _LegacyScores:
         that value" means the documents the row holds — the same mapping
         `_legacy_scores_by_row` performs on the read.
 
-        Costs one keyed read of the row, and only when the map is non-empty. That
-        read is the only way to learn what a row holds from a row id alone.
+        Takes the ROW RECORD, not a row id: the save has already read every named
+        row once to check it exists (`_fetched_ballot_rows`), and reading the same
+        key a second time here answered a question the request already answered.
+        The record is trusted defensively (`_row_document_ids` reads a malformed
+        one as holding nothing), the same stance the page read takes.
 
         Attempts a delete only for a document the map was seen to hold, so a row of
         25 freshly-generated documents in a deployment holding one legacy entry
@@ -1460,13 +1466,6 @@ class _LegacyScores:
         next save reads the map again and tries what is still there.
         """
         if self.empty:
-            return
-        try:
-            row = self._table.get_item(
-                Key={'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)}
-            ).get('Item')
-        except Exception as e:  # noqa: BLE001 - a landed ballot must never be failed
-            logger.warning(f"Legacy prioritization score removal could not read its row: {e}")
             return
         held = self._held()
         for document_id in _row_document_ids(row):
@@ -1524,13 +1523,21 @@ def _row_document_ids(row: Any) -> list[str]:
     return [value for value in stored if isinstance(value, str) and value]
 
 
-def _missing_ballot_rows(table, row_ids: list[str]) -> list[str]:
-    """The named rows that have NO row record — the ones a save must refuse.
+def _fetched_ballot_rows(table, row_ids: list[str]) -> dict[str, dict]:
+    """The row records for a save's named rows, keyed by row id — existing ones.
 
-    One keyed read per row, before the first write, so a body naming a vanished
-    row persists nothing (see the call site for why the refusal exists at all).
-    The ids are validated shapes by the time they arrive here, so the key is
-    always legal.
+    One keyed read per row, before the first write; a named row absent from the
+    result is one the save must refuse. The ids are validated shapes by the
+    time they arrive here, so the key is always legal. The FETCHED items are
+    returned rather than a mere existence verdict, because the legacy migration
+    needs each scored row's `document_ids` and reading the same key twice in
+    one save is a round trip that answers a question already answered.
+
+    Sequential keyed reads rather than `batch_get_item`, deliberately: the page
+    sends the rows a reader touched (single digits), the batch API lives on the
+    client with unmarshalled-attribute plumbing this module otherwise never
+    needs, and the loop stays inspectable by the same fakes the rest of the
+    suite uses. The bound is MAX_BALLOTS_PER_SAVE either way.
 
     A FAILED read raises rather than answering "present" or "missing": either
     invented answer is worse than the truth. Calling it missing refuses a save
@@ -1540,18 +1547,24 @@ def _missing_ballot_rows(table, row_ids: list[str]) -> list[str]:
     "the read failed" and "nobody has scored anything" must stay
     distinguishable — applied to the write side.
     """
-    missing = []
+    fetched: dict[str, dict] = {}
     for row_id in row_ids:
         try:
+            # Strongly consistent, because this read GATES a write and the case
+            # it exists to distinguish is "created moments ago": the row create
+            # answers the page, the page saves, and an eventually-consistent
+            # read can miss the row it just handed out — refusing a legitimate
+            # save with 404. Negligible cost for a keyed read on a save path.
             item = table.get_item(
-                Key={'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)}
+                Key={'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)},
+                ConsistentRead=True,
             ).get('Item')
         except Exception as e:
             logger.exception(f'Failed to read a prioritization row before a save: {e}')
             raise ServiceError('Failed to save prioritization scores') from e
-        if not isinstance(item, dict):
-            missing.append(row_id)
-    return missing
+        if isinstance(item, dict):
+            fetched[row_id] = item
+    return fetched
 
 
 def _is_default_row(row: Any) -> bool:
@@ -2262,14 +2275,17 @@ def api_patch_prioritization_scores():
     # the discard protects the READER, but the WRITER was answered 200
     # `updated_count: 1` for a vote that then appeared nowhere — silent loss
     # reported as success. A keyed read per row is the price, and it is paid
-    # only by a save (the page issues one per click, not per render).
+    # only by a save (the page issues one per click, not per render); the
+    # fetched records are then what the legacy migration reads, so the same key
+    # is never read twice in one save.
     #
     # A read-then-write, not a condition on the write itself — honest about the
     # race: a row deleted between this check and the write below would still
     # orphan its ballot. Nothing can delete a row today, so the gap is
     # unreachable; phase 2 of #339, which introduces deletion, owes the
     # DB-enforced condition (a transaction), and this check is where it goes.
-    if _missing_ballot_rows(table, [row_id for row_id, _ in validated]):
+    rows_by_id = _fetched_ballot_rows(table, [row_id for row_id, _ in validated])
+    if any(row_id not in rows_by_id for row_id, _ in validated):
         raise NotFoundError(
             'scores name a row that does not exist; reload the page to get '
             'the current rows'
@@ -2301,8 +2317,9 @@ def api_patch_prioritization_scores():
             # away — but ONLY when this ballot actually scored something, because
             # that value is a score and nothing else supersedes it. An entry that
             # expressed no axis would otherwise delete a value it did not replace.
+            # The row record was already fetched by the existence pass above.
             if _is_a_vote(entry):
-                legacy.drop_for_row(row_id)
+                legacy.drop_for_row(rows_by_id[row_id])
         return {'success': True, 'updated_count': ballots}
     except ApiError:
         raise

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -755,17 +755,21 @@ def _validated_ballot_row_id(raw: Any) -> str:
     input that a response body gains nothing by repeating (the same reasoning
     `validate_bool` in shared/api.py records).
 
-    WHAT THIS DELIBERATELY DOES NOT CHECK: that the row exists. A save against a
-    row that does not resolve writes a ballot nothing will read, which is the same
-    outcome the read already has to tolerate for a stored key naming a vanished
-    row — and requiring a keyed read per entry would put N round trips in front of
-    every save to refuse a body the shipped page cannot compose. That a row's
-    documents belong to its project is guaranteed one level up, where a row is
-    composed: `_default_row_composition` picks from the project's OWN partition
-    (`pk = PROJECT#{project_id}`), so an id from elsewhere cannot be selected, and
-    the caller never supplies one. Phase 2, which lets a caller name a set, is
-    where that becomes a check rather than a construction — and where
-    `_validated_source_id` in this module is the pattern to follow.
+    WHAT THIS CHECKS IS THE SHAPE, not the existence. Existence is checked by the
+    ROUTE, against the table, once per save (`_missing_ballot_rows`) — it cannot
+    live here because this function sees one key at a time with no table in hand.
+    The two checks answer differently on purpose: a malformed key is a 400 about
+    the request, a well-formed key naming no row is a 404 about the world.
+
+    An earlier version deliberately skipped the existence check, reasoning that an
+    orphaned ballot is "a ballot nothing will read, which is the same outcome the
+    read already has to tolerate". Production showed why that reasoning was wrong
+    (#342): the same outcome for the READER is not the same outcome for the
+    WRITER, who was told 200 `updated_count: 1` while their vote appeared nowhere
+    — silent loss reported as success, the exact fault class this module's read
+    side counts and warns about. That a row's documents belong to its project is
+    still guaranteed one level up, where a row is composed
+    (`_default_row_composition` picks from the project's own partition).
     """
     if not isinstance(raw, str) or not raw.strip():
         raise ValidationError('scores keys must be non-empty row id strings')
@@ -932,11 +936,13 @@ def _axis_value(entry: Any, axis: str) -> float:
     Values come back from DynamoDB as Decimal and may be absent, so this
     normalises to float and reads anything the entry did not express as 0.0.
 
-    0.0 here means ABSENT, and it matches the frontend's `DEFAULT_SCORE` for
-    `impact`, `confidence` and `strategic_fit` — but NOT for `time_to_market`,
-    whose frontend default is 3 and which `PRFAQRow` reads as its untouched signal
-    (`time_to_market !== 3`). So a stored ballot missing `time_to_market` reads
-    back as a deliberate lowest-possible score rather than "not set".
+    0.0 here means ABSENT, and since #343 the frontend adopts that reading for
+    ALL FOUR axes: `DEFAULT_SCORE` is 0 across the board, the slider renders a
+    0 as "not scored" rather than borrowing a 3, and the team chips print a
+    dash for a 0.0 mean. (Historically `time_to_market`'s frontend default was
+    3 while its siblings were 0, so a stored ballot missing that one axis read
+    back as a deliberate lowest-possible score — the divergence this paragraph
+    used to document is the one #343 removed.)
 
     An axis is absent whenever the caller has never sent it (see `_readable_axis`
     for the exhaustive list), which happens three ways: a legacy entry predating
@@ -944,8 +950,7 @@ def _axis_value(entry: Any, axis: str) -> float:
     writes the axes it was given; and a legacy value no number can be read out of,
     which predates the validation that now refuses one. A reviewer who saves only
     `notes`, or only `impact`, therefore reads back `time_to_market: 0.0`, which
-    the page renders as the lowest possible time-to-market and `PRFAQRow` treats as
-    touched. Pinned by
+    the page now renders as unscored. Pinned by
     `test_a_notes_only_first_save_reads_back_a_zero_time_to_market`.
 
     Not corrected on the read: seeding an absent axis from the frontend's default
@@ -1517,6 +1522,36 @@ def _row_document_ids(row: Any) -> list[str]:
     if not isinstance(stored, list):
         return []
     return [value for value in stored if isinstance(value, str) and value]
+
+
+def _missing_ballot_rows(table, row_ids: list[str]) -> list[str]:
+    """The named rows that have NO row record — the ones a save must refuse.
+
+    One keyed read per row, before the first write, so a body naming a vanished
+    row persists nothing (see the call site for why the refusal exists at all).
+    The ids are validated shapes by the time they arrive here, so the key is
+    always legal.
+
+    A FAILED read raises rather than answering "present" or "missing": either
+    invented answer is worse than the truth. Calling it missing refuses a save
+    the caller could legitimately make over a transient throttle; calling it
+    present waves through exactly the orphan this check exists to refuse. The
+    same reasoning the page read gives for raising on a failed partition read —
+    "the read failed" and "nobody has scored anything" must stay
+    distinguishable — applied to the write side.
+    """
+    missing = []
+    for row_id in row_ids:
+        try:
+            item = table.get_item(
+                Key={'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)}
+            ).get('Item')
+        except Exception as e:
+            logger.exception(f'Failed to read a prioritization row before a save: {e}')
+            raise ServiceError('Failed to save prioritization scores') from e
+        if not isinstance(item, dict):
+            missing.append(row_id)
+    return missing
 
 
 def _is_default_row(row: Any) -> bool:
@@ -2219,6 +2254,27 @@ def api_patch_prioritization_scores():
     table = get_aggregates_table()
     if not table:
         raise ConfigurationError('Aggregates table not configured')
+
+    # EVERY named row must exist BEFORE the first write, joining the up-front
+    # pass above: a body naming one vanished row among five persists NOTHING,
+    # which keeps the promise that only a mid-save infrastructure failure can
+    # half-persist. Checked here rather than left to the read's discard (#342):
+    # the discard protects the READER, but the WRITER was answered 200
+    # `updated_count: 1` for a vote that then appeared nowhere — silent loss
+    # reported as success. A keyed read per row is the price, and it is paid
+    # only by a save (the page issues one per click, not per render).
+    #
+    # A read-then-write, not a condition on the write itself — honest about the
+    # race: a row deleted between this check and the write below would still
+    # orphan its ballot. Nothing can delete a row today, so the gap is
+    # unreachable; phase 2 of #339, which introduces deletion, owes the
+    # DB-enforced condition (a transaction), and this check is where it goes.
+    if _missing_ballot_rows(table, [row_id for row_id, _ in validated]):
+        raise NotFoundError(
+            'scores name a row that does not exist; reload the page to get '
+            'the current rows'
+        )
+
     now = datetime.now(timezone.utc).isoformat()
 
     # Counted so a failure part way through a multi-row save is diagnosable.

--- a/voc-datalake/lambda/api/test/test_anon_ballot_key_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_anon_ballot_key_lockstep.py
@@ -160,6 +160,18 @@ class TestBothWritersAgreeOnWhereABallotLives:
             f'anonymous ballots would be silently ignored by the aggregate.'
         )
 
+    def test_the_row_record_prefix_matches(self):
+        # ballots_handler READS row records it never writes: the session-open
+        # existence check (#342) looks a row up under the prefix projects_handler
+        # writes it under. If the two drift, the check answers "no such row" for
+        # every row, and no session can be opened at all.
+        ballots = _str_const(_read(BALLOTS_SOURCE), 'ROW_SK_PREFIX', BALLOTS_SOURCE)
+        projects = _str_const(_read(PROJECTS_SOURCE), 'ROW_SK_PREFIX', PROJECTS_SOURCE)
+        assert ballots == projects, (
+            f'ROW_SK_PREFIX differs: {ballots!r} vs {projects!r}. The existence '
+            f'check would look rows up under a key nothing writes.'
+        )
+
     def test_both_build_the_sort_key_in_the_same_shape(self):
         # The reader splits on the LAST '#', so the shape — prefix, ROW id, '#',
         # kind-namespaced subject — has to be identical in both writers.

--- a/voc-datalake/lambda/api/test/test_ballots_handler.py
+++ b/voc-datalake/lambda/api/test/test_ballots_handler.py
@@ -217,7 +217,23 @@ def _config(table, api_gateway_event, lambda_context, *, session_id=OPEN_SESSION
     return _call(table, event, lambda_context)
 
 
-def _create(table, api_gateway_event, lambda_context, *, body, subject='facilitator-sub'):
+def _create(table, api_gateway_event, lambda_context, *, body, subject='facilitator-sub',
+            seed_row=True):
+    """Open a session, seeding the named row's record first.
+
+    Seeded by default because that is the only state the page can reach: a
+    facilitator opens a vote from a row the page rendered, and the route refuses
+    a row with no record (#342). `seed_row=False` is for the tests asking about
+    exactly that refusal. A row id the route will refuse on SHAPE (empty, '#')
+    seeds nothing usable and the shape refusal is unaffected — the same rule
+    `_patch_scores` follows in the sibling harness.
+    """
+    row_id = body.get('row_id') if isinstance(body, dict) else None
+    if seed_row and isinstance(row_id, str) and row_id.strip() and '#' not in row_id:
+        table.items.setdefault(
+            (PRIORITIZATION_PK, f'ROW#{row_id}'),
+            {'pk': PRIORITIZATION_PK, 'sk': f'ROW#{row_id}', 'row_id': row_id},
+        )
     event = api_gateway_event(method='POST', path='/voting-sessions', body=body)
     claims = event['requestContext']['authorizer']['claims']
     if subject is None:
@@ -804,6 +820,51 @@ class TestTheFacilitatorHalf:
                             body={'row_id': 'row_p1#default'})
 
         assert status == 400
+        assert table.put_item_calls == []
+
+    def test_a_row_with_no_record_opens_no_session(
+            self, api_gateway_event, lambda_context):
+        """The anonymous half of #342. A session is a public write window onto its
+        row; opened for a row nothing describes, it collects a room's ballots that
+        the page then discards on read — and a room's votes cannot be recast. So
+        the window is refused at creation, where the facilitator is present to see
+        the answer, rather than the loss surfacing later as a warning in a log.
+
+        404, not 400: the id is well-formed and the page sent one it was shown —
+        the world changed, not the request. Reverting the fix (removing the
+        `_row_exists` check) fails this on the status: the session opens."""
+        table = FakeAggregatesTable([])
+
+        status, body = _create(table, api_gateway_event, lambda_context,
+                               body={'row_id': 'row_gone_default'}, seed_row=False)
+
+        assert status == 404
+        assert 'does not exist' in body['error']
+        assert 'row_gone_default' not in body['error'], 'no echo of caller input'
+        assert table.put_item_calls == []
+
+    def test_a_failed_row_read_is_a_server_fault_not_a_refusal(
+            self, api_gateway_event, lambda_context):
+        """'Missing' would refuse a facilitator standing in front of a room over a
+        transient throttle; 'present' would open the window #342 exists to close.
+        A failed read is neither — it raises, and the facilitator retries."""
+        table = FakeAggregatesTable([])
+        real_get = table.get_item
+
+        def failing_get(**kwargs):
+            if str(kwargs['Key']['sk']).startswith('ROW#'):
+                raise ClientError(
+                    {'Error': {'Code': 'ProvisionedThroughputExceededException'}},
+                    'GetItem',
+                )
+            return real_get(**kwargs)
+
+        table.get_item = failing_get
+
+        status, _ = _create(table, api_gateway_event, lambda_context,
+                            body={'row_id': 'row_p1_default'})
+
+        assert status == 500
         assert table.put_item_calls == []
 
     def test_the_session_id_is_unguessable_and_recognisable(

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -3667,12 +3667,17 @@ class TestTheOneLegacyScoreLandsOnItsProjectsDefaultRow:
         scored — and a save expressing nothing must not delete a value it did not
         replace. The one read that remains is the EXISTENCE check (#342), which
         every save pays even for a stamps-only entry: an entry that scores nothing
-        still writes a ballot record, and a phantom row must not collect one."""
+        still writes a ballot record, and a phantom row must not collect one.
+
+        The status is asserted so this cannot go vacuous: `self._table()` seeds
+        the row, but if that fixture ever stopped, the request would 404 and
+        'one read, map untouched' would hold for the wrong reason."""
         table = self._table()
 
-        _patch_scores(table, api_gateway_event, lambda_context,
-                      {'row-p1': {}}, subject='alice', seed_rows=False)
+        status, _ = _patch_scores(table, api_gateway_event, lambda_context,
+                                  {'row-p1': {}}, subject='alice', seed_rows=False)
 
+        assert status == 200
         assert len(table.get_item_calls) == 1, (
             'exactly the existence read: a second get_item would be the '
             'migration reading a row for a save that scored nothing'

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -436,6 +436,79 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
         assert table.update_item_calls == []
         assert table.ballot_keys == []
 
+    def test_a_row_with_no_record_is_refused_and_nothing_is_stored(
+        self, api_gateway_event, lambda_context
+    ):
+        """The write-side half of the orphan problem (#342). The read discards a
+        ballot whose row does not resolve — that protects the READER — but the
+        write answered `200 {"updated_count": 1}` and stored an orphan, so the
+        WRITER was told their vote saved while it appeared nowhere: silent loss
+        reported as success, verified against production. A row that does not
+        exist gets no ballot, and the caller is told the world changed (404)
+        rather than that their request was malformed (400).
+
+        Reverting the fix (removing the existence check) fails this on the
+        status: the save answers 200 and stores the orphan."""
+        table = FakeAggregatesTable()
+
+        status, body = _patch_scores(
+            table, api_gateway_event, lambda_context, {'row-ghost': AXES},
+            seed_rows=False,
+        )
+
+        assert status == 404
+        assert 'does not exist' in body['error']
+        assert 'row-ghost' not in body['error'], 'no echo of caller input'
+        assert table.update_item_calls == []
+        assert table.ballot_keys == []
+
+    def test_one_phantom_row_in_a_multi_row_save_persists_nothing(
+        self, api_gateway_event, lambda_context
+    ):
+        """The refusal joins the up-front pass: a body naming one vanished row
+        among several writes NOTHING, keeping the promise that only a mid-save
+        infrastructure failure can half-persist. Checking per row inside the
+        write loop instead would store the rows before the phantom and answer an
+        error about the whole body — a half-persist by design."""
+        table = FakeAggregatesTable().seed_rows('row-real')
+
+        status, _ = _patch_scores(
+            table, api_gateway_event, lambda_context,
+            {'row-real': AXES, 'row-ghost': AXES}, seed_rows=False,
+        )
+
+        assert status == 404
+        assert table.update_item_calls == []
+        assert table.ballot('row-real', 'reviewer-1') is None
+
+    def test_a_failed_existence_read_is_a_server_fault_not_a_refusal(
+        self, api_gateway_event, lambda_context
+    ):
+        """Either invented answer is worse than the truth: 'missing' refuses a
+        legitimate save over a transient throttle, 'present' waves through the
+        orphan the check exists to refuse. So a failed read raises, the caller
+        retries, and nothing is stored meanwhile."""
+        table = FakeAggregatesTable().seed_rows('row-1')
+        real_get = table.get_item
+
+        def failing_get(**kwargs):
+            if str(kwargs['Key']['sk']).startswith('ROW#'):
+                raise ClientError(
+                    {'Error': {'Code': 'ProvisionedThroughputExceededException'}},
+                    'GetItem',
+                )
+            return real_get(**kwargs)
+
+        table.get_item = failing_get
+
+        status, _ = _patch_scores(
+            table, api_gateway_event, lambda_context, {'row-1': AXES},
+            seed_rows=False,
+        )
+
+        assert status == 500
+        assert table.update_item_calls == []
+
     def test_a_save_larger_than_the_bound_is_refused(self, api_gateway_event, lambda_context):
         """Each row costs the ballot write plus, when it scored, a read of the row
         and one conditional removal per document it holds — so an unbounded body
@@ -571,14 +644,13 @@ class TestAPartialEntryLeavesTheOtherAxesAlone:
         than leaving it described in a docstring.
 
         With no prior ballot there is nothing to fall back on, so an axis the
-        caller never sent is simply absent — and `_axis_value` reads absent as 0.0.
-        For `time_to_market` that diverges from the page, whose own DEFAULT_SCORE
-        is 3 and whose `PRFAQRow` reads `time_to_market !== 3` as "touched": a
-        reviewer who only left a note therefore appears to have deliberately rated
-        it lowest. Deliberately not corrected on the read, because seeding the
-        frontend's default would put a number nobody entered into a field named for
-        what a reviewer scored; the aggregate makes the distinction instead, by
-        asking whether the axis is carried at all."""
+        caller never sent is simply absent — and `_axis_value` reads absent as
+        0.0. Since #343 the page reads a 0.0 back as UNSCORED for every axis (a
+        dash, not a number), so this wire value no longer presents as a
+        deliberate lowest score. Still deliberately not corrected on the read,
+        because seeding a display default would put a number nobody entered into
+        a field named for what a reviewer scored; the aggregate makes the
+        distinction instead, by asking whether the axis is carried at all."""
         table = FakeAggregatesTable()
 
         _patch_scores(table, api_gateway_event, lambda_context,
@@ -1164,11 +1236,16 @@ class TestTheMigrationCostsNothingWhereThereIsNothingToMigrate:
             if call['UpdateExpression'].strip().upper().startswith('REMOVE')
         ]
 
-    def test_a_deployment_with_no_legacy_map_issues_no_removals_and_no_row_reads(
+    def test_a_deployment_with_no_legacy_map_issues_no_removals_and_no_migration_reads(
         self, api_gateway_event, lambda_context
     ):
         """The common case, forever. Ten scored rows of five documents each would
-        otherwise be ten row reads and fifty refused conditional writes."""
+        otherwise be ten MIGRATION row reads and fifty refused conditional writes.
+
+        The row reads that remain are the EXISTENCE check every save now pays —
+        exactly one per named row (#342) — so the assertion is "one read per row,
+        none of them the migration's", not "no reads": a migration read would be a
+        SECOND read of the same key, and the count is what catches it."""
         table, row_ids = self._rows(10, 5)
 
         status, _ = _patch_scores(
@@ -1178,7 +1255,10 @@ class TestTheMigrationCostsNothingWhereThereIsNothingToMigrate:
 
         assert status == 200
         assert self._removals(table) == []
-        assert self._row_reads(table) == []
+        assert len(self._row_reads(table)) == len(row_ids), (
+            'one existence read per named row, and not one more: the legacy '
+            'migration must add zero'
+        )
 
     def test_the_map_is_read_once_per_save_not_once_per_row(
         self, api_gateway_event, lambda_context
@@ -2333,7 +2413,11 @@ class TestReviewerIdentityComesFromTheSharedHelper:
     ):
         import projects_handler
 
-        table = FakeAggregatesTable()
+        # Seeded because this test bypasses `_patch_scores` (whose fixture seeds
+        # rows) to patch the helper — and the route refuses a row with no record
+        # before writing (#342), which would end the request before the ballot
+        # write this asserts on.
+        table = FakeAggregatesTable().seed_rows('row-1')
         with (
             patch('projects_handler.get_caller_subject', return_value='alice') as helper,
             patch('projects_handler.get_aggregates_table', return_value=table),
@@ -3576,18 +3660,24 @@ class TestTheOneLegacyScoreLandsOnItsProjectsDefaultRow:
         assert body['aggregates']['row-p1']['reviewer_count'] == 1
         assert body['aggregates']['row-p1']['score_spread'] == 0.0
 
-    def test_a_save_that_scored_nothing_reads_no_row_and_removes_nothing(
+    def test_a_save_that_scored_nothing_pays_one_existence_read_and_removes_nothing(
         self, api_gateway_event, lambda_context
     ):
-        """The row read costs a round trip, so it is only paid for by a save that
-        actually scored — and a save expressing nothing must not delete a value it
-        did not replace."""
+        """The MIGRATION's row read is only paid for by a save that actually
+        scored — and a save expressing nothing must not delete a value it did not
+        replace. The one read that remains is the EXISTENCE check (#342), which
+        every save pays even for a stamps-only entry: an entry that scores nothing
+        still writes a ballot record, and a phantom row must not collect one."""
         table = self._table()
 
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-p1': {}}, subject='alice', seed_rows=False)
 
-        assert table.get_item_calls == []
+        assert len(table.get_item_calls) == 1, (
+            'exactly the existence read: a second get_item would be the '
+            'migration reading a row for a save that scored nothing'
+        )
+        assert table.get_item_calls[0]['Key']['sk'] == 'ROW#row-p1'
         assert table.items[(PARTITION, LEGACY_SK)]['scores']['prd-1']['impact'] == 4
 
 


### PR DESCRIPTION
Fixes the two bugs found while live-verifying #341, both filed from production reproductions: #343 (the slider display defect) and #342 (the phantom-row ballot write). One PR because they are one theme — **a partial ballot must read honestly at every layer** — with zero file overlap between the halves: #342 is backend-only, #343 is frontend-only.

## #343 — an unscored axis reads as unscored, not as a 3 or a 0

Move one slider and save. The record correctly held only the touched axis; the API read the other three back as `0.0` (its documented encoding of "absent"); the editor painted every stored 0 as a 3, before and after reload; and the row banded **Low Priority** off a composite that weighed the zeros as votes. A ballot that looked like 4/3/3/3 on screen was 4/0/0/0 in the record and ranked on the zeros — with no way to discover it, since the painted 3 was indistinguishable from a stored 3 and the stored 0 isn't even in the slider's 1–5 range.

Three individually-documented decisions composed into this, and only the third was wrong: the dirty-only PATCH body (deliberate — #338, itself a fix for untouched defaults dragging the whole team's means down), the absent-reads-as-0.0 rule (argued in the handler's docstrings — inventing a default would be indistinguishable from a vote), and the display coercion (`score.x === 0 ? 3`, #132) that no docstring reconciled. So the fix is **display-side** and the wire contract is untouched:

- **`ScoreSlider` renders a 0 as NOT SCORED**: dash badge, muted handle, `aria-valuetext="Not scored"`. The handle rests mid-track (a range input cannot be valueless) but no number is presented as the axis's value. Releasing the pointer on an unscored slider commits the resting value, so "exactly 3" stays reachable by a click; the first arrow key covers keyboard users.
- **`DEFAULT_SCORE` is 0 on every axis.** Its `time_to_market` was 3 beside three 0s — two unrelated sources of the number 3 that agreed only by accident — and `ownAxis` degraded an unreadable stored TTM to a real-looking mid vote. One shared sentinel now, everywhere.
- **The team composite covers what the team expressed**, weights renormalised over the expressed axes — derived by evaluating `calculatePriorityScore` on indicators, so the weights lockstep test still guards a single copy of the numbers. Impact 4 alone now reads **4.0 / High Priority** beside its reviewer count, not 1.6 / Low from three zeros nobody entered. An axis nobody scored is `null` and prints the same decorative dash the unscored row already uses; the sort ties on it rather than ranking "nobody mentioned TTM" below "the team rated it worst"; a notes-only ballot bands **Not Scored** rather than Low.

A fully-scored ballot's numbers are unchanged (expressed weights sum to 1 — pinned by a regression test), the PATCH body construction is untouched, and the anonymous Vote page is unaffected (it always sends all four axes as real 1–5 values; its `NEUTRAL = 3` comment updated to say how the two pages now differ, and why). New i18n key `scores.notScored` in all eight catalogues, sorted position.

## #342 — a ballot for a row that does not exist is refused, not stored

`PATCH /projects/prioritization` accepted a ballot naming a row with no row record and answered `200 {"updated_count": 1}`; every read then discarded it. The writer was told their vote saved while it appeared nowhere — the same silent-loss class #341 closed on the read side, still open on the write side, and verified against production (the discard-warning count rose and fell with an injected orphan).

Both write paths now check the row record exists **before any write**, by keyed read, and refuse with **404** (the world changed, not the request) without echoing the id:

- The PATCH checks every named row as part of the existing up-front validation pass, so one phantom row in a multi-row body persists **nothing** — the "nothing malformed can half-persist" promise gets stronger, not narrower.
- `POST /voting-sessions` checks at session creation: a session is a public write window onto its row, and one opened for a phantom row collects a room's unrepeatable ballots. Submit inherits safety from create — the row id comes from the stored session, never the body, and nothing can delete a row today.
- A **failed** existence read raises rather than answering either way: "missing" refuses a legitimate save over a throttle; "present" waves through the orphan the check exists to refuse.

Deliberately a read-then-write, not a transaction: the check-to-write race requires a concurrent row deletion, which no code path can perform until phase 2 of #339. That phase owes the DB-enforced condition (issue #342's atomicity criterion stays open for it), and the check added here is where the condition goes. The `ROW#` prefix the ballots handler now reads is pinned against the projects handler by the anon-ballot lockstep suite, so the two spellings cannot drift.

## Tests

Every new behaviour has a test that fails on revert, verified by mutation (check removed → the refusal tests answer 200; coercion restored → the editor-honesty test sees no `aria-valuetext`):

- Backend: phantom row refused with nothing stored (single and multi-row), failed existence read → 500 with nothing stored, session-open refusal + its 500 twin, the `ROW#` lockstep pin. The two tests that pinned "a save reads no rows" now pin the precise claim — one existence read per named row, and none of them the migration's — so a regression in either direction (check removed, or the migration reading blindly) fails on the count.
- Frontend: renormalisation (one axis → that axis's value; two axes → their weights; all four → unchanged 3.9), null axes and null composite, notes-only bands Not Scored, one-axis ballot bands by its axis, and the page-level pin of #343's acceptance nothing asserted before: **the editor never displays a number the record does not hold** (stored 4/0/0/0 → slider 4 plus three "Not scored", not 4/3/3/3).

## Gates

Backend pytest **2569** · frontend vitest **2941** (181 files) · CDK **250** · stream **339** · `tsc` clean (app + CDK + stream) · ESLint clean · ruff **523 = base** · i18n: one added key, present in all 8 catalogues in sorted position, one-line diff per file.

Not deployed yet — deploy + live verification before merge, per convention. Closes #343; #342 can close too if the phase-2 deferral of the atomic condition is acceptable there, otherwise it stays open scoped to that criterion.
