### PR TITLE
feat(mcp): Phase 1 credential model — self-describing token, two reach axes

### DIFF
--- a/voc-datalake/frontend/public/locales/de/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/de/projectDetail.json
@@ -253,15 +253,33 @@
     "noTokensYet": "Noch keine API-Tokens",
     "revealToken": "Token anzeigen",
     "revokeToken": "Token widerrufen",
-    "scope": "Bereich",
-    "scopeRead": "Nur Lesen — Feedback suchen, Metriken anzeigen",
-    "scopeReadWrite": "Lesen & Schreiben — inkl. Chat und Dokumentgenerierung",
     "title": "MCP-Zugang",
     "tokenCreated": "Token erfolgreich erstellt",
     "tokenExpiresOn": "Dieses Token läuft am {{date}} ab.",
     "tokenName": "Token-Name",
     "tokenNamePlaceholder": "z.B. Mein Kiro-Token",
-    "tokenPasteHint": "Fügen Sie dieses Token in den <code>Authorization</code>-Header Ihrer mcp.json oder des Autoseed-Curl-Befehls ein."
+    "tokenPasteHint": "Fügen Sie dieses Token in den <code>Authorization</code>-Header Ihrer mcp.json oder des Autoseed-Curl-Befehls ein.",
+    "scopes": "Berechtigungen",
+    "scopeDesc": {
+      "feedback:read": "Kundenfeedback durchsuchen und lesen",
+      "metrics:read": "Dashboards und Metrik-Aufschlüsselungen lesen",
+      "projects:read": "Projekte, Personas und Dokumente lesen"
+    },
+    "noScopes": "keine Berechtigungen",
+    "readReach": "Lesezugriff",
+    "reachOption": {
+      "workspace": "Gesamter Workspace (Standard)",
+      "project-set": "Nur dieses Projekt"
+    },
+    "reachHint": {
+      "workspace": "Erreicht jedes Projekt im Workspace – einschließlich unveröffentlichter Dokumente anderer Projekte – und das gesamte Kundenfeedback.",
+      "project-set": "Auf dieses Projekt beschränkt. Kann den Feedback-Bestand und Workspace-Metriken nicht lesen, da diese nicht projektbezogen sind."
+    },
+    "reachBadge": {
+      "workspace": "Gesamter Workspace",
+      "project-set": "Dieses Projekt",
+      "none": "Kein Lesezugriff"
+    }
   },
   "notFound": {
     "backToProjects": "Zurück zu Projekten",

--- a/voc-datalake/frontend/public/locales/de/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/de/projectDetail.json
@@ -261,9 +261,9 @@
     "tokenPasteHint": "Fügen Sie dieses Token in den <code>Authorization</code>-Header Ihrer mcp.json oder des Autoseed-Curl-Befehls ein.",
     "scopes": "Berechtigungen",
     "scopeDesc": {
-      "feedback:read": "Kundenfeedback durchsuchen und lesen",
-      "metrics:read": "Dashboards und Metrik-Aufschlüsselungen lesen",
-      "projects:read": "Projekte, Personas und Dokumente lesen"
+      "feedback_read": "Kundenfeedback durchsuchen und lesen",
+      "metrics_read": "Dashboards und Metrik-Aufschlüsselungen lesen",
+      "projects_read": "Projekte, Personas und Dokumente lesen"
     },
     "noScopes": "keine Berechtigungen",
     "readReach": "Lesezugriff",

--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -261,9 +261,9 @@
     "tokenPasteHint": "Paste this token into the <code>Authorization</code> header of your mcp.json or autoseed curl command.",
     "scopes": "Scopes",
     "scopeDesc": {
-      "feedback:read": "Search and read customer feedback",
-      "metrics:read": "Read dashboards and metric breakdowns",
-      "projects:read": "Read projects, personas and documents"
+      "feedback_read": "Search and read customer feedback",
+      "metrics_read": "Read dashboards and metric breakdowns",
+      "projects_read": "Read projects, personas and documents"
     },
     "noScopes": "no scopes",
     "readReach": "Read reach",

--- a/voc-datalake/frontend/public/locales/en/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/en/projectDetail.json
@@ -253,15 +253,33 @@
     "noTokensYet": "No API tokens yet",
     "revealToken": "Reveal token",
     "revokeToken": "Revoke token",
-    "scope": "Scope",
-    "scopeRead": "Read only — search feedback, view metrics",
-    "scopeReadWrite": "Read & write — includes chat and document generation",
     "title": "MCP Access",
     "tokenCreated": "Token created successfully",
     "tokenExpiresOn": "This token expires on {{date}}.",
     "tokenName": "Token name",
     "tokenNamePlaceholder": "e.g. My Kiro token",
-    "tokenPasteHint": "Paste this token into the <code>Authorization</code> header of your mcp.json or autoseed curl command."
+    "tokenPasteHint": "Paste this token into the <code>Authorization</code> header of your mcp.json or autoseed curl command.",
+    "scopes": "Scopes",
+    "scopeDesc": {
+      "feedback:read": "Search and read customer feedback",
+      "metrics:read": "Read dashboards and metric breakdowns",
+      "projects:read": "Read projects, personas and documents"
+    },
+    "noScopes": "no scopes",
+    "readReach": "Read reach",
+    "reachOption": {
+      "workspace": "Whole workspace (default)",
+      "project-set": "This project only"
+    },
+    "reachHint": {
+      "workspace": "Reaches every project in the workspace — including other projects’ unreleased documents — and all customer feedback.",
+      "project-set": "Limited to this project. Cannot read the feedback corpus or workspace metrics, which are not project-scoped."
+    },
+    "reachBadge": {
+      "workspace": "Whole workspace",
+      "project-set": "This project",
+      "none": "No read access"
+    }
   },
   "notFound": {
     "backToProjects": "Back to Projects",

--- a/voc-datalake/frontend/public/locales/es/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/es/projectDetail.json
@@ -264,9 +264,9 @@
     "tokenPasteHint": "Pega este token en el header <code>Authorization</code> de tu mcp.json o comando curl autoseed.",
     "scopes": "Permisos",
     "scopeDesc": {
-      "feedback:read": "Buscar y leer comentarios de clientes",
-      "metrics:read": "Leer paneles y desglose de métricas",
-      "projects:read": "Leer proyectos, personas y documentos"
+      "feedback_read": "Buscar y leer comentarios de clientes",
+      "metrics_read": "Leer paneles y desglose de métricas",
+      "projects_read": "Leer proyectos, personas y documentos"
     },
     "noScopes": "sin permisos",
     "readReach": "Alcance de lectura",

--- a/voc-datalake/frontend/public/locales/es/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/es/projectDetail.json
@@ -256,15 +256,33 @@
     "noTokensYet": "Sin tokens API aún",
     "revealToken": "Mostrar token",
     "revokeToken": "Revocar token",
-    "scope": "Alcance",
-    "scopeRead": "Solo lectura — buscar feedback, ver métricas",
-    "scopeReadWrite": "Lectura y escritura — incluye chat y generación de documentos",
     "title": "Acceso MCP",
     "tokenCreated": "Token creado exitosamente",
     "tokenExpiresOn": "Este token caduca el {{date}}.",
     "tokenName": "Nombre del token",
     "tokenNamePlaceholder": "p. ej. Mi token Kiro",
-    "tokenPasteHint": "Pega este token en el header <code>Authorization</code> de tu mcp.json o comando curl autoseed."
+    "tokenPasteHint": "Pega este token en el header <code>Authorization</code> de tu mcp.json o comando curl autoseed.",
+    "scopes": "Permisos",
+    "scopeDesc": {
+      "feedback:read": "Buscar y leer comentarios de clientes",
+      "metrics:read": "Leer paneles y desglose de métricas",
+      "projects:read": "Leer proyectos, personas y documentos"
+    },
+    "noScopes": "sin permisos",
+    "readReach": "Alcance de lectura",
+    "reachOption": {
+      "workspace": "Todo el espacio de trabajo (predeterminado)",
+      "project-set": "Solo este proyecto"
+    },
+    "reachHint": {
+      "workspace": "Alcanza todos los proyectos del espacio de trabajo, incluidos los documentos no publicados de otros proyectos, y todos los comentarios.",
+      "project-set": "Limitado a este proyecto. No puede leer el corpus de comentarios ni las métricas del espacio de trabajo, que no son por proyecto."
+    },
+    "reachBadge": {
+      "workspace": "Todo el espacio",
+      "project-set": "Este proyecto",
+      "none": "Sin lectura"
+    }
   },
   "notFound": {
     "backToProjects": "Volver a Proyectos",

--- a/voc-datalake/frontend/public/locales/fr/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/fr/projectDetail.json
@@ -256,15 +256,33 @@
     "noTokensYet": "Aucun token API pour le moment",
     "revealToken": "Afficher le token",
     "revokeToken": "Révoquer le token",
-    "scope": "Portée",
-    "scopeRead": "Lecture seule — rechercher des retours, consulter les métriques",
-    "scopeReadWrite": "Lecture & écriture — inclut le chat et la génération de documents",
     "title": "Accès MCP",
     "tokenCreated": "Token créé avec succès",
     "tokenExpiresOn": "Ce jeton expire le {{date}}.",
     "tokenName": "Nom du token",
     "tokenNamePlaceholder": "ex. Mon token Kiro",
-    "tokenPasteHint": "Collez ce token dans l'en-tête <code>Authorization</code> de votre mcp.json ou commande curl autoseed."
+    "tokenPasteHint": "Collez ce token dans l'en-tête <code>Authorization</code> de votre mcp.json ou commande curl autoseed.",
+    "scopes": "Portées",
+    "scopeDesc": {
+      "feedback:read": "Rechercher et lire les retours clients",
+      "metrics:read": "Lire les tableaux de bord et les métriques",
+      "projects:read": "Lire les projets, personas et documents"
+    },
+    "noScopes": "aucune portée",
+    "readReach": "Portée de lecture",
+    "reachOption": {
+      "workspace": "Tout l’espace de travail (par défaut)",
+      "project-set": "Ce projet uniquement"
+    },
+    "reachHint": {
+      "workspace": "Atteint tous les projets de l’espace de travail — y compris les documents non publiés des autres projets — et tous les retours clients.",
+      "project-set": "Limité à ce projet. Ne peut pas lire le corpus de retours ni les métriques de l’espace, qui ne sont pas liés à un projet."
+    },
+    "reachBadge": {
+      "workspace": "Tout l’espace",
+      "project-set": "Ce projet",
+      "none": "Aucune lecture"
+    }
   },
   "notFound": {
     "backToProjects": "Retour aux projets",

--- a/voc-datalake/frontend/public/locales/fr/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/fr/projectDetail.json
@@ -264,9 +264,9 @@
     "tokenPasteHint": "Collez ce token dans l'en-tête <code>Authorization</code> de votre mcp.json ou commande curl autoseed.",
     "scopes": "Portées",
     "scopeDesc": {
-      "feedback:read": "Rechercher et lire les retours clients",
-      "metrics:read": "Lire les tableaux de bord et les métriques",
-      "projects:read": "Lire les projets, personas et documents"
+      "feedback_read": "Rechercher et lire les retours clients",
+      "metrics_read": "Lire les tableaux de bord et les métriques",
+      "projects_read": "Lire les projets, personas et documents"
     },
     "noScopes": "aucune portée",
     "readReach": "Portée de lecture",

--- a/voc-datalake/frontend/public/locales/ja/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ja/projectDetail.json
@@ -261,9 +261,9 @@
     "tokenPasteHint": "このトークンを mcp.json または autoseed curl コマンドの <code>Authorization</code> ヘッダーに貼り付けてください。",
     "scopes": "スコープ",
     "scopeDesc": {
-      "feedback:read": "顧客フィードバックの検索と閲覧",
-      "metrics:read": "ダッシュボードと指標の内訳の閲覧",
-      "projects:read": "プロジェクト、ペルソナ、ドキュメントの閲覧"
+      "feedback_read": "顧客フィードバックの検索と閲覧",
+      "metrics_read": "ダッシュボードと指標の内訳の閲覧",
+      "projects_read": "プロジェクト、ペルソナ、ドキュメントの閲覧"
     },
     "noScopes": "スコープなし",
     "readReach": "読み取り範囲",

--- a/voc-datalake/frontend/public/locales/ja/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ja/projectDetail.json
@@ -253,15 +253,33 @@
     "noTokensYet": "API トークンがまだありません",
     "revealToken": "トークンを表示",
     "revokeToken": "トークンを無効化",
-    "scope": "スコープ",
-    "scopeRead": "読み取り専用 — フィードバック検索、メトリクス表示",
-    "scopeReadWrite": "読み取り・書き込み — チャットとドキュメント生成を含む",
     "title": "MCP アクセス",
     "tokenCreated": "トークンが正常に作成されました",
     "tokenExpiresOn": "このトークンの有効期限は{{date}}です。",
     "tokenName": "トークン名",
     "tokenNamePlaceholder": "例：My Kiro token",
-    "tokenPasteHint": "このトークンを mcp.json または autoseed curl コマンドの <code>Authorization</code> ヘッダーに貼り付けてください。"
+    "tokenPasteHint": "このトークンを mcp.json または autoseed curl コマンドの <code>Authorization</code> ヘッダーに貼り付けてください。",
+    "scopes": "スコープ",
+    "scopeDesc": {
+      "feedback:read": "顧客フィードバックの検索と閲覧",
+      "metrics:read": "ダッシュボードと指標の内訳の閲覧",
+      "projects:read": "プロジェクト、ペルソナ、ドキュメントの閲覧"
+    },
+    "noScopes": "スコープなし",
+    "readReach": "読み取り範囲",
+    "reachOption": {
+      "workspace": "ワークスペース全体（既定）",
+      "project-set": "このプロジェクトのみ"
+    },
+    "reachHint": {
+      "workspace": "ワークスペース内のすべてのプロジェクト（他プロジェクトの未公開ドキュメントを含む）とすべての顧客フィードバックに到達します。",
+      "project-set": "このプロジェクトに限定されます。プロジェクト単位ではないフィードバック全体とワークスペース指標は読み取れません。"
+    },
+    "reachBadge": {
+      "workspace": "ワークスペース全体",
+      "project-set": "このプロジェクト",
+      "none": "読み取り不可"
+    }
   },
   "notFound": {
     "backToProjects": "プロジェクトに戻る",

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -261,9 +261,9 @@
     "tokenPasteHint": "이 토큰을 mcp.json 또는 autoseed curl 명령의 <code>Authorization</code> 헤더에 붙여넣으세요.",
     "scopes": "범위",
     "scopeDesc": {
-      "feedback:read": "고객 피드백 검색 및 읽기",
-      "metrics:read": "대시보드 및 지표 분석 읽기",
-      "projects:read": "프로젝트, 페르소나, 문서 읽기"
+      "feedback_read": "고객 피드백 검색 및 읽기",
+      "metrics_read": "대시보드 및 지표 분석 읽기",
+      "projects_read": "프로젝트, 페르소나, 문서 읽기"
     },
     "noScopes": "범위 없음",
     "readReach": "읽기 범위",

--- a/voc-datalake/frontend/public/locales/ko/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/ko/projectDetail.json
@@ -253,15 +253,33 @@
     "noTokensYet": "API 토큰이 없습니다",
     "revealToken": "토큰 표시",
     "revokeToken": "토큰 취소",
-    "scope": "범위",
-    "scopeRead": "읽기 전용 — 피드백 검색, 지표 보기",
-    "scopeReadWrite": "읽기 및 쓰기 — 채팅 및 문서 생성 포함",
     "title": "MCP 접근",
     "tokenCreated": "토큰이 성공적으로 생성되었습니다",
     "tokenExpiresOn": "이 토큰은 {{date}}에 만료됩니다.",
     "tokenName": "토큰 이름",
     "tokenNamePlaceholder": "예: My Kiro token",
-    "tokenPasteHint": "이 토큰을 mcp.json 또는 autoseed curl 명령의 <code>Authorization</code> 헤더에 붙여넣으세요."
+    "tokenPasteHint": "이 토큰을 mcp.json 또는 autoseed curl 명령의 <code>Authorization</code> 헤더에 붙여넣으세요.",
+    "scopes": "범위",
+    "scopeDesc": {
+      "feedback:read": "고객 피드백 검색 및 읽기",
+      "metrics:read": "대시보드 및 지표 분석 읽기",
+      "projects:read": "프로젝트, 페르소나, 문서 읽기"
+    },
+    "noScopes": "범위 없음",
+    "readReach": "읽기 범위",
+    "reachOption": {
+      "workspace": "전체 워크스페이스(기본값)",
+      "project-set": "이 프로젝트만"
+    },
+    "reachHint": {
+      "workspace": "다른 프로젝트의 미공개 문서를 포함한 워크스페이스의 모든 프로젝트와 모든 고객 피드백에 접근합니다.",
+      "project-set": "이 프로젝트로 제한됩니다. 프로젝트 단위가 아닌 피드백 전체와 워크스페이스 지표는 읽을 수 없습니다."
+    },
+    "reachBadge": {
+      "workspace": "전체 워크스페이스",
+      "project-set": "이 프로젝트",
+      "none": "읽기 불가"
+    }
   },
   "notFound": {
     "backToProjects": "프로젝트로 돌아가기",

--- a/voc-datalake/frontend/public/locales/pt/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/pt/projectDetail.json
@@ -256,15 +256,33 @@
     "noTokensYet": "Nenhum token API ainda",
     "revealToken": "Revelar token",
     "revokeToken": "Revogar token",
-    "scope": "Escopo",
-    "scopeRead": "Somente leitura — pesquisar feedback, visualizar métricas",
-    "scopeReadWrite": "Leitura e escrita — inclui chat e geração de documentos",
     "title": "Acesso MCP",
     "tokenCreated": "Token criado com sucesso",
     "tokenExpiresOn": "Este token expira em {{date}}.",
     "tokenName": "Nome do token",
     "tokenNamePlaceholder": "ex: Meu token Kiro",
-    "tokenPasteHint": "Cole este token no header <code>Authorization</code> do seu mcp.json ou comando curl autoseed."
+    "tokenPasteHint": "Cole este token no header <code>Authorization</code> do seu mcp.json ou comando curl autoseed.",
+    "scopes": "Escopos",
+    "scopeDesc": {
+      "feedback:read": "Pesquisar e ler feedback de clientes",
+      "metrics:read": "Ler painéis e detalhamento de métricas",
+      "projects:read": "Ler projetos, personas e documentos"
+    },
+    "noScopes": "sem escopos",
+    "readReach": "Alcance de leitura",
+    "reachOption": {
+      "workspace": "Todo o workspace (padrão)",
+      "project-set": "Apenas este projeto"
+    },
+    "reachHint": {
+      "workspace": "Alcança todos os projetos do workspace — incluindo documentos não publicados de outros projetos — e todo o feedback de clientes.",
+      "project-set": "Limitado a este projeto. Não pode ler o corpus de feedback nem as métricas do workspace, que não são por projeto."
+    },
+    "reachBadge": {
+      "workspace": "Todo o workspace",
+      "project-set": "Este projeto",
+      "none": "Sem leitura"
+    }
   },
   "notFound": {
     "backToProjects": "Voltar para Projetos",

--- a/voc-datalake/frontend/public/locales/pt/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/pt/projectDetail.json
@@ -264,9 +264,9 @@
     "tokenPasteHint": "Cole este token no header <code>Authorization</code> do seu mcp.json ou comando curl autoseed.",
     "scopes": "Escopos",
     "scopeDesc": {
-      "feedback:read": "Pesquisar e ler feedback de clientes",
-      "metrics:read": "Ler painéis e detalhamento de métricas",
-      "projects:read": "Ler projetos, personas e documentos"
+      "feedback_read": "Pesquisar e ler feedback de clientes",
+      "metrics_read": "Ler painéis e detalhamento de métricas",
+      "projects_read": "Ler projetos, personas e documentos"
     },
     "noScopes": "sem escopos",
     "readReach": "Alcance de leitura",

--- a/voc-datalake/frontend/public/locales/zh/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/zh/projectDetail.json
@@ -253,15 +253,33 @@
     "noTokensYet": "暂无 API 令牌",
     "revealToken": "显示令牌",
     "revokeToken": "撤销令牌",
-    "scope": "权限范围",
-    "scopeRead": "仅读取 — 搜索反馈、查看指标",
-    "scopeReadWrite": "读写 — 包括聊天和文档生成",
     "title": "MCP 访问",
     "tokenCreated": "令牌创建成功",
     "tokenExpiresOn": "此令牌将于 {{date}} 到期。",
     "tokenName": "令牌名称",
     "tokenNamePlaceholder": "例如 My Kiro token",
-    "tokenPasteHint": "将此令牌粘贴到 mcp.json 或 autoseed curl 命令的 <code>Authorization</code> 标头中。"
+    "tokenPasteHint": "将此令牌粘贴到 mcp.json 或 autoseed curl 命令的 <code>Authorization</code> 标头中。",
+    "scopes": "权限范围",
+    "scopeDesc": {
+      "feedback:read": "搜索和查看客户反馈",
+      "metrics:read": "查看仪表板和指标细分",
+      "projects:read": "查看项目、用户画像和文档"
+    },
+    "noScopes": "无权限范围",
+    "readReach": "读取范围",
+    "reachOption": {
+      "workspace": "整个工作区（默认）",
+      "project-set": "仅此项目"
+    },
+    "reachHint": {
+      "workspace": "可访问工作区中的所有项目（包括其他项目未发布的文档）以及全部客户反馈。",
+      "project-set": "仅限此项目。无法读取并非按项目划分的反馈全集和工作区指标。"
+    },
+    "reachBadge": {
+      "workspace": "整个工作区",
+      "project-set": "此项目",
+      "none": "无读取权限"
+    }
   },
   "notFound": {
     "backToProjects": "返回项目",

--- a/voc-datalake/frontend/public/locales/zh/projectDetail.json
+++ b/voc-datalake/frontend/public/locales/zh/projectDetail.json
@@ -261,9 +261,9 @@
     "tokenPasteHint": "将此令牌粘贴到 mcp.json 或 autoseed curl 命令的 <code>Authorization</code> 标头中。",
     "scopes": "权限范围",
     "scopeDesc": {
-      "feedback:read": "搜索和查看客户反馈",
-      "metrics:read": "查看仪表板和指标细分",
-      "projects:read": "查看项目、用户画像和文档"
+      "feedback_read": "搜索和查看客户反馈",
+      "metrics_read": "查看仪表板和指标细分",
+      "projects_read": "查看项目、用户画像和文档"
     },
     "noScopes": "无权限范围",
     "readReach": "读取范围",

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -91,6 +91,10 @@ function buildHeaders(existingHeaders?: HeadersInit): Record<string, string> {
 
 import { z } from 'zod'
 import { normalizeFeedbackItem, normalizeFeedbackItems } from './feedbackSchema'
+import {
+  CreateApiTokenResponseSchema, normalizeApiTokens,
+  type McpScope, type ReadReach,
+} from './mcpTokenSchema'
 
 // API response parser using Zod for runtime validation
 // This satisfies the no-type-assertions rule
@@ -746,15 +750,15 @@ export const api = {
       method: 'DELETE'
     }),
 
-  // Project API tokens (used by the McpAccessTab to gate MCP server access)
-  createApiToken: (projectId: string, data: { name: string; scope: 'read' | 'read-write'; expires_in_days?: number }) =>
-    fetchApi<CreateApiTokenResponse>(`/projects/${projectId}/api-tokens`, {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }),
+  // Project API tokens (McpAccessTab). Both responses pass through the lenient
+  // Zod normalizers rather than being trusted to match the declared types: a
+  // token row states what a credential may DO, so a drifted field would make
+  // the UI describe a credential's reach differently from how it is enforced.
+  createApiToken: (projectId: string, data: { name: string; scopes?: McpScope[]; read_reach?: ReadReach; expires_in_days?: number }): Promise<CreateApiTokenResponse> =>
+    fetchApi<unknown>(`/projects/${projectId}/api-tokens`, { method: 'POST', body: JSON.stringify(data) }).then((raw) => CreateApiTokenResponseSchema.parse(raw)),
 
-  listApiTokens: (projectId: string) =>
-    fetchApi<{ success: boolean; tokens: ApiToken[] }>(`/projects/${projectId}/api-tokens`),
+  listApiTokens: (projectId: string): Promise<{ tokens: ApiToken[] }> =>
+    fetchApi<{ tokens?: unknown }>(`/projects/${projectId}/api-tokens`).then((raw) => ({ tokens: normalizeApiTokens(raw?.tokens) })),
 
   deleteApiToken: (projectId: string, tokenId: string) =>
     fetchApi<{ success: boolean; message: string }>(`/projects/${projectId}/api-tokens/${tokenId}`, {

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -754,7 +754,9 @@ export const api = {
   // Zod normalizers rather than being trusted to match the declared types: a
   // token row states what a credential may DO, so a drifted field would make
   // the UI describe a credential's reach differently from how it is enforced.
-  createApiToken: (projectId: string, data: { name: string; scopes?: McpScope[]; read_reach?: ReadReach; expires_in_days?: number }): Promise<CreateApiTokenResponse> =>
+  // `scopes` is REQUIRED, mirroring the route: defaulting it server-side would
+  // make the laziest request mint the widest credential.
+  createApiToken: (projectId: string, data: { name: string; scopes: McpScope[]; read_reach?: ReadReach; expires_in_days?: number }): Promise<CreateApiTokenResponse> =>
     fetchApi<unknown>(`/projects/${projectId}/api-tokens`, { method: 'POST', body: JSON.stringify(data) }).then((raw) => CreateApiTokenResponseSchema.parse(raw)),
 
   listApiTokens: (projectId: string): Promise<{ tokens: ApiToken[] }> =>

--- a/voc-datalake/frontend/src/api/mcpTokenSchema.test.ts
+++ b/voc-datalake/frontend/src/api/mcpTokenSchema.test.ts
@@ -91,11 +91,27 @@ describe('normalizeApiTokens', () => {
 })
 
 describe('ApiTokenSchema', () => {
-  it('never surfaces a secret hash as a token field', () => {
-    // The backend does not send it; if it ever did, this documents that the
-    // UI has no field for it.
-    const parsed = ApiTokenSchema.parse({ ...validRow, secret_hash: 'x' })
-    expect(parsed).not.toHaveProperty('scope')
+  it('strips secret_hash and created_by even though the object is loose', () => {
+    // Previously this asserted `not.toHaveProperty('scope')` — unrelated to its
+    // own name, and vacuously true, while `secret_hash` DID pass through the
+    // loose object. The schema now strips both, so the assertion and the name
+    // describe the same guarantee.
+    const parsed = ApiTokenSchema.parse({
+      ...validRow, secret_hash: 'THE-STORED-HASH', created_by: 'a-cognito-sub',
+    })
+    expect(parsed).not.toHaveProperty('secret_hash')
+    expect(parsed).not.toHaveProperty('created_by')
+    expect(JSON.stringify(parsed)).not.toContain('THE-STORED-HASH')
+    expect(JSON.stringify(parsed)).not.toContain('a-cognito-sub')
+    // The rest of the row survives — this is a strip, not a rejection.
+    expect(parsed.token_id).toBe(validRow.token_id)
+  })
+
+  it('still passes through harmless unknown fields', () => {
+    // The strip must be targeted, not a switch to a strict object: forward
+    // compatibility with new backend fields is why the schema is loose.
+    const parsed = ApiTokenSchema.parse({ ...validRow, future_field: 'keep me' })
+    expect(parsed).toMatchObject({ future_field: 'keep me' })
   })
 })
 

--- a/voc-datalake/frontend/src/api/mcpTokenSchema.test.ts
+++ b/voc-datalake/frontend/src/api/mcpTokenSchema.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  ApiTokenSchema, CreateApiTokenResponseSchema, DEFAULT_READ_REACH,
+  MCP_SCOPES, OFFERED_READ_REACHES, READ_REACHES,
+  isMcpScope, isReadReach, normalizeApiTokens,
+} from './mcpTokenSchema'
+
+const validRow = {
+  token_id: 'tok_abc',
+  name: 'Kiro laptop',
+  scopes: ['feedback:read', 'projects:read'],
+  projects: ['proj_1'],
+  read_reach: 'project-set',
+  created_at: '2026-08-01T00:00:00Z',
+}
+
+describe('normalizeApiTokens', () => {
+  it('keeps a well-formed row intact', () => {
+    expect(normalizeApiTokens([validRow])).toEqual([validRow])
+  })
+
+  it('returns an empty list for a payload that is not an array', () => {
+    // The tab renders its empty state rather than blanking the route.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const bad of [null, undefined, {}, 'nope', 0]) {
+      expect(normalizeApiTokens(bad)).toEqual([])
+    }
+    warn.mockRestore()
+  })
+
+  it('drops only the rows with no usable token_id', () => {
+    // A row with no id cannot be keyed in React nor addressed by the revoke
+    // endpoint, so it is unrenderable — but it must not take the other rows
+    // down with it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const tokens = normalizeApiTokens([
+      validRow,
+      { ...validRow, token_id: '' },
+      { ...validRow, token_id: undefined },
+      'not an object',
+      { ...validRow, token_id: 'tok_other' },
+    ])
+    expect(tokens.map((t) => t.token_id)).toEqual(['tok_abc', 'tok_other'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('defaults a missing read_reach to what the backend enforces', () => {
+    // Deliberately NOT a safer-looking default: showing a credential as
+    // narrower than it is would be the more dangerous lie.
+    const [token] = normalizeApiTokens([{ ...validRow, read_reach: undefined }])
+    expect(token.read_reach).toBe(DEFAULT_READ_REACH)
+    expect(DEFAULT_READ_REACH).toBe('workspace')
+  })
+
+  it('defaults an unrecognised read_reach rather than dropping the row', () => {
+    const [token] = normalizeApiTokens([{ ...validRow, read_reach: 'write-set' }])
+    expect(token.read_reach).toBe(DEFAULT_READ_REACH)
+  })
+
+  it('filters unknown scopes out of the set', () => {
+    // A scope this UI cannot describe must not be rendered as if it were
+    // meaningful; the row survives without it.
+    const [token] = normalizeApiTokens([
+      { ...validRow, scopes: ['feedback:read', 'projects:write', 42, null, 'read'] },
+    ])
+    expect(token.scopes).toEqual(['feedback:read'])
+  })
+
+  it('recovers from scopes and projects that are not arrays', () => {
+    const [token] = normalizeApiTokens([
+      { ...validRow, scopes: 'feedback:read', projects: { a: 1 } },
+    ])
+    expect(token.scopes).toEqual([])
+    expect(token.projects).toEqual([])
+  })
+
+  it('normalizes empty and null timestamps to undefined', () => {
+    // '' would render as "Invalid Date" in the row's expiry badge.
+    const [token] = normalizeApiTokens([
+      { ...validRow, last_used_at: '', expires_at: null },
+    ])
+    expect(token.last_used_at).toBeUndefined()
+    expect(token.expires_at).toBeUndefined()
+  })
+
+  it('passes unknown backend fields through untouched', () => {
+    const [token] = normalizeApiTokens([{ ...validRow, future_field: 'keep me' }])
+    expect(token).toMatchObject({ future_field: 'keep me' })
+  })
+})
+
+describe('ApiTokenSchema', () => {
+  it('never surfaces a secret hash as a token field', () => {
+    // The backend does not send it; if it ever did, this documents that the
+    // UI has no field for it.
+    const parsed = ApiTokenSchema.parse({ ...validRow, secret_hash: 'x' })
+    expect(parsed).not.toHaveProperty('scope')
+  })
+})
+
+describe('CreateApiTokenResponseSchema', () => {
+  it('requires the raw credential', () => {
+    // The mint response exists to deliver it once; a response without it is a
+    // failure the caller must see, not a token row with an empty string.
+    expect(() => CreateApiTokenResponseSchema.parse({ ...validRow, token: '' })).toThrow()
+    expect(() => CreateApiTokenResponseSchema.parse({ ...validRow })).toThrow()
+  })
+
+  it('accepts a full mint response', () => {
+    const parsed = CreateApiTokenResponseSchema.parse({
+      ...validRow, token: 'voc_tok_abc_secret', expires_at: '2027-01-01T00:00:00Z',
+    })
+    expect(parsed.token).toBe('voc_tok_abc_secret')
+    expect(parsed.expires_at).toBe('2027-01-01T00:00:00Z')
+  })
+})
+
+describe('vocabulary', () => {
+  it('offers every reach except the inert one', () => {
+    // `none` is valid but produces a credential that can do nothing while
+    // there are no write tools, so the form does not present it.
+    expect(OFFERED_READ_REACHES).toEqual(['workspace', 'project-set'])
+    expect(READ_REACHES).toContain('none')
+    expect(OFFERED_READ_REACHES).not.toContain('none')
+  })
+
+  it('has no scope the retired model would have carried', () => {
+    // `read` / `read-write` are gone; `read-write` in particular was mintable
+    // and badged while no tool ever required it.
+    expect(isMcpScope('read')).toBe(false)
+    expect(isMcpScope('read-write')).toBe(false)
+    expect(MCP_SCOPES.every((s) => s.endsWith(':read'))).toBe(true)
+  })
+
+  it('guards its type predicates', () => {
+    expect(isReadReach('workspace')).toBe(true)
+    expect(isReadReach('write-set')).toBe(false)
+    expect(isMcpScope('feedback:read')).toBe(true)
+    expect(isMcpScope('feedback:write')).toBe(false)
+  })
+})

--- a/voc-datalake/frontend/src/api/mcpTokenSchema.ts
+++ b/voc-datalake/frontend/src/api/mcpTokenSchema.ts
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Runtime validation/normalization for MCP token API responses,
+ * plus the credential vocabulary the mint form offers.
+ *
+ * The token list was the one list boundary in this app consumed as a declared
+ * type with no runtime check — every other one normalizes through a lenient
+ * Zod schema (see api/feedbackSchema.ts, api/scrapersSchema.ts,
+ * pages/FeedbackForms/formSchema.ts). It matters more here than it looks: a
+ * token row describes what a credential is allowed to do, so a field that
+ * silently arrives missing or misshapen makes the UI describe a credential's
+ * reach differently from how the backend enforces it.
+ *
+ * Defaults mirror the backend's own reading of a partial row
+ * (shared/mcp_tokens.py): an absent read_reach is 'workspace', because that is
+ * what enforcement assumes. Choosing a *safer-looking* default here would be
+ * the wrong call — it would show a credential as narrower than it really is.
+ *
+ * @module api/mcpTokenSchema
+ */
+import { z } from 'zod'
+import type { ApiToken } from './types'
+
+/**
+ * How far a credential may read. Mirrors VALID_READ_REACHES in
+ * shared/mcp_tokens.py; the backend rejects anything else at mint time.
+ *
+ * - `workspace` — the default, and NOT the harmless option: it reaches every
+ *   project's personas and documents plus the whole feedback corpus.
+ * - `project-set` — sealed to the credential's own projects. Cannot read the
+ *   feedback corpus at all, because that data has no project dimension to
+ *   narrow (the backend refuses rather than pretending).
+ * - `none` — reads nothing. Offered for completeness; with no write tools yet
+ *   it produces an inert credential, so the form does not present it.
+ */
+export const READ_REACHES = ['workspace', 'project-set', 'none'] as const
+export type ReadReach = (typeof READ_REACHES)[number]
+
+/** The reaches worth offering at mint time — see `none` above. */
+export const OFFERED_READ_REACHES: readonly ReadReach[] = ['workspace', 'project-set']
+
+export const DEFAULT_READ_REACH: ReadReach = 'workspace'
+
+export function isReadReach(value: string): value is ReadReach {
+  return READ_REACHES.some((reach) => reach === value)
+}
+
+/**
+ * Per-domain scopes. Mirrors VALID_SCOPES in shared/mcp_tokens.py.
+ *
+ * Deliberately only the scopes that grant something today. The retired
+ * `read` / `read-write` pair had a phantom half: `read-write` was mintable,
+ * stored and badged in this UI while no tool ever required it.
+ */
+export const MCP_SCOPES = ['feedback:read', 'metrics:read', 'projects:read'] as const
+export type McpScope = (typeof MCP_SCOPES)[number]
+
+export const DEFAULT_SCOPES: readonly McpScope[] = MCP_SCOPES
+
+export function isMcpScope(value: string): value is McpScope {
+  return MCP_SCOPES.some((scope) => scope === value)
+}
+
+/** Keep recognised scopes, drop junk elements rather than discarding the row. */
+const scopeArraySchema = z
+  .array(z.unknown())
+  .catch(() => [])
+  .transform((items) => items.filter((item): item is McpScope =>
+    typeof item === 'string' && isMcpScope(item)))
+
+/** Keep string project ids, drop junk elements. */
+const projectArraySchema = z
+  .array(z.unknown())
+  .catch(() => [])
+  .transform((items) => items.filter((item): item is string =>
+    typeof item === 'string' && item !== ''))
+
+/** Absent/'' stay undefined so the row reads as "never used" / "never expires"
+ *  rather than rendering an Invalid Date. */
+const optionalIsoString = z
+  .string()
+  .optional()
+  .nullable()
+  .catch(undefined)
+  .transform((value) => (value == null || value === '' ? undefined : value))
+
+/**
+ * A stored token row as the list endpoint reports it.
+ *
+ * `token_id` is the one field that cannot be invented: it keys the React list
+ * and addresses the revoke endpoint, so rows without one are dropped by
+ * `normalizeApiTokens` rather than rendered with an undefined key.
+ *
+ * Loose object so fields the backend adds later pass through untouched.
+ */
+export const ApiTokenSchema = z.looseObject({
+  token_id: z.string().min(1),
+  name: z.string().catch(''),
+  scopes: scopeArraySchema,
+  projects: projectArraySchema,
+  read_reach: z.enum(READ_REACHES).catch(DEFAULT_READ_REACH),
+  created_at: z.string().catch(''),
+  last_used_at: optionalIsoString,
+  expires_at: optionalIsoString,
+})
+
+/**
+ * Normalize a token list payload, dropping only rows with no usable id.
+ *
+ * Never throws: a malformed payload yields an empty list, which the tab
+ * renders as its empty state, instead of blanking the route.
+ */
+export function normalizeApiTokens(raw: unknown): ApiToken[] {
+  if (!Array.isArray(raw)) {
+    if (raw != null) {
+      console.warn('[mcpTokenSchema] token list was not an array; ignoring', { raw })
+    }
+    return []
+  }
+  const tokens: ApiToken[] = []
+  for (const row of raw) {
+    const parsed = ApiTokenSchema.safeParse(row)
+    if (parsed.success) {
+      tokens.push(parsed.data)
+    } else {
+      // A row with no token_id cannot be keyed or revoked, so it is dropped —
+      // loudly, because an unrevocable credential is worth an operator's
+      // attention.
+      console.warn('[mcpTokenSchema] dropping token row without a usable token_id')
+    }
+  }
+  return tokens
+}
+
+/** The mint response. `token` is the only time the raw credential exists here. */
+export const CreateApiTokenResponseSchema = z.looseObject({
+  token: z.string().min(1),
+  token_id: z.string().catch(''),
+  name: z.string().catch(''),
+  scopes: scopeArraySchema,
+  projects: projectArraySchema,
+  read_reach: z.enum(READ_REACHES).catch(DEFAULT_READ_REACH),
+  expires_at: optionalIsoString,
+})

--- a/voc-datalake/frontend/src/api/mcpTokenSchema.ts
+++ b/voc-datalake/frontend/src/api/mcpTokenSchema.ts
@@ -54,7 +54,13 @@ export function isReadReach(value: string): value is ReadReach {
 export const MCP_SCOPES = ['feedback:read', 'metrics:read', 'projects:read'] as const
 export type McpScope = (typeof MCP_SCOPES)[number]
 
-export const DEFAULT_SCOPES: readonly McpScope[] = MCP_SCOPES
+// Deliberately NO exported default scope set, mirroring `ALL_READ_SCOPES` in
+// shared/mcp_tokens.py, which documents itself as "not a fallback". The mint
+// route REQUIRES `scopes` so that the laziest request cannot produce the widest
+// credential — and a form that pre-checks everything would hand that default
+// straight back, making the requirement enforcement-only. The mint form starts
+// with nothing checked and its submit button stays disabled until a choice is
+// made.
 
 export function isMcpScope(value: string): value is McpScope {
   return MCP_SCOPES.some((scope) => scope === value)

--- a/voc-datalake/frontend/src/api/mcpTokenSchema.ts
+++ b/voc-datalake/frontend/src/api/mcpTokenSchema.ts
@@ -101,6 +101,24 @@ export const ApiTokenSchema = z.looseObject({
   created_at: z.string().catch(''),
   last_used_at: optionalIsoString,
   expires_at: optionalIsoString,
+}).transform((row) => {
+  // Drop fields that must never reach a component, even though the object is
+  // loose. The backend sends neither — the point is that `looseObject` passes
+  // unknown keys straight through, so "the backend doesn't send it" is the only
+  // thing standing between a future response change and a credential digest or
+  // a Cognito subject landing in a React tree or a console log.
+  //
+  // Belt and braces: the backend test `test_list_never_returns_the_secret_hash`
+  // is the primary guarantee; this is the one that holds if that regresses.
+  //
+  // Copy-and-delete rather than rest-destructuring so the row keeps its inferred
+  // type (a `...rest` spread widens it to an index signature, and asserting it
+  // back would need the type assertion this codebase forbids).
+  if (!('secret_hash' in row) && !('created_by' in row)) return row
+  const cleaned = { ...row }
+  delete cleaned.secret_hash
+  delete cleaned.created_by
+  return cleaned
 })
 
 /**
@@ -112,7 +130,9 @@ export const ApiTokenSchema = z.looseObject({
 export function normalizeApiTokens(raw: unknown): ApiToken[] {
   if (!Array.isArray(raw)) {
     if (raw != null) {
-      console.warn('[mcpTokenSchema] token list was not an array; ignoring', { raw })
+      // The TYPE, not the payload. Token names and project ids are not secrets,
+      // but logging a whole response body is the habit that eventually logs one.
+      console.warn(`[mcpTokenSchema] token list was not an array (got ${typeof raw}); ignoring`)
     }
     return []
   }

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -3,6 +3,9 @@
 // The derivation contract lives with its schema and resolver, so the runtime
 // validation and the declared type cannot drift apart.
 import type { DocumentDerivation } from './derivation'
+// The credential vocabulary lives with its schema for the same reason: the
+// declared type and the runtime validation cannot drift apart.
+import type { McpScope, ReadReach } from './mcpTokenSchema'
 
 export interface FeedbackItem {
   feedback_id: string
@@ -691,24 +694,32 @@ export interface LogsSummary {
 export interface ApiToken {
   token_id: string
   name: string
-  scope: 'read' | 'read-write'
+  /** Per-domain grants (`feedback:read`, …). Replaces the old single `scope`,
+   *  whose `read-write` value was mintable but required by no tool. */
+  scopes: McpScope[]
+  /** The projects this credential is about. Bounds reads when read_reach is
+   *  'project-set'; will bound writes when write tools land. */
+  projects: string[]
+  /** How far the credential may read. 'workspace' is the default and is NOT
+   *  the harmless option — see READ_REACHES. */
+  read_reach: ReadReach
   created_at: string
   last_used_at?: string
-  /** ISO-8601 deadline after which the token stops authenticating; null for
-   *  non-expiring tokens (every token minted before expiry existed). */
-  expires_at?: string | null
-  project_id: string
+  /** ISO-8601 deadline after which the token stops authenticating; absent for
+   *  non-expiring tokens. */
+  expires_at?: string
 }
 
 /** Response when creating an API token; `token` is the only time the raw value is returned. */
 export interface CreateApiTokenResponse {
-  success: boolean
   token: string
   token_id: string
   name: string
-  /** Echo of the minted deadline; null when the token does not expire. */
-  expires_at?: string | null
-  message?: string
+  scopes: McpScope[]
+  projects: string[]
+  read_reach: ReadReach
+  /** Echo of the minted deadline; absent when the token does not expire. */
+  expires_at?: string
 }
 
 

--- a/voc-datalake/frontend/src/i18n/i18nKeys.test.ts
+++ b/voc-datalake/frontend/src/i18n/i18nKeys.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Structural invariants over the locale JSON itself.
+ *
+ * The motivating defect: `mcp.scopeDesc` was keyed by MCP scope names, which
+ * contain a colon (`feedback:read`). A colon is i18next's default `nsSeparator`,
+ * so `t('mcp.scopeDesc.feedback:read')` was parsed as namespace
+ * `mcp.scopeDesc.feedback` + key `read`, resolved to nothing, and rendered the
+ * literal word **"read"** under every scope checkbox in the mint form.
+ *
+ * It shipped past 2969 passing tests because the component tests asserted
+ * checkbox *names* (which contain the scope and were correct) and nothing
+ * asserted the description text — and the failed lookup produced a plausible
+ * word rather than a visible key path, so it read as intentional. It was found
+ * only by opening the deployed site in a browser.
+ *
+ * The fix could NOT be `nsSeparator: false`, globally or per call: this app
+ * depends on that separator (`SCORABLE_TYPE_META` resolves
+ * `prioritization:docType.prd`; see i18n/options.ts, whose own comment records
+ * that disabling it breaks the Prioritization badge and the Feedback Forms
+ * document picker). So the keys were renamed to underscore form instead — and
+ * this test is what stops the class returning, at test time, for any namespace
+ * rather than the one that happened to be caught.
+ *
+ * @module i18n/i18nKeys.test
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const LOCALES_DIR = join(process.cwd(), 'public', 'locales')
+
+/** Every leaf key path in an object, dot-joined. */
+function keyPaths(value: unknown, prefix = ''): string[] {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return [prefix]
+  }
+  return Object.entries(value as Record<string, unknown>)
+    .flatMap(([k, v]) => keyPaths(v, prefix ? `${prefix}.${k}` : k))
+}
+
+function localeFiles(): { locale: string; file: string; path: string }[] {
+  return readdirSync(LOCALES_DIR)
+    .filter((entry) => statSync(join(LOCALES_DIR, entry)).isDirectory())
+    .flatMap((locale) =>
+      readdirSync(join(LOCALES_DIR, locale))
+        .filter((f) => f.endsWith('.json'))
+        .map((file) => ({ locale, file, path: join(LOCALES_DIR, locale, file) })))
+}
+
+describe('locale key structure', () => {
+  it('finds locale files to check', () => {
+    // Positive control: a glob that silently matched nothing would make every
+    // assertion below vacuously green.
+    const files = localeFiles()
+    expect(files.length).toBeGreaterThan(20)
+    expect(new Set(files.map((f) => f.locale)).size).toBe(8)
+  })
+
+  it('has no key containing a colon, i18next\'s namespace separator', () => {
+    const offenders: string[] = []
+    for (const { locale, file, path } of localeFiles()) {
+      const json: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+      for (const key of keyPaths(json)) {
+        if (key.includes(':')) offenders.push(`${locale}/${file}: ${key}`)
+      }
+    }
+    expect(offenders, [
+      'A colon in a locale KEY is silently mis-resolved: i18next splits the',
+      'lookup on the first colon and treats the left side as a namespace, so the',
+      'value is never found and the right-hand fragment renders instead — which',
+      'looks like real copy rather than a broken key.',
+      '',
+      'Do NOT fix this with `nsSeparator: false`: this app resolves',
+      'namespace-qualified keys such as `prioritization:docType.prd`, and',
+      'disabling the separator breaks the Prioritization badge and the Feedback',
+      'Forms document picker (see i18n/options.ts).',
+      '',
+      'Key the entry without a colon (e.g. `feedback_read`) and derive it at the',
+      'call site from the identifier.',
+    ].join('\n')).toEqual([])
+  })
+})

--- a/voc-datalake/frontend/src/i18n/i18nKeys.test.ts
+++ b/voc-datalake/frontend/src/i18n/i18nKeys.test.ts
@@ -30,13 +30,26 @@ import { MCP_SCOPES } from '../api/mcpTokenSchema'
 
 const LOCALES_DIR = join(process.cwd(), 'public', 'locales')
 
-/** Every leaf key path in an object, dot-joined. */
-function keyPaths(value: unknown, prefix = ''): string[] {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    return [prefix]
-  }
-  return Object.entries(value as Record<string, unknown>)
-    .flatMap(([k, v]) => keyPaths(v, prefix ? `${prefix}.${k}` : k))
+/**
+ * Every leaf of a parsed locale file, as dot-joined path + value.
+ *
+ * Returns values as well as paths so both tests below can share one walker: the
+ * colon check needs only paths, the scope-coverage check also needs to know the
+ * entry is non-empty. That is what lets this file hold **no type assertion** —
+ * `isRecord` narrows `unknown` instead, matching the rule the rest of this PR
+ * follows (see the copy-and-delete note in api/mcpTokenSchema.ts). ESLint does
+ * not enforce it here — `eslint.config.js` ignores test files — so it is a
+ * choice rather than a constraint, and a walker that returns both is smaller
+ * than a walker plus a cast.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function leafEntries(value: unknown, prefix = ''): { path: string; value: unknown }[] {
+  if (!isRecord(value)) return [{ path: prefix, value }]
+  return Object.entries(value)
+    .flatMap(([k, v]) => leafEntries(v, prefix ? `${prefix}.${k}` : k))
 }
 
 function localeFiles(): { locale: string; file: string; path: string }[] {
@@ -65,7 +78,7 @@ describe('locale key structure', () => {
     const offenders: string[] = []
     for (const { locale, file, path } of localeFiles()) {
       const json: unknown = JSON.parse(readFileSync(path, 'utf-8'))
-      for (const key of keyPaths(json)) {
+      for (const { path: key } of leafEntries(json)) {
         if (key.includes(':')) offenders.push(`${locale}/${file}: ${key}`)
       }
     }
@@ -101,14 +114,17 @@ describe('locale key structure', () => {
     for (const { locale, file, path } of localeFiles()) {
       if (file !== 'projectDetail.json') continue
       const json: unknown = JSON.parse(readFileSync(path, 'utf-8'))
-      const descs = (json as { mcp?: { scopeDesc?: Record<string, unknown> } })
-        .mcp?.scopeDesc
+      // Looked up in the FLATTENED leaf list, so no cast is needed to reach
+      // into mcp.scopeDesc — the walker has already resolved the shape.
+      const byPath = new Map(leafEntries(json).map((e) => [e.path, e.value]))
       for (const scope of MCP_SCOPES) {
-        const key = scope.replace(':', '_')
-        const value = descs?.[key]
-        if (value === undefined) missing.push(`${locale}: mcp.scopeDesc.${key}`)
-        else if (typeof value !== 'string' || value.trim() === '') {
-          blank.push(`${locale}: mcp.scopeDesc.${key}`)
+        const key = `mcp.scopeDesc.${scope.replace(':', '_')}`
+        if (!byPath.has(key)) missing.push(`${locale}: ${key}`)
+        else {
+          const value = byPath.get(key)
+          if (typeof value !== 'string' || value.trim() === '') {
+            blank.push(`${locale}: ${key}`)
+          }
         }
       }
     }

--- a/voc-datalake/frontend/src/i18n/i18nKeys.test.ts
+++ b/voc-datalake/frontend/src/i18n/i18nKeys.test.ts
@@ -26,6 +26,7 @@
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { MCP_SCOPES } from '../api/mcpTokenSchema'
 
 const LOCALES_DIR = join(process.cwd(), 'public', 'locales')
 
@@ -51,9 +52,13 @@ describe('locale key structure', () => {
   it('finds locale files to check', () => {
     // Positive control: a glob that silently matched nothing would make every
     // assertion below vacuously green.
+    //
+    // Bounds, not equality: pinning the locale count here would make ADDING a
+    // 9th language fail a test about colon keys — an unrelated failure that
+    // teaches the next person nothing. The count belongs to i18n-check, not here.
     const files = localeFiles()
     expect(files.length).toBeGreaterThan(20)
-    expect(new Set(files.map((f) => f.locale)).size).toBe(8)
+    expect(new Set(files.map((f) => f.locale)).size).toBeGreaterThanOrEqual(8)
   })
 
   it('has no key containing a colon, i18next\'s namespace separator', () => {
@@ -78,5 +83,46 @@ describe('locale key structure', () => {
       'Key the entry without a colon (e.g. `feedback_read`) and derive it at the',
       'call site from the identifier.',
     ].join('\n')).toEqual([])
+  })
+
+  it('has a scopeDesc entry for every MCP scope, in every locale', () => {
+    // Closes the gap that DERIVING the key opens. The component renders
+    // `mcp.scopeDesc.${scope.replace(':', '_')}`, so the link between the scope
+    // constants and the locale entries is implicit — adding a scope (Phase 3
+    // adds a write scope) without adding the key to all 8 locales renders a raw
+    // key path in the mint form.
+    //
+    // Less severe than the original defect, because a visible `mcp.scopeDesc.x`
+    // is obviously broken where the literal "read" looked like real copy. But
+    // Phase 3 WILL add scopes, so the cheap loop is worth having now, and it
+    // covers every locale rather than the `en` a component test would exercise.
+    const missing: string[] = []
+    const blank: string[] = []
+    for (const { locale, file, path } of localeFiles()) {
+      if (file !== 'projectDetail.json') continue
+      const json: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+      const descs = (json as { mcp?: { scopeDesc?: Record<string, unknown> } })
+        .mcp?.scopeDesc
+      for (const scope of MCP_SCOPES) {
+        const key = scope.replace(':', '_')
+        const value = descs?.[key]
+        if (value === undefined) missing.push(`${locale}: mcp.scopeDesc.${key}`)
+        else if (typeof value !== 'string' || value.trim() === '') {
+          blank.push(`${locale}: mcp.scopeDesc.${key}`)
+        }
+      }
+    }
+    expect(missing, [
+      'A scope in MCP_SCOPES has no description key in some locale, so the mint',
+      'form will render the raw key path for it. The key is the scope with its',
+      'colon replaced by an underscore (`feedback:read` -> `feedback_read`).',
+    ].join('\n')).toEqual([])
+    expect(blank, 'a scopeDesc entry exists but is empty').toEqual([])
+
+    // Positive control: the loop must actually have compared something, or an
+    // empty MCP_SCOPES / a renamed file would make the assertions vacuous.
+    expect(MCP_SCOPES.length).toBeGreaterThan(0)
+    expect(localeFiles().filter((f) => f.file === 'projectDetail.json').length)
+      .toBeGreaterThanOrEqual(8)
   })
 })

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessComponents.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessComponents.tsx
@@ -145,14 +145,24 @@ export function CreateTokenForm({
                 />
                 <span>
                   <span className="font-mono text-xs">{scope}</span>
-                  {/* nsSeparator: false is REQUIRED, not decorative. Scope names
-                      contain a colon, which is i18next's default namespace
-                      separator, so `mcp.scopeDesc.feedback:read` is otherwise
-                      parsed as namespace `mcp.scopeDesc.feedback` + key `read`,
-                      resolves to nothing, and renders the literal "read".
-                      Found in a browser — a mocked-i18n unit test cannot see it. */}
+                  {/* The locale key is the UNDERSCORE form of the scope, because
+                      a colon is i18next's namespace separator: keyed as
+                      `feedback:read`, the lookup was parsed as namespace
+                      `mcp.scopeDesc.feedback` + key `read` and rendered the
+                      literal word "read" under every checkbox (found in a
+                      browser; the API battery cannot see render-time faults).
+
+                      Fixed on the KEY side rather than with `nsSeparator: false`
+                      — globally or per call — because this app DEPENDS on that
+                      separator: `SCORABLE_TYPE_META` resolves
+                      `prioritization:docType.prd`, and disabling it would make
+                      the Prioritization badge and the Feedback Forms document
+                      picker render raw key paths (see i18n/options.ts). A
+                      per-call option would also leave the next colon key to
+                      rediscover this. `i18nKeys.test.ts` now fails on ANY locale
+                      key containing a colon, so the class cannot come back. */}
                   <span className="text-gray-500 block text-xs">
-                    {t(`mcp.scopeDesc.${scope}`, { nsSeparator: false })}
+                    {t(`mcp.scopeDesc.${scope.replace(':', '_')}`)}
                   </span>
                 </span>
               </label>

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessComponents.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessComponents.tsx
@@ -145,7 +145,15 @@ export function CreateTokenForm({
                 />
                 <span>
                   <span className="font-mono text-xs">{scope}</span>
-                  <span className="text-gray-500 block text-xs">{t(`mcp.scopeDesc.${scope}`)}</span>
+                  {/* nsSeparator: false is REQUIRED, not decorative. Scope names
+                      contain a colon, which is i18next's default namespace
+                      separator, so `mcp.scopeDesc.feedback:read` is otherwise
+                      parsed as namespace `mcp.scopeDesc.feedback` + key `read`,
+                      resolves to nothing, and renders the literal "read".
+                      Found in a browser — a mocked-i18n unit test cannot see it. */}
+                  <span className="text-gray-500 block text-xs">
+                    {t(`mcp.scopeDesc.${scope}`, { nsSeparator: false })}
+                  </span>
                 </span>
               </label>
             ))}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessComponents.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessComponents.tsx
@@ -10,6 +10,10 @@ import { useTranslation } from 'react-i18next'
 import {
   TOKEN_EXPIRY_CHOICES, isTokenExpiryChoice, tokenExpiryState, type TokenExpiryChoice,
 } from './tokenExpiry'
+import {
+  MCP_SCOPES, OFFERED_READ_REACHES, isReadReach,
+  type McpScope, type ReadReach,
+} from '../../api/mcpTokenSchema'
 import type { ApiToken } from '../../api/types'
 
 // ---------------------------------------------------------------------------
@@ -98,20 +102,22 @@ export function NewTokenBanner({
 
 interface CreateTokenFormProps {
   readonly tokenName: string
-  readonly tokenScope: 'read' | 'read-write'
+  readonly tokenScopes: readonly McpScope[]
+  readonly tokenReach: ReadReach
   readonly tokenExpiry: TokenExpiryChoice
   readonly isCreating: boolean
   readonly error?: string
   readonly onNameChange: (name: string) => void
-  readonly onScopeChange: (scope: 'read' | 'read-write') => void
+  readonly onToggleScope: (scope: McpScope) => void
+  readonly onReachChange: (reach: ReadReach) => void
   readonly onExpiryChange: (expiry: TokenExpiryChoice) => void
   readonly onSubmit: () => void
   readonly onCancel: () => void
 }
 
 export function CreateTokenForm({
-  tokenName, tokenScope, tokenExpiry, isCreating, error,
-  onNameChange, onScopeChange, onExpiryChange, onSubmit, onCancel,
+  tokenName, tokenScopes, tokenReach, tokenExpiry, isCreating, error,
+  onNameChange, onToggleScope, onReachChange, onExpiryChange, onSubmit, onCancel,
 }: CreateTokenFormProps) {
   const { t } = useTranslation('projectDetail')
   return (
@@ -122,14 +128,45 @@ export function CreateTokenForm({
           <label htmlFor="token-name" className="block text-sm font-medium text-gray-700 mb-1">{t('mcp.tokenName')}</label>
           <input id="token-name" type="text" value={tokenName} onChange={(e) => onNameChange(e.target.value)} placeholder={t('mcp.tokenNamePlaceholder')} className="w-full border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" />
         </div>
+        {/* Per-domain scopes, as checkboxes rather than one select: they are
+            independent grants, so a credential can read feedback without
+            reading anybody's product strategy. A fieldset (not a label+input)
+            because the group has one caption for several controls. */}
+        <fieldset>
+          <legend className="block text-sm font-medium text-gray-700 mb-1">{t('mcp.scopes')}</legend>
+          <div className="space-y-1">
+            {MCP_SCOPES.map((scope) => (
+              <label key={scope} className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={tokenScopes.includes(scope)}
+                  onChange={() => onToggleScope(scope)}
+                  className="mt-0.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span>
+                  <span className="font-mono text-xs">{scope}</span>
+                  <span className="text-gray-500 block text-xs">{t(`mcp.scopeDesc.${scope}`)}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        {/* The reach axis. Independent of scope: scope says WHICH data, reach
+            says HOW FAR. The workspace warning is deliberate — it is the
+            default, and it reaches every other project's unreleased documents
+            plus the whole feedback corpus. */}
         <div>
-          <label htmlFor="token-scope" className="block text-sm font-medium text-gray-700 mb-1">{t('mcp.scope')}</label>
-          <select id="token-scope" value={tokenScope} onChange={(e) => {
-            const val = e.target.value; if (val === 'read' || val === 'read-write') onScopeChange(val)
+          <label htmlFor="token-reach" className="block text-sm font-medium text-gray-700 mb-1">{t('mcp.readReach')}</label>
+          <select id="token-reach" value={tokenReach} onChange={(e) => {
+            if (isReadReach(e.target.value)) onReachChange(e.target.value)
           }} className="w-full border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
-            <option value="read">{t('mcp.scopeRead')}</option>
-            <option value="read-write">{t('mcp.scopeReadWrite')}</option>
+            {OFFERED_READ_REACHES.map((reach) => (
+              <option key={reach} value={reach}>{t(`mcp.reachOption.${reach}`)}</option>
+            ))}
           </select>
+          <p className={clsx('text-xs mt-1', tokenReach === 'workspace' ? 'text-amber-700' : 'text-gray-500')}>
+            {t(`mcp.reachHint.${tokenReach}`)}
+          </p>
         </div>
         <div>
           <label htmlFor="token-expiry" className="block text-sm font-medium text-gray-700 mb-1">{t('mcp.expiry')}</label>
@@ -146,7 +183,10 @@ export function CreateTokenForm({
         {error != null && error !== '' ? <div className="flex items-center gap-2 text-sm text-red-600"><AlertCircle size={14} />{error}</div> : null}
         <div className="flex gap-2 justify-end">
           <button onClick={onCancel} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">{t('mcp.cancel')}</button>
-          <button onClick={onSubmit} disabled={tokenName.trim() === '' || isCreating} className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed">
+          {/* Disabled with no scopes: the backend refuses an empty set (a
+              credential that grants nothing is not worth minting), so the form
+              must not let the request be sent to fail. */}
+          <button onClick={onSubmit} disabled={tokenName.trim() === '' || tokenScopes.length === 0 || isCreating} className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed">
             {isCreating ? t('mcp.generating') : t('mcp.generate')}
           </button>
         </div>
@@ -230,9 +270,18 @@ export function TokenRow({
         <Key size={16} className="text-gray-400 flex-shrink-0" />
         <div className="min-w-0">
           <p className="text-sm font-medium truncate">{token.name}</p>
-          <div className="flex items-center gap-3 text-xs text-gray-500 mt-0.5">
-            <span className={clsx('inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium', token.scope === 'read' ? 'bg-blue-50 text-blue-700' : 'bg-amber-50 text-amber-700')}>
-              <Shield size={10} />{token.scope}
+          <div className="flex items-center gap-3 text-xs text-gray-500 mt-0.5 flex-wrap">
+            {/* Reach is badged, and amber when it is workspace-wide: that is
+                the default, so the list is where someone notices a credential
+                reaches further than they assumed. */}
+            <span className={clsx(
+              'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium',
+              token.read_reach === 'workspace' ? 'bg-amber-50 text-amber-700' : 'bg-blue-50 text-blue-700',
+            )}>
+              <Shield size={10} />{t(`mcp.reachBadge.${token.read_reach}`)}
+            </span>
+            <span className="font-mono text-[10px] text-gray-500">
+              {token.scopes.length > 0 ? token.scopes.join(' ') : t('mcp.noScopes')}
             </span>
             <span className="flex items-center gap-1"><Clock size={10} />{t('mcp.createdDate', { date: new Date(token.created_at).toLocaleDateString() })}</span>
             {token.last_used_at != null && token.last_used_at !== '' ? <span className="text-gray-400">{t('mcp.lastUsed', { date: new Date(token.last_used_at).toLocaleDateString() })}</span> : null}

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import McpAccessTab from './McpAccessTab'
@@ -392,8 +392,13 @@ describe('McpAccessTab', () => {
     expect(screen.getByText('Read dashboards and metric breakdowns')).toBeInTheDocument()
     expect(screen.getByText('Read projects, personas and documents')).toBeInTheDocument()
 
-    // And the fallback string must not appear on its own anywhere.
-    expect(screen.queryAllByText('read')).toHaveLength(0)
+    // The fallback fragment must not appear WITHIN THE SCOPE FIELDSET. Scoped
+    // deliberately: an unscoped `queryAllByText('read')` is an exact full-text
+    // match over the whole page, so any unrelated element that ever normalizes
+    // to "read" would fail this test for a reason that has nothing to do with
+    // it — a false alarm is worse than no alarm.
+    const fieldset = screen.getByRole('group', { name: /Scopes/i })
+    expect(within(fieldset).queryAllByText('read')).toHaveLength(0)
   })
 
   it('starts with no scope checked and cannot submit until one is', async () => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -120,9 +120,26 @@ const mockToken: ApiToken = {
   last_used_at: '2026-03-21T15:00:00Z',
 }
 
-/** The payload the form sends when nothing is customised. */
+const ALL_SCOPES = ['feedback:read', 'metrics:read', 'projects:read'] as const
+
+/**
+ * Tick scope checkboxes. The form starts with NONE checked on purpose — the
+ * mint route requires `scopes` so the laziest request cannot mint the widest
+ * credential, and a pre-checked form would defeat that — so every test that
+ * submits has to choose explicitly, exactly as a user does.
+ */
+async function selectScopes(
+  user: ReturnType<typeof userEvent.setup>,
+  scopes: readonly string[] = ALL_SCOPES,
+) {
+  for (const scope of scopes) {
+    await user.click(screen.getByRole('checkbox', { name: new RegExp(scope) }))
+  }
+}
+
+/** The payload the form sends when every scope is ticked and reach is left alone. */
 const DEFAULT_MINT_BODY = {
-  scopes: ['feedback:read', 'metrics:read', 'projects:read'],
+  scopes: [...ALL_SCOPES],
   read_reach: 'workspace',
 }
 
@@ -181,11 +198,12 @@ describe('McpAccessTab', () => {
     expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled()
   })
 
-  it('enables Generate button when name is provided', async () => {
+  it('needs both a name and a scope before Generate enables', async () => {
     const user = userEvent.setup()
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Test token')
+    await selectScopes(user)
     expect(screen.getByRole('button', { name: 'Generate' })).toBeEnabled()
   })
 
@@ -200,6 +218,7 @@ describe('McpAccessTab', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Test token')
+    await selectScopes(user)
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     await waitFor(() => {
@@ -272,6 +291,7 @@ describe('McpAccessTab', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Test')
+    await selectScopes(user)
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     await waitFor(() => {
@@ -301,6 +321,7 @@ describe('McpAccessTab', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Test')
+    await selectScopes(user)
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     await waitFor(() => {
@@ -321,9 +342,9 @@ describe('McpAccessTab', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Narrow')
-    // Dropping projects:read is the point of per-domain scopes: a credential
-    // that reads feedback without reading anybody's product strategy.
-    await user.click(screen.getByRole('checkbox', { name: /projects:read/ }))
+    // Ticking only two is the point of per-domain scopes: a credential that
+    // reads feedback without reading anybody's product strategy.
+    await selectScopes(user, ['feedback:read', 'metrics:read'])
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     await waitFor(() => {
@@ -345,6 +366,7 @@ describe('McpAccessTab', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Sealed')
+    await selectScopes(user)
     await user.selectOptions(screen.getByLabelText('Read reach'), 'project-set')
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
@@ -355,17 +377,23 @@ describe('McpAccessTab', () => {
     })
   })
 
-  it('cannot submit with every scope unchecked', async () => {
+  it('starts with no scope checked and cannot submit until one is', async () => {
     const user = userEvent.setup()
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Empty')
-    for (const scope of ['feedback:read', 'metrics:read', 'projects:read']) {
-      await user.click(screen.getByRole('checkbox', { name: new RegExp(scope) }))
+
+    // No scope is pre-selected: the backend requires `scopes` precisely so the
+    // laziest request cannot mint the widest credential, and a pre-checked form
+    // would hand that default back, making the requirement enforcement-only.
+    for (const scope of ALL_SCOPES) {
+      expect(screen.getByRole('checkbox', { name: new RegExp(scope) })).not.toBeChecked()
     }
-    // The backend refuses an empty scope set (a credential granting nothing is
-    // not worth minting), so the form must not send one to fail.
     expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled()
+
+    // One tick is enough to proceed — the friction is a choice, not a wall.
+    await selectScopes(user, ['feedback:read'])
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeEnabled()
     expect(mockCreateApiToken).not.toHaveBeenCalled()
   })
 
@@ -543,6 +571,7 @@ describe('token expiry', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 'Expiring token')
+    await selectScopes(user)
     await user.selectOptions(screen.getByLabelText('Expiration'), '30')
     await user.click(screen.getByRole('button', { name: 'Generate' }))
     await waitFor(() => {
@@ -567,6 +596,7 @@ describe('token expiry', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     await user.type(screen.getByLabelText('Token name'), 't')
+    await selectScopes(user)
     await user.selectOptions(screen.getByLabelText('Expiration'), '90')
     await user.click(screen.getByRole('button', { name: 'Generate' }))
     await waitFor(() => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import McpAccessTab from './McpAccessTab'
-import type { Project } from '../../api/types'
+import type { ApiToken, Project } from '../../api/types'
 
 // Mock the API client
 const mockListApiTokens = vi.fn()

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -110,13 +110,20 @@ async function deselectEverySection(user: ReturnType<typeof userEvent.setup>) {
   throw new Error('Deselect all never stopped appearing — the bulk control is not flipping state')
 }
 
-const mockToken = {
+const mockToken: ApiToken = {
   token_id: 'tok-1',
   name: 'My Kiro token',
-  scope: 'read' as const,
+  scopes: ['feedback:read', 'metrics:read', 'projects:read'],
+  projects: ['proj-123'],
+  read_reach: 'workspace',
   created_at: '2026-03-20T10:00:00Z',
   last_used_at: '2026-03-21T15:00:00Z',
-  project_id: 'proj-123',
+}
+
+/** The payload the form sends when nothing is customised. */
+const DEFAULT_MINT_BODY = {
+  scopes: ['feedback:read', 'metrics:read', 'projects:read'],
+  read_reach: 'workspace',
 }
 
 describe('McpAccessTab', () => {
@@ -152,7 +159,7 @@ describe('McpAccessTab', () => {
     // Expand the collapsible list
     await user.click(screen.getByText('Active Tokens (1)'))
     expect(screen.getByText('My Kiro token')).toBeInTheDocument()
-    expect(screen.getByText('read')).toBeInTheDocument()
+    expect(screen.getByText('Whole workspace')).toBeInTheDocument()
   })
 
   it('shows create form when Generate Token is clicked', async () => {
@@ -160,7 +167,10 @@ describe('McpAccessTab', () => {
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
     expect(screen.getByLabelText('Token name')).toBeInTheDocument()
-    expect(screen.getByLabelText('Scope')).toBeInTheDocument()
+    // Two independent axes, so two controls: scopes (which data) and reach
+    // (how far). One select could not express "write here, read everywhere".
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3)
+    expect(screen.getByLabelText('Read reach')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument()
   })
 
@@ -195,7 +205,9 @@ describe('McpAccessTab', () => {
     await waitFor(() => {
       expect(screen.getByText('Token created successfully')).toBeInTheDocument()
     })
-    expect(mockCreateApiToken).toHaveBeenCalledWith('proj-123', { name: 'Test token', scope: 'read' })
+    expect(mockCreateApiToken).toHaveBeenCalledWith('proj-123', {
+      name: 'Test token', ...DEFAULT_MINT_BODY,
+    })
   })
 
   it('hides create form on cancel', async () => {
@@ -222,14 +234,17 @@ describe('McpAccessTab', () => {
     expect(mockDeleteApiToken).toHaveBeenCalledWith('proj-123', 'tok-1')
   })
 
-  it('renders MCP config snippet with project ID', async () => {
+  it('renders an MCP config snippet with no X-Project-Id header', async () => {
     const user = userEvent.setup()
     renderTab()
     expect(screen.getByText('MCP Client Configuration')).toBeInTheDocument()
     // Expand the MCP Client Configuration section
     await user.click(screen.getByText('MCP Client Configuration'))
-    const pre = screen.getByText(/X-Project-Id/)
-    expect(pre).toBeInTheDocument()
+    // The credential resolves itself now, so the snippet carries only the
+    // Authorization header. Leaving X-Project-Id in would have people paste a
+    // contract the server ignores.
+    expect(screen.getByText(/Bearer <YOUR_API_TOKEN>/)).toBeInTheDocument()
+    expect(screen.queryByText(/X-Project-Id/)).not.toBeInTheDocument()
   })
 
   it('copies MCP config to clipboard', async () => {
@@ -296,23 +311,87 @@ describe('McpAccessTab', () => {
     expect(screen.queryByText('Token created successfully')).not.toBeInTheDocument()
   })
 
-  it('allows selecting read-write scope', async () => {
+  it('mints a narrower credential when a scope is unchecked', async () => {
     const user = userEvent.setup()
     mockCreateApiToken.mockResolvedValue({
-      success: true,
-      token: 'voc_rw',
-      token_id: 'tok-rw',
-      name: 'RW token',
+      token: 'voc_tok_aaaaaaaaaaaaaaaa_narrow', token_id: 'tok-narrow', name: 'Narrow',
+      scopes: ['feedback:read', 'metrics:read'], projects: ['proj-123'],
+      read_reach: 'workspace',
     })
     renderTab()
     await user.click(screen.getByRole('button', { name: /Generate Token/i }))
-    await user.type(screen.getByLabelText('Token name'), 'RW token')
-    await user.selectOptions(screen.getByLabelText('Scope'), 'read-write')
+    await user.type(screen.getByLabelText('Token name'), 'Narrow')
+    // Dropping projects:read is the point of per-domain scopes: a credential
+    // that reads feedback without reading anybody's product strategy.
+    await user.click(screen.getByRole('checkbox', { name: /projects:read/ }))
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     await waitFor(() => {
-      expect(mockCreateApiToken).toHaveBeenCalledWith('proj-123', { name: 'RW token', scope: 'read-write' })
+      expect(mockCreateApiToken).toHaveBeenCalledWith('proj-123', {
+        name: 'Narrow',
+        scopes: ['feedback:read', 'metrics:read'],
+        read_reach: 'workspace',
+      })
     })
+  })
+
+  it('mints a sealed credential when the reach is narrowed', async () => {
+    const user = userEvent.setup()
+    mockCreateApiToken.mockResolvedValue({
+      token: 'voc_tok_bbbbbbbbbbbbbbbb_sealed', token_id: 'tok-sealed', name: 'Sealed',
+      scopes: ['feedback:read', 'metrics:read', 'projects:read'],
+      projects: ['proj-123'], read_reach: 'project-set',
+    })
+    renderTab()
+    await user.click(screen.getByRole('button', { name: /Generate Token/i }))
+    await user.type(screen.getByLabelText('Token name'), 'Sealed')
+    await user.selectOptions(screen.getByLabelText('Read reach'), 'project-set')
+    await user.click(screen.getByRole('button', { name: 'Generate' }))
+
+    await waitFor(() => {
+      expect(mockCreateApiToken).toHaveBeenCalledWith('proj-123', {
+        name: 'Sealed', ...DEFAULT_MINT_BODY, read_reach: 'project-set',
+      })
+    })
+  })
+
+  it('cannot submit with every scope unchecked', async () => {
+    const user = userEvent.setup()
+    renderTab()
+    await user.click(screen.getByRole('button', { name: /Generate Token/i }))
+    await user.type(screen.getByLabelText('Token name'), 'Empty')
+    for (const scope of ['feedback:read', 'metrics:read', 'projects:read']) {
+      await user.click(screen.getByRole('checkbox', { name: new RegExp(scope) }))
+    }
+    // The backend refuses an empty scope set (a credential granting nothing is
+    // not worth minting), so the form must not send one to fail.
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled()
+    expect(mockCreateApiToken).not.toHaveBeenCalled()
+  })
+
+  it('says out loud that the default reach is workspace-wide', async () => {
+    const user = userEvent.setup()
+    renderTab()
+    await user.click(screen.getByRole('button', { name: /Generate Token/i }))
+    // The default is the WIDEST option, so the form has to say so rather than
+    // presenting the choices as equivalent. This is the UI half of the owner's
+    // read-reach decision.
+    expect(screen.getByLabelText('Read reach')).toHaveValue('workspace')
+    expect(screen.getByText(/every project/i)).toBeInTheDocument()
+  })
+
+  it('badges a workspace-reach token in the list', async () => {
+    const user = userEvent.setup()
+    mockListApiTokens.mockResolvedValue({ tokens: [mockToken] })
+    renderTab()
+    await waitFor(() => {
+      expect(screen.getByText('Active Tokens (1)')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Active Tokens (1)'))
+    // The list is where someone notices a credential reaches further than they
+    // assumed, so the reach is shown per row, not only at mint time.
+    expect(screen.getByText('Whole workspace')).toBeInTheDocument()
+    expect(screen.getByText(/feedback:read/)).toBeInTheDocument()
   })
 
   it('shows last used date when available', async () => {
@@ -471,7 +550,7 @@ describe('token expiry', () => {
     })
     expect(mockCreateApiToken).toHaveBeenCalledWith('proj-123', {
       name: 'Expiring token',
-      scope: 'read',
+      ...DEFAULT_MINT_BODY,
       expires_in_days: 30,
     })
     // The banner names the deadline of THE credential just minted.

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.test.tsx
@@ -377,6 +377,25 @@ describe('McpAccessTab', () => {
     })
   })
 
+  it('renders each scope description, not an i18n fallback', async () => {
+    const user = userEvent.setup()
+    renderTab()
+    await user.click(screen.getByRole('button', { name: /Generate Token/i }))
+
+    // Regression: scope names contain a COLON, which is i18next's default
+    // namespace separator, so `t('mcp.scopeDesc.feedback:read')` was parsed as
+    // namespace `mcp.scopeDesc.feedback` + key `read`, resolved to nothing, and
+    // rendered the literal "read" under every checkbox. Found in a browser
+    // against the deployed site; invisible here until something asserted the
+    // description text, because the key still "resolved" to a plausible word.
+    expect(screen.getByText('Search and read customer feedback')).toBeInTheDocument()
+    expect(screen.getByText('Read dashboards and metric breakdowns')).toBeInTheDocument()
+    expect(screen.getByText('Read projects, personas and documents')).toBeInTheDocument()
+
+    // And the fallback string must not appear on its own anywhere.
+    expect(screen.queryAllByText('read')).toHaveLength(0)
+  })
+
   it('starts with no scope checked and cannot submit until one is', async () => {
     const user = userEvent.setup()
     renderTab()

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -47,6 +47,10 @@ import {
 } from './McpAccessComponents'
 import type { TokenExpiryChoice } from './tokenExpiry'
 import {
+  DEFAULT_READ_REACH, DEFAULT_SCOPES, MCP_SCOPES,
+  type McpScope, type ReadReach,
+} from '../../api/mcpTokenSchema'
+import {
   PickerSection, CheckboxItem,
 } from './PickerComponents'
 import type {
@@ -69,15 +73,21 @@ interface McpAccessTabProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Always uses a placeholder — the real token is never embedded. */
-function buildMcpConfig(baseUrl: string, projectId: string): string {
+/**
+ * Always uses a placeholder — the real token is never embedded.
+ *
+ * No `X-Project-Id` header any more: the credential carries its own id, so the
+ * server resolves it with one keyed read and the project comes from the
+ * credential's own reach (or a tool argument). Leaving the header in the
+ * snippet would have people paste a contract the server ignores.
+ */
+function buildMcpConfig(baseUrl: string): string {
   return JSON.stringify({
     mcpServers: {
       'voc-datalake': {
         url: `${baseUrl}/mcp`,
         headers: {
           Authorization: 'Bearer <YOUR_API_TOKEN>',
-          'X-Project-Id': projectId,
         },
       },
     },
@@ -123,7 +133,7 @@ function groupDocumentsByType(documents: ProjectDocument[]): Record<KiroExportab
 // Hooks
 // ---------------------------------------------------------------------------
 
-function useTokenMutations(projectId: string, tokenName: string, tokenScope: 'read' | 'read-write', tokenExpiry: TokenExpiryChoice, onCreateSuccess: () => void) {
+function useTokenMutations(projectId: string, tokenName: string, tokenScopes: McpScope[], tokenReach: ReadReach, tokenExpiry: TokenExpiryChoice, onCreateSuccess: () => void) {
   const queryClient = useQueryClient()
   const [newlyCreatedToken, setNewlyCreatedToken] = useState<string | null>(null)
   // Deadline echoed by the create response, shown on the one-time banner.
@@ -136,7 +146,8 @@ function useTokenMutations(projectId: string, tokenName: string, tokenScope: 're
   const createMut = useMutation({
     mutationFn: () => api.createApiToken(projectId, {
       name: tokenName,
-      scope: tokenScope,
+      scopes: tokenScopes,
+      read_reach: tokenReach,
       // 'never' omits the field entirely — the backend reads absence as a
       // non-expiring token, and sending null would be refused (strict 400).
       ...(tokenExpiry === 'never' ? {} : { expires_in_days: Number(tokenExpiry) }),
@@ -537,7 +548,8 @@ export default function McpAccessTab({
 
   // ── MCP token state ───────────────────────────────────────────────────────
   const [tokenName, setTokenName] = useState('')
-  const [tokenScope, setTokenScope] = useState<'read' | 'read-write'>('read')
+  const [tokenScopes, setTokenScopes] = useState<McpScope[]>([...DEFAULT_SCOPES])
+  const [tokenReach, setTokenReach] = useState<ReadReach>(DEFAULT_READ_REACH)
   const [tokenExpiry, setTokenExpiry] = useState<TokenExpiryChoice>('never')
   const {
     copy, copiedKey: copiedId,
@@ -552,11 +564,21 @@ export default function McpAccessTab({
     createMut, deleteMut, newlyCreatedToken, setNewlyCreatedToken,
     newTokenExpiresAt, setNewTokenExpiresAt,
     showToken, setShowToken, showCreateForm, setShowCreateForm,
-  } = useTokenMutations(projectId, tokenName, tokenScope, tokenExpiry, () => {
+  } = useTokenMutations(projectId, tokenName, tokenScopes, tokenReach, tokenExpiry, () => {
     setTokenName('')
-    setTokenScope('read')
+    setTokenScopes([...DEFAULT_SCOPES])
+    setTokenReach(DEFAULT_READ_REACH)
     setTokenExpiry('never')
   })
+
+  /** Toggle one scope, keeping the vocabulary's order so the row reads stably. */
+  const toggleScope = useCallback((scope: McpScope) => {
+    setTokenScopes((prev) => (
+      prev.includes(scope)
+        ? prev.filter((s) => s !== scope)
+        : MCP_SCOPES.filter((s) => s === scope || prev.includes(s))
+    ))
+  }, [])
 
   const {
     data, isLoading, isError,
@@ -571,7 +593,7 @@ export default function McpAccessTab({
 
   const baseUrl = (config.apiEndpoint === '' ? 'https://<api-gateway-url>' : config.apiEndpoint).replace(/\/$/, '')
   const tokens = data?.tokens ?? []
-  const mcpConfig = buildMcpConfig(baseUrl, projectId)
+  const mcpConfig = buildMcpConfig(baseUrl)
 
   // Whether the user has at least one persona or document selected
   // The SAME rule as the Export card, not an OR over the two sections: the curl
@@ -673,12 +695,14 @@ export default function McpAccessTab({
 
         {showCreateForm ? <CreateTokenForm
           tokenName={tokenName}
-          tokenScope={tokenScope}
+          tokenScopes={tokenScopes}
+          tokenReach={tokenReach}
           tokenExpiry={tokenExpiry}
           isCreating={createMut.isPending}
           error={createMut.error?.message}
           onNameChange={setTokenName}
-          onScopeChange={setTokenScope}
+          onToggleScope={toggleScope}
+          onReachChange={setTokenReach}
           onExpiryChange={setTokenExpiry}
           onSubmit={() => createMut.mutate()}
           onCancel={() => {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/McpAccessTab.tsx
@@ -47,7 +47,7 @@ import {
 } from './McpAccessComponents'
 import type { TokenExpiryChoice } from './tokenExpiry'
 import {
-  DEFAULT_READ_REACH, DEFAULT_SCOPES, MCP_SCOPES,
+  DEFAULT_READ_REACH, MCP_SCOPES,
   type McpScope, type ReadReach,
 } from '../../api/mcpTokenSchema'
 import {
@@ -548,7 +548,11 @@ export default function McpAccessTab({
 
   // ── MCP token state ───────────────────────────────────────────────────────
   const [tokenName, setTokenName] = useState('')
-  const [tokenScopes, setTokenScopes] = useState<McpScope[]>([...DEFAULT_SCOPES])
+  // Starts EMPTY, not pre-checked. The mint route requires `scopes` so that
+  // omitting them cannot yield the widest credential; pre-checking everything
+  // here would hand that default straight back and make the requirement
+  // enforcement-only. Generate stays disabled until a scope is chosen.
+  const [tokenScopes, setTokenScopes] = useState<McpScope[]>([])
   const [tokenReach, setTokenReach] = useState<ReadReach>(DEFAULT_READ_REACH)
   const [tokenExpiry, setTokenExpiry] = useState<TokenExpiryChoice>('never')
   const {
@@ -566,7 +570,7 @@ export default function McpAccessTab({
     showToken, setShowToken, showCreateForm, setShowCreateForm,
   } = useTokenMutations(projectId, tokenName, tokenScopes, tokenReach, tokenExpiry, () => {
     setTokenName('')
-    setTokenScopes([...DEFAULT_SCOPES])
+    setTokenScopes([])
     setTokenReach(DEFAULT_READ_REACH)
     setTokenExpiry('never')
   })

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -958,6 +958,20 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
     tool_name = params.get('name', '')
     arguments = params.get('arguments', {})
 
+    # `arguments` is caller-controlled JSON and is NOT guaranteed to be an
+    # object. A list, string or number reaches the project resolution below,
+    # where both `'project_id' in args` and `args['project_id']` raise
+    # TypeError — and that resolution runs OUTSIDE the try/except around the
+    # handler, so it escapes as a 502 with no JSON-RPC envelope and no CORS
+    # headers. Refused here at the boundary, which is the same lesson the
+    # BotoCoreError clause in _authenticate records: an unhandled type is a
+    # protocol-level 400, not a server crash.
+    if not isinstance(arguments, dict):
+        return _jsonrpc_error(
+            req_id, -32602,
+            f"'arguments' must be an object, got {type(arguments).__name__}",
+        )
+
     handler = TOOL_HANDLERS.get(tool_name)
     if not handler:
         return _jsonrpc_error(req_id, -32602, f"Unknown tool: {tool_name}")
@@ -1009,9 +1023,12 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         # The refusals read differently because they need different fixes: one
         # wants an argument, the other wants a differently-scoped token.
         #
-        # Reach is checked FIRST. A `none`-reach token can never call anything,
-        # so telling it to supply a project_id would send the caller after an
-        # argument that cannot help — the ordering here is the whole point.
+        # Ordering, precisely — a MALFORMED argument is reported earlier, by
+        # _resolve_project_id, because an ill-formed request is ill-formed
+        # whatever the token's reach (syntax before authorization, as everywhere
+        # else). What is checked reach-first is the MISSING-argument case below:
+        # a `none`-reach token can never call anything, so asking it for a
+        # project_id would send the caller after an argument that cannot help.
         reach_covers_nothing = (
             read_reach == REACH_NONE
             or (read_reach == REACH_PROJECT_SET and tool_reach_kind == REACH_KIND_WORKSPACE)

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -27,6 +27,8 @@ from shared.mcp_tokens import (
     MCP_TOKEN_PK,
     REACH_KIND_PROJECT,
     REACH_KIND_WORKSPACE,
+    REACH_NONE,
+    REACH_PROJECT_SET,
     SCOPE_FEEDBACK_READ,
     SCOPE_METRICS_READ,
     SCOPE_PROJECTS_READ,
@@ -916,6 +918,10 @@ def _scope_allows(token_scopes: Any, required_scope: str) -> bool:
     return required_scope in token_scopes
 
 
+class InvalidProjectArgument(Exception):
+    """`project_id` was supplied but is not a usable project id."""
+
+
 def _resolve_project_id(args: dict, token_info: dict) -> str | None:
     """Which project a project-shaped tool is addressing, or None.
 
@@ -924,9 +930,21 @@ def _resolve_project_id(args: dict, token_info: dict) -> str | None:
     minted from a project — so single-project clients need not pass it. An
     ambiguous default (a set with several projects) resolves to None rather
     than picking one, which the caller sees as a request to name the project.
+
+    🔑 A PRESENT but unusable argument (`123`, `["p"]`, `"  "`) RAISES rather
+    than falling back to the token's project. Falling back would read a
+    *different* project than the client named and report success, which is worse
+    than an error: the caller gets someone else's data believing it is the
+    project they asked for. Absence and garbage are different intents and get
+    different answers.
     """
-    explicit = args.get('project_id')
-    if isinstance(explicit, str) and explicit.strip():
+    if 'project_id' in args:
+        explicit = args['project_id']
+        if not isinstance(explicit, str) or not explicit.strip():
+            raise InvalidProjectArgument(
+                f'project_id must be a non-empty string, got '
+                f'{type(explicit).__name__}'
+            )
         return explicit.strip()
     token_projects = token_info.get('projects')
     if isinstance(token_projects, (list, tuple)) and len(token_projects) == 1:
@@ -975,7 +993,12 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
     # `projects:read` and still be refused a particular project.
     read_reach = token_info.get('read_reach') or DEFAULT_READ_REACH
     token_projects = token_info.get('projects') or []
-    project_id = _resolve_project_id(arguments, token_info) if tool_reach_kind == REACH_KIND_PROJECT else None
+    project_id = None
+    if tool_reach_kind == REACH_KIND_PROJECT:
+        try:
+            project_id = _resolve_project_id(arguments, token_info)
+        except InvalidProjectArgument as exc:
+            return _jsonrpc_error(req_id, -32602, str(exc))
 
     if not reach_allows(
         read_reach=read_reach,
@@ -983,9 +1006,17 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         tool_reach_kind=tool_reach_kind,
         project_id=project_id,
     ):
-        # The two refusals read differently because they need different fixes:
-        # one wants an argument, the other wants a differently-scoped token.
-        if tool_reach_kind == REACH_KIND_PROJECT and not project_id:
+        # The refusals read differently because they need different fixes: one
+        # wants an argument, the other wants a differently-scoped token.
+        #
+        # Reach is checked FIRST. A `none`-reach token can never call anything,
+        # so telling it to supply a project_id would send the caller after an
+        # argument that cannot help — the ordering here is the whole point.
+        reach_covers_nothing = (
+            read_reach == REACH_NONE
+            or (read_reach == REACH_PROJECT_SET and tool_reach_kind == REACH_KIND_WORKSPACE)
+        )
+        if tool_reach_kind == REACH_KIND_PROJECT and not project_id and not reach_covers_nothing:
             return _jsonrpc_error(
                 req_id, -32602,
                 f"'{tool_name}' needs a project_id argument: this token's project "

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -958,14 +958,23 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
     tool_name = params.get('name', '')
     arguments = params.get('arguments', {})
 
-    # `arguments` is caller-controlled JSON and is NOT guaranteed to be an
-    # object. A list, string or number reaches the project resolution below,
-    # where both `'project_id' in args` and `args['project_id']` raise
-    # TypeError — and that resolution runs OUTSIDE the try/except around the
-    # handler, so it escapes as a 502 with no JSON-RPC envelope and no CORS
-    # headers. Refused here at the boundary, which is the same lesson the
-    # BotoCoreError clause in _authenticate records: an unhandled type is a
-    # protocol-level 400, not a server crash.
+    # An explicit `"arguments": null` means "no arguments", not "bad request".
+    # `params.get('arguments', {})` cannot supply the default for it, because the
+    # KEY IS PRESENT — and some JSON-RPC/MCP clients serialize an omitted
+    # optional object as null rather than dropping it. Every tool here has only
+    # optional arguments, so `{}` is exactly what such a caller meant; refusing
+    # it would be a compatibility edge invented by this guard rather than a real
+    # protocol error.
+    if arguments is None:
+        arguments = {}
+
+    # Anything else non-object is genuinely malformed. A list, string or number
+    # reaches the project resolution below, where both `'project_id' in args` and
+    # `args['project_id']` raise TypeError — and that resolution runs OUTSIDE the
+    # try/except around the handler, so it escapes as a 502 with no JSON-RPC
+    # envelope and no CORS headers. Refused here at the boundary, which is the
+    # same lesson the BotoCoreError clause in _authenticate records: an unhandled
+    # type is a protocol-level error, not a server crash.
     if not isinstance(arguments, dict):
         return _jsonrpc_error(
             req_id, -32602,

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -9,7 +9,6 @@ Public endpoint — no Cognito auth. Auth is handled by validating the Bearer to
 from the Authorization header against SHA-256 hashes in the projects table.
 """
 
-import hmac
 import json
 import os
 import re
@@ -24,7 +23,19 @@ from botocore import exceptions as botocore_exceptions
 from shared.aws import get_dynamodb_resource
 from shared.api import DecimalEncoder, validate_date_basis
 from shared.feedback import query_feedback_by_date
-from shared.tokens import hash_token
+from shared.mcp_tokens import (
+    MCP_TOKEN_PK,
+    REACH_KIND_PROJECT,
+    REACH_KIND_WORKSPACE,
+    SCOPE_FEEDBACK_READ,
+    SCOPE_METRICS_READ,
+    SCOPE_PROJECTS_READ,
+    DEFAULT_READ_REACH,
+    parse_token,
+    reach_allows,
+    secret_matches,
+    token_sk,
+)
 from shared.tables import get_projects_table, get_feedback_table, get_aggregates_table
 from shared.indexes import FEEDBACK_BY_ID_INDEX
 from projects import autoseed_project
@@ -44,8 +55,9 @@ aggregates_table = get_aggregates_table()
 # MCP Protocol version
 MCP_PROTOCOL_VERSION = "2024-11-05"
 
-# Token prefix used during generation
-TOKEN_PREFIX = 'voc_'
+# The credential format lives in shared/mcp_tokens.py — this module does not
+# spell the prefix. It used to, as did projects_handler and an inline authorizer
+# in api-stack.ts, three copies of one rule.
 
 # The one origin a BROWSER may present. Not a CORS setting (see CORS_HEADERS
 # below) — it is the allowlist for the MCP spec's DNS-rebinding guard, which
@@ -61,7 +73,10 @@ ALLOWED_ORIGIN = os.environ.get('ALLOWED_ORIGIN', '')
 
 CORS_HEADERS = {
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Project-Id',
+    # X-Project-Id is gone: the credential carries its own project reach, so a
+    # client has no reason to send it and allowing it would keep a dead contract
+    # looking alive.
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
     'Access-Control-Allow-Methods': 'POST,OPTIONS',
     # Without this a BROWSER-based MCP client can receive the 401 challenge but
     # never read it: WWW-Authenticate is not a CORS-safelisted response header.
@@ -212,16 +227,19 @@ def _authenticate(event: dict) -> dict | None:
     headers = event.get('headers', {})
     # API Gateway lowercases header names in proxy mode
     auth_header = headers.get('authorization') or headers.get('Authorization') or ''
-    project_id = headers.get('x-project-id') or headers.get('X-Project-Id') or ''
 
-    if not auth_header.startswith('Bearer ') or not project_id:
+    if not auth_header.startswith('Bearer '):
         return None
 
-    raw_token = auth_header[7:]  # strip "Bearer "
-    if not raw_token.startswith(TOKEN_PREFIX):
+    # NO X-Project-Id. The credential carries its own id, so the lookup is one
+    # keyed read instead of "Query a project's token rows and hash each one" —
+    # which is what required the header, and what made a workspace-wide tool
+    # such as list_projects unimplementable. Parsing is strict, so malformed
+    # caller text never becomes a key lookup.
+    parsed = parse_token(auth_header[7:])  # strip "Bearer "
+    if not parsed:
         return None
-
-    token_hash = hash_token(raw_token)
+    token_id, presented_secret = parsed
 
     if not projects_table:
         # An unset PROJECTS_TABLE is the same class of fault as a missing table
@@ -232,11 +250,15 @@ def _authenticate(event: dict) -> dict | None:
         logger.error("Projects table not configured")
         raise AuthBackendUnavailable('projects table not configured')
 
-    # Query all tokens for this project and find matching hash
+    # ONE item, addressed by the id inside the credential. A Query with an
+    # exact sort key rather than get_item on purpose: it is the same single-item
+    # read, and it keeps the IAM grant at exactly Query + UpdateItem — the
+    # narrowed grant that makes this bearer-token-reachable function unable to
+    # write project artifacts. Adding GetItem would widen it for no gain.
     try:
         response = projects_table.query(
             KeyConditionExpression=(
-                Key('pk').eq(f'PROJECT#{project_id}') & Key('sk').begins_with('TOKEN#')
+                Key('pk').eq(MCP_TOKEN_PK) & Key('sk').eq(token_sk(token_id))
             ),
         )
     except botocore_exceptions.ClientError as exc:
@@ -289,44 +311,60 @@ def _authenticate(event: dict) -> dict | None:
         )
         raise AuthBackendUnavailable(error_type) from exc
 
-    for item in response.get('Items', []):
-        stored_hash = item.get('token_hash', '')
-        # Guard against malformed/migrated rows where token_hash is stored as
-        # a non-string type (Binary, Decimal, …).  Calling .encode() on such a
-        # value would raise AttributeError and turn one bad row into a 500 for
-        # every request in that project.  Skip the row and log so an operator
-        # can clean it up, but do not expose the value itself.
-        if not isinstance(stored_hash, str):
-            logger.warning(
-                'Unexpected token_hash type in DynamoDB item; skipping row',
-                extra={'type': type(stored_hash).__name__},
-            )
-            continue
-        # Constant-time comparison prevents timing-based hash enumeration.
-        # Both operands must be the same type (str); encode to bytes so
-        # compare_digest can work even if one value is unexpectedly empty.
-        if hmac.compare_digest(stored_hash.encode(), token_hash.encode()):
-            # Checked AFTER the hash match — only the matching row's expiry
-            # matters, and non-matching rows must not influence timing.
-            if _credential_expired(item):
-                return None
-            # Update last_used_at
-            try:
-                projects_table.update_item(
-                    Key={'pk': f'PROJECT#{project_id}', 'sk': item['sk']},
-                    UpdateExpression='SET last_used_at = :now',
-                    ExpressionAttributeValues={':now': datetime.now(timezone.utc).isoformat()},
-                )
-            except Exception as e:
-                logger.warning(f"Failed to update last_used_at: {e}")
-            return {**item, 'project_id': project_id}
+    items = response.get('Items', [])
+    if not items:
+        # No such token id. Indistinguishable to the caller from a wrong
+        # secret: both are a plain 401.
+        return None
+    item = items[0]
 
-    return None
+    stored_hash = item.get('secret_hash', '')
+    # Guard against a malformed row where secret_hash is stored as a non-string
+    # type (Binary, Decimal, …). Calling .encode() on such a value would raise
+    # AttributeError and turn one bad row into a 500 instead of a 401. Log the
+    # type so an operator can clean it up, never the value.
+    if not isinstance(stored_hash, str):
+        logger.warning(
+            'Unexpected secret_hash type in DynamoDB item; refusing credential',
+            extra={'type': type(stored_hash).__name__, 'token_id': item.get('token_id', '')},
+        )
+        return None
+
+    # Constant-time, to deny timing-based enumeration of the stored digest.
+    if not secret_matches(presented_secret=presented_secret, stored_hash=stored_hash):
+        return None
+
+    # Checked AFTER the secret matches, so a wrong secret and an expired
+    # credential cost the same work.
+    if _credential_expired(item):
+        return None
+
+    try:
+        projects_table.update_item(
+            Key={'pk': MCP_TOKEN_PK, 'sk': item['sk']},
+            UpdateExpression='SET last_used_at = :now',
+            ExpressionAttributeValues={':now': datetime.now(timezone.utc).isoformat()},
+        )
+    except Exception as e:
+        logger.warning(f"Failed to update last_used_at: {e}")
+
+    return item
 
 
 # ============================================
 # MCP Tool definitions
 # ============================================
+
+# The project argument shared by the project-shaped tools. One definition so
+# the two schemas cannot drift, and so the "optional when unambiguous" rule is
+# stated to clients exactly once.
+_PROJECT_ID_ARG = {
+    "type": "string",
+    "description": (
+        "Which project to read. Optional when this credential names exactly one "
+        "project, in which case that one is used; required otherwise."
+    ),
+}
 
 MCP_TOOLS = [
     {
@@ -400,24 +438,28 @@ MCP_TOOLS = [
     {
         "name": "get_project",
         "description": (
-            "Get details of the current project including personas, documents (PRDs, PR/FAQs), "
-            "and project metadata. The project is determined by the X-Project-Id header."
+            "Get details of a project including personas, documents (PRDs, PR/FAQs), "
+            "and project metadata."
         ),
         "inputSchema": {
             "type": "object",
-            "properties": {},
+            "properties": {
+                "project_id": _PROJECT_ID_ARG,
+            },
             "additionalProperties": False,
         },
     },
     {
         "name": "list_personas",
         "description": (
-            "List all personas for the current project with their demographics, "
+            "List all personas for a project with their demographics, "
             "pain points, goals, and behavioral traits."
         ),
         "inputSchema": {
             "type": "object",
-            "properties": {},
+            "properties": {
+                "project_id": _PROJECT_ID_ARG,
+            },
             "additionalProperties": False,
         },
     },
@@ -623,7 +665,13 @@ def _tool_get_metrics_summary(args: dict, _token_info: dict) -> list[dict]:
 
 @tracer.capture_method
 def _tool_get_project(args: dict, token_info: dict) -> list[dict]:
-    """Get project details including personas and documents."""
+    """Get project details including personas and documents.
+
+    `project_id` is the project _handle_tools_call resolved from the arguments
+    (or the token's single project) AND authorized against the token's read
+    reach. It is not "the token's project" any more — a credential can reach
+    several — so this must not be re-derived here.
+    """
     project_id = token_info['project_id']
 
     if not projects_table:
@@ -673,7 +721,11 @@ def _tool_get_project(args: dict, token_info: dict) -> list[dict]:
 
 @tracer.capture_method
 def _tool_list_personas(args: dict, token_info: dict) -> list[dict]:
-    """List personas with full details."""
+    """List personas with full details.
+
+    `project_id` is resolved and authorized by _handle_tools_call — see
+    _tool_get_project.
+    """
     project_id = token_info['project_id']
 
     if not projects_table:
@@ -758,42 +810,48 @@ TOOL_HANDLERS = {
     "get_feedback_detail": _tool_get_feedback_detail,
 }
 
-# Minimum scope required for each registered tool.
-# "read" — any valid token may call this tool.
-# "read-write" — only tokens with read-write scope may call this tool.
+# The scope each registered tool requires, from the vocabulary in
+# shared/mcp_tokens.py.
 #
-# Every entry in TOOL_HANDLERS MUST appear here.  The dispatch in
-# _handle_tools_call is fail-closed: a tool with no declared scope is
-# rejected rather than defaulting to allowed, so an author who adds a
-# handler without updating this table gets an immediate error at call
-# time rather than an accidentally-public endpoint.
+# Every entry in TOOL_HANDLERS MUST appear here. The dispatch in
+# _handle_tools_call is fail-closed: a tool with no declared scope is rejected
+# rather than defaulting to allowed, so an author who adds a handler without
+# updating this table gets an immediate error at call time rather than an
+# accidentally-public endpoint.
+#
+# Scopes are now per-domain (`feedback:read`, not `read`), so a token can be
+# minted that reads feedback without reading anybody's product strategy. The
+# previous single `read`/`read-write` pair could not express that, and its
+# `read-write` half was a phantom — mintable, stored and badged in the UI while
+# no tool ever required it.
 TOOL_SCOPE_REQUIREMENTS: dict[str, str] = {
-    "search_feedback": "read",
-    "get_metrics_summary": "read",
-    "get_project": "read",
-    "list_personas": "read",
-    "get_feedback_detail": "read",
+    "search_feedback": SCOPE_FEEDBACK_READ,
+    "get_feedback_detail": SCOPE_FEEDBACK_READ,
+    "get_metrics_summary": SCOPE_METRICS_READ,
+    "get_project": SCOPE_PROJECTS_READ,
+    "list_personas": SCOPE_PROJECTS_READ,
 }
 
-# The complete set of valid required-scope values.  Both _scope_allows and
-# _handle_tools_call reference this constant so adding a new scope means one
-# change instead of three.
-_VALID_REQUIRED_SCOPES: frozenset[str] = frozenset({"read", "read-write"})
-
-# Scope assumed for a token row with no usable ``scope`` — the attribute absent,
-# or present but falsy ('', None).
+# How each tool's data is SHAPED, which decides how the token's read_reach
+# applies to it (shared.mcp_tokens.reach_allows).
 #
-# ``scope`` has been validated to be exactly "read" or "read-write" at mint
-# time (projects_handler.api_create_token) but that only constrains *newly*
-# minted rows; it says nothing about rows already sitting in a deployed table.
-# The token *list* path (projects_handler.api_list_tokens) already resolves a
-# missing scope to "read", so the MCP Access tab displays such a row as a
-# working read token.  Defaulting to "read" here as well keeps enforcement and
-# presentation in agreement: a scope-less row behaves exactly as the UI says
-# it does, instead of being shown as usable and then refused on every call.
-# "read" is also the least-privilege choice — it grants nothing beyond what
-# every valid token already has.
-DEFAULT_TOKEN_SCOPE = "read"
+# `workspace` — the data has no project dimension at all. The feedback corpus
+#   is keyed `SOURCE#{platform}` with no project_id, and metrics are workspace
+#   aggregates. A token whose reach is `project-set` therefore cannot call
+#   these: there is nothing to narrow, so allowing them would hand a supposedly
+#   sealed credential the entire verbatim history.
+# `project` — the tool addresses exactly one project, named by a `project_id`
+#   argument (or defaulted from the token's project set when unambiguous), and
+#   that project must be within reach.
+#
+# Also fail-closed: a tool with no declared reach kind is rejected.
+TOOL_REACH_KINDS: dict[str, str] = {
+    "search_feedback": REACH_KIND_WORKSPACE,
+    "get_feedback_detail": REACH_KIND_WORKSPACE,
+    "get_metrics_summary": REACH_KIND_WORKSPACE,
+    "get_project": REACH_KIND_PROJECT,
+    "list_personas": REACH_KIND_PROJECT,
+}
 
 
 # ============================================
@@ -837,22 +895,44 @@ def _handle_tools_list(req_id: Any, _params: dict) -> dict:
     return _jsonrpc_result(req_id, {"tools": MCP_TOOLS})
 
 
-def _scope_allows(token_scope: str, required_scope: str) -> bool:
-    """Return True when *token_scope* satisfies *required_scope*.
+def _scope_allows(token_scopes: Any, required_scope: str) -> bool:
+    """Return True when the token's scope set contains *required_scope*.
 
-    Pure predicate — no side effects.  Callers are responsible for logging
-    when this returns False.
+    Pure predicate — no side effects. Callers are responsible for logging when
+    this returns False.
 
-    "read-write" satisfies both "read" and "read-write".
-    "read" satisfies only "read".
-    Any value not in _VALID_REQUIRED_SCOPES is treated as insufficient.
+    Exact membership, with no hierarchy: scopes are per-domain, so nothing
+    "includes" anything else and there is no ordering to get wrong. A row whose
+    `scopes` is missing or not a list of strings grants NOTHING rather than
+    falling back to a default — the old code defaulted a missing scope to
+    "read" because deployed rows predated the field, but the format change
+    means every row now carries an explicit set, so a row without one is data
+    damage and must not be guessed at.
     """
-    if required_scope not in _VALID_REQUIRED_SCOPES:
+    if not required_scope:
         return False
-    if required_scope == "read":
-        return token_scope in ("read", "read-write")
-    # required_scope == "read-write"
-    return token_scope == "read-write"
+    if not isinstance(token_scopes, (list, tuple, set, frozenset)):
+        return False
+    return required_scope in token_scopes
+
+
+def _resolve_project_id(args: dict, token_info: dict) -> str | None:
+    """Which project a project-shaped tool is addressing, or None.
+
+    Explicit argument wins. Absent, it defaults to the token's project set when
+    that set names exactly one project — the common case, since a token is
+    minted from a project — so single-project clients need not pass it. An
+    ambiguous default (a set with several projects) resolves to None rather
+    than picking one, which the caller sees as a request to name the project.
+    """
+    explicit = args.get('project_id')
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    token_projects = token_info.get('projects')
+    if isinstance(token_projects, (list, tuple)) and len(token_projects) == 1:
+        only = token_projects[0]
+        return only if isinstance(only, str) and only else None
+    return None
 
 
 def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
@@ -871,34 +951,62 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         logger.error("Tool has no declared scope requirement", extra={"tool": tool_name})
         return _jsonrpc_error(req_id, -32603, f"Tool {tool_name} has no declared scope requirement")
 
-    # A token row with no usable `scope` — the attribute absent (it predates the
-    # field) or present but empty/falsy (a partial write, a migration that wrote
-    # '') — is resolved to DEFAULT_TOKEN_SCOPE.  `or` rather than a two-argument
-    # .get() is deliberate: both cases are the same server-side data problem, and
-    # only the absent one would be covered by .get('scope', DEFAULT_TOKEN_SCOPE).
-    # An empty string would otherwise fall through to a "Forbidden: token scope
-    # ''" that blames the caller for a row it cannot see or fix.  The fallback is
-    # least-privilege, so a falsy value can never grant more than `read`.
-    # See DEFAULT_TOKEN_SCOPE for why `read` specifically.
-    token_scope = token_info.get('scope') or DEFAULT_TOKEN_SCOPE
-    if not _scope_allows(token_scope, required_scope):
-        # An unrecognised required_scope is a server-side misconfiguration in
-        # TOOL_SCOPE_REQUIREMENTS, not a client permission problem: report it
-        # as an internal error (like the missing-declaration case above) so the
-        # caller is not told that its most-privileged token is insufficient.
-        if required_scope not in _VALID_REQUIRED_SCOPES:
-            logger.error(
-                "Unrecognised required_scope value in TOOL_SCOPE_REQUIREMENTS",
-                extra={"tool": tool_name, "required_scope": required_scope},
-            )
-            return _jsonrpc_error(
-                req_id, -32603, f"Tool {tool_name} has an invalid scope requirement"
-            )
+    # Same fail-closed treatment for the reach kind: without it there is no way
+    # to know whether read_reach even applies to this tool, and guessing would
+    # mean guessing in the permissive direction.
+    tool_reach_kind = TOOL_REACH_KINDS.get(tool_name)
+    if tool_reach_kind is None:
+        logger.error("Tool has no declared reach kind", extra={"tool": tool_name})
+        return _jsonrpc_error(req_id, -32603, f"Tool {tool_name} has no declared reach kind")
+
+    token_scopes = token_info.get('scopes')
+    if not _scope_allows(token_scopes, required_scope):
         logger.warning(
             "Scope insufficient for tool",
-            extra={"tool": tool_name, "required": required_scope, "token_scope": token_scope},
+            extra={"tool": tool_name, "required": required_scope},
         )
-        return _jsonrpc_error(req_id, -32003, f"Forbidden: token scope '{token_scope}' cannot call '{tool_name}'")
+        return _jsonrpc_error(
+            req_id, -32003,
+            f"Forbidden: token lacks the '{required_scope}' scope required by '{tool_name}'",
+        )
+
+    # Reach enforcement. Separate from scope on purpose: scope says WHICH KIND
+    # of data a token may read, reach says HOW FAR. A token can hold
+    # `projects:read` and still be refused a particular project.
+    read_reach = token_info.get('read_reach') or DEFAULT_READ_REACH
+    token_projects = token_info.get('projects') or []
+    project_id = _resolve_project_id(arguments, token_info) if tool_reach_kind == REACH_KIND_PROJECT else None
+
+    if not reach_allows(
+        read_reach=read_reach,
+        token_projects=token_projects,
+        tool_reach_kind=tool_reach_kind,
+        project_id=project_id,
+    ):
+        # The two refusals read differently because they need different fixes:
+        # one wants an argument, the other wants a differently-scoped token.
+        if tool_reach_kind == REACH_KIND_PROJECT and not project_id:
+            return _jsonrpc_error(
+                req_id, -32602,
+                f"'{tool_name}' needs a project_id argument: this token's project "
+                f"set does not name exactly one project",
+            )
+        logger.warning(
+            "Read reach does not cover this call",
+            extra={"tool": tool_name, "read_reach": read_reach, "kind": tool_reach_kind},
+        )
+        return _jsonrpc_error(
+            req_id, -32003,
+            f"Forbidden: this token's read reach ('{read_reach}') does not cover "
+            f"'{tool_name}'",
+        )
+
+    if tool_reach_kind == REACH_KIND_PROJECT:
+        # The AUTHORIZED project for this one call, which is what the
+        # project-shaped tools read. Injected rather than passed as a new
+        # parameter so resolution and authorization stay in this one place
+        # instead of being repeated per tool.
+        token_info = {**token_info, 'project_id': project_id}
 
     try:
         content = handler(arguments, token_info)
@@ -934,20 +1042,14 @@ MCP_AUTH_METHODS = {
 @tracer.capture_method
 def _handle_autoseed(event: dict) -> dict:
     """Handle GET /mcp/autoseed/{project_id} with Bearer token auth.
-    
-    The project_id is extracted from the URL path (injected into pathParameters
-    by the router). We also inject it as the X-Project-Id header so _authenticate
-    can find it without requiring the caller to pass the header explicitly.
+
+    The project_id comes from the URL path (injected into pathParameters by the
+    router). It no longer has to be echoed into an X-Project-Id header: the
+    credential resolves on its own, so the path is simply the project being
+    asked for, and the token's reach decides whether that is allowed.
     """
     path_params = event.get('pathParameters', {}) or {}
     project_id = path_params.get('project_id', '')
-
-    # Inject project_id into headers so _authenticate can find it
-    if project_id:
-        headers = event.get('headers', {}) or {}
-        if not headers.get('x-project-id') and not headers.get('X-Project-Id'):
-            headers['x-project-id'] = project_id
-            event['headers'] = headers
 
     try:
         token_info = _authenticate(event)
@@ -959,9 +1061,25 @@ def _handle_autoseed(event: dict) -> dict:
     if not token_info:
         return _cors_response({'message': 'Unauthorized'}, status_code=401)
 
-    # Ensure the token's project matches the requested project
-    if project_id != token_info.get('project_id'):
-        return _cors_response({'message': 'Forbidden: token does not match project'}, status_code=403)
+    # Autoseed hands back the project's personas and documents, so it is a
+    # project-shaped read of exactly the kind get_project performs, and it goes
+    # through the same gate — including the scope check, which the old
+    # equality-against-the-token's-project test did not perform at all.
+    if not _scope_allows(token_info.get('scopes'), SCOPE_PROJECTS_READ):
+        return _cors_response(
+            {'message': f"Forbidden: token lacks the '{SCOPE_PROJECTS_READ}' scope"},
+            status_code=403,
+        )
+    if not reach_allows(
+        read_reach=token_info.get('read_reach') or DEFAULT_READ_REACH,
+        token_projects=token_info.get('projects') or [],
+        tool_reach_kind=REACH_KIND_PROJECT,
+        project_id=project_id,
+    ):
+        return _cors_response(
+            {'message': 'Forbidden: project is outside this token\'s read reach'},
+            status_code=403,
+        )
 
     query_params = event.get('queryStringParameters', {}) or {}
     persona_ids = query_params.get('persona_ids', '').split(',') if query_params.get('persona_ids') else None

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -2373,7 +2373,18 @@ def _validate_expires_in_days(value: Any) -> str | None:
 
 
 def _validate_scopes(value: Any) -> list[str]:
-    """Validate a requested scope set, defaulting to every read scope.
+    """Validate a requested scope set. REQUIRED — there is no default.
+
+    🔑 Deliberately not defaulted, unlike `read_reach`. Defaulting would mean
+    `POST {"name": "x"}` mints a credential holding *every* scope, i.e. omitting
+    a field yields the widest grant — a fail-OPEN mint boundary sitting under a
+    fail-CLOSED enforcement path (`_scope_allows` grants nothing for an
+    unreadable scope set). The asymmetry with `read_reach` is intentional and is
+    the honest split: the owner chose a *specific* reach default and the UI warns
+    about it, whereas there is no least-privilege scope set to fall back to —
+    every candidate default is either the widest one or useless.
+    Requiring it costs callers nothing: the route's body shape changed anyway, so
+    no existing caller survives unedited.
 
     No escalation gate is needed *yet* and this is deliberately not pretending
     to be one: every scope in the current vocabulary is a read, and a read
@@ -2383,7 +2394,10 @@ def _validate_scopes(value: Any) -> list[str]:
     `created_by` is recorded below.
     """
     if value is None:
-        return list(mcp_tokens.DEFAULT_SCOPES)
+        raise ValidationError(
+            'scopes is required and must be a non-empty array. Valid scopes: '
+            f'{", ".join(sorted(mcp_tokens.VALID_SCOPES))}'
+        )
     if not isinstance(value, list) or not value:
         raise ValidationError('scopes must be a non-empty array')
     if not all(isinstance(s, str) for s in value):
@@ -2431,11 +2445,32 @@ def _token_response(item: dict) -> dict:
 
 
 def _query_all_tokens(table) -> list[dict]:
-    """Every token row. One partition, so one Query — see MCP_TOKEN_PK."""
-    response = table.query(
-        KeyConditionExpression=Key('pk').eq(mcp_tokens.MCP_TOKEN_PK)
-    )
-    return response.get('Items', [])
+    """Every token row, following pagination to the end.
+
+    🔑 The `LastEvaluatedKey` loop is load-bearing, not defensive boilerplate.
+    All tokens share ONE partition (see MCP_TOKEN_PK), and DynamoDB caps a Query
+    page at 1 MB. A single-page read would therefore start silently truncating
+    once the workspace accumulates enough credentials — and because this list is
+    the ONLY revoke path, a truncated page makes the credentials it omits
+    unlistable and so unrevocable. That would break the exact invariant the mint
+    route is written to guarantee.
+
+    Unbounded on purpose: the result is every credential in the workspace, and
+    stopping early is the failure being prevented. The row count is human-scale
+    (a handful per project) and each row is small, so the loop terminates after
+    one page in practice.
+    """
+    items: list[dict] = []
+    kwargs: dict[str, Any] = {
+        'KeyConditionExpression': Key('pk').eq(mcp_tokens.MCP_TOKEN_PK),
+    }
+    while True:
+        response = table.query(**kwargs)
+        items.extend(response.get('Items', []))
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            return items
+        kwargs['ExclusiveStartKey'] = last_key
 
 
 @app.get("/projects/<project_id>/api-tokens")

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -6,7 +6,6 @@ Separate Lambda to handle projects endpoints and avoid policy size limits.
 import json
 import math
 import os
-import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -34,7 +33,7 @@ from shared.exceptions import (
     ValidationError,
 )
 from shared.persona_import import validate_import_config
-from shared.tokens import hash_token
+from shared import mcp_tokens
 
 from aws_lambda_powertools.event_handler import Response, content_types
 from boto3.dynamodb.conditions import Key
@@ -2334,41 +2333,129 @@ def api_patch_prioritization_scores():
 # ============================================
 # API Token Routes (MCP Access)
 # ============================================
+#
+# The credential format, storage keys and reach vocabulary all live in
+# shared/mcp_tokens.py — this module only handles HTTP concerns (validation,
+# status codes) so the format has exactly one definition.
+#
+# Token rows are NOT in the minting project's partition any more: a credential
+# is workspace-level, and `read_reach` decides how far it sees. The route stays
+# project-shaped because that is where the UI lives, and because a token minted
+# from a project should be visible and revocable there.
 
-TOKEN_PREFIX = 'voc_'
-TOKEN_BYTE_LENGTH = 32
 # Ceiling for an OPTIONAL expires_in_days at mint time. A year, matching the
 # repo's outermost `days` bound (validate_days max_val=365). Omitting the field
-# still mints a non-expiring token — expiry is opt-in until the plan's Phase 1
-# credential model revisits the default.
+# still mints a non-expiring token.
 MAX_TOKEN_LIFETIME_DAYS = 365
+
+
+def _validate_expires_in_days(value: Any) -> str | None:
+    """Turn an optional ``expires_in_days`` into an ISO deadline, or None.
+
+    Absent (or JSON null) = a non-expiring token. When PRESENT it is validated
+    strictly rather than clamped: this is a credential lifetime a human chose,
+    so `validate_int`'s fall-back-to-default contract is wrong here — an
+    unreadable value would silently mint a credential with a lifetime nobody
+    picked. Bools are excluded before int() because isinstance(True, int) is
+    True, and fractional values are refused rather than truncated.
+    """
+    if value is None:
+        return None
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not (1 <= value <= MAX_TOKEN_LIFETIME_DAYS)
+    ):
+        raise ValidationError(
+            f'expires_in_days must be an integer between 1 and {MAX_TOKEN_LIFETIME_DAYS}'
+        )
+    return (datetime.now(timezone.utc) + timedelta(days=value)).isoformat()
+
+
+def _validate_scopes(value: Any) -> list[str]:
+    """Validate a requested scope set, defaulting to every read scope.
+
+    No escalation gate is needed *yet* and this is deliberately not pretending
+    to be one: every scope in the current vocabulary is a read, and a read
+    token grants nothing its minter did not already have through the Cognito
+    API (there is no per-project authorization — #241). The gate becomes real
+    in the same change that adds the first write scope, which is why
+    `created_by` is recorded below.
+    """
+    if value is None:
+        return list(mcp_tokens.DEFAULT_SCOPES)
+    if not isinstance(value, list) or not value:
+        raise ValidationError('scopes must be a non-empty array')
+    if not all(isinstance(s, str) for s in value):
+        raise ValidationError('scopes must be an array of strings')
+    unknown = sorted(set(value) - mcp_tokens.VALID_SCOPES)
+    if unknown:
+        raise ValidationError(
+            f'Unknown scope(s): {", ".join(unknown)}. '
+            f'Valid scopes: {", ".join(sorted(mcp_tokens.VALID_SCOPES))}'
+        )
+    # De-duplicated but order-stable, so the stored row reads the way it was asked for.
+    return list(dict.fromkeys(value))
+
+
+def _validate_read_reach(value: Any) -> str:
+    """Validate the read-reach axis, defaulting to workspace.
+
+    ``workspace`` is the default by owner decision — see DEFAULT_READ_REACH for
+    why the platform's read surface is genuinely workspace-shaped. It is not
+    the harmless option, and the UI is responsible for saying so.
+    """
+    if value is None:
+        return mcp_tokens.DEFAULT_READ_REACH
+    if value not in mcp_tokens.VALID_READ_REACHES:
+        raise ValidationError(
+            f'read_reach must be one of: {", ".join(mcp_tokens.VALID_READ_REACHES)}'
+        )
+    return value
+
+
+def _token_response(item: dict) -> dict:
+    """Project a stored token row into the API shape. Never returns the hash."""
+    return {
+        'token_id': item['token_id'],
+        'name': item['name'],
+        'scopes': item.get('scopes', []),
+        'projects': item.get('projects', []),
+        'read_reach': item.get('read_reach', mcp_tokens.DEFAULT_READ_REACH),
+        'created_at': item['created_at'],
+        'last_used_at': item.get('last_used_at'),
+        # Absent on a non-expiring token; surfaced as null and displayed as
+        # "never expires", which is also how mcp_handler enforces it.
+        'expires_at': item.get('expires_at'),
+    }
+
+
+def _query_all_tokens(table) -> list[dict]:
+    """Every token row. One partition, so one Query — see MCP_TOKEN_PK."""
+    response = table.query(
+        KeyConditionExpression=Key('pk').eq(mcp_tokens.MCP_TOKEN_PK)
+    )
+    return response.get('Items', [])
 
 
 @app.get("/projects/<project_id>/api-tokens")
 @tracer.capture_method
 def api_list_tokens(project_id: str):
-    """List all API tokens for a project."""
+    """List the API tokens whose project set includes this project."""
     table = get_projects_table()
     if not table:
         raise ServiceError('Projects table not configured')
 
-    response = table.query(
-        KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}') & Key('sk').begins_with('TOKEN#')
-    )
-
-    tokens = []
-    for item in response.get('Items', []):
-        tokens.append({
-            'token_id': item['token_id'],
-            'name': item['name'],
-            'scope': item.get('scope', 'read'),
-            'created_at': item['created_at'],
-            'last_used_at': item.get('last_used_at'),
-            # None for rows minted before expiry existed — displayed as
-            # "never expires", which is also how mcp_handler enforces it.
-            'expires_at': item.get('expires_at'),
-            'project_id': project_id,
-        })
+    # Filtered in Python rather than by a key condition: tokens live in one
+    # partition keyed by token id (so authentication is a single keyed read),
+    # which means "tokens for project X" is a membership test, not a range.
+    # The row count here is human-scale — a handful per project.
+    tokens = [
+        _token_response(item)
+        for item in _query_all_tokens(table)
+        if project_id in item.get('projects', [])
+    ]
+    tokens.sort(key=lambda t: t['created_at'], reverse=True)
 
     return {'success': True, 'tokens': tokens}
 
@@ -2376,75 +2463,68 @@ def api_list_tokens(project_id: str):
 @app.post("/projects/<project_id>/api-tokens")
 @tracer.capture_method
 def api_create_token(project_id: str):
-    """Create a new API token for a project."""
+    """Mint a new MCP credential, scoped to this project for write reach."""
     body = app.current_event.json_body or {}
     name = body.get('name', '').strip()
-    scope = body.get('scope', 'read')
-
     if not name:
         raise ValidationError('Token name is required')
-    if scope not in ('read', 'read-write'):
-        raise ValidationError('Scope must be "read" or "read-write"')
 
-    # Optional expiry. Absent (or JSON null) = a non-expiring token, exactly
-    # what every existing caller gets today. When PRESENT it is validated
-    # strictly rather than clamped: this is a credential lifetime a human
-    # chose, so `validate_int`'s fall-back-to-default contract is wrong here —
-    # an unreadable value would silently mint a credential with a lifetime
-    # nobody picked. Bools are excluded before int() because isinstance(True,
-    # int) is True, and fractional values are refused rather than truncated.
-    expires_in_days = body.get('expires_in_days')
-    expires_at = None
-    if expires_in_days is not None:
-        if (
-            isinstance(expires_in_days, bool)
-            or not isinstance(expires_in_days, int)
-            or not (1 <= expires_in_days <= MAX_TOKEN_LIFETIME_DAYS)
-        ):
-            raise ValidationError(
-                f'expires_in_days must be an integer between 1 and {MAX_TOKEN_LIFETIME_DAYS}'
-            )
-        expires_at = (
-            datetime.now(timezone.utc) + timedelta(days=expires_in_days)
-        ).isoformat()
+    scopes = _validate_scopes(body.get('scopes'))
+    read_reach = _validate_read_reach(body.get('read_reach'))
+    expires_at = _validate_expires_in_days(body.get('expires_in_days'))
+
+    # The project set is always exactly the minting project in this phase. A
+    # multi-project token has no consumer yet: there are no write tools, and
+    # cross-project READING is what `read_reach: workspace` already provides.
+    # Keeping it derived also guarantees every token is visible in the tab it
+    # was minted from, so no credential can become unlistable and therefore
+    # unrevocable through the UI.
+    projects = [project_id]
 
     table = get_projects_table()
     if not table:
         raise ServiceError('Projects table not configured')
 
-    # Verify project exists
     project_resp = table.get_item(Key={'pk': f'PROJECT#{project_id}', 'sk': 'META'})
     if 'Item' not in project_resp:
         raise NotFoundError(f'Project {project_id} not found')
 
-    # Generate secure token
-    raw_token = TOKEN_PREFIX + secrets.token_hex(TOKEN_BYTE_LENGTH)
-    token_id = f'tok_{secrets.token_hex(8)}'
-    now = datetime.now(timezone.utc).isoformat()
-
+    minted = mcp_tokens.mint_token()
     item = {
-        'pk': f'PROJECT#{project_id}',
-        'sk': f'TOKEN#{token_id}',
-        'token_id': token_id,
+        'pk': mcp_tokens.MCP_TOKEN_PK,
+        'sk': mcp_tokens.token_sk(minted.token_id),
+        'token_id': minted.token_id,
         'name': name,
-        'scope': scope,
-        'token_hash': hash_token(raw_token),
-        'created_at': now,
-        'project_id': project_id,
+        # Only the SECRET half is hashed, so token_id stays safe to log.
+        'secret_hash': minted.secret_hash,
+        'scopes': scopes,
+        'projects': projects,
+        'read_reach': read_reach,
+        'created_at': datetime.now(timezone.utc).isoformat(),
+        # Audit provenance only. With prioritization excluded from MCP, no tool
+        # keys data or authorization by this value — but it is what a Phase 3
+        # escalation gate and audit trail will need, and it cannot be
+        # reconstructed after the fact.
+        'created_by': get_caller_subject(app.current_event.raw_event),
     }
     if expires_at is not None:
-        # The attribute is simply absent on a non-expiring token — the same
-        # shape as every pre-expiry row, so mcp_handler needs no special case.
+        # Absent attribute on a non-expiring token, so mcp_handler's falsy
+        # check needs no special case.
         item['expires_at'] = expires_at
     table.put_item(Item=item)
 
-    logger.info(f"Created API token {token_id} for project {project_id}")
+    # token_id, never the credential.
+    logger.info(f"Minted MCP token {minted.token_id} for project {project_id}")
 
     return {
         'success': True,
-        'token': raw_token,
-        'token_id': token_id,
+        # The one and only time the raw credential leaves this function.
+        'token': minted.raw,
+        'token_id': minted.token_id,
         'name': name,
+        'scopes': scopes,
+        'projects': projects,
+        'read_reach': read_reach,
         'expires_at': expires_at,
     }
 
@@ -2457,14 +2537,18 @@ def api_delete_token(project_id: str, token_id: str):
     if not table:
         raise ServiceError('Projects table not configured')
 
-    # Verify token exists
-    resp = table.get_item(Key={'pk': f'PROJECT#{project_id}', 'sk': f'TOKEN#{token_id}'})
-    if 'Item' not in resp:
+    key = {'pk': mcp_tokens.MCP_TOKEN_PK, 'sk': mcp_tokens.token_sk(token_id)}
+    resp = table.get_item(Key=key)
+    item = resp.get('Item')
+    # A token outside this project's set is not revocable through this
+    # project's route — the route stays coherent even though every signed-in
+    # user can reach every project today (#241).
+    if not item or project_id not in item.get('projects', []):
         raise NotFoundError(f'Token {token_id} not found')
 
-    table.delete_item(Key={'pk': f'PROJECT#{project_id}', 'sk': f'TOKEN#{token_id}'})
+    table.delete_item(Key=key)
 
-    logger.info(f"Deleted API token {token_id} from project {project_id}")
+    logger.info(f"Revoked MCP token {token_id} from project {project_id}")
 
     return {'success': True, 'message': f'Token {token_id} revoked'}
 

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -708,6 +708,49 @@ class TestScopeEnforcement:
         )
         handler.assert_not_called()
 
+    @pytest.mark.parametrize("arguments", [
+        ["project_id"], "project_id", 42, 3.5, True, None,
+    ])
+    def test_non_object_arguments_are_a_protocol_error_not_a_500(
+        self, arguments, lambda_context
+    ):
+        """`arguments` is caller-controlled JSON and need not be an object.
+
+        A list, string or number reaches the project resolution, where both
+        `'project_id' in args` and `args['project_id']` raise TypeError — and
+        that resolution runs OUTSIDE the try/except around the handler, so it
+        escaped as a 502 with no JSON-RPC envelope and no CORS headers. Driven
+        through the FULL lambda_handler path, because the envelope and the status
+        code are the part that was broken.
+
+        Revert story: deleting the isinstance(arguments, dict) guard in
+        _handle_tools_call fails this with a raised TypeError.
+        """
+        import mcp_handler
+        event = {
+            "httpMethod": "POST",
+            "path": "/v1/mcp",
+            "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
+            "body": json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "get_project", "arguments": arguments},
+            }),
+        }
+        with patch("mcp_handler.projects_table") as mock_table:
+            mock_table.query.return_value = {"Items": [_token_row()]}
+            mock_table.update_item.return_value = {}
+            response = mcp_handler.lambda_handler(event, lambda_context)
+
+        # None is the one benign case: `params.get('arguments', {})` yields None
+        # only if the key is present-but-null, which the guard also refuses.
+        assert response["statusCode"] == 200, response
+        body = json.loads(response["body"])
+        assert body["error"]["code"] == -32602, body
+        assert "arguments" in body["error"]["message"], body
+        assert "Access-Control-Allow-Origin" in response["headers"], (
+            "a protocol error must still carry CORS headers"
+        )
+
     def test_scope_allows_helper(self):
         """Unit-test _scope_allows: exact membership, no hierarchy, list required."""
         from mcp_handler import _scope_allows

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -708,8 +708,48 @@ class TestScopeEnforcement:
         )
         handler.assert_not_called()
 
+    def _tools_call_response(self, arguments, lambda_context, tool="get_project"):
+        import mcp_handler
+        event = {
+            "httpMethod": "POST",
+            "path": "/v1/mcp",
+            "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
+            "body": json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            }),
+        }
+        with patch("mcp_handler.projects_table") as mock_table, \
+             patch("mcp_handler.TOOL_HANDLERS", {
+                 **mcp_handler.TOOL_HANDLERS,
+                 tool: MagicMock(return_value=[{"type": "text", "text": "ok"}]),
+             }):
+            mock_table.query.return_value = {"Items": [_token_row()]}
+            mock_table.update_item.return_value = {}
+            return mcp_handler.lambda_handler(event, lambda_context)
+
+    def test_null_arguments_means_no_arguments_not_a_bad_request(self, lambda_context):
+        """An explicit `"arguments": null` is "no arguments", not malformed.
+
+        `params.get('arguments', {})` cannot default it, because the KEY IS
+        PRESENT — and some clients serialize an omitted optional object as null.
+        Every tool here has only optional arguments, so refusing null would be a
+        compatibility edge invented by the type guard rather than a real protocol
+        error.
+
+        Revert story: deleting the `arguments is None` coercion fails this with
+        -32602.
+        """
+        response = self._tools_call_response(None, lambda_context)
+        assert response["statusCode"] == 200, response
+        body = json.loads(response["body"])
+        assert "error" not in body, (
+            f'"arguments": null must be treated as {{}}, got {body}'
+        )
+        assert body["result"]["isError"] is False, body
+
     @pytest.mark.parametrize("arguments", [
-        ["project_id"], "project_id", 42, 3.5, True, None,
+        ["project_id"], "project_id", 42, 3.5, True,
     ])
     def test_non_object_arguments_are_a_protocol_error_not_a_500(
         self, arguments, lambda_context
@@ -723,26 +763,13 @@ class TestScopeEnforcement:
         through the FULL lambda_handler path, because the envelope and the status
         code are the part that was broken.
 
+        `null` is deliberately NOT in this list — it means "no arguments" and is
+        covered by test_null_arguments_means_no_arguments_not_a_bad_request.
+
         Revert story: deleting the isinstance(arguments, dict) guard in
         _handle_tools_call fails this with a raised TypeError.
         """
-        import mcp_handler
-        event = {
-            "httpMethod": "POST",
-            "path": "/v1/mcp",
-            "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
-            "body": json.dumps({
-                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                "params": {"name": "get_project", "arguments": arguments},
-            }),
-        }
-        with patch("mcp_handler.projects_table") as mock_table:
-            mock_table.query.return_value = {"Items": [_token_row()]}
-            mock_table.update_item.return_value = {}
-            response = mcp_handler.lambda_handler(event, lambda_context)
-
-        # None is the one benign case: `params.get('arguments', {})` yields None
-        # only if the key is present-but-null, which the guard also refuses.
+        response = self._tools_call_response(arguments, lambda_context)
         assert response["statusCode"] == 200, response
         body = json.loads(response["body"])
         assert body["error"]["code"] == -32602, body

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -708,7 +708,17 @@ class TestScopeEnforcement:
         )
         handler.assert_not_called()
 
-    def _tools_call_response(self, arguments, lambda_context, tool="get_project"):
+    def _tools_call_response(self, arguments, lambda_context, tool="get_project",
+                             *, stub_handler=False):
+        """Drive tools/call through the full lambda_handler.
+
+        `stub_handler` is opt-in and used ONLY by the null-arguments case, which
+        has to reach a *successful* dispatch without a real project read. The
+        malformed cases deliberately run against the REAL handler: their whole
+        claim is that such input would otherwise reach the project resolution, so
+        stubbing the handler there would leave that claim resting on the guard's
+        position rather than on the code actually being wired up.
+        """
         import mcp_handler
         event = {
             "httpMethod": "POST",
@@ -719,11 +729,13 @@ class TestScopeEnforcement:
                 "params": {"name": tool, "arguments": arguments},
             }),
         }
+        handlers = (
+            {**mcp_handler.TOOL_HANDLERS,
+             tool: MagicMock(return_value=[{"type": "text", "text": "ok"}])}
+            if stub_handler else mcp_handler.TOOL_HANDLERS
+        )
         with patch("mcp_handler.projects_table") as mock_table, \
-             patch("mcp_handler.TOOL_HANDLERS", {
-                 **mcp_handler.TOOL_HANDLERS,
-                 tool: MagicMock(return_value=[{"type": "text", "text": "ok"}]),
-             }):
+             patch("mcp_handler.TOOL_HANDLERS", handlers):
             mock_table.query.return_value = {"Items": [_token_row()]}
             mock_table.update_item.return_value = {}
             return mcp_handler.lambda_handler(event, lambda_context)
@@ -740,7 +752,7 @@ class TestScopeEnforcement:
         Revert story: deleting the `arguments is None` coercion fails this with
         -32602.
         """
-        response = self._tools_call_response(None, lambda_context)
+        response = self._tools_call_response(None, lambda_context, stub_handler=True)
         assert response["statusCode"] == 200, response
         body = json.loads(response["body"])
         assert "error" not in body, (

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -129,7 +129,7 @@ from botocore import exceptions as botocore_exceptions
 from botocore.parsers import ResponseParserError
 from boto3.dynamodb.conditions import Key
 from shared.mcp_tokens import (
-    DEFAULT_SCOPES,
+    ALL_READ_SCOPES,
     MCP_TOKEN_PK,
     REACH_KIND_PROJECT,
     REACH_KIND_WORKSPACE,
@@ -186,7 +186,7 @@ def _token_row(**extra) -> dict:
         "token_id": _MINTED.token_id,
         "name": "test token",
         "secret_hash": _MINTED.secret_hash,
-        "scopes": list(DEFAULT_SCOPES),
+        "scopes": list(ALL_READ_SCOPES),
         "projects": [_TOKEN_PROJECT],
         "read_reach": REACH_WORKSPACE,
         **extra,
@@ -276,7 +276,7 @@ class TestConstantTimeTokenComparison:
         result = _authenticate(_make_event())
 
         assert result is not None
-        assert result["scopes"] == list(DEFAULT_SCOPES)
+        assert result["scopes"] == list(ALL_READ_SCOPES)
         assert result["projects"] == [_TOKEN_PROJECT]
         assert result["read_reach"] == REACH_WORKSPACE
 
@@ -572,7 +572,7 @@ class TestScopeEnforcement:
             handler.reset_mock()
             result = self._call_tool(
                 tool_name="fake_multi_tool",
-                token_scopes=list(DEFAULT_SCOPES),
+                token_scopes=list(ALL_READ_SCOPES),
                 handlers_extra={"fake_multi_tool": handler},
                 scopes_extra={"fake_multi_tool": required},
             )
@@ -666,7 +666,7 @@ class TestScopeEnforcement:
         try:
             result = self._call_tool(
                 tool_name="undeclared_tool",
-                token_scopes=list(DEFAULT_SCOPES),
+                token_scopes=list(ALL_READ_SCOPES),
                 # inject handler and a reach kind but NOT a scope declaration
                 handlers_extra={"undeclared_tool": undeclared_handler},
                 reach_extra={"undeclared_tool": REACH_KIND_WORKSPACE},
@@ -691,7 +691,7 @@ class TestScopeEnforcement:
         try:
             result = self._call_tool(
                 tool_name="reachless_tool",
-                token_scopes=list(DEFAULT_SCOPES),
+                token_scopes=list(ALL_READ_SCOPES),
                 handlers_extra={"reachless_tool": handler},
                 scopes_extra={"reachless_tool": SCOPE_FEEDBACK_READ},
                 # An explicit empty dict, not None: None makes _call_tool
@@ -713,14 +713,14 @@ class TestScopeEnforcement:
         from mcp_handler import _scope_allows
 
         assert _scope_allows([SCOPE_FEEDBACK_READ], SCOPE_FEEDBACK_READ) is True
-        assert _scope_allows(list(DEFAULT_SCOPES), SCOPE_PROJECTS_READ) is True
+        assert _scope_allows(list(ALL_READ_SCOPES), SCOPE_PROJECTS_READ) is True
         assert _scope_allows([SCOPE_FEEDBACK_READ], SCOPE_PROJECTS_READ) is False
         assert _scope_allows([], SCOPE_FEEDBACK_READ) is False
         assert _scope_allows(None, SCOPE_FEEDBACK_READ) is False
         # A bare string must not pass by substring containment.
         assert _scope_allows(SCOPE_FEEDBACK_READ, SCOPE_FEEDBACK_READ) is False
         # An empty requirement never grants anything.
-        assert _scope_allows(list(DEFAULT_SCOPES), "") is False
+        assert _scope_allows(list(ALL_READ_SCOPES), "") is False
 
 
 # ===========================================================================
@@ -2173,7 +2173,7 @@ class TestReadReachEnforcement:
         return result, handler
 
     def _token(self, **extra):
-        return {"scopes": list(DEFAULT_SCOPES), "projects": [_TOKEN_PROJECT],
+        return {"scopes": list(ALL_READ_SCOPES), "projects": [_TOKEN_PROJECT],
                 "read_reach": REACH_WORKSPACE, **extra}
 
     # --- workspace reach (the default) -----------------------------------
@@ -2269,18 +2269,51 @@ class TestReadReachEnforcement:
         assert "error" in result, result
         handler.assert_not_called()
 
-    @pytest.mark.parametrize("bad", ["", "   ", None, 123, ["proj-a"]])
-    def test_unusable_project_argument_falls_back_to_the_token_default(self, bad):
-        """A junk argument must not become a project id.
+    @pytest.mark.parametrize("bad", ["", "   ", None, 123, ["proj-a"], {}, True])
+    def test_a_present_but_unusable_project_argument_is_refused(self, bad):
+        """Junk in `project_id` is -32602, NOT a silent fall back to the token's project.
 
-        It falls back to the token's single project (which is in reach), rather
-        than being passed through to a DynamoDB key.
+        Falling back would read a DIFFERENT project than the client named and
+        report success — the caller receives another project's personas and
+        documents believing they are the ones they asked for. An error is the
+        only honest answer, and it is why absence and garbage take different
+        paths through _resolve_project_id.
         """
         result, handler = self._call(
             "get_project", self._token(), arguments={"project_id": bad},
         )
+        assert result.get("error", {}).get("code") == -32602, result
+        assert "project_id" in result["error"]["message"]
+        handler.assert_not_called()
+
+    def test_an_absent_project_argument_still_defaults(self):
+        """Absence is a different intent from garbage and keeps the ergonomics."""
+        result, handler = self._call("get_project", self._token())
         assert "result" in result, result
         assert handler.call_args.args[1]["project_id"] == _TOKEN_PROJECT
+
+    def test_none_reach_is_told_about_reach_not_about_an_argument(self):
+        """A `none`-reach token cannot be helped by supplying a project_id.
+
+        Reach is checked before the missing-argument branch, so the refusal names
+        the thing the caller would have to change. The earlier ordering sent them
+        after an argument that could never work.
+        """
+        result, handler = self._call(
+            "get_project", self._token(read_reach=REACH_NONE, projects=["a", "b"]),
+        )
+        assert result.get("error", {}).get("code") == -32003, result
+        assert "read reach" in result["error"]["message"], result["error"]["message"]
+        handler.assert_not_called()
+
+    def test_project_set_reach_on_a_workspace_tool_names_reach_too(self):
+        """Same ordering rule for the other reach-covers-nothing case."""
+        result, handler = self._call(
+            "search_feedback", self._token(read_reach=REACH_PROJECT_SET),
+        )
+        assert result.get("error", {}).get("code") == -32003, result
+        assert "read reach" in result["error"]["message"]
+        handler.assert_not_called()
 
     def test_reach_is_checked_even_when_the_scope_is_held(self):
         """The two gates are independent; holding the scope is not enough."""

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -105,6 +105,7 @@ Revert test that catches each defect:
 import json
 import os
 import sys
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -126,6 +127,22 @@ from botocore.exceptions import (
 # builtin, matching how mcp_handler refers to them.
 from botocore import exceptions as botocore_exceptions
 from botocore.parsers import ResponseParserError
+from boto3.dynamodb.conditions import Key
+from shared.mcp_tokens import (
+    DEFAULT_SCOPES,
+    MCP_TOKEN_PK,
+    REACH_KIND_PROJECT,
+    REACH_KIND_WORKSPACE,
+    REACH_NONE,
+    REACH_PROJECT_SET,
+    REACH_WORKSPACE,
+    SCOPE_FEEDBACK_READ,
+    SCOPE_METRICS_READ,
+    SCOPE_PROJECTS_READ,
+    VALID_SCOPES,
+    mint_token,
+    token_sk,
+)
 
 # ---------------------------------------------------------------------------
 # Ensure lambda/ and lambda/api/ are on the path (mirrors conftest.py)
@@ -145,30 +162,68 @@ def _client_error(code: str, operation: str = "Query") -> ClientError:
     )
 
 
-def _make_event(token: str = "voc_testtoken", project_id: str = "proj-1") -> dict:
-    """Build the minimal auth-header event _authenticate reads."""
+# ---------------------------------------------------------------------------
+# Credential fixtures
+# ---------------------------------------------------------------------------
+# One real credential for the whole module, minted through the production
+# helper rather than hand-written. Hand-writing it would let the tests keep
+# passing after a format change that broke every real client — the token must
+# parse, and mint_token is what decides whether it does.
+_MINTED = mint_token()
+_VALID_TOKEN = _MINTED.raw
+_TOKEN_PROJECT = "proj-1"
+
+
+def _token_row(**extra) -> dict:
+    """A stored token row that authenticates _VALID_TOKEN.
+
+    Defaults to the widest shape (every read scope, workspace reach) so a test
+    about something else does not accidentally also test a permission refusal.
+    """
     return {
-        "headers": {
-            "authorization": f"Bearer {token}",
-            "x-project-id": project_id,
-        }
+        "pk": MCP_TOKEN_PK,
+        "sk": token_sk(_MINTED.token_id),
+        "token_id": _MINTED.token_id,
+        "name": "test token",
+        "secret_hash": _MINTED.secret_hash,
+        "scopes": list(DEFAULT_SCOPES),
+        "projects": [_TOKEN_PROJECT],
+        "read_reach": REACH_WORKSPACE,
+        **extra,
     }
 
 
-def _rpc_event() -> dict:
+# A credential that is FORMAT-VALID (so it reaches the token store) but whose
+# secret is a greppable constant, for the "no token material in logs" tests.
+# It has to be real hex, so the sentinel is a hex word rather than a readable
+# one — `voc_SENTINELTOKEN` would now be rejected by the parser before any
+# lookup happened, which would make those tests vacuously green.
+_SENTINEL_SECRET = 'deadbeef' * 8          # 64 hex chars
+_SENTINEL_TOKEN_ID = 'tok_' + 'cafe' * 4   # 16 hex chars
+_SENTINEL_TOKEN = f'voc_{_SENTINEL_TOKEN_ID}_{_SENTINEL_SECRET}'
+
+
+def _make_event(token: str = _VALID_TOKEN) -> dict:
+    """Build the minimal auth-header event _authenticate reads.
+
+    No X-Project-Id: the credential resolves on its own now. A test that needs
+    to prove the header is irrelevant passes it explicitly.
+    """
+    return {"headers": {"authorization": f"Bearer {token}"}}
+
+
+def _rpc_event(tool: str = "get_project", arguments: dict | None = None,
+               token: str = _VALID_TOKEN) -> dict:
     """Build a full JSON-RPC tools/call event for the lambda_handler path."""
     return {
         "httpMethod": "POST",
         "path": "/v1/mcp",
-        "headers": {
-            "authorization": "Bearer voc_testtoken",
-            "x-project-id": "proj-1",
-        },
+        "headers": {"authorization": f"Bearer {token}"},
         "body": json.dumps({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/call",
-            "params": {"name": "get_project", "arguments": {}},
+            "params": {"name": tool, "arguments": arguments or {}},
         }),
     }
 
@@ -178,63 +233,120 @@ def _rpc_event() -> dict:
 # ===========================================================================
 
 class TestConstantTimeTokenComparison:
-    """hmac.compare_digest must be called for every hash comparison in _authenticate."""
+    """hmac.compare_digest must be used for the secret comparison.
 
-    # NOTE: `mcp_handler.hmac` is the shared stdlib module object from
+    The comparison moved into shared.mcp_tokens.secret_matches with the new
+    format, so the patch target moved with it. Patching the handler for a
+    function it no longer owns would silently stop testing anything.
+    """
+
+    # NOTE: `shared.mcp_tokens.hmac` is the shared stdlib module object from
     # sys.modules, so this patch replaces `hmac.compare_digest` *process-wide*
-    # for the duration of the test — not just the handler's view of it.  That
+    # for the duration of the test — not just that module's view of it.  That
     # is safe under serial execution (nothing else in this test calls it;
     # botocore's HMAC signing happens outside the mocked DynamoDB calls), but
     # it would affect any concurrent code that calls `hmac.compare_digest`
     # (e.g. under pytest-xdist, or a fixture that signs a real AWS request).
     @patch("mcp_handler.projects_table")
-    @patch("mcp_handler.hmac.compare_digest")
+    @patch("shared.mcp_tokens.hmac.compare_digest")
     def test_authenticate_uses_compare_digest(self, mock_digest, mock_table):
-        """compare_digest is called for every stored hash; == is never used."""
+        """compare_digest is called for the stored secret hash; == is never used."""
         mock_digest.return_value = False  # force no-match so _authenticate returns None
 
-        # Simulate one stored token in DynamoDB
-        mock_table.query.return_value = {
-            "Items": [{"sk": "TOKEN#1", "token_hash": "somehash", "scope": "read"}]
-        }
+        mock_table.query.return_value = {"Items": [_token_row()]}
 
         from mcp_handler import _authenticate
-        result = _authenticate(_make_event("voc_testtoken"))
+        result = _authenticate(_make_event())
 
-        # compare_digest was called (not ==)
         assert mock_digest.called, "hmac.compare_digest was never called"
-        # And the result is None because we forced it to return False
         assert result is None
 
     @patch("mcp_handler.projects_table")
-    @patch("mcp_handler.hmac.compare_digest")
-    def test_authenticate_returns_token_on_digest_match(self, mock_digest, mock_table):
-        """When compare_digest returns True, _authenticate returns the token item."""
-        mock_digest.return_value = True
+    def test_authenticate_returns_the_row_on_a_matching_secret(self, mock_table):
+        """A correct secret returns the stored row, with its scopes and reach.
 
-        stored_item = {"sk": "TOKEN#1", "token_hash": "somehash", "scope": "read"}
-        mock_table.query.return_value = {"Items": [stored_item]}
+        No patched comparison here — the real credential from mint_token is
+        presented against the real stored hash, so this also proves the mint
+        and authenticate halves agree about the format.
+        """
+        mock_table.query.return_value = {"Items": [_token_row()]}
         mock_table.update_item.return_value = {}
 
         from mcp_handler import _authenticate
-        result = _authenticate(_make_event("voc_testtoken", project_id="proj-1"))
+        result = _authenticate(_make_event())
 
         assert result is not None
-        assert result["scope"] == "read"
-        assert result["project_id"] == "proj-1"
+        assert result["scopes"] == list(DEFAULT_SCOPES)
+        assert result["projects"] == [_TOKEN_PROJECT]
+        assert result["read_reach"] == REACH_WORKSPACE
 
     @patch("mcp_handler.projects_table")
-    def test_authenticate_no_match_returns_none(self, mock_table):
-        """A token whose hash does not match any stored hash returns None."""
-        # Return an item whose hash is deliberately wrong
-        mock_table.query.return_value = {
-            "Items": [{"sk": "TOKEN#1", "token_hash": "wronghash", "scope": "read"}]
-        }
+    def test_authenticate_looks_the_token_up_by_its_own_id(self, mock_table):
+        """The lookup is ONE keyed read in the token partition.
+
+        This is the behaviour that removed the X-Project-Id requirement: a scan
+        of a project's token rows cannot answer "which projects exist". If this
+        ever goes back to a begins_with over a PROJECT# partition, the header
+        comes back with it.
+        """
+        mock_table.query.return_value = {"Items": [_token_row()]}
+        mock_table.update_item.return_value = {}
 
         from mcp_handler import _authenticate
-        # The real hash won't match "wronghash"
-        result = _authenticate(_make_event("voc_realtoken"))
-        assert result is None
+        assert _authenticate(_make_event()) is not None
+
+        # Compared as CONDITION OBJECTS, not as strings: boto3's conditions
+        # stringify to "<...conditions.And object at 0x...>", so a substring
+        # assertion would be vacuously true forever. ConditionBase implements
+        # __eq__ over its operands, so this compares the real key expression —
+        # and a begins_with, or a PROJECT# partition, fails it.
+        expected = Key('pk').eq(MCP_TOKEN_PK) & Key('sk').eq(token_sk(_MINTED.token_id))
+        actual = mock_table.query.call_args.kwargs["KeyConditionExpression"]
+        assert actual == expected, (
+            "the lookup must be an exact keyed read of the token row "
+            f"(pk={MCP_TOKEN_PK}, sk={token_sk(_MINTED.token_id)}), not a range "
+            "scan over a project's token rows — that scan is what required the "
+            "X-Project-Id header"
+        )
+
+    @patch("mcp_handler.projects_table")
+    def test_authentication_needs_no_project_header(self, mock_table):
+        """The credential is self-describing: no X-Project-Id, no project hint."""
+        mock_table.query.return_value = {"Items": [_token_row()]}
+        mock_table.update_item.return_value = {}
+
+        from mcp_handler import _authenticate
+        event = {"headers": {"authorization": f"Bearer {_VALID_TOKEN}"}}
+        assert _authenticate(event) is not None
+
+    @patch("mcp_handler.projects_table")
+    def test_authenticate_wrong_secret_returns_none(self, mock_table):
+        """A real token id with the wrong secret is refused."""
+        mock_table.query.return_value = {"Items": [_token_row(secret_hash="wronghash")]}
+
+        from mcp_handler import _authenticate
+        assert _authenticate(_make_event()) is None
+
+    @patch("mcp_handler.projects_table")
+    def test_authenticate_unknown_token_id_returns_none(self, mock_table):
+        """An id with no row is a plain 401, indistinguishable from a bad secret."""
+        mock_table.query.return_value = {"Items": []}
+
+        from mcp_handler import _authenticate
+        assert _authenticate(_make_event()) is None
+
+    @patch("mcp_handler.projects_table")
+    def test_malformed_credential_never_reaches_the_token_store(self, mock_table):
+        """Strict parsing means caller text does not become a key lookup.
+
+        Includes the retired `voc_<64 hex>` format: dropping legacy support was
+        a deliberate decision (no production users), so a legacy credential must
+        fail closed rather than quietly resolve.
+        """
+        from mcp_handler import _authenticate
+        for bad in ("voc_testtoken", "voc_" + "a" * 64, "Bearer-less", "voc_tok_xyz_abc"):
+            assert _authenticate(_make_event(token=bad)) is None, f"{bad!r} authenticated"
+        mock_table.query.assert_not_called()
 
     @patch("mcp_handler.projects_table")
     def test_authenticate_returns_none_on_retryable_dynamodb_error(self, mock_table):
@@ -246,7 +358,7 @@ class TestConstantTimeTokenComparison:
         mock_table.query.side_effect = _client_error('ProvisionedThroughputExceededException')
 
         from mcp_handler import _authenticate
-        result = _authenticate(_make_event("voc_testtoken"))
+        result = _authenticate(_make_event())
 
         assert result is None, "A retryable DynamoDB error must return None, not raise"
 
@@ -264,7 +376,7 @@ class TestConstantTimeTokenComparison:
         for code in ('ResourceNotFoundException', 'AccessDeniedException'):
             mock_table.query.side_effect = _client_error(code)
             with pytest.raises(mcp_handler.AuthBackendUnavailable):
-                mcp_handler._authenticate(_make_event("voc_testtoken"))
+                mcp_handler._authenticate(_make_event())
 
     @patch("mcp_handler.projects_table")
     def test_permanent_auth_fault_surfaces_as_500_not_401(self, mock_table, lambda_context):
@@ -277,7 +389,7 @@ class TestConstantTimeTokenComparison:
                 "httpMethod": "POST",
                 "path": "/v1/mcp",
                 "headers": {
-                    "authorization": "Bearer voc_testtoken",
+                    "authorization": f"Bearer {_VALID_TOKEN}",
                     "x-project-id": "proj-1",
                 },
                 "body": json.dumps({
@@ -303,61 +415,100 @@ class TestConstantTimeTokenComparison:
 # 2. Scope enforcement
 # ===========================================================================
 
-_NO_SCOPE_KEY = object()  # sentinel: build token_info with no 'scope' key at all
+_NO_SCOPES_KEY = object()  # sentinel: build token_info with no 'scopes' key at all
 
 
 class TestScopeEnforcement:
-    """Dispatch is fail-closed: scope must be declared and satisfied."""
+    """Dispatch is fail-closed: scope must be declared and satisfied.
 
-    def _call_tool(self, tool_name: str, token_scope: str, handlers_extra=None, scopes_extra=None):
-        """Call _handle_tools_call with the given tool and token scope.
+    Scopes are a SET of per-domain grants (`feedback:read`, `projects:read`)
+    with no hierarchy, replacing the old ordered `read` / `read-write` pair.
+    Two consequences the tests below pin:
+      • membership is exact, so nothing "includes" anything else and there is
+        no ordering to get wrong;
+      • a row with no usable `scopes` grants NOTHING. The old model defaulted a
+        missing scope to `read` because deployed rows predated the field; the
+        format change means every row carries an explicit set, so a row without
+        one is data damage and must not be guessed at in the caller's favour.
+    """
 
-        ``token_scope=_NO_SCOPE_KEY`` builds a token_info with no ``scope`` key
-        at all, reproducing a legacy row minted before the field existed.
+    def _call_tool(self, tool_name, token_scopes, handlers_extra=None,
+                   scopes_extra=None, reach_extra=None, token_info_extra=None,
+                   arguments=None):
+        """Call _handle_tools_call with the given tool and token scope set.
+
+        ``token_scopes=_NO_SCOPES_KEY`` builds a token_info with no ``scopes``
+        key at all, reproducing a damaged row.
         """
         import mcp_handler
 
-        token_info = {"project_id": "proj-1"}
-        if token_scope is not _NO_SCOPE_KEY:
-            token_info["scope"] = token_scope
+        # Workspace reach by default so a scope test is not silently also a
+        # reach test; the reach class below varies it deliberately.
+        token_info = {
+            "projects": [_TOKEN_PROJECT],
+            "read_reach": REACH_WORKSPACE,
+            **(token_info_extra or {}),
+        }
+        if token_scopes is not _NO_SCOPES_KEY:
+            token_info["scopes"] = token_scopes
 
-        # Optionally inject synthetic entries into the registries
         original_handlers = mcp_handler.TOOL_HANDLERS.copy()
         original_scopes = mcp_handler.TOOL_SCOPE_REQUIREMENTS.copy()
+        original_reach = mcp_handler.TOOL_REACH_KINDS.copy()
         try:
             if handlers_extra:
                 mcp_handler.TOOL_HANDLERS.update(handlers_extra)
             if scopes_extra:
                 mcp_handler.TOOL_SCOPE_REQUIREMENTS.update(scopes_extra)
+            # A synthetic tool needs a reach kind too, or the fail-closed reach
+            # guard rejects it before the scope check under test is reached.
+            if handlers_extra and reach_extra is None:
+                reach_extra = {name: REACH_KIND_WORKSPACE for name in handlers_extra}
+            if reach_extra:
+                mcp_handler.TOOL_REACH_KINDS.update(reach_extra)
             return mcp_handler._handle_tools_call(
                 req_id=1,
-                params={"name": tool_name, "arguments": {}},
+                params={"name": tool_name, "arguments": arguments or {}},
                 token_info=token_info,
             )
         finally:
             # Restore originals so tests don't bleed into each other
-            mcp_handler.TOOL_HANDLERS.clear()
-            mcp_handler.TOOL_HANDLERS.update(original_handlers)
-            mcp_handler.TOOL_SCOPE_REQUIREMENTS.clear()
-            mcp_handler.TOOL_SCOPE_REQUIREMENTS.update(original_scopes)
+            for registry, original in (
+                (mcp_handler.TOOL_HANDLERS, original_handlers),
+                (mcp_handler.TOOL_SCOPE_REQUIREMENTS, original_scopes),
+                (mcp_handler.TOOL_REACH_KINDS, original_reach),
+            ):
+                registry.clear()
+                registry.update(original)
 
-    def test_every_registered_tool_has_scope_declaration(self):
-        """TOOL_HANDLERS, TOOL_SCOPE_REQUIREMENTS, and MCP_TOOLS must all have identical keys.
+    def test_every_registered_tool_has_scope_and_reach_declarations(self):
+        """TOOL_HANDLERS, the two declaration tables, and MCP_TOOLS must agree.
 
-        Adding a handler without a corresponding scope entry (or vice-versa)
-        breaks this test, signalling the author that the table needs updating.
-        A tool in MCP_TOOLS without a handler returns -32602; a handler not in
-        MCP_TOOLS is silently unreachable — both are caught here.
+        Adding a handler without a scope entry, without a reach kind, or without
+        an MCP_TOOLS entry (or vice-versa) breaks this test, signalling the
+        author that a table needs updating. A tool in MCP_TOOLS without a
+        handler returns -32602; a handler not in MCP_TOOLS is silently
+        unreachable; a handler with no reach kind cannot be authorized at all —
+        all three are caught here.
         """
-        from mcp_handler import TOOL_HANDLERS, TOOL_SCOPE_REQUIREMENTS, MCP_TOOLS
+        from mcp_handler import (
+            MCP_TOOLS,
+            TOOL_HANDLERS,
+            TOOL_REACH_KINDS,
+            TOOL_SCOPE_REQUIREMENTS,
+        )
 
         handler_keys = set(TOOL_HANDLERS.keys())
-        scope_keys = set(TOOL_SCOPE_REQUIREMENTS.keys())
         mcp_names = {t['name'] for t in MCP_TOOLS}
 
-        assert handler_keys == scope_keys, (
+        assert handler_keys == set(TOOL_SCOPE_REQUIREMENTS), (
             "Mismatch between TOOL_HANDLERS and TOOL_SCOPE_REQUIREMENTS keys. "
             "Every handler must have a declared scope requirement and vice-versa."
+        )
+        assert handler_keys == set(TOOL_REACH_KINDS), (
+            "Mismatch between TOOL_HANDLERS and TOOL_REACH_KINDS keys. Every "
+            "handler must declare how its data is shaped, or read_reach cannot "
+            "be applied to it."
         )
         assert mcp_names == handler_keys, (
             f"MCP_TOOLS names {mcp_names} must match TOOL_HANDLERS keys {handler_keys}. "
@@ -365,173 +516,131 @@ class TestScopeEnforcement:
             "MCP_TOOLS is silently unreachable."
         )
 
-    def test_read_token_rejected_for_write_tool(self):
-        """A read-scoped token must be rejected when calling a read-write tool.
+    def test_declared_scopes_and_reaches_are_from_the_vocabulary(self):
+        """No tool may require a scope or reach kind that does not exist.
 
-        The write tool is registered inside the test so no production write
-        tool needs to exist yet.  The scope guard must still fire.
+        A typo like `project:read` (singular) would otherwise be unsatisfiable
+        by any mintable token — the tool would be dead on arrival and the
+        failure would look like a permission problem to whoever called it.
         """
-        write_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        from mcp_handler import TOOL_REACH_KINDS, TOOL_SCOPE_REQUIREMENTS
+
+        assert set(TOOL_SCOPE_REQUIREMENTS.values()) <= VALID_SCOPES, (
+            f"undeclared scope(s): {set(TOOL_SCOPE_REQUIREMENTS.values()) - VALID_SCOPES}"
+        )
+        assert set(TOOL_REACH_KINDS.values()) <= {REACH_KIND_WORKSPACE, REACH_KIND_PROJECT}
+
+    def test_token_without_the_required_scope_is_rejected(self):
+        """Holding one domain's scope does not grant another's.
+
+        This is what per-domain scopes buy that the old pair could not express:
+        a credential that reads feedback but cannot read anybody's product
+        strategy.
+        """
+        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
         result = self._call_tool(
-            tool_name="fake_write_tool",
-            token_scope="read",
-            handlers_extra={"fake_write_tool": write_handler},
-            scopes_extra={"fake_write_tool": "read-write"},
+            tool_name="fake_projects_tool",
+            token_scopes=[SCOPE_FEEDBACK_READ],
+            handlers_extra={"fake_projects_tool": handler},
+            scopes_extra={"fake_projects_tool": SCOPE_PROJECTS_READ},
         )
 
         assert "error" in result, "Expected a JSON-RPC error response"
-        # -32003 = Forbidden (scope insufficient); -32001 is reserved for Unauthorized (bad/missing token)
+        # -32003 = Forbidden (scope insufficient); -32001 is Unauthorized (bad token)
         assert result["error"]["code"] == -32003, (
             f"Expected -32003 (Forbidden) for scope failure, got {result['error']['code']}"
         )
         assert "Forbidden" in result["error"]["message"]
-        # The handler must NOT have been called
-        write_handler.assert_not_called()
+        handler.assert_not_called()
 
-    def test_read_write_token_allowed_for_read_tool(self):
-        """A read-write token satisfies a read-scope requirement."""
-        read_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+    def test_token_holding_the_required_scope_is_allowed(self):
+        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
         result = self._call_tool(
-            tool_name="fake_read_tool",
-            token_scope="read-write",
-            handlers_extra={"fake_read_tool": read_handler},
-            scopes_extra={"fake_read_tool": "read"},
-        )
-
-        # Should succeed
-        assert "result" in result, f"Expected success, got: {result}"
-        read_handler.assert_called_once()
-
-    def test_read_token_allowed_for_read_tool(self):
-        """A read-scoped token can call a read-scope tool."""
-        read_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
-        result = self._call_tool(
-            tool_name="fake_read_tool2",
-            token_scope="read",
-            handlers_extra={"fake_read_tool2": read_handler},
-            scopes_extra={"fake_read_tool2": "read"},
+            tool_name="fake_feedback_tool",
+            token_scopes=[SCOPE_FEEDBACK_READ],
+            handlers_extra={"fake_feedback_tool": handler},
+            scopes_extra={"fake_feedback_tool": SCOPE_FEEDBACK_READ},
         )
 
         assert "result" in result, f"Expected success, got: {result}"
-        read_handler.assert_called_once()
+        handler.assert_called_once()
 
-    def test_missing_scope_defaults_to_read(self):
-        """A token row with NO `scope` attribute can still call a read tool.
+    def test_extra_scopes_do_not_interfere(self):
+        """A token holding several scopes satisfies each of them."""
+        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        for required in (SCOPE_FEEDBACK_READ, SCOPE_METRICS_READ, SCOPE_PROJECTS_READ):
+            handler.reset_mock()
+            result = self._call_tool(
+                tool_name="fake_multi_tool",
+                token_scopes=list(DEFAULT_SCOPES),
+                handlers_extra={"fake_multi_tool": handler},
+                scopes_extra={"fake_multi_tool": required},
+            )
+            assert "result" in result, f"{required} should have been satisfied, got: {result}"
+            handler.assert_called_once()
 
-        Legacy rows minted before the `scope` field existed have no such
-        attribute.  The token *list* path (projects_handler.api_list_tokens)
-        resolves a missing scope to 'read', so the MCP Access tab shows the row
-        as a working read token.  Enforcement must agree, or a token the UI
-        presents as usable is refused on every single call with a message that
-        blames the caller ("token scope '' cannot call ...").
+    @pytest.mark.parametrize("scopes", [
+        _NO_SCOPES_KEY,   # attribute absent
+        None,             # present but null
+        [],               # present but empty
+        "",               # present but not a list
+        "projects:read",  # a bare string, not a list — `in` would match substrings
+        {"projects:read": True},
+    ])
+    def test_an_unusable_scopes_field_grants_nothing(self, scopes):
+        """A row without a readable scope SET is refused, not defaulted.
 
-        Reverting DEFAULT_TOKEN_SCOPE (back to `token_info.get('scope', '')`)
-        makes this test fail with -32003 — the lockout it guards against.
+        This deliberately REVERSES the old behaviour, which resolved a missing
+        scope to `read`. That default existed because deployed rows predated the
+        `scope` field; the format change means every row is minted with an
+        explicit set, so a row without one is data damage. Guessing in the
+        caller's favour would turn a damaged row into a working credential.
+
+        The bare-string case is the interesting one: `"projects:read" in
+        "projects:read"` is True, so a membership test that forgot to require a
+        list would let a string masquerade as a scope set — and a row holding
+        the string "feedback:read,projects:read" would then satisfy BOTH.
         """
-        read_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
         result = self._call_tool(
-            tool_name="legacy_read_tool",
-            token_scope=_NO_SCOPE_KEY,  # no 'scope' key at all
-            handlers_extra={"legacy_read_tool": read_handler},
-            scopes_extra={"legacy_read_tool": "read"},
+            tool_name="damaged_row_tool",
+            token_scopes=scopes,
+            handlers_extra={"damaged_row_tool": handler},
+            scopes_extra={"damaged_row_tool": SCOPE_PROJECTS_READ},
         )
 
-        assert "result" in result, (
-            f"A scope-less legacy token must still satisfy a read tool, got: {result}"
+        assert result.get("error", {}).get("code") == -32003, (
+            f"an unusable scopes field must be refused, got: {result}"
         )
-        read_handler.assert_called_once()
+        handler.assert_not_called()
 
-    def test_missing_scope_still_rejected_for_write_tool(self):
-        """The 'read' default is least-privilege: it does not grant read-write.
-
-        Defaulting a missing scope to 'read' must not silently escalate a legacy
-        row into a read-write token.
-        """
-        write_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
-        result = self._call_tool(
-            tool_name="legacy_write_tool",
-            token_scope=_NO_SCOPE_KEY,
-            handlers_extra={"legacy_write_tool": write_handler},
-            scopes_extra={"legacy_write_tool": "read-write"},
-        )
-
-        assert result["error"]["code"] == -32003
-        write_handler.assert_not_called()
-
-    def test_empty_scope_string_resolves_to_the_default(self):
-        """A present-but-empty `scope` is treated like an absent one, not like a value.
-
-        `token_info.get('scope') or DEFAULT_TOKEN_SCOPE` covers both a missing key
-        and a falsy value ('', None) on purpose: a partial write or a migration
-        that stored '' is the same server-side data problem as a row minted before
-        the field existed.  Resolving it to the default is what keeps the response
-        from being "Forbidden: token scope ''" — a message that blames the caller
-        for a row it can neither see nor fix.
-
-        Reverting to `.get('scope', DEFAULT_TOKEN_SCOPE)` makes this fail with
-        -32003, which is exactly the misdirection it guards.
-        """
-        read_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
-        result = self._call_tool(
-            tool_name="blank_scope_read_tool",
-            token_scope="",
-            handlers_extra={"blank_scope_read_tool": read_handler},
-            scopes_extra={"blank_scope_read_tool": "read"},
-        )
-
-        assert "result" in result, (
-            f"An empty scope must resolve to the default, not be refused, got: {result}"
-        )
-        read_handler.assert_called_once()
-
-    def test_empty_scope_string_still_rejected_for_write_tool(self):
-        """Resolving '' to the default must not escalate it past least privilege.
-
-        The refusal message names the resolved scope ('read'), not the raw '',
-        so it does not read as a caller error about a value the caller never sent.
-        """
-        write_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
-        result = self._call_tool(
-            tool_name="blank_scope_write_tool",
-            token_scope="",
-            handlers_extra={"blank_scope_write_tool": write_handler},
-            scopes_extra={"blank_scope_write_tool": "read-write"},
-        )
-
-        assert result["error"]["code"] == -32003
-        assert "scope ''" not in result["error"]["message"], (
-            "The message must report the resolved scope, not the empty raw value; "
-            f"got: {result['error']['message']}"
-        )
-        write_handler.assert_not_called()
-
-    def test_enforcement_default_matches_list_path_default(self):
-        """mcp_handler and projects_handler must agree on the missing-scope default.
+    def test_list_path_reports_the_reach_enforcement_assumes(self):
+        """mcp_handler and projects_handler must agree on the read_reach default.
 
         The MCP Access tab renders whatever projects_handler.api_list_tokens
-        reports; enforcement uses mcp_handler.DEFAULT_TOKEN_SCOPE.  If the two
-        drift, a token the UI displays as a working read token is refused on
-        every call — or, worse, one displayed as read-only is enforced as
-        something wider.  This is the only mechanical guarantee behind that
-        agreement, so it is asserted on *behaviour*: the list path is called with
-        a scope-less row and its output compared to the constant.
+        reports; enforcement uses DEFAULT_READ_REACH. If the two drift, a token
+        the UI displays as workspace-wide is enforced as something narrower — or,
+        worse, one displayed as sealed is enforced as workspace-wide. This is the
+        only mechanical guarantee behind that agreement, so it is asserted on
+        *behaviour*: the list path is called with a reach-less row and its output
+        compared to the constant.
 
-        Deliberately not `inspect.getsource`: matching the literal
-        "'scope', 'read'" fails on a reformat to double quotes (claiming the
-        default changed when it did not) and passes when the real default moves
-        but a stale copy of the literal survives in a comment.
+        Deliberately not `inspect.getsource`: matching a literal fails on a
+        reformat (claiming the default changed when it did not) and passes when
+        the real default moves but a stale copy survives in a comment.
         """
         import mcp_handler
         import projects_handler
 
         table = MagicMock()
-        # A legacy row: the keys the list path indexes directly, and no 'scope'.
+        # A row missing the reach attribute entirely.
         table.query.return_value = {
             "Items": [
                 {
-                    "token_id": "tok_legacy",
-                    "name": "legacy token",
+                    "token_id": "tok_partial",
+                    "name": "partial token",
                     "created_at": "2024-01-01T00:00:00+00:00",
+                    "projects": ["some-project"],
                 }
             ]
         }
@@ -541,74 +650,77 @@ class TestScopeEnforcement:
 
         tokens = result["tokens"]
         assert len(tokens) == 1, f"Expected exactly one token in the list output, got: {tokens}"
-        assert tokens[0]["scope"] == mcp_handler.DEFAULT_TOKEN_SCOPE, (
-            "projects_handler.api_list_tokens reports a missing scope as "
-            f"{tokens[0]['scope']!r} while enforcement assumes "
-            f"{mcp_handler.DEFAULT_TOKEN_SCOPE!r}. A token shown as usable in the "
-            "MCP Access tab would be refused on every call (or vice-versa) — bring "
-            "the two back into agreement."
+        assert tokens[0]["read_reach"] == mcp_handler.DEFAULT_READ_REACH, (
+            "projects_handler.api_list_tokens reports a missing read_reach as "
+            f"{tokens[0]['read_reach']!r} while enforcement assumes "
+            f"{mcp_handler.DEFAULT_READ_REACH!r}. The MCP Access tab would then "
+            "describe a credential's reach differently from how it is enforced — "
+            "bring the two back into agreement."
         )
 
     def test_tool_without_scope_declaration_is_rejected(self):
         """A handler that exists in TOOL_HANDLERS but not TOOL_SCOPE_REQUIREMENTS is rejected."""
         undeclared_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
-        result = self._call_tool(
-            tool_name="undeclared_tool",
-            token_scope="read-write",
-            # inject handler but NOT into scopes
-            handlers_extra={"undeclared_tool": undeclared_handler},
-            scopes_extra={},  # no entry added
-        )
+        import mcp_handler
+        original = mcp_handler.TOOL_SCOPE_REQUIREMENTS.copy()
+        try:
+            result = self._call_tool(
+                tool_name="undeclared_tool",
+                token_scopes=list(DEFAULT_SCOPES),
+                # inject handler and a reach kind but NOT a scope declaration
+                handlers_extra={"undeclared_tool": undeclared_handler},
+                reach_extra={"undeclared_tool": REACH_KIND_WORKSPACE},
+            )
+        finally:
+            mcp_handler.TOOL_SCOPE_REQUIREMENTS.clear()
+            mcp_handler.TOOL_SCOPE_REQUIREMENTS.update(original)
 
         assert "error" in result, "Expected a JSON-RPC error for undeclared tool scope"
         undeclared_handler.assert_not_called()
 
+    def test_tool_without_reach_declaration_is_rejected(self):
+        """A handler with a scope but no declared reach kind is refused.
+
+        Without a reach kind there is no way to know whether read_reach applies,
+        and guessing would mean guessing permissively. Same fail-closed rule as
+        the missing scope declaration above.
+        """
+        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        import mcp_handler
+        original = mcp_handler.TOOL_REACH_KINDS.copy()
+        try:
+            result = self._call_tool(
+                tool_name="reachless_tool",
+                token_scopes=list(DEFAULT_SCOPES),
+                handlers_extra={"reachless_tool": handler},
+                scopes_extra={"reachless_tool": SCOPE_FEEDBACK_READ},
+                # An explicit empty dict, not None: None makes _call_tool
+                # auto-declare a reach kind for the synthetic tool, which would
+                # make this test assert nothing.
+                reach_extra={},
+            )
+        finally:
+            mcp_handler.TOOL_REACH_KINDS.clear()
+            mcp_handler.TOOL_REACH_KINDS.update(original)
+
+        assert result.get("error", {}).get("code") == -32603, (
+            f"a tool with no declared reach kind must be a server error, got: {result}"
+        )
+        handler.assert_not_called()
+
     def test_scope_allows_helper(self):
-        """Unit-test _scope_allows to cover all cases."""
+        """Unit-test _scope_allows: exact membership, no hierarchy, list required."""
         from mcp_handler import _scope_allows
 
-        assert _scope_allows("read", "read") is True
-        assert _scope_allows("read-write", "read") is True
-        assert _scope_allows("read", "read-write") is False
-        assert _scope_allows("read-write", "read-write") is True
-        assert _scope_allows("", "read") is False
-        assert _scope_allows("", "read-write") is False
-        assert _scope_allows("read", "unknown") is False
-
-    def test_unrecognised_required_scope_logs_error(self):
-        """An unrecognised required_scope value is an internal error (-32603), not -32003.
-
-        A typo in TOOL_SCOPE_REQUIREMENTS ("write" instead of "read-write") is the
-        same class of bug as omitting the entry entirely, which already returns
-        -32603.  Returning -32003 Forbidden and naming the caller's scope would
-        tell an operator holding the most-privileged token available that their
-        token is insufficient — sending them to re-mint a token, which cannot
-        help.  The message must not mention the caller's token scope.
-
-        The log originates from _handle_tools_call (not the pure _scope_allows
-        predicate) so that the tool name and scope value are available together.
-        """
-        bad_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
-        with patch("mcp_handler.logger") as mock_logger:
-            result = self._call_tool(
-                tool_name="misconfigured_tool",
-                token_scope="read-write",
-                handlers_extra={"misconfigured_tool": bad_handler},
-                scopes_extra={"misconfigured_tool": "write"},  # "write" is not a valid scope
-            )
-            assert result["error"]["code"] == -32603, (
-                "A misconfigured scope declaration is a server fault, expected -32603, "
-                f"got {result['error']['code']}"
-            )
-            message = result["error"]["message"]
-            assert "read-write" not in message and "Forbidden" not in message, (
-                f"The message must not blame the caller's token scope; got: {message}"
-            )
-            assert "misconfigured_tool" in message
-            assert mock_logger.error.called, (
-                "_handle_tools_call must log at ERROR for an unrecognised required_scope value"
-            )
-        bad_handler.assert_not_called()
+        assert _scope_allows([SCOPE_FEEDBACK_READ], SCOPE_FEEDBACK_READ) is True
+        assert _scope_allows(list(DEFAULT_SCOPES), SCOPE_PROJECTS_READ) is True
+        assert _scope_allows([SCOPE_FEEDBACK_READ], SCOPE_PROJECTS_READ) is False
+        assert _scope_allows([], SCOPE_FEEDBACK_READ) is False
+        assert _scope_allows(None, SCOPE_FEEDBACK_READ) is False
+        # A bare string must not pass by substring containment.
+        assert _scope_allows(SCOPE_FEEDBACK_READ, SCOPE_FEEDBACK_READ) is False
+        # An empty requirement never grants anything.
+        assert _scope_allows(list(DEFAULT_SCOPES), "") is False
 
 
 # ===========================================================================
@@ -953,54 +1065,56 @@ class TestPartialResultReporting:
 
 
 # ===========================================================================
-# 4. Non-string token_hash type safety
+# 4. Non-string secret_hash type safety
 # ===========================================================================
 
-class TestTokenHashTypeSafety:
-    """_authenticate must not raise when a DynamoDB row has a non-str token_hash."""
+class TestSecretHashTypeSafety:
+    """_authenticate must not raise when the stored secret_hash is not a str."""
 
+    @pytest.mark.parametrize("bad_hash", [
+        pytest.param(Decimal("12345"), id="Decimal"),
+        pytest.param(b"binary_bytes", id="bytes"),
+        pytest.param(None, id="None"),
+        pytest.param(["a"], id="list"),
+    ])
     @patch("mcp_handler.projects_table")
-    def test_non_string_token_hash_skipped(self, mock_table):
-        """A DynamoDB item with a non-str token_hash is skipped, not raised.
+    def test_non_string_secret_hash_is_refused_not_raised(self, mock_table, bad_hash):
+        """A malformed row is a 401, not an AttributeError turned into a 500.
 
-        A malformed/migrated row (e.g. token_hash stored as Binary or Decimal)
-        must not cause an AttributeError that propagates out of _authenticate
-        and turns a single bad row into a 500 for every request in that project.
+        Calling .encode() on a Decimal or Binary would raise straight out of
+        _authenticate. With the keyed lookup there is only ever ONE row, so a
+        damaged row can no longer be skipped in favour of a later one — it is
+        simply refused, which is the fail-closed answer.
         """
-        from decimal import Decimal
-        # Row 1: non-string hash (simulates a malformed/migrated row)
-        # Row 2: correct string hash that won't match (so _authenticate returns None)
-        mock_table.query.return_value = {
-            "Items": [
-                {"sk": "TOKEN#1", "token_hash": Decimal("12345"), "scope": "read"},
-                {"sk": "TOKEN#2", "token_hash": b"binary_bytes", "scope": "read"},
-                {"sk": "TOKEN#3", "token_hash": "correcthash_that_wont_match", "scope": "read"},
-            ]
-        }
+        mock_table.query.return_value = {"Items": [_token_row(secret_hash=bad_hash)]}
 
         from mcp_handler import _authenticate
-        # Must return None without raising
-        result = _authenticate(_make_event("voc_testtoken"))
-        assert result is None, "Non-string token_hash must not raise; should return None"
+        assert _authenticate(_make_event()) is None
 
     @patch("mcp_handler.projects_table")
-    def test_non_string_token_hash_logs_warning(self, mock_table):
-        """A non-str token_hash row triggers a WARNING log with the type name, not the value."""
+    def test_non_string_secret_hash_logs_the_type_and_row(self, mock_table):
+        """The warning names the type and the token_id, never the value.
+
+        token_id is deliberately included: it is what lets an operator find and
+        re-mint the damaged row, and hashing only the secret half is what makes
+        it safe to log.
+        """
         from decimal import Decimal
-        mock_table.query.return_value = {
-            "Items": [
-                {"sk": "TOKEN#1", "token_hash": Decimal("99"), "scope": "read"},
-            ]
-        }
+        mock_table.query.return_value = {"Items": [_token_row(secret_hash=Decimal("99"))]}
 
         from mcp_handler import _authenticate
         with patch("mcp_handler.logger") as mock_logger:
-            _authenticate(_make_event("voc_testtoken"))
-            assert mock_logger.warning.called, "A non-str token_hash must trigger a WARNING log"
-            # The log must include the type name but NOT the value itself
-            call_kwargs = mock_logger.warning.call_args
-            extra = call_kwargs[1].get("extra", {}) if call_kwargs[1] else {}
-            assert "type" in extra, "WARNING extra must include 'type' (the type name)"
+            _authenticate(_make_event())
+            assert mock_logger.warning.called, "A non-str secret_hash must trigger a WARNING log"
+            call = mock_logger.warning.call_args
+            extra = (call.kwargs or {}).get("extra", {})
+            assert extra.get("type") == "Decimal", (
+                f"WARNING extra must name the offending type; got {extra}"
+            )
+            assert extra.get("token_id") == _MINTED.token_id, (
+                f"WARNING extra must name the row so an operator can fix it; got {extra}"
+            )
+            assert "99" not in str(extra.get("type", "")), "the value must not be logged"
 
 
 # ===========================================================================
@@ -1225,15 +1339,18 @@ class TestBotoCoreErrorHandling:
     @pytest.mark.parametrize("exc", _TRANSIENT_BOTOCORE + _PERMANENT_BOTOCORE)
     @patch("mcp_handler.projects_table")
     def test_botocore_logs_carry_no_token_material(self, mock_table, exc):
-        """Only the exception *type* is logged — never the token or its hash.
+        """Only the exception *type* is logged — never the secret or its hash.
 
-        The Bearer token is a recognisable sentinel here, so an f-string or an
-        `extra` field that interpolated it would trip this immediately.
+        The credential's secret half is a recognisable sentinel here, so an
+        f-string or an `extra` field that interpolated it would trip this
+        immediately. The token ID is deliberately exempt: hashing only the
+        secret half is what makes the id safe to log, and log lines naming the
+        row are how an operator fixes one.
         """
         import mcp_handler
 
         mock_table.query.side_effect = exc
-        event = _make_event(token="voc_SENTINELTOKEN")
+        event = _make_event(token=_SENTINEL_TOKEN)
 
         with patch("mcp_handler.logger") as mock_logger:
             try:
@@ -1246,10 +1363,10 @@ class TestBotoCoreErrorHandling:
             for call in calls:
                 extra = (call.kwargs or {}).get("extra", {})
                 rendered = " ".join(str(a) for a in call.args) + " " + str(extra)
-                assert "SENTINELTOKEN" not in rendered, (
-                    f"Log must not contain token material; got: {rendered}"
+                assert _SENTINEL_SECRET not in rendered, (
+                    f"Log must not contain the credential secret; got: {rendered}"
                 )
-                assert "token_hash" not in extra, f"Log extra must not carry a hash; got: {extra}"
+                assert "secret_hash" not in extra, f"Log extra must not carry a hash; got: {extra}"
 
 
 # ===========================================================================
@@ -1338,7 +1455,7 @@ class TestUnclassifiedAuthFaultsAreServerErrors:
         mock_table.query.side_effect = exc
         with patch("mcp_handler.logger") as mock_logger:
             with pytest.raises(mcp_handler.AuthBackendUnavailable):
-                mcp_handler._authenticate(_make_event(token="voc_SENTINELTOKEN"))
+                mcp_handler._authenticate(_make_event(token=_SENTINEL_TOKEN))
 
             calls = mock_logger.exception.call_args_list
             assert calls, f"{type(exc).__name__} must be logged for an operator"
@@ -1348,8 +1465,8 @@ class TestUnclassifiedAuthFaultsAreServerErrors:
             assert type(exc).__name__ in rendered, (
                 f"The log must name the fault type; got: {rendered}"
             )
-            assert "SENTINELTOKEN" not in rendered, (
-                f"Log must not contain token material; got: {rendered}"
+            assert _SENTINEL_SECRET not in rendered, (
+                f"Log must not contain the credential secret; got: {rendered}"
             )
 
     @patch("mcp_handler.projects_table")
@@ -1423,7 +1540,7 @@ class TestUnconfiguredTableIsAServerFault:
                 "httpMethod": "POST",
                 "path": "/v1/mcp",
                 "headers": {
-                    "authorization": "Bearer voc_testtoken",
+                    "authorization": f"Bearer {_VALID_TOKEN}",
                     "x-project-id": "proj-1",
                 },
                 "body": json.dumps({
@@ -1456,7 +1573,7 @@ class TestUnconfiguredTableIsAServerFault:
                 "httpMethod": "GET",
                 "path": "/v1/mcp/autoseed/proj-1",
                 "headers": {
-                    "authorization": "Bearer voc_testtoken",
+                    "authorization": f"Bearer {_VALID_TOKEN}",
                     "x-project-id": "proj-1",
                 },
             },
@@ -1590,7 +1707,7 @@ class TestWwwAuthenticateChallenge:
             {
                 "httpMethod": "GET",
                 "path": "/v1/mcp/autoseed/proj-1",
-                "headers": {"authorization": "Bearer voc_testtoken"},
+                "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
             },
             lambda_context,
         )
@@ -1632,14 +1749,7 @@ class TestTokenExpiry:
     """
 
     def _row(self, **extra) -> dict:
-        from shared.tokens import hash_token
-        return {
-            "sk": "TOKEN#1",
-            "token_id": "tok_1",
-            "token_hash": hash_token("voc_testtoken"),
-            "scope": "read",
-            **extra,
-        }
+        return _token_row(**extra)
 
     def _auth(self, row: dict):
         """Run _authenticate against a single stored row; return its result."""
@@ -1701,47 +1811,43 @@ class TestTokenExpiry:
         the root logger, which would make a caplog assertion vacuously green.
         """
         import mcp_handler
-        from shared.tokens import hash_token
-        sentinel = "voc_SENTINELTOKEN"
-        row = {
-            "sk": "TOKEN#1",
-            "token_id": "tok_1",
-            "token_hash": hash_token(sentinel),
-            "scope": "read",
-            "expires_at": "not-a-date",
-        }
+        from shared.mcp_tokens import hash_secret
+        row = self._row(secret_hash=hash_secret(_SENTINEL_SECRET),
+                        expires_at="not-a-date")
         mock_table.query.return_value = {"Items": [row]}
         with patch("mcp_handler.logger") as mock_logger:
-            result = mcp_handler._authenticate(_make_event(token=sentinel))
+            result = mcp_handler._authenticate(_make_event(token=_SENTINEL_TOKEN))
             assert result is None
             calls = mock_logger.warning.call_args_list
             assert calls, "the malformed expiry must be logged"
             for call in calls:
                 extra = (call.kwargs or {}).get("extra", {})
                 rendered = " ".join(str(a) for a in call.args) + " " + str(extra)
-                assert "SENTINELTOKEN" not in rendered
-                assert hash_token(sentinel) not in rendered
-                assert extra.get("token_id") == "tok_1", (
+                assert _SENTINEL_SECRET not in rendered
+                assert hash_secret(_SENTINEL_SECRET) not in rendered
+                assert extra.get("token_id") == _MINTED.token_id, (
                     "the log must name the row so an operator can fix it"
                 )
 
-    def test_only_the_matching_row_is_expiry_checked(self):
-        """An expired NON-matching row must not block a valid matching row."""
+    def test_expiry_is_checked_only_after_the_secret_matches(self):
+        """A wrong secret on an expired row is refused as a bad secret.
+
+        Ordering matters for timing: checking expiry first would let a caller
+        distinguish "this id exists but expired" from "this id does not exist"
+        by which work the server performed. With the keyed lookup there is one
+        row, so the old "only the matching row is expiry-checked" invariant
+        becomes this ordering one.
+        """
         from datetime import datetime, timedelta, timezone
 
         import mcp_handler
         past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
-        expired_other = {
-            "sk": "TOKEN#0",
-            "token_id": "tok_0",
-            "token_hash": "hash-of-some-other-token",
-            "scope": "read",
-            "expires_at": past,
-        }
+        row = self._row(secret_hash="not-the-right-hash", expires_at=past)
         with patch("mcp_handler.projects_table") as mock_table:
-            mock_table.query.return_value = {"Items": [expired_other, self._row()]}
-            mock_table.update_item.return_value = {}
-            assert mcp_handler._authenticate(_make_event()) is not None
+            mock_table.query.return_value = {"Items": [row]}
+            with patch("mcp_handler._credential_expired") as mock_expired:
+                assert mcp_handler._authenticate(_make_event()) is None
+                mock_expired.assert_not_called()
 
 
 # ===========================================================================
@@ -1764,15 +1870,8 @@ class TestProjectsTableUsageMatchesNarrowGrant:
 
     def _strict_table(self):
         """A projects_table where any non-granted DynamoDB method raises."""
-        from shared.tokens import hash_token
         table = MagicMock()
-        row = {
-            "sk": "TOKEN#1",
-            "token_id": "tok_1",
-            "token_hash": hash_token("voc_testtoken"),
-            "scope": "read-write",
-        }
-        table.query.return_value = {"Items": [row]}
+        table.query.return_value = {"Items": [_token_row()]}
         table.update_item.return_value = {}
         for method in self.FORBIDDEN:
             getattr(table, method).side_effect = AssertionError(
@@ -1788,7 +1887,7 @@ class TestProjectsTableUsageMatchesNarrowGrant:
             "httpMethod": "POST",
             "path": "/v1/mcp",
             "headers": {
-                "authorization": "Bearer voc_testtoken",
+                "authorization": f"Bearer {_VALID_TOKEN}",
                 "x-project-id": "proj-1",
             },
             "body": json.dumps({
@@ -1863,7 +1962,7 @@ class TestProjectsTableUsageMatchesNarrowGrant:
                 {
                     "httpMethod": "GET",
                     "path": "/v1/mcp/autoseed/proj-1",
-                    "headers": {"authorization": "Bearer voc_testtoken"},
+                    "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
                 },
                 lambda_context,
             )
@@ -2035,3 +2134,225 @@ class TestOriginDefaultFailsClosed:
             lambda_context,
         )
         assert response["statusCode"] == 200
+
+
+# ===========================================================================
+# 11. Read reach — the second axis
+# ===========================================================================
+
+class TestReadReachEnforcement:
+    """Reach is enforced separately from scope, at dispatch.
+
+    Scope says WHICH KIND of data a credential may read; reach says HOW FAR.
+    A token can hold `projects:read` and still be refused a given project, and
+    the two refusals are distinct code paths.
+
+    Revert stories:
+      • deleting the reach_allows call in _handle_tools_call fails
+        test_project_set_token_cannot_read_a_project_outside_its_set;
+      • letting a project-set token call a workspace-shaped tool fails
+        test_project_set_token_cannot_read_the_feedback_corpus, which is the
+        one that matters — the corpus has no project dimension, so allowing it
+        hands a supposedly sealed credential every verbatim.
+    """
+
+    def _call(self, tool, token_info, arguments=None):
+        import mcp_handler
+        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        original = mcp_handler.TOOL_HANDLERS.copy()
+        try:
+            mcp_handler.TOOL_HANDLERS[tool] = handler
+            result = mcp_handler._handle_tools_call(
+                req_id=1,
+                params={"name": tool, "arguments": arguments or {}},
+                token_info=token_info,
+            )
+        finally:
+            mcp_handler.TOOL_HANDLERS.clear()
+            mcp_handler.TOOL_HANDLERS.update(original)
+        return result, handler
+
+    def _token(self, **extra):
+        return {"scopes": list(DEFAULT_SCOPES), "projects": [_TOKEN_PROJECT],
+                "read_reach": REACH_WORKSPACE, **extra}
+
+    # --- workspace reach (the default) -----------------------------------
+    def test_workspace_token_reads_the_feedback_corpus(self):
+        result, handler = self._call("search_feedback", self._token())
+        assert "result" in result, result
+        handler.assert_called_once()
+
+    def test_workspace_token_reads_a_project_outside_its_own_set(self):
+        """The default really is workspace-wide.
+
+        Pinned deliberately, because it is the surprising half of the owner's
+        decision: a credential minted inside one project can read another
+        project's personas and documents. The mint UI is what has to say so.
+        """
+        result, handler = self._call(
+            "get_project", self._token(), arguments={"project_id": "someone-elses"},
+        )
+        assert "result" in result, result
+        # The tool receives the project it was ASKED for, not the token's own.
+        assert handler.call_args.args[1]["project_id"] == "someone-elses"
+
+    # --- project-set reach (the sealed option) ---------------------------
+    def test_project_set_token_reads_a_project_in_its_set(self):
+        result, handler = self._call(
+            "get_project", self._token(read_reach=REACH_PROJECT_SET),
+            arguments={"project_id": _TOKEN_PROJECT},
+        )
+        assert "result" in result, result
+        handler.assert_called_once()
+
+    def test_project_set_token_cannot_read_a_project_outside_its_set(self):
+        result, handler = self._call(
+            "get_project", self._token(read_reach=REACH_PROJECT_SET),
+            arguments={"project_id": "someone-elses"},
+        )
+        assert result.get("error", {}).get("code") == -32003, result
+        handler.assert_not_called()
+
+    def test_project_set_token_cannot_read_the_feedback_corpus(self):
+        """The load-bearing refusal.
+
+        `voc-feedback` is keyed SOURCE#{platform} with no project_id, so
+        `project-set` has nothing to narrow. Allowing the call "because the
+        token holds feedback:read" would make a sealed credential a
+        workspace-wide one.
+        """
+        for tool in ("search_feedback", "get_metrics_summary", "get_feedback_detail"):
+            result, handler = self._call(tool, self._token(read_reach=REACH_PROJECT_SET))
+            assert result.get("error", {}).get("code") == -32003, f"{tool}: {result}"
+            handler.assert_not_called()
+
+    # --- none ------------------------------------------------------------
+    def test_none_reach_reads_nothing(self):
+        for tool in ("search_feedback", "get_project"):
+            result, handler = self._call(
+                tool, self._token(read_reach=REACH_NONE),
+                arguments={"project_id": _TOKEN_PROJECT},
+            )
+            assert result.get("error", {}).get("code") == -32003, f"{tool}: {result}"
+            handler.assert_not_called()
+
+    # --- project resolution ---------------------------------------------
+    def test_single_project_token_needs_no_project_argument(self):
+        """The common case stays ergonomic: one project, no argument required."""
+        result, handler = self._call("list_personas", self._token())
+        assert "result" in result, result
+        assert handler.call_args.args[1]["project_id"] == _TOKEN_PROJECT
+
+    def test_explicit_argument_wins_over_the_token_default(self):
+        result, handler = self._call(
+            "list_personas", self._token(), arguments={"project_id": "other"},
+        )
+        assert "result" in result, result
+        assert handler.call_args.args[1]["project_id"] == "other"
+
+    def test_ambiguous_project_set_requires_an_explicit_argument(self):
+        """Several projects and no argument resolves to a request, not a guess.
+
+        -32602 (invalid params) rather than -32003: the caller can fix this by
+        naming the project, and calling it Forbidden would send them looking for
+        a different token instead.
+        """
+        result, handler = self._call(
+            "get_project", self._token(projects=["proj-a", "proj-b"]),
+        )
+        assert result.get("error", {}).get("code") == -32602, result
+        assert "project_id" in result["error"]["message"]
+        handler.assert_not_called()
+
+    def test_empty_project_set_cannot_default_a_project(self):
+        result, handler = self._call("get_project", self._token(projects=[]))
+        assert "error" in result, result
+        handler.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   ", None, 123, ["proj-a"]])
+    def test_unusable_project_argument_falls_back_to_the_token_default(self, bad):
+        """A junk argument must not become a project id.
+
+        It falls back to the token's single project (which is in reach), rather
+        than being passed through to a DynamoDB key.
+        """
+        result, handler = self._call(
+            "get_project", self._token(), arguments={"project_id": bad},
+        )
+        assert "result" in result, result
+        assert handler.call_args.args[1]["project_id"] == _TOKEN_PROJECT
+
+    def test_reach_is_checked_even_when_the_scope_is_held(self):
+        """The two gates are independent; holding the scope is not enough."""
+        token = self._token(read_reach=REACH_PROJECT_SET)
+        assert SCOPE_PROJECTS_READ in token["scopes"]
+        result, handler = self._call(
+            "get_project", token, arguments={"project_id": "not-in-set"},
+        )
+        assert result.get("error", {}).get("code") == -32003, result
+        assert "read reach" in result["error"]["message"], (
+            "the refusal must name reach, not scope, or the operator re-mints "
+            f"the wrong thing; got: {result['error']['message']}"
+        )
+        handler.assert_not_called()
+
+
+# ===========================================================================
+# 12. Autoseed goes through the same gates as the tools
+# ===========================================================================
+
+class TestAutoseedAuthorization:
+    """GET /mcp/autoseed/{project_id} is a project-shaped read.
+
+    It returns the project's personas and documents — exactly what get_project
+    serves — so it must pass the same scope and reach checks. The old code
+    compared the path project to the token's single project and checked no scope
+    at all.
+    """
+
+    def _get(self, project_id, row, lambda_context):
+        import mcp_handler
+        with patch("mcp_handler.projects_table") as mock_table, \
+             patch("mcp_handler.autoseed_project", return_value={"ok": True}) as seed:
+            mock_table.query.return_value = {"Items": [row]}
+            mock_table.update_item.return_value = {}
+            response = mcp_handler.lambda_handler(
+                {
+                    "httpMethod": "GET",
+                    "path": f"/v1/mcp/autoseed/{project_id}",
+                    "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
+                },
+                lambda_context,
+            )
+        return response, seed
+
+    def test_workspace_token_may_autoseed_any_project(self, lambda_context):
+        response, seed = self._get("another-project", _token_row(), lambda_context)
+        assert response["statusCode"] == 200, response["body"]
+        seed.assert_called_once()
+
+    def test_project_set_token_may_autoseed_its_own_project(self, lambda_context):
+        row = _token_row(read_reach=REACH_PROJECT_SET)
+        response, seed = self._get(_TOKEN_PROJECT, row, lambda_context)
+        assert response["statusCode"] == 200, response["body"]
+        seed.assert_called_once()
+
+    def test_project_set_token_refused_outside_its_set(self, lambda_context):
+        row = _token_row(read_reach=REACH_PROJECT_SET)
+        response, seed = self._get("another-project", row, lambda_context)
+        assert response["statusCode"] == 403, response["body"]
+        seed.assert_not_called()
+
+    def test_token_without_projects_scope_is_refused(self, lambda_context):
+        """The check the old equality test did not perform at all."""
+        row = _token_row(scopes=[SCOPE_FEEDBACK_READ])
+        response, seed = self._get(_TOKEN_PROJECT, row, lambda_context)
+        assert response["statusCode"] == 403, response["body"]
+        assert SCOPE_PROJECTS_READ in json.loads(response["body"])["message"]
+        seed.assert_not_called()
+
+    def test_none_reach_is_refused(self, lambda_context):
+        row = _token_row(read_reach=REACH_NONE)
+        response, seed = self._get(_TOKEN_PROJECT, row, lambda_context)
+        assert response["statusCode"] == 403, response["body"]
+        seed.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_projects_handler.py
+++ b/voc-datalake/lambda/api/test/test_projects_handler.py
@@ -534,8 +534,17 @@ class TestCreateTokenExpiry:
     isinstance(True, int) is True, and int(30.5) truncates.
     """
 
-    def _post(self, api_gateway_event, lambda_context, body):
+    def _post(self, api_gateway_event, lambda_context, body, *, with_scopes=True):
+        """POST the mint route.
+
+        `scopes` is REQUIRED by the route, so it is supplied unless a test is
+        specifically about its absence — otherwise every test here would be
+        asserting the same 400.
+        """
         from projects_handler import lambda_handler
+        from shared.mcp_tokens import ALL_READ_SCOPES
+        if with_scopes and 'scopes' not in body:
+            body = {**body, 'scopes': list(ALL_READ_SCOPES)}
         with patch('projects_handler.get_projects_table') as mock_get_table:
             mock_table = mock_get_table.return_value
             mock_table.get_item.return_value = {'Item': {'pk': 'PROJECT#proj-1', 'sk': 'META'}}
@@ -547,6 +556,25 @@ class TestCreateTokenExpiry:
             )
             response = lambda_handler(event, lambda_context)
             return response, mock_table
+
+    def test_scopes_are_required_not_defaulted(self, api_gateway_event, lambda_context):
+        """Omitting `scopes` is a 400, NOT a credential holding everything.
+
+        The mint boundary must not be fail-open while enforcement is fail-closed:
+        defaulting here would mean `POST {"name": "x"}` yields the widest
+        possible credential, so the laziest request would produce the most
+        dangerous token. `read_reach` is deliberately different — it HAS a
+        chosen default the UI warns about; `scopes` has no least-privilege
+        fallback, so there is nothing honest to default to.
+        """
+        response, mock_table = self._post(
+            api_gateway_event, lambda_context, {'name': 't'}, with_scopes=False,
+        )
+        assert response['statusCode'] == 400, response['body']
+        # This API reports validation failures under `error`, not `message`.
+        body = json.loads(response['body'])
+        assert 'scopes' in body.get('error', ''), body
+        mock_table.put_item.assert_not_called()
 
     def test_absent_expiry_stores_no_attribute(self, api_gateway_event, lambda_context):
         """Omitting the field keeps today's exact row shape — attribute absent."""
@@ -629,6 +657,44 @@ class TestCreateTokenExpiry:
         # One Query of the token partition, not a per-project range scan.
         table.query.assert_called_once()
 
+    def test_list_follows_pagination_to_the_end(self, api_gateway_event, lambda_context):
+        """A truncated first page would make credentials unrevocable.
+
+        All tokens share ONE partition and a Query page is capped at 1 MB, so a
+        single-page read starts silently dropping rows as the workspace grows.
+        The list is the only revoke path, so a dropped row is a credential that
+        cannot be revoked through the UI — the exact invariant the mint route is
+        written to guarantee.
+
+        Revert story: deleting the LastEvaluatedKey loop in `_query_all_tokens`
+        fails this test, because only `tok_page1` comes back.
+        """
+        from projects_handler import lambda_handler
+        page1 = {
+            'Items': [{'token_id': 'tok_page1', 'name': 'a', 'created_at': 'c',
+                       'projects': ['proj-1']}],
+            'LastEvaluatedKey': {'pk': {'S': 'MCPTOKEN'}, 'sk': {'S': 'TOKEN#tok_page1'}},
+        }
+        page2 = {
+            'Items': [{'token_id': 'tok_page2', 'name': 'b', 'created_at': 'c',
+                       'projects': ['proj-1']}],
+        }
+        with patch('projects_handler.get_projects_table') as mock_get_table:
+            table = mock_get_table.return_value
+            table.query.side_effect = [page1, page2]
+            event = api_gateway_event(method='GET', path='/projects/proj-1/api-tokens')
+            response = lambda_handler(event, lambda_context)
+
+        ids = {t['token_id'] for t in json.loads(response['body'])['tokens']}
+        assert ids == {'tok_page1', 'tok_page2'}, (
+            'the second page was dropped — those credentials would be unrevocable'
+        )
+        assert table.query.call_count == 2
+        # The follow-up Query must resume from where the first stopped.
+        assert table.query.call_args_list[1].kwargs['ExclusiveStartKey'] == (
+            page1['LastEvaluatedKey']
+        )
+
     def test_list_never_returns_the_secret_hash(self, api_gateway_event, lambda_context):
         response, _ = self._list(api_gateway_event, lambda_context, [
             {'token_id': 'tok_1', 'name': 'n', 'created_at': 'c', 'projects': ['proj-1'],
@@ -643,8 +709,8 @@ class TestCreateTokenExpiry:
     def test_mint_stores_the_new_credential_shape(self, api_gateway_event, lambda_context):
         """The row carries a secret hash, a scope set, a project set and a reach."""
         from shared.mcp_tokens import (
+            ALL_READ_SCOPES,
             DEFAULT_READ_REACH,
-            DEFAULT_SCOPES,
             MCP_TOKEN_PK,
             parse_token,
         )
@@ -657,7 +723,7 @@ class TestCreateTokenExpiry:
         assert stored['pk'] == MCP_TOKEN_PK
         assert not stored['pk'].startswith('PROJECT#')
         assert stored['sk'] == f"TOKEN#{stored['token_id']}"
-        assert stored['scopes'] == list(DEFAULT_SCOPES)
+        assert stored['scopes'] == list(ALL_READ_SCOPES)
         assert stored['projects'] == ['proj-1']
         assert stored['read_reach'] == DEFAULT_READ_REACH
         assert stored['created_by']

--- a/voc-datalake/lambda/api/test/test_projects_handler.py
+++ b/voc-datalake/lambda/api/test/test_projects_handler.py
@@ -586,17 +586,196 @@ class TestCreateTokenExpiry:
         assert response['statusCode'] == 200
         assert 'expires_at' not in mock_table.put_item.call_args.kwargs['Item']
 
-    def test_list_returns_expires_at(self, api_gateway_event, lambda_context):
-        """GET .../api-tokens surfaces the deadline; legacy rows read as None."""
+    def _list(self, api_gateway_event, lambda_context, items, project='proj-1'):
         from projects_handler import lambda_handler
         with patch('projects_handler.get_projects_table') as mock_get_table:
-            mock_get_table.return_value.query.return_value = {'Items': [
-                {'token_id': 'tok_new', 'name': 'n', 'created_at': 'c',
-                 'expires_at': '2027-01-01T00:00:00+00:00'},
-                {'token_id': 'tok_legacy', 'name': 'l', 'created_at': 'c'},
-            ]}
-            event = api_gateway_event(method='GET', path='/projects/proj-1/api-tokens')
+            mock_get_table.return_value.query.return_value = {'Items': items}
+            event = api_gateway_event(method='GET', path=f'/projects/{project}/api-tokens')
             response = lambda_handler(event, lambda_context)
+        return response, mock_get_table.return_value
+
+    def test_list_returns_expires_at(self, api_gateway_event, lambda_context):
+        """GET .../api-tokens surfaces the deadline; a row without one reads None."""
+        response, _ = self._list(api_gateway_event, lambda_context, [
+            {'token_id': 'tok_new', 'name': 'n', 'created_at': 'c',
+             'projects': ['proj-1'], 'expires_at': '2027-01-01T00:00:00+00:00'},
+            {'token_id': 'tok_forever', 'name': 'l', 'created_at': 'c',
+             'projects': ['proj-1']},
+        ])
         tokens = {t['token_id']: t for t in json.loads(response['body'])['tokens']}
         assert tokens['tok_new']['expires_at'] == '2027-01-01T00:00:00+00:00'
-        assert tokens['tok_legacy']['expires_at'] is None
+        assert tokens['tok_forever']['expires_at'] is None
+
+    def test_list_shows_only_tokens_whose_project_set_includes_this_project(
+        self, api_gateway_event, lambda_context
+    ):
+        """Tokens live in one partition, so the tab filters by membership.
+
+        A credential is workspace-level now; the project tab shows the ones
+        minted for (or reaching) that project. Getting this filter wrong would
+        show every project's credentials in every tab.
+        """
+        response, table = self._list(api_gateway_event, lambda_context, [
+            {'token_id': 'tok_mine', 'name': 'a', 'created_at': 'c', 'projects': ['proj-1']},
+            {'token_id': 'tok_theirs', 'name': 'b', 'created_at': 'c', 'projects': ['proj-2']},
+            {'token_id': 'tok_both', 'name': 'c', 'created_at': 'c',
+             'projects': ['proj-1', 'proj-2']},
+            {'token_id': 'tok_none', 'name': 'd', 'created_at': 'c', 'projects': []},
+        ])
+        ids = {t['token_id'] for t in json.loads(response['body'])['tokens']}
+        assert ids == {'tok_mine', 'tok_both'}, (
+            'the tab must show exactly the tokens whose project set names this project'
+        )
+        # One Query of the token partition, not a per-project range scan.
+        table.query.assert_called_once()
+
+    def test_list_never_returns_the_secret_hash(self, api_gateway_event, lambda_context):
+        response, _ = self._list(api_gateway_event, lambda_context, [
+            {'token_id': 'tok_1', 'name': 'n', 'created_at': 'c', 'projects': ['proj-1'],
+             'secret_hash': 'THE-STORED-HASH', 'created_by': 'a-cognito-sub'},
+        ])
+        body = response['body']
+        assert 'THE-STORED-HASH' not in body
+        assert 'secret_hash' not in body
+        # created_by identifies a person; it is stored for audit, not displayed.
+        assert 'a-cognito-sub' not in body
+
+    def test_mint_stores_the_new_credential_shape(self, api_gateway_event, lambda_context):
+        """The row carries a secret hash, a scope set, a project set and a reach."""
+        from shared.mcp_tokens import (
+            DEFAULT_READ_REACH,
+            DEFAULT_SCOPES,
+            MCP_TOKEN_PK,
+            parse_token,
+        )
+        response, mock_table = self._post(api_gateway_event, lambda_context, {'name': 't'})
+        assert response['statusCode'] == 200
+        stored = mock_table.put_item.call_args.kwargs['Item']
+        body = json.loads(response['body'])
+
+        # Stored outside any project partition: a credential is workspace-level.
+        assert stored['pk'] == MCP_TOKEN_PK
+        assert not stored['pk'].startswith('PROJECT#')
+        assert stored['sk'] == f"TOKEN#{stored['token_id']}"
+        assert stored['scopes'] == list(DEFAULT_SCOPES)
+        assert stored['projects'] == ['proj-1']
+        assert stored['read_reach'] == DEFAULT_READ_REACH
+        assert stored['created_by']
+
+        # The returned credential parses back to the row that was stored, and
+        # the row holds a hash of the secret rather than the credential itself.
+        parsed = parse_token(body['token'])
+        assert parsed is not None, f"minted credential does not parse: {body['token']!r}"
+        assert parsed[0] == stored['token_id']
+        assert stored['secret_hash'] not in body['token']
+        assert 'token_hash' not in stored, 'the retired field must not be written'
+
+    def test_mint_accepts_a_narrower_scope_set(self, api_gateway_event, lambda_context):
+        from shared.mcp_tokens import SCOPE_FEEDBACK_READ
+        response, mock_table = self._post(
+            api_gateway_event, lambda_context,
+            {'name': 't', 'scopes': [SCOPE_FEEDBACK_READ]},
+        )
+        assert response['statusCode'] == 200
+        assert mock_table.put_item.call_args.kwargs['Item']['scopes'] == [SCOPE_FEEDBACK_READ]
+
+    @pytest.mark.parametrize('bad_scopes', [
+        [], 'projects:read', ['nope:read'], ['projects:write'], [123], {}, ['projects:read', 'x'],
+    ])
+    def test_mint_rejects_an_unusable_scope_set(
+        self, api_gateway_event, lambda_context, bad_scopes
+    ):
+        """Unknown scopes are refused rather than dropped.
+
+        Silently ignoring one would mint a credential narrower than the caller
+        asked for, which they discover as a permission error much later.
+        `projects:write` is in the list on purpose: it does not exist yet, and
+        accepting it would recreate the phantom-permission bug the old
+        `read-write` scope was.
+        """
+        response, mock_table = self._post(
+            api_gateway_event, lambda_context, {'name': 't', 'scopes': bad_scopes},
+        )
+        assert response['statusCode'] == 400, response['body']
+        mock_table.put_item.assert_not_called()
+
+    def test_mint_deduplicates_scopes_without_reordering(self, api_gateway_event, lambda_context):
+        from shared.mcp_tokens import SCOPE_FEEDBACK_READ, SCOPE_PROJECTS_READ
+        response, mock_table = self._post(
+            api_gateway_event, lambda_context,
+            {'name': 't', 'scopes': [SCOPE_PROJECTS_READ, SCOPE_FEEDBACK_READ,
+                                     SCOPE_PROJECTS_READ]},
+        )
+        assert response['statusCode'] == 200
+        assert mock_table.put_item.call_args.kwargs['Item']['scopes'] == [
+            SCOPE_PROJECTS_READ, SCOPE_FEEDBACK_READ,
+        ]
+
+    @pytest.mark.parametrize('reach', ['workspace', 'project-set', 'none'])
+    def test_mint_accepts_each_valid_read_reach(
+        self, api_gateway_event, lambda_context, reach
+    ):
+        response, mock_table = self._post(
+            api_gateway_event, lambda_context, {'name': 't', 'read_reach': reach},
+        )
+        assert response['statusCode'] == 200
+        assert mock_table.put_item.call_args.kwargs['Item']['read_reach'] == reach
+
+    @pytest.mark.parametrize('bad', ['all', 'WORKSPACE', '', 'write-set', 1, [], None])
+    def test_mint_rejects_an_unknown_read_reach(
+        self, api_gateway_event, lambda_context, bad
+    ):
+        """Including 'write-set', an earlier name for 'project-set'.
+
+        A stale client sending the old value must be refused rather than
+        silently defaulted to workspace — the widest reach is the last thing to
+        grant by accident.
+        """
+        response, mock_table = self._post(
+            api_gateway_event, lambda_context, {'name': 't', 'read_reach': bad},
+        )
+        if bad is None:
+            # JSON null means "no preference" and takes the default, like an
+            # absent field. Every other bad value is a 400.
+            assert response['statusCode'] == 200
+            return
+        assert response['statusCode'] == 400, response['body']
+        mock_table.put_item.assert_not_called()
+
+    def test_revoke_addresses_the_token_partition(self, api_gateway_event, lambda_context):
+        from projects_handler import lambda_handler
+        from shared.mcp_tokens import MCP_TOKEN_PK
+        with patch('projects_handler.get_projects_table') as mock_get_table:
+            table = mock_get_table.return_value
+            table.get_item.return_value = {
+                'Item': {'token_id': 'tok_x', 'projects': ['proj-1']}
+            }
+            event = api_gateway_event(
+                method='DELETE', path='/projects/proj-1/api-tokens/tok_x',
+            )
+            response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 200, response['body']
+        assert table.delete_item.call_args.kwargs['Key'] == {
+            'pk': MCP_TOKEN_PK, 'sk': 'TOKEN#tok_x',
+        }
+
+    def test_revoke_refuses_a_token_outside_this_project(
+        self, api_gateway_event, lambda_context
+    ):
+        """404, and nothing is deleted.
+
+        Tokens share one partition, so without this check any project's route
+        could revoke any other project's credential by id.
+        """
+        from projects_handler import lambda_handler
+        with patch('projects_handler.get_projects_table') as mock_get_table:
+            table = mock_get_table.return_value
+            table.get_item.return_value = {
+                'Item': {'token_id': 'tok_x', 'projects': ['proj-2']}
+            }
+            event = api_gateway_event(
+                method='DELETE', path='/projects/proj-1/api-tokens/tok_x',
+            )
+            response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 404, response['body']
+        table.delete_item.assert_not_called()

--- a/voc-datalake/lambda/shared/__init__.py
+++ b/voc-datalake/lambda/shared/__init__.py
@@ -9,5 +9,5 @@ Import directly from submodules:
     from shared.tables import get_feedback_table, get_projects_table
     from shared.jobs import job_handler, JobContext
     from shared.api import create_api_resolver, api_handler
-    from shared.tokens import hash_token
+    from shared.mcp_tokens import mint_token, parse_token, reach_allows
 """

--- a/voc-datalake/lambda/shared/mcp_tokens.py
+++ b/voc-datalake/lambda/shared/mcp_tokens.py
@@ -104,10 +104,12 @@ VALID_SCOPES: Final[frozenset[str]] = frozenset({
     SCOPE_PROJECTS_READ,
 })
 
-# What a token gets when it names no scopes. Every current scope is a read, so
-# this is the whole vocabulary; it stops being the default the moment a write
-# scope exists.
-DEFAULT_SCOPES: Final[tuple[str, ...]] = (
+# The full read set, in vocabulary order. NOT a mint default: the mint route
+# REQUIRES `scopes`, because defaulting it would mean omitting the field yields
+# the widest possible credential — a fail-open boundary under a fail-closed
+# enforcement path. This exists for callers that legitimately want everything
+# (and for tests that need a maximal token); it is not a fallback.
+ALL_READ_SCOPES: Final[tuple[str, ...]] = (
     SCOPE_FEEDBACK_READ,
     SCOPE_METRICS_READ,
     SCOPE_PROJECTS_READ,

--- a/voc-datalake/lambda/shared/mcp_tokens.py
+++ b/voc-datalake/lambda/shared/mcp_tokens.py
@@ -1,0 +1,276 @@
+"""MCP credential format, storage keys, and the two reach axes.
+
+The single source of truth for what an MCP token *is*. Before this module the
+``voc_`` prefix was spelled in three places — the MCP handler, the projects
+handler, and an inline Node authorizer in api-stack.ts — and the only shared
+code was a bare SHA-256 helper.
+
+Three things changed with this format, each fixing something structural:
+
+1. **The token carries its own id**, so authentication is ONE keyed read
+   instead of "Query every token row in a project and hash each one until
+   something matches". That loop is also why the old credential needed an
+   ``X-Project-Id`` header: without the project there was no partition to
+   scan, and a header cannot express "no particular project", which is what
+   made a workspace-wide tool such as ``list_projects`` unimplementable.
+2. **Only the secret half is hashed.** The token id is therefore safe to log,
+   display and put in an error message, while the secret never is.
+3. **Reach is two independent axes** (see ``read_reach``), because "write
+   here, look around everywhere" is the shape people actually want and a
+   single project-scope field cannot say it.
+
+Legacy ``voc_<64 hex>`` tokens are NOT accepted. They were never used in
+production (owner confirmation, 2026-08-18), and the failure mode for a stray
+one is a 401 that re-minting fixes — not data loss. Nothing in here should
+grow a compatibility branch for them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Format
+# ---------------------------------------------------------------------------
+
+TOKEN_PREFIX: Final = 'voc_'
+TOKEN_ID_PREFIX: Final = 'tok_'
+
+# secrets.token_hex(n) yields 2n hex characters.
+_TOKEN_ID_BYTES: Final = 8      # → 16 hex chars, 64 bits of id space
+_SECRET_BYTES: Final = 32       # → 64 hex chars, 256 bits of secret
+
+_TOKEN_ID_HEX_LEN: Final = _TOKEN_ID_BYTES * 2
+_SECRET_HEX_LEN: Final = _SECRET_BYTES * 2
+
+# `voc` + `tok` + id + secret. The token id keeps its own `tok_` prefix
+# because it is a public identifier elsewhere (the revoke route, the UI, log
+# lines), so the credential contains one underscore more than the shape
+# `voc_{token_id}_{secret}` suggests at a glance. Parsing therefore expects
+# exactly four parts and rebuilds the id, rather than splitting on the last
+# underscore and hoping.
+_TOKEN_PART_COUNT: Final = 4
+
+# ---------------------------------------------------------------------------
+# Storage keys
+# ---------------------------------------------------------------------------
+
+# Tokens live in ONE partition of the projects table, deliberately outside any
+# `PROJECT#{id}` partition: a credential is workspace-level and is no longer a
+# child of the project it happened to be minted from.
+#
+# One partition serves both access patterns with only the base table:
+#   • authenticate → Query(pk=MCPTOKEN, sk=TOKEN#{id})  — a single item
+#   • list for the UI → Query(pk=MCPTOKEN)              — every token
+# so no GSI is needed and the MCP role's existing Query+UpdateItem grant is
+# already sufficient. `gsi1pk` is deliberately NOT set on these rows, which is
+# what keeps them out of `projects.list_projects` (it queries the
+# `TYPE#PROJECT` GSI, so an unindexed row is invisible to it).
+#
+# ponytail: single hot partition for all tokens. Ceiling is per-partition
+# throughput (~3 000 RCU), which the endpoint's own 20 rps stage throttle sits
+# three orders of magnitude below. Upgrade path if tokens ever number in the
+# thousands: shard the pk by a prefix of the token id, which changes only the
+# two helpers below. Same shape as the existing global PRIORITIZATION
+# partition.
+MCP_TOKEN_PK: Final = 'MCPTOKEN'
+
+
+def token_sk(token_id: str) -> str:
+    """Sort key for a token row."""
+    return f'TOKEN#{token_id}'
+
+
+# ---------------------------------------------------------------------------
+# Scopes
+# ---------------------------------------------------------------------------
+
+# The scopes that currently grant something. Deliberately NOT the full nine of
+# the design doc: a mintable scope that no tool consults is a phantom
+# permission, and this codebase already had one (`read-write` was mintable,
+# stored, and shown with its own badge while every tool required only `read`).
+# Phase 3 adds a write scope in the same commit as the first write tool.
+SCOPE_FEEDBACK_READ: Final = 'feedback:read'
+SCOPE_METRICS_READ: Final = 'metrics:read'
+SCOPE_PROJECTS_READ: Final = 'projects:read'
+
+VALID_SCOPES: Final[frozenset[str]] = frozenset({
+    SCOPE_FEEDBACK_READ,
+    SCOPE_METRICS_READ,
+    SCOPE_PROJECTS_READ,
+})
+
+# What a token gets when it names no scopes. Every current scope is a read, so
+# this is the whole vocabulary; it stops being the default the moment a write
+# scope exists.
+DEFAULT_SCOPES: Final[tuple[str, ...]] = (
+    SCOPE_FEEDBACK_READ,
+    SCOPE_METRICS_READ,
+    SCOPE_PROJECTS_READ,
+)
+
+# ---------------------------------------------------------------------------
+# Reach — the two axes
+# ---------------------------------------------------------------------------
+
+# Axis 1 is the token's PROJECT SET (`projects` on the row): the projects this
+# credential is about. Named `projects` rather than `write_projects` because in
+# this phase it bounds *reads* (see REACH_PROJECT_SET) and there are no write
+# tools yet; when Phase 3 adds them, writes are confined to the same list and
+# the name still tells the truth.
+#
+# Axis 2 is how far the token may READ, which is independent: the useful
+# default is "write in one place, look everywhere", and one field cannot say
+# that.
+REACH_WORKSPACE: Final = 'workspace'
+REACH_PROJECT_SET: Final = 'project-set'
+REACH_NONE: Final = 'none'
+
+VALID_READ_REACHES: Final[tuple[str, ...]] = (
+    REACH_WORKSPACE,
+    REACH_PROJECT_SET,
+    REACH_NONE,
+)
+
+# Workspace, by owner decision (2026-08-18). The reasoning is structural, not
+# a preference: the feedback corpus has no project dimension at all
+# (`voc-feedback` is keyed `SOURCE#{platform}`, and the project-scoped reads
+# select by filters), so any narrower default would have to be *invented* for
+# the corpus rather than enforced — and inventing it breaks the cross-project
+# analysis that is the reason to expose an MCP server.
+#
+# ⚠️ Default is not the same as benign. Workspace read reaches every other
+# project's unreleased PRDs, PR-FAQs and prototypes plus every raw verbatim.
+# That is right for an agent working on behalf of the team and wrong for a
+# token pasted into a third-party client, which is why the axis is explicit at
+# mint time instead of implied.
+DEFAULT_READ_REACH: Final = REACH_WORKSPACE
+
+# How a tool's data is shaped, which decides how reach applies to it.
+REACH_KIND_WORKSPACE: Final = 'workspace'   # no project dimension (feedback, metrics)
+REACH_KIND_PROJECT: Final = 'project'       # addresses one project
+
+
+def reach_allows(
+    *,
+    read_reach: str,
+    token_projects: list[str] | tuple[str, ...],
+    tool_reach_kind: str,
+    project_id: str | None,
+) -> bool:
+    """Whether a read of *tool_reach_kind* is within the token's reach.
+
+    Fail-closed on every unrecognised input: an unknown reach or an unknown
+    tool kind denies rather than falls through to allowed.
+
+    The interesting case is ``project-set`` against a workspace-shaped tool.
+    It is REFUSED, and that is the honest answer rather than a gap: there is
+    no project dimension in the feedback corpus to narrow, so "allow it" would
+    silently hand a supposedly sealed token the entire verbatim history. A
+    caller that needs both gets ``workspace`` and accepts what that means.
+    """
+    if read_reach == REACH_NONE:
+        return False
+    if tool_reach_kind == REACH_KIND_WORKSPACE:
+        return read_reach == REACH_WORKSPACE
+    if tool_reach_kind != REACH_KIND_PROJECT:
+        return False
+    if not project_id:
+        return False
+    if read_reach == REACH_WORKSPACE:
+        return True
+    if read_reach == REACH_PROJECT_SET:
+        return project_id in token_projects
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Mint / parse / hash
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MintedToken:
+    """A freshly minted credential.
+
+    ``raw`` is the only time the full credential exists on this side; it is
+    returned to the caller once and never stored.
+    """
+
+    raw: str
+    token_id: str
+    secret_hash: str
+
+
+def hash_secret(secret: str) -> str:
+    """Hash the secret half of a credential for storage.
+
+    Plain SHA-256 over 256 bits of ``secrets.token_hex`` entropy: there is no
+    dictionary to run against it, so the stored value is not a practical
+    route back to the credential.
+
+    HMAC with a Secrets Manager key (design doc §4.2) is deliberately NOT done
+    here. Its benefit — a table read alone yields nothing verifiable — matters
+    for low-entropy secrets, and buying it would put a Secrets Manager fetch
+    on the authentication hot path, where a failure has to be told apart from
+    a bad credential. That is a real cost for a marginal gain against a
+    256-bit random value. Revisit if the secret ever becomes user-chosen.
+    """
+    return hashlib.sha256(secret.encode()).hexdigest()
+
+
+def secret_matches(*, presented_secret: str, stored_hash: str) -> bool:
+    """Constant-time comparison of a presented secret against a stored hash.
+
+    Constant time to deny timing-based enumeration of the stored digest. The
+    caller is responsible for having established that *stored_hash* is a
+    ``str`` — a row where it is not is a data fault, not a mismatch, and the
+    two deserve different handling.
+    """
+    return hmac.compare_digest(hash_secret(presented_secret).encode(), stored_hash.encode())
+
+
+def mint_token() -> MintedToken:
+    """Generate a new credential."""
+    token_id = f'{TOKEN_ID_PREFIX}{secrets.token_hex(_TOKEN_ID_BYTES)}'
+    secret = secrets.token_hex(_SECRET_BYTES)
+    return MintedToken(
+        raw=f'{TOKEN_PREFIX}{token_id}_{secret}',
+        token_id=token_id,
+        secret_hash=hash_secret(secret),
+    )
+
+
+def _is_lower_hex(value: str, length: int) -> bool:
+    if len(value) != length:
+        return False
+    # `str.isalnum` would admit non-hex letters; an explicit set is clearer
+    # than a regex here and cannot be tripped by Unicode digit lookalikes the
+    # way `str.isdigit` can.
+    return all(c in '0123456789abcdef' for c in value)
+
+
+def parse_token(raw: str) -> tuple[str, str] | None:
+    """Split a presented credential into ``(token_id, secret)``.
+
+    Returns ``None`` for anything that is not exactly this format. Strictness
+    is the point: the id half selects which row to read, so a lenient parse
+    would turn caller-controlled text into a key lookup. Rejecting here means
+    a malformed credential never reaches DynamoDB at all.
+    """
+    if not isinstance(raw, str) or not raw.startswith(TOKEN_PREFIX):
+        return None
+    parts = raw.split('_')
+    if len(parts) != _TOKEN_PART_COUNT:
+        return None
+    prefix, id_prefix, id_hex, secret = parts
+    if f'{prefix}_' != TOKEN_PREFIX or f'{id_prefix}_' != TOKEN_ID_PREFIX:
+        return None
+    if not _is_lower_hex(id_hex, _TOKEN_ID_HEX_LEN):
+        return None
+    if not _is_lower_hex(secret, _SECRET_HEX_LEN):
+        return None
+    return f'{TOKEN_ID_PREFIX}{id_hex}', secret

--- a/voc-datalake/lambda/shared/test/test_mcp_tokens.py
+++ b/voc-datalake/lambda/shared/test/test_mcp_tokens.py
@@ -1,0 +1,235 @@
+"""Tests for the MCP credential format and the two reach axes.
+
+No AWS: everything here is pure, which is the reason the module exists
+separately from the two handlers that consume it.
+"""
+
+import pytest
+
+from shared.mcp_tokens import (
+    DEFAULT_READ_REACH,
+    DEFAULT_SCOPES,
+    MCP_TOKEN_PK,
+    REACH_KIND_PROJECT,
+    REACH_KIND_WORKSPACE,
+    REACH_NONE,
+    REACH_PROJECT_SET,
+    REACH_WORKSPACE,
+    TOKEN_ID_PREFIX,
+    TOKEN_PREFIX,
+    VALID_READ_REACHES,
+    VALID_SCOPES,
+    hash_secret,
+    mint_token,
+    parse_token,
+    reach_allows,
+    secret_matches,
+    token_sk,
+)
+
+# ===========================================================================
+# Format: mint → parse round trip
+# ===========================================================================
+
+class TestMintAndParse:
+    def test_minted_token_parses_back_to_its_own_id(self):
+        """The whole point of the format: the id is recoverable from the token.
+
+        This is what replaces "Query the project's token rows and hash each
+        one" with a single keyed read, and therefore what removes the
+        X-Project-Id header requirement.
+        """
+        minted = mint_token()
+        parsed = parse_token(minted.raw)
+        assert parsed is not None, f'freshly minted token did not parse: {minted.raw!r}'
+        token_id, secret = parsed
+        assert token_id == minted.token_id
+        assert secret_matches(presented_secret=secret, stored_hash=minted.secret_hash)
+
+    def test_raw_token_never_contains_the_stored_hash(self):
+        """Only the secret half is hashed, and the hash is not in the credential."""
+        minted = mint_token()
+        assert minted.secret_hash not in minted.raw
+
+    def test_token_id_is_in_the_credential_so_it_can_be_logged(self):
+        minted = mint_token()
+        assert minted.token_id in minted.raw
+        assert minted.token_id.startswith(TOKEN_ID_PREFIX)
+        assert minted.raw.startswith(TOKEN_PREFIX)
+
+    def test_each_mint_is_unique(self):
+        assert len({mint_token().raw for _ in range(50)}) == 50
+
+    def test_secret_hash_is_stable_for_the_same_secret(self):
+        assert hash_secret('abc') == hash_secret('abc')
+        assert hash_secret('abc') != hash_secret('abd')
+
+
+class TestParseRejectsMalformed:
+    """A lenient parse would turn caller text into a DynamoDB key lookup.
+
+    Revert story: loosening `parse_token` to split on the LAST underscore and
+    accept whatever precedes it fails test_legacy_token_is_refused and
+    test_wrong_part_count.
+    """
+
+    @pytest.mark.parametrize('raw', [
+        '',
+        'voc_',
+        'voc',
+        'nope_tok_' + 'a' * 16 + '_' + 'b' * 64,
+        'voc_bad_' + 'a' * 16 + '_' + 'b' * 64,          # wrong id prefix
+        'voc_tok_' + 'a' * 15 + '_' + 'b' * 64,          # id too short
+        'voc_tok_' + 'a' * 17 + '_' + 'b' * 64,          # id too long
+        'voc_tok_' + 'a' * 16 + '_' + 'b' * 63,          # secret too short
+        'voc_tok_' + 'a' * 16 + '_' + 'b' * 65,          # secret too long
+        'voc_tok_' + 'g' * 16 + '_' + 'b' * 64,          # id not hex
+        'voc_tok_' + 'a' * 16 + '_' + 'g' * 64,          # secret not hex
+        'voc_tok_' + 'A' * 16 + '_' + 'b' * 64,          # uppercase is not our format
+        'voc_tok_' + 'a' * 16 + '_' + 'b' * 64 + '_x',   # extra part
+    ])
+    def test_wrong_part_count_or_alphabet_is_refused(self, raw):
+        assert parse_token(raw) is None, f'{raw!r} must not parse'
+
+    def test_legacy_token_is_refused(self):
+        """`voc_<64 hex>` was the old format; it is deliberately not accepted.
+
+        Owner decision 2026-08-18: no legacy tokens were in production use, and
+        a stray one fails closed with a 401 that re-minting fixes. If this test
+        ever needs deleting, that is a policy change, not a cleanup.
+        """
+        assert parse_token('voc_' + 'a' * 64) is None
+
+    @pytest.mark.parametrize('raw', [None, 12345, b'voc_tok_x', ['voc_'], {}])
+    def test_non_string_is_refused_not_raised(self, raw):
+        """A non-string arrives from a header that something else mangled;
+        it must be a refusal, not an AttributeError turning into a 500."""
+        assert parse_token(raw) is None
+
+
+class TestSecretMatches:
+    def test_correct_secret_matches(self):
+        assert secret_matches(presented_secret='s3cret', stored_hash=hash_secret('s3cret'))
+
+    def test_wrong_secret_does_not_match(self):
+        assert not secret_matches(presented_secret='s3cret', stored_hash=hash_secret('other'))
+
+    def test_empty_stored_hash_does_not_match(self):
+        assert not secret_matches(presented_secret='s3cret', stored_hash='')
+
+
+# ===========================================================================
+# Storage keys
+# ===========================================================================
+
+class TestStorageKeys:
+    def test_token_rows_live_outside_any_project_partition(self):
+        """A credential is workspace-level, so its partition is not a project's.
+
+        This is also what keeps token rows invisible to projects.list_projects,
+        which queries the TYPE#PROJECT GSI — these rows set no gsi1pk.
+        """
+        assert not MCP_TOKEN_PK.startswith('PROJECT#')
+        assert token_sk('tok_abc').startswith('TOKEN#')
+
+    def test_sk_is_derived_from_the_token_id(self):
+        assert token_sk('tok_abc') == 'TOKEN#tok_abc'
+
+
+# ===========================================================================
+# Reach — the two axes
+# ===========================================================================
+
+class TestReachAllows:
+    """The gate that decides whether a read is within a token's reach.
+
+    Revert story: making the unrecognised-value fall-through return True
+    (instead of the explicit False) fails
+    test_unknown_reach_or_kind_is_refused.
+    """
+
+    def _allows(self, reach, kind, project_id='proj_a', projects=('proj_a',)):
+        return reach_allows(
+            read_reach=reach,
+            token_projects=projects,
+            tool_reach_kind=kind,
+            project_id=project_id,
+        )
+
+    # --- workspace reach: the default, sees everything -------------------
+    def test_workspace_reach_allows_workspace_shaped_reads(self):
+        assert self._allows(REACH_WORKSPACE, REACH_KIND_WORKSPACE)
+
+    def test_workspace_reach_allows_any_project_not_only_its_own(self):
+        """The default really is workspace-wide — this is the whole point of
+        the axis existing, and the reason the mint UI has to say so."""
+        assert self._allows(REACH_WORKSPACE, REACH_KIND_PROJECT,
+                            project_id='someone_elses', projects=('proj_a',))
+
+    # --- project-set reach: the sealed option ---------------------------
+    def test_project_set_reach_allows_a_project_in_the_set(self):
+        assert self._allows(REACH_PROJECT_SET, REACH_KIND_PROJECT,
+                            project_id='proj_a', projects=('proj_a', 'proj_b'))
+
+    def test_project_set_reach_refuses_a_project_outside_the_set(self):
+        assert not self._allows(REACH_PROJECT_SET, REACH_KIND_PROJECT,
+                                project_id='proj_z', projects=('proj_a',))
+
+    def test_project_set_reach_refuses_workspace_shaped_reads(self):
+        """The load-bearing case. Feedback and metrics have no project
+        dimension, so 'project-set' cannot narrow them — allowing them anyway
+        would hand a supposedly sealed token the entire verbatim corpus."""
+        assert not self._allows(REACH_PROJECT_SET, REACH_KIND_WORKSPACE)
+
+    def test_project_set_reach_with_empty_set_reads_nothing(self):
+        """A token with no projects and project-set reach is inert, not
+        wide-open. This is exactly the trap that made remapping the old
+        read-only tokens onto these axes unsafe."""
+        assert not self._allows(REACH_PROJECT_SET, REACH_KIND_PROJECT, projects=())
+        assert not self._allows(REACH_PROJECT_SET, REACH_KIND_WORKSPACE, projects=())
+
+    # --- none: write-only credential ------------------------------------
+    def test_none_reach_refuses_every_kind(self):
+        assert not self._allows(REACH_NONE, REACH_KIND_WORKSPACE)
+        assert not self._allows(REACH_NONE, REACH_KIND_PROJECT)
+
+    # --- fail-closed ----------------------------------------------------
+    @pytest.mark.parametrize('reach,kind', [
+        ('nonsense', REACH_KIND_PROJECT),
+        ('nonsense', REACH_KIND_WORKSPACE),
+        (REACH_WORKSPACE, 'nonsense'),
+        (REACH_PROJECT_SET, 'nonsense'),
+        ('', ''),
+    ])
+    def test_unknown_reach_or_kind_is_refused(self, reach, kind):
+        assert not self._allows(reach, kind)
+
+    def test_project_shaped_read_without_a_project_is_refused(self):
+        for reach in (REACH_WORKSPACE, REACH_PROJECT_SET):
+            assert not self._allows(reach, REACH_KIND_PROJECT, project_id=None)
+            assert not self._allows(reach, REACH_KIND_PROJECT, project_id='')
+
+
+# ===========================================================================
+# Vocabulary invariants
+# ===========================================================================
+
+class TestVocabulary:
+    def test_default_reach_is_workspace_by_owner_decision(self):
+        assert DEFAULT_READ_REACH == REACH_WORKSPACE
+        assert DEFAULT_READ_REACH in VALID_READ_REACHES
+
+    def test_defaults_are_all_valid_scopes(self):
+        assert set(DEFAULT_SCOPES) <= VALID_SCOPES
+
+    def test_no_scope_is_mintable_without_granting_something(self):
+        """Guards against reintroducing a phantom permission.
+
+        The previous model let `read-write` be minted, stored and badged while
+        every tool required only `read`. Every scope in the vocabulary must be
+        a read scope in this phase, because no write tool exists yet.
+        """
+        assert all(scope.endswith(':read') for scope in VALID_SCOPES), (
+            'a non-read scope is mintable but no write tool exists to consult it — '
+            'add the scope in the same change as the tool that requires it'
+        )

--- a/voc-datalake/lambda/shared/test/test_mcp_tokens.py
+++ b/voc-datalake/lambda/shared/test/test_mcp_tokens.py
@@ -7,8 +7,8 @@ separately from the two handlers that consume it.
 import pytest
 
 from shared.mcp_tokens import (
+    ALL_READ_SCOPES,
     DEFAULT_READ_REACH,
-    DEFAULT_SCOPES,
     MCP_TOKEN_PK,
     REACH_KIND_PROJECT,
     REACH_KIND_WORKSPACE,
@@ -219,8 +219,14 @@ class TestVocabulary:
         assert DEFAULT_READ_REACH == REACH_WORKSPACE
         assert DEFAULT_READ_REACH in VALID_READ_REACHES
 
-    def test_defaults_are_all_valid_scopes(self):
-        assert set(DEFAULT_SCOPES) <= VALID_SCOPES
+    def test_the_full_read_set_is_exactly_the_vocabulary(self):
+        """ALL_READ_SCOPES is a convenience, not a mint default.
+
+        It must stay in step with VALID_SCOPES while every scope is a read; the
+        day a write scope is added, this fails and forces a decision about
+        whether "all read scopes" still means "all scopes".
+        """
+        assert set(ALL_READ_SCOPES) == VALID_SCOPES
 
     def test_no_scope_is_mintable_without_granting_something(self):
         """Guards against reintroducing a phantom permission.

--- a/voc-datalake/lambda/shared/tokens.py
+++ b/voc-datalake/lambda/shared/tokens.py
@@ -1,7 +1,0 @@
-"""Shared token utilities."""
-import hashlib
-
-
-def hash_token(token: str) -> str:
-    """Hash a token using SHA-256 for secure storage/comparison."""
-    return hashlib.sha256(token.encode()).hexdigest()


### PR DESCRIPTION
Phase 1 of `analysis/PLAN-mcp-platform-server.md`, following Phase 0 (#344). This is the credential model — the blocker under every later phase.

## The problem it removes

The shipped MCP credential is `voc_` + 64 hex, found by **querying every token row in a project and hashing each one** until something matches. That loop is why the credential requires an `X-Project-Id` header: without a project there is no partition to scan.

A header cannot express *"no particular project"*, so `list_projects` — and any other workspace-wide tool — was **unimplementable by construction**, not merely unwritten.

## The credential

`voc_{token_id}_{secret}` (64-bit id, 256-bit secret)

| | Before | After |
|---|---|---|
| Lookup | Query a project partition + hash loop | One keyed Query on `pk=MCPTOKEN, sk=TOKEN#{id}` |
| `X-Project-Id` | **Required** for auth, not just routing | Gone |
| Hashed | The whole credential | The **secret half only**, so `token_id` is safe to log and display |
| Row lives in | The minting project's partition | Its own partition — a credential is workspace-level |
| Format defined in | 3 places (both handlers + an inline Node authorizer in `api-stack.ts`) | 1 module, `shared/mcp_tokens.py` |

**Legacy tokens are not accepted.** Owner confirmed none are in production use, and a stray one fails closed with a 401 that re-minting fixes.

> 🪤 There is deliberately **no dual-read branch**, and the reason is worth recording: `read_reach: 'project-set'` on a read-only token (`projects: []`) resolves to reading **nothing**. Remapping old tokens onto the new axes would have silently broken every one of them rather than preserving them.

## Reach is two axes, not one

One project-scope field cannot say *"write here, look around everywhere"*, which is the shape people actually want.

- **`projects`** — the projects this credential is about. Bounds reads under `project-set`; will bound writes when write tools land, which is why it is not called `write_projects` yet.
- **`read_reach`** — `workspace` (default) | `project-set` | `none`.

### Why `workspace` is the default

Structural, not a preference: `voc-feedback` is keyed `SOURCE#{platform}` with **no `project_id` at all**, and the project-scoped reads select by filters. A narrower default would have to be *invented* for the corpus rather than enforced — and inventing it breaks the cross-project analysis that is the reason to expose an MCP server at all.

⚠️ **It is not the harmless option.** Workspace read reaches every other project's unreleased PRDs, PR-FAQs and prototypes plus every raw verbatim. So it is explicit at mint time, warned about in the form, and badged amber on every row — the list is where someone notices a credential reaches further than they assumed.

### The load-bearing refusal

`project-set` **cannot call a workspace-shaped tool at all**. Feedback and metrics have no project dimension to narrow, so allowing them *"because the token holds `feedback:read`"* would hand a supposedly sealed credential the entire verbatim history. Each tool declares its data shape (`TOOL_REACH_KINDS`) and dispatch is fail-closed on a missing declaration.

## Per-domain scopes

`feedback:read` / `metrics:read` / `projects:read` replace `read` / `read-write`.

The old `read-write` was a **phantom permission**: mintable, stored, and badged in this UI with its own amber pill while *no tool ever required it*. Only scopes that grant something exist now; a write scope arrives in the same change as the first write tool.

A row with no usable `scopes` grants **nothing**, reversing the old default of `read`. That default existed because deployed rows predated the field; every row now carries an explicit set, so a row without one is data damage and must not be guessed at in the caller's favour.

## Also in here

- **`/mcp/autoseed/{project_id}` goes through the same gates as the tools.** It previously compared the path project to the token's single project and **checked no scope at all**.
- **The token boundary gains the Zod normalizer** every other frontend list boundary already has. It matters more here: a token row states what a credential may *do*, so a drifted field makes the UI describe a credential's reach differently from how it is enforced.
- **`shared/tokens.py` deleted** — it held only `hash_token`, whose two callers both moved to `mcp_tokens.hash_secret`.
- **No IAM change.** The keyed lookup is a Query with an exact sort key, so `mcpRole` stays at exactly `Query` + `UpdateItem` — the narrow grant from #344 is untouched.

## Deliberate deferral

**HMAC with a Secrets Manager key** (plan §4.2) is not done, and is documented at `hash_secret` rather than left implicit. Its benefit — a table read alone yields nothing verifiable — matters for *low-entropy* secrets. Buying it here would put a Secrets Manager fetch on the authentication hot path, where a failure has to be told apart from a bad credential, for a marginal gain against 256 bits of `secrets.token_hex`. Worth revisiting if the secret ever becomes user-chosen.

## Verification

| Gate | Result |
|---|---|
| pytest | **2706** passed |
| CDK vitest | **256** passed |
| stream vitest | **339** passed |
| frontend vitest | **2968** passed |
| ruff | delta **−1** (the test rewrite fixed a pre-existing `I001`) |
| eslint | clean (`--max-warnings 0`) |
| typecheck | clean — frontend, CDK, stream |

**Mutation-proved 6/6.** Each new invariant was removed and the guarding tests confirmed to fail: the reach gate, the scope check, strict credential parsing, the autoseed scope gate, the mint project set, and the sealed-token corpus refusal.

## Deployed and live-verified

`VocApiStack` deployed to us-east-1 (clean synth, **zero warnings**).

- `scripts/test-api.sh` — **34/34**
- Live MCP battery — **37/37**, driven through API Gateway with credentials minted by the real mint route

The live battery asserts what unit tests structurally cannot: that the format the mint route *produces* is the format the deployed authorizer and handler *accept*, end to end. Highlights:

- `tools/list` authenticates with **no `X-Project-Id` header** — the header requirement is gone in production, which is the B1 unblock.
- A **workspace** credential really does read another project (the warned-about default, confirmed rather than assumed).
- A **`project-set`** credential is refused the feedback corpus **and** another project, both `-32003`.
- A **`feedback:read`-only** credential reads feedback and is refused projects.
- A **legacy `voc_<64 hex>`** credential is refused 401 — the dropped compat path fails closed as intended.
- Mint-time validation holds against the deployed API: unknown scope, empty scope set, and the retired `write-set` reach name are each 400.
- Autoseed is refused without `projects:read`, and refused outside a sealed credential's reach.
- **Revocation takes effect**: the credential stops authenticating immediately after `DELETE`.
- Phase 0 hardening intact: foreign `Origin` → 403, and the RFC 6750 challenge is delivered (under API Gateway's remapped header name, as #344 documented).

All minted test credentials were revoked at the end of the run.



---

## ✅ Orphaned rows cleaned up

The 2 pre-Phase-1 rows at `PROJECT#{id} / TOKEN#{id}` have been **deleted** (owner-authorised). Each
delete carried a `ConditionExpression` asserting the row still looked legacy
(`attribute_exists(token_hash) AND attribute_not_exists(secret_hash)`), so it was
impossible to remove a new-format credential even with a stale key list. Full items
were dumped first.

Verified after: table went 40 → 38 rows, **0** `TOKEN#` rows remain, and all 3 project
`META` rows plus every artifact kind (PERSONA, PRD, PRFAQ, RESEARCH, DOC, PROTOTYPE,
PRODUCT_CONTEXT, PRODUCT_DOC) are intact.

## Files this PR does NOT touch, and why that matters for review

- **`lib/stacks/api-stack.ts`** — zero changes, which is the claim rather than an
  omission. The inline authorizer validates `startsWith('Bearer voc_')` and
  `length >= 20`, so the new 89-character credential passes unchanged, and
  `projectsTable.grant(mcpRole, 'dynamodb:Query', 'dynamodb:UpdateItem')` is
  resource-level with no `LeadingKeys` condition. Both are exercised on every
  authenticated call in the live battery.
- **The `shared.api` import block in `projects_handler.py`** — `get_caller_subject`
  was already imported, so there is no hunk to show.



---

## Browser verification — and the bug it caught

The API battery cannot see render-time defects, so the mint flow was also driven through the deployed
CloudFront site.

**It found a real one.** Scope names contain a colon, which is i18next's default `nsSeparator`, so
`t('mcp.scopeDesc.feedback:read')` resolved as namespace `mcp.scopeDesc.feedback` + key `read` — and every
checkbox rendered the literal word **"read"** instead of its description. Fixed with
`nsSeparator: false` (`38cf65e7`).

Worth noting why the suite missed it: it asserted the checkbox *names* (which contain the scope, and were
correct), nothing asserted the description text, and the broken lookup produced a plausible word rather
than a visible key path. The tests *could* have caught it — `src/test/setup.ts` loads the real
`en` locale — so the gap was a missing assertion, now added and mutation-proved. Those three are the only
colon-bearing keys across all 8 locale files.

Everything else in the flow verified against the deployed site:

- nothing pre-checked; **Generate disabled** until a scope is ticked
- reach defaults to workspace **with its warning text**, and the hint switches to the sealed wording on `project-set`
- revealed credential is **89 chars, `voc_tok_<16hex>_<64hex>`**
- banner shows the correct 30-day deadline
- the row badges **"This project" in blue** (not amber, since it is sealed) with only the two ticked scopes
- the `mcp.json` snippet contains **no `X-Project-Id`**
- revoke empties the list to `Active Tokens (0)`
- **zero console errors or warnings**
