### PR TITLE
feat(prioritization): compose rows, freeze at the first ballot, delete with ballots

### DIFF
--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -476,6 +476,14 @@ export interface PrioritizationScore {
  * it was cast about. `prototype_id` is context a reviewer looks at rather than a
  * document the row is scored on, which is why it is its own field; it is `''` when
  * the project has no prototype.
+ *
+ * `is_frozen` says a ballot has landed, so the composition can no longer change. A
+ * fact the page DISPLAYS, never one it enforces: the freeze is a condition on the
+ * write itself, so a composition change racing the first ballot loses to it in the
+ * database and answers 409 whatever this field said a moment earlier. The timestamp
+ * behind it, and the write count the delete fences on, are deliberately NOT published
+ * — a client computing the freeze itself would eventually disagree with the condition
+ * that enforces it.
  */
 export interface PrioritizationRow {
   row_id: string
@@ -484,6 +492,7 @@ export interface PrioritizationRow {
   prototype_id: string
   is_default: boolean
   created_at: string
+  is_frozen: boolean
 }
 
 /**

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -503,6 +503,29 @@ describe('normalizeRow validates the ONE row a create answers with', () => {
     expect(normalizeRow(storedRow('r', 'p1', ids(MAX_ROW_DOCUMENT_IDS)))?.row_id).toBe('r')
     expect(normalizeRow(storedRow('r', 'p1', ids(MAX_ROW_DOCUMENT_IDS + 1)))).toBeUndefined()
   })
+
+  it('keeps the frozen flag the API sends', () => {
+    // The schema is a `z.object`, which STRIPS what it does not declare — so an
+    // undeclared `is_frozen` parses fine and is silently discarded, and the page could
+    // never learn a row was frozen with nothing failing to say so. That is the whole
+    // reason the field has to be declared rather than left to arrive.
+    expect(normalizeRow({ ...storedRow('r', 'p1', ['prd-1']), is_frozen: true })?.is_frozen)
+      .toBe(true)
+    expect(normalizeRow({ ...storedRow('r', 'p1', ['prd-1']), is_frozen: false })?.is_frozen)
+      .toBe(false)
+  })
+
+  it('reads an unstated or unreadable frozen flag as NOT frozen', () => {
+    // The direction matters. `is_frozen` only decides whether a control is OFFERED —
+    // the freeze itself is a condition on the write, which answers 409 whatever this
+    // said. Defaulting to `true` would hide a control on a row that is perfectly
+    // editable with nothing explaining why; defaulting to `false` offers one whose
+    // request the server refuses with a reason the page can state.
+    for (const value of [undefined, null, 'yes', 1, {}]) {
+      expect(normalizeRow({ ...storedRow('r', 'p1', ['prd-1']), is_frozen: value })?.is_frozen)
+        .toBe(false)
+    }
+  })
 })
 
 /**

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -706,12 +706,25 @@ export function normalizeRow(raw: unknown, rowId?: string): PrioritizationRow | 
  * reason, so the two agree.
  *
  * The rest degrades, because none of it decides whether the row exists: a missing
- * `prototype_id` means "no prototype", and `is_default`/`created_at` are metadata the
- * list does not depend on.
+ * `prototype_id` means "no prototype", and `is_default`/`created_at`/`is_frozen` are
+ * metadata the list does not depend on.
+ *
+ * `is_frozen` degrades to FALSE, and that direction is deliberate. It is the API's
+ * answer to "has a ballot landed on this row", and the freeze itself is a DATABASE
+ * CONDITION on the write — so this field only ever decides whether a control is
+ * offered, never whether an edit is allowed. An unreadable value that defaulted to
+ * `true` would hide a control on a row that is perfectly editable, with nothing on
+ * screen explaining why; defaulting to `false` offers a control whose request the
+ * server refuses with a 409 the page can state. A courtesy that occasionally shows
+ * too much beats one that silently withholds.
  *
  * `z.object`, not `looseObject`: this is the shape the page ACCEPTS, matching
  * `OwnBallotSchema`'s reasoning — a boundary that keeps what it does not understand
- * is not saying what it accepts.
+ * is not saying what it accepts. Which is why a field the API publishes has to be
+ * DECLARED here rather than left to be stripped: an undeclared `is_frozen` parses
+ * fine and is silently discarded, so the page could never learn the row was frozen
+ * and nothing would fail to say so. `test_prioritization_row_payload_lockstep.py`
+ * pins every key `_row_payload` returns against this list for that reason.
  */
 /**
  * How many documents one row may hold.
@@ -745,6 +758,7 @@ const RowSchema = z.object({
   prototype_id: z.string().catch(''),
   is_default: z.boolean().catch(false),
   created_at: z.string().catch(''),
+  is_frozen: z.boolean().catch(false),
 })
 
 /**

--- a/voc-datalake/lambda/api/ballots_handler.py
+++ b/voc-datalake/lambda/api/ballots_handler.py
@@ -254,6 +254,14 @@ BALLOT_TRANSACT_ROW_INDEX = 1
 # Small and few on purpose. The room is holding a phone waiting for the response, and
 # a conflict clears in single-digit milliseconds; a long backoff would spend the
 # request's remaining time to no better end than the retry it already has.
+#
+# WHAT THESE VALUES COST WHEN RAISED: the backoff is `time.sleep` inside the Lambda,
+# so it is billed wall-clock on a PUBLIC, unauthenticated request a phone is
+# waiting on — worst case with these values ~150ms (25-50ms after attempt 1,
+# 50-100ms after attempt 2), which is deliberate and small next to the round trip a
+# retry saves. Raising either constant raises HELD CONCURRENCY for exactly the
+# contended case the retry exists to help: the room that conflicts is the room
+# whose Lambdas are now also sleeping.
 BALLOT_WRITE_ATTEMPTS = 3
 BALLOT_WRITE_BACKOFF_SECONDS = 0.05
 
@@ -1255,14 +1263,17 @@ def _write_ballot(
                 # this device's own key.
                 #
                 # Jittered, so a room whose phones all conflicted does not re-collide
-                # in lockstep having waited the same interval.
+                # in lockstep having waited the same interval. Logged BEFORE the
+                # sleep: the log records the decision to retry, and a reader timing
+                # a slow submission should see the line at the moment the wait
+                # began, not after it ended.
                 delay = BALLOT_WRITE_BACKOFF_SECONDS * (2 ** attempt)
-                time.sleep(delay * (0.5 + secrets.randbelow(500) / 1000))
                 logger.warning(
                     f'An anonymous ballot write was cancelled without a failed '
                     f'condition on session {_session_ref(session_id)}; retrying '
                     f'(attempt {attempt + 2} of {BALLOT_WRITE_ATTEMPTS}).'
                 )
+                time.sleep(delay * (0.5 + secrets.randbelow(500) / 1000))
                 continue
             # Never echoes the note or the display name — both are submitter
             # content, and one of them is PII.
@@ -1286,6 +1297,14 @@ def _write_ballot(
     # `test_the_write_attempts_bound_leaves_at_least_one_attempt` pins the bound
     # itself, the way `MAX_ROW_BALLOTS_PER_DELETE + 2 <= 100` pins the delete's
     # reservation; this is the guard for the case where it stops holding anyway.
+    #
+    # The refused submission's CAP SLOT IS ALREADY SPENT — `_hold_open_session`
+    # claimed it before this function ran, and here that is EVERY ballot in the
+    # room, not one unlucky device. Accepted for the same reason the `_RowIsGone`
+    # branch accepts it: releasing races other claimers, and the cap must bound a
+    # public route's writes even while the route itself is misconfigured. The cost
+    # of this guard firing is a room whose session must be reopened, which is the
+    # right price for never thanking a room for ballots that were not written.
     logger.error(
         'An anonymous ballot write made no attempt at all, which means '
         'BALLOT_WRITE_ATTEMPTS is not at least 1. Refusing rather than reporting a '

--- a/voc-datalake/lambda/api/ballots_handler.py
+++ b/voc-datalake/lambda/api/ballots_handler.py
@@ -78,6 +78,21 @@ Nothing here reads or changes the aggregate. `_aggregate_scores` in
 kind, so a correctly keyed `anon:` ballot appears in the team's combined score,
 `reviewer_count` and `score_spread` with no change to the read, its response shape
 or the page that renders it.
+
+AND A BALLOT MARKS ITS ROW, WHOEVER CAST IT
+-------------------------------------------
+An anonymous ballot is a ballot, so `_write_ballot` is a TRANSACTION rather than a
+lone `update_item`: it writes the ballot and, on the row record, the freeze mark a
+composition change asserts the absence of plus the counter a row delete fences on.
+The alternative was an invariant that held for signed-in reviewers and not for a
+room — a row carrying nothing but real anonymous votes staying recomposable, and a
+room ballot landing during a delete being orphaned by it — which would have failed
+precisely where the votes are least attributable and hardest to reconstruct.
+
+Those two attribute names are duplicated from `projects_handler` (the bundles cannot
+import each other) and pinned by `test_anon_row_mark_lockstep.py`, because a drift is
+a freeze that does not freeze and a fence that does not fence, and neither failure is
+loud.
 """
 import json
 import math
@@ -178,6 +193,34 @@ BALLOT_SK_PREFIX = 'BALLOT#'
 # exists (`_row_exists`). This module still never composes or interprets a row.
 ROW_SK_PREFIX = 'ROW#'
 REVIEWER_KIND_ANON = 'anon'
+
+# The two attributes a ballot stamps on its ROW, spelled exactly as
+# `projects_handler` spells them (ROW_FROZEN_AT_FIELD, ROW_BALLOT_WRITES_FIELD) and
+# duplicated here for the same reason the key prefixes are: the two handlers are
+# separate Lambda bundles and neither may import the other.
+#
+# WHAT A DRIFT HERE WOULD COST, and why it is pinned by
+# `test_anon_row_mark_lockstep.py` rather than trusted to this comment:
+#
+# * `first_ballot_at` under another name is a FREEZE THAT DOES NOT FREEZE. The
+#   recompose route asserts `attribute_not_exists(first_ballot_at)`, so a row whose
+#   only ballots were cast in a room would stay recomposable — and those ballots
+#   would end up describing documents the room never saw.
+# * `ballot_writes` under another name is a FENCE THAT DOES NOT FENCE. The row
+#   delete asserts that attribute has not moved since it listed the row's ballots,
+#   so an anonymous ballot landing in that window would be orphaned by a delete
+#   that committed anyway.
+#
+# Neither failure is loud. Both are the invariants #339 and #342 are about.
+ROW_FROZEN_AT_FIELD = 'first_ballot_at'
+ROW_BALLOT_WRITES_FIELD = 'ballot_writes'
+
+# Where the ROW's write sits in the ballot transaction, and so which
+# `CancellationReasons` entry says whether the row is what refused.
+#
+# The ballot's own half carries no condition, so a cancellation reported against
+# index 0 is not a fact about the row — see `_row_condition_failed`.
+BALLOT_TRANSACT_ROW_INDEX = 1
 
 # Minted here, never accepted from a caller — see `_minted_ballot_id`.
 BALLOT_ID_BYTES = 16
@@ -404,12 +447,18 @@ def _validated_row_id(raw: Any) -> str:
     honestly — one `get_item` on the aggregates table, which is exactly the
     read this Lambda's role already grants — and it must (#342): a session
     opened for a row that does not resolve collects a room's ballots that the
-    page then discards on read, and a room's votes are unrepeatable. The check
-    is at session CREATION and not at submit, deliberately: submit takes the
-    row id from the stored session, never from the body, so a session that
-    named a real row cannot start naming a phantom one (nothing deletes rows
-    today — phase 2's delete path owes the write-time condition), and the
-    public submit path stays at its current cost.
+    page then discards on read, and a room's votes are unrepeatable.
+
+    That read is at session CREATION and is not the whole of the story, because a
+    row CAN now be deleted (`projects_handler.api_delete_prioritization_row`) and a
+    room can vote an hour after the facilitator opened the vote. Submit does not
+    repeat the read — it takes the row id from the STORED SESSION, never from the
+    body, so a session that named a real row cannot start naming a different one, and
+    the public path keeps its current cost. What closes the remaining window is a
+    CONDITION ON THE WRITE rather than another read: `_write_ballot`'s transaction
+    asserts `attribute_exists(sk)` on the row, so a ballot on a row deleted in the
+    meantime is refused instead of being orphaned — and refused without resurrecting
+    the row, which `update_item`'s upsert would otherwise do.
     """
     if not isinstance(raw, str) or not raw.strip():
         raise ValidationError('row_id is required')
@@ -956,6 +1005,33 @@ def _hold_open_session(session_id: str, now: datetime, *, claim_slot: bool) -> b
         raise ServiceError('Failed to record the ballot') from e
 
 
+def _row_condition_failed(e: ClientError) -> bool:
+    """Did the ROW's condition cancel this transaction, or did contention?
+
+    A `TransactionCanceledException` IS NOT ONLY A FAILED CONDITION. DynamoDB
+    cancels with the same exception for `TransactionConflict` (another in-flight
+    transaction touching one of the same items), `ThrottlingError`,
+    `ProvisionedThroughputExceeded` and `ValidationError`, and botocore does not
+    auto-retry it — so all of them arrive here.
+
+    `TransactionConflict` is the ORDINARY CASE in this handler, not a corner: a room
+    of phones submitting at once is exactly what this feature is for, and every one
+    of those ballots writes the same row record. Reading the exception as "the row is
+    gone" would tell a phone that lost a race that the proposal no longer exists — a
+    settled refusal, in place of the transient failure the page already retries.
+
+    Read at the ROW's index specifically, because the ballot's own half carries no
+    condition: a reason reported against it is not a fact about the row. A missing or
+    short `CancellationReasons` answers False, so an unreadable cancellation is
+    handled as the transient failure it might be rather than the fact it might not be.
+    """
+    reasons = e.response.get('CancellationReasons')
+    if not isinstance(reasons, list) or BALLOT_TRANSACT_ROW_INDEX >= len(reasons):
+        return False
+    reason = reasons[BALLOT_TRANSACT_ROW_INDEX]
+    return isinstance(reason, dict) and reason.get('Code') == 'ConditionalCheckFailed'
+
+
 def _write_ballot(
     row_id: str,
     ballot_id: str,
@@ -965,11 +1041,46 @@ def _write_ballot(
     display_name: str,
     now: datetime,
 ) -> None:
-    """Upsert one anonymous ballot on its own key.
+    """Write one anonymous ballot and mark its ROW, in ONE transaction.
 
-    A single `update_item`, so a device correcting its vote replaces its own
-    record and touches nobody else's — the same property that lets two signed-in
-    reviewers save at the same moment without losing each other's numbers.
+    The ballot lands on its own key, so a device correcting its vote replaces its
+    own record and touches nobody else's — the same property that lets two
+    signed-in reviewers save at the same moment without losing each other's
+    numbers.
+
+    THE ROW HALF IS WHY THIS IS A TRANSACTION RATHER THAN AN `update_item`. An
+    anonymous ballot is a ballot: it is a durable decision record about the set of
+    documents the row held when the room voted, and it is counted in the same
+    aggregate a signed-in reviewer's is. So it has to do the same three things a
+    signed-in save does, and all three are properties of the WRITE:
+
+    * FREEZE THE COMPOSITION. `first_ballot_at` is what
+      `projects_handler.api_recompose_prioritization_row` asserts the absence of.
+      Without it, a row carrying nothing but real anonymous votes stayed
+      recomposable, and those ballots would end up describing documents the room
+      never saw — the invariant that route advertises as database-enforced, with
+      a hole in it exactly where the votes are least attributable.
+    * MOVE THE DELETE'S FENCE. `ballot_writes` is what
+      `projects_handler._transact_delete_row` asserts has not changed since it
+      enumerated the row's ballots. An anonymous ballot landing in that gap that
+      did not move it left the delete free to commit — and leave that ballot
+      orphaned, which is the #342 fault the fence exists to close.
+    * ASSERT THE ROW STILL EXISTS. `_row_exists` is checked when the session is
+      OPENED, which can be an hour before the room votes; `attribute_exists(sk)`
+      on the write is what makes a ballot on a row deleted in between fail instead
+      of resurrecting the row as a bare record.
+
+    Every one of those is spelled here the way `projects_handler` spells it, and
+    `test_anon_row_mark_lockstep.py` pins the three attribute names across the two
+    bundles — the same protection `test_anon_ballot_key_lockstep.py` gives the sort
+    key, and for the same reason: a drifted name here is a freeze that does not
+    freeze and a fence that does not fence, with nothing failing loudly.
+
+    A CORRECTION TAKES THIS PATH TOO, and stamps the same marks. `first_ballot_at`
+    is `if_not_exists`, so a correction cannot move a freeze instant that a first
+    ballot already recorded; `ballot_writes` DOES move, which is correct — it counts
+    writes precisely so that a delete which enumerated the row's ballots before a
+    correction landed is cancelled rather than committing over it.
 
     NO `ttl` IS EVER ASSIGNED HERE. The aggregates table expires anything carrying
     that attribute, and a ballot is a durable decision record: an expiring one
@@ -980,6 +1091,13 @@ def _write_ballot(
     (see `_existing_ballot`) and because a ballot nobody's name is on should at
     least record which room cast it. `display_name` is stored only when the
     submitter gave one, and no read exposes it today.
+
+    A CANCELLED TRANSACTION IS ANSWERED BY THE REASON, not by the exception.
+    DynamoDB cancels for `TransactionConflict` and throttling as well as for a
+    failed condition, and a room of phones submitting at once contends on the one
+    row record — so only a condition failure on the row means the row is gone
+    (`REASON_NOT_FOUND`, which the page states); anything else is the transient
+    failure the page already retries.
     """
     # `row_id`, the same attribute name the signed-in save stamps
     # (`BALLOT_STAMP_FIELDS` in `projects_handler`), because both write the same
@@ -1011,18 +1129,61 @@ def _write_ballot(
         names['#display_name'] = 'display_name'
         values[':display_name'] = display_name
 
+    table = _table()
     try:
-        _table().update_item(
-            Key={'pk': PRIORITIZATION_PK, 'sk': _ballot_sk(row_id, ballot_id)},
-            UpdateExpression='SET ' + ', '.join(assignments),
-            ExpressionAttributeNames=names,
-            ExpressionAttributeValues=values,
+        table.meta.client.transact_write_items(TransactItems=[
+            {'Update': {
+                'TableName': table.name,
+                'Key': {'pk': PRIORITIZATION_PK, 'sk': _ballot_sk(row_id, ballot_id)},
+                'UpdateExpression': 'SET ' + ', '.join(assignments),
+                'ExpressionAttributeNames': names,
+                'ExpressionAttributeValues': values,
+            }},
+            {'Update': {
+                'TableName': table.name,
+                'Key': {'pk': PRIORITIZATION_PK, 'sk': f'{ROW_SK_PREFIX}{row_id}'},
+                # `attribute_exists(sk)` on the ROW rather than on the ballot,
+                # because `update_item` is an upsert: without it this would CREATE a
+                # bare row record for a row somebody deleted.
+                'ConditionExpression': 'attribute_exists(sk)',
+                'UpdateExpression': (
+                    'SET #frozen_at = if_not_exists(#frozen_at, :now) '
+                    'ADD #ballot_writes :one'
+                ),
+                'ExpressionAttributeNames': {
+                    '#frozen_at': ROW_FROZEN_AT_FIELD,
+                    '#ballot_writes': ROW_BALLOT_WRITES_FIELD,
+                },
+                'ExpressionAttributeValues': {':now': now.isoformat(), ':one': 1},
+            }},
+        ])
+    except ClientError as e:
+        if (
+            e.response.get('Error', {}).get('Code') != 'TransactionCanceledException'
+            or not _row_condition_failed(e)
+        ):
+            # Never echoes the note or the display name — both are submitter
+            # content, and one of them is PII.
+            logger.exception(
+                f'Failed to write an anonymous ballot for session '
+                f'{_session_ref(session_id)}: {e}'
+            )
+            raise ServiceError('Failed to record the ballot') from e
+        # The row's only condition is its existence, so this row went away between
+        # the session being opened and the room voting. The device is told the same
+        # thing a vanished session is answered with, because from the phone's side
+        # it is the same fact: there is nothing here to score any more. Nothing was
+        # written — a transaction applies whole or not at all — so the slot this
+        # submission claimed is spent, which is the honest direction: the cap exists
+        # to bound writes, and refusing to record a ballot never lets one past it.
+        logger.warning(
+            f'An anonymous ballot named a row that no longer exists, on session '
+            f'{_session_ref(session_id)}. Nothing was written.'
         )
+        raise NotFoundError('That proposal no longer exists') from e
     except ApiError:
         raise
     except Exception as e:
-        # Never echoes the note or the display name — both are submitter content,
-        # and one of them is PII.
         logger.exception(f'Failed to write an anonymous ballot for session {_session_ref(session_id)}: {e}')
         raise ServiceError('Failed to record the ballot') from e
 

--- a/voc-datalake/lambda/api/ballots_handler.py
+++ b/voc-datalake/lambda/api/ballots_handler.py
@@ -93,12 +93,19 @@ Those two attribute names are duplicated from `projects_handler` (the bundles ca
 import each other) and pinned by `test_anon_row_mark_lockstep.py`, because a drift is
 a freeze that does not freeze and a fence that does not fence, and neither failure is
 loud.
+
+The row record is also what makes CONTENTION ordinary here rather than exceptional:
+every ballot of a session updates the same one, so a room submitting together
+conflicts by design. `_write_ballot` retries such a cancellation instead of reporting
+it, because by then the submission's cap slot is already spent and the page offers the
+voter no way to try again.
 """
 import json
 import math
 import os
 import re
 import secrets
+import time
 import unicodedata
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -221,6 +228,34 @@ ROW_BALLOT_WRITES_FIELD = 'ballot_writes'
 # The ballot's own half carries no condition, so a cancellation reported against
 # index 0 is not a fact about the row — see `_row_condition_failed`.
 BALLOT_TRANSACT_ROW_INDEX = 1
+
+# How many times the ballot's transaction is attempted before its failure is
+# reported, and how long the wait between attempts starts at.
+#
+# CONTENTION IS THE DESIGNED CASE HERE, WHICH IS WHY THIS EXISTS. Every ballot of a
+# session `ADD`s to the SAME row record, so a room submitting on the facilitator's
+# count of three contends on one item — and DynamoDB answers that with
+# `TransactionCanceledException`/`TransactionConflict`, which botocore does NOT
+# auto-retry (`botocore/data/_retry.json` lists `TransactionInProgressException` and
+# `ReplicatedWriteConflictException`, not this one). So it arrives here.
+#
+# Without a retry the cost falls on the voter and is unrecoverable: the caller has
+# ALREADY claimed a slot of the cap (`_hold_open_session(claim_slot=True)`), and the
+# page renders a terminal panel on failure with no way to resubmit. So a contended
+# room would burn slots on conflicts and then refuse ballots with `cap_reached` that
+# it should have accepted.
+#
+# RETRIED RATHER THAN THE SLOT RELEASED, because releasing races every other
+# claimer: two submissions each releasing a slot they are about to re-claim can let a
+# third past the cap, and the cap is the one thing that bounds what a public route
+# writes. A retry has no such interaction — the ballot's half is an upsert on the
+# device's OWN key, so re-attempting it cannot double-count a vote.
+#
+# Small and few on purpose. The room is holding a phone waiting for the response, and
+# a conflict clears in single-digit milliseconds; a long backoff would spend the
+# request's remaining time to no better end than the retry it already has.
+BALLOT_WRITE_ATTEMPTS = 3
+BALLOT_WRITE_BACKOFF_SECONDS = 0.05
 
 # Minted here, never accepted from a caller — see `_minted_ballot_id`.
 BALLOT_ID_BYTES = 16
@@ -1005,6 +1040,25 @@ def _hold_open_session(session_id: str, now: datetime, *, claim_slot: bool) -> b
         raise ServiceError('Failed to record the ballot') from e
 
 
+class _RowIsGone(Exception):
+    """The row a ballot names no longer exists.
+
+    A module-private signal rather than a `NotFoundError`, because of the SHAPE the
+    answer has to have. Every refusal in this module goes through `_refusal`, which
+    emits `{'success': False, 'reason': ..., 'error': ...}`, and the ballot page
+    dispatches on `reason` alone — `submitBallot` parses the body with
+    `ballotRefusalSchema` and falls back to `unknown` when the field is absent, which
+    renders as "try again in a moment".
+
+    `NotFoundError` is rendered by the shared handler as `{'success': False, 'error':
+    ...}` with NO `reason`, so raising one here answered the single case where the row
+    is PERMANENTLY gone with the copy reserved for transient failures — exactly
+    inverting the distinction `_row_condition_failed` exists to draw. Raised so the
+    route can answer `_refusal(REASON_NOT_FOUND)`, whose translated copy states the
+    fact rather than inviting a retry that cannot work.
+    """
+
+
 def _row_condition_failed(e: ClientError) -> bool:
     """Did the ROW's condition cancel this transaction, or did contention?
 
@@ -1071,10 +1125,11 @@ def _write_ballot(
       of resurrecting the row as a bare record.
 
     Every one of those is spelled here the way `projects_handler` spells it, and
-    `test_anon_row_mark_lockstep.py` pins the three attribute names across the two
-    bundles — the same protection `test_anon_ballot_key_lockstep.py` gives the sort
-    key, and for the same reason: a drifted name here is a freeze that does not
-    freeze and a fence that does not fence, with nothing failing loudly.
+    `test_anon_row_mark_lockstep.py` pins the two attribute names and the reason
+    index across the two bundles — the same protection
+    `test_anon_ballot_key_lockstep.py` gives the sort key (including this row key's
+    `ROW_SK_PREFIX`), and for the same reason: a drifted name here is a freeze that
+    does not freeze and a fence that does not fence, with nothing failing loudly.
 
     A CORRECTION TAKES THIS PATH TOO, and stamps the same marks. `first_ballot_at`
     is `if_not_exists`, so a correction cannot move a freeze instant that a first
@@ -1094,10 +1149,22 @@ def _write_ballot(
 
     A CANCELLED TRANSACTION IS ANSWERED BY THE REASON, not by the exception.
     DynamoDB cancels for `TransactionConflict` and throttling as well as for a
-    failed condition, and a room of phones submitting at once contends on the one
-    row record — so only a condition failure on the row means the row is gone
-    (`REASON_NOT_FOUND`, which the page states); anything else is the transient
-    failure the page already retries.
+    failed condition, so the two are answered differently and only one of them is
+    retried:
+
+    * A FAILED CONDITION ON THE ROW means the row is gone. Reported at once, since
+      a deleted row does not come back, and raised as `_RowIsGone` so the route can
+      answer `_refusal(REASON_NOT_FOUND)` — a body carrying the `reason` the page
+      dispatches on. A `NotFoundError` here would render as `unknown`, i.e. "try
+      again in a moment" about a row that is permanently gone.
+    * ANYTHING ELSE IS TRANSIENT, and is re-attempted up to
+      BALLOT_WRITE_ATTEMPTS times with a jittered backoff before it becomes a 500.
+      A room of phones submitting at once all `ADD` to the one row record, so
+      contention is the ORDINARY case here rather than a corner — and the voter
+      cannot recover from a failure themselves: their cap slot is already claimed
+      and the page's error panel offers no resubmit. Retrying is safe because the
+      ballot's half is an upsert on this device's own key, so a repeated attempt
+      cannot double-count a vote.
     """
     # `row_id`, the same attribute name the signed-in save stamps
     # (`BALLOT_STAMP_FIELDS` in `projects_handler`), because both write the same
@@ -1130,38 +1197,73 @@ def _write_ballot(
         values[':display_name'] = display_name
 
     table = _table()
-    try:
-        table.meta.client.transact_write_items(TransactItems=[
-            {'Update': {
-                'TableName': table.name,
-                'Key': {'pk': PRIORITIZATION_PK, 'sk': _ballot_sk(row_id, ballot_id)},
-                'UpdateExpression': 'SET ' + ', '.join(assignments),
-                'ExpressionAttributeNames': names,
-                'ExpressionAttributeValues': values,
-            }},
-            {'Update': {
-                'TableName': table.name,
-                'Key': {'pk': PRIORITIZATION_PK, 'sk': f'{ROW_SK_PREFIX}{row_id}'},
-                # `attribute_exists(sk)` on the ROW rather than on the ballot,
-                # because `update_item` is an upsert: without it this would CREATE a
-                # bare row record for a row somebody deleted.
-                'ConditionExpression': 'attribute_exists(sk)',
-                'UpdateExpression': (
-                    'SET #frozen_at = if_not_exists(#frozen_at, :now) '
-                    'ADD #ballot_writes :one'
-                ),
-                'ExpressionAttributeNames': {
-                    '#frozen_at': ROW_FROZEN_AT_FIELD,
-                    '#ballot_writes': ROW_BALLOT_WRITES_FIELD,
-                },
-                'ExpressionAttributeValues': {':now': now.isoformat(), ':one': 1},
-            }},
-        ])
-    except ClientError as e:
-        if (
-            e.response.get('Error', {}).get('Code') != 'TransactionCanceledException'
-            or not _row_condition_failed(e)
-        ):
+    transact_items = [
+        {'Update': {
+            'TableName': table.name,
+            'Key': {'pk': PRIORITIZATION_PK, 'sk': _ballot_sk(row_id, ballot_id)},
+            'UpdateExpression': 'SET ' + ', '.join(assignments),
+            'ExpressionAttributeNames': names,
+            'ExpressionAttributeValues': values,
+        }},
+        {'Update': {
+            'TableName': table.name,
+            'Key': {'pk': PRIORITIZATION_PK, 'sk': f'{ROW_SK_PREFIX}{row_id}'},
+            # `attribute_exists(sk)` on the ROW rather than on the ballot,
+            # because `update_item` is an upsert: without it this would CREATE a
+            # bare row record for a row somebody deleted.
+            'ConditionExpression': 'attribute_exists(sk)',
+            'UpdateExpression': (
+                'SET #frozen_at = if_not_exists(#frozen_at, :now) '
+                'ADD #ballot_writes :one'
+            ),
+            'ExpressionAttributeNames': {
+                '#frozen_at': ROW_FROZEN_AT_FIELD,
+                '#ballot_writes': ROW_BALLOT_WRITES_FIELD,
+            },
+            'ExpressionAttributeValues': {':now': now.isoformat(), ':one': 1},
+        }},
+    ]
+    for attempt in range(BALLOT_WRITE_ATTEMPTS):
+        try:
+            table.meta.client.transact_write_items(TransactItems=transact_items)
+            return
+        except ClientError as e:
+            cancelled = (
+                e.response.get('Error', {}).get('Code')
+                == 'TransactionCanceledException'
+            )
+            if cancelled and _row_condition_failed(e):
+                # The row's only condition is its existence, so this row went away
+                # between the session being opened and the room voting. NOT RETRIED:
+                # a deleted row does not come back, so re-attempting would spend the
+                # request's time to reach the same answer. Nothing was written — a
+                # transaction applies whole or not at all — so the slot this
+                # submission claimed is spent, which is the honest direction: the cap
+                # exists to bound writes, and refusing to record a ballot never lets
+                # one past it.
+                logger.warning(
+                    f'An anonymous ballot named a row that no longer exists, on '
+                    f'session {_session_ref(session_id)}. Nothing was written.'
+                )
+                raise _RowIsGone from e
+            if cancelled and attempt + 1 < BALLOT_WRITE_ATTEMPTS:
+                # A cancellation NO CONDITION CAUSED: contention on the row record,
+                # throttling. Transient, and the ordinary case for the room this
+                # feature is for — so it is re-attempted rather than reported, because
+                # the caller's cap slot is already spent and the page offers the voter
+                # no way to resubmit. Safe to repeat: the ballot's half is an upsert on
+                # this device's own key.
+                #
+                # Jittered, so a room whose phones all conflicted does not re-collide
+                # in lockstep having waited the same interval.
+                delay = BALLOT_WRITE_BACKOFF_SECONDS * (2 ** attempt)
+                time.sleep(delay * (0.5 + secrets.randbelow(500) / 1000))
+                logger.warning(
+                    f'An anonymous ballot write was cancelled without a failed '
+                    f'condition on session {_session_ref(session_id)}; retrying '
+                    f'(attempt {attempt + 2} of {BALLOT_WRITE_ATTEMPTS}).'
+                )
+                continue
             # Never echoes the note or the display name — both are submitter
             # content, and one of them is PII.
             logger.exception(
@@ -1169,23 +1271,11 @@ def _write_ballot(
                 f'{_session_ref(session_id)}: {e}'
             )
             raise ServiceError('Failed to record the ballot') from e
-        # The row's only condition is its existence, so this row went away between
-        # the session being opened and the room voting. The device is told the same
-        # thing a vanished session is answered with, because from the phone's side
-        # it is the same fact: there is nothing here to score any more. Nothing was
-        # written — a transaction applies whole or not at all — so the slot this
-        # submission claimed is spent, which is the honest direction: the cap exists
-        # to bound writes, and refusing to record a ballot never lets one past it.
-        logger.warning(
-            f'An anonymous ballot named a row that no longer exists, on session '
-            f'{_session_ref(session_id)}. Nothing was written.'
-        )
-        raise NotFoundError('That proposal no longer exists') from e
-    except ApiError:
-        raise
-    except Exception as e:
-        logger.exception(f'Failed to write an anonymous ballot for session {_session_ref(session_id)}: {e}')
-        raise ServiceError('Failed to record the ballot') from e
+        except ApiError:
+            raise
+        except Exception as e:
+            logger.exception(f'Failed to write an anonymous ballot for session {_session_ref(session_id)}: {e}')
+            raise ServiceError('Failed to record the ballot') from e
 
 
 @app.post('/voting-sessions/<session_id>/submit')
@@ -1210,7 +1300,16 @@ def submit_ballot(session_id: str):
 
     A failure between 4 and 5 loses a slot without recording a ballot, and answers
     500. That is the honest direction: the alternative (write first, count after)
-    would let a flood past the cap, which is the whole thing the cap exists for.
+    would let a flood past the cap, which is the whole thing the cap exists for. It
+    is also why step 5 RETRIES a write cancelled by contention rather than reporting
+    it — the slot is already spent by then and the page gives the voter no way to
+    resubmit, so a conflict the room caused simply by voting together would otherwise
+    cost a ballot AND its slot (see `_write_ballot`).
+
+    A row that went away between steps 4 and 5 is answered as a refusal carrying
+    `REASON_NOT_FOUND`, not as a 500 and not as a bare 404: the page dispatches on
+    the reason, and this is a permanent fact rather than something to retry.
+
     The row id comes from the SESSION, never from the body — a public caller
     does not get to choose which proposal it is scoring.
     """
@@ -1278,7 +1377,16 @@ def submit_ballot(session_id: str):
     if ballot_id is None:
         ballot_id = _minted_ballot_id()
 
-    _write_ballot(row_id, ballot_id, validated_session, axes, note, display_name, now)
+    try:
+        _write_ballot(row_id, ballot_id, validated_session, axes, note, display_name,
+                      now)
+    except _RowIsGone:
+        # Answered with the same `reason` a vanished SESSION is, because from the
+        # phone's side it is the same fact: there is nothing here to score any more.
+        # As a refusal rather than a raise, so the body carries that reason — the page
+        # reads only the reason, and a 404 without one renders as "try again in a
+        # moment" about a row that will never be back.
+        return _refusal(REASON_NOT_FOUND, 'That proposal no longer exists')
 
     # The ballot id is the device's own credential for correcting its vote, so it
     # is never logged; nor is the note or the display name.

--- a/voc-datalake/lambda/api/ballots_handler.py
+++ b/voc-datalake/lambda/api/ballots_handler.py
@@ -1276,6 +1276,22 @@ def _write_ballot(
         except Exception as e:
             logger.exception(f'Failed to write an anonymous ballot for session {_session_ref(session_id)}: {e}')
             raise ServiceError('Failed to record the ballot') from e
+    # UNREACHABLE while BALLOT_WRITE_ATTEMPTS >= 1, and kept because falling out of
+    # this loop is INDISTINGUISHABLE FROM SUCCESS: this function signals a written
+    # ballot by returning None, so a bound of 0 would make `range` yield nothing, log
+    # 'Recorded an anonymous ballot' and answer the device 200 having written nothing
+    # at all — a silent false success on a public vote-recording write. The bound is a
+    # tuning number, exactly the kind a later change lowers or reads from the
+    # environment, so the assumption is stated as a raise rather than left to hold.
+    # `test_the_write_attempts_bound_leaves_at_least_one_attempt` pins the bound
+    # itself, the way `MAX_ROW_BALLOTS_PER_DELETE + 2 <= 100` pins the delete's
+    # reservation; this is the guard for the case where it stops holding anyway.
+    logger.error(
+        'An anonymous ballot write made no attempt at all, which means '
+        'BALLOT_WRITE_ATTEMPTS is not at least 1. Refusing rather than reporting a '
+        'ballot that was never written.'
+    )
+    raise ServiceError('Failed to record the ballot')
 
 
 @app.post('/voting-sessions/<session_id>/submit')

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -1888,19 +1888,28 @@ def _default_row_composition(documents: list[dict]) -> tuple[list[str], str]:
         if document_id not in document_ids:
             document_ids.append(document_id)
     document_ids = document_ids[:MAX_ROW_DOCUMENT_IDS]
+    return document_ids, _latest_prototype_id(documents)
 
+
+def _latest_prototype_id(documents: list[dict]) -> str:
+    """The project's newest prototype id, or ''.
+
+    Its own function because BOTH row-creating routes carry it and only one of them
+    composes `document_ids`: the compose route takes the caller's document set and
+    this prototype, so calling `_default_row_composition` for the prototype alone
+    would have it deriving "latest of each type" for a set it then discards — a
+    derivation sitting inside the one route whose whole contract is not to derive.
+    """
     prototypes = [
         item for item in documents
         if str(item.get('sk', '')).startswith(PROTOTYPE_SK_PREFIX)
     ]
     prototypes.sort(key=lambda item: str(item.get('created_at', '')), reverse=True)
-    prototype_id = ''
     for item in prototypes:
         candidate = item.get('document_id')
         if isinstance(candidate, str) and candidate:
-            prototype_id = candidate
-            break
-    return document_ids, prototype_id
+            return candidate
+    return ''
 
 
 def _minted_row_id() -> str:
@@ -2038,7 +2047,7 @@ def api_compose_prioritization_row():
     if not any(item.get('sk') == 'META' for item in documents):
         raise NotFoundError(f'Project {project_id} not found')
     document_ids = _validated_row_document_ids(body.get('document_ids'), documents)
-    _, prototype_id = _default_row_composition(documents)
+    prototype_id = _latest_prototype_id(documents)
 
     table = get_aggregates_table()
     if not table:
@@ -2242,7 +2251,11 @@ def _row_ballot_sort_keys(table, row_id: str) -> list[str]:
 
     Bounded at MAX_ROW_BALLOTS_PER_DELETE and then REFUSED rather than truncated: a
     short read here would delete the row and leave the ballots that did not fit,
-    which is exactly the orphan the whole path exists to prevent.
+    which is exactly the orphan the whole path exists to prevent. Page exhaustion
+    raises SEPARATELY, and the two messages differ because the remedies do: one is a
+    row too heavily balloted for one transaction, the other a partition that has
+    outgrown the read this module performs everywhere. A single message covering both
+    would name the wrong cause for whichever case it was not written about.
     """
     query_kwargs: dict[str, Any] = {
         'KeyConditionExpression': (
@@ -2260,21 +2273,28 @@ def _row_ballot_sort_keys(table, row_id: str) -> list[str]:
             if isinstance(item, dict) and item.get('sk')
         )
         if len(sort_keys) > MAX_ROW_BALLOTS_PER_DELETE:
-            break
+            logger.error(
+                'A prioritization row holds more than the %d ballots one atomic '
+                'delete can remove. Deleting it in several writes would leave '
+                'orphaned ballots between them, which is the fault this path exists '
+                'to prevent.',
+                MAX_ROW_BALLOTS_PER_DELETE,
+            )
+            raise ConflictError(
+                f'This row holds more than the {MAX_ROW_BALLOTS_PER_DELETE} ballots '
+                'that can be removed together with it in one atomic write'
+            )
         last_key = response.get('LastEvaluatedKey')
         if not last_key:
             return sort_keys
         query_kwargs['ExclusiveStartKey'] = last_key
     logger.error(
-        'A prioritization row holds more than the %d ballots one atomic delete can '
-        'remove. Deleting it in several writes would leave orphaned ballots between '
-        'them, which is the fault this path exists to prevent.',
-        MAX_ROW_BALLOTS_PER_DELETE,
+        "A prioritization row's ballots exceed %d query pages, so the delete cannot "
+        'enumerate them all. Deleting the row on a short read would orphan the '
+        'ballots it did not see.',
+        MAX_PRIORITIZATION_PAGES,
     )
-    raise ConflictError(
-        f'This row holds more than the {MAX_ROW_BALLOTS_PER_DELETE} ballots that '
-        'can be removed together with it in one atomic write'
-    )
+    raise ServiceError('Too many ballots on this row to read in one request')
 
 
 def _transact_delete_row(

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -3183,22 +3183,42 @@ def api_patch_prioritization_scores():
     Body shape is `{'scores': {row_id: {...}}}`; every entry is written as the
     CALLER'S ballot on that row.
 
-    Each row is one `update_item` on the caller's own key — never a
-    read-modify-write of a shared map — so concurrent reviewers cannot overwrite
-    each other. Only the fields an entry carries are written, so a partial entry
-    leaves the reviewer's other axes untouched. No `ttl` attribute is ever
-    written: the aggregates table expires anything carrying one, and a ballot is a
-    durable decision record.
+    Each row is one TRANSACTION carrying two writes: the ballot, on the caller's own
+    key — never a read-modify-write of a shared map, so concurrent reviewers cannot
+    overwrite each other — and its row's mark (see `_ballot_transact_items`). Only the
+    fields an entry carries are written, so a partial entry leaves the reviewer's
+    other axes untouched. No `ttl` attribute is ever written: the aggregates table
+    expires anything carrying one, and a ballot is a durable decision record.
 
     PARTIAL FAILURE, and why RETRYING IS SAFE. This is NOT all-or-nothing. Nothing
     malformed can half-apply — every key and every value is refused before the
-    first write — but the rows are written sequentially, so a throttle or a
-    timeout on row 3 of 10 leaves the first two durably persisted and answers
-    a bare 500 that does not say so. Retrying the identical body is nonetheless
-    safe: every write is an idempotent `update_item` on a deterministic key derived
-    from the row id and the caller's own subject, so replaying converges on
-    the same ballots rather than duplicating or compounding anything. A client that
-    sees a 500 should re-send the whole body, not try to work out what landed.
+    first write, and each row's two writes land together or not at all — but the rows
+    are written sequentially, so a throttle or a timeout on row 3 of 10 leaves the
+    first two durably persisted and answers a bare 500 that does not say so.
+    Retrying the identical body is nonetheless safe, and it is worth being exact about
+    WHICH of the two writes converges, because they do not converge in the same sense:
+
+    * THE BALLOT CONVERGES. It is an upsert on a deterministic key derived from the
+      row id and the caller's own subject, so a replay overwrites the reviewer's own
+      record with the same values rather than adding a second one. This is the part
+      that matters, and it is what makes "re-send the whole body" the right advice.
+    * ROW_FROZEN_AT_FIELD CONVERGES TOO, because it is written with `if_not_exists`:
+      a replay cannot move the instant a first ballot recorded.
+    * ROW_BALLOT_WRITES_FIELD DOES NOT, and is not meant to. It is an `ADD`, so it
+      counts WRITE ATTEMPTS THAT COMMITTED rather than reviewers, and a replay
+      advances it — which is exactly what the delete's fence needs, since a fence
+      that did not move under a replay would let a delete that enumerated before it
+      commit over it. Nothing reads this number as a count of anything: it is
+      published nowhere (`_row_payload`), and `reviewer_count` is derived from the
+      ballot records themselves. The only consequence of the extra increment is that
+      a delete racing the replay is cancelled with a 409 its caller retries — the
+      conservative direction `_transact_delete_row` already argues for, where a
+      spurious 409 costs a retry and a missed one costs an orphan.
+
+    So a client that sees a 500 should re-send the whole body, not try to work out
+    what landed: no ballot is lost, none is double-counted, and no freeze instant
+    moves. A change that started publishing ROW_BALLOT_WRITES_FIELD, or deriving a
+    reviewer count from it, would be relying on an idempotence it does not have.
 
     `updated_count` is returned only on success, where it is the number of BALLOTS
     WRITTEN — saves that stored a value the reviewer entered — which is at most the

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -565,6 +565,25 @@ ROW_BALLOT_WRITES_FIELD = 'ballot_writes'
 # than about the exception.
 BALLOT_TRANSACT_ROW_INDEX = 1
 
+# What a `TransactItems[].Update` accepts, per the DynamoDB API — a NARROWER set than
+# `update_item` takes, which is why it is stated. `_ballot_transact_items` spreads the
+# kwargs `_ballot_update_kwargs` built for `update_item` into one of these, so a
+# resource-only key added there later (`ReturnValues`, `ReturnConsumedCapacity`) would
+# have DynamoDB reject the whole transaction. Asserted against rather than filtered:
+# dropping such a key silently would discard part of what that function decided to
+# write while still answering 200.
+#
+# `TableName` is supplied by the caller of this list rather than by the kwargs.
+TRANSACT_UPDATE_KEYS = frozenset({
+    'TableName',
+    'Key',
+    'UpdateExpression',
+    'ConditionExpression',
+    'ExpressionAttributeNames',
+    'ExpressionAttributeValues',
+    'ReturnValuesOnConditionCheckFailure',
+})
+
 # How many documents one row may hold. A row is a project's scorable documents
 # plus its latest prototype, and the composition is stored verbatim and read back
 # on every page load. Generous next to any real project (a handful of PRDs and
@@ -1804,12 +1823,16 @@ def _project_documents(project_id: str) -> list[dict]:
       * truncation later composes a row from a superseded PRD, or refuses with "no
         PRD or PR/FAQ to score" for a project that has one.
 
-    And a composition is FROZEN: the create is idempotent on the row id and there is
-    no recompose route, so a row built from a short read cannot be corrected through
-    the product, and every ballot on it then describes documents nobody chose. That
-    asymmetry is why this refuses instead of returning what it has — the same reading
-    `_read_prioritization_partition` takes one screen up, where "a silently-short
-    window is exactly how this codebase has been bitten before".
+    And a composition BECOMES FROZEN at the first ballot. The create is idempotent on
+    the row id, so it never rewrites a row it finds; a recompose route exists, but the
+    database refuses it once anybody has balloted (ROW_FROZEN_AT_FIELD), and a row
+    composed from a short read is not marked as suspect in any way that would prompt
+    somebody to correct it before that happens. So the repair window is real but
+    closes on its own, unannounced — and after it closes every ballot on the row
+    describes documents nobody chose. That asymmetry is why this refuses instead of
+    returning what it has — the same reading `_read_prioritization_partition` takes one
+    screen up, where "a silently-short window is exactly how this codebase has been
+    bitten before".
     """
     table = get_projects_table()
     if not table:
@@ -2157,6 +2180,24 @@ def api_recompose_prioritization_row(row_id: str):
     state is what refuses — the caller was permitted, and what they asked for
     conflicts with a fact about the world that a reload will show them.
 
+    A DEFAULT ROW MAY BE RECOMPOSED, and the condition deliberately says nothing about
+    `is_default`. "Latest of each type" is how a default row is FIRST COMPOSED, not a
+    property it keeps: `_default_row_composition` is a starting point for a project
+    nobody has set up, and narrowing it before anyone votes is the ordinary case this
+    route exists for — a project holding four PRDs gets all four in one row, and the
+    reviewer who wants to score two of them is editing the row they were handed, not
+    replacing it. Refusing here would force compose-then-delete for that, which needs
+    an admin (the delete is admin-gated) and leaves the project's derived key holding
+    the row nobody wanted.
+
+    The consequence is that after a recompose, `POST .../rows` answers `created: false`
+    with a composition that is no longer what `_default_row_composition` would derive.
+    That is the honest reading rather than a gap: the create's contract is "this
+    project's row, whatever it now holds", and a create that re-derived would silently
+    discard a choice somebody made. `is_default` continues to mean what it has always
+    meant — the row a project got without a setup step, which is what makes it the one
+    that cannot be deleted while it is the project's only row.
+
     `project_id` is asserted in the same condition rather than trusted from the
     row's stored value, so a recompose can only ever hold documents of the project
     the caller validated the ids against. Without it, naming another project's row
@@ -2449,12 +2490,15 @@ def _transact_delete_row(
     on the attribute being ABSENT, which is the same assertion for the same reason.
 
     The fence value is passed through UNCONVERTED. It was read at the resource layer
-    (a `Decimal`) and goes back as `:seen_writes` through `table.meta.client`, which
-    is the resource's client and so carries the resource's type serializer — a
-    `Decimal('1')` serialises to `{'N': '1'}` and the comparison holds. Coercing it
-    to `int` here, or issuing this transaction on a bare `boto3.client('dynamodb')`,
-    would break that: this is the one place in the module where a value read at the
-    resource layer is fed back through a client-layer call.
+    (a `Decimal`) and goes back as `:seen_writes` through `table.meta.client` — the
+    RESOURCE'S client, which carries the resource's type serializer, so the `Decimal`
+    becomes `{'N': '1'}` and the comparison holds. This is the one place in the module
+    where a value read at the resource layer is fed back through a client-layer call,
+    which is why it is written down: issuing this transaction on a bare
+    `boto3.client('dynamodb')` instead would reject every native value in it outright.
+    `test_projects_prioritization_row_lifecycle_moto.py` executes this against a real
+    implementation for exactly that reason — the suite's fake accepts whatever `dict`
+    it is handed, so it cannot tell a legal request from an illegal one.
 
     `sibling_sk`, when present, is a `ConditionCheck` asserting that another row of
     the project still exists. It is what makes "the default row is not deleted while
@@ -3026,6 +3070,21 @@ def _ballot_transact_items(table, update_kwargs: dict, row_id: str, now: str) ->
     row_update['UpdateExpression'] = (
         (('SET ' + ', '.join(assignments) + ' ') if assignments else '')
         + 'ADD #ballot_writes :one'
+    )
+    # SPREAD rather than rebuilt field by field, and checked rather than trusted. A
+    # `TransactItems[].Update` accepts a narrower set of keys than `update_item` does,
+    # so a resource-only one (`ReturnValues`, `ReturnConsumedCapacity`) reaching here
+    # is rejected by DynamoDB for the whole transaction — a ballot save failing on
+    # something the ballot itself is not about. Rebuilding the item here instead would
+    # SILENTLY DROP such a key, which is worse: it would discard part of what
+    # `_ballot_update_kwargs` decided to write while answering 200. So the mismatch is
+    # asserted, which turns a future addition there into a failure that names the
+    # cause. (`test_projects_prioritization_row_lifecycle_moto.py` executes the shape
+    # against a real implementation; the suite's fake accepts any `dict`.)
+    unsupported = set(update_kwargs) - TRANSACT_UPDATE_KEYS
+    assert not unsupported, (
+        f'_ballot_update_kwargs returned {sorted(unsupported)}, which a transaction '
+        'Update does not accept'
     )
     items = [
         {'Update': {'TableName': table.name, **update_kwargs}},

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -21,6 +21,10 @@ from shared.api import (
     api_handler,
     validate_date_basis,
     MAX_PERSONAS_PER_GENERATION,
+    # APPENDED rather than sorted into place: two open pull requests (#344, #330)
+    # also edit this import block, and re-sorting a list this change did not need
+    # to reorder is a conflict invented for tidiness.
+    require_admin,
 )
 from shared.tables import get_jobs_table, get_aggregates_table, get_projects_table
 from shared.jobs import create_job
@@ -515,6 +519,43 @@ ROW_SK_PREFIX = 'ROW#'
 DEFAULT_ROW_ID_PREFIX = 'row_'
 DEFAULT_ROW_ID_SUFFIX = '_default'
 
+# How many random bytes a NON-default row's id carries, and how one is spelled.
+#
+# Minted server-side, never accepted from a caller, for the reason
+# `_validated_ballot_row_id` records at length: the row id becomes the FIRST SEGMENT
+# of every ballot sort key on that row, so a caller-chosen id puts the shape of that
+# key under a caller's control. Hex under the same DEFAULT_ROW_ID_PREFIX namespace,
+# so every row id in the partition reads alike and none of them can contain the '#'
+# the key is split on.
+#
+# The DEFAULT suffix is deliberately NOT appended: a minted id must never be able to
+# collide with the derived default id of any project, and `_default_row_id` is the
+# only thing that composes that spelling.
+ROW_ID_BYTES = 16
+
+# The mark a row carries once a ballot has landed on it, and what the composition
+# change asserts about.
+#
+# THIS ATTRIBUTE IS THE FREEZE. A composition change is one conditional
+# `update_item` carrying `attribute_not_exists(first_ballot_at)`, so the DATABASE is
+# what refuses a change to a row somebody has voted on — a read of a ballot count
+# followed by a write would lose the race against the first ballot and leave a row
+# whose documents nobody balloting on it ever saw. Written by the ballot save in the
+# SAME transaction as the ballot itself (`_ballot_transact_items`), which is what
+# makes "the first ballot froze it" true at the instant the ballot lands rather than
+# on a later reconciliation.
+#
+# `if_not_exists`, so it records the FIRST ballot and every later one leaves it
+# alone: it is the freeze instant, not a last-modified stamp.
+ROW_FROZEN_AT_FIELD = 'first_ballot_at'
+
+# How many ballot writes a row has taken. Not a reviewer count and not shown to
+# anybody — it exists so a DELETE can be fenced on the row not having changed
+# between the read that enumerated its ballots and the write that removes them (see
+# `api_delete_prioritization_row`). Incremented with `ADD` in the ballot
+# transaction, so two concurrent ballots each move it.
+ROW_BALLOT_WRITES_FIELD = 'ballot_writes'
+
 # How many documents one row may hold. A row is a project's scorable documents
 # plus its latest prototype, and the composition is stored verbatim and read back
 # on every page load. Generous next to any real project (a handful of PRDs and
@@ -586,6 +627,20 @@ MAX_BALLOTS_PER_SAVE = 100
 # that eventually times out on the page's primary read. Generous enough that the
 # documented team-sized deployment can never reach it.
 MAX_PRIORITIZATION_PAGES = 20
+
+# How many ballots one row may hold and still be deletable together with them.
+#
+# DynamoDB caps a transaction at 100 items, and the delete spends items on the row
+# record and, for a default row, one `ConditionCheck` on a sibling — so this is that
+# ceiling minus the two the transaction reserves for itself. Not a product bound: a
+# row is one project's set of documents, and a reviewer count that reaches this is a
+# deployment far past the team-sized shape the partition itself is scaled for.
+#
+# Crossing it REFUSES rather than deleting in batches, which is the whole argument
+# for the transaction: several writes would leave the ballots that did not fit in the
+# first one orphaned between them, and an orphaned ballot is precisely what this path
+# exists to make impossible.
+MAX_ROW_BALLOTS_PER_DELETE = 98
 
 # How many document pages a row COMPOSITION will follow.
 #
@@ -779,6 +834,32 @@ def _validated_ballot_row_id(raw: Any) -> str:
     if len(row_id) > MAX_KEY_SEGMENT_ID_LEN:
         raise ValidationError(
             f'scores keys must be at most {MAX_KEY_SEGMENT_ID_LEN} characters'
+        )
+    return row_id
+
+
+def _validated_path_row_id(raw: Any) -> str:
+    """Check that a row id taken from the URL PATH can be a sort key.
+
+    The same three rules `_validated_ballot_row_id` applies, for the same reasons
+    recorded there, with messages that name `row_id` rather than "scores keys": a
+    caller who addressed `PATCH /projects/prioritization/rows/{row_id}` and was told
+    their "scores keys" were wrong would be reading about a field their request does
+    not have.
+
+    A path segment reaches the same sort key as a body key does, so the no-'#' rule
+    is not merely inherited — a '%23' that arrives decoded would compose
+    `ROW#a#b`, and the row a later ballot's `BALLOT#a#b#user:x` key parses to is then
+    not the row that was written.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValidationError('row_id is required')
+    row_id = raw.strip()
+    if '#' in row_id:
+        raise ValidationError("row_id must not contain '#', the sort-key delimiter")
+    if len(row_id) > MAX_KEY_SEGMENT_ID_LEN:
+        raise ValidationError(
+            f'row_id must be at most {MAX_KEY_SEGMENT_ID_LEN} characters'
         )
     return row_id
 
@@ -1567,6 +1648,25 @@ def _fetched_ballot_rows(table, row_ids: list[str]) -> dict[str, dict]:
     return fetched
 
 
+def _fetched_row(table, row_id: str) -> dict | None:
+    """One row record, or None — the DELETE's read.
+
+    Separate from `_fetched_ballot_rows` for one reason: that helper's failed-read
+    message says a SAVE failed, and a delete that reported "Failed to save
+    prioritization scores" would send an operator reading the wrong route's logs. The
+    consistency argument is the same and stated there.
+    """
+    try:
+        item = table.get_item(
+            Key={'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)},
+            ConsistentRead=True,
+        ).get('Item')
+    except Exception as e:
+        logger.exception(f'Failed to read a prioritization row before a delete: {e}')
+        raise ServiceError('Failed to delete the prioritization row') from e
+    return item if isinstance(item, dict) else None
+
+
 def _is_default_row(row: Any) -> bool:
     """Is this the project's default row?
 
@@ -1578,6 +1678,21 @@ def _is_default_row(row: Any) -> bool:
     return isinstance(row, dict) and row.get('is_default') is True
 
 
+def _is_frozen_row(row: Any) -> bool:
+    """Has a ballot landed on this row, so its composition is settled?
+
+    Read off the presence of ROW_FROZEN_AT_FIELD, which is the SAME attribute the
+    composition change's condition names. One fact, asked one way: a predicate that
+    counted ballots instead could answer "not frozen" for a row the database will
+    nonetheless refuse to recompose, which is a page saying the opposite of what the
+    save does.
+    """
+    if not isinstance(row, dict):
+        return False
+    frozen_at = row.get(ROW_FROZEN_AT_FIELD)
+    return isinstance(frozen_at, str) and bool(frozen_at)
+
+
 def _row_payload(row: dict) -> dict:
     """One entry of the `rows` map the page consumes.
 
@@ -1585,6 +1700,15 @@ def _row_payload(row: dict) -> dict:
     `item_to_widget_config` records in the feedback-form handler: `pk`/`sk` are
     storage detail, and a field added to the record later must not reach the page
     without somebody deciding it should.
+
+    `is_frozen` is ADDITIVE and every existing field keeps its name and meaning, so
+    the shipped page keeps working unchanged. It is a boolean rather than the stored
+    instant because what a consumer can act on is whether the composition may still
+    change; the instant itself is storage detail nothing on the page renders, and
+    publishing it would invite a client to compute the freeze itself and disagree
+    with the condition that actually enforces it. `ballot_writes` is not published
+    for the same reason and a stronger one — it counts writes, not reviewers, and a
+    number that looks like a reviewer count but is not is worse than no number.
     """
     return {
         'row_id': row.get('row_id', ''),
@@ -1595,6 +1719,7 @@ def _row_payload(row: dict) -> dict:
         ),
         'is_default': _is_default_row(row),
         'created_at': row.get('created_at', ''),
+        'is_frozen': _is_frozen_row(row),
     }
 
 
@@ -1776,6 +1901,522 @@ def _default_row_composition(documents: list[dict]) -> tuple[list[str], str]:
             prototype_id = candidate
             break
     return document_ids, prototype_id
+
+
+def _minted_row_id() -> str:
+    """A new NON-default row's id.
+
+    Always minted here, never taken from the request, for the reason
+    `_validated_ballot_row_id` records: the id becomes the first segment of every
+    ballot sort key on the row, so a caller-chosen id would put that key's shape
+    under a caller's control. Hex, so it cannot carry the '#' the key is split on,
+    and prefixed like the derived default ids so every row id in the partition reads
+    alike.
+    """
+    return f'{DEFAULT_ROW_ID_PREFIX}{secrets.token_hex(ROW_ID_BYTES)}'
+
+
+def _scorable_document_ids(documents: list[dict]) -> dict[str, str]:
+    """Every SCORABLE document of the project, as document_id -> sort-key prefix.
+
+    The candidate set a caller may compose a row from. Built from the project's own
+    partition and keyed by the sort-key prefix, so "this project owns it" and "this
+    type is scorable" are one lookup rather than two checks that could disagree —
+    `pk` is the project and `sk` carries the type, which is the same reasoning
+    `_validated_source_id` records for the generation routes' trust boundary.
+
+    A prototype is deliberately absent: it is context a reviewer looks at rather
+    than a document a row is scored on (see `_default_row_composition`), so offering
+    one as a row member would put an unscorable id in `document_ids`.
+    """
+    owned: dict[str, str] = {}
+    for item in documents:
+        sk = str(item.get('sk', ''))
+        prefix = next((p for p in SCORABLE_SK_PREFIXES if sk.startswith(p)), None)
+        if prefix is None:
+            continue
+        document_id = item.get('document_id')
+        if isinstance(document_id, str) and document_id:
+            owned.setdefault(document_id, prefix)
+    return owned
+
+
+def _validated_row_document_ids(raw: Any, documents: list[dict]) -> list[str]:
+    """The concrete document ids a caller asked a row to hold, or a refusal.
+
+    STORED VERBATIM by the caller's choosing — this is what makes a row mean the
+    same set forever. Nothing here re-derives "latest of each type": that rule
+    composes a DEFAULT row once (`_default_row_composition`) and has no business
+    reinterpreting a set somebody picked.
+
+    Every refusal happens BEFORE anything is written, and each names the rule it
+    failed rather than echoing the id, which is unbounded caller input a response
+    body gains nothing by repeating (the reasoning `_validated_ballot_row_id` and
+    `validate_bool` both record). Five rules, and the reason each one is a refusal
+    rather than a repair:
+
+    * NOT A LIST OF STRINGS — there is no set to store, and coercing one would
+      invent a composition nobody chose.
+    * EMPTY — a row with nothing to score is not a row. The same refusal the default
+      row's create already makes for a project with no scorable document, in the
+      same words the page already has an answer for.
+    * AN ID THIS PROJECT DOES NOT OWN — the trust boundary. A row is a PROJECT'S set
+      of documents, and a ballot's aggregate is read per project, so an id from
+      elsewhere would put another project's document inside this project's team
+      score. Checked against the project's own partition rather than against a
+      caller-supplied project field.
+    * AN ID THAT IS NOT SCORABLE — a prototype or a research report has no sliders
+      on the page, so a row holding one would show a member nobody can score and
+      the row's own copy would miscount what it holds.
+    * A DUPLICATE — the same document twice says nothing new about the row, and it
+      spends the bound twice; refused rather than de-duplicated for the reason the
+      duplicate-key refusal in the save path records, that the request states
+      something contradictory and there is nothing to prefer.
+
+    Ownership and type share one message on purpose, and it is the one exception to
+    "name the rule that failed": distinguishing them would tell a caller whether a
+    document id exists in a project they may not have named, which is the same
+    reason `_validated_source_id` answers one 404 for both.
+    """
+    if not isinstance(raw, list):
+        raise ValidationError('document_ids must be a list of document id strings')
+    if not raw:
+        raise ValidationError(
+            'document_ids must name at least one document, so the row has '
+            'something to score'
+        )
+    if len(raw) > MAX_ROW_DOCUMENT_IDS:
+        raise ValidationError(
+            f'document_ids must name at most {MAX_ROW_DOCUMENT_IDS} documents'
+        )
+    owned = _scorable_document_ids(documents)
+    document_ids: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            raise ValidationError('document_ids must be non-empty document id strings')
+        document_id = entry.strip()
+        if document_id not in owned:
+            raise NotFoundError(
+                'document_ids name a document this project does not hold, or one '
+                'that is not a PRD or a PR/FAQ'
+            )
+        if document_id in document_ids:
+            raise ValidationError('document_ids must name distinct documents')
+        document_ids.append(document_id)
+    return document_ids
+
+
+@app.post("/projects/prioritization/rows/compose")
+@tracer.capture_method
+def api_compose_prioritization_row():
+    """Create a row for another combination of one project's documents.
+
+    A ROW IS WHAT THE CALLER NAMED. The request carries the project and the concrete
+    document ids, and those ids are stored verbatim — nothing here re-derives them,
+    so the row means the same set forever and generating a newer PR/FAQ later leaves
+    it composed exactly as it was. That is the same guarantee the default row has
+    (`_default_row_composition`), stated for a set somebody picked.
+
+    Open to any signed-in reviewer, per the decision recorded on #339: the identity
+    of whoever composed a row is not the protection — the freeze is, and deletion is
+    the one action that is admin-gated.
+
+    Never a DEFAULT row. `is_default` is stamped false and the id is minted
+    (`_minted_row_id`) rather than derived, so `POST .../rows` keeps its idempotence
+    on a key nothing here can occupy: two calls to this route deliberately produce
+    two rows, because "score another combination" is a request to add one.
+
+    A minted id makes the conditional put a formality rather than an idempotence —
+    it is kept anyway, because a put with no condition is an upsert, and the one
+    thing worse than a failed create is a create that silently replaced a row whose
+    ballots already exist.
+    """
+    body = _json_object_body()
+    project_id = _validated_row_project_id(body.get('project_id'))
+
+    documents = _project_documents(project_id)
+    if not any(item.get('sk') == 'META' for item in documents):
+        raise NotFoundError(f'Project {project_id} not found')
+    document_ids = _validated_row_document_ids(body.get('document_ids'), documents)
+    _, prototype_id = _default_row_composition(documents)
+
+    table = get_aggregates_table()
+    if not table:
+        raise ConfigurationError('Aggregates table not configured')
+
+    row_id = _minted_row_id()
+    now = datetime.now(timezone.utc).isoformat()
+    item = {
+        'pk': PRIORITIZATION_PK,
+        'sk': _row_sk(row_id),
+        'row_id': row_id,
+        'project_id': project_id,
+        'document_ids': document_ids,
+        # The project's latest prototype, as context, exactly as the default row
+        # carries it. Not composable per row: a prototype is not scored, so a
+        # separate selector for it would be a second dimension of choice over
+        # something no ballot is about.
+        'prototype_id': prototype_id,
+        'is_default': False,
+        'created_at': now,
+        'updated_at': now,
+        # No `ttl`: the aggregates table expires anything carrying one, and a row is
+        # as durable as the ballots keyed to it.
+    }
+    try:
+        table.put_item(Item=item, ConditionExpression='attribute_not_exists(sk)')
+    except Exception as e:
+        logger.exception(f'Failed to compose a prioritization row for {project_id}: {e}')
+        raise ServiceError('Failed to create the prioritization row') from e
+
+    return {'success': True, 'created': True, 'row': _row_payload(item)}
+
+
+@app.patch("/projects/prioritization/rows/<row_id>")
+@tracer.capture_method
+def api_recompose_prioritization_row(row_id: str):
+    """Change which documents an UN-BALLOTED row holds.
+
+    THE DATABASE REFUSES A FROZEN ROW, not this function. The write is one
+    conditional `update_item` whose condition asserts the row exists and carries no
+    ROW_FROZEN_AT_FIELD, and the ballot save writes that attribute in the same
+    transaction as the ballot itself — so a composition change racing the first
+    ballot LOSES TO IT rather than being sorted out afterwards. Reading a ballot
+    count first and then writing would land the change in the gap between the two
+    calls, leaving a row whose documents nobody who balloted on it ever saw; that is
+    the race #339 records as the reason the condition has to be the rule and
+    disabled controls only a courtesy.
+
+    A refusal answers 409 and writes nothing. 409 rather than 403, because the row's
+    state is what refuses — the caller was permitted, and what they asked for
+    conflicts with a fact about the world that a reload will show them.
+
+    `project_id` is asserted in the same condition rather than trusted from the
+    row's stored value, so a recompose can only ever hold documents of the project
+    the caller validated the ids against. Without it, naming another project's row
+    id would install this project's documents on it.
+
+    Open to any signed-in reviewer, for the same reason the create is.
+    """
+    validated_row_id = _validated_path_row_id(row_id)
+    body = _json_object_body()
+    project_id = _validated_row_project_id(body.get('project_id'))
+
+    documents = _project_documents(project_id)
+    if not any(item.get('sk') == 'META' for item in documents):
+        raise NotFoundError(f'Project {project_id} not found')
+    document_ids = _validated_row_document_ids(body.get('document_ids'), documents)
+
+    table = get_aggregates_table()
+    if not table:
+        raise ConfigurationError('Aggregates table not configured')
+
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        response = table.update_item(
+            Key={'pk': PRIORITIZATION_PK, 'sk': _row_sk(validated_row_id)},
+            UpdateExpression=(
+                'SET #document_ids = :document_ids, #updated_at = :updated_at'
+            ),
+            # THE FREEZE. All three conjuncts matter: `attribute_exists` because
+            # `update_item` is an upsert and would otherwise create a bare row
+            # record for an id that never existed; the frozen mark because that is
+            # what the first ballot writes; the project because the ids were
+            # validated against THAT project's documents and no other.
+            ConditionExpression=(
+                f'attribute_exists(sk) AND attribute_not_exists({ROW_FROZEN_AT_FIELD}) '
+                'AND #project_id = :project_id'
+            ),
+            ExpressionAttributeNames={
+                '#document_ids': 'document_ids',
+                '#updated_at': 'updated_at',
+                '#project_id': 'project_id',
+            },
+            ExpressionAttributeValues={
+                ':document_ids': document_ids,
+                ':updated_at': now,
+                ':project_id': project_id,
+            },
+            ReturnValues='ALL_NEW',
+        )
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') != 'ConditionalCheckFailedException':
+            logger.exception(f'Failed to recompose prioritization row: {e}')
+            raise ServiceError('Failed to change the row composition') from e
+        # ONE answer for all three ways the condition fails, and it is a 409 rather
+        # than three statuses. Telling them apart would need a read the condition
+        # exists to avoid, and the read could disagree with the write it is
+        # explaining; what a caller can act on is the same in every case — reload
+        # and see the current rows.
+        raise ConflictError(
+            'This row cannot be recomposed: it does not exist, it belongs to '
+            'another project, or a ballot has already frozen its composition'
+        ) from e
+    except Exception as e:
+        logger.exception(f'Failed to recompose prioritization row: {e}')
+        raise ServiceError('Failed to change the row composition') from e
+
+    stored = response.get('Attributes')
+    if not isinstance(stored, dict):
+        # `ALL_NEW` on a landed update always carries the item; answering the
+        # composed request instead would claim a stored state nothing read.
+        raise ServiceError('Failed to read the recomposed row back')
+    return {'success': True, 'row': _row_payload(stored)}
+
+
+def _project_row_records(table, project_id: str) -> list[dict]:
+    """Every ROW record of one project, from the prioritization partition.
+
+    A bounded, strongly-consistent query over the row keys only
+    (`begins_with(sk, 'ROW#')`), so the ballots — which outnumber the rows — are not
+    read to answer a question about rows. Strongly consistent because it GATES a
+    delete, and the case that matters is "composed moments ago".
+
+    Filtered on the stored `project_id` field rather than by parsing the row id: a
+    minted id says nothing about its project, which is exactly why the record carries
+    the field (see DEFAULT_ROW_ID_PREFIX).
+    """
+    query_kwargs: dict[str, Any] = {
+        'KeyConditionExpression': (
+            Key('pk').eq(PRIORITIZATION_PK) & Key('sk').begins_with(ROW_SK_PREFIX)
+        ),
+        'ConsistentRead': True,
+    }
+    rows: list[dict] = []
+    for _ in range(MAX_PRIORITIZATION_PAGES):
+        response = table.query(**query_kwargs)
+        rows.extend(
+            item for item in response.get('Items', [])
+            if isinstance(item, dict) and item.get('project_id') == project_id
+        )
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            return rows
+        query_kwargs['ExclusiveStartKey'] = last_key
+    logger.error(
+        'Prioritization rows exceed %d query pages while deciding whether a '
+        "project's default row is its only row.",
+        MAX_PRIORITIZATION_PAGES,
+    )
+    raise ServiceError('Too many prioritization rows to read in one request')
+
+
+def _sibling_row_sk(table, row: dict, row_id: str) -> str | None:
+    """The sort key of one OTHER row of this row's project, if there is one.
+
+    Returned rather than a bare "has siblings" verdict, because the delete FENCES on
+    it: the sibling's key goes into the transaction as a `ConditionCheck`, so a
+    concurrent delete of the last sibling cancels this one instead of leaving the
+    project with no row at all. A read that merely counted would let two admins each
+    see two rows and each delete one.
+
+    Deterministic (the lowest sort key) so the same delete fences on the same
+    sibling on a retry.
+    """
+    project_id = row.get('project_id')
+    if not isinstance(project_id, str) or not project_id:
+        # A row whose project cannot be read has no siblings that can be found.
+        # Treated as "no sibling", which only ever makes the delete of a DEFAULT row
+        # stricter — it refuses. A non-default row is unaffected.
+        return None
+    siblings = sorted(
+        str(item.get('sk', ''))
+        for item in _project_row_records(table, project_id)
+        if str(item.get('sk', '')) not in ('', _row_sk(row_id))
+    )
+    return siblings[0] if siblings else None
+
+
+def _row_ballot_sort_keys(table, row_id: str) -> list[str]:
+    """The sort key of every ballot keyed to one row.
+
+    `begins_with(sk, 'BALLOT#{row_id}#')` — the trailing '#' is what keeps the prefix
+    from also matching a row id this one is a prefix of, which minted ids make
+    possible in principle and a hand-created one makes possible in practice.
+    Strongly consistent, because a ballot missed here is a ballot the delete leaves
+    behind.
+
+    PROJECTED to the key. Nothing about a ballot's contents decides whether it is
+    deleted — it is deleted because the row it describes is going — and the ballots
+    of a heavily-reviewed row carry notes this would otherwise pull across the wire.
+
+    Bounded at MAX_ROW_BALLOTS_PER_DELETE and then REFUSED rather than truncated: a
+    short read here would delete the row and leave the ballots that did not fit,
+    which is exactly the orphan the whole path exists to prevent.
+    """
+    query_kwargs: dict[str, Any] = {
+        'KeyConditionExpression': (
+            Key('pk').eq(PRIORITIZATION_PK)
+            & Key('sk').begins_with(f'{BALLOT_SK_PREFIX}{row_id}#')
+        ),
+        'ProjectionExpression': 'sk',
+        'ConsistentRead': True,
+    }
+    sort_keys: list[str] = []
+    for _ in range(MAX_PRIORITIZATION_PAGES):
+        response = table.query(**query_kwargs)
+        sort_keys.extend(
+            str(item['sk']) for item in response.get('Items', [])
+            if isinstance(item, dict) and item.get('sk')
+        )
+        if len(sort_keys) > MAX_ROW_BALLOTS_PER_DELETE:
+            break
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            return sort_keys
+        query_kwargs['ExclusiveStartKey'] = last_key
+    logger.error(
+        'A prioritization row holds more than the %d ballots one atomic delete can '
+        'remove. Deleting it in several writes would leave orphaned ballots between '
+        'them, which is the fault this path exists to prevent.',
+        MAX_ROW_BALLOTS_PER_DELETE,
+    )
+    raise ConflictError(
+        f'This row holds more than the {MAX_ROW_BALLOTS_PER_DELETE} ballots that '
+        'can be removed together with it in one atomic write'
+    )
+
+
+def _transact_delete_row(
+    table, row: dict, row_id: str, ballot_sks: list[str], sibling_sk: str | None
+) -> None:
+    """Remove the row record and every listed ballot in ONE transaction.
+
+    The row's delete carries the fence: it must still exist, and its
+    ROW_BALLOT_WRITES_FIELD must read exactly what it read when the ballots were
+    enumerated — which the ballot transaction increments, so a ballot landing in
+    between cancels this write rather than being orphaned by it. A row that had
+    never taken a ballot fences on the attribute being ABSENT, which is the same
+    assertion for the same reason.
+
+    `sibling_sk`, when present, is a `ConditionCheck` asserting that another row of
+    the project still exists. It is what makes "the default row is not deleted while
+    it is the project's only row" survive two admins acting at once.
+
+    A cancelled transaction is a 409 naming the state that moved, and nothing is
+    written — a transaction either applies whole or not at all, which is the property
+    this path is built on.
+    """
+    items: list[dict] = []
+    if sibling_sk:
+        items.append({
+            'ConditionCheck': {
+                'TableName': table.name,
+                'Key': {'pk': PRIORITIZATION_PK, 'sk': sibling_sk},
+                'ConditionExpression': 'attribute_exists(sk)',
+            },
+        })
+    seen_writes = row.get(ROW_BALLOT_WRITES_FIELD)
+    row_delete: dict[str, Any] = {
+        'TableName': table.name,
+        'Key': {'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)},
+        'ExpressionAttributeNames': {'#ballot_writes': ROW_BALLOT_WRITES_FIELD},
+    }
+    if seen_writes is None:
+        row_delete['ConditionExpression'] = (
+            'attribute_exists(sk) AND attribute_not_exists(#ballot_writes)'
+        )
+    else:
+        row_delete['ConditionExpression'] = (
+            'attribute_exists(sk) AND #ballot_writes = :seen_writes'
+        )
+        row_delete['ExpressionAttributeValues'] = {':seen_writes': seen_writes}
+    items.append({'Delete': row_delete})
+    items.extend(
+        {'Delete': {
+            'TableName': table.name,
+            'Key': {'pk': PRIORITIZATION_PK, 'sk': sort_key},
+        }}
+        for sort_key in ballot_sks
+    )
+
+    try:
+        table.meta.client.transact_write_items(TransactItems=items)
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') != 'TransactionCanceledException':
+            logger.exception(f'Failed to delete a prioritization row: {e}')
+            raise ServiceError('Failed to delete the prioritization row') from e
+        logger.warning(
+            'A prioritization row delete was cancelled; the row changed between '
+            'reading its ballots and removing them, or its last sibling row was '
+            'deleted concurrently. Nothing was written.'
+        )
+        raise ConflictError(
+            'This row changed while it was being deleted; reload the page and '
+            'try again'
+        ) from e
+    except Exception as e:
+        logger.exception(f'Failed to delete a prioritization row: {e}')
+        raise ServiceError('Failed to delete the prioritization row') from e
+
+
+@app.delete("/projects/prioritization/rows/<row_id>")
+@tracer.capture_method
+def api_delete_prioritization_row(row_id: str):
+    """Delete one row TOGETHER WITH ITS BALLOTS. Admin only.
+
+    ONE ATOMIC WRITE, so no ballot outlives the row it describes. A row and its
+    ballots share a partition precisely so this is possible: the ballots are read
+    with `begins_with(sk, 'BALLOT#{row_id}#')`, and the row record plus every ballot
+    found go into a single `transact_write_items`. Deleting the row first and its
+    ballots afterwards would leave, on any failure between the two, exactly the
+    orphaned ballots the page read counts and warns about — the warning whose rising
+    count is the signal that this path is NOT working (#342).
+
+    FENCED on the row not having changed since the ballots were enumerated.
+    ROW_BALLOT_WRITES_FIELD is what the ballot transaction increments, so a ballot
+    landing between the read and the delete moves it and the transaction is
+    cancelled rather than committing a delete that would leave that ballot behind.
+    The caller is answered 409 and retries against the current state. A transaction
+    cannot both enumerate and delete, so the fence is what closes the gap the
+    enumeration opens.
+
+    `ballots_deleted` IS THE EVIDENCE the deletion was complete. It is the only
+    thing the caller has: the row is gone, so nothing can be re-read to check, and a
+    bare `{'success': True}` would be identical whether the ballots went with the
+    row or were left orphaned in the partition.
+
+    ADMIN ONLY, through the shared `require_admin` — the one destructive action on a
+    row, per the decision recorded on #339, and the reason a frozen row is never
+    edited but may be deleted. A non-admin caller is refused BEFORE anything is
+    read, so a 403 costs no round trip and, more importantly, cannot be a 403 that
+    deleted something first.
+
+    THE DEFAULT ROW IS NOT DELETABLE WHILE IT IS THE PROJECT'S ONLY ROW. The page
+    invites a PRD or a PR/FAQ for a project with no scorable document, so a project
+    whose only row was deleted would show that invitation beside documents it still
+    holds — and the create route is idempotent on a derived key, which makes the
+    resulting state one nothing in the product can repair by asking again.
+    """
+    require_admin(app.current_event.raw_event)
+    validated_row_id = _validated_path_row_id(row_id)
+
+    table = get_aggregates_table()
+    if not table:
+        raise ConfigurationError('Aggregates table not configured')
+
+    row = _fetched_row(table, validated_row_id)
+    if row is None:
+        raise NotFoundError('That prioritization row does not exist')
+
+    # Only a DEFAULT row needs a sibling, and only a default row pays the query that
+    # looks for one: a row somebody composed is never the reason a project has a row
+    # at all, so deleting it can never leave the page inviting a PRD for a project
+    # that has one.
+    sibling_sk = _sibling_row_sk(table, row, validated_row_id) if _is_default_row(row) else None
+    if _is_default_row(row) and sibling_sk is None:
+        raise ConflictError(
+            "A project's default row cannot be deleted while it is the project's "
+            'only row'
+        )
+
+    ballot_sks = _row_ballot_sort_keys(table, validated_row_id)
+    _transact_delete_row(table, row, validated_row_id, ballot_sks, sibling_sk)
+    return {
+        'success': True,
+        'row_id': validated_row_id,
+        'ballots_deleted': len(ballot_sks),
+    }
 
 
 @app.post("/projects/prioritization/rows")
@@ -2135,6 +2776,69 @@ def _writes_a_reviewer_value(update_kwargs: dict) -> bool:
     return bool(assigned - set(BALLOT_STAMP_FIELDS))
 
 
+def _ballot_transact_items(table, update_kwargs: dict, row_id: str, now: str) -> list[dict]:
+    """One reviewer's ballot and its row's freeze mark, as ONE transaction.
+
+    TWO WRITES THAT MUST NOT BE SEPARABLE, for two reasons that arrive from opposite
+    directions:
+
+    * THE ROW MUST STILL EXIST (#342, and the criterion that issue keeps open). The
+      route already reads every named row before the first write, but a keyed read
+      followed by a write is complete only while nothing can delete a row. Deletion
+      now exists, so the read and the write race: the row's `attribute_exists(sk)`
+      moves onto the WRITE, in the same transaction as the ballot, and a delete
+      landing between the two cancels the ballot instead of orphaning it.
+    * THE BALLOT MUST FREEZE THE COMPOSITION. ROW_FROZEN_AT_FIELD is what a
+      composition change asserts the absence of, so it has to be written at the
+      instant the ballot lands — not afterwards, where a recompose could slip in
+      between and leave a row whose documents nobody balloting on it ever saw.
+
+    FREEZING FOLLOWS `_writes_a_reviewer_value`, NOT `_is_a_vote`. A ballot carrying
+    only a note freezes exactly as a scored one does: the note is a durable decision
+    record about the set of documents the row held when it was written, and
+    recomposing the row afterwards would leave that record describing documents its
+    author never saw. The module already distinguishes the two questions — "expressed
+    a score" gates the legacy migration and the aggregate, "changed something" counts
+    a ballot written — and this is the second reading. #339 records it as a
+    deliberately stricter predicate than the vote-supersession helper, and says not
+    to reuse that helper here.
+
+    A stamp-only save — `{}`, an all-null entry — writes no reviewer value and so
+    freezes nothing. It still takes this path, though, and that is not an oversight:
+    the row's `attribute_exists(sk)` still has to hold, because such a save does
+    write a ballot record and an orphan is an orphan whether or not a reviewer
+    expressed anything in it.
+
+    `ADD` on ROW_BALLOT_WRITES_FIELD rather than `if_not_exists(...) + 1`, so two
+    concurrent ballots each move it and neither reads it first. It is what the delete
+    fences on.
+    """
+    row_update: dict[str, Any] = {
+        'TableName': table.name,
+        'Key': {'pk': PRIORITIZATION_PK, 'sk': _row_sk(row_id)},
+        # `attribute_exists(sk)` is on the ROW's write rather than the ballot's,
+        # because `update_item` is an upsert: without it this would CREATE a bare row
+        # record for a row somebody deleted, resurrecting a deleted proposal as a
+        # side effect of scoring it — the outcome #342 rules out by name.
+        'ConditionExpression': 'attribute_exists(sk)',
+        'ExpressionAttributeNames': {'#ballot_writes': ROW_BALLOT_WRITES_FIELD},
+        'ExpressionAttributeValues': {':one': 1},
+    }
+    assignments: list[str] = []
+    if _writes_a_reviewer_value(update_kwargs):
+        assignments.append('#frozen_at = if_not_exists(#frozen_at, :now)')
+        row_update['ExpressionAttributeNames']['#frozen_at'] = ROW_FROZEN_AT_FIELD
+        row_update['ExpressionAttributeValues'][':now'] = now
+    row_update['UpdateExpression'] = (
+        (('SET ' + ', '.join(assignments) + ' ') if assignments else '')
+        + 'ADD #ballot_writes :one'
+    )
+    return [
+        {'Update': {'TableName': table.name, **update_kwargs}},
+        {'Update': row_update},
+    ]
+
+
 @app.put("/projects/prioritization")
 @tracer.capture_method
 def api_put_prioritization_scores():
@@ -2279,11 +2983,17 @@ def api_patch_prioritization_scores():
     # fetched records are then what the legacy migration reads, so the same key
     # is never read twice in one save.
     #
-    # A read-then-write, not a condition on the write itself — honest about the
-    # race: a row deleted between this check and the write below would still
-    # orphan its ballot. Nothing can delete a row today, so the gap is
-    # unreachable; phase 2 of #339, which introduces deletion, owes the
-    # DB-enforced condition (a transaction), and this check is where it goes.
+    # NO LONGER THE WHOLE STORY, and the difference is the point. This read used to
+    # be the only existence check, which was honest only while nothing could delete a
+    # row; deletion now exists, so the SAME assertion also rides on the write, inside
+    # the transaction `_ballot_transact_items` builds. A delete landing between this
+    # read and that write cancels the ballot rather than orphaning it.
+    #
+    # The read is kept for two things the condition cannot do: it refuses a body
+    # naming one vanished row among five BEFORE the first write, so such a body
+    # persists nothing rather than persisting the rows before the phantom; and it
+    # returns the row records the legacy migration reads, so the same key is never
+    # read twice in one save.
     rows_by_id = _fetched_ballot_rows(table, [row_id for row_id, _ in validated])
     if any(row_id not in rows_by_id for row_id, _ in validated):
         raise NotFoundError(
@@ -2309,7 +3019,27 @@ def api_patch_prioritization_scores():
     try:
         for row_id, entry in validated:
             update_kwargs = _ballot_update_kwargs(row_id, subject, entry, now)
-            table.update_item(**update_kwargs)
+            # ONE TRANSACTION per row, not one `update_item`: the ballot, the row's
+            # continued existence and the freeze mark land together or not at all.
+            # See `_ballot_transact_items` for why each of the three has to be in the
+            # same write as the others.
+            try:
+                table.meta.client.transact_write_items(
+                    TransactItems=_ballot_transact_items(table, update_kwargs, row_id, now)
+                )
+            except ClientError as e:
+                if e.response.get('Error', {}).get('Code') != 'TransactionCanceledException':
+                    raise
+                # The only condition in the transaction is the row's existence, so a
+                # cancellation means the row went away between the pass above and
+                # this write — the delete-racing-a-ballot case (#342). 404, the same
+                # answer the up-front pass gives, because it is the same fact about
+                # the world; and nothing of this row's ballot was written, because a
+                # transaction applies whole or not at all.
+                raise NotFoundError(
+                    'scores name a row that does not exist; reload the page to get '
+                    'the current rows'
+                ) from e
             rows_written += 1
             if _writes_a_reviewer_value(update_kwargs):
                 ballots += 1

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import secrets
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -535,14 +536,21 @@ ROW_ID_BYTES = 16
 # The mark a row carries once a ballot has landed on it, and what the composition
 # change asserts about.
 #
-# THIS ATTRIBUTE IS THE FREEZE. A composition change is one conditional
+# THIS ATTRIBUTE IS THE FREEZE'S RACE HALF. A composition change is one conditional
 # `update_item` carrying `attribute_not_exists(first_ballot_at)`, so the DATABASE is
-# what refuses a change to a row somebody has voted on — a read of a ballot count
-# followed by a write would lose the race against the first ballot and leave a row
-# whose documents nobody balloting on it ever saw. Written by the ballot save in the
-# SAME transaction as the ballot itself (`_ballot_transact_items`), which is what
-# makes "the first ballot froze it" true at the instant the ballot lands rather than
-# on a later reconciliation.
+# what refuses a change racing the first ballot — a read of a ballot count followed
+# by a write would land in the gap and leave a row whose documents nobody balloting
+# on it ever saw. Written by the ballot save in the SAME transaction as the ballot
+# itself (`_ballot_transact_items`), which is what makes "the first ballot froze it"
+# true at the instant the ballot lands rather than on a later reconciliation.
+#
+# IT IS NOT THE WHOLE FREEZE, because it has an epoch: ballots written by the code
+# deployed before this attribute existed stamped nothing, and nothing migrates a
+# mark in until the next save against that row. So "is this row frozen?" is the
+# mark OR a stored value-bearing ballot (`_is_frozen_row`,
+# `_row_holds_a_value_bearing_ballot`) — the recompose asks the ballots before its
+# conditional write, and the page read answers off the ballots it already holds.
+# Asking the mark alone recomposes exactly the rows that already carry real votes.
 #
 # `if_not_exists`, so it records the FIRST ballot and every later one leaves it
 # alone: it is the freeze instant, not a last-modified stamp.
@@ -1731,22 +1739,53 @@ def _is_default_row(row: Any) -> bool:
     return isinstance(row, dict) and row.get('is_default') is True
 
 
-def _is_frozen_row(row: Any) -> bool:
+def _ballot_expressed_a_value(ballot: Any) -> bool:
+    """Whether a STORED ballot carries anything a reviewer expressed.
+
+    The stored-record mirror of `_writes_a_reviewer_value`, which asks the same
+    question of a write about to happen. The save assigns an axis only when the
+    entry carried a readable one and `notes` only when the caller sent a string, so
+    presence on the record is exactly "was assigned" — a stamp-only save leaves a
+    ballot holding nothing but BALLOT_STAMP_FIELDS, and that record must not freeze
+    a row any more than the write that produced it did.
+
+    `'notes' in ballot` rather than `_expresses_something`, deliberately: a
+    reviewer who CLEARED their note (`{'notes': ''}`) wrote a real change and froze
+    the row at save time, and this predicate exists to agree with that write. The
+    read-through helper strips whitespace because its question is "is there
+    anything to show", which is a different question from "did somebody decide".
+
+    Anonymous ballots also store `voting_session` and sometimes `display_name`;
+    neither is a value ABOUT the row's documents, and neither needs asking — an
+    anonymous ballot always scores at least one axis, so the axes answer for it.
+    """
+    if not isinstance(ballot, dict):
+        return False
+    return 'notes' in ballot or any(axis in ballot for axis in SCORE_AXES)
+
+
+def _is_frozen_row(row: Any, row_ballots: Iterable[Any] = ()) -> bool:
     """Has a ballot landed on this row, so its composition is settled?
 
-    Read off the presence of ROW_FROZEN_AT_FIELD, which is the SAME attribute the
-    composition change's condition names. One fact, asked one way: a predicate that
-    counted ballots instead could answer "not frozen" for a row the database will
-    nonetheless refuse to recompose, which is a page saying the opposite of what the
-    save does.
+    TWO halves, because the mark alone has an upgrade-path hole. The presence of
+    ROW_FROZEN_AT_FIELD is the write-side authority — the SAME attribute the
+    composition change's condition names, so the page and the save cannot disagree
+    about a marked row. But the attribute did not always exist: ballots written by
+    the code deployed before it carry real reviewer values on rows that hold NO
+    mark, and nothing migrates one in until the next save against that row. So a
+    caller that has the row's ballots in hand passes them, and any that stored a
+    reviewer value freezes the row exactly as it would have at write time — a
+    stamp-only record does not, agreeing with `_writes_a_reviewer_value`.
     """
     if not isinstance(row, dict):
         return False
     frozen_at = row.get(ROW_FROZEN_AT_FIELD)
-    return isinstance(frozen_at, str) and bool(frozen_at)
+    if isinstance(frozen_at, str) and bool(frozen_at):
+        return True
+    return any(_ballot_expressed_a_value(ballot) for ballot in row_ballots)
 
 
-def _row_payload(row: dict) -> dict:
+def _row_payload(row: dict, row_ballots: Iterable[Any] = ()) -> dict:
     """One entry of the `rows` map the page consumes.
 
     Explicitly projected rather than returned whole, the same reasoning
@@ -1762,6 +1801,19 @@ def _row_payload(row: dict) -> dict:
     with the condition that actually enforces it. `ballot_writes` is not published
     for the same reason and a stronger one — it counts writes, not reviewers, and a
     number that looks like a reviewer count but is not is worse than no number.
+
+    `row_ballots` is the legacy half of `is_frozen` (see `_is_frozen_row`) and is
+    passed only where the caller already holds the row's ballots — the page read,
+    which reads the partition whole. The write-shaped callers pass nothing: a row
+    both creates just wrote has no ballots, and a recompose that landed has just
+    proven its row holds no value-bearing one. The default create's `created:
+    false` branch also passes nothing, and THAT one is a decision rather than a
+    fact: a row that pre-dates the freeze mark could hold unmarked ballots this
+    payload would then miss — but the page only asks to create rows its own read
+    did not return, and a legacy row is in every read, so reaching that branch
+    with one takes a hand-made call. Paying a ballot query on the page's per-
+    project load path to perfect an unreachable payload is the wrong trade; the
+    write itself stays guarded either way.
     """
     return {
         'row_id': row.get('row_id', ''),
@@ -1772,7 +1824,7 @@ def _row_payload(row: dict) -> dict:
         ),
         'is_default': _is_default_row(row),
         'created_at': row.get('created_at', ''),
-        'is_frozen': _is_frozen_row(row),
+        'is_frozen': _is_frozen_row(row, row_ballots),
     }
 
 
@@ -2187,10 +2239,20 @@ def api_recompose_prioritization_row(row_id: str):
     ROW_FROZEN_AT_FIELD, and the ballot save writes that attribute in the same
     transaction as the ballot itself — so a composition change racing the first
     ballot LOSES TO IT rather than being sorted out afterwards. Reading a ballot
-    count first and then writing would land the change in the gap between the two
-    calls, leaving a row whose documents nobody who balloted on it ever saw; that is
-    the race #339 records as the reason the condition has to be the rule and
-    disabled controls only a courtesy.
+    count first and then writing INSTEAD OF the condition would land the change in
+    the gap between the two calls, leaving a row whose documents nobody who
+    balloted on it ever saw; that is the race #339 records as the reason the
+    condition has to be the rule and disabled controls only a courtesy.
+
+    ONE READ STANDS IN FRONT OF THE CONDITION ANYWAY, for the ballots the condition
+    cannot see: rows balloted before ROW_FROZEN_AT_FIELD existed carry no mark, so
+    the condition alone recomposes exactly the rows that already hold real votes —
+    the ones hardest to reconstruct, because they were cast against a composition
+    this write would replace. `_row_holds_a_value_bearing_ballot` closes that
+    half, and read-then-write is sound FOR IT because a stored reviewer value
+    cannot un-exist; the condition stays on the write because only the database
+    can settle the race against a first ballot landing NOW. Two mechanisms, two
+    failure modes, each covered by the one that can cover it.
 
     A refusal answers 409 and writes nothing. 409 rather than 403, because the row's
     state is what refuses — the caller was permitted, and what they asked for
@@ -2233,6 +2295,16 @@ def api_recompose_prioritization_row(row_id: str):
     table = get_aggregates_table()
     if not table:
         raise ConfigurationError('Aggregates table not configured')
+
+    # The LEGACY half of the freeze — see the docstring. A row balloted before the
+    # mark existed satisfies the write's condition, so it has to be refused here,
+    # with the same 409 the condition produces: which mechanism refused is plumbing,
+    # and the caller's remedy (reload, see the current rows) is identical.
+    if _row_holds_a_value_bearing_ballot(table, validated_row_id):
+        raise ConflictError(
+            'This row cannot be recomposed: a ballot has already frozen its '
+            'composition'
+        )
 
     now = datetime.now(timezone.utc).isoformat()
     try:
@@ -2287,6 +2359,72 @@ def api_recompose_prioritization_row(row_id: str):
     return {'success': True, 'row': _row_payload(stored)}
 
 
+def _row_holds_a_value_bearing_ballot(table, row_id: str) -> bool:
+    """Does any stored ballot on this row carry a reviewer value?
+
+    THE LEGACY HALF OF THE FREEZE, asked only by the recompose. The condition on
+    the write (`attribute_not_exists(ROW_FROZEN_AT_FIELD)`) is the enforcement for
+    every ballot written since that attribute existed — but ballots written by the
+    code deployed BEFORE it carry no mark, and nothing migrates one in until the
+    next save against that row. Asking the mark alone therefore recomposes exactly
+    the rows that already hold real votes, which is the outcome the condition
+    exists to rule out. This read closes that half; the condition keeps settling
+    the race against a CONCURRENT first ballot, which a read can never do.
+
+    Read-then-write is SOUND for this half where it is unsound for the race: a
+    ballot that expressed a value cannot un-express it (a correction only assigns,
+    never removes, and deleting ballots deletes their row with them), so "held one
+    at the read" cannot go stale in the direction that matters.
+
+    A VALUE-BEARING ballot, not any ballot record. A stamp-only save (`{}`, an
+    all-null entry) writes a ballot record and deliberately does NOT freeze —
+    `_ballot_transact_items` stamps the mark only when `_writes_a_reviewer_value`
+    — and this read must not be stricter than the write it stands in for, or a
+    page that PATCHes an empty entry on load would freeze every row it touched.
+
+    Strongly consistent and projected to the value fields, for the same reasons
+    `_row_ballot_sort_keys` states: this read GATES a write, and a ballot's note
+    is content this question has no use for beyond its presence. Short-circuits on
+    the first value found; past the page budget it RAISES like every bounded read
+    here, because "could not enumerate the ballots" must not be read as "there are
+    none" by a route about to recompose the row.
+    """
+    query_kwargs: dict[str, Any] = {
+        'KeyConditionExpression': (
+            Key('pk').eq(PRIORITIZATION_PK)
+            & Key('sk').begins_with(f'{BALLOT_SK_PREFIX}{row_id}#')
+        ),
+        # Aliased wholesale rather than checked one by one against the reserved-word
+        # list: the axes are config (SCORE_AXES), and an axis added later must not
+        # break this read by colliding with a word DynamoDB reserves.
+        'ProjectionExpression': ', '.join(
+            f'#axis_{i}' for i in range(len(SCORE_AXES))
+        ) + ', #notes',
+        'ExpressionAttributeNames': {
+            **{f'#axis_{i}': axis for i, axis in enumerate(SCORE_AXES)},
+            '#notes': 'notes',
+        },
+        'ConsistentRead': True,
+    }
+    for _ in range(MAX_PRIORITIZATION_PAGES):
+        response = table.query(**query_kwargs)
+        if any(
+            _ballot_expressed_a_value(item) for item in response.get('Items', [])
+        ):
+            return True
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            return False
+        query_kwargs['ExclusiveStartKey'] = last_key
+    logger.error(
+        "A prioritization row's ballots exceed %d query pages, so the recompose "
+        'cannot tell whether one of them holds a reviewer value. Proceeding would '
+        'recompose a row that may hold real votes.',
+        MAX_PRIORITIZATION_PAGES,
+    )
+    raise ServiceError('Too many ballots on this row to read in one request')
+
+
 def _project_row_sort_keys(table, project_id: str, *, limit: int | None = None) -> list[str]:
     """The sort key of every ROW of one project, in ascending key order.
 
@@ -2313,6 +2451,22 @@ def _project_row_sort_keys(table, project_id: str, *, limit: int | None = None) 
     row. Ascending key order is preserved, so "the lowest-keyed sibling" is still
     deterministic: the first qualifying key of the first page is the lowest one there
     is.
+
+    WHERE THE PAGE BUDGET ACTUALLY BINDS, in the style of the 98/20 arithmetic on
+    `_row_ballot_sort_keys` — reachable there was ruled out; here it is NOT. The 1MB
+    page is spent on items as STORED, before the projection: a row record is its
+    keys, flags and timestamps (~0.3KB) plus up to MAX_ROW_DOCUMENT_IDS document
+    ids, so call it 0.5KB typically and ~4KB adversarially. That is ~2,000 rows per
+    page typically (40,000 across 20 pages ≈ 800 projects at the 50-row cap) but
+    only ~250 adversarial rows per page — 5,000 across the budget, ≈ 100 maxed-out
+    projects. A deployment CAN reach that, and because the walk is over the WHOLE
+    `ROW#` keyspace, crossing it raises for every project at once, on BOTH callers:
+    the compose's count and the delete's sibling lookup share this read, so the two
+    remedies for an over-large keyspace — stop adding rows, remove some — go down
+    together, and only an operator deleting items directly can shrink it. That
+    simultaneous lock-out is the concrete case for the `project_id` GSI follow-up
+    the compose call site names: a GSI turns both callers into bounded queries on
+    one project's rows and retires this walk entirely.
     """
     query_kwargs: dict[str, Any] = {
         'KeyConditionExpression': (
@@ -2923,7 +3077,13 @@ def api_get_prioritization_scores():
         scores[row_id] = _score_payload(row_id, entry)
 
     return {
-        'rows': {row_id: _row_payload(row) for row_id, row in rows_by_id.items()},
+        # The ballots ride along so `is_frozen` covers rows balloted before the
+        # freeze mark existed (see `_is_frozen_row`) — this read already holds the
+        # partition whole, so the legacy half costs nothing here.
+        'rows': {
+            row_id: _row_payload(row, ballots_by_row.get(row_id, ()))
+            for row_id, row in rows_by_id.items()
+        },
         'scores': scores,
         'aggregates': _aggregate_scores(ballots_by_row, legacy_by_row),
     }
@@ -3106,16 +3266,17 @@ def _ballot_transact_items(table, update_kwargs: dict, row_id: str, now: str) ->
     # through. These were the only two bare asserts in the production Lambda tree.
     unsupported = set(update_kwargs) - TRANSACT_UPDATE_KEYS
     if unsupported:
+        # The offending key is NAMED HERE AND ONLY HERE. A ServiceError's message
+        # goes to the client verbatim (`handle_service_error`), and a reviewer
+        # saving scores has no use for an internal function's kwargs — the log is
+        # where the person who can act on the name will read it.
         logger.error(
             '_ballot_update_kwargs returned %s, which a transaction Update does not '
             'accept. The ballot was not written: DynamoDB would reject the whole '
             'transaction for a key the ballot itself is not about.',
             sorted(unsupported),
         )
-        raise ServiceError(
-            f'_ballot_update_kwargs returned {sorted(unsupported)}, which a '
-            'transaction Update does not accept'
-        )
+        raise ServiceError('Failed to save prioritization scores')
     # The row's write is the ONE this transaction carries a condition on, and the save
     # reads the cancellation reason at BALLOT_TRANSACT_ROW_INDEX to tell a vanished row
     # from contention — so that constant is only meaningful while the row's write sits

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -21,9 +21,8 @@ from shared.api import (
     api_handler,
     validate_date_basis,
     MAX_PERSONAS_PER_GENERATION,
-    # APPENDED rather than sorted into place: two open pull requests (#344, #330)
-    # also edit this import block, and re-sorting a list this change did not need
-    # to reorder is a conflict invented for tidiness.
+    # Appended rather than sorted in, to avoid a conflict with #344 and #330 while
+    # they are open; sort this block once both have landed.
     require_admin,
 )
 from shared.tables import get_jobs_table, get_aggregates_table, get_projects_table
@@ -555,6 +554,16 @@ ROW_FROZEN_AT_FIELD = 'first_ballot_at'
 # `api_delete_prioritization_row`). Incremented with `ADD` in the ballot
 # transaction, so two concurrent ballots each move it.
 ROW_BALLOT_WRITES_FIELD = 'ballot_writes'
+
+# Where the ROW's write sits in the ballot transaction `_ballot_transact_items`
+# builds — the ballot's own write is first, the row's second.
+#
+# Named because the save READS THE CANCELLATION REASON AT THIS INDEX. A
+# `TransactionCanceledException` does not mean a condition failed (see
+# `_cancelled_by_condition`), and the only condition in that transaction is on the
+# row, so "the row went away" is a claim about this position specifically rather
+# than about the exception.
+BALLOT_TRANSACT_ROW_INDEX = 1
 
 # How many documents one row may hold. A row is a project's scorable documents
 # plus its latest prototype, and the composition is stored verbatim and read back
@@ -2297,25 +2306,82 @@ def _row_ballot_sort_keys(table, row_id: str) -> list[str]:
     raise ServiceError('Too many ballots on this row to read in one request')
 
 
+def _cancelled_by_condition(e: ClientError, index: int | None = None) -> bool:
+    """Did a CONDITION cancel this transaction, or did contention?
+
+    A `TransactionCanceledException` IS NOT ONLY A FAILED CONDITION. DynamoDB
+    cancels a transaction with the same exception for `TransactionConflict`
+    (another in-flight transaction touching one of the same items),
+    `ThrottlingError`, `ProvisionedThroughputExceeded`,
+    `ItemCollectionSizeLimitExceeded` and `ValidationError` — and botocore does not
+    auto-retry it, so every one of those arrives at the caller's `except`. Reading
+    the exception as "the condition failed" therefore reports a TRANSIENT failure
+    as a settled fact about the world, which is the worst direction to be wrong in:
+    the page treats a 4xx as a refusal retrying cannot fix, so the reviewer is told
+    to reload a row that is still there and their ballot is simply gone, where a
+    500 would have been released for a retry and saved.
+
+    `TransactionConflict` is not theoretical on these writes. Every ballot on a row
+    `ADD`s to the SAME row record, so two reviewers scoring one row at the same
+    moment — the ordinary case — contend on one item, and an admin's delete of that
+    row is a third contender.
+
+    `index`, when given, is the position in the `TransactItems` list whose condition
+    the caller is asking about, so a condition failure somewhere else in the same
+    transaction cannot be mistaken for this one. `None` asks "did any condition
+    fail", which is what a caller answers the same way whichever of its conditions
+    it was.
+
+    A MISSING or SHORT `CancellationReasons` answers False, so an unreadable
+    cancellation is handled as the transient failure it might be rather than as the
+    condition it might not be.
+    """
+    reasons = e.response.get('CancellationReasons')
+    if not isinstance(reasons, list):
+        return False
+    if index is not None:
+        if index >= len(reasons):
+            return False
+        reasons = [reasons[index]]
+    return any(
+        isinstance(reason, dict) and reason.get('Code') == 'ConditionalCheckFailed'
+        for reason in reasons
+    )
+
+
 def _transact_delete_row(
     table, row: dict, row_id: str, ballot_sks: list[str], sibling_sk: str | None
 ) -> None:
     """Remove the row record and every listed ballot in ONE transaction.
 
     The row's delete carries the fence: it must still exist, and its
-    ROW_BALLOT_WRITES_FIELD must read exactly what it read when the ballots were
-    enumerated — which the ballot transaction increments, so a ballot landing in
-    between cancels this write rather than being orphaned by it. A row that had
-    never taken a ballot fences on the attribute being ABSENT, which is the same
-    assertion for the same reason.
+    ROW_BALLOT_WRITES_FIELD must read exactly what it read when the row was fetched
+    — which the ballot transaction increments, so a ballot landing at any point
+    after that fetch cancels this write rather than being orphaned by it. The
+    snapshot is taken BEFORE the ballots are enumerated, so a ballot arriving during
+    the enumeration also cancels the delete even though the enumeration saw it: the
+    fence is deliberately conservative, because a spurious 409 costs a retry and a
+    missed one costs an orphaned ballot. A row that had never taken a ballot fences
+    on the attribute being ABSENT, which is the same assertion for the same reason.
+
+    The fence value is passed through UNCONVERTED. It was read at the resource layer
+    (a `Decimal`) and goes back as `:seen_writes` through `table.meta.client`, which
+    is the resource's client and so carries the resource's type serializer — a
+    `Decimal('1')` serialises to `{'N': '1'}` and the comparison holds. Coercing it
+    to `int` here, or issuing this transaction on a bare `boto3.client('dynamodb')`,
+    would break that: this is the one place in the module where a value read at the
+    resource layer is fed back through a client-layer call.
 
     `sibling_sk`, when present, is a `ConditionCheck` asserting that another row of
     the project still exists. It is what makes "the default row is not deleted while
     it is the project's only row" survive two admins acting at once.
 
-    A cancelled transaction is a 409 naming the state that moved, and nothing is
-    written — a transaction either applies whole or not at all, which is the property
-    this path is built on.
+    A transaction cancelled BY A CONDITION is a 409 naming the state that moved, and
+    nothing is written — a transaction either applies whole or not at all, which is
+    the property this path is built on. A cancellation for any other reason
+    (contention, throttling) is a 500, because "reload the page and try again" is
+    advice about a state that did not actually change; see
+    `_cancelled_by_condition`.
     """
     items: list[dict] = []
     if sibling_sk:
@@ -2353,7 +2419,15 @@ def _transact_delete_row(
     try:
         table.meta.client.transact_write_items(TransactItems=items)
     except ClientError as e:
-        if e.response.get('Error', {}).get('Code') != 'TransactionCanceledException':
+        if (
+            e.response.get('Error', {}).get('Code') != 'TransactionCanceledException'
+            # Any condition in this transaction: the row's fence and the sibling's
+            # existence are both states the caller reloads to see, so which one it
+            # was does not change the answer. What DOES change it is a cancellation
+            # that no condition caused — that is contention, and it is a 500 the page
+            # will retry rather than a 409 it will not.
+            or not _cancelled_by_condition(e)
+        ):
             logger.exception(f'Failed to delete a prioritization row: {e}')
             raise ServiceError('Failed to delete the prioritization row') from e
         logger.warning(
@@ -2853,10 +2927,15 @@ def _ballot_transact_items(table, update_kwargs: dict, row_id: str, now: str) ->
         (('SET ' + ', '.join(assignments) + ' ') if assignments else '')
         + 'ADD #ballot_writes :one'
     )
-    return [
+    items = [
         {'Update': {'TableName': table.name, **update_kwargs}},
         {'Update': row_update},
     ]
+    # The row's write is the ONE this transaction carries a condition on, and the
+    # save reads the cancellation reason at its index to tell a vanished row from
+    # contention. Asserted rather than commented, so the two cannot drift.
+    assert 'ConditionExpression' in items[BALLOT_TRANSACT_ROW_INDEX]['Update']
+    return items
 
 
 @app.put("/projects/prioritization")
@@ -3048,14 +3127,26 @@ def api_patch_prioritization_scores():
                     TransactItems=_ballot_transact_items(table, update_kwargs, row_id, now)
                 )
             except ClientError as e:
-                if e.response.get('Error', {}).get('Code') != 'TransactionCanceledException':
+                if (
+                    e.response.get('Error', {}).get('Code')
+                    != 'TransactionCanceledException'
+                    # ONLY a failed condition on the ROW's half means the row went
+                    # away. A cancellation for any other reason — above all
+                    # `TransactionConflict`, which two reviewers scoring one row at
+                    # the same moment reach because both `ADD` to the same record —
+                    # is re-raised into the 500 below, so the page releases it for a
+                    # retry. Answering 404 there told a reviewer whose save merely
+                    # lost a race to reload a row that is still there, and dropped
+                    # their ballot on advice that could never work.
+                    or not _cancelled_by_condition(e, BALLOT_TRANSACT_ROW_INDEX)
+                ):
                     raise
-                # The only condition in the transaction is the row's existence, so a
-                # cancellation means the row went away between the pass above and
-                # this write — the delete-racing-a-ballot case (#342). 404, the same
-                # answer the up-front pass gives, because it is the same fact about
-                # the world; and nothing of this row's ballot was written, because a
-                # transaction applies whole or not at all.
+                # The row's own condition failed, and the only thing it asserts is
+                # that the row exists — so the row went away between the pass above
+                # and this write, the delete-racing-a-ballot case (#342). 404, the
+                # same answer the up-front pass gives, because it is the same fact
+                # about the world; and nothing of this row's ballot was written,
+                # because a transaction applies whole or not at all.
                 raise NotFoundError(
                     'scores name a row that does not exist; reload the page to get '
                     'the current rows'

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -2332,11 +2332,23 @@ def _row_ballot_sort_keys(table, row_id: str) -> list[str]:
 
     Bounded at MAX_ROW_BALLOTS_PER_DELETE and then REFUSED rather than truncated: a
     short read here would delete the row and leave the ballots that did not fit,
-    which is exactly the orphan the whole path exists to prevent. Page exhaustion
-    raises SEPARATELY, and the two messages differ because the remedies do: one is a
-    row too heavily balloted for one transaction, the other a partition that has
-    outgrown the read this module performs everywhere. A single message covering both
-    would name the wrong cause for whichever case it was not written about.
+    which is exactly the orphan the whole path exists to prevent.
+
+    THE PAGE-EXHAUSTION BRANCH IS UNREACHABLE TODAY, and kept as a guard rather than
+    dropped. A page of key-only projected items holds far more than the 98/20 ≈ 5
+    ballots that would be needed to spend the page budget before the ballot bound, so
+    the ballot bound always binds first. It is retained because the two limits are
+    independent — MAX_ROW_BALLOTS_PER_DELETE follows DynamoDB's transaction cap and
+    MAX_PRIORITIZATION_PAGES the read this module performs everywhere — so raising
+    either without the other makes it live, and a loop with no terminating case is
+    not something to leave behind on the strength of an arithmetic coincidence.
+    Stated here rather than left to a reader, because a distinct, carefully-worded
+    message reads as a live path.
+
+    The two messages differ because the remedies would: one is a row too heavily
+    balloted for one transaction, the other a partition that has outgrown the read. A
+    single message covering both would name the wrong cause for whichever case it was
+    not written about.
     """
     query_kwargs: dict[str, Any] = {
         'KeyConditionExpression': (
@@ -2569,8 +2581,9 @@ def api_delete_prioritization_row(row_id: str):
     # looks for one: a row somebody composed is never the reason a project has a row
     # at all, so deleting it can never leave the page inviting a PRD for a project
     # that has one.
-    sibling_sk = _sibling_row_sk(table, row, validated_row_id) if _is_default_row(row) else None
-    if _is_default_row(row) and sibling_sk is None:
+    is_default = _is_default_row(row)
+    sibling_sk = _sibling_row_sk(table, row, validated_row_id) if is_default else None
+    if is_default and sibling_sk is None:
         raise ConflictError(
             "A project's default row cannot be deleted while it is the project's "
             'only row'
@@ -2578,6 +2591,21 @@ def api_delete_prioritization_row(row_id: str):
 
     ballot_sks = _row_ballot_sort_keys(table, validated_row_id)
     _transact_delete_row(table, row, validated_row_id, ballot_sks, sibling_sk)
+    # THE ONLY TRACE A COMPLETED DELETE LEAVES. `ballots_deleted` is evidence only in
+    # the caller's own response body, and every ballot removed here is a durable
+    # decision record — so an operator asked "where did the team's score go?" has
+    # nothing to read without this, and the page read's discard-warning count cannot
+    # tell a legitimate delete from the orphaning it is watching for. The cancelled
+    # case already logs; leaving the successful one silent made the delete that
+    # actually removed data the one with no record of it.
+    #
+    # No caller identity and no ballot content, per the module's standing rule: the
+    # row id and the counts are what an investigation needs, and a reviewer's subject
+    # is not.
+    logger.info(
+        'Deleted prioritization row %s (default: %s) with %d ballot(s)',
+        validated_row_id, is_default, len(ballot_sks),
+    )
     return {
         'success': True,
         'row_id': validated_row_id,

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -651,6 +651,30 @@ MAX_PRIORITIZATION_PAGES = 20
 # exists to make impossible.
 MAX_ROW_BALLOTS_PER_DELETE = 98
 
+# How many rows one project may hold.
+#
+# THE ONLY BOUND ON A ROUTE THAT ADDS ONE ROW PER CALL. `POST .../rows/compose` is
+# open to any signed-in reviewer and deliberately produces a new row every time it is
+# asked, so without this the partition the page reads WHOLE grows without limit under
+# ordinary authorized requests — and `_read_prioritization_partition` raises past
+# MAX_PRIORITIZATION_PAGES rather than truncating, which would take the prioritization
+# page down FOR EVERYBODY rather than only for whoever composed the rows. That
+# asymmetry is the reason the bound is here rather than left to API Gateway's throttle.
+#
+# Generous next to the product: a row is one combination of a project's documents, the
+# page renders one line per row, and a backlog nobody can read on one screen is past
+# the point where another row helps. Small enough that even every project holding this
+# many leaves the whole-partition read inside its page budget.
+#
+# Crossing it REFUSES with a 409 naming the bound — the shape MAX_ROW_BALLOTS_PER_DELETE
+# uses — rather than evicting an existing row: a row carries ballots, and deleting one
+# to make room for another is a destructive act, which is admin-gated for that reason.
+#
+# The DEFAULT row is exempt. `POST .../rows` must keep answering for a project whose
+# rows were all composed, because it is idempotent on a derived key and the page has
+# no other way to get the row a project is entitled to.
+MAX_ROWS_PER_PROJECT = 50
+
 # How many document pages a row COMPOSITION will follow.
 #
 # This bounds a project's total STORED BYTES, not its document count. DynamoDB's 1MB
@@ -2048,6 +2072,21 @@ def api_compose_prioritization_row():
     it is kept anyway, because a put with no condition is an upsert, and the one
     thing worse than a failed create is a create that silently replaced a row whose
     ballots already exist.
+
+    BOUNDED AT MAX_ROWS_PER_PROJECT, because this is the one route that adds a row
+    per call and it is open to any signed-in reviewer. The partition the page reads
+    WHOLE would otherwise grow without limit under ordinary authorized requests, and
+    the read raises past its page budget rather than truncating — so enough composed
+    rows takes the prioritization page down for everybody, not only for whoever
+    composed them.
+
+    The count is read and then the put is made, which is a read-then-write: two
+    reviewers composing simultaneously against a project one row under the bound can
+    both pass it and leave the project one row over. Accepted deliberately. Making it
+    exact needs a counter item every compose contends on, and the bound is a
+    protection against unbounded growth rather than an exact quota — one row over it
+    is not a state the reads care about, while a hundred is. The bound still holds as
+    a bound: the next call reads the crossed count and refuses.
     """
     body = _json_object_body()
     project_id = _validated_row_project_id(body.get('project_id'))
@@ -2061,6 +2100,15 @@ def api_compose_prioritization_row():
     table = get_aggregates_table()
     if not table:
         raise ConfigurationError('Aggregates table not configured')
+
+    # Read no further than the bound: what this asks is "are there already this
+    # many", and the keys past that answer nothing.
+    existing = _project_row_sort_keys(table, project_id, limit=MAX_ROWS_PER_PROJECT)
+    if len(existing) >= MAX_ROWS_PER_PROJECT:
+        raise ConflictError(
+            f'This project already holds the {MAX_ROWS_PER_PROJECT} prioritization '
+            'rows one project may have; delete a row before composing another'
+        )
 
     row_id = _minted_row_id()
     now = datetime.now(timezone.utc).isoformat()
@@ -2182,38 +2230,59 @@ def api_recompose_prioritization_row(row_id: str):
     return {'success': True, 'row': _row_payload(stored)}
 
 
-def _project_row_records(table, project_id: str) -> list[dict]:
-    """Every ROW record of one project, from the prioritization partition.
+def _project_row_sort_keys(table, project_id: str, *, limit: int | None = None) -> list[str]:
+    """The sort key of every ROW of one project, in ascending key order.
 
     A bounded, strongly-consistent query over the row keys only
     (`begins_with(sk, 'ROW#')`), so the ballots — which outnumber the rows — are not
-    read to answer a question about rows. Strongly consistent because it GATES a
-    delete, and the case that matters is "composed moments ago".
+    read to answer a question about rows. Strongly consistent because it GATES both
+    of its callers' writes, and the case that matters is "composed moments ago".
+
+    PROJECTED to `sk` and `project_id`, which is everything either caller reads.
+    Without it every row of every project crossed the wire with its `document_ids`
+    inline to answer a question about one project's row COUNT — the same cost
+    `_row_ballot_sort_keys` projects away one screen down.
 
     Filtered on the stored `project_id` field rather than by parsing the row id: a
     minted id says nothing about its project, which is exactly why the record carries
-    the field (see DEFAULT_ROW_ID_PREFIX).
+    the field (see DEFAULT_ROW_ID_PREFIX). That filter is applied HERE rather than as
+    a DynamoDB `FilterExpression` because a filter is applied after the page is read
+    and so changes nothing about what is paid for, while making the page's item count
+    unpredictable — the pagination this loop performs is easier to reason about when
+    every page it sees is a full one.
+
+    `limit` STOPS EARLY once that many of the project's rows have been seen, which is
+    what keeps the delete's sibling lookup from reading a whole keyspace to find one
+    row. Ascending key order is preserved, so "the lowest-keyed sibling" is still
+    deterministic: the first qualifying key of the first page is the lowest one there
+    is.
     """
     query_kwargs: dict[str, Any] = {
         'KeyConditionExpression': (
             Key('pk').eq(PRIORITIZATION_PK) & Key('sk').begins_with(ROW_SK_PREFIX)
         ),
+        # `project_id` is not a DynamoDB reserved word; `sk` is the key itself.
+        'ProjectionExpression': 'sk, project_id',
         'ConsistentRead': True,
     }
-    rows: list[dict] = []
+    sort_keys: list[str] = []
     for _ in range(MAX_PRIORITIZATION_PAGES):
         response = table.query(**query_kwargs)
-        rows.extend(
-            item for item in response.get('Items', [])
-            if isinstance(item, dict) and item.get('project_id') == project_id
-        )
+        for item in response.get('Items', []):
+            if not isinstance(item, dict) or item.get('project_id') != project_id:
+                continue
+            sort_key = str(item.get('sk', ''))
+            if sort_key:
+                sort_keys.append(sort_key)
+            if limit is not None and len(sort_keys) >= limit:
+                return sort_keys
         last_key = response.get('LastEvaluatedKey')
         if not last_key:
-            return rows
+            return sort_keys
         query_kwargs['ExclusiveStartKey'] = last_key
     logger.error(
-        'Prioritization rows exceed %d query pages while deciding whether a '
-        "project's default row is its only row.",
+        'Prioritization rows exceed %d query pages while counting one '
+        "project's rows.",
         MAX_PRIORITIZATION_PAGES,
     )
     raise ServiceError('Too many prioritization rows to read in one request')
@@ -2229,7 +2298,10 @@ def _sibling_row_sk(table, row: dict, row_id: str) -> str | None:
     see two rows and each delete one.
 
     Deterministic (the lowest sort key) so the same delete fences on the same
-    sibling on a retry.
+    sibling on a retry. TWO keys are asked for, not one, because the row being
+    deleted is itself one of the project's rows and is dropped below — asking for
+    one could return only that row and report a project with a sibling as having
+    none.
     """
     project_id = row.get('project_id')
     if not isinstance(project_id, str) or not project_id:
@@ -2238,9 +2310,9 @@ def _sibling_row_sk(table, row: dict, row_id: str) -> str | None:
         # stricter — it refuses. A non-default row is unaffected.
         return None
     siblings = sorted(
-        str(item.get('sk', ''))
-        for item in _project_row_records(table, project_id)
-        if str(item.get('sk', '')) not in ('', _row_sk(row_id))
+        sort_key
+        for sort_key in _project_row_sort_keys(table, project_id, limit=2)
+        if sort_key != _row_sk(row_id)
     )
     return siblings[0] if siblings else None
 

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -2382,6 +2382,21 @@ def _row_holds_a_value_bearing_ballot(table, row_id: str) -> bool:
     — and this read must not be stricter than the write it stands in for, or a
     page that PATCHes an empty entry on load would freeze every row it touched.
 
+    A LEGACY `SCORES`-MAP VALUE DOES NOT FREEZE EITHER, and that is a decision,
+    not a further gap of the same kind. A ballot's claim is "I scored THIS SET of
+    documents", which is what a recompose would falsify; a pre-ballot value's
+    claim is "somebody once scored THIS DOCUMENT", unattributed — and the
+    read-through honours that claim through any recomposition, because
+    `_legacy_scores_by_row` surfaces a value only on a row that still HOLDS its
+    document. Drop the document and the value stops appearing; it is never left
+    describing a set its author never saw, because it never described a set at
+    all. Freezing on it would also freeze every default row of every pre-ballot
+    deployment permanently — refusing this route's primary use (narrowing a
+    default composition before anyone votes) for exactly the deployments
+    upgrading, on values the module elsewhere treats as superseded by any real
+    ballot. Pinned by
+    `test_a_row_holding_only_a_legacy_scores_value_is_not_frozen`.
+
     Strongly consistent and projected to the value fields, for the same reasons
     `_row_ballot_sort_keys` states: this read GATES a write, and a ballot's note
     is content this question has no use for beyond its presence. Short-circuits on
@@ -2396,10 +2411,11 @@ def _row_holds_a_value_bearing_ballot(table, row_id: str) -> bool:
         ),
         # Aliased wholesale rather than checked one by one against the reserved-word
         # list: the axes are config (SCORE_AXES), and an axis added later must not
-        # break this read by colliding with a word DynamoDB reserves.
+        # break this read by colliding with a word DynamoDB reserves. ONE join over
+        # all the aliases, so no shape of that config can produce a stray comma.
         'ProjectionExpression': ', '.join(
-            f'#axis_{i}' for i in range(len(SCORE_AXES))
-        ) + ', #notes',
+            [f'#axis_{i}' for i in range(len(SCORE_AXES))] + ['#notes']
+        ),
         'ExpressionAttributeNames': {
             **{f'#axis_{i}': axis for i, axis in enumerate(SCORE_AXES)},
             '#notes': 'notes',
@@ -2422,7 +2438,13 @@ def _row_holds_a_value_bearing_ballot(table, row_id: str) -> bool:
         'recompose a row that may hold real votes.',
         MAX_PRIORITIZATION_PAGES,
     )
-    raise ServiceError('Too many ballots on this row to read in one request')
+    # Its own words, not `_row_ballot_sort_keys`' — that helper's docstring states
+    # the rule this follows: the messages differ because the remedies would. Its
+    # 500 is about a delete that cannot enumerate; this one is about a composition
+    # change refused on unreadable history.
+    raise ServiceError(
+        'Too many ballots on this row to tell whether its composition is frozen'
+    )
 
 
 def _project_row_sort_keys(table, project_id: str, *, limit: int | None = None) -> list[str]:

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -569,9 +569,10 @@ BALLOT_TRANSACT_ROW_INDEX = 1
 # `update_item` takes, which is why it is stated. `_ballot_transact_items` spreads the
 # kwargs `_ballot_update_kwargs` built for `update_item` into one of these, so a
 # resource-only key added there later (`ReturnValues`, `ReturnConsumedCapacity`) would
-# have DynamoDB reject the whole transaction. Asserted against rather than filtered:
+# have DynamoDB reject the whole transaction. CHECKED against rather than filtered:
 # dropping such a key silently would discard part of what that function decided to
-# write while still answering 200.
+# write while still answering 200. Checked with a raise rather than an `assert`, so it
+# survives `python -O` and logs like every other failure here.
 #
 # `TableName` is supplied by the caller of this list rather than by the kwargs.
 TRANSACT_UPDATE_KEYS = frozenset({
@@ -2126,6 +2127,21 @@ def api_compose_prioritization_row():
 
     # Read no further than the bound: what this asks is "are there already this
     # many", and the keys past that answer nothing.
+    #
+    # THE `limit` DOES NOT BOUND THE READ, and that cost is accepted rather than
+    # accidental. `_project_row_sort_keys` walks the whole `ROW#` keyspace of the
+    # partition and filters on `project_id` in Python, so the early stop only fires
+    # once it has seen this many rows OF THIS PROJECT — a deployment with many
+    # projects holding few rows each pays a full keyspace walk on every compose, and
+    # this is the more frequent of that helper's two callers.
+    #
+    # Kept because the alternative today is worse than the cost: with no count, the
+    # partition the page reads WHOLE grows without limit under ordinary authorized
+    # requests, and that read raises past its page budget rather than truncating — so
+    # enough composed rows takes the page down for everybody. A GSI on `project_id` is
+    # the follow-up that makes this a bounded `Select='COUNT'` query; until it lands
+    # the walk is at least cheap per item, since the keys are projected
+    # (`sk, project_id`) rather than read whole.
     existing = _project_row_sort_keys(table, project_id, limit=MAX_ROWS_PER_PROJECT)
     if len(existing) >= MAX_ROWS_PER_PROJECT:
         raise ConflictError(
@@ -3078,23 +3094,42 @@ def _ballot_transact_items(table, update_kwargs: dict, row_id: str, now: str) ->
     # something the ballot itself is not about. Rebuilding the item here instead would
     # SILENTLY DROP such a key, which is worse: it would discard part of what
     # `_ballot_update_kwargs` decided to write while answering 200. So the mismatch is
-    # asserted, which turns a future addition there into a failure that names the
+    # REFUSED, which turns a future addition there into a failure that names the
     # cause. (`test_projects_prioritization_row_lifecycle_moto.py` executes the shape
     # against a real implementation; the suite's fake accepts any `dict`.)
+    #
+    # RAISED RATHER THAN `assert`ed, though the reasoning above is why it is checked
+    # at all. A bare `assert` is stripped under `python -O`/`PYTHONOPTIMIZE`, which
+    # would leave the malformed key reaching DynamoDB — the exact outcome this exists
+    # to name — and an `AssertionError` in a request path is an unhandled 500 with a
+    # bare message, bypassing the logging every other failure in this module routes
+    # through. These were the only two bare asserts in the production Lambda tree.
     unsupported = set(update_kwargs) - TRANSACT_UPDATE_KEYS
-    assert not unsupported, (
-        f'_ballot_update_kwargs returned {sorted(unsupported)}, which a transaction '
-        'Update does not accept'
-    )
-    items = [
+    if unsupported:
+        logger.error(
+            '_ballot_update_kwargs returned %s, which a transaction Update does not '
+            'accept. The ballot was not written: DynamoDB would reject the whole '
+            'transaction for a key the ballot itself is not about.',
+            sorted(unsupported),
+        )
+        raise ServiceError(
+            f'_ballot_update_kwargs returned {sorted(unsupported)}, which a '
+            'transaction Update does not accept'
+        )
+    # The row's write is the ONE this transaction carries a condition on, and the save
+    # reads the cancellation reason at BALLOT_TRANSACT_ROW_INDEX to tell a vanished row
+    # from contention — so that constant is only meaningful while the row's write sits
+    # at that position, carrying that condition.
+    #
+    # Pinned by a TEST rather than by a runtime check
+    # (`test_the_row_index_the_reason_is_read_at_is_where_the_condition_actually_is`
+    # builds this list and asserts both). It is a self-check over a literal built three
+    # lines up and cannot fail from any input, so a runtime copy adds nothing the suite
+    # does not already give — and would inherit the same `-O` caveat as the check above.
+    return [
         {'Update': {'TableName': table.name, **update_kwargs}},
         {'Update': row_update},
     ]
-    # The row's write is the ONE this transaction carries a condition on, and the
-    # save reads the cancellation reason at its index to tell a vanished row from
-    # contention. Asserted rather than commented, so the two cannot drift.
-    assert 'ConditionExpression' in items[BALLOT_TRANSACT_ROW_INDEX]['Update']
-    return items
 
 
 @app.put("/projects/prioritization")

--- a/voc-datalake/lambda/api/test/test_anon_ballot_key_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_anon_ballot_key_lockstep.py
@@ -56,7 +56,9 @@ reading text needs neither the AWS-shaped Python import graph nor a bundler.
 
 Pattern follows test_visual_selection_bound_lockstep.py (same directory).
 """
+import io
 import re
+import tokenize
 from pathlib import Path
 
 BALLOTS_SOURCE = 'lambda/api/ballots_handler.py'
@@ -280,7 +282,20 @@ class TestABallotNeverCarriesAnExpiry:
         # retried ("thro-ttl-ing") failed this test while the code was correct. A
         # lockstep test that fails on a comment is one that gets deleted rather than
         # heeded.
-        body = re.sub(r'#[^\n]*', '', body)
+        #
+        # Stripped by the TOKENIZER, not by a regex. `re.sub(r'#[^\n]*', ...)` cuts
+        # from the first '#' on a line, and this function's expression attribute
+        # names ('#frozen_at', '#ballot_writes') live INSIDE string literals — a
+        # regex strip erased them to end-of-line, code and all, so an expiry
+        # spelled `'#ttl': 'ttl'` would have been deleted before the assertion
+        # looked. That is the guard silently blind to exactly the aliased spelling
+        # DynamoDB expressions use; the tokenizer knows a COMMENT from a STRING.
+        tokens = [
+            token
+            for token in tokenize.generate_tokens(io.StringIO(body).readline)
+            if token.type != tokenize.COMMENT
+        ]
+        body = tokenize.untokenize(tokens)
         assert ttl_attribute not in body, (
             f'_write_ballot sets {ttl_attribute!r}. The aggregates table expires any '
             f'item carrying it, so ballots would disappear from the team score '

--- a/voc-datalake/lambda/api/test/test_anon_ballot_key_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_anon_ballot_key_lockstep.py
@@ -272,6 +272,15 @@ class TestABallotNeverCarriesAnExpiry:
             f'failed to strip _write_ballot\'s docstring in {BALLOTS_SOURCE}; this '
             f'test would otherwise assert against prose rather than code.'
         )
+        # COMMENTS ARE PROSE TOO, and stripped for the same reason. `ttl` is asserted
+        # as a bare substring rather than as an attribute reference — which is the
+        # right direction for a guard against an expiry reaching this write, since it
+        # catches every spelling — but it also matches the three letters inside an
+        # ordinary English word, so a comment explaining WHY a cancellation is
+        # retried ("thro-ttl-ing") failed this test while the code was correct. A
+        # lockstep test that fails on a comment is one that gets deleted rather than
+        # heeded.
+        body = re.sub(r'#[^\n]*', '', body)
         assert ttl_attribute not in body, (
             f'_write_ballot sets {ttl_attribute!r}. The aggregates table expires any '
             f'item carrying it, so ballots would disappear from the team score '

--- a/voc-datalake/lambda/api/test/test_anon_row_mark_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_anon_row_mark_lockstep.py
@@ -1,0 +1,185 @@
+"""Lockstep test: the two marks a ballot stamps on its ROW are spelled in two
+separate Lambda bundles and must agree.
+
+`ballots_handler.py` is the one unauthenticated writer into the PRIORITIZATION
+partition; `projects_handler.py` owns it — it writes a signed-in reviewer's ballot,
+it is the only reader, and it is where a composition change and a row delete assert
+these attributes. The two are packaged as SEPARATE bundles, so neither may import
+the other and the constants are duplicated by necessity. This file is what keeps the
+copies honest, exactly as `test_anon_ballot_key_lockstep.py` does for the sort key.
+
+WHAT EACH DRIFT COSTS, WHICH IS WHY THIS IS A TEST AND NOT A COMMENT
+--------------------------------------------------------------------
+
+  * `first_ballot_at` UNDER ANOTHER NAME IS A FREEZE THAT DOES NOT FREEZE.
+    `api_recompose_prioritization_row` refuses a change by asserting
+    `attribute_not_exists(first_ballot_at)`. If the anonymous writer stamps a
+    differently-named attribute, a row whose only ballots were cast in a room stays
+    recomposable — and recomposing it leaves every one of those ballots describing
+    documents the room never saw. That is the invariant #339 records as
+    database-enforced, with the hole placed exactly where the votes are least
+    attributable.
+
+  * `ballot_writes` UNDER ANOTHER NAME IS A FENCE THAT DOES NOT FENCE.
+    `_transact_delete_row` asserts that attribute still reads what it read when the
+    row's ballots were enumerated. If the anonymous writer moves something else, a
+    room ballot landing in that window is orphaned by a delete that commits anyway —
+    the #342 fault the fence exists to close.
+
+  * THE TRANSACTION'S ROW INDEX. Both handlers read `CancellationReasons` at the
+    position of the row's write to tell a vanished row from a write conflict. Two
+    items each, row second, in both — a disagreement means one of them reads a reason
+    belonging to the other item and answers a transient conflict as a settled fact.
+
+Neither of the first two failures is loud. Nothing errors, no log line appears: the
+room votes, every phone says thanks, and an invariant the API advertises is quietly
+not true.
+
+Every value is read as SOURCE TEXT rather than imported, for the reason
+`test_anon_ballot_key_lockstep.py` records: the assertion must not be satisfiable by
+whatever either module happens to resolve at import time.
+"""
+import re
+from pathlib import Path
+
+BALLOTS_SOURCE = 'lambda/api/ballots_handler.py'
+PROJECTS_SOURCE = 'lambda/api/projects_handler.py'
+
+
+def _read(relative: str) -> str:
+    # lambda/api/test/ -> voc-datalake/
+    path = Path(__file__).resolve().parents[3] / relative
+    assert path.is_file(), (
+        f'{relative} not found — did the file move? '
+        f'If so, update the path constant in this test file.'
+    )
+    return path.read_text(encoding='utf-8')
+
+
+def _single(source: str, pattern: str, where: str, what: str) -> str:
+    """The one match for `pattern`, or a failure naming what drifted.
+
+    Exactly one is required deliberately: a second assignment of the same constant
+    is itself the drift this file exists to prevent, and taking the first match
+    would hide it.
+    """
+    matches = re.findall(pattern, source, re.MULTILINE)
+    assert len(matches) == 1, (
+        f'Expected exactly one {what} assignment in {where}; found {len(matches)}. '
+        f'A second copy is the drift this test exists to prevent — if the '
+        f'declaration was restructured, update the pattern in this test file.'
+    )
+    return matches[0]
+
+
+def _str_const(source: str, name: str, where: str) -> str:
+    return _single(source, rf"^{name}\s*=\s*'([^']*)'", where, name)
+
+
+def _int_const(source: str, name: str, where: str) -> int:
+    return int(_single(source, rf'^{name}\s*=\s*(\d+)', where, name))
+
+
+class TestTheFreezeMarkIsOneAttributeInBothBundles:
+    """The mark a composition change asserts the absence of."""
+
+    def test_both_writers_name_the_same_attribute(self):
+        anon = _str_const(_read(BALLOTS_SOURCE), 'ROW_FROZEN_AT_FIELD', BALLOTS_SOURCE)
+        owner = _str_const(_read(PROJECTS_SOURCE), 'ROW_FROZEN_AT_FIELD',
+                           PROJECTS_SOURCE)
+
+        assert anon == owner, (
+            f'ROW_FROZEN_AT_FIELD is {anon!r} in {BALLOTS_SOURCE} and {owner!r} in '
+            f'{PROJECTS_SOURCE}. The recompose route asserts the absence of the '
+            f"OWNER'S spelling, so a row whose only ballots came from a room would "
+            f'stay recomposable — and those ballots would end up describing '
+            f'documents nobody who cast them ever saw. Nothing errors when this '
+            f'drifts.'
+        )
+
+    def test_the_recompose_condition_asserts_that_attribute(self):
+        """That the constant AGREES is not the contract; that the refusal is built on
+        it is. A condition naming the attribute literally would satisfy the assertion
+        above while ignoring the constant entirely."""
+        source = _read(PROJECTS_SOURCE)
+
+        assert re.search(
+            r'attribute_not_exists\(\{?ROW_FROZEN_AT_FIELD\}?\)', source
+        ), (
+            f'{PROJECTS_SOURCE} declares ROW_FROZEN_AT_FIELD but no condition '
+            f'asserts its absence. An unapplied constant is a comment: the freeze '
+            f'would be a stored attribute nothing refuses a change on.'
+        )
+
+    def test_the_anonymous_writer_stamps_it_with_if_not_exists(self):
+        """`if_not_exists` is what makes the mark a FREEZE INSTANT rather than a
+        last-modified stamp. A plain assignment would move it on every correction, so
+        "the first ballot froze this" would name whichever phone submitted last."""
+        source = _read(BALLOTS_SOURCE)
+
+        assert re.search(r'if_not_exists\(#frozen_at, :now\)', source), (
+            f'{BALLOTS_SOURCE} does not stamp the freeze mark with `if_not_exists`. '
+            f'A plain assignment turns the freeze instant into a last-modified stamp.'
+        )
+
+
+class TestTheDeleteFenceIsOneAttributeInBothBundles:
+    """The counter a row delete asserts has not moved."""
+
+    def test_both_writers_name_the_same_attribute(self):
+        anon = _str_const(_read(BALLOTS_SOURCE), 'ROW_BALLOT_WRITES_FIELD',
+                          BALLOTS_SOURCE)
+        owner = _str_const(_read(PROJECTS_SOURCE), 'ROW_BALLOT_WRITES_FIELD',
+                           PROJECTS_SOURCE)
+
+        assert anon == owner, (
+            f'ROW_BALLOT_WRITES_FIELD is {anon!r} in {BALLOTS_SOURCE} and {owner!r} '
+            f'in {PROJECTS_SOURCE}. The row delete fences on the OWNER\'S spelling, '
+            f'so an anonymous ballot landing between the enumeration and the delete '
+            f'would not move it — and the delete would commit, leaving that ballot '
+            f'orphaned. That is the #342 fault the fence exists to close.'
+        )
+
+    def test_the_anonymous_writer_moves_it_with_ADD(self):
+        """`ADD` rather than a read-then-increment, so a room of phones submitting at
+        once each move it and none of them reads it first."""
+        source = _read(BALLOTS_SOURCE)
+
+        assert re.search(r'ADD #ballot_writes :one', source), (
+            f'{BALLOTS_SOURCE} does not ADD to the fence counter. An increment that '
+            f'reads first loses exactly the concurrent case this feature is for.'
+        )
+
+    def test_neither_attribute_is_the_other(self):
+        """One name for both marks would make the freeze instant and the write count
+        the same field: the freeze would be overwritten by a counter, and the fence
+        would compare timestamps."""
+        source = _read(PROJECTS_SOURCE)
+        frozen = _str_const(source, 'ROW_FROZEN_AT_FIELD', PROJECTS_SOURCE)
+        writes = _str_const(source, 'ROW_BALLOT_WRITES_FIELD', PROJECTS_SOURCE)
+
+        assert frozen != writes
+
+
+class TestBothBundlesReadTheCancellationReasonAtTheSamePosition:
+    """Two items each, the row's write second, in both handlers."""
+
+    def test_the_row_index_agrees(self):
+        anon = _int_const(_read(BALLOTS_SOURCE), 'BALLOT_TRANSACT_ROW_INDEX',
+                          BALLOTS_SOURCE)
+        owner = _int_const(_read(PROJECTS_SOURCE), 'BALLOT_TRANSACT_ROW_INDEX',
+                           PROJECTS_SOURCE)
+
+        assert anon == owner, (
+            f'BALLOT_TRANSACT_ROW_INDEX is {anon} in {BALLOTS_SOURCE} and {owner} in '
+            f'{PROJECTS_SOURCE}. Both read the cancellation reason at that position '
+            f'to tell a vanished row from a write conflict, so a disagreement means '
+            f'one of them answers contention as a settled 404 and drops a ballot.'
+        )
+
+    def test_the_index_names_the_second_of_two_items(self):
+        """Stated as a number rather than derived, so a transaction that grew a third
+        participant — or reordered the two — fails here."""
+        for source, where in ((_read(BALLOTS_SOURCE), BALLOTS_SOURCE),
+                              (_read(PROJECTS_SOURCE), PROJECTS_SOURCE)):
+            assert _int_const(source, 'BALLOT_TRANSACT_ROW_INDEX', where) == 1

--- a/voc-datalake/lambda/api/test/test_anon_row_mark_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_anon_row_mark_lockstep.py
@@ -49,6 +49,17 @@ PROJECTS_SOURCE = 'lambda/api/projects_handler.py'
 def _read(relative: str) -> str:
     # lambda/api/test/ -> voc-datalake/
     path = Path(__file__).resolve().parents[3] / relative
+    # ASSERTED, not skipped, and the difference from
+    # `test_prioritization_row_payload_lockstep.py` is deliberate. BOTH files this
+    # reads are backend sources in this same tree, packaged and checked out together
+    # with the test — so an absent one means the file MOVED, which is a real drift
+    # this test should report rather than step around.
+    #
+    # The locksteps that skip reach ACROSS into the frontend tree, which can
+    # legitimately be absent (packaging a lambda bundle, a partial checkout): there is
+    # nothing to compare, and skipping beats a failure that says nothing about the code
+    # under test. Neither policy is the general rule; which one is right follows from
+    # whether a missing file is possible without anything having gone wrong.
     assert path.is_file(), (
         f'{relative} not found — did the file move? '
         f'If so, update the path constant in this test file.'

--- a/voc-datalake/lambda/api/test/test_ballots_handler.py
+++ b/voc-datalake/lambda/api/test/test_ballots_handler.py
@@ -825,7 +825,8 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
 
         table.meta.client.transact_write_items = conflict
 
-        status, _ = _submit(table, api_gateway_event, lambda_context)
+        with patch('ballots_handler.time.sleep'):
+            status, _ = _submit(table, api_gateway_event, lambda_context)
 
         assert status == 500, 'a retryable failure, not a 404'
 
@@ -858,11 +859,17 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
 
         table.meta.client.transact_write_items = conflict_once
 
-        status, body = _submit(table, api_gateway_event, lambda_context)
+        # The retry's backoff is real `time.sleep`, and a test suite paying it is
+        # the same money-for-nothing the jitter comment warns about — stubbed here
+        # and in the other retry tests, with the DELAYS still asserted so the wait
+        # itself cannot silently disappear.
+        with patch('ballots_handler.time.sleep') as slept:
+            status, body = _submit(table, api_gateway_event, lambda_context)
 
         assert status == 200
         assert body['success'] is True
         assert len(attempts) == 2, 'the conflict was re-attempted'
+        assert slept.call_count == 1, 'one conflict, one backoff'
 
     def test_a_retried_ballot_is_written_exactly_once(
             self, api_gateway_event, lambda_context):
@@ -887,7 +894,8 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
 
         table.meta.client.transact_write_items = conflict_once
 
-        _submit(table, api_gateway_event, lambda_context)
+        with patch('ballots_handler.time.sleep'):
+            _submit(table, api_gateway_event, lambda_context)
 
         assert len(table.ballot_keys) == 1
         assert table.row()['ballot_writes'] == 1
@@ -915,21 +923,17 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
 
         table.meta.client.transact_write_items = always_conflict
 
-        status, _ = _submit(table, api_gateway_event, lambda_context)
+        with patch('ballots_handler.time.sleep') as slept:
+            status, _ = _submit(table, api_gateway_event, lambda_context)
 
         assert status == 500, 'transient, not a vanished proposal'
         assert len(attempts) == ballots_handler.BALLOT_WRITE_ATTEMPTS
         assert table.ballot_keys == [], 'and nothing was written'
-
-    def test_the_write_attempts_bound_leaves_at_least_one_attempt(self):
-        """A bound of 0 makes `range` yield nothing, so the write loop is never
-        entered — and this function signals a written ballot by returning, which makes
-        falling out of the loop indistinguishable from success. Pinned as a number the
-        way `MAX_ROW_BALLOTS_PER_DELETE + 2 <= 100` pins the delete's reservation,
-        because it is a tuning constant and a later change may lower it."""
-        import ballots_handler
-
-        assert ballots_handler.BALLOT_WRITE_ATTEMPTS >= 1
+        # The backoff is jittered around an exponential base; what must hold is that
+        # every wait happened and each stayed under a second, not an exact schedule.
+        delays = [call.args[0] for call in slept.call_args_list]
+        assert len(delays) == ballots_handler.BALLOT_WRITE_ATTEMPTS - 1
+        assert all(0 < delay < 1 for delay in delays)
 
     def test_a_bound_that_allows_no_attempt_is_a_500_and_not_a_silent_success(
             self, api_gateway_event, lambda_context):
@@ -964,6 +968,41 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
         row = table.row()
         assert ballots_handler.ROW_FROZEN_AT_FIELD in row
         assert ballots_handler.ROW_BALLOT_WRITES_FIELD in row
+
+
+class TestTheTuningConstantsKeepTheirAssumptions:
+    """Constant pins, in one place — the shape `MAX_ROW_BALLOTS_PER_DELETE + 2 <= 100`
+    uses in the projects suite. Separate from the route classes because these tests
+    involve no request at all: each pins a number some mechanism silently depends
+    on, so the failure names the assumption rather than a symptom."""
+
+    def test_the_write_attempts_bound_leaves_at_least_one_attempt(self):
+        """A bound of 0 makes `range` yield nothing, so the write loop is never
+        entered — and `_write_ballot` signals a written ballot by returning, which
+        makes falling out of the loop indistinguishable from success. It is a tuning
+        constant and a later change may lower it; the post-loop guard is what fires
+        if this stops holding anyway."""
+        import ballots_handler
+
+        assert ballots_handler.BALLOT_WRITE_ATTEMPTS >= 1
+
+    def test_the_worst_case_backoff_stays_well_inside_the_route_budget(self):
+        """The retry's sleeps are billed wall-clock inside a PUBLIC request a phone
+        is waiting on. The comment on the constants states ~150ms as the worst case;
+        this pins that the constants cannot drift to where the sleeps rival the 30s
+        route timeout while the comment keeps promising milliseconds."""
+        import ballots_handler
+
+        # The jitter multiplier tops out just under 1.0, so the un-jittered sum is
+        # the bound.
+        worst_case = sum(
+            ballots_handler.BALLOT_WRITE_BACKOFF_SECONDS * (2 ** attempt)
+            for attempt in range(ballots_handler.BALLOT_WRITE_ATTEMPTS - 1)
+        )
+        assert worst_case < 1, (
+            f'the retry can now sleep {worst_case:.2f}s inside a public request; '
+            f'if that is intended, move the submission budget, not just this pin'
+        )
 
 
 class TestValidationRefusalsAreTheirOwnReason:

--- a/voc-datalake/lambda/api/test/test_ballots_handler.py
+++ b/voc-datalake/lambda/api/test/test_ballots_handler.py
@@ -921,6 +921,34 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
         assert len(attempts) == ballots_handler.BALLOT_WRITE_ATTEMPTS
         assert table.ballot_keys == [], 'and nothing was written'
 
+    def test_the_write_attempts_bound_leaves_at_least_one_attempt(self):
+        """A bound of 0 makes `range` yield nothing, so the write loop is never
+        entered — and this function signals a written ballot by returning, which makes
+        falling out of the loop indistinguishable from success. Pinned as a number the
+        way `MAX_ROW_BALLOTS_PER_DELETE + 2 <= 100` pins the delete's reservation,
+        because it is a tuning constant and a later change may lower it."""
+        import ballots_handler
+
+        assert ballots_handler.BALLOT_WRITE_ATTEMPTS >= 1
+
+    def test_a_bound_that_allows_no_attempt_is_a_500_and_not_a_silent_success(
+            self, api_gateway_event, lambda_context):
+        """The guard for the bound going wrong anyway. Without the raise after the
+        loop the device is told 200 and the room is thanked for a ballot that was
+        never written — the one failure this module makes loud everywhere else. A
+        misconfigured bound is a server fault, so it reads as one."""
+        import ballots_handler
+
+        table = FakeAggregatesTable([open_session()])
+
+        with patch.object(ballots_handler, 'BALLOT_WRITE_ATTEMPTS', 0):
+            status, body = _submit(table, api_gateway_event, lambda_context)
+
+        assert status == 500
+        assert body['success'] is False
+        assert table.transact_calls == [], 'no attempt was made'
+        assert table.ballot_keys == [], 'and nothing was written'
+
     def test_the_marks_are_spelled_the_way_the_other_bundle_reads_them(
             self, api_gateway_event, lambda_context):
         """The two handlers are separate Lambda bundles and neither may import the

--- a/voc-datalake/lambda/api/test/test_ballots_handler.py
+++ b/voc-datalake/lambda/api/test/test_ballots_handler.py
@@ -25,6 +25,7 @@ write, so a change to one of those expressions has to be reflected here.
 """
 import json
 import re
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -42,21 +43,76 @@ FUTURE = 4_000_000_000
 PAST = 1_000_000_000
 
 
+def _split_top_level(text, separator=','):
+    """Split on `separator` outside parentheses.
+
+    `if_not_exists(#frozen_at, :now)` carries a comma of its own, so a naive split
+    would cut it in half and report an assignment the route never made.
+    """
+    parts, depth, current = [], 0, ''
+    for character in text:
+        if character == '(':
+            depth += 1
+        elif character == ')':
+            depth -= 1
+        if character == separator and depth == 0:
+            parts.append(current)
+            current = ''
+            continue
+        current += character
+    parts.append(current)
+    return [part.strip() for part in parts if part.strip()]
+
+
 class FakeAggregatesTable:
     """An in-memory stand-in for the aggregates table.
 
-    Supports `get_item`, `put_item`, and the conditional `SET` updates these
-    routes issue. The condition evaluator understands only the four forms the
-    handler uses (`attribute_exists(sk)`, `#name = :value`, `#name > :value`,
-    `attr < attr`) and raises on anything else, so a new conjunct cannot pass
-    unnoticed by being silently treated as true.
+    Supports `get_item`, `put_item`, the conditional `SET`/`ADD` updates these
+    routes issue, and the `transact_write_items` the ballot write issues. The
+    condition evaluator understands only the four forms the handler uses
+    (`attribute_exists(sk)`, `#name = :value`, `#name > :value`, `attr < attr`) and
+    raises on anything else, so a new conjunct cannot pass unnoticed by being
+    silently treated as true.
+
+    The TRANSACTION is all-or-nothing here as it is in DynamoDB — every condition is
+    evaluated before any item is applied — because that is the property the ballot
+    write depends on: the ballot and its row's freeze mark land together or neither
+    does, and a fake that applied items as it walked them would let a test about that
+    pass against code that wrote one without the other.
     """
 
-    def __init__(self, items=None, close_after_reads=None):
+    def __init__(self, items=None, close_after_reads=None, rows_exist=True):
         self.items = {(i['pk'], i['sk']): dict(i) for i in (items or [])}
+        if rows_exist:
+            # THE ROW RECORD OF EVERY SEEDED SESSION, because that is the only state
+            # the product can reach: a session is created only for a row that exists
+            # (`_row_exists` gates it), and a ballot now asserts the row still does —
+            # it stamps that record's freeze mark and moves the fence a row delete
+            # reads. A fixture with a session and no row is a row deleted after the
+            # vote opened, which is what `rows_exist=False` is for.
+            for (pk, _), item in list(self.items.items()):
+                if pk != SESSION_PK:
+                    continue
+                row_id = item.get('row_id')
+                if not isinstance(row_id, str) or not row_id:
+                    continue
+                key = (PRIORITIZATION_PK, f'ROW#{row_id}')
+                self.items.setdefault(key, {
+                    'pk': key[0], 'sk': key[1], 'row_id': row_id,
+                    'project_id': 'proj', 'document_ids': [f'{row_id}-prd'],
+                    'is_default': True, 'created_at': '2026-08-17T10:00:00+00:00',
+                })
         self.get_item_calls = []
         self.put_item_calls = []
         self.update_item_calls = []
+        self.transact_calls = []
+        # `table.name` and `table.meta.client` are what a transaction needs: it is
+        # issued on the resource's underlying CLIENT, which takes the table name per
+        # item rather than being bound to one table.
+        self.name = 'test-aggregates'
+        self.meta = SimpleNamespace(client=SimpleNamespace(
+            transact_write_items=self._transact_write_items,
+        ))
         # Models the RACE: the facilitator closes the vote after the handler has
         # read the session and before it writes. `None` disables it.
         self.close_after_reads = close_after_reads
@@ -103,17 +159,89 @@ class FakeAggregatesTable:
                 'UpdateItem',
             )
 
+        self._apply(key, kwargs)
+        item = self.items[key]
+        return {'Attributes': dict(item)} if kwargs.get('ReturnValues') == 'ALL_NEW' else {}
+
+    def _apply(self, key, kwargs):
+        """The `SET` / `ADD` clauses these routes write, condition already checked."""
+        names = kwargs.get('ExpressionAttributeNames', {})
+        values = kwargs.get('ExpressionAttributeValues', {})
+        item = self.items.get(key)
         if item is None:
             item = {'pk': key[0], 'sk': key[1]}
             self.items[key] = item
 
         expression = kwargs['UpdateExpression'].strip()
-        assert expression.upper().startswith('SET'), expression
-        for assignment in expression[len('SET'):].split(','):
-            target, _, source = (part.strip() for part in assignment.partition('='))
+        # One expression may carry both clauses: the row half of the ballot
+        # transaction is `SET #frozen_at = if_not_exists(...) ADD #ballot_writes :one`.
+        set_clause, add_clause = expression, ''
+        if ' ADD ' in expression:
+            set_clause, _, add_clause = expression.partition(' ADD ')
+        elif expression.upper().startswith('ADD'):
+            set_clause, add_clause = '', expression[len('ADD'):]
+        if set_clause:
+            assert set_clause.strip().upper().startswith('SET'), expression
+            for assignment in _split_top_level(set_clause.strip()[len('SET'):]):
+                target, _, source = (part.strip() for part in assignment.partition('='))
+                attribute = names.get(target, target)
+                if source.startswith('if_not_exists('):
+                    existing, fallback = _split_top_level(
+                        source[len('if_not_exists('):-1]
+                    )
+                    # `if_not_exists` is what makes the freeze mark record the FIRST
+                    # ballot rather than the latest, so it is honoured rather than
+                    # treated as a plain assignment: a fake that overwrote would let
+                    # an assignment pass as a freeze instant.
+                    if names.get(existing.strip(), existing.strip()) in item:
+                        continue
+                    item[attribute] = values[fallback.strip()]
+                    continue
+                item[attribute] = self._value(source, item, names, values)
+        if add_clause:
+            target, source = add_clause.split()
             attribute = names.get(target, target)
-            item[attribute] = self._value(source, item, names, values)
-        return {'Attributes': dict(item)} if kwargs.get('ReturnValues') == 'ALL_NEW' else {}
+            item[attribute] = (item.get(attribute) or 0) + values[source]
+
+    def _transact_write_items(self, TransactItems):
+        """All-or-nothing, which is what the ballot write depends on.
+
+        The capitalised parameter is boto3's own spelling of it, kept so the fake
+        accepts exactly the call the route makes.
+
+        `CancellationReasons` is ONE ENTRY PER ITEM, POSITIONALLY, with `'None'` for
+        the items that did not fail — DynamoDB's own shape. The route reads the reason
+        at the ROW's index to tell a vanished row from a write conflict, so a
+        single-element list would let it pass here while reading the wrong position in
+        production.
+        """
+        self.transact_calls.append(TransactItems)
+        reasons = []
+        for entry in TransactItems:
+            (operation, request), = entry.items()
+            assert operation == 'Update', operation
+            assert request['TableName'] == self.name, request['TableName']
+            key = (request['Key']['pk'], request['Key']['sk'])
+            holds = self._holds(
+                request['ConditionExpression'], self.items.get(key),
+                request.get('ExpressionAttributeNames', {}),
+                request.get('ExpressionAttributeValues', {}),
+            ) if request.get('ConditionExpression') else True
+            reasons.append({'Code': 'None'} if holds else {
+                'Code': 'ConditionalCheckFailed',
+                'Message': 'The conditional request failed',
+            })
+        if any(reason['Code'] != 'None' for reason in reasons):
+            raise ClientError(
+                {'Error': {'Code': 'TransactionCanceledException',
+                           'Message': 'Transaction cancelled'},
+                 'CancellationReasons': reasons},
+                'TransactWriteItems',
+            )
+        for entry in TransactItems:
+            (_, request), = entry.items()
+            self._apply((request['Key']['pk'], request['Key']['sk']), request)
+        return {}
 
     # -- expression evaluation --------------------------------------------
     def _value(self, source, item, names, values):
@@ -157,10 +285,21 @@ class FakeAggregatesTable:
     # -- helpers -----------------------------------------------------------
     @property
     def ballot_keys(self):
-        return sorted(sk for (pk, sk) in self.items if pk == PRIORITIZATION_PK)
+        """Only the BALLOT keys. The row records the ballot write now stamps share
+        this partition, and every "nothing was written" assertion here is about
+        ballots — counting a fixture's row record among them would make each of them
+        fail while saying nothing about the ballot."""
+        return sorted(
+            sk for (pk, sk) in self.items
+            if pk == PRIORITIZATION_PK and sk.startswith('BALLOT#')
+        )
 
     def ballot(self, sort_key):
         return self.items.get((PRIORITIZATION_PK, sort_key))
+
+    def row(self, row_id='row_proj_20260817_default'):
+        """The ROW record a ballot stamps — the freeze mark and the delete's fence."""
+        return self.items.get((PRIORITIZATION_PK, f'ROW#{row_id}'))
 
     def session(self, session_id=OPEN_SESSION_ID):
         return self.items.get((SESSION_PK, f'SESSION#{session_id}'))
@@ -534,6 +673,150 @@ class TestWhatABallotIsAndIsNot:
         _submit(table, api_gateway_event, lambda_context)
 
         assert table.ballot(table.ballot_keys[0])['voting_session'] == OPEN_SESSION_ID
+
+
+class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
+    """An anonymous ballot is A BALLOT: a durable decision record about the set of
+    documents the row held when the room voted, counted in the same aggregate a
+    signed-in reviewer's is.
+
+    So it has to do the same three things to its row, and all three are properties of
+    the write rather than of some later reconciliation — which is why they are
+    asserted here, against the real route, rather than trusted to the attribute names
+    the lockstep test pins.
+    """
+
+    ROW = 'row_proj_20260817_default'
+
+    def test_a_room_ballot_freezes_the_rows_composition(
+            self, api_gateway_event, lambda_context):
+        """Without this, a row carrying nothing but REAL anonymous votes stayed
+        recomposable — and recomposing it would leave every one of those ballots
+        describing documents the room never saw. `first_ballot_at` is exactly what
+        `projects_handler`'s recompose route asserts the absence of."""
+        table = FakeAggregatesTable([open_session()])
+        assert 'first_ballot_at' not in table.row()
+
+        _submit(table, api_gateway_event, lambda_context)
+
+        assert table.row()['first_ballot_at']
+
+    def test_the_freeze_mark_records_the_first_room_ballot_and_not_the_latest(
+            self, api_gateway_event, lambda_context):
+        """`if_not_exists`, so it is a freeze instant and not a last-modified stamp:
+        the composition froze when the FIRST phone submitted."""
+        table = FakeAggregatesTable([open_session()])
+
+        _submit(table, api_gateway_event, lambda_context)
+        first = table.row()['first_ballot_at']
+        _submit(table, api_gateway_event, lambda_context)
+
+        assert table.row()['first_ballot_at'] == first
+
+    def test_a_room_ballot_moves_the_deletes_fence(
+            self, api_gateway_event, lambda_context):
+        """`ballot_writes` is what a row delete asserts has not changed since it
+        enumerated the row's ballots. An anonymous ballot that did not move it left
+        the delete free to commit and orphan that ballot — the #342 fault the fence
+        exists to close, surviving in the one path least able to notice it."""
+        table = FakeAggregatesTable([open_session()])
+
+        _submit(table, api_gateway_event, lambda_context)
+        _submit(table, api_gateway_event, lambda_context)
+
+        assert table.row()['ballot_writes'] == 2
+
+    def test_a_correction_moves_the_fence_without_moving_the_freeze(
+            self, api_gateway_event, lambda_context):
+        """A correction is a write, so the fence has to move: a delete that listed the
+        row's ballots before the correction landed must be cancelled rather than
+        committing over it. The freeze instant does not move, because the first ballot
+        is what froze the composition and a correction is not a new decision about
+        which documents the row holds."""
+        table = FakeAggregatesTable([open_session()])
+        _, first = _submit(table, api_gateway_event, lambda_context)
+        froze_at = table.row()['first_ballot_at']
+
+        _, second = _submit(table, api_gateway_event, lambda_context,
+                            body={**AXES, 'ballot_id': first['ballot_id']})
+
+        assert second['corrected'] is True
+        assert table.row()['first_ballot_at'] == froze_at
+        assert table.row()['ballot_writes'] == 2
+
+    def test_the_ballot_and_its_rows_marks_land_in_ONE_write(
+            self, api_gateway_event, lambda_context):
+        """Two writes would leave a window in which the ballot exists and its row is
+        still recomposable — the freeze arriving a moment late, which is precisely the
+        interleaving the condition on a composition change exists to lose to."""
+        table = FakeAggregatesTable([open_session()])
+
+        _submit(table, api_gateway_event, lambda_context)
+
+        assert len(table.transact_calls) == 1
+        keys = sorted(
+            request['Key']['sk'] for entry in table.transact_calls[0]
+            for request in entry.values()
+        )
+        assert keys == [
+            f'BALLOT#{self.ROW}#anon:{table.ballot_keys[0].rsplit(":", 1)[1]}',
+            f'ROW#{self.ROW}',
+        ]
+
+    def test_a_ballot_on_a_row_deleted_after_the_vote_opened_is_refused(
+            self, api_gateway_event, lambda_context):
+        """`_row_exists` is checked when the session is OPENED, which can be an hour
+        before the room votes. `attribute_exists(sk)` on the write is what makes a
+        ballot on a row deleted in between fail — instead of resurrecting the row as
+        a bare record, since `update_item` is an upsert."""
+        table = FakeAggregatesTable([open_session()], rows_exist=False)
+
+        status, body = _submit(table, api_gateway_event, lambda_context)
+
+        assert status == 404
+        assert table.ballot_keys == [], 'no orphan was left behind'
+        assert table.row() is None, 'and the row was not resurrected'
+        assert body['success'] is False
+
+    def test_a_write_conflict_is_a_retryable_failure_not_a_vanished_proposal(
+            self, api_gateway_event, lambda_context):
+        """The ordinary case in this handler: a room of phones submitting at once all
+        write the SAME row record, so `TransactionConflict` is what contention looks
+        like here. Reading it as "the row is gone" would tell a phone that lost a race
+        that the proposal no longer exists — a settled refusal in place of the
+        transient failure the page already retries."""
+        table = FakeAggregatesTable([open_session()])
+
+        def conflict(**kwargs):
+            raise ClientError(
+                {'Error': {'Code': 'TransactionCanceledException',
+                           'Message': 'Transaction cancelled'},
+                 'CancellationReasons': [{'Code': 'None'},
+                                         {'Code': 'TransactionConflict'}]},
+                'TransactWriteItems',
+            )
+
+        table.meta.client.transact_write_items = conflict
+
+        status, _ = _submit(table, api_gateway_event, lambda_context)
+
+        assert status == 500, 'a retryable failure, not a 404'
+
+    def test_the_marks_are_spelled_the_way_the_other_bundle_reads_them(
+            self, api_gateway_event, lambda_context):
+        """The two handlers are separate Lambda bundles and neither may import the
+        other, so the attribute names are duplicated. Pinned against the real writer
+        here and across the two source files by `test_anon_row_mark_lockstep.py`: a
+        drift is a freeze that does not freeze and a fence that does not fence, and
+        neither failure is loud."""
+        import ballots_handler
+
+        table = FakeAggregatesTable([open_session()])
+        _submit(table, api_gateway_event, lambda_context)
+
+        row = table.row()
+        assert ballots_handler.ROW_FROZEN_AT_FIELD in row
+        assert ballots_handler.ROW_BALLOT_WRITES_FIELD in row
 
 
 class TestValidationRefusalsAreTheirOwnReason:

--- a/voc-datalake/lambda/api/test/test_ballots_handler.py
+++ b/voc-datalake/lambda/api/test/test_ballots_handler.py
@@ -778,6 +778,33 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
         assert table.row() is None, 'and the row was not resurrected'
         assert body['success'] is False
 
+    def test_the_vanished_row_is_refused_with_a_reason_the_page_can_state(
+            self, api_gateway_event, lambda_context):
+        """THE SHAPE, not the status. The page dispatches on `reason` alone —
+        `submitBallot` parses the body with `ballotRefusalSchema` and falls back to
+        `unknown` when the field is absent, which renders as "try again in a moment".
+
+        A bare `NotFoundError` is rendered by the shared handler WITHOUT a `reason`,
+        so the one case where the row is permanently gone got the copy reserved for
+        transient failures — inverting the very distinction the cancellation-reason
+        read exists to draw. `not_found` already has its own translated sentence."""
+        table = FakeAggregatesTable([open_session()], rows_exist=False)
+
+        _, body = _submit(table, api_gateway_event, lambda_context)
+
+        assert body['reason'] == 'not_found'
+
+    def test_a_vanished_row_is_not_retried(
+            self, api_gateway_event, lambda_context):
+        """A deleted row does not come back, so re-attempting would spend the room's
+        request time to reach the same answer. Only a cancellation NO CONDITION caused
+        is transient."""
+        table = FakeAggregatesTable([open_session()], rows_exist=False)
+
+        _submit(table, api_gateway_event, lambda_context)
+
+        assert len(table.transact_calls) == 1
+
     def test_a_write_conflict_is_a_retryable_failure_not_a_vanished_proposal(
             self, api_gateway_event, lambda_context):
         """The ordinary case in this handler: a room of phones submitting at once all
@@ -801,6 +828,98 @@ class TestAnAnonymousBallotMarksItsRowLikeAnyOther:
         status, _ = _submit(table, api_gateway_event, lambda_context)
 
         assert status == 500, 'a retryable failure, not a 404'
+
+    def test_a_conflict_that_clears_records_the_ballot_rather_than_failing(
+            self, api_gateway_event, lambda_context):
+        """CONTENTION IS THE DESIGNED CASE, so it is retried rather than reported.
+
+        Every ballot of a session `ADD`s to the SAME row record, so a room submitting
+        on the facilitator's count of three conflicts by construction — and botocore
+        does not auto-retry `TransactionCanceledException`, so it arrives at the
+        handler. Reporting it costs the voter their ballot AND their cap slot: the
+        slot was claimed before this write, and the page renders a terminal panel
+        with no way to resubmit, so a contended room would burn slots on conflicts
+        and then refuse ballots with `cap_reached` it should have accepted."""
+        table = FakeAggregatesTable([open_session()])
+        real = table.meta.client.transact_write_items
+        attempts = []
+
+        def conflict_once(**kwargs):
+            attempts.append(kwargs)
+            if len(attempts) == 1:
+                raise ClientError(
+                    {'Error': {'Code': 'TransactionCanceledException',
+                               'Message': 'Transaction cancelled'},
+                     'CancellationReasons': [{'Code': 'None'},
+                                             {'Code': 'TransactionConflict'}]},
+                    'TransactWriteItems',
+                )
+            return real(**kwargs)
+
+        table.meta.client.transact_write_items = conflict_once
+
+        status, body = _submit(table, api_gateway_event, lambda_context)
+
+        assert status == 200
+        assert body['success'] is True
+        assert len(attempts) == 2, 'the conflict was re-attempted'
+
+    def test_a_retried_ballot_is_written_exactly_once(
+            self, api_gateway_event, lambda_context):
+        """The retry is safe BECAUSE the ballot's half is an upsert on this device's
+        own key: re-attempting cannot leave two records or count a vote twice. The
+        fence moves once too, since the cancelled attempt wrote nothing at all."""
+        table = FakeAggregatesTable([open_session()])
+        real = table.meta.client.transact_write_items
+        attempts = []
+
+        def conflict_once(**kwargs):
+            attempts.append(kwargs)
+            if len(attempts) == 1:
+                raise ClientError(
+                    {'Error': {'Code': 'TransactionCanceledException',
+                               'Message': 'Transaction cancelled'},
+                     'CancellationReasons': [{'Code': 'None'},
+                                             {'Code': 'TransactionConflict'}]},
+                    'TransactWriteItems',
+                )
+            return real(**kwargs)
+
+        table.meta.client.transact_write_items = conflict_once
+
+        _submit(table, api_gateway_event, lambda_context)
+
+        assert len(table.ballot_keys) == 1
+        assert table.row()['ballot_writes'] == 1
+
+    def test_a_conflict_that_never_clears_is_still_a_retryable_500(
+            self, api_gateway_event, lambda_context):
+        """The retries are BOUNDED. A room holding phones cannot be made to wait
+        indefinitely, and a conflict that outlasts the attempts is reported as the
+        transient failure it is — a 500, which the page may retry, rather than a 404
+        claiming the proposal is gone."""
+        import ballots_handler
+
+        table = FakeAggregatesTable([open_session()])
+        attempts = []
+
+        def always_conflict(**kwargs):
+            attempts.append(kwargs)
+            raise ClientError(
+                {'Error': {'Code': 'TransactionCanceledException',
+                           'Message': 'Transaction cancelled'},
+                 'CancellationReasons': [{'Code': 'None'},
+                                         {'Code': 'TransactionConflict'}]},
+                'TransactWriteItems',
+            )
+
+        table.meta.client.transact_write_items = always_conflict
+
+        status, _ = _submit(table, api_gateway_event, lambda_context)
+
+        assert status == 500, 'transient, not a vanished proposal'
+        assert len(attempts) == ballots_handler.BALLOT_WRITE_ATTEMPTS
+        assert table.ballot_keys == [], 'and nothing was written'
 
     def test_the_marks_are_spelled_the_way_the_other_bundle_reads_them(
             self, api_gateway_event, lambda_context):

--- a/voc-datalake/lambda/api/test/test_prioritization_row_payload_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_prioritization_row_payload_lockstep.py
@@ -1,0 +1,104 @@
+"""Every field the API publishes on a row must be one the page declares.
+
+`_row_payload` in `projects_handler.py` is the row as it goes on the wire, and
+`RowSchema` in `prioritizationUtils.ts` is the row as the page accepts it. The
+schema is a `z.object`, and zod's default object STRIPS an undeclared key rather
+than failing on it — so a field the API adds and the page does not declare is
+discarded silently at the boundary. Nothing breaks, nothing logs, and the page
+simply never learns the thing the API went to the trouble of telling it.
+
+`is_frozen` is exactly that shape of field: it says a ballot has landed so the
+composition can no longer change, and a page that never receives it offers an edit
+control the server then refuses. The failure is invisible on both sides, which is
+why it is pinned here rather than left to a comment claiming the two agree.
+
+ONE DIRECTION ONLY. A key the API sends must be declared; a key the schema declares
+need not be sent, because every optional field of the schema carries a `.catch()`
+fallback and a page tolerating a field the API has retired is how a client survives
+a deployment where the two halves ship at different moments.
+
+Separate from `test_prioritization_row_bound_lockstep.py` for the reason recorded
+there: a file named for one contract should not quietly grow a second. That one pins
+a NUMBER the two sides must agree on; this one pins the SET OF FIELDS.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+FRONTEND_SOURCE = 'frontend/src/pages/Prioritization/prioritizationUtils.ts'
+
+# The `RowSchema = z.object({ ... })` literal, and then the field names declared
+# inside it. Matched as a block rather than by scanning the whole file, so a `row_id:`
+# belonging to some other schema cannot satisfy this one.
+_SCHEMA = re.compile(r'const\s+RowSchema\s*=\s*z\.object\(\{(.*?)\n\}\)', re.DOTALL)
+_FIELD = re.compile(r'^\s*([a-z_][a-z0-9_]*)\s*:', re.MULTILINE)
+
+
+def _repo_root() -> Path:
+    # lambda/api/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _declared_fields() -> set[str]:
+    path = _repo_root() / FRONTEND_SOURCE
+    if not path.is_file():
+        # A backend test reaching into the frontend tree. Where only the lambda
+        # sources are present (packaging, a partial checkout) there is nothing to
+        # compare, and skipping beats a failure that says nothing about the code
+        # under test — the same reasoning as the other prioritization locksteps.
+        pytest.skip(f'{FRONTEND_SOURCE} not present in this tree')
+    match = _SCHEMA.search(path.read_text(encoding='utf-8'))
+    assert match, (
+        f'RowSchema not found in {FRONTEND_SOURCE}. It is the shape the page accepts '
+        'a row in, and without it this test cannot tell whether a published field '
+        'reaches the page at all.'
+    )
+    return set(_FIELD.findall(match.group(1)))
+
+
+def _published_fields() -> set[str]:
+    import projects_handler
+
+    # An empty row rather than a realistic one: what is asserted is the KEY SET the
+    # payload always carries, and every field of it is unconditional.
+    return set(projects_handler._row_payload({}))
+
+
+class TestPrioritizationRowPayloadLockstep:
+    def test_every_published_field_is_one_the_page_declares(self):
+        undeclared = _published_fields() - _declared_fields()
+
+        assert not undeclared, (
+            f'_row_payload publishes {sorted(undeclared)}, which RowSchema in '
+            f'{FRONTEND_SOURCE} does not declare. `z.object` STRIPS what it does not '
+            'declare, so those fields are discarded at the boundary in silence: the '
+            'page never sees them and nothing fails to say so. Declare each one with '
+            'a `.catch()` fallback, or stop publishing it.'
+        )
+
+    def test_the_two_sides_still_agree_on_the_fields_the_page_renders(self):
+        """The fields both halves have always carried, named so a rename on either
+        side fails here rather than emptying a column on the page."""
+        both = _published_fields() & _declared_fields()
+
+        assert {'row_id', 'project_id', 'document_ids', 'prototype_id',
+                'is_default', 'created_at'} <= both
+
+    def test_the_frozen_flag_reaches_the_page(self):
+        """Named on its own because it is the field this test was written for: the
+        composition freeze is enforced by a database condition, and `is_frozen` is the
+        only thing that lets the page say so before the refusal arrives."""
+        assert 'is_frozen' in _published_fields()
+        assert 'is_frozen' in _declared_fields()
+
+    def test_the_stored_freeze_instant_and_write_count_stay_unpublished(self):
+        """The other direction of the same contract. The instant would invite a client
+        to compute the freeze itself and eventually disagree with the condition that
+        enforces it, and `ballot_writes` counts WRITES rather than reviewers — a number
+        that looks like a reviewer count but is not is worse than no number."""
+        import projects_handler
+
+        published = _published_fields()
+        assert projects_handler.ROW_FROZEN_AT_FIELD not in published
+        assert projects_handler.ROW_BALLOT_WRITES_FIELD not in published

--- a/voc-datalake/lambda/api/test/test_prioritization_row_payload_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_prioritization_row_payload_lockstep.py
@@ -46,7 +46,14 @@ def _declared_fields() -> set[str]:
         # A backend test reaching into the frontend tree. Where only the lambda
         # sources are present (packaging, a partial checkout) there is nothing to
         # compare, and skipping beats a failure that says nothing about the code
-        # under test — the same reasoning as the other prioritization locksteps.
+        # under test — the same reasoning as the other locksteps that cross this
+        # boundary (`test_prioritization_row_bound_lockstep.py`,
+        # `test_prioritization_scorable_types_lockstep.py`).
+        #
+        # The ones comparing two BACKEND sources assert instead
+        # (`test_anon_row_mark_lockstep.py`), and correctly: those files ship together
+        # with the test, so an absent one means the file moved rather than that this
+        # checkout never had it.
         pytest.skip(f'{FRONTEND_SOURCE} not present in this tree')
     match = _SCHEMA.search(path.read_text(encoding='utf-8'))
     assert match, (

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -4175,3 +4175,1444 @@ class TestTheRowCreateRouteIsNotShadowedByTheProjectUpsert:
 
         assert status == 405
         assert update_project.call_count == 0
+
+
+# ============================================
+# Phase 2 — the rest of a row's life
+# ============================================
+#
+# Phase 1 gave every project a default row. What follows pins the lifecycle around
+# it: a second row for another combination, the freeze at the first ballot, and the
+# one destructive action.
+#
+# The two shapes worth naming, because a test that asserts them loosely cannot fail:
+# a freeze test that changes a composition on a row with NO ballots proves nothing
+# about freezing, and a delete test on a row with no ballots proves nothing about
+# ballots going with it. Every test below that claims either states the ballot first.
+
+
+def _compose_row(aggregates, projects, api_gateway_event, lambda_context,
+                 body=None, subject='reviewer-1', raw_body=None):
+    """POST the compose route. Same plumbing as `_create_row`, different path."""
+    from projects_handler import lambda_handler
+
+    event = api_gateway_event(
+        method='POST', path='/projects/prioritization/rows/compose', body=body,
+    )
+    if raw_body is not None:
+        event['body'] = raw_body
+    event['requestContext']['authorizer']['claims']['sub'] = subject
+    with (
+        patch('projects_handler.get_aggregates_table', return_value=aggregates),
+        patch('projects_handler.get_projects_table', return_value=projects),
+    ):
+        response = lambda_handler(event, lambda_context)
+    return response['statusCode'], json.loads(response['body'])
+
+
+def _recompose_row(aggregates, projects, api_gateway_event, lambda_context, row_id,
+                   body=None, subject='reviewer-1'):
+    from projects_handler import lambda_handler
+
+    event = api_gateway_event(
+        method='PATCH', path=f'/projects/prioritization/rows/{row_id}', body=body,
+    )
+    event['requestContext']['authorizer']['claims']['sub'] = subject
+    with (
+        patch('projects_handler.get_aggregates_table', return_value=aggregates),
+        patch('projects_handler.get_projects_table', return_value=projects),
+    ):
+        response = lambda_handler(event, lambda_context)
+    return response['statusCode'], json.loads(response['body'])
+
+
+def _delete_row(aggregates, api_gateway_event, lambda_context, row_id,
+                subject='admin-1', groups='admins'):
+    """DELETE one row. `groups` is what the admin gate reads.
+
+    The projects table is deliberately NOT patched: a delete that reached for a
+    project's documents would fail here rather than passing against a fake that
+    happened to be in scope, and the route has no business reading them.
+    """
+    from projects_handler import lambda_handler
+
+    event = api_gateway_event(
+        method='DELETE', path=f'/projects/prioritization/rows/{row_id}',
+    )
+    claims = event['requestContext']['authorizer']['claims']
+    claims['sub'] = subject
+    if groups is None:
+        claims.pop('cognito:groups', None)
+    else:
+        claims['cognito:groups'] = groups
+    with patch('projects_handler.get_aggregates_table', return_value=aggregates):
+        response = lambda_handler(event, lambda_context)
+    return response['statusCode'], json.loads(response['body'])
+
+
+def _project_with(*documents, project_id='p1'):
+    """A project holding META plus the named `(sk_prefix, document_id)` documents."""
+    items = [project_meta(project_id)]
+    items.extend(
+        project_document(project_id, sk_prefix, document_id,
+                         f'2026-08-{index + 1:02d}T00:00:00+00:00')
+        for index, (sk_prefix, document_id) in enumerate(documents)
+    )
+    return FakeProjectsTable(items)
+
+
+TWO_SCORABLE = (('PRD#', 'prd-1'), ('PRFAQ#', 'prfaq-1'))
+FOUR_SCORABLE = TWO_SCORABLE + (('PRD#', 'prd-2'), ('PRFAQ#', 'prfaq-2'))
+
+
+class TestASecondRowCanBeComposedForAnotherCombination:
+    """"Score another combination" is the escape hatch a frozen row leaves — so a
+    project has to be able to hold more than one row, and the caller has to be able
+    to say which documents the new one holds.
+
+    STORED VERBATIM is the load-bearing half. A route that re-derived "latest of each
+    type" would answer 200 to a request naming an older PRD and quietly compose
+    something else, so the ballots on that row would describe documents nobody chose.
+    """
+
+    def test_a_reviewer_can_compose_a_row_for_a_chosen_pair_of_documents(
+        self, api_gateway_event, lambda_context
+    ):
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1', 'prfaq-2']},
+        )
+
+        assert status == 200
+        assert body['created'] is True
+        assert body['row']['document_ids'] == ['prd-1', 'prfaq-2']
+        assert body['row']['project_id'] == 'p1'
+        assert body['row']['is_default'] is False
+
+    def test_the_stored_row_holds_the_ids_the_caller_named_and_not_the_latest(
+        self, api_gateway_event, lambda_context
+    ):
+        """The whole point of the route. Reverting to "compose it from the project"
+        fails here: `prd-2` and `prfaq-2` are the latest of each type, and this row
+        asked for neither."""
+        aggregates = FakeAggregatesTable()
+
+        _, body = _compose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        stored = aggregates.items[(PARTITION, f"ROW#{body['row']['row_id']}")]
+        assert stored['document_ids'] == ['prd-1']
+
+    def test_composing_twice_gives_the_project_two_rows(
+        self, api_gateway_event, lambda_context
+    ):
+        """DELIBERATELY not idempotent, unlike the default row's create: "add a row
+        for another combination" is a request to add one, and two clicks that
+        collapsed into one row would make the escape hatch unusable."""
+        aggregates = FakeAggregatesTable()
+        projects = _project_with(*FOUR_SCORABLE)
+
+        _, first = _compose_row(aggregates, projects, api_gateway_event, lambda_context,
+                                body={'project_id': 'p1', 'document_ids': ['prd-1']})
+        _, second = _compose_row(aggregates, projects, api_gateway_event, lambda_context,
+                                 body={'project_id': 'p1', 'document_ids': ['prd-2']})
+
+        assert first['row']['row_id'] != second['row']['row_id']
+        assert len(aggregates.row_keys) == 2
+
+    def test_the_row_id_is_minted_here_and_never_taken_from_the_caller(
+        self, api_gateway_event, lambda_context
+    ):
+        """A row id becomes the FIRST SEGMENT of every ballot sort key on the row, so
+        a caller-chosen one puts that key's shape under a caller's control. A
+        `row_id` in the body is ignored, not honoured and not refused: it names no
+        field this route has."""
+        aggregates = FakeAggregatesTable()
+
+        _, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1'],
+                  'row_id': 'row_chosen#by:the-caller'},
+        )
+
+        assert body['row']['row_id'] != 'row_chosen#by:the-caller'
+        assert '#' not in body['row']['row_id']
+        assert aggregates.row_keys == [f"ROW#{body['row']['row_id']}"]
+
+    def test_a_composed_row_can_never_occupy_the_default_rows_key(
+        self, api_gateway_event, lambda_context
+    ):
+        """The default row's idempotence is a conditional put on a DERIVED key. A
+        minted id that could spell that key would let this route take it and turn
+        `POST .../rows` into a permanent 'already exists' for a row nobody composed
+        as the default."""
+        aggregates = FakeAggregatesTable()
+
+        for _ in range(5):
+            _, body = _compose_row(
+                aggregates, _project_with(*TWO_SCORABLE), api_gateway_event,
+                lambda_context, body={'project_id': 'p1', 'document_ids': ['prd-1']},
+            )
+            assert body['row']['row_id'] != 'row_p1_default'
+
+    def test_any_signed_in_reviewer_may_compose_one(
+        self, api_gateway_event, lambda_context
+    ):
+        """Per the decision recorded on #339: the identity of whoever created a row
+        is not the protection — the freeze is. Only the DELETE is admin-gated, and a
+        caller in no group composes a row."""
+        aggregates = FakeAggregatesTable()
+        from projects_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST', path='/projects/prioritization/rows/compose',
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+        event['requestContext']['authorizer']['claims'].pop('cognito:groups', None)
+        with (
+            patch('projects_handler.get_aggregates_table', return_value=aggregates),
+            patch('projects_handler.get_projects_table',
+                  return_value=_project_with(*TWO_SCORABLE)),
+        ):
+            response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+
+    def test_the_composed_row_never_carries_an_expiry(
+        self, api_gateway_event, lambda_context
+    ):
+        """The aggregates table expires anything carrying `ttl`, and a row is as
+        durable as the ballots keyed to it."""
+        aggregates = FakeAggregatesTable()
+
+        _compose_row(aggregates, _project_with(*TWO_SCORABLE), api_gateway_event,
+                     lambda_context, body={'project_id': 'p1', 'document_ids': ['prd-1']})
+
+        for call in aggregates.put_item_calls:
+            assert 'ttl' not in call['Item']
+
+    def test_a_ballot_on_a_composed_row_is_keyed_to_it_and_reads_back(
+        self, api_gateway_event, lambda_context
+    ):
+        """End to end in the unit that matters: the row this route produced is a row
+        a save addresses and the read answers about, exactly as the default row is."""
+        aggregates = FakeAggregatesTable()
+        _, created = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1', 'prfaq-1']},
+        )
+        row_id = created['row']['row_id']
+
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {row_id: AXES}, subject='alice', seed_rows=False)
+        _, body = _get_scores(aggregates, api_gateway_event, lambda_context, subject='alice')
+
+        assert aggregates.ballot_keys == [f'BALLOT#{row_id}#user:alice']
+        assert body['aggregates'][row_id]['reviewer_count'] == 1
+        assert body['rows'][row_id]['document_ids'] == ['prd-1', 'prfaq-1']
+
+
+class TestARowsDocumentSetIsRefusedBeforeAnythingIsWritten:
+    """Five ways a requested composition is not one, each refused before the put.
+
+    Every one of these is a row that would otherwise be durable and — once anybody
+    ballots on it — unrecomposable, so a repair through the product is not available
+    afterwards. That asymmetry is why they are refusals rather than corrections.
+    """
+
+    def test_an_empty_document_set_is_refused(self, api_gateway_event, lambda_context):
+        """A row with nothing to score is not a row — the same rule the default row's
+        create already applies to a project with no scorable document."""
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': []},
+        )
+
+        assert status == 400
+        assert 'at least one document' in body['error']
+        assert aggregates.put_item_calls == []
+
+    def test_a_document_the_project_does_not_own_is_refused(
+        self, api_gateway_event, lambda_context
+    ):
+        """The trust boundary. A row is a PROJECT'S set of documents and the team
+        aggregate is read per project, so an id from elsewhere would put another
+        project's document inside this project's team score."""
+        aggregates = FakeAggregatesTable()
+        projects = FakeProjectsTable([
+            project_meta('p1'),
+            project_document('p1', 'PRD#', 'prd-1', '2026-08-01T00:00:00+00:00'),
+            project_meta('p2'),
+            project_document('p2', 'PRD#', 'other-prd', '2026-08-02T00:00:00+00:00'),
+        ])
+
+        status, body = _compose_row(
+            aggregates, projects, api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1', 'other-prd']},
+        )
+
+        assert status == 404
+        assert 'does not hold' in body['error']
+        assert 'other-prd' not in body['error'], 'no echo of caller input'
+        assert aggregates.put_item_calls == []
+
+    @pytest.mark.parametrize('sk_prefix,document_id', [
+        ('PROTOTYPE#', 'proto-1'),
+        ('RESEARCH#', 'research-1'),
+        ('DOC#', 'doc-1'),
+    ])
+    def test_a_document_that_is_not_scorable_is_refused(
+        self, api_gateway_event, lambda_context, sk_prefix, document_id
+    ):
+        """A prototype or a research report has no sliders on the page, so a row
+        holding one would show a member nobody can score and would miscount what it
+        holds. PRD and PR/FAQ remain the scorable set."""
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates,
+            _project_with(*TWO_SCORABLE, (sk_prefix, document_id)),
+            api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1', document_id]},
+        )
+
+        assert status == 404
+        assert 'PRD or a PR/FAQ' in body['error']
+        assert aggregates.put_item_calls == []
+
+    def test_a_duplicated_document_id_is_refused_rather_than_collapsed(
+        self, api_gateway_event, lambda_context
+    ):
+        """The same document twice says nothing new about the row and spends the
+        bound twice. Refused rather than de-duplicated, for the reason the save
+        path's duplicate-key refusal records: the request states something
+        contradictory and there is nothing to prefer."""
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1', 'prd-1']},
+        )
+
+        assert status == 400
+        assert 'distinct' in body['error']
+        assert aggregates.put_item_calls == []
+
+    @pytest.mark.parametrize('raw', [None, 'prd-1', {'0': 'prd-1'}, 7, [None], [''], [7]])
+    def test_a_document_set_that_is_not_a_list_of_ids_is_refused(
+        self, api_gateway_event, lambda_context, raw
+    ):
+        """There is no set to store, and coercing one would invent a composition
+        nobody chose."""
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': raw},
+        )
+
+        assert status == 400
+        assert 'document_ids' in body['error']
+        assert aggregates.put_item_calls == []
+
+    def test_a_set_at_the_bound_is_accepted_and_one_over_it_is_refused(
+        self, api_gateway_event, lambda_context
+    ):
+        """MAX_ROW_DOCUMENT_IDS keeps bounding a row's composition — the same number
+        the page's row schema states, which is what
+        `test_prioritization_row_bound_lockstep.py` pins."""
+        from projects_handler import MAX_ROW_DOCUMENT_IDS
+
+        at_the_bound = [('PRD#', f'prd-{i}') for i in range(MAX_ROW_DOCUMENT_IDS)]
+        over = at_the_bound + [('PRD#', 'prd-one-too-many')]
+
+        ok_status, ok_body = _compose_row(
+            FakeAggregatesTable(), _project_with(*at_the_bound), api_gateway_event,
+            lambda_context,
+            body={'project_id': 'p1',
+                  'document_ids': [document_id for _, document_id in at_the_bound]},
+        )
+        refused_aggregates = FakeAggregatesTable()
+        refused_status, refused_body = _compose_row(
+            refused_aggregates, _project_with(*over), api_gateway_event, lambda_context,
+            body={'project_id': 'p1',
+                  'document_ids': [document_id for _, document_id in over]},
+        )
+
+        assert (ok_status, len(ok_body['row']['document_ids'])) == (200, MAX_ROW_DOCUMENT_IDS)
+        assert refused_status == 400
+        assert str(MAX_ROW_DOCUMENT_IDS) in refused_body['error']
+        assert refused_aggregates.put_item_calls == []
+
+    def test_a_project_that_does_not_exist_is_a_404(self, api_gateway_event, lambda_context):
+        aggregates = FakeAggregatesTable()
+
+        status, _ = _compose_row(
+            aggregates, FakeProjectsTable([]), api_gateway_event, lambda_context,
+            body={'project_id': 'nope', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 404
+        assert aggregates.put_item_calls == []
+
+    @pytest.mark.parametrize('project_id,expected', [
+        (None, 'required'),
+        ('', 'required'),
+        ('p#1', "must not contain '#'"),
+        ('x' * 300, 'at most 256 characters'),
+    ])
+    def test_a_project_id_that_cannot_name_a_row_is_refused(
+        self, api_gateway_event, lambda_context, project_id, expected
+    ):
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates, FakeProjectsTable([]), api_gateway_event, lambda_context,
+            body={'project_id': project_id, 'document_ids': ['prd-1']},
+        )
+
+        assert status == 400
+        assert expected in body['error']
+        assert aggregates.put_item_calls == []
+
+    @pytest.mark.parametrize('raw_body', ['{not json', '[1,2]', '"hi"'])
+    def test_a_body_that_is_not_a_json_object_is_the_callers_mistake(
+        self, api_gateway_event, lambda_context, raw_body
+    ):
+        """The same reading `_json_object_body` records for every prioritization
+        route: a malformed REQUEST reported as a server fault says nothing the page
+        can act on."""
+        aggregates = FakeAggregatesTable()
+
+        status, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            raw_body=raw_body,
+        )
+
+        assert status == 400
+        assert 'JSON' in body['error']
+        assert aggregates.put_item_calls == []
+
+
+class TestAnUnBallotedRowsCompositionCanStillChange:
+    """Before the first ballot a row is still being decided, so swapping documents in
+    and out is ordinary. These are the tests the freeze class below is only
+    meaningful next to: without them, "the freeze refuses everything" would pass."""
+
+    def test_a_row_with_no_ballots_can_be_recomposed(
+        self, api_gateway_event, lambda_context
+    ):
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2', 'prfaq-2']},
+        )
+
+        assert status == 200
+        assert body['row']['document_ids'] == ['prd-2', 'prfaq-2']
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'prd-2', 'prfaq-2',
+        ]
+
+    def test_the_recomposed_row_reads_back_as_un_frozen(
+        self, api_gateway_event, lambda_context
+    ):
+        """Changing a composition is not a ballot: the row stays open to the next
+        change until somebody votes or comments on it."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+
+        _, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert body['row']['is_frozen'] is False
+
+    def test_a_recompose_refuses_the_same_document_sets_a_compose_refuses(
+        self, api_gateway_event, lambda_context
+    ):
+        """One validator, so the two routes cannot disagree about what a row may
+        hold. A composition legal to create and illegal to change into, or the
+        reverse, would be two contracts for one field."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+
+        empty, _ = _recompose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': []},
+        )
+        foreign, _ = _recompose_row(
+            aggregates,
+            FakeProjectsTable([
+                project_meta('p1'),
+                project_document('p1', 'PRD#', 'prd-1', '2026-08-01T00:00:00+00:00'),
+                project_meta('p2'),
+                project_document('p2', 'PRD#', 'other', '2026-08-01T00:00:00+00:00'),
+            ]),
+            api_gateway_event, lambda_context, 'row-1',
+            body={'project_id': 'p1', 'document_ids': ['other']},
+        )
+        unscorable, _ = _recompose_row(
+            aggregates,
+            _project_with(*TWO_SCORABLE, ('PROTOTYPE#', 'proto-1')),
+            api_gateway_event, lambda_context, 'row-1',
+            body={'project_id': 'p1', 'document_ids': ['proto-1']},
+        )
+
+        assert (empty, foreign, unscorable) == (400, 404, 404)
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == ['row-1-prfaq']
+
+    def test_a_row_that_does_not_exist_is_refused_and_no_row_record_is_created(
+        self, api_gateway_event, lambda_context
+    ):
+        """`update_item` is an upsert, so without `attribute_exists(sk)` in the
+        condition this would CREATE a bare row for an id that never existed — a
+        phantom row on the page, composed by whoever guessed the id."""
+        aggregates = FakeAggregatesTable()
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            'row-ghost', body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 409
+        assert aggregates.row_keys == []
+
+    def test_a_row_belonging_to_another_project_is_refused(
+        self, api_gateway_event, lambda_context
+    ):
+        """The ids were validated against the project the CALLER named, so a row of
+        another project must not receive them — otherwise naming someone else's row
+        id installs this project's documents on it."""
+        aggregates = FakeAggregatesTable().seed_rows('row-other', project_id='p2')
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            'row-other', body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 409
+        assert aggregates.items[(PARTITION, 'ROW#row-other')]['document_ids'] == [
+            'row-other-prfaq',
+        ]
+
+    def test_an_over_long_row_id_is_refused_by_this_route(
+        self, api_gateway_event, lambda_context
+    ):
+        """A 400 naming the bound rather than a DynamoDB ValidationException
+        surfacing as a 500 — the same reasoning the save path's row-id check
+        records, on the id's other entry point."""
+        aggregates = FakeAggregatesTable()
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            'x' * 300, body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 400
+        assert 'at most 256 characters' in body['error']
+        assert aggregates.writes == []
+
+    @pytest.mark.parametrize('row_id', ['row#1', 'row-1#user:alice'])
+    def test_a_row_id_carrying_the_delimiter_reaches_no_route_and_writes_nothing(
+        self, api_gateway_event, lambda_context, row_id
+    ):
+        """A path segment reaches the same sort key a body key does: a '#' in it would
+        compose `ROW#a#b`, and a later ballot's key would then parse to a different
+        row than the one written.
+
+        Refused TWICE OVER, and the outer refusal is why the status is a 404 rather
+        than the 400 the validator would give: Powertools' dynamic-segment pattern
+        excludes '#', so such a path resolves to no route at all. The check inside the
+        route is kept anyway rather than relied upon being unreachable — it is one
+        resolver upgrade away from mattering, and the assertion that survives either
+        way is that nothing was written."""
+        aggregates = FakeAggregatesTable()
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            row_id, body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status != 200
+        assert aggregates.writes == []
+        assert aggregates.row_keys == []
+
+    def test_that_refusal_is_the_routes_own_and_not_only_the_resolvers(self):
+        """The validator behind the path segment, asked directly.
+
+        The route's own refusal cannot be observed end to end (the resolver answers
+        first), and a check nothing exercises is a check that quietly stops working.
+        Asked of the function so that deleting it fails a test rather than nothing."""
+        import projects_handler
+        from shared.exceptions import ValidationError
+
+        with pytest.raises(ValidationError, match="must not contain '#'"):
+            projects_handler._validated_path_row_id('row#1')
+        with pytest.raises(ValidationError, match='required'):
+            projects_handler._validated_path_row_id('   ')
+
+    def test_any_signed_in_reviewer_may_recompose_an_un_balloted_row(
+        self, api_gateway_event, lambda_context
+    ):
+        """#339: any signed-in reviewer may edit an un-balloted row's composition —
+        the freeze is the protection, not the identity of the author."""
+        from projects_handler import lambda_handler
+
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        event = api_gateway_event(
+            method='PATCH', path='/projects/prioritization/rows/row-1',
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+        event['requestContext']['authorizer']['claims'].pop('cognito:groups', None)
+        with (
+            patch('projects_handler.get_aggregates_table', return_value=aggregates),
+            patch('projects_handler.get_projects_table',
+                  return_value=_project_with(*TWO_SCORABLE)),
+        ):
+            response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+
+
+class TestTheFirstBallotFreezesTheComposition:
+    """The acceptance criterion, and the one the wording of #339 is emphatic about:
+    "when the first vote comes in, no changes are possible", enforced by the DATABASE
+    rather than by the UI.
+
+    EVERY TEST HERE BALLOTS FIRST. A freeze test that changed a composition on a row
+    with no ballots would prove nothing about freezing — it would pass against a
+    route with no condition at all.
+    """
+
+    @staticmethod
+    def _balloted(api_gateway_event, lambda_context, entry, subject='alice'):
+        """A row with `entry` saved on it as a real ballot, through the real route.
+
+        Through the route rather than by seeding the freeze mark directly, because
+        what is being pinned is that THE BALLOT WRITE sets it: seeding it by hand
+        would let a route that never stamps it pass every test below.
+        """
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        status, _ = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                  {'row-1': entry}, subject=subject, seed_rows=False)
+        assert status == 200, 'the ballot itself must land, or this proves nothing'
+        return aggregates
+
+    def test_a_scored_ballot_freezes_the_row(self, api_gateway_event, lambda_context):
+        """Reverting the condition on the composition change fails here: the
+        recompose answers 200 and the stored documents become `prd-2`."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, AXES)
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 409
+        assert 'frozen' in body['error']
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'row-1-prfaq',
+        ], 'the refusal must write nothing'
+
+    def test_a_note_only_ballot_freezes_the_row_exactly_as_a_scored_one_does(
+        self, api_gateway_event, lambda_context
+    ):
+        """A note is a durable decision record ABOUT the set of documents the row
+        held when it was written, so recomposing afterwards would leave that record
+        describing documents its author never saw.
+
+        This is where freezing follows `_writes_a_reviewer_value` rather than
+        `_is_a_vote`: the vote predicate calls a notes-only ballot silence, and
+        reusing it here — which #339 explicitly warns against — fails this test while
+        leaving the scored case above passing."""
+        aggregates = self._balloted(
+            api_gateway_event, lambda_context, {'notes': 'this pair is the wrong scope'},
+        )
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 409
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'row-1-prfaq',
+        ]
+
+    def test_a_ballot_clearing_a_note_freezes_the_row_too(
+        self, api_gateway_event, lambda_context
+    ):
+        """`{'notes': ''}` is a reviewer deliberately deciding the row needs no
+        justification — a change they wrote, which the counter already treats as a
+        ballot written. The same reading applies here."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, {'notes': ''})
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 409
+
+    @pytest.mark.parametrize('entry', [{}, {'impact': None}, {'notes': None},
+                                       {'typo_axis': 3}])
+    def test_a_save_that_stored_nothing_a_reviewer_entered_does_not_freeze(
+        self, api_gateway_event, lambda_context, entry
+    ):
+        """The other side of the same predicate. These entries stamp a ballot and
+        answer 200 while storing no value the reviewer expressed — the module already
+        declines to count them (`updated_count`) — so they are not a decision about
+        the row's documents and must not settle them.
+
+        Freezing on "a ballot record exists" instead would fail here, and the failure
+        matters: a page that PATCHes an empty entry on load would freeze every row
+        nobody had touched."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, entry)
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 200
+        assert body['row']['document_ids'] == ['prd-2']
+
+    def test_the_freeze_is_a_condition_on_the_write_not_a_count_read_first(
+        self, api_gateway_event, lambda_context
+    ):
+        """THE RACE, pinned on the write itself. A read that counted ballots and then
+        wrote would land the change in the gap between the two calls, leaving a row
+        whose documents nobody balloting on it ever saw — which is why #339 records
+        disabled dropdowns as a courtesy and the condition as the rule.
+
+        A read-then-write refactor leaves this assertion with nothing to find."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+
+        _recompose_row(aggregates, _project_with(*TWO_SCORABLE), api_gateway_event,
+                       lambda_context, 'row-1',
+                       body={'project_id': 'p1', 'document_ids': ['prd-1']})
+
+        composition_writes = [
+            call for call in aggregates.update_item_calls
+            if str(call['Key']['sk']).startswith('ROW#')
+        ]
+        assert composition_writes, 'the recompose must reach the row record'
+        for call in composition_writes:
+            condition = call['ConditionExpression']
+            assert 'attribute_not_exists(first_ballot_at)' in condition
+            assert 'attribute_exists(sk)' in condition
+
+    def test_a_composition_change_racing_the_first_ballot_loses_to_it(
+        self, api_gateway_event, lambda_context
+    ):
+        """The interleaving itself, as the DB sees it: the ballot lands between the
+        recompose reading the project and its conditional write, and the write is the
+        loser. Simulated by ballotting from inside the projects-table read the
+        recompose performs, which is the only point where the two can cross.
+
+        A read-then-write freeze passes with the change applied — that is the whole
+        defect — so this test is what distinguishes them."""
+        from projects_handler import lambda_handler
+
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        projects = _project_with(*FOUR_SCORABLE)
+        real_query = projects.query
+        raced = {'done': False}
+
+        def ballot_mid_flight(**kwargs):
+            if not raced['done']:
+                raced['done'] = True
+                _patch_scores(aggregates, api_gateway_event, lambda_context,
+                              {'row-1': AXES}, subject='alice', seed_rows=False)
+            return real_query(**kwargs)
+
+        projects.query = ballot_mid_flight
+        event = api_gateway_event(
+            method='PATCH', path='/projects/prioritization/rows/row-1',
+            body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+        with (
+            patch('projects_handler.get_aggregates_table', return_value=aggregates),
+            patch('projects_handler.get_projects_table', return_value=projects),
+        ):
+            response = lambda_handler(event, lambda_context)
+
+        assert raced['done'], 'the race never happened, so this asserts nothing'
+        assert response['statusCode'] == 409
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'row-1-prfaq',
+        ]
+
+    def test_the_freeze_mark_records_the_first_ballot_and_not_the_latest(
+        self, api_gateway_event, lambda_context
+    ):
+        """`if_not_exists`, so a second reviewer's ballot leaves it alone: it is the
+        freeze instant, not a last-modified stamp. A plain assignment would leave the
+        field describing whoever saved most recently."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, AXES)
+        first = aggregates.items[(PARTITION, 'ROW#row-1')]['first_ballot_at']
+
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row-1': {'impact': 1}}, subject='bob', seed_rows=False)
+
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['first_ballot_at'] == first
+
+    def test_the_read_reports_a_frozen_row_as_frozen(
+        self, api_gateway_event, lambda_context
+    ):
+        """The page needs the state to explain why its controls are inert, and it has
+        to be the SAME fact the condition enforces — a page computing the freeze
+        itself would eventually say the opposite of what the save does."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, AXES)
+        aggregates.seed_rows('row-untouched', project_id='p1')
+
+        _, body = _get_scores(aggregates, api_gateway_event, lambda_context, subject='alice')
+
+        assert body['rows']['row-1']['is_frozen'] is True
+        assert body['rows']['row-untouched']['is_frozen'] is False
+
+    def test_the_row_payload_keeps_every_field_the_page_already_reads(
+        self, api_gateway_event, lambda_context
+    ):
+        """Additive only: the frozen state is a new field, and no existing one changes
+        name or meaning, so the shipped page keeps working."""
+        aggregates = FakeAggregatesTable().seed_rows(
+            'row-1', project_id='proj-1', document_ids=['prd-1'],
+        )
+
+        _, body = _get_scores(aggregates, api_gateway_event, lambda_context, subject='alice')
+
+        assert set(body['rows']['row-1']) == {
+            'row_id', 'project_id', 'document_ids', 'prototype_id', 'is_default',
+            'created_at', 'is_frozen',
+        }
+
+    def test_a_frozen_row_still_takes_more_ballots(
+        self, api_gateway_event, lambda_context
+    ):
+        """The freeze settles the COMPOSITION, not the scoring. A second reviewer
+        arriving after the first must still be able to vote — freezing the ballots
+        too would make the first reviewer the only one."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, AXES)
+
+        status, body = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                     {'row-1': {'impact': 2}}, subject='bob',
+                                     seed_rows=False)
+
+        assert (status, body['updated_count']) == (200, 1)
+        assert aggregates.ballot('row-1', 'bob')['impact'] == 2
+
+    def test_regenerating_a_document_changes_no_existing_row(
+        self, api_gateway_event, lambda_context
+    ):
+        """A row holds CONCRETE ids, so a newer PR/FAQ leaves every existing row
+        composed exactly as it was — which is what keeps a ballot describing the
+        documents it was cast about.
+
+        This follows from how a composition is stored rather than from any new code;
+        the test exists so that a future change which starts re-deriving the set
+        fails here. Asserted through the read the page uses, on a row that has been
+        balloted, because that is the state where a silent re-derivation would do the
+        damage."""
+        aggregates = self._balloted(api_gateway_event, lambda_context, AXES)
+        composed_at_ballot_time = list(
+            aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids']
+        )
+
+        # The project generates a newer document of each scorable type, and the page
+        # is re-read and the default row re-requested — the two things a client does
+        # after a generation.
+        grown = _project_with(*FOUR_SCORABLE)
+        _create_row(aggregates, grown, api_gateway_event, lambda_context,
+                    body={'project_id': 'p1'})
+        _, body = _get_scores(aggregates, api_gateway_event, lambda_context, subject='alice')
+
+        assert body['rows']['row-1']['document_ids'] == composed_at_ballot_time
+        assert 'prd-2' not in body['rows']['row-1']['document_ids']
+
+
+class TestAFrozenRowIsDeletedTogetherWithItsBallots:
+    """The one destructive action, and the reason a frozen row is never edited: the
+    escape hatch is adding a row, and the way out is removing one whole.
+
+    EVERY TEST HERE THAT CLAIMS ANYTHING ABOUT BALLOTS BALLOTS FIRST. A delete test
+    on a row with no ballots proves nothing about ballots being removed with it — it
+    would pass against a route that deleted only the row record and left every ballot
+    in the partition, which is the exact fault the page's discard warning counts.
+    """
+
+    @staticmethod
+    def _row_with_ballots(api_gateway_event, lambda_context, *subjects, row_id='row-1'):
+        """A row with one real ballot per named reviewer, through the real route.
+
+        Plus a SIBLING row carrying its own ballot, in every case: the delete must
+        take this row's ballots and no others, and a fake partition holding only one
+        row's items could not tell "deleted its ballots" from "cleared the
+        partition".
+        """
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows(row_id, project_id='p1', is_default=False)
+        aggregates.seed_rows('row-sibling', project_id='p1', is_default=False)
+        for subject in subjects:
+            status, _ = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                      {row_id: AXES}, subject=subject, seed_rows=False)
+            assert status == 200, 'the ballots must land, or this proves nothing'
+        status, _ = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                  {'row-sibling': AXES}, subject='carol', seed_rows=False)
+        assert status == 200
+        return aggregates
+
+    def test_the_row_and_every_ballot_on_it_are_gone(
+        self, api_gateway_event, lambda_context
+    ):
+        """Reverting to "delete the row record only" fails here on the ballot keys:
+        the row disappears either way, and the ballots are what distinguishes the two.
+        """
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context,
+                                            'alice', 'bob')
+        assert sorted(aggregates.ballot_keys) == [
+            'BALLOT#row-1#user:alice', 'BALLOT#row-1#user:bob',
+            'BALLOT#row-sibling#user:carol',
+        ]
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert status == 200
+        assert aggregates.row_keys == ['ROW#row-sibling']
+        assert aggregates.ballot_keys == ['BALLOT#row-sibling#user:carol']
+
+    def test_the_response_reports_how_many_ballots_went_with_the_row(
+        self, api_gateway_event, lambda_context
+    ):
+        """That count is the ONLY evidence the caller has that the deletion was
+        complete: the row is gone, so nothing can be re-read to check, and a bare
+        `{'success': True}` would read identically whether the ballots went or were
+        orphaned."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context,
+                                            'alice', 'bob', 'dave')
+
+        _, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert body['ballots_deleted'] == 3
+        assert body['row_id'] == 'row-1'
+
+    def test_a_row_nobody_balloted_on_reports_no_ballots_deleted(
+        self, api_gateway_event, lambda_context
+    ):
+        """The count is a count, not a flag: a row deleted before anybody voted says
+        zero rather than omitting the field, so a caller reading it never has to tell
+        'none' from 'not reported'."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+
+        _, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert body['ballots_deleted'] == 0
+        assert aggregates.row_keys == []
+
+    def test_the_row_and_its_ballots_go_in_ONE_atomic_write(
+        self, api_gateway_event, lambda_context
+    ):
+        """No ballot may outlive the row it describes, not even for the moment
+        between two writes: a failure in that moment leaves exactly the orphaned
+        ballots the page's read counts and warns about, and the warning's rising count
+        is what would report this path not working.
+
+        Asserted on the SHAPE of the write, because the end state of a loop of deletes
+        is identical."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context,
+                                            'alice', 'bob')
+        aggregates.transact_calls.clear()
+
+        _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert len(aggregates.transact_calls) == 1
+        deleted = sorted(
+            request['Key']['sk']
+            for entry in aggregates.transact_calls[0]
+            for operation, request in entry.items() if operation == 'Delete'
+        )
+        assert deleted == [
+            'BALLOT#row-1#user:alice', 'BALLOT#row-1#user:bob', 'ROW#row-1',
+        ]
+
+    def test_an_anonymous_room_ballot_goes_with_the_row_too(
+        self, api_gateway_event, lambda_context
+    ):
+        """A room's ballots are keyed `BALLOT#{row_id}#anon:{ballot_id}` by
+        `ballots_handler`, in the same partition. The enumeration is by row prefix
+        rather than by reviewer kind, so nothing about which kind wrote a ballot
+        decides whether it goes — the row it describes does."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+        aggregates.items[(PARTITION, 'BALLOT#row-1#anon:deadbeef')] = {
+            'pk': PARTITION, 'sk': 'BALLOT#row-1#anon:deadbeef',
+            'row_id': 'row-1', 'reviewer': 'anon:deadbeef', **AXES,
+        }
+
+        _, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert body['ballots_deleted'] == 1
+        assert aggregates.ballot_keys == []
+
+    def test_a_row_whose_id_is_a_prefix_of_another_keeps_that_others_ballots(
+        self, api_gateway_event, lambda_context
+    ):
+        """The enumeration prefix ends with the '#' delimiter, so `row-1` cannot
+        sweep up `row-10`'s ballots. Without that character the delete would take
+        another row's votes and report them in its own count."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+        aggregates.seed_rows('row-10', project_id='p1', is_default=False)
+        for row_id in ('row-1', 'row-10'):
+            _patch_scores(aggregates, api_gateway_event, lambda_context,
+                          {row_id: AXES}, subject='alice', seed_rows=False)
+
+        _, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert body['ballots_deleted'] == 1
+        assert aggregates.ballot_keys == ['BALLOT#row-10#user:alice']
+        assert aggregates.row_keys == ['ROW#row-10']
+
+    def test_the_legacy_score_item_is_never_touched(
+        self, api_gateway_event, lambda_context
+    ):
+        """It lives in the same partition and is keyed by DOCUMENT, so a delete that
+        reached for "everything about this row" could take it. It is not a ballot on
+        any row and outlives every one of them."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context, 'alice')
+        aggregates.items[(PARTITION, LEGACY_SK)] = {
+            'pk': PARTITION, 'sk': LEGACY_SK, 'scores': {'prd-1': {'impact': 4}},
+        }
+
+        _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert aggregates.items[(PARTITION, LEGACY_SK)]['scores'] == {
+            'prd-1': {'impact': 4},
+        }
+
+    def test_a_frozen_row_is_deletable(self, api_gateway_event, lambda_context):
+        """The point of the pairing: a frozen row is never EDITED, and deletion is the
+        one thing it still admits. A delete that inherited the composition change's
+        no-ballots condition would leave a balloted row permanently unremovable."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context, 'alice')
+        assert aggregates.items[(PARTITION, 'ROW#row-1')].get('first_ballot_at')
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert status == 200
+        assert aggregates.row_keys == ['ROW#row-sibling']
+
+    def test_the_page_read_no_longer_discards_anything_after_a_delete(
+        self, api_gateway_event, lambda_context
+    ):
+        """The acceptance criterion #342 names: the discard warning's count must not
+        rise in the delete case, which is what distinguishes 'handled' from 'still
+        orphaning, just less often'. A delete leaving its ballots behind would make
+        every later page load log that warning."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context,
+                                            'alice', 'bob')
+        _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+        logger = MagicMock()
+
+        status, body = _get_scores(aggregates, api_gateway_event, lambda_context,
+                                   subject='alice', logger=logger)
+
+        assert status == 200
+        assert 'row-1' not in body['rows']
+        assert 'row-1' not in body['aggregates']
+        assert logger.warning.call_count == 0
+
+    def test_a_ballot_racing_the_delete_is_not_left_behind(
+        self, api_gateway_event, lambda_context
+    ):
+        """The gap the enumeration opens, closed by a fence. A reviewer saving between
+        the read that listed the ballots and the write that removes them would
+        otherwise have their ballot orphaned — the row gone, the ballot not.
+
+        Simulated by ballotting from inside the ballot enumeration, which is the only
+        point where the two can cross. The delete is refused, nothing is written, and
+        the reviewer's ballot survives with its row."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context, 'alice')
+        real_query = aggregates.query
+        raced = {'done': False}
+
+        def ballot_mid_flight(**kwargs):
+            result = real_query(**kwargs)
+            if not raced['done'] and 'ProjectionExpression' in kwargs:
+                raced['done'] = True
+                _patch_scores(aggregates, api_gateway_event, lambda_context,
+                              {'row-1': {'impact': 1}}, subject='bob', seed_rows=False)
+            return result
+
+        aggregates.query = ballot_mid_flight
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert raced['done'], 'the race never happened, so this asserts nothing'
+        assert status == 409
+        assert 'reload' in body['error']
+        assert aggregates.items.get((PARTITION, 'ROW#row-1')) is not None
+        assert aggregates.ballot('row-1', 'bob') is not None
+
+    def test_the_delete_is_fenced_on_the_write_rather_than_on_the_read(
+        self, api_gateway_event, lambda_context
+    ):
+        """The fence, pinned on the transaction itself: removing it leaves the
+        race above with nothing to lose to."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context, 'alice')
+        aggregates.transact_calls.clear()
+
+        _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        row_deletes = [
+            request for entry in aggregates.transact_calls[0]
+            for operation, request in entry.items()
+            if operation == 'Delete' and request['Key']['sk'] == 'ROW#row-1'
+        ]
+        assert len(row_deletes) == 1
+        condition = row_deletes[0]['ConditionExpression']
+        assert 'attribute_exists(sk)' in condition
+        assert 'ballot_writes' in condition
+
+
+class TestOnlyAnAdminDeletesARow:
+    """The one admin-gated action on a row, per the decision recorded on #339 —
+    everything else about a row is open to any signed-in reviewer."""
+
+    @staticmethod
+    def _balloted_row(api_gateway_event, lambda_context):
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row-1': AXES}, subject='alice', seed_rows=False)
+        return aggregates
+
+    @pytest.mark.parametrize('groups', ['users', '', None, 'admins-of-something-else'])
+    def test_a_non_admin_caller_is_refused_and_nothing_is_deleted(
+        self, api_gateway_event, lambda_context, groups
+    ):
+        """403, and the row and its ballot both survive — a refusal that deleted
+        something first would be the worst of both."""
+        aggregates = self._balloted_row(api_gateway_event, lambda_context)
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                   'row-1', subject='bob', groups=groups)
+
+        assert status == 403
+        assert body['success'] is False
+        assert aggregates.row_keys == ['ROW#row-1']
+        assert aggregates.ballot_keys == ['BALLOT#row-1#user:alice']
+
+    def test_the_refusal_costs_no_read_at_all(self, api_gateway_event, lambda_context):
+        """Checked before anything is read, so a 403 is one decision rather than a
+        round trip — and, more to the point, cannot be a 403 that read and wrote
+        first."""
+        aggregates = self._balloted_row(api_gateway_event, lambda_context)
+        aggregates.get_item_calls.clear()
+        aggregates.query_calls.clear()
+        aggregates.transact_calls.clear()
+
+        _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1',
+                    groups='users')
+
+        assert aggregates.get_item_calls == []
+        assert aggregates.query_calls == []
+        assert aggregates.transact_calls == []
+
+    def test_an_admin_caller_is_allowed(self, api_gateway_event, lambda_context):
+        aggregates = self._balloted_row(api_gateway_event, lambda_context)
+        aggregates.seed_rows('row-sibling', project_id='p1', is_default=False)
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1',
+                                groups='admins')
+
+        assert status == 200
+        assert aggregates.row_keys == ['ROW#row-sibling']
+
+    def test_the_gate_is_the_shared_helper_rather_than_a_local_group_check(
+        self, api_gateway_event, lambda_context
+    ):
+        """`shared.api.require_admin` is the one place this codebase decides who is an
+        admin — `users_handler` and `settings_handler` are the existing examples. A
+        local re-reading of `cognito:groups` is what this repo forbids, because a
+        comment saying 'keep these in step' cannot fail CI.
+
+        Asserted by DELEGATION: the helper is patched, so a route deciding for itself
+        records zero calls here whatever its verdict happens to be today."""
+        import projects_handler
+
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+        event = api_gateway_event(
+            method='DELETE', path='/projects/prioritization/rows/row-1',
+        )
+        with (
+            patch('projects_handler.require_admin') as require_admin,
+            patch('projects_handler.get_aggregates_table', return_value=aggregates),
+        ):
+            response = projects_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert require_admin.call_count == 1
+        assert require_admin.call_args.args[0] is event, (
+            'the helper must be handed the raw event, which is where the claims are'
+        )
+
+
+class TestTheDefaultRowSurvivesAsAProjectsLastRow:
+    """A project whose only row was deleted would show the page's "create a PRD or a
+    PR/FAQ" invitation beside documents it still holds — and the create route is
+    idempotent on a DERIVED key, so asking again cannot repair it."""
+
+    @staticmethod
+    def _project_rows(*, extra_rows=()):
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row_p1_default', project_id='p1', is_default=True)
+        for row_id in extra_rows:
+            aggregates.seed_rows(row_id, project_id='p1', is_default=False)
+        return aggregates
+
+    def test_a_projects_only_row_cannot_be_deleted_even_with_ballots_on_it(
+        self, api_gateway_event, lambda_context
+    ):
+        aggregates = self._project_rows()
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row_p1_default': AXES}, subject='alice', seed_rows=False)
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                   'row_p1_default')
+
+        assert status == 409
+        assert 'only row' in body['error']
+        assert aggregates.row_keys == ['ROW#row_p1_default']
+        assert aggregates.ballot_keys == ['BALLOT#row_p1_default#user:alice']
+
+    def test_the_default_row_becomes_deletable_once_the_project_has_another(
+        self, api_gateway_event, lambda_context
+    ):
+        """"Not while it is the only row" rather than "never": once another row holds
+        the project's place on the page, the default one carries no special duty."""
+        aggregates = self._project_rows(extra_rows=('row-composed',))
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row_p1_default': AXES}, subject='alice', seed_rows=False)
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                   'row_p1_default')
+
+        assert status == 200
+        assert body['ballots_deleted'] == 1
+        assert aggregates.row_keys == ['ROW#row-composed']
+
+    def test_another_projects_row_does_not_count_as_a_sibling(
+        self, api_gateway_event, lambda_context
+    ):
+        """Siblings are read off the stored `project_id`, not off the partition:
+        every row in the deployment shares one partition, so counting rows rather
+        than the project's rows would let another project's row authorise this
+        deletion."""
+        aggregates = self._project_rows()
+        aggregates.seed_rows('row_p2_default', project_id='p2', is_default=True)
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                'row_p1_default')
+
+        assert status == 409
+        assert sorted(aggregates.row_keys) == ['ROW#row_p1_default', 'ROW#row_p2_default']
+
+    def test_a_composed_row_is_deletable_even_as_a_projects_last_row(
+        self, api_gateway_event, lambda_context
+    ):
+        """A composed row is never the reason a project has a row at all — its default
+        row is — so removing the last composed one cannot leave the page inviting a
+        PRD for a project that has one. Asserted so the rule stays about the DEFAULT
+        row rather than becoming 'a project must always have a row'."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-composed', project_id='p1', is_default=False)
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                'row-composed')
+
+        assert status == 200
+        assert aggregates.row_keys == []
+
+    def test_the_last_sibling_disappearing_concurrently_cancels_the_delete(
+        self, api_gateway_event, lambda_context
+    ):
+        """Two admins each see two rows and each delete one, and the project ends with
+        none. The sibling's continued existence is asserted inside the same
+        transaction, so the second delete is cancelled instead."""
+        aggregates = self._project_rows(extra_rows=('row-composed',))
+        real_query = aggregates.query
+        raced = {'done': False}
+
+        def delete_sibling_mid_flight(**kwargs):
+            result = real_query(**kwargs)
+            if not raced['done'] and 'ProjectionExpression' in kwargs:
+                raced['done'] = True
+                aggregates.items.pop((PARTITION, 'ROW#row-composed'), None)
+            return result
+
+        aggregates.query = delete_sibling_mid_flight
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                'row_p1_default')
+
+        assert raced['done'], 'the race never happened, so this asserts nothing'
+        assert status == 409
+        assert aggregates.row_keys == ['ROW#row_p1_default']
+
+    def test_a_row_that_does_not_exist_is_a_404_and_nothing_is_written(
+        self, api_gateway_event, lambda_context
+    ):
+        aggregates = FakeAggregatesTable()
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                   'row-ghost')
+
+        assert status == 404
+        assert 'does not exist' in body['error']
+        assert 'row-ghost' not in body['error'], 'no echo of caller input'
+        assert aggregates.transact_calls == []
+
+
+class TestABallotAndItsRowsExistenceAreSettledTogether:
+    """#342's remaining criterion. The existence check used to be a keyed read
+    followed by a write, which is complete only while nothing can delete a row —
+    and deletion now exists, so the two race.
+
+    The up-front read is still there and still does its own job (a body naming one
+    vanished row among five persists nothing). What these tests are about is the
+    part it cannot do.
+    """
+
+    def test_a_row_deleted_between_the_check_and_the_write_gets_no_ballot(
+        self, api_gateway_event, lambda_context
+    ):
+        """The sequence #342 describes as ordinary: a reviewer has the page open, an
+        admin deletes the row, the reviewer saves. Simulated by deleting the row from
+        inside the existence read, which is the only point where the two can cross.
+
+        A read-then-write leaves the ballot stored and answers 200 `updated_count: 1`
+        — silent loss reported as success, which is the whole defect."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        real_get = aggregates.get_item
+        raced = {'done': False}
+
+        def delete_mid_flight(**kwargs):
+            result = real_get(**kwargs)
+            if not raced['done'] and str(kwargs['Key']['sk']).startswith('ROW#'):
+                raced['done'] = True
+                aggregates.items.pop((PARTITION, 'ROW#row-1'), None)
+            return result
+
+        aggregates.get_item = delete_mid_flight
+
+        status, body = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                     {'row-1': AXES}, subject='alice', seed_rows=False)
+
+        assert raced['done'], 'the race never happened, so this asserts nothing'
+        assert status == 404
+        assert 'does not exist' in body['error']
+        assert aggregates.ballot_keys == [], 'the reviewer must not be left an orphan'
+
+    def test_that_reviewer_is_told_the_row_is_gone_rather_than_told_it_saved(
+        self, api_gateway_event, lambda_context
+    ):
+        """The acceptance criterion in the reviewer's own terms — and the reason the
+        answer is a status rather than a silent drop: 404 is a state the client can
+        act on by refetching."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        real_get = aggregates.get_item
+
+        def delete_mid_flight(**kwargs):
+            result = real_get(**kwargs)
+            aggregates.items.pop((PARTITION, 'ROW#row-1'), None)
+            return result
+
+        aggregates.get_item = delete_mid_flight
+
+        status, body = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                     {'row-1': AXES}, subject='alice', seed_rows=False)
+
+        assert status == 404
+        assert 'updated_count' not in body
+        assert body['success'] is False
+
+    def test_the_existence_assertion_rides_on_the_write_itself(
+        self, api_gateway_event, lambda_context
+    ):
+        """Pinned on the transaction, because that is what makes the race above
+        winnable: dropping the condition leaves the ballot landing anyway, and only
+        this assertion and that test would notice."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        aggregates.transact_calls.clear()
+
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row-1': AXES}, subject='alice', seed_rows=False)
+
+        assert len(aggregates.transact_calls) == 1
+        row_writes = [
+            request for entry in aggregates.transact_calls[0]
+            for operation, request in entry.items()
+            if str(request['Key']['sk']).startswith('ROW#')
+        ]
+        assert len(row_writes) == 1
+        assert 'attribute_exists(sk)' in row_writes[0]['ConditionExpression']
+
+    def test_a_ballot_and_its_rows_freeze_mark_land_in_the_same_write(
+        self, api_gateway_event, lambda_context
+    ):
+        """Two writes would leave a window in which the ballot exists and its row is
+        still recomposable — the freeze arriving a moment late, which is exactly the
+        interleaving the condition on the composition change exists to lose to."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        aggregates.transact_calls.clear()
+
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row-1': AXES}, subject='alice', seed_rows=False)
+
+        keys = sorted(
+            request['Key']['sk'] for entry in aggregates.transact_calls[0]
+            for request in entry.values()
+        )
+        assert keys == ['BALLOT#row-1#user:alice', 'ROW#row-1']
+
+    def test_a_ballot_write_never_creates_the_row_it_names(
+        self, api_gateway_event, lambda_context
+    ):
+        """`update_item` is an upsert, so the row half of the transaction has to carry
+        `attribute_exists(sk)`: without it, scoring a deleted row would resurrect it
+        as a bare record — a deleted proposal reappearing as a side effect of somebody
+        scoring it, which #342 rules out by name."""
+        aggregates = FakeAggregatesTable()
+
+        status, _ = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                  {'row-ghost': AXES}, subject='alice', seed_rows=False)
+
+        assert status == 404
+        assert aggregates.row_keys == []
+        assert aggregates.ballot_keys == []
+
+    def test_a_multi_row_save_still_persists_nothing_when_one_row_is_gone(
+        self, api_gateway_event, lambda_context
+    ):
+        """The up-front read's own job, unchanged: it is what makes a body naming one
+        vanished row among several persist NOTHING, rather than persisting the rows
+        before the phantom and then failing."""
+        aggregates = FakeAggregatesTable().seed_rows('row-real', project_id='p1')
+
+        status, _ = _patch_scores(aggregates, api_gateway_event, lambda_context,
+                                  {'row-real': AXES, 'row-ghost': AXES},
+                                  subject='alice', seed_rows=False)
+
+        assert status == 404
+        assert aggregates.ballot_keys == []
+        assert aggregates.transact_calls == []

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -5261,6 +5261,163 @@ class TestTheFirstBallotFreezesTheComposition:
         assert 'prd-2' not in body['rows']['row-1']['document_ids']
 
 
+class TestARowBallotedBeforeTheMarkExistedIsStillFrozen:
+    """THE UPGRADE PATH. ROW_FROZEN_AT_FIELD was introduced by this change, so every
+    ballot already in a deployed table was written WITHOUT it — and those rows are
+    precisely the ones that already carry real votes. A freeze that asked only the
+    mark recomposed exactly them, with a 200, leaving each ballot describing
+    documents its author never saw.
+
+    EVERY TEST HERE SEEDS ITS BALLOT DIRECTLY, which is the one thing the class
+    above must never do: the route stamps the mark, so no route-seeded fixture can
+    reproduce a pre-mark row. The two classes are the two halves of one predicate —
+    "a ballot has landed", enforced by the condition where the mark exists and by
+    `_row_holds_a_value_bearing_ballot` where it cannot.
+    """
+
+    @staticmethod
+    def _legacy_balloted(entry, reviewer='user:alice'):
+        """A row holding a ballot the PREVIOUSLY DEPLOYED code wrote: real reviewer
+        values, no freeze mark on the row, no `ballot_writes` — the stored shape a
+        phase-1 save left behind."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        sk = f'BALLOT#row-1#{reviewer}'
+        aggregates.items[(PARTITION, sk)] = {
+            'pk': PARTITION, 'sk': sk, 'row_id': 'row-1', 'reviewer': reviewer,
+            'updated_at': '2026-08-01T10:00:00+00:00', **entry,
+        }
+        return aggregates
+
+    def test_a_recompose_of_a_pre_mark_balloted_row_is_refused(
+        self, api_gateway_event, lambda_context
+    ):
+        """The reviewer's reproduction, closed: before this guard the recompose
+        answered 200 and alice's surviving ballot described documents she never
+        saw."""
+        aggregates = self._legacy_balloted(AXES)
+        assert 'first_ballot_at' not in aggregates.items[(PARTITION, 'ROW#row-1')], (
+            'the fixture must hold no mark, or this tests the condition instead'
+        )
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 409
+        assert 'frozen' in body['error']
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'row-1-prfaq',
+        ], 'the refusal must write nothing'
+
+    def test_a_pre_mark_note_only_ballot_freezes_too(
+        self, api_gateway_event, lambda_context
+    ):
+        """The same reading the write side has: a note is a durable decision record
+        about the row's documents, whichever deployment stored it."""
+        aggregates = self._legacy_balloted({'notes': 'this pair is the wrong scope'})
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 409
+
+    def test_a_stamp_only_ballot_record_does_not_freeze_without_the_mark(
+        self, api_gateway_event, lambda_context
+    ):
+        """The guard must not be STRICTER than the write it stands in for. A
+        stamp-only save writes a ballot record and deliberately does not freeze
+        (`_writes_a_reviewer_value`), so its stored record must not freeze either —
+        refusing on "any ballot record exists" would fail this and re-open the
+        page-that-PATCHes-on-load hazard the write side already closed."""
+        aggregates = self._legacy_balloted({})
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 200
+        assert body['row']['document_ids'] == ['prd-2']
+
+    def test_the_page_reports_a_pre_mark_balloted_row_as_frozen(
+        self, api_gateway_event, lambda_context
+    ):
+        """The read half. `_is_frozen_row` answers off the ballots the page read
+        already holds, so the page offers no edit control on a row the recompose
+        would refuse — the two halves saying the same thing about the same row."""
+        aggregates = self._legacy_balloted(AXES)
+        aggregates.seed_rows('row-untouched', project_id='p1')
+
+        _, body = _get_scores(aggregates, api_gateway_event, lambda_context, subject='alice')
+
+        assert body['rows']['row-1']['is_frozen'] is True
+        assert body['rows']['row-untouched']['is_frozen'] is False
+
+    def test_a_first_ballot_landing_after_the_legacy_read_still_loses_the_race(
+        self, api_gateway_event, lambda_context
+    ):
+        """The guard READS, so it re-opens the exact window the condition exists to
+        close — a first ballot landing between the ballot query and the write. The
+        condition, kept on the write, is what settles it: this test lands alice's
+        ballot through the real route the moment the guard's query has answered
+        "no value-bearing ballot", and the recompose must still lose."""
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+        real_query = aggregates.query
+        raced = {'done': False}
+
+        def ballot_after_the_guard_read(**kwargs):
+            response = real_query(**kwargs)
+            _, prefix = _key_condition(kwargs['KeyConditionExpression'])
+            if not raced['done'] and prefix == 'BALLOT#row-1#':
+                raced['done'] = True
+                _patch_scores(aggregates, api_gateway_event, lambda_context,
+                              {'row-1': AXES}, subject='alice', seed_rows=False)
+            return response
+
+        aggregates.query = ballot_after_the_guard_read
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert raced['done'], 'the race never happened, so this asserts nothing'
+        assert status == 409
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'row-1-prfaq',
+        ]
+
+    def test_ballots_the_guard_cannot_enumerate_refuse_the_recompose(
+        self, api_gateway_event, lambda_context
+    ):
+        """Past the page budget the guard RAISES, like every bounded read in the
+        module: "could not read the ballots" must not be read as "there are none"
+        by a route about to recompose the row. A 500 rather than a silent
+        proceed-on-partial-knowledge."""
+        aggregates = FakeAggregatesTable(page_size=1).seed_rows('row-1', project_id='p1')
+        from projects_handler import MAX_PRIORITIZATION_PAGES
+        for count in range(MAX_PRIORITIZATION_PAGES + 1):
+            sk = f'BALLOT#row-1#user:reviewer-{count:03d}'
+            aggregates.items[(PARTITION, sk)] = {
+                'pk': PARTITION, 'sk': sk, 'row_id': 'row-1',
+                'reviewer': f'user:reviewer-{count:03d}',
+                'updated_at': '2026-08-01T10:00:00+00:00',
+            }
+
+        status, _ = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert status == 500
+        assert aggregates.items[(PARTITION, 'ROW#row-1')]['document_ids'] == [
+            'row-1-prfaq',
+        ], 'and nothing was recomposed on partial knowledge'
+
+
 class TestAFrozenRowIsDeletedTogetherWithItsBallots:
     """The one destructive action, and the reason a frozen row is never edited: the
     escape hatch is adding a row, and the way out is removing one whole.
@@ -6087,18 +6244,31 @@ class TestOnlyAFailedConditionMeansTheRowIsGone:
         `python -O`/`PYTHONOPTIMIZE`, which would let exactly the malformed key it
         names through to DynamoDB, and an `AssertionError` in a request path is an
         unhandled 500 that bypasses this module's logging. Pinned as a `ServiceError`
-        so the mechanism cannot quietly regress to one."""
+        so the mechanism cannot quietly regress to one.
+
+        The offending key is named in the LOG, not the raise: a ServiceError's
+        message reaches the client verbatim, and an internal function's kwargs are
+        for whoever reads the log, not for a reviewer saving scores."""
         import projects_handler
         from shared.exceptions import ServiceError
 
         table = FakeAggregatesTable()
         kwargs = projects_handler._ballot_update_kwargs('row-1', 'alice', AXES, 'now')
         kwargs['ReturnValues'] = 'ALL_NEW'
+        log = MagicMock()
 
-        with pytest.raises(ServiceError) as refused:
+        with (
+            patch('projects_handler.logger', log),
+            pytest.raises(ServiceError) as refused,
+        ):
             projects_handler._ballot_transact_items(table, kwargs, 'row-1', 'now')
 
-        assert 'ReturnValues' in str(refused.value), 'it names the key that failed'
+        assert 'ReturnValues' not in str(refused.value), (
+            'internal kwargs must not reach the client'
+        )
+        assert any(
+            'ReturnValues' in str(call) for call in log.error.call_args_list
+        ), 'the log names the key that failed'
 
     def test_no_check_in_the_production_lambda_tree_is_a_bare_assert(self):
         """WHY the check above is a raise, pinned where it can actually regress.
@@ -6111,12 +6281,31 @@ class TestOnlyAFailedConditionMeansTheRowIsGone:
 
         Read as SOURCE TEXT over the whole production tree rather than by re-executing
         one module under `optimize=2`, because the property is a convention about all
-        of it, and the failure names the file and line to fix."""
-        tree = Path(__file__).resolve().parents[1]
+        of it, and the failure names the file and line to fix.
+
+        "The whole production tree" MEANS ALL OF IT: `lambda/` — including `shared/`,
+        which is bundled into every API Lambda and is where the exception handlers
+        this finding was originally about live — and `plugins/`. A scan of
+        `lambda/api` alone would not fail on a bare `assert` reintroduced one
+        directory up, which is the same "guard narrower than the property it states"
+        shape this test exists to close. `layers/` is excluded as vendored
+        third-party (ruff's `extend-exclude` draws the same line), and test files by
+        both path component and name — `test` as a component alone would keep a
+        `test_helpers.py` in scope and drop a production package that happened to be
+        called `contest`."""
+        lambda_tree = Path(__file__).resolve().parents[2]
+        production_trees = (lambda_tree, lambda_tree.parent / 'plugins')
+
+        def _is_production(path):
+            if any(part in ('test', 'tests', 'layers') for part in path.parts):
+                return False
+            return not (path.name.startswith('test_') or path.name == 'conftest.py')
+
         offenders = [
-            f'{path.relative_to(tree.parent)}:{number}'
+            f'{path.relative_to(lambda_tree.parent)}:{number}'
+            for tree in production_trees
             for path in sorted(tree.rglob('*.py'))
-            if 'test' not in path.parts
+            if _is_production(path.relative_to(tree))
             for number, line in enumerate(
                 path.read_text(encoding='utf-8').splitlines(), start=1
             )

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -284,24 +284,33 @@ class FakeAggregatesTable:
         failure cancels the whole transaction with nothing written. A fake that
         applied items as it walked them would let a test about atomicity pass
         against code that wrote the ballot and then failed to freeze its row.
+
+        `CancellationReasons` is ONE ENTRY PER ITEM, POSITIONALLY, with `'None'` for
+        the items that did not fail — DynamoDB's own shape, verified against moto.
+        A single-element list would let a route that reads the reason at a specific
+        item's index (the ballot save does, so a lost write-conflict is not reported
+        as a vanished row) pass here while reading the wrong position in production.
         """
         self.transact_calls.append(TransactItems)
+        reasons = []
         for entry in TransactItems:
             (operation, request), = entry.items()
             assert request['TableName'] == self.name, request['TableName']
+            assert operation in ('Update', 'Delete', 'ConditionCheck'), operation
             key = (request['Key']['pk'], request['Key']['sk'])
-            if not _condition_holds(
+            reasons.append({'Code': 'None'} if _condition_holds(
                 request.get('ConditionExpression'), self.items.get(key),
                 request.get('ExpressionAttributeNames', {}),
                 request.get('ExpressionAttributeValues', {}),
-            ):
-                raise ClientError(
-                    {'Error': {'Code': 'TransactionCanceledException',
-                               'Message': 'Transaction cancelled'},
-                     'CancellationReasons': [{'Code': 'ConditionalCheckFailed'}]},
-                    'TransactWriteItems',
-                )
-            assert operation in ('Update', 'Delete', 'ConditionCheck'), operation
+            ) else {'Code': 'ConditionalCheckFailed',
+                    'Message': 'The conditional request failed'})
+        if any(reason['Code'] != 'None' for reason in reasons):
+            raise ClientError(
+                {'Error': {'Code': 'TransactionCanceledException',
+                           'Message': 'Transaction cancelled'},
+                 'CancellationReasons': reasons},
+                'TransactWriteItems',
+            )
         for entry in TransactItems:
             (operation, request), = entry.items()
             key = (request['Key']['pk'], request['Key']['sk'])
@@ -5634,6 +5643,177 @@ class TestABallotAndItsRowsExistenceAreSettledTogether:
         assert status == 404
         assert aggregates.ballot_keys == []
         assert aggregates.transact_calls == []
+
+
+def _cancelled_transaction(reasons):
+    """A `TransactionCanceledException` carrying the given per-item reasons.
+
+    Positional and one entry per item, with `'None'` for the items that did not
+    fail, which is DynamoDB's own shape — verified against moto, whose reasons for a
+    two-item transaction failing on the second read
+    `[{'Code': 'None'}, {'Code': 'ConditionalCheckFailed', ...}]`.
+    """
+    return ClientError(
+        {'Error': {'Code': 'TransactionCanceledException',
+                   'Message': 'Transaction cancelled'},
+         'CancellationReasons': list(reasons)},
+        'TransactWriteItems',
+    )
+
+
+class TestOnlyAFailedConditionMeansTheRowIsGone:
+    """A cancelled transaction is not only a failed condition.
+
+    DynamoDB cancels with the same exception for `TransactionConflict`,
+    `ThrottlingError` and `ProvisionedThroughputExceeded`, and botocore does not
+    auto-retry it. `TransactionConflict` is reachable on the ordinary path: every
+    ballot on a row `ADD`s to the SAME row record, so two reviewers scoring one row
+    at the same moment contend on one item.
+
+    The direction of the mistake is what matters. The page treats a 4xx as a
+    refusal that retrying cannot fix, so answering 404 to a lost write-conflict
+    costs the reviewer their ballot AND tells them to reload a row that is still
+    there. A 500 is released for a retry, so the save survives.
+    """
+
+    @staticmethod
+    def _save_cancelled_with(reasons, api_gateway_event, lambda_context):
+        aggregates = FakeAggregatesTable().seed_rows('row-1', project_id='p1')
+
+        def cancel(**kwargs):
+            raise _cancelled_transaction(reasons)
+
+        aggregates.meta.client.transact_write_items = cancel
+        return _patch_scores(aggregates, api_gateway_event, lambda_context,
+                             {'row-1': AXES}, subject='alice', seed_rows=False)
+
+    def test_a_write_conflict_is_a_retryable_500_not_a_404(
+        self, api_gateway_event, lambda_context
+    ):
+        """Two reviewers saving on one row at the same instant. A 404 here would tell
+        one of them the row does not exist, which is false and unretryable."""
+        status, body = self._save_cancelled_with(
+            [{'Code': 'None'}, {'Code': 'TransactionConflict'}],
+            api_gateway_event, lambda_context,
+        )
+
+        assert status == 500
+        assert 'does not exist' not in body['error']
+
+    def test_throttling_is_a_retryable_500_too(self, api_gateway_event, lambda_context):
+        """The same reading for the other transient codes: nothing about the row
+        changed, so nothing a reload would show the reviewer is different."""
+        for code in ('ThrottlingError', 'ProvisionedThroughputExceeded',
+                     'ItemCollectionSizeLimitExceeded', 'ValidationError'):
+            status, _ = self._save_cancelled_with(
+                [{'Code': 'None'}, {'Code': code}], api_gateway_event, lambda_context,
+            )
+            assert status == 500, code
+
+    def test_a_failed_condition_on_the_row_is_still_a_404(
+        self, api_gateway_event, lambda_context
+    ):
+        """The case the discrimination must not break: the row's own condition is its
+        existence, so a condition failure there really is a vanished row."""
+        status, body = self._save_cancelled_with(
+            [{'Code': 'None'}, {'Code': 'ConditionalCheckFailed'}],
+            api_gateway_event, lambda_context,
+        )
+
+        assert status == 404
+        assert 'does not exist' in body['error']
+
+    def test_a_condition_failure_on_the_BALLOTs_half_is_not_read_as_a_missing_row(
+        self, api_gateway_event, lambda_context
+    ):
+        """The reason is read at the ROW's index, not "any reason in the list". The
+        ballot's own write carries no condition today, so a failure reported against
+        it is not a fact about the row and must not be answered as one."""
+        status, body = self._save_cancelled_with(
+            [{'Code': 'ConditionalCheckFailed'}, {'Code': 'None'}],
+            api_gateway_event, lambda_context,
+        )
+
+        assert status == 500
+        assert 'does not exist' not in body['error']
+
+    def test_an_unreadable_cancellation_is_treated_as_transient(
+        self, api_gateway_event, lambda_context
+    ):
+        """A missing or short `CancellationReasons` cannot establish that the row
+        went away, and the safe direction is the retryable one: a 500 costs a retry,
+        a wrong 404 costs a ballot."""
+        for reasons in ([], [{'Code': 'None'}], [{}, {}], 'not-a-list'):
+            status, _ = self._save_cancelled_with(
+                reasons, api_gateway_event, lambda_context,
+            )
+            assert status == 500, reasons
+
+    def test_the_row_index_the_reason_is_read_at_is_where_the_condition_actually_is(
+        self, api_gateway_event, lambda_context
+    ):
+        """The index is only meaningful while the transaction is built in that order.
+        Pinned against the real builder rather than restated, so reordering the two
+        items fails here instead of silently reading the wrong reason."""
+        import projects_handler
+
+        index_read = projects_handler.BALLOT_TRANSACT_ROW_INDEX
+        table = FakeAggregatesTable()
+        items = projects_handler._ballot_transact_items(
+            table,
+            projects_handler._ballot_update_kwargs('row-1', 'alice', AXES, 'now'),
+            'row-1', 'now',
+        )
+
+        assert len(items) == 2
+        row_write = items[index_read]['Update']
+        assert row_write['Key']['sk'] == 'ROW#row-1'
+        assert row_write['ConditionExpression'] == 'attribute_exists(sk)'
+        others = [
+            item for index, item in enumerate(items) if index != index_read
+        ]
+        assert all(
+            'ConditionExpression' not in request
+            for item in others for request in item.values()
+        ), 'a second condition would make one index too little to tell them apart'
+
+    def test_a_delete_cancelled_by_contention_is_a_500_not_a_409(
+        self, api_gateway_event, lambda_context
+    ):
+        """The delete's 409 says "this row changed while it was being deleted", which
+        is a claim about the world. Contention did not change the row, and the page
+        does not retry a 4xx, so the admin's delete would simply not happen."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+
+        def cancel(**kwargs):
+            raise _cancelled_transaction([{'Code': 'TransactionConflict'}])
+
+        aggregates.meta.client.transact_write_items = cancel
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert status == 500
+        assert 'changed while it was being deleted' not in body['error']
+        assert aggregates.row_keys == ['ROW#row-1'], 'nothing was written'
+
+    def test_a_delete_cancelled_by_its_fence_is_still_a_409(
+        self, api_gateway_event, lambda_context
+    ):
+        """The actionable case, unchanged: a ballot landed in the gap, the fence
+        caught it, and reloading really does show the admin something different."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+
+        def cancel(**kwargs):
+            raise _cancelled_transaction([{'Code': 'ConditionalCheckFailed'}])
+
+        aggregates.meta.client.transact_write_items = cancel
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert status == 409
+        assert 'changed while it was being deleted' in body['error']
 
 
 class TestARowWithMoreBallotsThanOneWriteCanRemoveIsRefused:

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -5324,6 +5324,33 @@ class TestARowBallotedBeforeTheMarkExistedIsStillFrozen:
 
         assert status == 409
 
+    def test_a_row_holding_only_a_legacy_scores_value_is_not_frozen(
+        self, api_gateway_event, lambda_context
+    ):
+        """ONE EPOCH FURTHER BACK, and the answer flips — deliberately. A ballot
+        claims "I scored this SET", which a recompose falsifies; a pre-ballot
+        `SCORES` value claims "somebody once scored this DOCUMENT", and the
+        read-through honours that claim through any recomposition (the value
+        surfaces only on a row still holding its document). Freezing on it would
+        permanently freeze every pre-ballot deployment's default rows — refusing
+        this route's primary use for exactly the deployments upgrading."""
+        aggregates = FakeAggregatesTable([{
+            'pk': PARTITION, 'sk': LEGACY_SK, 'scores': {'row-1-doc': {'impact': 4}},
+        }]).seed_rows('row-1', project_id='p1', document_ids=['row-1-doc'])
+
+        _, page = _get_scores(aggregates, api_gateway_event, lambda_context)
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row-1', body={'project_id': 'p1', 'document_ids': ['prd-2']},
+        )
+
+        assert page['scores']['row-1']['impact'] == 4.0, (
+            'the fixture must read through, or this proves nothing about legacy values'
+        )
+        assert page['rows']['row-1']['is_frozen'] is False
+        assert status == 200
+        assert body['row']['document_ids'] == ['prd-2']
+
     def test_a_stamp_only_ballot_record_does_not_freeze_without_the_mark(
         self, api_gateway_event, lambda_context
     ):

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -22,6 +22,7 @@ not a general DynamoDB — it implements exactly the expressions this route
 writes, so that a change to those expressions has to be reflected here.
 """
 import json
+from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
@@ -58,14 +59,115 @@ def row_item(row_id, *, project_id=None, document_ids=None, is_default=True, **o
     }
 
 
+def _split_top_level(text, separator=','):
+    """Split on `separator` outside parentheses.
+
+    `if_not_exists(#frozen_at, :now)` carries a comma of its own, so a naive split
+    of a `SET` clause tears that call in half — and a fake that mis-parsed it would
+    report an update the route never made.
+    """
+    parts, depth, current = [], 0, ''
+    for char in text:
+        if char == '(':
+            depth += 1
+        elif char == ')':
+            depth -= 1
+        if char == separator and depth == 0:
+            parts.append(current)
+            current = ''
+            continue
+        current += char
+    parts.append(current)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _resolved_path(path, names):
+    """One attribute path, with `#alias` segments resolved. `sk` stays `sk`."""
+    return [names.get(segment, segment) for segment in path.strip().split('.')]
+
+
+def _attribute_present(item, path, names):
+    cursor = item
+    for segment in _resolved_path(path, names):
+        if not isinstance(cursor, dict) or segment not in cursor:
+            return False
+        cursor = cursor[segment]
+    return True
+
+
+def _condition_holds(condition, item, names, values):
+    """Evaluate the condition expressions THIS MODULE writes, and no others.
+
+    `attribute_exists`, `attribute_not_exists` and `path = :value`, joined by AND.
+    Deliberately narrow: the conditions here are the freeze, the create's
+    idempotence and the delete's fence, so a fake that waved one through would let
+    a test pass against code that had lost it. Anything unrecognised raises rather
+    than being assumed true, which is what keeps that true as the module grows.
+    """
+    for conjunct in (part.strip() for part in (condition or '').split(' AND ')):
+        if not conjunct:
+            continue
+        if conjunct.startswith('attribute_exists(') and conjunct.endswith(')'):
+            if not _attribute_present(item or {}, conjunct[17:-1], names):
+                return False
+        elif conjunct.startswith('attribute_not_exists(') and conjunct.endswith(')'):
+            if _attribute_present(item or {}, conjunct[21:-1], names):
+                return False
+        elif '=' in conjunct:
+            path, _, value_alias = (part.strip() for part in conjunct.partition('='))
+            segments = _resolved_path(path, names)
+            cursor = item or {}
+            for segment in segments:
+                cursor = cursor.get(segment) if isinstance(cursor, dict) else None
+            if cursor != values[value_alias]:
+                return False
+        else:
+            raise AssertionError(f'unsupported condition: {conjunct!r}')
+    return True
+
+
+def _key_condition(expression):
+    """`(pk, sk_prefix)` out of a boto3 key-condition tree.
+
+    Read back rather than accepted wholesale, so a read of the WRONG partition — or
+    a ballot enumeration whose prefix stopped naming one row — fails here instead of
+    passing against a permissive fake.
+    """
+    pk, prefix = None, None
+
+    def walk(node):
+        nonlocal pk, prefix
+        parsed = node.get_expression()
+        operator = parsed['operator']
+        if operator == 'AND':
+            for value in parsed['values']:
+                walk(value)
+        elif operator == '=':
+            pk = parsed['values'][1]
+        elif operator == 'begins_with':
+            prefix = parsed['values'][1]
+        else:
+            raise AssertionError(f'unsupported key condition: {operator}')
+
+    walk(expression)
+    return pk, prefix
+
+
 class FakeAggregatesTable:
     """An in-memory stand-in for the aggregates table.
 
     Supports the single-key `SET` update a ballot save issues, the conditional
-    `REMOVE #scores.#document` the legacy migration issues, and a paginated query
-    of one partition. Every call is recorded so a test can assert HOW the write
-    was made, not just what it left behind — "one update_item on its own key"
-    is the invariant, and a put_item of a merged map would leave the same state.
+    `REMOVE #scores.#document` the legacy migration issues, the conditional
+    `transact_write_items` the ballot save and the row delete issue, and a
+    paginated query of one partition. Every call is recorded so a test can assert
+    HOW the write was made, not just what it left behind — "the ballot and its
+    row's freeze mark in ONE transaction" is the invariant, and two separate
+    writes would leave the same state.
+
+    CONDITIONS ARE ENFORCED, never ignored. They are the whole contract of this
+    change: the freeze, the create's idempotence and the delete's fence are all
+    conditions, and a fake that accepted every write would let every one of those
+    tests pass against code that had lost them.
     """
 
     def __init__(self, items=None, page_size=None):
@@ -75,6 +177,14 @@ class FakeAggregatesTable:
         self.put_item_calls = []
         self.get_item_calls = []
         self.query_calls = []
+        self.transact_calls = []
+        # `table.name` and `table.meta.client` are what a transaction needs: it is
+        # issued on the resource's underlying CLIENT, which takes the table name per
+        # item rather than being bound to one table.
+        self.name = 'test-aggregates'
+        self.meta = SimpleNamespace(client=SimpleNamespace(
+            transact_write_items=self._transact_write_items,
+        ))
 
     # -- writes ------------------------------------------------------------
     def put_item(self, **kwargs):
@@ -98,9 +208,8 @@ class FakeAggregatesTable:
         self.items[key] = dict(item)
         return {}
 
-    def update_item(self, **kwargs):
-        self.update_item_calls.append(kwargs)
-        key = (kwargs['Key']['pk'], kwargs['Key']['sk'])
+    def _apply_update(self, key, kwargs):
+        """The `SET` / `ADD` / `REMOVE` clauses this module writes."""
         expression = kwargs['UpdateExpression'].strip()
         names = kwargs.get('ExpressionAttributeNames', {})
         values = kwargs.get('ExpressionAttributeValues', {})
@@ -111,22 +220,95 @@ class FakeAggregatesTable:
             attr = names[attr_alias]
             member = names[member_alias]
             item = self.items.get(key)
-            present = isinstance(item, dict) and member in (item.get(attr) or {})
-            if kwargs.get('ConditionExpression') and not present:
-                raise ClientError(
-                    {'Error': {'Code': 'ConditionalCheckFailedException',
-                               'Message': 'The conditional request failed'}},
-                    'UpdateItem',
-                )
-            if present:
+            if isinstance(item, dict) and member in (item.get(attr) or {}):
                 del item[attr][member]
-            return {}
+            return None
 
-        assert expression.upper().startswith('SET'), expression
         item = self.items.setdefault(key, {'pk': key[0], 'sk': key[1]})
-        for assignment in expression[len('SET'):].split(','):
-            name_alias, _, value_alias = (part.strip() for part in assignment.partition('='))
-            item[names[name_alias]] = values[value_alias]
+        # One expression may carry both clauses: the row half of a ballot
+        # transaction is `SET #frozen_at = if_not_exists(...) ADD #ballot_writes :one`.
+        set_clause, add_clause = expression, ''
+        if ' ADD ' in expression:
+            set_clause, _, add_clause = expression.partition(' ADD ')
+        elif expression.upper().startswith('ADD'):
+            set_clause, add_clause = '', expression[len('ADD'):]
+        if set_clause:
+            assert set_clause.strip().upper().startswith('SET'), expression
+            for assignment in _split_top_level(set_clause.strip()[len('SET'):]):
+                name_alias, _, value_expression = (
+                    part.strip() for part in assignment.partition('=')
+                )
+                attribute = names[name_alias]
+                if value_expression.startswith('if_not_exists('):
+                    existing_alias, fallback_alias = _split_top_level(
+                        value_expression[len('if_not_exists('):-1]
+                    )
+                    existing = names[existing_alias]
+                    if existing in item:
+                        continue
+                    item[attribute] = values[fallback_alias]
+                    continue
+                item[attribute] = values[value_expression]
+        if add_clause:
+            name_alias, value_alias = add_clause.split()
+            attribute = names[name_alias]
+            item[attribute] = (item.get(attribute) or 0) + values[value_alias]
+        return dict(item)
+
+    def update_item(self, **kwargs):
+        self.update_item_calls.append(kwargs)
+        key = (kwargs['Key']['pk'], kwargs['Key']['sk'])
+        condition = kwargs.get('ConditionExpression')
+        if condition and not _condition_holds(
+            condition, self.items.get(key),
+            kwargs.get('ExpressionAttributeNames', {}),
+            kwargs.get('ExpressionAttributeValues', {}),
+        ):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException',
+                           'Message': 'The conditional request failed'}},
+                'UpdateItem',
+            )
+        stored = self._apply_update(key, kwargs)
+        if kwargs.get('ReturnValues') == 'ALL_NEW' and stored is not None:
+            return {'Attributes': stored}
+        return {}
+
+    def _transact_write_items(self, TransactItems):
+        """All-or-nothing, which is the property every caller of this depends on.
+
+        The capitalised parameter is boto3's own spelling of it, kept so the fake
+        accepts exactly the call the route makes.
+
+        Every condition is evaluated BEFORE any item is applied, and a single
+        failure cancels the whole transaction with nothing written. A fake that
+        applied items as it walked them would let a test about atomicity pass
+        against code that wrote the ballot and then failed to freeze its row.
+        """
+        self.transact_calls.append(TransactItems)
+        for entry in TransactItems:
+            (operation, request), = entry.items()
+            assert request['TableName'] == self.name, request['TableName']
+            key = (request['Key']['pk'], request['Key']['sk'])
+            if not _condition_holds(
+                request.get('ConditionExpression'), self.items.get(key),
+                request.get('ExpressionAttributeNames', {}),
+                request.get('ExpressionAttributeValues', {}),
+            ):
+                raise ClientError(
+                    {'Error': {'Code': 'TransactionCanceledException',
+                               'Message': 'Transaction cancelled'},
+                     'CancellationReasons': [{'Code': 'ConditionalCheckFailed'}]},
+                    'TransactWriteItems',
+                )
+            assert operation in ('Update', 'Delete', 'ConditionCheck'), operation
+        for entry in TransactItems:
+            (operation, request), = entry.items()
+            key = (request['Key']['pk'], request['Key']['sk'])
+            if operation == 'Update':
+                self._apply_update(key, request)
+            elif operation == 'Delete':
+                self.items.pop(key, None)
         return {}
 
     # -- reads -------------------------------------------------------------
@@ -141,14 +323,18 @@ class FakeAggregatesTable:
 
     def query(self, **kwargs):
         self.query_calls.append(kwargs)
-        rows = [dict(i) for (pk, _), i in sorted(self.items.items()) if pk == PARTITION]
+        wanted, prefix = _key_condition(kwargs['KeyConditionExpression'])
+        rows = [
+            dict(i) for (pk, sk), i in sorted(self.items.items())
+            if pk == wanted and (prefix is None or sk.startswith(prefix))
+        ]
         start = kwargs.get('ExclusiveStartKey')
         if start:
             skips = [r['sk'] for r in rows]
             rows = rows[skips.index(start['sk']) + 1:]
         if self.page_size and len(rows) > self.page_size:
             page = rows[:self.page_size]
-            return {'Items': page, 'LastEvaluatedKey': {'pk': PARTITION, 'sk': page[-1]['sk']}}
+            return {'Items': page, 'LastEvaluatedKey': {'pk': wanted, 'sk': page[-1]['sk']}}
         return {'Items': rows}
 
     # -- helpers -----------------------------------------------------------
@@ -158,6 +344,48 @@ class FakeAggregatesTable:
     @property
     def ballot_keys(self):
         return sorted(sk for (_, sk) in self.items if sk.startswith('BALLOT#'))
+
+    @property
+    def row_keys(self):
+        return sorted(sk for (_, sk) in self.items if sk.startswith('ROW#'))
+
+    @property
+    def writes(self):
+        """Every mutating call this table took, whatever shape it arrived in.
+
+        The unit "was anything written at all?" is asked in, and it has to span all
+        three paths: a ballot arrives as a transaction, the legacy migration as an
+        `update_item`, a row create as a `put_item`. Counting only one of them would
+        make "the refusal wrote nothing" vacuously true for the others — which is
+        exactly what happened to every such assertion the moment the ballot write
+        became a transaction.
+        """
+        return (
+            self.put_item_calls
+            + self.update_item_calls
+            + [request for items in self.transact_calls for entry in items
+               for operation, request in entry.items() if operation != 'ConditionCheck']
+        )
+
+    @property
+    def ballot_writes(self):
+        """The update kwargs of every write aimed at a BALLOT key.
+
+        Spans the transaction and a bare `update_item` on purpose: a change that
+        stopped using a transaction would still be found here, so the tests about
+        what a ballot STORES keep testing that, and the tests about atomicity are the
+        ones that fail.
+        """
+        direct = [
+            call for call in self.update_item_calls
+            if str(call['Key']['sk']).startswith('BALLOT#')
+        ]
+        transacted = [
+            request for items in self.transact_calls for entry in items
+            for operation, request in entry.items()
+            if operation == 'Update' and str(request['Key']['sk']).startswith('BALLOT#')
+        ]
+        return direct + transacted
 
     def seed_rows(self, *row_ids, **kwargs):
         """Put a row record in place for each id, WITHOUT going through put_item.
@@ -333,15 +561,15 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
 
         assert status == 200
         assert body == {'success': True, 'updated_count': 1}
-        ballot_writes = [
-            call for call in table.update_item_calls
-            if call['Key']['sk'].startswith('BALLOT#')
-        ]
-        assert len(ballot_writes) == 1
-        assert ballot_writes[0]['Key'] == {
+        # One update AIMED AT THE BALLOT KEY, wherever it was issued from. The write
+        # is now inside a transaction beside its row's freeze mark (#339 phase 2);
+        # what this class is about is that a reviewer's numbers land on their own key
+        # by an update rather than by a merged whole-map put, and that is unchanged.
+        assert len(table.ballot_writes) == 1
+        assert table.ballot_writes[0]['Key'] == {
             'pk': PARTITION, 'sk': 'BALLOT#row-1#user:alice',
         }
-        assert ballot_writes[0]['UpdateExpression'].strip().upper().startswith('SET')
+        assert table.ballot_writes[0]['UpdateExpression'].strip().upper().startswith('SET')
 
     def test_a_save_never_put_items_a_merged_map(self, api_gateway_event, lambda_context):
         table = FakeAggregatesTable(items=[{
@@ -377,8 +605,8 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
         _patch_scores(table, api_gateway_event, lambda_context, {'row-1': AXES}, subject='alice')
 
         assert 'ttl' not in table.ballot('row-1', 'alice')
-        for call in table.update_item_calls:
-            assert 'ttl' not in call['UpdateExpression']
+        for call in table.writes:
+            assert 'ttl' not in call.get('UpdateExpression', '')
 
     def test_an_empty_body_writes_nothing(self, api_gateway_event, lambda_context):
         table = FakeAggregatesTable()
@@ -387,7 +615,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
 
         assert status == 200
         assert body['success'] is True
-        assert table.update_item_calls == []
+        assert table.writes == []
 
     @pytest.mark.parametrize('bad_key,expected', [
         ('', 'non-empty'),
@@ -413,7 +641,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
 
         assert status == 400
         assert expected in body['error']
-        assert table.update_item_calls == []
+        assert table.writes == []
 
     @pytest.mark.parametrize('bad_entry', ['nonsense', None, [1, 2], 7, True])
     def test_a_non_object_score_entry_is_refused_before_any_write(
@@ -433,7 +661,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
 
         assert status == 400
         assert 'must be objects' in body['error']
-        assert table.update_item_calls == []
+        assert table.writes == []
         assert table.ballot_keys == []
 
     def test_a_row_with_no_record_is_refused_and_nothing_is_stored(
@@ -459,7 +687,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
         assert status == 404
         assert 'does not exist' in body['error']
         assert 'row-ghost' not in body['error'], 'no echo of caller input'
-        assert table.update_item_calls == []
+        assert table.writes == []
         assert table.ballot_keys == []
 
     def test_one_phantom_row_in_a_multi_row_save_persists_nothing(
@@ -478,7 +706,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
         )
 
         assert status == 404
-        assert table.update_item_calls == []
+        assert table.writes == []
         assert table.ballot('row-real', 'reviewer-1') is None
 
     def test_a_failed_existence_read_is_a_server_fault_not_a_refusal(
@@ -507,7 +735,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
         )
 
         assert status == 500
-        assert table.update_item_calls == []
+        assert table.writes == []
 
     def test_a_save_larger_than_the_bound_is_refused(self, api_gateway_event, lambda_context):
         """Each row costs the ballot write plus, when it scored, a read of the row
@@ -522,7 +750,7 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
 
         assert status == 400
         assert 'at most 100 rows' in body['error']
-        assert table.update_item_calls == []
+        assert table.writes == []
 
     def test_a_save_at_the_bound_is_accepted(self, api_gateway_event, lambda_context):
         """The bound is a ceiling on absurdity, not a limit the product can hit —
@@ -544,22 +772,24 @@ class TestSaveIsAnAtomicUpdateOfOneKey:
         cause that, only a write failure can, so the request is a 500 and the count
         of rows that DID persist is logged rather than silently lost."""
         table = FakeAggregatesTable()
-        real_update = table.update_item
+        real_transact = table.meta.client.transact_write_items
         # Counts only BALLOT writes, so the legacy-migration removals a scoring save
         # also issues cannot absorb the injected failure and leave the request a 200.
         ballot_calls = {'n': 0}
 
-        def failing_update(**kwargs):
-            if kwargs['Key']['sk'].startswith('BALLOT#'):
-                ballot_calls['n'] += 1
-                if ballot_calls['n'] > 1:
-                    raise ClientError(
-                        {'Error': {'Code': 'ProvisionedThroughputExceededException'}},
-                        'UpdateItem',
-                    )
-            return real_update(**kwargs)
+        def failing_transact(TransactItems):
+            ballot_calls['n'] += 1
+            if ballot_calls['n'] > 1:
+                # NOT a TransactionCanceledException: a cancellation means the row
+                # went away and is a 404. This is a throttle — the class that leaves
+                # the earlier rows durably written and answers 500.
+                raise ClientError(
+                    {'Error': {'Code': 'ProvisionedThroughputExceededException'}},
+                    'TransactWriteItems',
+                )
+            return real_transact(TransactItems)
 
-        table.update_item = failing_update
+        table.meta.client.transact_write_items = failing_transact
 
         status, body = _patch_scores(
             table, api_gateway_event, lambda_context,
@@ -615,7 +845,7 @@ class TestAPartialEntryLeavesTheOtherAxesAlone:
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-1': {'impact': 5}}, subject='alice')
 
-        expression = table.update_item_calls[0]['UpdateExpression']
+        expression = table.ballot_writes[0]['UpdateExpression']
         assert 'impact' in expression
         for axis in ('time_to_market', 'confidence', 'strategic_fit', 'notes'):
             assert axis not in expression
@@ -768,10 +998,10 @@ class TestANonNumberIsRefusedRatherThanFlooredAtZero:
         if existing:
             _patch_scores(table, api_gateway_event, lambda_context,
                           {'row-1': existing}, subject='alice')
-        writes_before = len(table.update_item_calls)
+        writes_before = len(table.writes)
         status, body = _patch_scores(table, api_gateway_event, lambda_context,
                                      {'row-1': entry}, subject='alice')
-        return status, body, table, len(table.update_item_calls) - writes_before
+        return status, body, table, len(table.writes) - writes_before
 
     @pytest.mark.parametrize('value', ['high', [1, 2], {'a': 1}, True, False,
                                        float('inf'), float('-inf'), float('nan')])
@@ -862,7 +1092,7 @@ class TestANonNumberIsRefusedRatherThanFlooredAtZero:
         assert status == 400
         assert 'impact' in body['error']
         assert table.ballot_keys == []
-        assert table.update_item_calls == []
+        assert table.writes == []
 
     @pytest.mark.parametrize('value', [99, -4, 2.7, '3', 0, 5])
     def test_a_number_still_clamps_rather_than_being_refused(
@@ -913,7 +1143,7 @@ class TestANonStringNoteCannotDestroyTheStoredNote:
         table = FakeAggregatesTable()
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-1': {'notes': 'ship this in Q3'}}, subject='alice')
-        writes_before = len(table.update_item_calls)
+        writes_before = len(table.writes)
 
         status, body = _patch_scores(table, api_gateway_event, lambda_context,
                                      {'row-1': {'notes': value}}, subject='alice')
@@ -921,7 +1151,7 @@ class TestANonStringNoteCannotDestroyTheStoredNote:
         assert status == 400
         assert 'notes' in body['error']
         assert table.ballot('row-1', 'alice')['notes'] == 'ship this in Q3'
-        assert len(table.update_item_calls) == writes_before
+        assert len(table.writes) == writes_before
 
     def test_the_caller_still_reads_back_the_note_they_saved(
         self, api_gateway_event, lambda_context
@@ -965,7 +1195,7 @@ class TestReviewerIdentityFailsClosed:
 
         assert status == 403
         assert body['success'] is False
-        assert table.update_item_calls == []
+        assert table.writes == []
         assert table.ballot_keys == []
 
     @pytest.mark.parametrize('subject', [None, '', '   '])
@@ -1018,7 +1248,7 @@ class TestAReviewerSubjectCannotCorruptTheBallotKey:
         assert status == 403
         assert body['success'] is False
         assert "'#'" in body['error']
-        assert table.update_item_calls == [], 'nothing may be written under a bad key'
+        assert table.writes == [], 'nothing may be written under a bad key'
         assert table.ballot_keys == []
 
     @pytest.mark.parametrize('subject', ['has#hash', '#leading', 'trailing#'])
@@ -1915,7 +2145,7 @@ class TestAnExplicitNullAxisMeansLeaveItAlone:
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-1': {'impact': 3, 'confidence': None}}, subject='alice')
 
-        expression = table.update_item_calls[0]['UpdateExpression']
+        expression = table.ballot_writes[0]['UpdateExpression']
         assert 'impact' in expression
         assert 'confidence' not in expression
 
@@ -1996,7 +2226,7 @@ class TestDuplicateRowKeysAreRefused:
             subject='alice',
         )
 
-        assert table.update_item_calls == []
+        assert table.writes == []
         assert table.ballot_keys == []
 
     def test_distinct_keys_are_still_accepted(self, api_gateway_event, lambda_context):
@@ -2318,7 +2548,7 @@ class TestWholeMapOverwriteRouteIsGone:
         )
 
         assert table.put_item_calls == []
-        assert table.update_item_calls == []
+        assert table.writes == []
 
     def test_the_old_whole_map_handler_no_longer_exists(self):
         import projects_handler
@@ -2810,12 +3040,12 @@ class TestAnOverLongNoteIsRefusedRatherThanTruncated:
         table = FakeAggregatesTable()
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-1': {'notes': 'ship this in Q3'}}, subject='alice')
-        writes_before = len(table.update_item_calls)
+        writes_before = len(table.writes)
 
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-1': {'notes': self._over_long()}}, subject='alice')
 
-        assert len(table.update_item_calls) == writes_before
+        assert len(table.writes) == writes_before
 
     def test_an_over_long_note_cannot_half_persist_a_multi_document_save(
         self, api_gateway_event, lambda_context
@@ -2971,7 +3201,7 @@ class TestUpdatedCountCountsBallotsNotKeys:
         _patch_scores(table, api_gateway_event, lambda_context,
                       {'row-1': {}}, subject='alice')
 
-        assigned = set(table.update_item_calls[0]['ExpressionAttributeNames'].values())
+        assigned = set(table.ballot_writes[0]['ExpressionAttributeNames'].values())
         assert assigned == set(BALLOT_STAMP_FIELDS)
 
     def test_the_save_bound_still_counts_keys(self, api_gateway_event, lambda_context):
@@ -3723,7 +3953,7 @@ class TestABodyThatIsNotAJsonObjectIsTheCallersMistake:
 
         assert status == 400
         assert 'JSON' in body['error']
-        assert table.update_item_calls == []
+        assert table.writes == []
         assert table.ballot_keys == []
 
     @pytest.mark.parametrize('raw_body', NON_OBJECT_BODIES)

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -4382,6 +4382,24 @@ class TestASecondRowCanBeComposedForAnotherCombination:
 
         assert response['statusCode'] == 200
 
+    def test_the_composed_row_carries_the_projects_latest_prototype_as_context(
+        self, api_gateway_event, lambda_context
+    ):
+        """A prototype is context a reviewer looks at rather than a document the row
+        is scored on, so it rides in its own field exactly as it does on the default
+        row — and it is not composable, because a second dimension of choice over
+        something no ballot is about would mean nothing."""
+        aggregates = FakeAggregatesTable()
+        projects = _project_with(
+            *TWO_SCORABLE, ('PROTOTYPE#', 'proto-old'), ('PROTOTYPE#', 'proto-new'),
+        )
+
+        _, body = _compose_row(aggregates, projects, api_gateway_event, lambda_context,
+                               body={'project_id': 'p1', 'document_ids': ['prd-1']})
+
+        assert body['row']['prototype_id'] == 'proto-new'
+        assert body['row']['document_ids'] == ['prd-1']
+
     def test_the_composed_row_never_carries_an_expiry(
         self, api_gateway_event, lambda_context
     ):
@@ -5616,3 +5634,68 @@ class TestABallotAndItsRowsExistenceAreSettledTogether:
         assert status == 404
         assert aggregates.ballot_keys == []
         assert aggregates.transact_calls == []
+
+
+class TestARowWithMoreBallotsThanOneWriteCanRemoveIsRefused:
+    """DynamoDB caps a transaction at 100 items. A row past that bound is refused
+    rather than deleted in batches, which is the whole argument for the transaction:
+    several writes would leave the ballots that did not fit in the first one orphaned
+    between them.
+
+    Far outside the team-sized shape the partition itself is scaled for, and asserted
+    anyway, because what happens at the edge is the difference between a refusal and
+    the silent orphaning this path exists to prevent.
+    """
+
+    @staticmethod
+    def _row_with(count):
+        from projects_handler import MAX_ROW_BALLOTS_PER_DELETE
+
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row-1', project_id='p1', is_default=False)
+        for index in range(count):
+            sort_key = f'BALLOT#row-1#user:reviewer-{index:03d}'
+            aggregates.items[(PARTITION, sort_key)] = {
+                'pk': PARTITION, 'sk': sort_key, 'row_id': 'row-1', **AXES,
+            }
+        return aggregates, MAX_ROW_BALLOTS_PER_DELETE
+
+    def test_a_row_at_the_bound_is_still_deleted_whole(
+        self, api_gateway_event, lambda_context
+    ):
+        from projects_handler import MAX_ROW_BALLOTS_PER_DELETE
+
+        aggregates, bound = self._row_with(MAX_ROW_BALLOTS_PER_DELETE)
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert status == 200
+        assert body['ballots_deleted'] == bound
+        assert aggregates.ballot_keys == []
+        assert aggregates.row_keys == []
+
+    def test_a_row_past_the_bound_is_refused_and_nothing_is_removed(
+        self, api_gateway_event, lambda_context
+    ):
+        """A partial delete would be strictly worse than this refusal: the row would
+        be gone and the ballots that did not fit would remain, which is the orphan
+        the page's read counts and warns about."""
+        from projects_handler import MAX_ROW_BALLOTS_PER_DELETE
+
+        aggregates, bound = self._row_with(MAX_ROW_BALLOTS_PER_DELETE + 1)
+
+        status, body = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1')
+
+        assert status == 409
+        assert str(bound) in body['error']
+        assert aggregates.transact_calls == []
+        assert aggregates.row_keys == ['ROW#row-1']
+        assert len(aggregates.ballot_keys) == bound + 1
+
+    def test_the_bound_leaves_room_for_the_items_the_transaction_reserves(self):
+        """The row's own delete, and a `ConditionCheck` on a sibling when the row is a
+        default one. A bound of 100 would make a full row's delete exceed the
+        transaction cap and fail as a server error instead of as this refusal."""
+        from projects_handler import MAX_ROW_BALLOTS_PER_DELETE
+
+        assert MAX_ROW_BALLOTS_PER_DELETE + 2 <= 100

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -4236,12 +4236,16 @@ def _recompose_row(aggregates, projects, api_gateway_event, lambda_context, row_
 
 
 def _delete_row(aggregates, api_gateway_event, lambda_context, row_id,
-                subject='admin-1', groups='admins'):
+                subject='admin-1', groups='admins', logger=None):
     """DELETE one row. `groups` is what the admin gate reads.
 
     The projects table is deliberately NOT patched: a delete that reached for a
     project's documents would fail here rather than passing against a fake that
     happened to be in scope, and the route has no business reading them.
+
+    `logger` follows the pattern `_get_scores` uses: pass a double to assert on what
+    the delete REPORTED, which for the one destructive action on this data is part of
+    what it is supposed to do rather than incidental.
     """
     from projects_handler import lambda_handler
 
@@ -4255,7 +4259,11 @@ def _delete_row(aggregates, api_gateway_event, lambda_context, row_id,
     else:
         claims['cognito:groups'] = groups
     with patch('projects_handler.get_aggregates_table', return_value=aggregates):
-        response = lambda_handler(event, lambda_context)
+        if logger is None:
+            response = lambda_handler(event, lambda_context)
+        else:
+            with patch('projects_handler.logger', logger):
+                response = lambda_handler(event, lambda_context)
     return response['statusCode'], json.loads(response['body'])
 
 
@@ -5250,6 +5258,66 @@ class TestAFrozenRowIsDeletedTogetherWithItsBallots:
 
         assert body['ballots_deleted'] == 3
         assert body['row_id'] == 'row-1'
+
+    def test_a_completed_delete_leaves_a_record_of_what_it_removed(
+        self, api_gateway_event, lambda_context
+    ):
+        """`ballots_deleted` is evidence only in the caller's own response body. An
+        operator asked "where did the team's score go?" reads CloudWatch, and the
+        cancelled case already logs — so leaving the successful one silent made the
+        delete that actually removed data the one with no record of it."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context,
+                                            'alice', 'bob')
+        logger = MagicMock()
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1',
+                                logger=logger)
+
+        assert status == 200
+        # `lambda_handler` logs its own "Returning response" through the same logger,
+        # so the delete's line is picked out rather than counted.
+        deletions = [
+            call.args for call in logger.info.call_args_list
+            if 'Deleted prioritization row' in str(call.args[0])
+        ]
+        assert len(deletions) == 1
+        assert 'row-1' in deletions[0]
+        assert 2 in deletions[0], 'the ballot count is the whole point of the line'
+        assert False in deletions[0], 'whether it was the default row'
+
+    def test_the_delete_log_names_no_reviewer(self, api_gateway_event, lambda_context):
+        """The module's standing rule. A row id and a count are what an investigation
+        needs; whose ballots they were is not, and a note never is."""
+        aggregates = self._row_with_ballots(api_gateway_event, lambda_context, 'alice')
+        logger = MagicMock()
+
+        _delete_row(aggregates, api_gateway_event, lambda_context, 'row-1',
+                    logger=logger)
+
+        emitted = ' '.join(
+            str(part) for call in logger.info.call_args_list for part in call.args
+        )
+        assert 'alice' not in emitted
+        assert 'admin-1' not in emitted
+
+    def test_a_refused_delete_reports_no_completed_delete(
+        self, api_gateway_event, lambda_context
+    ):
+        """The line has to mean "this row is gone". A delete refused for its only-row
+        rule writes nothing, so logging it would put a deletion in the record that
+        never happened."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row_p1_default', project_id='p1', is_default=True)
+        logger = MagicMock()
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                'row_p1_default', logger=logger)
+
+        assert status == 409
+        assert not [
+            call for call in logger.info.call_args_list
+            if 'Deleted prioritization row' in str(call.args[0])
+        ]
 
     def test_a_row_nobody_balloted_on_reports_no_ballots_deleted(
         self, api_gateway_event, lambda_context

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -22,6 +22,8 @@ not a general DynamoDB — it implements exactly the expressions this route
 writes, so that a change to those expressions has to be reflected here.
 """
 import json
+import re
+from pathlib import Path
 from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
@@ -6073,6 +6075,59 @@ class TestOnlyAFailedConditionMeansTheRowIsGone:
             'ConditionExpression' not in request
             for item in others for request in item.values()
         ), 'a second condition would make one index too little to tell them apart'
+
+    def test_a_key_a_transaction_cannot_carry_is_refused_rather_than_asserted(
+        self, api_gateway_event, lambda_context
+    ):
+        """A `TransactItems[].Update` accepts a NARROWER set of keys than `update_item`
+        does, so a resource-only one reaching the builder has DynamoDB reject the whole
+        transaction — a ballot failing on something the ballot is not about.
+
+        REFUSED WITH A RAISE, not a bare `assert`. An `assert` is stripped under
+        `python -O`/`PYTHONOPTIMIZE`, which would let exactly the malformed key it
+        names through to DynamoDB, and an `AssertionError` in a request path is an
+        unhandled 500 that bypasses this module's logging. Pinned as a `ServiceError`
+        so the mechanism cannot quietly regress to one."""
+        import projects_handler
+        from shared.exceptions import ServiceError
+
+        table = FakeAggregatesTable()
+        kwargs = projects_handler._ballot_update_kwargs('row-1', 'alice', AXES, 'now')
+        kwargs['ReturnValues'] = 'ALL_NEW'
+
+        with pytest.raises(ServiceError) as refused:
+            projects_handler._ballot_transact_items(table, kwargs, 'row-1', 'now')
+
+        assert 'ReturnValues' in str(refused.value), 'it names the key that failed'
+
+    def test_no_check_in_the_production_lambda_tree_is_a_bare_assert(self):
+        """WHY the check above is a raise, pinned where it can actually regress.
+
+        `assert` is stripped under `python -O`/`PYTHONOPTIMIZE`, so a guard written
+        that way silently is not there — and an `AssertionError` in a request path is
+        an unhandled 500 with a bare message, bypassing the logging every failure in
+        these modules routes through. Every invariant in this tree is a raise, and
+        this is what keeps that true: a reviewer's comment cannot fail CI.
+
+        Read as SOURCE TEXT over the whole production tree rather than by re-executing
+        one module under `optimize=2`, because the property is a convention about all
+        of it, and the failure names the file and line to fix."""
+        tree = Path(__file__).resolve().parents[1]
+        offenders = [
+            f'{path.relative_to(tree.parent)}:{number}'
+            for path in sorted(tree.rglob('*.py'))
+            if 'test' not in path.parts
+            for number, line in enumerate(
+                path.read_text(encoding='utf-8').splitlines(), start=1
+            )
+            if re.match(r'^\s*assert\s', line)
+        ]
+
+        assert offenders == [], (
+            f'bare `assert` in the production Lambda tree: {offenders}. Stripped '
+            f'under `python -O`, so the invariant it states would not be checked at '
+            f'all, and an AssertionError bypasses this tree\'s logging. Raise instead.'
+        )
 
     def test_a_delete_cancelled_by_contention_is_a_500_not_a_409(
         self, api_gateway_event, lambda_context

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -5350,6 +5350,16 @@ class TestARowBallotedBeforeTheMarkExistedIsStillFrozen:
         assert page['rows']['row-1']['is_frozen'] is False
         assert status == 200
         assert body['row']['document_ids'] == ['prd-2']
+        # THE CONSEQUENCE the decision rests on, not only its premise: once the row
+        # no longer holds the value's document, the value stops surfacing rather
+        # than being re-attributed to a set its author never scored. A change to
+        # `_legacy_scores_by_row` that broke this would break the "it never
+        # described a set at all" argument, and this is what would catch it.
+        _, reread = _get_scores(aggregates, api_gateway_event, lambda_context)
+        assert 'row-1' not in reread['scores'], (
+            'a legacy value must follow its document out of the row, not migrate '
+            'onto documents nobody scored'
+        )
 
     def test_a_stamp_only_ballot_record_does_not_freeze_without_the_mark(
         self, api_gateway_event, lambda_context

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -4777,6 +4777,71 @@ class TestAnUnBallotedRowsCompositionCanStillChange:
             'prd-2', 'prfaq-2',
         ]
 
+    def test_a_default_row_can_be_narrowed_before_anybody_votes(
+        self, api_gateway_event, lambda_context
+    ):
+        """DELIBERATE, and the ordinary case this route exists for. "Latest of each
+        type" is how a default row is FIRST composed, not a property it keeps: a
+        reviewer who wants to score two of the four documents they were handed is
+        editing the row they got, not replacing it.
+
+        Refusing here would force compose-then-delete for that — and the delete is
+        admin-gated, so an ordinary reviewer could not complete it, while the project's
+        derived key would go on holding the row nobody wanted."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row_p1_default', project_id='p1', is_default=True)
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row_p1_default', body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 200
+        assert body['row']['document_ids'] == ['prd-1']
+        assert body['row']['is_default'] is True, (
+            'it is still the row the project got without a setup step, which is what '
+            'keeps it undeletable as the only one'
+        )
+
+    def test_the_create_hands_back_the_recomposed_default_row_rather_than_re_deriving(
+        self, api_gateway_event, lambda_context
+    ):
+        """The consequence of the above, asserted so it is a decision rather than a
+        surprise. `POST .../rows` is idempotent and answers with what is STORED — a
+        create that re-derived "latest of each type" would silently discard the choice
+        the recompose recorded, on a row somebody may be about to ballot on."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row_p1_default', project_id='p1', is_default=True)
+        projects = _project_with(*FOUR_SCORABLE)
+        _recompose_row(aggregates, projects, api_gateway_event, lambda_context,
+                       'row_p1_default', body={'project_id': 'p1',
+                                               'document_ids': ['prd-1']})
+
+        status, body = _create_row(aggregates, projects, api_gateway_event,
+                                   lambda_context, body={'project_id': 'p1'})
+
+        assert status == 200
+        assert body['created'] is False
+        assert body['row']['document_ids'] == ['prd-1']
+
+    def test_a_default_row_frozen_by_a_ballot_is_refused_like_any_other(
+        self, api_gateway_event, lambda_context
+    ):
+        """Being the default row buys no exemption in either direction: the freeze is
+        about ballots, not about which row it is."""
+        aggregates = FakeAggregatesTable()
+        aggregates.seed_rows('row_p1_default', project_id='p1', is_default=True)
+        _patch_scores(aggregates, api_gateway_event, lambda_context,
+                      {'row_p1_default': AXES}, subject='alice', seed_rows=False)
+
+        status, body = _recompose_row(
+            aggregates, _project_with(*FOUR_SCORABLE), api_gateway_event, lambda_context,
+            'row_p1_default', body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 409
+        assert 'frozen' in body['error']
+
     def test_the_recomposed_row_reads_back_as_un_frozen(
         self, api_gateway_event, lambda_context
     ):

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py
@@ -4443,6 +4443,127 @@ class TestASecondRowCanBeComposedForAnotherCombination:
         assert body['rows'][row_id]['document_ids'] == ['prd-1', 'prfaq-1']
 
 
+class TestAProjectCannotHoldUnboundedlyManyRows:
+    """The compose route adds a row per call and is open to any signed-in reviewer,
+    so it is the one place the partition the page reads WHOLE can be grown by an
+    ordinary authorized request.
+
+    What makes the bound load-bearing rather than tidy: `_read_prioritization_partition`
+    RAISES past its page budget rather than truncating, so enough composed rows takes
+    the prioritization page down for everybody — not only for whoever composed them.
+
+    Every count here is read from the module, so raising the bound moves these tests
+    with it instead of leaving a stale number asserting nothing.
+    """
+
+    @staticmethod
+    def _project_holding(count, project_id='p1'):
+        aggregates = FakeAggregatesTable()
+        for index in range(count):
+            aggregates.seed_rows(f'row-{index:03d}', project_id=project_id,
+                                 is_default=False)
+        return aggregates
+
+    def test_a_project_at_the_bound_is_refused_and_nothing_is_written(
+        self, api_gateway_event, lambda_context
+    ):
+        from projects_handler import MAX_ROWS_PER_PROJECT
+
+        aggregates = self._project_holding(MAX_ROWS_PER_PROJECT)
+        aggregates.put_item_calls.clear()
+
+        status, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 409
+        assert str(MAX_ROWS_PER_PROJECT) in body['error']
+        assert aggregates.put_item_calls == []
+        assert len(aggregates.row_keys) == MAX_ROWS_PER_PROJECT
+
+    def test_a_project_one_row_under_the_bound_still_composes(
+        self, api_gateway_event, lambda_context
+    ):
+        """The bound has to admit the last row it allows, or it is off by one against
+        a reviewer who did nothing wrong."""
+        from projects_handler import MAX_ROWS_PER_PROJECT
+
+        aggregates = self._project_holding(MAX_ROWS_PER_PROJECT - 1)
+
+        status, _ = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 200
+        assert len(aggregates.row_keys) == MAX_ROWS_PER_PROJECT
+
+    def test_another_projects_rows_do_not_spend_this_projects_bound(
+        self, api_gateway_event, lambda_context
+    ):
+        """The bound is PER PROJECT. Counting the partition instead would refuse a
+        project holding no rows at all once the deployment had enough of them."""
+        from projects_handler import MAX_ROWS_PER_PROJECT
+
+        aggregates = self._project_holding(MAX_ROWS_PER_PROJECT, project_id='p2')
+
+        status, body = _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        assert status == 200
+        assert body['row']['project_id'] == 'p1'
+
+    def test_the_default_row_is_still_created_for_a_project_at_the_bound(
+        self, api_gateway_event, lambda_context
+    ):
+        """`POST .../rows` is exempt, and must be: it is idempotent on a derived key,
+        so the page has no other way to get the row a project is entitled to. A bound
+        applied there would leave a project whose rows were all composed unable to
+        ever obtain its own."""
+        from projects_handler import MAX_ROWS_PER_PROJECT
+
+        aggregates = self._project_holding(MAX_ROWS_PER_PROJECT)
+
+        status, body = _create_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1'},
+        )
+
+        assert status == 200
+        assert body['row']['is_default'] is True
+
+    def test_the_row_count_read_pulls_no_document_ids_across_the_wire(
+        self, api_gateway_event, lambda_context
+    ):
+        """A question about one project's row COUNT paid for every row of every
+        project WITH ITS COMPOSITION INLINE, because the 1MB page limit applies
+        before a projection is taken. The row keys and the project id are everything
+        either caller of this read looks at."""
+        aggregates = self._project_holding(3)
+        aggregates.query_calls.clear()
+
+        _compose_row(
+            aggregates, _project_with(*TWO_SCORABLE), api_gateway_event, lambda_context,
+            body={'project_id': 'p1', 'document_ids': ['prd-1']},
+        )
+
+        row_queries = [
+            call for call in aggregates.query_calls
+            if _key_condition(call['KeyConditionExpression'])[1] == 'ROW#'
+        ]
+        assert row_queries, 'the count must read the rows'
+        for call in row_queries:
+            projected = {
+                field.strip() for field in call['ProjectionExpression'].split(',')
+            }
+            assert projected == {'sk', 'project_id'}, (
+                'anything else here is a stored composition being paid for'
+            )
+
+
 class TestARowsDocumentSetIsRefusedBeforeAnythingIsWritten:
     """Five ways a requested composition is not one, each refused before the put.
 
@@ -5273,7 +5394,12 @@ class TestAFrozenRowIsDeletedTogetherWithItsBallots:
 
         def ballot_mid_flight(**kwargs):
             result = real_query(**kwargs)
-            if not raced['done'] and 'ProjectionExpression' in kwargs:
+            # Keyed on the BALLOT enumeration specifically, not on any projected
+            # query: the delete's sibling lookup is projected too, and racing that
+            # one would test a different window.
+            if not raced['done'] and _key_condition(
+                kwargs['KeyConditionExpression']
+            )[1] == 'BALLOT#row-1#':
                 raced['done'] = True
                 _patch_scores(aggregates, api_gateway_event, lambda_context,
                               {'row-1': {'impact': 1}}, subject='bob', seed_rows=False)
@@ -5454,6 +5580,39 @@ class TestTheDefaultRowSurvivesAsAProjectsLastRow:
         assert status == 409
         assert sorted(aggregates.row_keys) == ['ROW#row_p1_default', 'ROW#row_p2_default']
 
+    def test_a_sibling_sorting_after_the_deleted_row_is_still_found(
+        self, api_gateway_event, lambda_context
+    ):
+        """The sibling lookup stops reading early, and the row being deleted is itself
+        one of the project's rows — so a lookup that stopped at ONE key could see only
+        that row and report a project with a sibling as having none. Pinned with the
+        sibling sorting AFTER the deleted row, which is the ordering that reaches it:
+        'ROW#row_p1_default' < 'ROW#zzz-later'."""
+        aggregates = self._project_rows(extra_rows=('zzz-later',))
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                'row_p1_default')
+
+        assert status == 200
+        assert aggregates.row_keys == ['ROW#zzz-later']
+
+    def test_a_sibling_sorting_before_the_deleted_row_is_the_one_fenced_on(
+        self, api_gateway_event, lambda_context
+    ):
+        """The other ordering, and the lowest-keyed sibling is what the transaction
+        asserts on — deterministic, so a retry fences on the same row."""
+        aggregates = self._project_rows(extra_rows=('aaa-earlier', 'zzz-later'))
+
+        status, _ = _delete_row(aggregates, api_gateway_event, lambda_context,
+                                'row_p1_default')
+
+        assert status == 200
+        checks = [
+            request for entry in aggregates.transact_calls[-1]
+            for operation, request in entry.items() if operation == 'ConditionCheck'
+        ]
+        assert [check['Key']['sk'] for check in checks] == ['ROW#aaa-earlier']
+
     def test_a_composed_row_is_deletable_even_as_a_projects_last_row(
         self, api_gateway_event, lambda_context
     ):
@@ -5482,7 +5641,12 @@ class TestTheDefaultRowSurvivesAsAProjectsLastRow:
 
         def delete_sibling_mid_flight(**kwargs):
             result = real_query(**kwargs)
-            if not raced['done'] and 'ProjectionExpression' in kwargs:
+            # From inside the SIBLING lookup, which is where the two admins' reads
+            # cross: the ballot enumeration is projected too, and racing that one
+            # would leave the sibling still present when the transaction ran.
+            if not raced['done'] and _key_condition(
+                kwargs['KeyConditionExpression']
+            )[1] == 'ROW#':
                 raced['done'] = True
                 aggregates.items.pop((PARTITION, 'ROW#row-composed'), None)
             return result

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
@@ -94,6 +94,43 @@ def _call(aggregates, projects, lambda_context, method, path, body=None,
     return response['statusCode'], json.loads(response['body'])
 
 
+def _room_ballot(aggregates, lambda_context, row_id, axes=None, ballot_id=None):
+    """One ANONYMOUS ballot, through `ballots_handler`'s own public route.
+
+    Both handlers against ONE table, which is the only way to show that the two
+    bundles' duplicated attribute names actually meet. `test_anon_row_mark_lockstep.py`
+    pins the spellings as source text; this exercises the consequence.
+    """
+    import ballots_handler
+
+    session_id = 'vs_' + '1a' * 16
+    aggregates.put_item(Item={
+        'pk': 'VOTING_SESSION', 'sk': f'SESSION#{session_id}',
+        'session_id': session_id, 'row_id': row_id, 'row_title': 'Instant refunds',
+        'status': 'open', 'ballot_cap': 40, 'ballot_count': 0,
+        'created_by': 'facilitator', 'created_at': '2026-08-17T10:00:00+00:00',
+        'expires_at': '2096-10-02T07:06:40+00:00', 'ttl': 4_000_000_000,
+    })
+    body = dict(axes or AXES)
+    if ballot_id:
+        body['ballot_id'] = ballot_id
+    path = f'/voting-sessions/{session_id}/submit'
+    event = {
+        'httpMethod': 'POST', 'path': path, 'resource': path,
+        'headers': {'Content-Type': 'application/json'},
+        'requestContext': {'requestId': 'test-request', 'stage': 'test',
+                           'httpMethod': 'POST', 'path': path,
+                           'identity': {'sourceIp': '1.2.3.4'}},
+        'body': json.dumps(body),
+        'pathParameters': {'session_id': session_id},
+        'queryStringParameters': None, 'multiValueQueryStringParameters': None,
+        'stageVariables': None, 'multiValueHeaders': {}, 'isBase64Encoded': False,
+    }
+    with patch.object(ballots_handler, 'get_aggregates_table', return_value=aggregates):
+        response = ballots_handler.lambda_handler(event, lambda_context)
+    return response['statusCode'], json.loads(response['body'])
+
+
 @pytest.fixture()
 def lambda_context():
     return MagicMock()
@@ -314,3 +351,181 @@ class TestTheRowLifecycleAgainstARealTable:
         assert status == 200
         assert body['rows'][balloted_id]['is_frozen'] is True
         assert body['rows'][open_row['row']['row_id']]['is_frozen'] is False
+
+
+class TestAnAnonymousBallotCarriesTheSameInvariantsAsASignedInOne:
+    """BOTH HANDLERS, ONE TABLE — which is the only place the two bundles' duplicated
+    attribute names actually meet.
+
+    `test_anon_row_mark_lockstep.py` pins the spellings as source text, and
+    `test_ballots_handler.py` shows the anonymous write stamps them. Neither can show
+    the CONSEQUENCE: that the mark one bundle writes is the mark the other bundle's
+    condition refuses on. That is what these tests are for, and they are here rather
+    than in either handler's own file because they are about the pair.
+
+    A room's ballots are the least attributable votes in the product — nobody's name
+    is on them — so an invariant that held for signed-in reviewers and not for these
+    would fail exactly where it is hardest to notice.
+    """
+
+    @mock_aws
+    def test_a_room_ballot_freezes_the_row_against_a_recompose(self, lambda_context):
+        """The invariant #339 advertises as database-enforced, across the bundle
+        boundary. Before the anonymous write stamped the mark, a row carrying nothing
+        but real room votes stayed recomposable — and recomposing it left every one of
+        those ballots describing documents the room never saw."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+
+        assert _room_ballot(aggregates, lambda_context, row_id)[0] == 200
+
+        status, body = _call(aggregates, projects, lambda_context, 'PATCH',
+                             f'/projects/prioritization/rows/{row_id}',
+                             {'project_id': 'p1', 'document_ids': ['d2']})
+
+        assert status == 409
+        assert 'frozen' in body['error']
+        row = aggregates.get_item(Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']
+        assert row['document_ids'] == ['d1'], 'the refusal wrote nothing'
+
+    @mock_aws
+    def test_the_page_reports_a_row_frozen_by_a_room_as_frozen(self, lambda_context):
+        """`is_frozen` is one question with one answer, whoever voted. A page that
+        showed such a row as editable would offer a control the server refuses."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _room_ballot(aggregates, lambda_context, row_id)
+
+        _, body = _call(aggregates, projects, lambda_context, 'GET',
+                        '/projects/prioritization')
+
+        assert body['rows'][row_id]['is_frozen'] is True
+        assert body['aggregates'][row_id]['reviewer_count'] == 1
+
+    @mock_aws
+    def test_a_room_ballot_racing_a_delete_cancels_it_rather_than_being_orphaned(
+        self, lambda_context
+    ):
+        """The #342 fault the fence exists to close, in the path that used to bypass
+        it. The ballot is cast from inside the delete's ballot enumeration — the only
+        point where the two can cross — and it moves `ballot_writes`, so the delete's
+        fence fails and the whole transaction is cancelled. Before the anonymous write
+        moved that counter the delete committed and left the ballot behind."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+
+        real_query = aggregates.query
+        raced = {'done': False}
+
+        def ballot_mid_enumeration(**kwargs):
+            response = real_query(**kwargs)
+            # From inside the BALLOT enumeration specifically — the only point where
+            # a ballot and this delete can cross. Recognised by the projection the
+            # enumeration takes, since the delete's other read (the sibling lookup)
+            # projects `sk, project_id`.
+            if not raced['done'] and kwargs.get('ProjectionExpression') == 'sk':
+                raced['done'] = True
+                assert _room_ballot(aggregates, lambda_context, row_id)[0] == 200
+            return response
+
+        racing = MagicMock()
+        racing.name = aggregates.name
+        racing.meta = aggregates.meta
+        racing.get_item.side_effect = aggregates.get_item
+        racing.query.side_effect = ballot_mid_enumeration
+
+        status, body = _call(racing, projects, lambda_context, 'DELETE',
+                             f'/projects/prioritization/rows/{row_id}')
+
+        assert raced['done'], 'the race never happened, so this asserts nothing'
+        assert status == 409
+        assert 'reload' in body['error']
+        stored = sorted(item['sk'] for item in aggregates.scan()['Items']
+                        if item['pk'] == PARTITION)
+        assert stored[-1] == f'ROW#{row_id}', 'the row survived'
+        assert any(sk.startswith(f'BALLOT#{row_id}#anon:') for sk in stored), (
+            "and so did the room's ballot"
+        )
+
+    @mock_aws
+    def test_a_delete_takes_a_rooms_ballots_with_the_row(self, lambda_context):
+        """The other half of the same contract: once nothing is racing, a room's
+        ballots go with their row exactly as a reviewer's do. The enumeration is by
+        row prefix, so nothing about which kind wrote a ballot decides whether it
+        goes."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _room_ballot(aggregates, lambda_context, row_id)
+        _call(aggregates, projects, lambda_context, 'PATCH', '/projects/prioritization',
+              {'scores': {row_id: AXES}})
+
+        status, body = _call(aggregates, projects, lambda_context, 'DELETE',
+                             f'/projects/prioritization/rows/{row_id}')
+
+        assert status == 200
+        assert body['ballots_deleted'] == 2, 'the room ballot and the reviewer ballot'
+        assert [item['sk'] for item in aggregates.scan()['Items']
+                if item['pk'] == PARTITION] == []
+
+    @mock_aws
+    def test_a_room_ballot_on_a_deleted_row_is_refused_rather_than_resurrecting_it(
+        self, lambda_context
+    ):
+        """A session is opened against a row that exists, but the room can vote an
+        hour later. `attribute_exists(sk)` on the row half of the anonymous write is
+        what makes a ballot on a row deleted in between fail — rather than recreating
+        the row as a bare record, which `update_item`'s upsert would otherwise do."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _call(aggregates, projects, lambda_context, 'DELETE',
+              f'/projects/prioritization/rows/{row_id}')
+
+        status, _ = _room_ballot(aggregates, lambda_context, row_id)
+
+        assert status == 404
+        assert [item['sk'] for item in aggregates.scan()['Items']
+                if item['pk'] == PARTITION] == [], 'nothing was resurrected'
+
+    @mock_aws
+    def test_a_room_correction_leaves_the_freeze_instant_where_the_first_ballot_put_it(
+        self, lambda_context
+    ):
+        """`if_not_exists` across the bundle boundary and across a correction: the
+        composition froze when the first phone submitted, and a device amending its
+        own vote is not a new decision about which documents the row holds."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _, first = _room_ballot(aggregates, lambda_context, row_id)
+        froze_at = aggregates.get_item(
+            Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item'][ 'first_ballot_at']
+
+        status, corrected = _room_ballot(aggregates, lambda_context, row_id,
+                                        axes={**AXES, 'impact': 1},
+                                        ballot_id=first['ballot_id'])
+
+        assert status == 200
+        assert corrected['corrected'] is True
+        row = aggregates.get_item(Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']
+        assert row['first_ballot_at'] == froze_at
+        assert row['ballot_writes'] == Decimal(2), (
+            'the fence moves for a correction, so a delete that listed the ballots '
+            'before it landed is cancelled rather than committing over it'
+        )

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
@@ -290,6 +290,48 @@ class TestTheRowLifecycleAgainstARealTable:
         assert row['document_ids'] == ['d1'], 'the refusal wrote nothing'
 
     @mock_aws
+    def test_a_row_balloted_before_the_mark_existed_is_refused_too(self, lambda_context):
+        """THE UPGRADE PATH, against the real implementation — the exact reproduction
+        review round 3 ran: a row and a reviewer ballot in the shape the previously
+        deployed code wrote (real values, no `first_ballot_at`, no `ballot_writes`),
+        which recomposed with a 200 before the guard existed.
+
+        In THIS file rather than only the fast suite because the guard is a new WIRE
+        SHAPE: a query whose projection aliases every attribute it names. The fake
+        ignores `ProjectionExpression` entirely, so a malformed one — an unaliased
+        reserved word, a syntax error in the alias list — passes every fast test and
+        fails on the first real call. Moto parses it the way DynamoDB does."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        aggregates.put_item(Item={
+            'pk': PARTITION, 'sk': 'ROW#row-legacy', 'row_id': 'row-legacy',
+            'project_id': 'p1', 'document_ids': ['d1', 'd2'], 'prototype_id': '',
+            'is_default': True, 'created_at': '2026-07-01T10:00:00+00:00',
+        })
+        aggregates.put_item(Item={
+            'pk': PARTITION, 'sk': 'BALLOT#row-legacy#user:alice',
+            'row_id': 'row-legacy', 'reviewer': 'user:alice',
+            'updated_at': '2026-07-01T11:00:00+00:00',
+            'impact': Decimal(5), 'notes': 'we must ship both',
+        })
+
+        status, body = _call(aggregates, projects, lambda_context, 'PATCH',
+                             '/projects/prioritization/rows/row-legacy',
+                             {'project_id': 'p1', 'document_ids': ['d1']})
+
+        assert status == 409
+        assert 'frozen' in body['error']
+        row = aggregates.get_item(
+            Key={'pk': PARTITION, 'sk': 'ROW#row-legacy'})['Item']
+        assert row['document_ids'] == ['d1', 'd2'], (
+            "alice's ballot still describes the documents she saw"
+        )
+        _, page = _call(aggregates, projects, lambda_context, 'GET',
+                        '/projects/prioritization')
+        assert page['rows']['row-legacy']['is_frozen'] is True, (
+            'and the page must not offer the control the write refuses'
+        )
+
+    @mock_aws
     def test_a_row_and_its_ballots_go_in_one_real_transaction(self, lambda_context):
         """The delete's transaction, including the part only a real table exercises:
         the fence value is a `Decimal` read through the RESOURCE and passed back

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
@@ -1,0 +1,316 @@
+"""The row lifecycle against a REAL DynamoDB implementation, not the suite's fake.
+
+`test_projects_prioritization_ballots.py` holds the behaviour, one assertion per
+test, against an in-memory fake that evaluates condition expressions. That fake is
+what makes those tests fast and precise, and it is also the one thing that cannot
+tell whether the REQUEST SHAPE is legal: it accepts whatever `dict` the route hands
+it, so a `transact_write_items` call built wrong — resource-shaped values where the
+low-level client wants `{'S': ...}`, a key the `Update` struct does not accept —
+would pass every one of those tests and fail on the first real invocation.
+
+So these tests exist for the WIRE, not the behaviour, and there are deliberately few
+of them: three shapes the fake cannot vouch for.
+
+  * the ballot save's transaction, which carries native Python values, an
+    `if_not_exists` and an `ADD` in one expression;
+  * the row delete's transaction, whose fence value is a `Decimal` read at the
+    RESOURCE layer and passed back through a CLIENT-layer call unconverted;
+  * a stale fence, which is the one condition whose failure this module answers with
+    a 409 rather than a 500.
+
+moto rather than a live table: it implements the transaction semantics these routes
+depend on (all-or-nothing, per-item `CancellationReasons`, `if_not_exists`, `ADD`)
+and it rejects a malformed request the way DynamoDB does, which is the whole point.
+Anything about WHICH conditions the routes should carry belongs in the fast suite,
+where a failure names the behaviour rather than the protocol.
+"""
+import json
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+PARTITION = 'PRIORITIZATION'
+AXES = {'impact': 4, 'time_to_market': 3, 'confidence': 2, 'strategic_fit': 5}
+
+
+def _table(name):
+    return boto3.resource('dynamodb', region_name='us-east-1').create_table(
+        TableName=name,
+        KeySchema=[
+            {'AttributeName': 'pk', 'KeyType': 'HASH'},
+            {'AttributeName': 'sk', 'KeyType': 'RANGE'},
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'pk', 'AttributeType': 'S'},
+            {'AttributeName': 'sk', 'AttributeType': 'S'},
+        ],
+        BillingMode='PAY_PER_REQUEST',
+    )
+
+
+def _seeded_project(projects):
+    """One project holding a PRD and a PR/FAQ, which is enough to compose a row."""
+    projects.put_item(Item={'pk': 'PROJECT#p1', 'sk': 'META', 'project_id': 'p1',
+                            'name': 'Project One'})
+    projects.put_item(Item={'pk': 'PROJECT#p1', 'sk': 'PRD#d1', 'document_id': 'd1',
+                            'created_at': '2026-01-01'})
+    projects.put_item(Item={'pk': 'PROJECT#p1', 'sk': 'PRFAQ#d2', 'document_id': 'd2',
+                            'created_at': '2026-01-02'})
+    return projects
+
+
+def _call(aggregates, projects, lambda_context, method, path, body=None,
+          subject='alice', groups='admins'):
+    """One request through `lambda_handler`, with both tables real."""
+    import projects_handler
+
+    event = {
+        'httpMethod': method,
+        'path': path,
+        'resource': path,
+        'headers': {'Content-Type': 'application/json'},
+        'requestContext': {
+            'authorizer': {'claims': {'sub': subject, 'cognito:groups': groups}},
+            'requestId': 'test-request', 'stage': 'test',
+            'httpMethod': method, 'path': path,
+            'identity': {'sourceIp': '1.2.3.4'},
+        },
+        'body': json.dumps(body) if body is not None else None,
+        'queryStringParameters': None,
+        'multiValueQueryStringParameters': None,
+        'pathParameters': None,
+        'stageVariables': None,
+        'multiValueHeaders': {},
+        'isBase64Encoded': False,
+    }
+    with (
+        patch.object(projects_handler, 'get_aggregates_table', return_value=aggregates),
+        patch.object(projects_handler, 'get_projects_table', return_value=projects),
+    ):
+        response = projects_handler.lambda_handler(event, lambda_context)
+    return response['statusCode'], json.loads(response['body'])
+
+
+@pytest.fixture()
+def lambda_context():
+    return MagicMock()
+
+
+class TestTheRowLifecycleAgainstARealTable:
+    """Every write these routes make, executed by an implementation that would reject
+    a malformed one."""
+
+    @mock_aws
+    def test_a_ballot_transaction_lands_and_stamps_its_rows_freeze(self, lambda_context):
+        """The shape the fake cannot vouch for: one `transact_write_items` carrying
+        native Python values, `SET ... if_not_exists(...)` and `ADD` in ONE expression,
+        issued on `table.meta.client`. A request built for the low-level client with
+        resource-shaped values would fail here with `ParamValidationError` before any
+        condition was evaluated."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1', 'd2']})
+        row_id = created['row']['row_id']
+
+        status, body = _call(aggregates, projects, lambda_context, 'PATCH',
+                             '/projects/prioritization',
+                             {'scores': {row_id: {**AXES, 'notes': 'ship it'}}})
+
+        assert status == 200
+        assert body['updated_count'] == 1
+        row = aggregates.get_item(
+            Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']
+        assert row['first_ballot_at']
+        assert row['ballot_writes'] == Decimal(1)
+        ballot = aggregates.get_item(
+            Key={'pk': PARTITION, 'sk': f'BALLOT#{row_id}#user:alice'})['Item']
+        assert ballot['impact'] == Decimal(4)
+        assert ballot['notes'] == 'ship it'
+
+    @mock_aws
+    def test_the_freeze_mark_records_the_first_ballot_and_no_later_one(
+        self, lambda_context
+    ):
+        """`if_not_exists` executed by something that implements it, rather than by
+        the fake's reading of the expression."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+
+        _call(aggregates, projects, lambda_context, 'PATCH', '/projects/prioritization',
+              {'scores': {row_id: AXES}}, subject='alice')
+        first = aggregates.get_item(
+            Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']['first_ballot_at']
+        _call(aggregates, projects, lambda_context, 'PATCH', '/projects/prioritization',
+              {'scores': {row_id: AXES}}, subject='bob')
+
+        row = aggregates.get_item(Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']
+        assert row['first_ballot_at'] == first
+        assert row['ballot_writes'] == Decimal(2), 'ADD moved for each of them'
+
+    @mock_aws
+    def test_a_frozen_row_is_refused_by_the_database_not_by_the_handler(
+        self, lambda_context
+    ):
+        """The recompose condition, evaluated by DynamoDB. The fake reads the
+        expression; this asserts the expression means what the fake thinks."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _call(aggregates, projects, lambda_context, 'PATCH', '/projects/prioritization',
+              {'scores': {row_id: AXES}})
+
+        status, body = _call(aggregates, projects, lambda_context, 'PATCH',
+                             f'/projects/prioritization/rows/{row_id}',
+                             {'project_id': 'p1', 'document_ids': ['d2']})
+
+        assert status == 409
+        assert 'frozen' in body['error']
+        row = aggregates.get_item(Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']
+        assert row['document_ids'] == ['d1'], 'the refusal wrote nothing'
+
+    @mock_aws
+    def test_a_row_and_its_ballots_go_in_one_real_transaction(self, lambda_context):
+        """The delete's transaction, including the part only a real table exercises:
+        the fence value is a `Decimal` read through the RESOURCE and passed back
+        unconverted into a CLIENT-layer condition. Coercing it to `int`, or issuing
+        this on a bare `boto3.client('dynamodb')`, breaks here and nowhere else."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        for subject in ('alice', 'bob'):
+            _call(aggregates, projects, lambda_context, 'PATCH',
+                  '/projects/prioritization', {'scores': {row_id: AXES}},
+                  subject=subject)
+
+        status, body = _call(aggregates, projects, lambda_context, 'DELETE',
+                             f'/projects/prioritization/rows/{row_id}')
+
+        assert status == 200
+        assert body['ballots_deleted'] == 2
+        assert aggregates.scan()['Items'] == [], (
+            'the row and both ballots went together'
+        )
+
+    @mock_aws
+    def test_a_stale_fence_cancels_the_delete_and_writes_nothing(self, lambda_context):
+        """The fence, failed on purpose against a real evaluator. `ballot_writes` is
+        advanced behind the route's back after it reads the row, which is exactly what
+        a ballot landing in the gap does — and the transaction has to be cancelled
+        WHOLE, leaving both the row and every ballot in place."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _call(aggregates, projects, lambda_context, 'PATCH', '/projects/prioritization',
+              {'scores': {row_id: AXES}})
+
+        real_get_item = aggregates.get_item
+
+        def advance_the_fence_after_reading(**kwargs):
+            response = real_get_item(**kwargs)
+            if str(kwargs['Key']['sk']).startswith('ROW#'):
+                aggregates.update_item(
+                    Key=kwargs['Key'],
+                    UpdateExpression='ADD #bw :one',
+                    ExpressionAttributeNames={'#bw': 'ballot_writes'},
+                    ExpressionAttributeValues={':one': 1},
+                )
+            return response
+
+        racing = MagicMock()
+        racing.name = aggregates.name
+        racing.meta = aggregates.meta
+        racing.get_item.side_effect = advance_the_fence_after_reading
+        racing.query.side_effect = aggregates.query
+
+        status, body = _call(racing, projects, lambda_context, 'DELETE',
+                             f'/projects/prioritization/rows/{row_id}')
+
+        assert status == 409
+        assert 'reload' in body['error']
+        assert sorted(item['sk'] for item in aggregates.scan()['Items']) == [
+            f'BALLOT#{row_id}#user:alice', f'ROW#{row_id}',
+        ]
+
+    @mock_aws
+    def test_a_projects_only_default_row_is_refused_by_the_sibling_check(
+        self, lambda_context
+    ):
+        """The `ConditionCheck` participant, which a real transaction validates the
+        struct of — it takes no `UpdateExpression` and would be rejected outright if
+        one were built for it."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows', {'project_id': 'p1'})
+        default_row = created['row']['row_id']
+        assert created['row']['is_default'] is True
+
+        refused, _ = _call(aggregates, projects, lambda_context, 'DELETE',
+                           f'/projects/prioritization/rows/{default_row}')
+        assert refused == 409
+
+        _call(aggregates, projects, lambda_context, 'POST',
+              '/projects/prioritization/rows/compose',
+              {'project_id': 'p1', 'document_ids': ['d2']})
+        allowed, _ = _call(aggregates, projects, lambda_context, 'DELETE',
+                           f'/projects/prioritization/rows/{default_row}')
+
+        assert allowed == 200
+        assert [item['sk'] for item in aggregates.scan()['Items']] != []
+
+    @mock_aws
+    def test_a_ballot_on_a_deleted_row_is_refused_rather_than_resurrecting_it(
+        self, lambda_context
+    ):
+        """`attribute_exists(sk)` on the row half, evaluated for real. `update_item`
+        is an upsert, so without it this transaction would CREATE a bare row record
+        for a row somebody deleted."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        _call(aggregates, projects, lambda_context, 'DELETE',
+              f'/projects/prioritization/rows/{row_id}')
+
+        status, _ = _call(aggregates, projects, lambda_context, 'PATCH',
+                          '/projects/prioritization', {'scores': {row_id: AXES}})
+
+        assert status == 404
+        assert aggregates.scan()['Items'] == [], 'nothing was resurrected'
+
+    @mock_aws
+    def test_the_page_read_answers_with_the_frozen_flag_the_write_set(
+        self, lambda_context
+    ):
+        """End to end through both halves, so `is_frozen` is not merely computed but
+        computed from what a real write actually stored."""
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, open_row = _call(aggregates, projects, lambda_context, 'POST',
+                            '/projects/prioritization/rows/compose',
+                            {'project_id': 'p1', 'document_ids': ['d1']})
+        _, balloted = _call(aggregates, projects, lambda_context, 'POST',
+                            '/projects/prioritization/rows/compose',
+                            {'project_id': 'p1', 'document_ids': ['d2']})
+        balloted_id = balloted['row']['row_id']
+        _call(aggregates, projects, lambda_context, 'PATCH', '/projects/prioritization',
+              {'scores': {balloted_id: AXES}})
+
+        status, body = _call(aggregates, projects, lambda_context, 'GET',
+                             '/projects/prioritization')
+
+        assert status == 200
+        assert body['rows'][balloted_id]['is_frozen'] is True
+        assert body['rows'][open_row['row']['row_id']]['is_frozen'] is False

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
@@ -225,6 +225,48 @@ class TestTheRowLifecycleAgainstARealTable:
         assert row['ballot_writes'] == Decimal(2), 'ADD moved for each of them'
 
     @mock_aws
+    def test_replaying_an_identical_save_converges_on_one_ballot_and_one_instant(
+        self, lambda_context
+    ):
+        """The save's docstring tells a client that sees a 500 to RE-SEND THE WHOLE
+        BODY, so what a replay does is a contract rather than an implementation
+        detail — and the row half's `ADD` is not idempotent, which makes the claim
+        worth executing rather than asserting.
+
+        Both halves of it, against a real evaluator: the BALLOT converges (one record,
+        the same values) and ROW_FROZEN_AT_FIELD converges (`if_not_exists` cannot move
+        an instant a first ballot recorded), which is the whole of what "safe to
+        retry" has to mean. ROW_BALLOT_WRITES_FIELD is asserted to ADVANCE, because it
+        counts committed writes rather than reviewers and a fence that stood still
+        under a replay would let a delete that enumerated before it commit over it.
+        """
+        aggregates, projects = _table('aggr'), _seeded_project(_table('projects'))
+        _, created = _call(aggregates, projects, lambda_context, 'POST',
+                           '/projects/prioritization/rows/compose',
+                           {'project_id': 'p1', 'document_ids': ['d1']})
+        row_id = created['row']['row_id']
+        body = {'scores': {row_id: {**AXES, 'notes': 'ship it'}}}
+
+        _call(aggregates, projects, lambda_context, 'PATCH',
+              '/projects/prioritization', body)
+        first = aggregates.get_item(
+            Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']['first_ballot_at']
+        status, replayed = _call(aggregates, projects, lambda_context, 'PATCH',
+                                 '/projects/prioritization', body)
+
+        assert (status, replayed['updated_count']) == (200, 1)
+        ballots = [item for item in aggregates.scan()['Items']
+                   if str(item['sk']).startswith('BALLOT#')]
+        assert len(ballots) == 1, 'the replay overwrote the one record, not added one'
+        assert (ballots[0]['impact'], ballots[0]['notes']) == (Decimal(4), 'ship it')
+        row = aggregates.get_item(Key={'pk': PARTITION, 'sk': f'ROW#{row_id}'})['Item']
+        assert row['first_ballot_at'] == first, 'if_not_exists held the first instant'
+        assert row['ballot_writes'] == Decimal(2), (
+            'the fence counts committed writes, so a replay advances it — which is '
+            'what cancels a delete that enumerated before the replay landed'
+        )
+
+    @mock_aws
     def test_a_frozen_row_is_refused_by_the_database_not_by_the_handler(
         self, lambda_context
     ):

--- a/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
+++ b/voc-datalake/lambda/api/test/test_projects_prioritization_row_lifecycle_moto.py
@@ -51,6 +51,39 @@ def _table(name):
     )
 
 
+class _RacingTable:
+    """The real table, with ONE read hooked to land a concurrent write in the gap.
+
+    Delegating rather than a `MagicMock`, and the difference is the whole point of
+    this file. A `MagicMock` answers ANY attribute — so a future refactor having the
+    delete path read something else off the table would get a mock back, and these
+    tests would keep passing while exercising a call that returned no data. That is
+    precisely the property these tests exist NOT to have: the module docstring's
+    argument is that the fast suite's fake "accepts whatever `dict` it is handed", and
+    a `MagicMock` is a strictly looser fake than the one being escaped.
+
+    So everything except the hooked method reaches the real moto table, and an
+    unanticipated call behaves — or fails — exactly as it would in production.
+    """
+
+    def __init__(self, table, *, get_item=None, query=None):
+        self._table = table
+        self._get_item = get_item
+        self._query = query
+
+    def __getattr__(self, attribute):
+        # Reached only for what is not defined on this class, so `name`, `meta` and
+        # every other member — including ones no test anticipated — come from the real
+        # table rather than from a mock.
+        return getattr(self._table, attribute)
+
+    def get_item(self, **kwargs):
+        return (self._get_item or self._table.get_item)(**kwargs)
+
+    def query(self, **kwargs):
+        return (self._query or self._table.query)(**kwargs)
+
+
 def _seeded_project(projects):
     """One project holding a PRD and a PR/FAQ, which is enough to compose a row."""
     projects.put_item(Item={'pk': 'PROJECT#p1', 'sk': 'META', 'project_id': 'p1',
@@ -266,11 +299,7 @@ class TestTheRowLifecycleAgainstARealTable:
                 )
             return response
 
-        racing = MagicMock()
-        racing.name = aggregates.name
-        racing.meta = aggregates.meta
-        racing.get_item.side_effect = advance_the_fence_after_reading
-        racing.query.side_effect = aggregates.query
+        racing = _RacingTable(aggregates, get_item=advance_the_fence_after_reading)
 
         status, body = _call(racing, projects, lambda_context, 'DELETE',
                              f'/projects/prioritization/rows/{row_id}')
@@ -437,11 +466,7 @@ class TestAnAnonymousBallotCarriesTheSameInvariantsAsASignedInOne:
                 assert _room_ballot(aggregates, lambda_context, row_id)[0] == 200
             return response
 
-        racing = MagicMock()
-        racing.name = aggregates.name
-        racing.meta = aggregates.meta
-        racing.get_item.side_effect = aggregates.get_item
-        racing.query.side_effect = ballot_mid_enumeration
+        racing = _RacingTable(aggregates, query=ballot_mid_enumeration)
 
         status, body = _call(racing, projects, lambda_context, 'DELETE',
                              f'/projects/prioritization/rows/{row_id}')

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -441,6 +441,14 @@ export class VocApiStack extends VocStack {
     // caller who found a flaw in it still cannot enumerate the table or erase
     // anybody's vote. `ballots Lambda IAM grants` in api-stack.test.ts pins both
     // the three actions and the absence of the rest.
+    //
+    // `UpdateItem` also covers the ballot write's TRANSACTION, and no fourth action
+    // is needed for it. `TransactWriteItems` is authorised per PARTICIPANT rather
+    // than as an action of its own, and both of that transaction's participants are
+    // `Update` — the ballot record, and the row's freeze mark plus the counter a row
+    // delete fences on. It needs no `ConditionCheckItem`, because the row's condition
+    // rides on its own `Update` rather than on a separate `ConditionCheck`; that
+    // shape is what keeps this role at three actions.
     const ballotsRole = this.createLambdaRole('BallotsLambdaRole');
     aggregatesTable.grant(ballotsRole, 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:UpdateItem');
     kmsKey.grantEncryptDecrypt(ballotsRole);


### PR DESCRIPTION
## Summary

The BACKEND half of phase 2 of #339 — the lifecycle around the default row phase 1
(#341) shipped. Two files change: `voc-datalake/lambda/api/projects_handler.py` and
`voc-datalake/lambda/api/test/test_projects_prioritization_ballots.py`. No file under
`voc-datalake/frontend/` is touched, and no locale catalogue gains a string.

**New routes**

| Route | What it does | Who may |
| --- | --- | --- |
| `POST /projects/prioritization/rows/compose` | Creates a row for another combination of one project's documents, storing the ids **verbatim** | any signed-in reviewer |
| `PATCH /projects/prioritization/rows/{row_id}` | Changes an **un-balloted** row's composition | any signed-in reviewer |
| `DELETE /projects/prioritization/rows/{row_id}` | Removes the row **and every ballot keyed to it** in one atomic write | admin only (`require_admin`) |

**The freeze is a database condition, not a read-then-write.** The ballot save now
issues one `transact_write_items` per row carrying two updates: the reviewer's ballot
on its own key, and the row's `first_ballot_at` (`if_not_exists`, so it records the
FIRST ballot) plus an `ADD` on `ballot_writes`. A composition change is one
conditional `update_item` asserting `attribute_exists(sk) AND
attribute_not_exists(first_ballot_at) AND project_id = :project_id`, so a composition
change racing the first ballot loses to it and answers 409 having written nothing.

**Freezing follows `_writes_a_reviewer_value`, not `_is_a_vote`.** A note-only ballot
freezes exactly as a scored one does — a note is a durable decision record about the
set of documents the row held when it was written. #339 records this as deliberately
stricter than the vote-supersession helper and says not to reuse that helper here. A
save that stored nothing a reviewer entered (`{}`, `{'impact': null}`) does **not**
freeze, because the module already declines to count it as a ballot written.

**A ballot write and its row's existence are now settled in one operation** (#342's
remaining criterion). The up-front keyed read stays — it is what makes a body naming
one vanished row among five persist nothing, and it returns the records the legacy
migration reads — but the same `attribute_exists(sk)` assertion now also rides on the
write, inside the transaction. A delete landing between the read and the write
cancels the ballot instead of orphaning it, and the reviewer is told 404 rather than
`200 {"updated_count": 1}`.

**The delete is fenced.** A transaction cannot both enumerate and delete, so the row's
`Delete` asserts `ballot_writes` still reads what it read when the ballots were
listed. A ballot landing in that gap cancels the delete (409, reload and retry) rather
than being left behind — which is what keeps the page read's discard-warning count
from rising, the criterion #342 names as distinguishing "handled" from "still
orphaning, just less often".

**The default row keeps its behaviour.** `POST .../rows` is untouched and still
idempotent on its derived key; composed rows get server-minted ids under the same
`row_` namespace and can never occupy that key. A default row cannot be deleted while
it is the project's only row — and the sibling's continued existence is asserted
inside the same transaction, so two admins each deleting one of two rows cannot leave
the project with none.

**Additive response shape.** `_row_payload` gains `is_frozen`; every existing field
keeps its name and meaning, so the shipped page keeps working. The stored instant and
`ballot_writes` are deliberately NOT published — a client computing the freeze itself
would eventually disagree with the condition that enforces it, and a write count that
looks like a reviewer count is worse than no number.

Link: #339 (phase 2), #342.

## Which test catches which revert

Verified by reverting each behaviour in isolation against the full file and recording
what failed. Every revert was caught, and by tests that claim that behaviour:

| Revert | Failing tests |
| --- | --- |
| Drop `attribute_not_exists(first_ballot_at)` from the recompose condition | `test_a_scored_ballot_freezes_the_row`, `test_a_note_only_ballot_freezes_the_row_exactly_as_a_scored_one_does`, `test_a_ballot_clearing_a_note_freezes_the_row_too`, `test_the_freeze_is_a_condition_on_the_write_not_a_count_read_first`, `test_a_composition_change_racing_the_first_ballot_loses_to_it` |
| Freeze on `_is_a_vote` (any axis) instead of "changed something" | `test_a_note_only_ballot_freezes_the_row_exactly_as_a_scored_one_does`, `test_a_ballot_clearing_a_note_freezes_the_row_too` — and **only** those two, which is the isolation that matters |
| Assign `first_ballot_at` rather than `if_not_exists` | `test_the_freeze_mark_records_the_first_ballot_and_not_the_latest` |
| Delete the row record only, leaving its ballots | `test_the_row_and_every_ballot_on_it_are_gone`, `test_the_row_and_its_ballots_go_in_ONE_atomic_write`, `test_an_anonymous_room_ballot_goes_with_the_row_too`, `test_a_row_whose_id_is_a_prefix_of_another_keeps_that_others_ballots`, `test_the_page_read_no_longer_discards_anything_after_a_delete` |
| Drop the delete's `ballot_writes` fence | `test_a_ballot_racing_the_delete_is_not_left_behind`, `test_the_delete_is_fenced_on_the_write_rather_than_on_the_read` |
| Drop `require_admin` from the delete | all four `test_a_non_admin_caller_is_refused_and_nothing_is_deleted` cases, `test_the_refusal_costs_no_read_at_all`, `test_the_gate_is_the_shared_helper_rather_than_a_local_group_check` |
| Allow a default row to be deleted as a project's only row | `test_a_projects_only_row_cannot_be_deleted_even_with_ballots_on_it`, `test_another_projects_row_does_not_count_as_a_sibling` |
| Ballot write back to a plain `update_item` (no atomicity, no freeze) | 13 tests, including `test_a_row_deleted_between_the_check_and_the_write_gets_no_ballot`, `test_a_ballot_and_its_rows_freeze_mark_land_in_the_same_write` |
| Drop only `attribute_exists(sk)` from the transaction's row half | `test_a_row_deleted_between_the_check_and_the_write_gets_no_ballot`, `test_that_reviewer_is_told_the_row_is_gone_rather_than_told_it_saved`, `test_the_existence_assertion_rides_on_the_write_itself` |
| Compose re-derives "latest of each type" instead of storing what was named | `test_a_reviewer_can_compose_a_row_for_a_chosen_pair_of_documents`, `test_the_stored_row_holds_the_ids_the_caller_named_and_not_the_latest`, `test_a_set_at_the_bound_is_accepted_and_one_over_it_is_refused` |
| Drop `project_id = :project_id` from the recompose condition | `test_a_row_belonging_to_another_project_is_refused` |
| Ballot enumeration prefix loses its trailing `#` | `test_a_row_whose_id_is_a_prefix_of_another_keeps_that_others_ballots` |

The two shapes the task warns about are stated explicitly in the code:
`TestTheFirstBallotFreezesTheComposition._balloted` puts a real ballot on the row
**through the real route** before every freeze assertion (seeding the mark by hand
would let a route that never stamps it pass), and
`TestAFrozenRowIsDeletedTogetherWithItsBallots._row_with_ballots` puts real ballots on
the row *and on a sibling row* before every delete assertion (so "deleted its ballots"
cannot be confused with "cleared the partition").

`test_regenerating_a_document_changes_no_existing_row` is the test the task asks for
against a future re-derivation: it ballots a row, then generates newer documents of
both scorable types, re-requests the default row and re-reads the page, and asserts the
balloted row's `document_ids` are byte-for-byte what they were when the ballot landed.

## Build and test results

`mise run build` — **not available**: `mise tasks` reports "no tasks defined" for this
repository, and the root `package.json` has no `build` covering the backend (`npm run
build` builds the frontend, which this change does not touch). The backend commands
the task names were run instead.

* `.venv/bin/python -m pytest lambda/api/test/ -q` — **1429 passed**, 0 failed
  (`test_projects_prioritization_ballots.py` alone: **337 passed**, up from 249).
* `.venv/bin/python -m ruff check lambda/ plugins/` — **523 errors, identical to the
  base branch**. This change adds none and introduces no new rule; the two files it
  touches were checked alone and report only the three findings they already had
  (`I001` on the pre-existing import block, two `BLE001` on pre-existing handlers). The
  new test file reports **zero**.
* `.venv/bin/python -m pytest lambda/ -q` — 14 failures, all in
  `lambda/shared/test/test_http.py`, all `ModuleNotFoundError: No module named
  'tenacity'`. **Confirmed pre-existing**: the same 14 fail with this change stashed.
  The container had no `.venv`, so one was built from `requirements-dev.txt`, which
  does not list the production `tenacity`/`google_play_scraper` dependencies; the same
  gap makes four `plugins/` test modules uncollectable. Untouched by this change.
* Every command ran under `timeout 150` or less; the module's own suite finishes in
  ~12s.
* Also exercised end to end against `moto` (a real DynamoDB implementation, not the
  suite's fake) to confirm the transaction shapes, `if_not_exists`, `ADD`,
  `ConditionCheck`, `TransactionCanceledException` and the `Decimal` round-trip of the
  fence value behave as the routes assume.

## Decisions made

* **A new route rather than a `document_ids` field on `POST .../rows`.** That route's
  contract is idempotence on a derived key; accepting a composition there would make
  "ask twice, get the same row" mean something different depending on the body.
* **`row_id` in the path, minted server-side.** A caller does not choose it — it
  becomes the first segment of every ballot sort key on the row. A `row_id` in a
  compose body is ignored rather than refused, since it names no field of that request.
* **One 409 for all three ways the recompose condition fails** (absent row, wrong
  project, frozen). Telling them apart needs the read the condition exists to avoid,
  and that read could disagree with the write it is explaining; what a caller can act
  on is the same in every case.
* **Ownership and non-scorability share one 404 message.** Distinguishing them would
  tell a caller whether a document id exists in a project they may not have named —
  the same reason `_validated_source_id` answers one 404 for both.
* **`MAX_ROW_BALLOTS_PER_DELETE = 98`.** DynamoDB caps a transaction at 100 items and
  the delete reserves two (the row, and a sibling `ConditionCheck` for a default row).
  A row past it is **refused**, not deleted in batches — several writes would orphan
  the ballots that did not fit, which is the fault the transaction exists to prevent.
* **Additive import.** `require_admin` is appended to the `shared.api` import list
  rather than sorted into it, because #344 and #330 also edit that block.
* **`ballots_handler.py` was left alone.** Its `_validated_row_id` docstring now
  contains one stale clause ("nothing deletes rows today"), and the anonymous submit
  path takes its row id from the stored session rather than from the body, so it has
  the same exposure #342 lists for that file. Both belong with a change that edits
  that module; touching it here would widen a diff the task scopes to two files.
* **No CDK change.** `aggregatesTable.grantReadWriteData(projectsRole)` already covers
  `TransactWriteItems` — CDK's `READ_DATA_ACTIONS` includes `dynamodb:ConditionCheckItem`
  and `WRITE_DATA_ACTIONS` includes `PutItem`/`UpdateItem`/`DeleteItem`, which is what a
  transaction is authorised against (verified against `aws-cdk-lib@2.261.0`'s
  `aws-dynamodb/lib/perms.js`). The routes live under the existing `/projects` proxy.

## Out of scope, as specified

Every screen and locale catalogue (the frozen-controls wording, the confirmation
dialog and the compose interface are a separate change), phase 3 of #339 (lineage,
staleness, suggest-a-row), the scorable type set, and the prioritization read's
existing response fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).