### PR TITLE
feat(mcp): delegate every tool to the domain function that owns its route

### DIFF
--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -179,9 +179,13 @@ def _reserved_for(template: str, name: str) -> frozenset[str]:
     position = segments.index(f'{{{name}}}')
     prefix = '/' + '/'.join(segments[:position])
     if prefix not in _RESERVED_PATH_SEGMENTS:
-        raise InvalidToolArgument(
-            f'{name} cannot be validated: no reserved-segment set declared for {prefix}'
-        )
+        # DelegationUnavailable, not InvalidToolArgument: this is a SERVER
+        # misconfiguration, and -32602 "Invalid params" would tell the caller its
+        # arguments are wrong when nothing it could send would work. The state is
+        # unreachable in a deployed build — the prefix lockstep fails first — so
+        # this is about not lying if it ever is reached.
+        logger.error('No reserved-segment set declared', extra={'prefix': prefix})
+        raise DelegationUnavailable(f'no reserved-segment set declared for {prefix}')
     return _RESERVED_PATH_SEGMENTS[prefix]
 
 
@@ -196,8 +200,13 @@ def _validated_path_parameters(route_key: str, params: dict[str, str]) -> dict[s
         # Distinct messages per condition: the caller can act on each of these
         # differently, and "must be a single path segment" for a stray space sends
         # them looking for a slash they never sent.
-        if not isinstance(value, str) or not value or value.strip() != value:
+        if not isinstance(value, str) or not value:
             raise InvalidToolArgument(f'{name} must be a non-empty identifier')
+        if value.strip() != value:
+            # Split from the emptiness check on purpose: bundling them reported
+            # "must be a non-empty identifier" for a value that plainly was not
+            # empty, which is the same misdirection the messages below avoid.
+            raise InvalidToolArgument(f'{name} must not be surrounded by whitespace')
         offending = sorted(_FORBIDDEN_PATH_CHARS & set(value))
         if offending:
             raise InvalidToolArgument(

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -59,6 +59,20 @@ metrics = Metrics(namespace="VoC-MCP")
 projects_table = get_projects_table()
 
 # MCP Protocol version
+#
+# ⚠️ KNOWN SKEW, and it is temporary by plan rather than by oversight.
+# `structuredContent` and `outputSchema` (below) arrived in the 2025-06-18
+# revision, while this still advertises 2024-11-05 and `initialize` declares no
+# capability for them. The version range — negotiating 2026-07-28 / 2025-11-25 /
+# 2025-06-18 and answering `server/discover` — is the next phase of the plan, and
+# bumping the number here without that negotiation would claim conformance this
+# handler does not yet have (no `resultType`, no header validation).
+#
+# Shipping the structured fields early is safe in the meantime because both are
+# ADDITIVE: a 2024-11-05 client reads `content[0].text`, which still carries the
+# same payload serialized, and JSON-RPC clients ignore result fields they do not
+# know. The reverse order — negotiate first, add the fields later — would have
+# meant two breaking output changes instead of one.
 MCP_PROTOCOL_VERSION = "2024-11-05"
 
 # Semver on the SERVER, independent of the protocol revision above. 2.0.0
@@ -104,6 +118,52 @@ DOMAIN_ROUTES: dict[str, tuple[str, str, str]] = {
 }
 
 
+# What each path parameter must look like before it is allowed into a route path.
+#
+# 🔑 This is a ROUTE-CONFUSION guard, not input tidiness. The delegated path is
+# what the Powertools resolver matches on, so a parameter value is not data — it
+# is part of the routing key. Two ways an unvalidated value changes which route
+# answers:
+#
+#   • extra segments: project_id='p/api-tokens' builds '/projects/p/api-tokens'
+#     and lands on the token-list route instead of the project route;
+#   • a value that collides with a STATIC sibling: project_id='prioritization'
+#     builds '/projects/prioritization', and Powertools checks static routes
+#     BEFORE dynamic ones, so it lands on api_get_prioritization_scores — the
+#     surface deliberately excluded from MCP entirely. Segment counting does not
+#     catch this one, which is why these are format checks rather than a
+#     "no slashes" rule. The same trick reaches /feedback/search, /feedback/urgent
+#     and /feedback/entities through get_feedback_detail.
+#
+# Both formats are what the writers actually produce: `proj_` + a timestamp
+# (projects.py) and a 32-character hex digest (processor/handler.py). Anything
+# else fails CLOSED with a -32602, which is the right direction for a component
+# that decides both the route and the scope that applies to it. Pinned by
+# TestPathParameterConfinement, including a lockstep against the id generators.
+_PATH_PARAM_PATTERNS: dict[str, re.Pattern[str]] = {
+    'project_id': re.compile(r'^proj_[A-Za-z0-9_-]+$'),
+    'feedback_id': re.compile(r'^[0-9a-f]{32}$'),
+}
+
+
+def _validated_path_parameters(route_key: str, params: dict[str, str]) -> dict[str, str]:
+    """Refuse any path parameter that could change which route answers."""
+    for name, value in params.items():
+        pattern = _PATH_PARAM_PATTERNS.get(name)
+        if pattern is None:
+            # Fail closed on an UNDECLARED parameter rather than passing it
+            # through: a future route whose author forgets to add a pattern
+            # would otherwise reopen exactly this hole, silently.
+            raise InvalidToolArgument(
+                f"{route_key}: no validation declared for path parameter '{name}'"
+            )
+        if not isinstance(value, str) or not pattern.match(value):
+            # The expected SHAPE is not echoed back: it is a storage detail, and
+            # a caller who guessed wrong is better served by the parameter name.
+            raise InvalidToolArgument(f'{name} is not a valid identifier')
+    return params
+
+
 def _domain_call(
     route_key: str,
     *,
@@ -115,9 +175,12 @@ def _domain_call(
     The env var is read per call rather than captured at import so a test can
     set it, and so a missing one surfaces as this route being unconfigured
     rather than as the whole module failing to load.
+
+    Every delegated call is built here — tools and the autoseed route alike — so
+    this is the one place path parameters have to be confined.
     """
     domain, method, template = DOMAIN_ROUTES[route_key]
-    params = dict(path_parameters or {})
+    params = _validated_path_parameters(route_key, dict(path_parameters or {}))
     return DomainCall(
         function_name=os.environ.get(_DOMAIN_FUNCTION_ENV[domain], ''),
         method=method,
@@ -819,6 +882,9 @@ MCP_TOOLS = [
         "outputSchema": {
             "type": "object",
             "properties": _FEEDBACK_DETAIL_PROPERTIES,
+            # Every key is always emitted (the projection uses typed defaults),
+            # so declaring them costs nothing and lets a client rely on them.
+            "required": sorted(_FEEDBACK_DETAIL_PROPERTIES),
             "additionalProperties": False,
         },
     },
@@ -916,12 +982,16 @@ def _tool_search_feedback(args: dict, token_info: dict) -> ToolResult:
         call = _domain_call('feedback_list', query=shared_filters)
 
     body = _delegate(call, token_info).payload
-    items = body.get('items', []) if isinstance(body, dict) else []
+    raw_items = body.get('items', []) if isinstance(body, dict) else []
+    # Projected FIRST, then counted, so `count` describes what the caller
+    # received. Counting the route's list instead would let a non-dict entry make
+    # `count` exceed `len(items)` in the same payload.
+    items = [_project_feedback(item, summary=True) for item in raw_items
+             if isinstance(item, dict)]
     return ToolResult({
         "count": len(items),
         "query": query,
-        "items": [_project_feedback(item, summary=True) for item in items
-                  if isinstance(item, dict)],
+        "items": items,
     })
 
 
@@ -1502,10 +1572,17 @@ def _handle_autoseed(event: dict) -> dict:
     # through as the route's own query string rather than re-parsed here — the
     # comma-splitting used to be duplicated in both places.
     query_params = event.get('queryStringParameters') or {}
-    call = _domain_call('project_autoseed', path_parameters={'project_id': project_id}, query={
-        'persona_ids': query_params.get('persona_ids'),
-        'document_ids': query_params.get('document_ids'),
-    })
+    try:
+        call = _domain_call('project_autoseed', path_parameters={'project_id': project_id}, query={
+            'persona_ids': query_params.get('persona_ids'),
+            'document_ids': query_params.get('document_ids'),
+        })
+    except InvalidToolArgument as exc:
+        # This route takes its project id straight from the URL, so the
+        # route-confusion guard matters here as much as on a tool call — and it
+        # is a 400 rather than a 403, because the credential is fine and the
+        # path is not.
+        return _cors_response({'message': str(exc)}, status_code=400)
     try:
         result = call_domain(call, claims=synthetic_claims(token_info))
     except DelegationUnavailable:
@@ -1513,7 +1590,12 @@ def _handle_autoseed(event: dict) -> dict:
         return _cors_response({'message': 'Upstream service unavailable'}, status_code=502)
     # The route's own status travels with its body: a 404 for an unknown project
     # stays a 404 here instead of becoming the 500 this used to answer for it.
-    return _cors_response(result.payload, status_code=result.status_code)
+    #
+    # An empty upstream body becomes `{}` rather than `null`: this route's clients
+    # read fields off the response, and `null` makes that a TypeError where `{}`
+    # makes it a missing key.
+    return _cors_response(result.payload if result.payload is not None else {},
+                          status_code=result.status_code)
 
 
 # ============================================

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -118,49 +118,80 @@ DOMAIN_ROUTES: dict[str, tuple[str, str, str]] = {
 }
 
 
-# What each path parameter must look like before it is allowed into a route path.
+# ---------------------------------------------------------------------------
+# Path-parameter confinement
+# ---------------------------------------------------------------------------
 #
-# 🔑 This is a ROUTE-CONFUSION guard, not input tidiness. The delegated path is
-# what the Powertools resolver matches on, so a parameter value is not data — it
-# is part of the routing key. Two ways an unvalidated value changes which route
-# answers:
+# 🔑 A ROUTE-CONFUSION guard, not input tidiness. The delegated path is what the
+# Powertools resolver matches on — `pathParameters` is never consulted — so a
+# parameter value is not data, it is part of the routing key. Two ways an
+# unvalidated value changes which route answers:
 #
-#   • extra segments: project_id='p/api-tokens' builds '/projects/p/api-tokens'
-#     and lands on the token-list route instead of the project route;
-#   • a value that collides with a STATIC sibling: project_id='prioritization'
-#     builds '/projects/prioritization', and Powertools checks static routes
-#     BEFORE dynamic ones, so it lands on api_get_prioritization_scores — the
-#     surface deliberately excluded from MCP entirely. Segment counting does not
-#     catch this one, which is why these are format checks rather than a
-#     "no slashes" rule. The same trick reaches /feedback/search, /feedback/urgent
-#     and /feedback/entities through get_feedback_detail.
+#   • EXTRA SEGMENTS. `project_id='p/api-tokens'` builds `/projects/p/api-tokens`
+#     and lands on the token-list route instead of the project route.
+#   • A COLLISION WITH A STATIC SIBLING. `project_id='prioritization'` builds
+#     `/projects/prioritization`, and Powertools resolves static routes BEFORE
+#     dynamic ones, so it lands on `api_get_prioritization_scores` — the surface
+#     deliberately excluded from MCP altogether. Segment counting does not catch
+#     this: it is a well-formed single segment.
 #
-# Both formats are what the writers actually produce: `proj_` + a timestamp
-# (projects.py) and a 32-character hex digest (processor/handler.py). Anything
-# else fails CLOSED with a -32602, which is the right direction for a component
-# that decides both the route and the scope that applies to it. Pinned by
-# TestPathParameterConfinement, including a lockstep against the id generators.
-_PATH_PARAM_PATTERNS: dict[str, re.Pattern[str]] = {
-    'project_id': re.compile(r'^proj_[A-Za-z0-9_-]+$'),
-    'feedback_id': re.compile(r'^[0-9a-f]{32}$'),
+# The guard is a SHAPE rule plus a reserved-segment set, deliberately NOT a
+# format allowlist per id. An allowlist (`proj_…`, 32 hex) was the first
+# implementation and it bet on id PROVENANCE: any project seeded, imported or
+# minted by an older generator becomes permanently unreachable through MCP, and
+# reported as a malformed argument rather than as a missing project. That trades
+# a security property for an availability one, and it is avoidable — the shape
+# rule stops segment injection, and the reserved set stops sibling collisions,
+# without either caring where an id came from.
+#
+# The reserved sets are DERIVED from the owning handlers' static routes by
+# `test_reserved_segments_cover_every_static_sibling`, so a new static sibling
+# added to one of those handlers fails the suite instead of quietly becoming
+# reachable. That is the same lockstep shape as the route and throttle tests.
+_RESERVED_PATH_SEGMENTS: dict[str, frozenset[str]] = {
+    '/projects': frozenset({'config', 'prioritization'}),
+    '/feedback': frozenset({'search', 'urgent', 'entities'}),
 }
+
+# Characters that would let a value escape its segment or its path entirely.
+# `/` is the injection above; `?` and `#` would graft a query or fragment onto
+# the routing key; `%` would let a percent-encoded `/` arrive decoded at a
+# resolver that has already matched.
+_FORBIDDEN_PATH_CHARS = frozenset('/?#%\\')
+
+
+def _reserved_for(template: str, name: str) -> frozenset[str]:
+    """The static sibling segments a parameter must not impersonate.
+
+    Keyed on the path PREFIX above the parameter, so `/projects/{project_id}` and
+    `/projects/{project_id}/autoseed` share one set — both put the value in the
+    same position, which is what decides which siblings it can collide with.
+    """
+    segments = template.strip('/').split('/')
+    position = segments.index(f'{{{name}}}')
+    return _RESERVED_PATH_SEGMENTS.get('/' + '/'.join(segments[:position]), frozenset())
 
 
 def _validated_path_parameters(route_key: str, params: dict[str, str]) -> dict[str, str]:
     """Refuse any path parameter that could change which route answers."""
+    _domain, _method, template = DOMAIN_ROUTES[route_key]
     for name, value in params.items():
-        pattern = _PATH_PARAM_PATTERNS.get(name)
-        if pattern is None:
-            # Fail closed on an UNDECLARED parameter rather than passing it
-            # through: a future route whose author forgets to add a pattern
-            # would otherwise reopen exactly this hole, silently.
+        if f'{{{name}}}' not in template:
+            # Fail closed rather than ignoring it: a parameter the template does
+            # not interpolate means caller and route disagree about the call.
+            raise InvalidToolArgument(f"{route_key}: unexpected path parameter '{name}'")
+        if not isinstance(value, str) or not value or value.strip() != value:
+            raise InvalidToolArgument(f'{name} must be a non-empty identifier')
+        if _FORBIDDEN_PATH_CHARS & set(value):
+            raise InvalidToolArgument(f'{name} must be a single path segment')
+        if value in {'.', '..'} or any(c.isspace() or ord(c) < 0x20 for c in value):
+            raise InvalidToolArgument(f'{name} must be a single path segment')
+        if value in _reserved_for(template, name):
+            # Named explicitly, because "not found" would be a lie and the caller
+            # cannot otherwise tell why a plausible-looking id was refused.
             raise InvalidToolArgument(
-                f"{route_key}: no validation declared for path parameter '{name}'"
+                f"{name} may not be '{value}': that names a different route"
             )
-        if not isinstance(value, str) or not pattern.match(value):
-            # The expected SHAPE is not echoed back: it is a storage detail, and
-            # a caller who guessed wrong is better served by the parameter name.
-            raise InvalidToolArgument(f'{name} is not a valid identifier')
     return params
 
 

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -12,7 +12,8 @@ from the Authorization header against SHA-256 hashes in the projects table.
 import json
 import os
 import re
-from datetime import datetime, timezone, timedelta
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from aws_lambda_powertools import Logger, Tracer, Metrics
@@ -20,9 +21,14 @@ from boto3.dynamodb.conditions import Key
 # Imported as a module because botocore's own `ConnectionError` would shadow the builtin.
 from botocore import exceptions as botocore_exceptions
 
-from shared.aws import get_dynamodb_resource
-from shared.api import DecimalEncoder, validate_date_basis
-from shared.feedback import query_feedback_by_date
+from shared.api import DecimalEncoder
+from shared.mcp_delegate import (
+    DelegationUnavailable,
+    DomainCall,
+    DomainResult,
+    call_domain,
+    synthetic_claims,
+)
 from shared.mcp_tokens import (
     MCP_TOKEN_PK,
     REACH_KIND_PROJECT,
@@ -38,24 +44,145 @@ from shared.mcp_tokens import (
     secret_matches,
     token_sk,
 )
-from shared.tables import get_projects_table, get_feedback_table, get_aggregates_table
-from shared.indexes import FEEDBACK_BY_ID_INDEX
-from projects import autoseed_project
+from shared.tables import get_projects_table
 
 logger = Logger()
 tracer = Tracer()
 metrics = Metrics(namespace="VoC-MCP")
 
-# AWS Clients
-dynamodb = get_dynamodb_resource()
-
-# Configuration
+# The ONLY table this function reads directly, and only its token partition:
+# authentication is the one thing that cannot be delegated, because it is what
+# decides who the delegated call is made as. Every tool's data now comes from
+# the domain function that owns the route (shared/mcp_delegate.py), which is why
+# FEEDBACK_TABLE and AGGREGATES_TABLE are gone from this Lambda's environment
+# and its role no longer holds a grant on either.
 projects_table = get_projects_table()
-feedback_table = get_feedback_table()
-aggregates_table = get_aggregates_table()
 
 # MCP Protocol version
 MCP_PROTOCOL_VERSION = "2024-11-05"
+
+# Semver on the SERVER, independent of the protocol revision above. 2.0.0
+# because tool output shapes changed: results now carry `structuredContent`
+# alongside the text block, sad paths that used to arrive as prose in a
+# successful result are now tool errors, and `get_project` reports the
+# documents it previously dropped.
+MCP_SERVER_VERSION = "2.0.0"
+
+
+# ============================================
+# Domain routes — the delegation map
+# ============================================
+
+# Which domain function owns which route. Two functions serve all five tools:
+# the metrics Lambda owns /feedback/* and /metrics/*, the projects Lambda owns
+# /projects/*. Adding a tool for a third domain means adding its function here
+# AND a grantInvoke in api-stack.ts — the lockstep test in api-stack.test.ts
+# fails if a route named here is not wired and invokable.
+DOMAIN_METRICS = 'metrics'
+DOMAIN_PROJECTS = 'projects'
+
+_DOMAIN_FUNCTION_ENV: dict[str, str] = {
+    DOMAIN_METRICS: 'METRICS_FUNCTION',
+    DOMAIN_PROJECTS: 'PROJECTS_FUNCTION',
+}
+
+# route key → (owning domain, method, path template). Load-bearing at runtime
+# (every call is built from it) so it cannot rot into stale documentation the
+# way a test-only table would.
+DOMAIN_ROUTES: dict[str, tuple[str, str, str]] = {
+    'feedback_list': (DOMAIN_METRICS, 'GET', '/feedback'),
+    'feedback_search': (DOMAIN_METRICS, 'GET', '/feedback/search'),
+    'feedback_item': (DOMAIN_METRICS, 'GET', '/feedback/{feedback_id}'),
+    'metrics_summary': (DOMAIN_METRICS, 'GET', '/metrics/summary'),
+    # The four breakdown axes behind the single get_metrics_breakdown tool.
+    'metrics_sentiment': (DOMAIN_METRICS, 'GET', '/metrics/sentiment'),
+    'metrics_categories': (DOMAIN_METRICS, 'GET', '/metrics/categories'),
+    'metrics_sources': (DOMAIN_METRICS, 'GET', '/metrics/sources'),
+    'metrics_personas': (DOMAIN_METRICS, 'GET', '/metrics/personas'),
+    'project_get': (DOMAIN_PROJECTS, 'GET', '/projects/{project_id}'),
+    'project_autoseed': (DOMAIN_PROJECTS, 'GET', '/projects/{project_id}/autoseed'),
+}
+
+
+def _domain_call(
+    route_key: str,
+    *,
+    path_parameters: dict[str, str] | None = None,
+    query: dict[str, Any] | None = None,
+) -> DomainCall:
+    """Build the call for a declared route, resolving its function name.
+
+    The env var is read per call rather than captured at import so a test can
+    set it, and so a missing one surfaces as this route being unconfigured
+    rather than as the whole module failing to load.
+    """
+    domain, method, template = DOMAIN_ROUTES[route_key]
+    params = dict(path_parameters or {})
+    return DomainCall(
+        function_name=os.environ.get(_DOMAIN_FUNCTION_ENV[domain], ''),
+        method=method,
+        path=template.format(**params) if params else template,
+        path_parameters=params,
+        query=dict(query or {}),
+    )
+
+
+class ToolRouteError(Exception):
+    """The delegated route refused the call — a 4xx the model should hear.
+
+    Distinct from DelegationUnavailable (a 5xx or transport fault, which is a
+    server problem the model cannot fix). The MCP spec draws exactly this line:
+    input-validation and business-logic failures belong in the tool RESULT with
+    `isError: true`, because a model can self-correct from them, while malformed
+    requests and server faults belong in the JSON-RPC `error`.
+    """
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """A tool's answer: the structured payload plus its serialized text form.
+
+    Both are returned because the spec says a tool SHOULD keep sending the
+    serialized JSON in a `TextContent` for clients that predate structured
+    output, and `structuredContent` is what a modern client validates against
+    the tool's `outputSchema`. One value produces both, so they cannot drift.
+    """
+
+    structured: dict
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self.structured, indent=2, cls=DecimalEncoder)
+
+
+def _delegate(call: DomainCall, token_info: dict) -> DomainResult:
+    """Invoke a domain route and map its refusals onto the MCP error taxonomy."""
+    result = call_domain(call, claims=synthetic_claims(token_info))
+    if result.ok:
+        return result
+    if 400 <= result.status_code < 500:
+        raise ToolRouteError(_route_error_message(result))
+    # A 5xx from the route is a server fault, not something a model can fix.
+    logger.error(
+        'Delegated route returned a server error',
+        extra={'route': f'{call.method} {call.path}', 'status': result.status_code},
+    )
+    raise DelegationUnavailable(f'{call.method} {call.path} returned {result.status_code}')
+
+
+def _route_error_message(result: DomainResult) -> str:
+    """The route's own message, so the model reads the real reason.
+
+    Powertools serializes its exceptions as `{"message": ...}`; anything else is
+    reported by status alone rather than by dumping an unknown body into the
+    model's context.
+    """
+    payload = result.payload
+    if isinstance(payload, dict):
+        message = payload.get('message') or payload.get('error')
+        if isinstance(message, str) and message:
+            return message
+    return f'The request was refused (HTTP {result.status_code})'
 
 # The credential format lives in shared/mcp_tokens.py — this module does not
 # spell the prefix. It used to, as did projects_handler and an inline authorizer
@@ -368,6 +495,96 @@ _PROJECT_ID_ARG = {
     ),
 }
 
+# How much of a verbatim a LIST answer carries. A single item is never
+# truncated; twenty of them would otherwise crowd out the model's own reasoning.
+_SUMMARY_TEXT_LIMIT = 500
+
+
+# ---------------------------------------------------------------------------
+# Output schemas
+# ---------------------------------------------------------------------------
+#
+# `outputSchema` describes what a tool puts in `structuredContent`, so a client
+# can validate the answer instead of parsing prose. The schemas are built from
+# shared pieces for the same reason the projections are: the two feedback tools
+# agree on ten fields, and two hand-maintained copies is how the declaration
+# stops matching the code.
+#
+# 🔑 `additionalProperties` is deliberately NOT uniform, and the split is the
+# honest one: a tool that PROJECTS its answer controls every key, so it declares
+# `false` and a stray field becomes a test failure. A tool that PASSES THROUGH a
+# route's payload does not control the keys — the route may add one tomorrow —
+# so declaring `false` there would make this file the thing that breaks when a
+# route grows a field, which is precisely the coupling delegation removes.
+
+_FEEDBACK_SUMMARY_PROPERTIES: dict[str, Any] = {
+    "id": {"type": "string"},
+    "source": {"type": "string", "description": "Source platform"},
+    "date": {"type": "string", "description": "YYYY-MM-DD"},
+    "sentiment": {"type": "string"},
+    "sentiment_score": {"type": "string", "description": "Stringified decimal"},
+    "category": {"type": "string"},
+    "urgency": {"type": "string"},
+    "rating": {"type": "string", "description": "Stringified, or 'N/A'"},
+    "persona_type": {"type": "string"},
+    "text": {"type": "string", "description": f"Verbatim, first {_SUMMARY_TEXT_LIMIT} characters"},
+    "problem_summary": {"type": "string"},
+}
+
+_FEEDBACK_DETAIL_PROPERTIES: dict[str, Any] = {
+    **_FEEDBACK_SUMMARY_PROPERTIES,
+    "date": {"type": "string", "description": "Full ISO-8601 timestamp"},
+    "text": {"type": "string", "description": "Full verbatim, untruncated"},
+    "journey_stage": {"type": "string"},
+    "problem_root_cause": {"type": "string"},
+    "direct_quote": {"type": "string"},
+    "keywords": {"type": "array", "items": {"type": "string"}},
+}
+
+# The document sort-key prefixes, mapped to the kind of document each names.
+#
+# 🔑 This map is why delegating mattered. The in-process tool recognised two of
+# these six — `PRD#` and `PRFAQ#` — so an MCP client saw a third of a project's
+# documents and was told nothing had been filtered: no research reports, no
+# uploaded documents, no product reports, no prototypes. The route always knew
+# all six. Reading the kind from the sort key rather than from a `type`
+# attribute is deliberate: the four formerly-invisible kinds do not all carry
+# one, so keying on `type` alone would have made them visible but unlabelled.
+_DOCUMENT_KINDS: dict[str, str] = {
+    'PRD#': 'prd',
+    'PRFAQ#': 'prfaq',
+    'RESEARCH#': 'research',
+    'DOC#': 'document',
+    'PRODUCT_REPORT#': 'product_report',
+    'PROTOTYPE#': 'prototype',
+}
+
+_PERSONA_PROPERTIES: dict[str, Any] = {
+    "persona_id": {"type": "string"},
+    "name": {"type": "string"},
+    "type": {"type": "string"},
+    "age_range": {"type": "string"},
+    "occupation": {"type": "string"},
+    "goals": {"type": "array", "items": {"type": "string"}},
+    "pain_points": {"type": "array", "items": {"type": "string"}},
+    "behaviors": {"type": "array", "items": {"type": "string"}},
+    "quote": {"type": "string"},
+    "journey_stage": {"type": "string"},
+}
+
+# A window argument, stated once. `maximum` is the route's real ceiling
+# (`validate_days` bounds to 365) rather than a tighter number restated here:
+# the adapter no longer clamps, so a limit this file invented would be a
+# promise nothing keeps. The route CLAMPS rather than refuses, which is why an
+# out-of-range value is not an error.
+_DAYS_ARG: dict[str, Any] = {
+    "type": "integer",
+    "description": "Days to look back (default 7). Values above the route's ceiling are clamped, not refused.",
+    "default": 7,
+    "minimum": 1,
+    "maximum": 365,
+}
+
 MCP_TOOLS = [
     {
         "name": "search_feedback",
@@ -380,13 +597,12 @@ MCP_TOOLS = [
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Text to search for in feedback (substring match on original_text)",
+                    "description": (
+                        "Text to match in the verbatim, title or problem summary. "
+                        "Must be at least 2 characters. Omit to list by filters alone."
+                    ),
                 },
-                "days": {
-                    "type": "integer",
-                    "description": "Number of days to look back (default 7, max 30)",
-                    "default": 7,
-                },
+                "days": _DAYS_ARG,
                 "category": {
                     "type": "string",
                     "description": "Filter by category (e.g. delivery, pricing, product_quality)",
@@ -412,42 +628,147 @@ MCP_TOOLS = [
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Max items to return (default 20, max 50)",
+                    "description": "Max items to return (default 20). Clamped to the route's ceiling of 100.",
                     "default": 20,
+                    "minimum": 1,
+                    "maximum": 100,
                 },
             },
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "count": {"type": "integer", "description": "Items returned"},
+                "query": {"type": "string", "description": "The text matched, empty when filtering only"},
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": _FEEDBACK_SUMMARY_PROPERTIES,
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["count", "query", "items"],
             "additionalProperties": False,
         },
     },
     {
         "name": "get_metrics_summary",
         "description": (
-            "Get dashboard summary metrics: total feedback count, sentiment breakdown, "
-            "top categories, and average rating over a time period."
+            "Dashboard summary over a time window: total feedback, average sentiment, "
+            "urgent count, and the daily totals and sentiment series. "
+            "For counts per category, sentiment, source or persona use get_metrics_breakdown."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "days": {
-                    "type": "integer",
-                    "description": "Number of days to aggregate (default 7, max 30)",
-                    "default": 7,
-                },
+                "days": {**_DAYS_ARG, "description": "Days to aggregate (default 7)."},
             },
             "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "period_days": {"type": "integer"},
+                "total_feedback": {"type": "integer"},
+                "avg_sentiment": {"type": "number", "description": "Weighted mean, -1..1"},
+                "urgent_count": {"type": "integer"},
+                "daily_totals": {"type": "array", "items": {"type": "object"}},
+                "daily_sentiment": {"type": "array", "items": {"type": "object"}},
+            },
+        },
+    },
+    {
+        "name": "get_metrics_breakdown",
+        "description": (
+            "Counts along one axis over a time window: sentiment labels, categories, "
+            "source platforms, or inferred personas."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "dimension": {
+                    "type": "string",
+                    "enum": ["sentiment", "categories", "sources", "personas"],
+                    "description": "Which axis to break the window down by",
+                },
+                "days": {**_DAYS_ARG, "description": "Days to aggregate (default 7)."},
+            },
+            "required": ["dimension"],
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "period_days": {"type": "integer"},
+                "is_partial": {
+                    "type": "boolean",
+                    "description": "True when an aggregate read failed and counts are incomplete",
+                },
+                "breakdown": {"type": "object", "description": "Counts, when dimension=sentiment"},
+                "percentages": {"type": "object", "description": "Shares, when dimension=sentiment"},
+                "categories": {"type": "object", "description": "When dimension=categories"},
+                "sources": {"type": "object", "description": "When dimension=sources"},
+                "personas": {"type": "object", "description": "When dimension=personas"},
+            },
         },
     },
     {
         "name": "get_project",
         "description": (
-            "Get details of a project including personas, documents (PRDs, PR/FAQs), "
-            "and project metadata."
+            "Project metadata with its personas and its documents listed by title. "
+            "Documents cover PRDs, PR/FAQs, research reports, uploaded documents, "
+            "product reports and prototypes; bodies are not included."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "project_id": _PROJECT_ID_ARG,
             },
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "project_id": {"type": "string"},
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "created_at": {"type": "string"},
+                "persona_count": {"type": "integer"},
+                "document_count": {"type": "integer"},
+                "personas": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "persona_id": {"type": "string"},
+                            "name": {"type": "string"},
+                            "type": {"type": "string"},
+                        },
+                        "additionalProperties": False,
+                    },
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "document_id": {"type": "string"},
+                            "title": {"type": "string"},
+                            "type": {"type": "string"},
+                            "kind": {
+                                "type": "string",
+                                "enum": sorted(set(_DOCUMENT_KINDS.values())) + [""],
+                                "description": "Document kind, derived from its storage prefix",
+                            },
+                        },
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["project_id", "persona_count", "document_count", "personas", "documents"],
             "additionalProperties": False,
         },
     },
@@ -462,6 +783,22 @@ MCP_TOOLS = [
             "properties": {
                 "project_id": _PROJECT_ID_ARG,
             },
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "count": {"type": "integer"},
+                "personas": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": _PERSONA_PROPERTIES,
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["count", "personas"],
             "additionalProperties": False,
         },
     },
@@ -479,6 +816,11 @@ MCP_TOOLS = [
             "required": ["feedback_id"],
             "additionalProperties": False,
         },
+        "outputSchema": {
+            "type": "object",
+            "properties": _FEEDBACK_DETAIL_PROPERTIES,
+            "additionalProperties": False,
+        },
     },
 ]
 
@@ -487,329 +829,282 @@ MCP_TOOLS = [
 # MCP Tool implementations
 # ============================================
 
-@tracer.capture_method
-def _tool_search_feedback(args: dict, _token_info: dict) -> list[dict]:
-    """Search feedback items with filters."""
-    if not feedback_table:
-        return [{"type": "text", "text": "Feedback table not configured"}]
+def _project_feedback(item: dict, *, summary: bool) -> dict:
+    """Reshape one raw feedback record for a model to read.
 
-    days = min(args.get('days', 7), 30)
-    category = args.get('category')
-    sentiment = args.get('sentiment')
-    source = args.get('source')
-    query = args.get('query', '').lower()
-    limit = min(args.get('limit', 20), 50)
-    date_basis = validate_date_basis(args.get('date_basis'))
+    The projection is the adapter's job, not the route's: a raw record carries
+    pk/sk/gsi keys, enrichment internals and the full verbatim, and a list of 20
+    of them would spend a model's context on fields it cannot use. The renames
+    (`source_platform`→`source`, `sentiment_label`→`sentiment`,
+    `original_text`→`text`) are the names the tools have always reported.
 
-    items = query_feedback_by_date(
-        feedback_table,
-        days=days,
-        sources=[source] if source else None,
-        categories=[category] if category else None,
-        sentiments=[sentiment] if sentiment else None,
-        limit=limit,
-        date_basis=date_basis,
-    )
+    ONE function for both feedback tools, parameterized by `summary`, because
+    they agree on ten fields and differ only in truncation and in the five
+    detail-only fields. Two copies is how the pair drifts — which is exactly the
+    defect that made delegating worth doing in the first place.
 
-    if query:
-        items = [i for i in items if query in (i.get('original_text', '') or '').lower()]
-        items = items[:limit]
-
-    if not items:
-        return [{"type": "text", "text": "No feedback items found matching the filters."}]
-
-    results = []
-    for item in items:
-        results.append({
-            "id": item.get('id', ''),
-            "source": item.get('source_platform', ''),
-            "date": (item.get('source_created_at', '') or '')[:10],
-            "sentiment": item.get('sentiment_label', ''),
-            "sentiment_score": str(item.get('sentiment_score', '')),
-            "category": item.get('category', ''),
-            "urgency": item.get('urgency', ''),
-            "rating": str(item.get('rating', 'N/A')),
-            "persona_type": item.get('persona_type', ''),
-            "text": (item.get('original_text', '') or '')[:500],
-            "problem_summary": item.get('problem_summary', ''),
-        })
-
-    return [{"type": "text", "text": json.dumps(results, indent=2, cls=DecimalEncoder)}]
-
-
-_DEFAULT_METRICS_DAYS = 7
-_MAX_METRICS_DAYS = 30
-
-
-def _resolve_days(raw: Any) -> int:
-    """Coerce and clamp a caller-supplied ``days`` argument to 1..30.
-
-    Pure helper.  A missing or non-numeric value falls back to the default
-    rather than raising, so ``period_days`` is always an ``int`` inside the
-    advertised range regardless of what the client sent.  That includes the
-    infinities: ``json`` parses both ``1e400`` and ``Infinity`` to ``inf``, and
-    ``int(float('inf'))`` raises ``OverflowError`` rather than the ``ValueError``
-    a non-numeric string gives, so ``OverflowError`` is caught alongside them —
-    without it, ``{"days": 1e400}`` bypassed this fallback and surfaced as an
-    opaque error from the ``_handle_tools_call`` catch-all.
-
-    A value that is not an integer *by the tool's own ``inputSchema``* also
-    falls back rather than being silently reinterpreted: JSON Schema counts
-    neither ``true`` nor ``2.9`` as an integer, but ``int(True) == 1`` and
-    ``int(2.9) == 2`` in Python, so coercing them would answer a window the
-    caller never asked for.  A numeric *string* is still accepted — ``"14"``
-    can only mean 14, and the resolved value is echoed back as ``period_days``.
+    `sentiment_score` and `rating` are stringified, preserving the existing
+    contract: both are DynamoDB Decimals, and a client that pattern-matched on
+    `"rating": "N/A"` for an unrated item still sees it.
     """
-    if raw is None:
-        return _DEFAULT_METRICS_DAYS
-    # isinstance(True, int) is True in Python, so bools must be excluded before
-    # the int() call or `days: true` quietly becomes a 1-day window.
-    if isinstance(raw, bool):
-        return _DEFAULT_METRICS_DAYS
-    try:
-        days = int(raw)
-    except (TypeError, ValueError, OverflowError):
-        # OverflowError is the infinities: int(float('inf')) raises it, not
-        # ValueError, and json parses 1e400 / Infinity to inf.  int(float('nan'))
-        # does raise ValueError, so NaN is covered by the clause above.
-        return _DEFAULT_METRICS_DAYS
-    # Fractional input: int() truncates, which narrows the window rather than
-    # rejecting it.  Strings are exempt — int("14") is exact, and "14" != 14.
-    if not isinstance(raw, str) and days != raw:
-        return _DEFAULT_METRICS_DAYS
-    return max(1, min(days, _MAX_METRICS_DAYS))
-
-
-@tracer.capture_method
-def _tool_get_metrics_summary(args: dict, _token_info: dict) -> list[dict]:
-    """Get aggregated metrics summary.
-
-    Mirrors the ``is_partial`` convention used by the REST metrics endpoints:
-    if any underlying DynamoDB read raises, the partial result is still returned
-    (so the readable portion is not lost), but ``is_partial`` is set to ``True``
-    and the failure is logged at WARNING level — without any token or hash.
-    """
-    # Resolve `days` once, before the early exit, so both paths report the same
-    # window.  The value is caller-supplied and echoed back as `period_days`,
-    # so coerce it as well as clamp it: `inputSchema` declares "integer" but
-    # nothing enforces that server-side, and `min()` against a str raises.
-    days = _resolve_days(args.get('days'))
-
-    if not aggregates_table:
-        return [{"type": "text", "text": json.dumps({
-            "is_partial": True,
-            "error": "Aggregates table not configured",
-            "period_days": days,
-            "total_feedback": 0,
-            "sentiment_breakdown": {},
-            "top_categories": {},
-        })}]
-
-    current_date = datetime.now(timezone.utc)
-
-    total = 0
-    sentiment_counts: dict[str, int] = {}
-    category_counts: dict[str, int] = {}
-    is_partial = False
-
-    for i in range(days):
-        date = (current_date - timedelta(days=i)).strftime('%Y-%m-%d')
-
-        # Daily total
-        try:
-            resp = aggregates_table.get_item(Key={'pk': 'METRIC#daily_total', 'sk': date})
-            item = resp.get('Item')
-            if item:
-                total += int(item.get('count', 0))
-        except Exception as exc:
-            logger.warning("Failed to read daily_total aggregate", extra={"date": date, "error": str(exc)})
-            is_partial = True
-
-        # Sentiment counts
-        for sent in ['positive', 'negative', 'neutral', 'mixed']:
-            try:
-                resp = aggregates_table.get_item(Key={'pk': f'METRIC#daily_sentiment#{sent}', 'sk': date})
-                item = resp.get('Item')
-                if item:
-                    sentiment_counts[sent] = sentiment_counts.get(sent, 0) + int(item.get('count', 0))
-            except Exception as exc:
-                logger.warning(
-                    "Failed to read sentiment aggregate",
-                    extra={"sentiment": sent, "date": date, "error": str(exc)},
-                )
-                is_partial = True
-
-    # Category breakdown from latest aggregate
-    try:
-        resp = aggregates_table.query(
-            KeyConditionExpression=Key('pk').eq('METRIC#category_breakdown'),
-            ScanIndexForward=False,
-            Limit=1,
-        )
-        for item in resp.get('Items', []):
-            cats = item.get('categories', {})
-            if isinstance(cats, dict):
-                category_counts = {k: int(v) for k, v in cats.items()}
-    except Exception as exc:
-        logger.warning("Failed to read category_breakdown aggregate", extra={"error": str(exc)})
-        is_partial = True
-
-    summary = {
-        "period_days": days,
-        "total_feedback": total,
-        "is_partial": is_partial,
-        "sentiment_breakdown": sentiment_counts,
-        "top_categories": dict(sorted(category_counts.items(), key=lambda x: x[1], reverse=True)[:10]),
-    }
-
-    return [{"type": "text", "text": json.dumps(summary, indent=2)}]
-
-
-@tracer.capture_method
-def _tool_get_project(args: dict, token_info: dict) -> list[dict]:
-    """Get project details including personas and documents.
-
-    `project_id` is the project _handle_tools_call resolved from the arguments
-    (or the token's single project) AND authorized against the token's read
-    reach. It is not "the token's project" any more — a credential can reach
-    several — so this must not be re-derived here.
-    """
-    project_id = token_info['project_id']
-
-    if not projects_table:
-        return [{"type": "text", "text": "Projects table not configured"}]
-
-    # Get all items for this project
-    response = projects_table.query(
-        KeyConditionExpression=Key('pk').eq(f'PROJECT#{project_id}'),
-    )
-    items = response.get('Items', [])
-
-    project_meta = None
-    personas = []
-    documents = []
-
-    for item in items:
-        sk = item.get('sk', '')
-        if sk == 'META':
-            project_meta = item
-        elif sk.startswith('PERSONA#'):
-            personas.append(item)
-        elif sk.startswith('PRD#') or sk.startswith('PRFAQ#'):
-            documents.append(item)
-
-    if not project_meta:
-        return [{"type": "text", "text": f"Project {project_id} not found"}]
-
-    result = {
-        "project_id": project_id,
-        "name": project_meta.get('name', ''),
-        "description": project_meta.get('description', ''),
-        "created_at": project_meta.get('created_at', ''),
-        "persona_count": len(personas),
-        "document_count": len(documents),
-        "personas": [
-            {"persona_id": p.get('persona_id', ''), "name": p.get('name', ''), "type": p.get('type', '')}
-            for p in personas
-        ],
-        "documents": [
-            {"document_id": d.get('document_id', ''), "title": d.get('title', ''), "type": d.get('type', '')}
-            for d in documents
-        ],
-    }
-
-    return [{"type": "text", "text": json.dumps(result, indent=2, cls=DecimalEncoder)}]
-
-
-@tracer.capture_method
-def _tool_list_personas(args: dict, token_info: dict) -> list[dict]:
-    """List personas with full details.
-
-    `project_id` is resolved and authorized by _handle_tools_call — see
-    _tool_get_project.
-    """
-    project_id = token_info['project_id']
-
-    if not projects_table:
-        return [{"type": "text", "text": "Projects table not configured"}]
-
-    response = projects_table.query(
-        KeyConditionExpression=(
-            Key('pk').eq(f'PROJECT#{project_id}') & Key('sk').begins_with('PERSONA#')
-        ),
-    )
-    items = response.get('Items', [])
-
-    if not items:
-        return [{"type": "text", "text": "No personas found for this project."}]
-
-    personas = []
-    for item in items:
-        personas.append({
-            "persona_id": item.get('persona_id', ''),
-            "name": item.get('name', ''),
-            "type": item.get('type', ''),
-            "age_range": item.get('age_range', ''),
-            "occupation": item.get('occupation', ''),
-            "goals": item.get('goals', []),
-            "pain_points": item.get('pain_points', []),
-            "behaviors": item.get('behaviors', []),
-            "quote": item.get('quote', ''),
-            "journey_stage": item.get('journey_stage', ''),
-        })
-
-    return [{"type": "text", "text": json.dumps(personas, indent=2, cls=DecimalEncoder)}]
-
-
-@tracer.capture_method
-def _tool_get_feedback_detail(args: dict, _token_info: dict) -> list[dict]:
-    """Get a single feedback item by ID."""
-    feedback_id = args.get('feedback_id', '')
-    if not feedback_id:
-        return [{"type": "text", "text": "feedback_id is required"}]
-
-    if not feedback_table:
-        return [{"type": "text", "text": "Feedback table not configured"}]
-
-    response = feedback_table.query(
-        IndexName=FEEDBACK_BY_ID_INDEX,
-        KeyConditionExpression=Key('feedback_id').eq(feedback_id),
-        Limit=1,
-    )
-    items = response.get('Items', [])
-
-    if not items:
-        return [{"type": "text", "text": f"Feedback item {feedback_id} not found"}]
-
-    item = items[0]
-    result = {
+    projected = {
         "id": item.get('id', ''),
         "source": item.get('source_platform', ''),
-        "date": item.get('source_created_at', ''),
+        "date": item.get('source_created_at', '') or '',
         "sentiment": item.get('sentiment_label', ''),
         "sentiment_score": str(item.get('sentiment_score', '')),
         "category": item.get('category', ''),
         "urgency": item.get('urgency', ''),
         "rating": str(item.get('rating', 'N/A')),
         "persona_type": item.get('persona_type', ''),
-        "journey_stage": item.get('journey_stage', ''),
-        "text": item.get('original_text', ''),
+        "text": item.get('original_text', '') or '',
         "problem_summary": item.get('problem_summary', ''),
+    }
+    if summary:
+        # A list answer carries the date as a plain day and clips the verbatim;
+        # the single-item answer carries both in full.
+        projected["date"] = projected["date"][:10]
+        projected["text"] = projected["text"][:_SUMMARY_TEXT_LIMIT]
+        return projected
+    projected.update({
+        "journey_stage": item.get('journey_stage', ''),
         "problem_root_cause": item.get('problem_root_cause_hypothesis', ''),
         "direct_quote": item.get('direct_customer_quote', ''),
         "keywords": item.get('keywords', []),
+    })
+    return projected
+
+
+@tracer.capture_method
+def _tool_search_feedback(args: dict, token_info: dict) -> ToolResult:
+    """Search feedback, via the route that owns the corpus.
+
+    TWO routes behind one tool, chosen by whether a `query` was given, because
+    that is what this tool has always done: `GET /feedback/search` is a text
+    search and REFUSES a query shorter than two characters, while the filters
+    alone (no text) are what `GET /feedback` answers. Mapping the tool onto
+    `/feedback/search` alone would have made every filter-only call return
+    nothing; splitting it into two tools is Phase 3's `list_feedback`.
+    """
+    query = args.get('query')
+    query = query.strip() if isinstance(query, str) else ''
+    shared_filters = {
+        'days': args.get('days', 7),
+        'limit': args.get('limit', 20),
+        'category': args.get('category'),
+        'sentiment': args.get('sentiment'),
+        'source': args.get('source'),
+        'date_basis': args.get('date_basis'),
     }
 
-    return [{"type": "text", "text": json.dumps(result, indent=2, cls=DecimalEncoder)}]
+    if query:
+        call = _domain_call('feedback_search', query={'q': query, **shared_filters})
+    else:
+        call = _domain_call('feedback_list', query=shared_filters)
+
+    body = _delegate(call, token_info).payload
+    items = body.get('items', []) if isinstance(body, dict) else []
+    return ToolResult({
+        "count": len(items),
+        "query": query,
+        "items": [_project_feedback(item, summary=True) for item in items
+                  if isinstance(item, dict)],
+    })
+
+
+@tracer.capture_method
+def _tool_get_metrics_summary(args: dict, token_info: dict) -> ToolResult:
+    """Dashboard summary metrics, from the route the dashboard itself uses.
+
+    ⚠️ The answer's SHAPE changed at server 2.0.0, and not only by field names.
+    This tool used to recompute the summary from raw aggregate rows and reported
+    `sentiment_breakdown` + `top_categories`; the route reports `avg_sentiment`,
+    `urgent_count` and the daily series instead. The counts per sentiment and
+    per category now come from `get_metrics_breakdown`, which is why that tool
+    is in this phase rather than the next one — between them the two tools
+    report strictly more than the old one did, so no client loses information.
+
+    The window-clamping helper this used to need is gone with it: `days` is
+    bounded by the route's own `validate_days`, which is a validator documented
+    never to raise (it clamps and defaults), so a nonsense window degrades the
+    same way it does for every other caller of that route instead of the way
+    one hand-written clamp in this file happened to.
+    """
+    body = _delegate(
+        _domain_call('metrics_summary', query={'days': args.get('days', 7)}),
+        token_info,
+    ).payload
+    return ToolResult(body if isinstance(body, dict) else {})
+
+
+# The four breakdown routes, as the `dimension` argument names them. One tool
+# over four routes: they answer the same question about different axes, and four
+# near-identical tool declarations would spend a model's context to say so.
+_BREAKDOWN_DIMENSIONS: dict[str, str] = {
+    'sentiment': '/metrics/sentiment',
+    'categories': '/metrics/categories',
+    'sources': '/metrics/sources',
+    'personas': '/metrics/personas',
+}
+
+
+@tracer.capture_method
+def _tool_get_metrics_breakdown(args: dict, token_info: dict) -> ToolResult:
+    """Counts along one axis: sentiment, categories, sources or personas.
+
+    Passed through unprojected, deliberately: each of these routes answers with
+    a small `{period_days, is_partial, <axis>: {...}}` object that is already
+    exactly what a model needs, and re-shaping it here would reintroduce the
+    second implementation that delegating exists to remove. It also carries the
+    routes' own `is_partial`, so a degraded aggregate read is still reported.
+    """
+    dimension = args.get('dimension')
+    if dimension not in _BREAKDOWN_DIMENSIONS:
+        # A -32602 rather than a delegated 404: the enum is this tool's own
+        # contract, so an unknown value is a malformed call, not a route refusal.
+        raise InvalidToolArgument(
+            f"dimension must be one of: {', '.join(sorted(_BREAKDOWN_DIMENSIONS))}"
+        )
+    body = _delegate(
+        _domain_call(f'metrics_{dimension}', query={'days': args.get('days', 7)}),
+        token_info,
+    ).payload
+    return ToolResult(body if isinstance(body, dict) else {})
+
+
+def _document_kind(item: dict) -> str:
+    sk = item.get('sk', '')
+    for prefix, kind in _DOCUMENT_KINDS.items():
+        if sk.startswith(prefix):
+            return kind
+    return ''
+
+
+def _project_persona(item: dict) -> dict:
+    """The persona fields the tools report, with typed defaults.
+
+    Shared by both project-shaped tools so a persona reads the same either way.
+    Everything else on the row — avatar keys, source feedback ids, notes,
+    timestamps — is dropped: a project's personas are the answer, not its
+    storage layout.
+    """
+    return {
+        "persona_id": item.get('persona_id', ''),
+        "name": item.get('name', ''),
+        "type": item.get('type', ''),
+        "age_range": item.get('age_range', ''),
+        "occupation": item.get('occupation', ''),
+        "goals": item.get('goals', []),
+        "pain_points": item.get('pain_points', []),
+        "behaviors": item.get('behaviors', []),
+        "quote": item.get('quote', ''),
+        "journey_stage": item.get('journey_stage', ''),
+    }
+
+
+def _get_project_payload(token_info: dict) -> tuple[dict, list[dict], list[dict]]:
+    """Fetch one project from the route that owns it.
+
+    `project_id` is the project `_handle_tools_call` resolved from the arguments
+    (or the token's single project) AND authorized against the token's read
+    reach. It is not "the token's project" — a credential can reach several — so
+    it must not be re-derived here.
+    """
+    project_id = token_info['project_id']
+    body = _delegate(
+        _domain_call('project_get', path_parameters={'project_id': project_id}),
+        token_info,
+    ).payload
+    if not isinstance(body, dict):
+        raise DelegationUnavailable('project route returned no object')
+    meta = body.get('project')
+    personas = body.get('personas') or []
+    documents = body.get('documents') or []
+    return (
+        meta if isinstance(meta, dict) else {},
+        [p for p in personas if isinstance(p, dict)],
+        [d for d in documents if isinstance(d, dict)],
+    )
+
+
+@tracer.capture_method
+def _tool_get_project(args: dict, token_info: dict) -> ToolResult:
+    """Project metadata with its personas and documents listed by name.
+
+    Documents are listed, never inlined: a generated prototype is hundreds of
+    kilobytes and a PRD is thousands of words, so returning bodies here would
+    blow both the model's context and the 6 MB synchronous-invoke ceiling.
+    Bodies become resources in a later phase.
+    """
+    meta, personas, documents = _get_project_payload(token_info)
+    return ToolResult({
+        "project_id": token_info['project_id'],
+        "name": meta.get('name', ''),
+        "description": meta.get('description', ''),
+        "created_at": meta.get('created_at', ''),
+        "persona_count": len(personas),
+        "document_count": len(documents),
+        "personas": [
+            {"persona_id": p.get('persona_id', ''), "name": p.get('name', ''),
+             "type": p.get('type', '')}
+            for p in personas
+        ],
+        "documents": [
+            {"document_id": d.get('document_id', ''), "title": d.get('title', ''),
+             "type": d.get('type', ''), "kind": _document_kind(d)}
+            for d in documents
+        ],
+    })
+
+
+@tracer.capture_method
+def _tool_list_personas(args: dict, token_info: dict) -> ToolResult:
+    """Every persona for a project, in full.
+
+    Derived from the same project route rather than from a personas-only read:
+    there is no such route, and inventing a second path to the same rows is what
+    delegating exists to avoid. The cost is reading the project's documents to
+    discard them, which is one Query either way.
+    """
+    _meta, personas, _documents = _get_project_payload(token_info)
+    return ToolResult({
+        "count": len(personas),
+        "personas": [_project_persona(p) for p in personas],
+    })
+
+
+@tracer.capture_method
+def _tool_get_feedback_detail(args: dict, token_info: dict) -> ToolResult:
+    """One feedback item in full, by id.
+
+    A missing item is now the route's 404 arriving as a tool ERROR rather than
+    the prose "not found" inside a successful result this tool used to return.
+    That is the point of the change: a model reading `isError: false` has been
+    told the call worked, so it treats the prose as data and reports the item as
+    empty rather than retrying with a different id.
+    """
+    feedback_id = args.get('feedback_id')
+    if not isinstance(feedback_id, str) or not feedback_id.strip():
+        raise InvalidToolArgument('feedback_id must be a non-empty string')
+
+    body = _delegate(
+        _domain_call('feedback_item',
+                     path_parameters={'feedback_id': feedback_id.strip()}),
+        token_info,
+    ).payload
+    if not isinstance(body, dict):
+        raise DelegationUnavailable('feedback route returned no object')
+    return ToolResult(_project_feedback(body, summary=False))
 
 
 # Tool name → implementation mapping
 TOOL_HANDLERS = {
     "search_feedback": _tool_search_feedback,
+    "get_feedback_detail": _tool_get_feedback_detail,
     "get_metrics_summary": _tool_get_metrics_summary,
+    "get_metrics_breakdown": _tool_get_metrics_breakdown,
     "get_project": _tool_get_project,
     "list_personas": _tool_list_personas,
-    "get_feedback_detail": _tool_get_feedback_detail,
 }
 
 # The scope each registered tool requires, from the vocabulary in
@@ -830,6 +1125,7 @@ TOOL_SCOPE_REQUIREMENTS: dict[str, str] = {
     "search_feedback": SCOPE_FEEDBACK_READ,
     "get_feedback_detail": SCOPE_FEEDBACK_READ,
     "get_metrics_summary": SCOPE_METRICS_READ,
+    "get_metrics_breakdown": SCOPE_METRICS_READ,
     "get_project": SCOPE_PROJECTS_READ,
     "list_personas": SCOPE_PROJECTS_READ,
 }
@@ -851,6 +1147,7 @@ TOOL_REACH_KINDS: dict[str, str] = {
     "search_feedback": REACH_KIND_WORKSPACE,
     "get_feedback_detail": REACH_KIND_WORKSPACE,
     "get_metrics_summary": REACH_KIND_WORKSPACE,
+    "get_metrics_breakdown": REACH_KIND_WORKSPACE,
     "get_project": REACH_KIND_PROJECT,
     "list_personas": REACH_KIND_PROJECT,
 }
@@ -887,7 +1184,7 @@ def _handle_initialize(req_id: Any, _params: dict) -> dict:
         },
         "serverInfo": {
             "name": "voc-datalake",
-            "version": "1.0.0",
+            "version": MCP_SERVER_VERSION,
         },
     })
 
@@ -918,7 +1215,19 @@ def _scope_allows(token_scopes: Any, required_scope: str) -> bool:
     return required_scope in token_scopes
 
 
-class InvalidProjectArgument(Exception):
+class InvalidToolArgument(Exception):
+    """A tool argument is malformed on the tool's OWN terms.
+
+    Reported as `-32602 Invalid params` and never delegated, which is the line
+    worth keeping straight: a value the tool's `inputSchema` forbids (an unknown
+    enum member, a `project_id` that is not a string) is a malformed request,
+    while a well-formed value the DATA refuses (a project that does not exist)
+    is the route's 404 and arrives as a tool error the model can act on. Sending
+    the first kind downstream would turn a client bug into a domain lookup.
+    """
+
+
+class InvalidProjectArgument(InvalidToolArgument):
     """`project_id` was supplied but is not a usable project id."""
 
 
@@ -1065,15 +1374,51 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         # instead of being repeated per tool.
         token_info = {**token_info, 'project_id': project_id}
 
+    # The three outcomes are separated because the MCP spec separates them, and
+    # the distinction is what lets a model behave sensibly:
+    #
+    #   malformed call        → JSON-RPC error   (-32602) — the client is wrong
+    #   route refused a call  → RESULT isError   — the model can try something else
+    #   infrastructure fault  → JSON-RPC error   (-32603) — nobody upstream can fix it
+    #
+    # Collapsing the middle case into the first would tell a model its request
+    # was malformed when it was merely unlucky; collapsing it into a successful
+    # result (what this handler used to do for "not found") tells the model the
+    # call worked and the data is empty, which it then reports as fact.
     try:
-        content = handler(arguments, token_info)
-        return _jsonrpc_result(req_id, {"content": content, "isError": False})
+        result = handler(arguments, token_info)
+    except InvalidToolArgument as exc:
+        return _jsonrpc_error(req_id, -32602, str(exc))
+    except ToolRouteError as exc:
+        return _tool_error(req_id, str(exc))
+    except DelegationUnavailable:
+        # Already logged with the route and fault type at the point of failure.
+        # The client is told only that the server failed: the detail is a
+        # function name, a status code or a stack trace, none of which is the
+        # caller's business and one of which is a fingerprint of the topology.
+        logger.error("Delegation failed", extra={"tool": tool_name})
+        return _jsonrpc_error(req_id, -32603, "Internal error: upstream service unavailable")
     except Exception as e:
         logger.exception(f"Tool execution error: {tool_name}")
-        return _jsonrpc_result(req_id, {
-            "content": [{"type": "text", "text": f"Error: {str(e)}"}],
-            "isError": True,
-        })
+        return _tool_error(req_id, f"Error: {str(e)}")
+
+    return _jsonrpc_result(req_id, {
+        "content": [{"type": "text", "text": result.text}],
+        # Structured output alongside the text block, not instead of it: the
+        # spec says a tool SHOULD keep sending the serialized form for clients
+        # that predate `structuredContent`, and both come from one value here so
+        # they cannot disagree.
+        "structuredContent": result.structured,
+        "isError": False,
+    })
+
+
+def _tool_error(req_id: Any, message: str) -> dict:
+    """A tool EXECUTION error: a successful JSON-RPC call reporting a failure."""
+    return _jsonrpc_result(req_id, {
+        "content": [{"type": "text", "text": message}],
+        "isError": True,
+    })
 
 
 def _handle_ping(req_id: Any, _params: dict) -> dict:
@@ -1138,16 +1483,24 @@ def _handle_autoseed(event: dict) -> dict:
             status_code=403,
         )
 
-    query_params = event.get('queryStringParameters', {}) or {}
-    persona_ids = query_params.get('persona_ids', '').split(',') if query_params.get('persona_ids') else None
-    document_ids = query_params.get('document_ids', '').split(',') if query_params.get('document_ids') else None
-
+    # Delegated like every tool, and this one is why the projects-table grant
+    # could be narrowed to the token partition: autoseed was the last reader of
+    # project ARTIFACT rows in this function. The filter arguments are passed
+    # through as the route's own query string rather than re-parsed here — the
+    # comma-splitting used to be duplicated in both places.
+    query_params = event.get('queryStringParameters') or {}
+    call = _domain_call('project_autoseed', path_parameters={'project_id': project_id}, query={
+        'persona_ids': query_params.get('persona_ids'),
+        'document_ids': query_params.get('document_ids'),
+    })
     try:
-        result = autoseed_project(project_id, persona_ids=persona_ids, document_ids=document_ids)
-        return _cors_response(result)
-    except Exception as e:
-        logger.exception(f"Autoseed error for project {project_id}")
-        return _cors_response({'message': str(e)}, status_code=500)
+        result = call_domain(call, claims=synthetic_claims(token_info))
+    except DelegationUnavailable:
+        logger.error('Autoseed delegation failed', extra={'project_id': project_id})
+        return _cors_response({'message': 'Upstream service unavailable'}, status_code=502)
+    # The route's own status travels with its body: a 404 for an unknown project
+    # stays a 404 here instead of becoming the 500 this used to answer for it.
+    return _cors_response(result.payload, status_code=result.status_code)
 
 
 # ============================================

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -166,10 +166,23 @@ def _reserved_for(template: str, name: str) -> frozenset[str]:
     Keyed on the path PREFIX above the parameter, so `/projects/{project_id}` and
     `/projects/{project_id}/autoseed` share one set — both put the value in the
     same position, which is what decides which siblings it can collide with.
+
+    FAILS CLOSED on a prefix with no entry, which is the property the previous
+    format-allowlist version had and this one lost when it was rewritten: a
+    `.get(prefix, frozenset())` silently permits sibling collisions for any
+    future templated route whose prefix nobody remembered to declare, so adding
+    a route becomes how the hole reopens. Declaring an explicit
+    `frozenset()` is how a prefix with genuinely no static siblings opts out, and
+    that is a deliberate line in a diff rather than an omission.
     """
     segments = template.strip('/').split('/')
     position = segments.index(f'{{{name}}}')
-    return _RESERVED_PATH_SEGMENTS.get('/' + '/'.join(segments[:position]), frozenset())
+    prefix = '/' + '/'.join(segments[:position])
+    if prefix not in _RESERVED_PATH_SEGMENTS:
+        raise InvalidToolArgument(
+            f'{name} cannot be validated: no reserved-segment set declared for {prefix}'
+        )
+    return _RESERVED_PATH_SEGMENTS[prefix]
 
 
 def _validated_path_parameters(route_key: str, params: dict[str, str]) -> dict[str, str]:
@@ -180,12 +193,20 @@ def _validated_path_parameters(route_key: str, params: dict[str, str]) -> dict[s
             # Fail closed rather than ignoring it: a parameter the template does
             # not interpolate means caller and route disagree about the call.
             raise InvalidToolArgument(f"{route_key}: unexpected path parameter '{name}'")
+        # Distinct messages per condition: the caller can act on each of these
+        # differently, and "must be a single path segment" for a stray space sends
+        # them looking for a slash they never sent.
         if not isinstance(value, str) or not value or value.strip() != value:
             raise InvalidToolArgument(f'{name} must be a non-empty identifier')
-        if _FORBIDDEN_PATH_CHARS & set(value):
-            raise InvalidToolArgument(f'{name} must be a single path segment')
-        if value in {'.', '..'} or any(c.isspace() or ord(c) < 0x20 for c in value):
-            raise InvalidToolArgument(f'{name} must be a single path segment')
+        offending = sorted(_FORBIDDEN_PATH_CHARS & set(value))
+        if offending:
+            raise InvalidToolArgument(
+                f'{name} may not contain {" ".join(offending)}: it must be a single path segment'
+            )
+        if any(c.isspace() or ord(c) < 0x20 for c in value):
+            raise InvalidToolArgument(f'{name} may not contain whitespace or control characters')
+        if value in {'.', '..'}:
+            raise InvalidToolArgument(f'{name} may not be a relative path segment')
         if value in _reserved_for(template, name):
             # Named explicitly, because "not found" would be a lie and the caller
             # cannot otherwise tell why a plausible-looking id was refused.

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -1633,19 +1633,20 @@ def _handle_autoseed(event: dict) -> dict:
     # through as the route's own query string rather than re-parsed here — the
     # comma-splitting used to be duplicated in both places.
     query_params = event.get('queryStringParameters') or {}
+    # ONE try around both steps, because both can raise both kinds. Building the
+    # call can fail on a malformed path parameter (400 — the credential is fine
+    # and the path is not) OR on a missing reserved-segment declaration, which is
+    # a server fault and belongs with the delegation failure below. Two separate
+    # try blocks let the second kind escape from the first step to the outer
+    # catch-all, answering something other than the 502 this route establishes.
     try:
         call = _domain_call('project_autoseed', path_parameters={'project_id': project_id}, query={
             'persona_ids': query_params.get('persona_ids'),
             'document_ids': query_params.get('document_ids'),
         })
-    except InvalidToolArgument as exc:
-        # This route takes its project id straight from the URL, so the
-        # route-confusion guard matters here as much as on a tool call — and it
-        # is a 400 rather than a 403, because the credential is fine and the
-        # path is not.
-        return _cors_response({'message': str(exc)}, status_code=400)
-    try:
         result = call_domain(call, claims=synthetic_claims(token_info))
+    except InvalidToolArgument as exc:
+        return _cors_response({'message': str(exc)}, status_code=400)
     except DelegationUnavailable:
         logger.error('Autoseed delegation failed', extra={'project_id': project_id})
         return _cors_response({'message': 'Upstream service unavailable'}, status_code=502)

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -848,7 +848,20 @@ def _project_feedback(item: dict, *, summary: bool) -> dict:
     `"rating": "N/A"` for an unrated item still sees it.
     """
     projected = {
-        "id": item.get('id', ''),
+        # `feedback_id` FIRST, and this is a bug fix rather than a rename.
+        #
+        # Both feedback tools reported `item.get('id')`, and the processor that
+        # writes these rows never sets a plain `id` — the identifier is
+        # `feedback_id`, which is also the key `GET /feedback/{id}` looks up on
+        # its GSI. So `search_feedback` advertised an `id` field and filled it
+        # with `""` for every item in the corpus, which made
+        # `get_feedback_detail` unreachable for an agent: the only way to learn a
+        # feedback id is to search, and search reported none. Verified live
+        # against the deployed API before fixing.
+        #
+        # `item.get('id')` is kept as the fallback rather than dropped, because a
+        # row that does carry one is not worth breaking to make a point.
+        "id": item.get('feedback_id') or item.get('id', ''),
         "source": item.get('source_platform', ''),
         "date": item.get('source_created_at', '') or '',
         "sentiment": item.get('sentiment_label', ''),

--- a/voc-datalake/lambda/api/test/test_mcp_date_basis.py
+++ b/voc-datalake/lambda/api/test/test_mcp_date_basis.py
@@ -1,45 +1,86 @@
 """
 Tests for date_basis threading through the MCP search_feedback tool (issue #150).
+
+The tool delegates now, so what "threading" means has moved: it used to pass a
+locally-validated `date_basis` into the shared query helper, and it now forwards
+the caller's value to the route as a query-string parameter, where
+`validate_date_basis` is applied by the same code path every other client of
+`GET /feedback` goes through.
+
+That relocation is the point rather than an accident. The adapter validating
+first would be a second implementation of the allowlist — the class of drift the
+delegation change exists to remove — and the route cannot skip its own check,
+because the browser hits it directly too.
 """
+import io
+import json
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
+def _stub_client():
+    """A domain function that answers with an empty feedback page."""
+    client = MagicMock()
+    client.invoke.side_effect = lambda **_kwargs: {
+        "Payload": io.BytesIO(json.dumps({
+            "statusCode": 200,
+            "body": json.dumps({"count": 0, "items": []}),
+        }).encode()),
+    }
+    return client
+
+
+def _search(args: dict) -> dict:
+    """Run search_feedback and return the query string the route received."""
+    import mcp_handler
+    client = _stub_client()
+    with patch("shared.mcp_delegate.get_lambda_client", return_value=client), \
+         patch.dict(os.environ, {"METRICS_FUNCTION": "voc-metrics-api"}):
+        mcp_handler._tool_search_feedback(args, {"token_id": "tok_1"})
+    event = json.loads(client.invoke.call_args.kwargs["Payload"])
+    return event.get("queryStringParameters") or {}
+
+
 class TestMcpSearchFeedbackDateBasis:
-    @patch('mcp_handler.query_feedback_by_date')
-    @patch('mcp_handler.feedback_table')
-    def test_passes_validated_date_basis_to_shared_query(self, _mock_table, mock_query):
-        mock_query.return_value = []
-        from mcp_handler import _tool_search_feedback
+    def test_passes_date_basis_to_the_route(self):
+        assert _search({"days": 7, "date_basis": "review"})["date_basis"] == "review"
 
-        _tool_search_feedback({'days': 7, 'date_basis': 'review'}, {})
+    def test_omits_date_basis_when_the_caller_gave_none(self):
+        """Absence is forwarded as absence, not as an invented default.
 
-        assert mock_query.call_args.kwargs['date_basis'] == 'review'
+        The route's own default is 'imported'; sending it explicitly would mean
+        two places deciding the same thing, and the adapter's copy would be the
+        one that goes stale.
+        """
+        assert "date_basis" not in _search({"days": 7})
 
-    @patch('mcp_handler.query_feedback_by_date')
-    @patch('mcp_handler.feedback_table')
-    def test_defaults_to_imported_basis(self, _mock_table, mock_query):
-        mock_query.return_value = []
-        from mcp_handler import _tool_search_feedback
+    def test_an_off_allowlist_basis_is_forwarded_for_the_route_to_degrade(self):
+        """LLM-supplied args are untrusted, and the refusal still happens — one
+        layer further in.
 
-        _tool_search_feedback({'days': 7}, {})
+        `validate_date_basis` on the route degrades anything off the allowlist to
+        'imported' (pinned by the metrics-handler date-basis tests), so the
+        caller-visible behaviour is unchanged. What this test protects is that
+        the adapter does not quietly "fix" the value first: a value silently
+        corrected here would hide a client bug that the route reports honestly,
+        and would drift the moment the allowlist gains a member.
+        """
+        assert _search({"days": 7, "date_basis": "DROP TABLE"})["date_basis"] == "DROP TABLE"
 
-        assert mock_query.call_args.kwargs['date_basis'] == 'imported'
+    def test_the_route_still_rejects_what_the_adapter_forwards(self):
+        """The other half of the invariant above, asserted rather than assumed.
 
-    @patch('mcp_handler.query_feedback_by_date')
-    @patch('mcp_handler.feedback_table')
-    def test_invalid_basis_falls_back_to_imported(self, _mock_table, mock_query):
-        """LLM-supplied args are untrusted; anything off the allowlist
-        degrades to the default instead of erroring the tool call."""
-        mock_query.return_value = []
-        from mcp_handler import _tool_search_feedback
+        Without this, "the adapter forwards it" and "somebody validates it" are
+        two claims with a gap between them wide enough for an injection.
+        """
+        from shared.api import validate_date_basis
 
-        _tool_search_feedback({'days': 7, 'date_basis': 'DROP TABLE'}, {})
-
-        assert mock_query.call_args.kwargs['date_basis'] == 'imported'
+        assert validate_date_basis("DROP TABLE") == "imported"
+        assert validate_date_basis(None) == "imported"
+        assert validate_date_basis("review") == "review"
 
     def test_tool_schema_declares_date_basis_enum(self):
         from mcp_handler import MCP_TOOLS

--- a/voc-datalake/lambda/api/test/test_mcp_date_basis.py
+++ b/voc-datalake/lambda/api/test/test_mcp_date_basis.py
@@ -37,7 +37,7 @@ def _search(args: dict) -> dict:
     """Run search_feedback and return the query string the route received."""
     import mcp_handler
     client = _stub_client()
-    with patch("shared.mcp_delegate.get_lambda_client", return_value=client), \
+    with patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=client), \
          patch.dict(os.environ, {"METRICS_FUNCTION": "voc-metrics-api"}):
         mcp_handler._tool_search_feedback(args, {"token_id": "tok_1"})
     event = json.loads(client.invoke.call_args.kwargs["Payload"])

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -62,6 +62,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -655,6 +656,48 @@ class TestPathParameterConfinement:
         assert result["result"]["isError"] is False
         assert fake.paths == [f"/projects/{legacy}"]
 
+    # Every decorator form Powertools registers a route with. `patch` is not
+    # hypothetical — projects_handler uses it twice, and an earlier version of
+    # this regex missed it, which is precisely how a security argument that rests
+    # on set completeness goes quietly wrong.
+    ROUTE_DECORATOR = re.compile(
+        r'@\w+\.(?:get|post|put|delete|patch|head|options|route)\(\s*[\'"]([^\'"]+)[\'"]'
+    )
+    OWNERS: ClassVar[dict[str, str]] = {
+        "/projects": "projects_handler.py",
+        "/feedback": "metrics_handler.py",
+    }
+
+    def _static_siblings(self, prefix: str, handler: str) -> set[str]:
+        source = (Path(__file__).resolve().parents[1] / handler).read_text()
+        depth = len(prefix.strip("/").split("/"))
+        siblings = set()
+        for match in self.ROUTE_DECORATOR.finditer(source):
+            parts = match.group(1).strip("/").split("/")
+            if (len(parts) > depth
+                    and "/".join(parts[:depth]) == prefix.strip("/")
+                    and not parts[depth].startswith("<")):
+                siblings.add(parts[depth])
+        return siblings
+
+    def test_the_sibling_derivation_actually_finds_routes(self):
+        """Positive control, because the assertion below is a subset test.
+
+        `siblings <= declared` passes trivially when the regex matches nothing —
+        so a decorator form this pattern does not know (a new verb, a Router, a
+        rename of `app`) would turn the whole reserved-segment argument green and
+        empty. This is the test that fails instead.
+        """
+        for prefix, handler in self.OWNERS.items():
+            siblings = self._static_siblings(prefix, handler)
+            assert siblings, (
+                f"no static routes found under {prefix} in {handler} — the route "
+                f"decorator pattern has drifted, and the lockstep below is vacuous"
+            )
+        # And a specific one, so "found something" cannot pass on an unrelated match.
+        assert "prioritization" in self._static_siblings("/projects", "projects_handler.py")
+        assert "search" in self._static_siblings("/feedback", "metrics_handler.py")
+
     def test_reserved_segments_cover_every_static_sibling(self):
         """Lockstep: the reserved sets are derived from the handlers, not guessed.
 
@@ -663,17 +706,8 @@ class TestPathParameterConfinement:
         otherwise become quietly reachable through the tool that interpolates
         there; adding it now fails this test until it is reserved.
         """
-        owners = {"/projects": "projects_handler.py", "/feedback": "metrics_handler.py"}
-        for prefix, handler in owners.items():
-            source = (Path(__file__).resolve().parents[1] / handler).read_text()
-            depth = len(prefix.strip("/").split("/"))
-            siblings = set()
-            for match in re.finditer(r'@app\.(?:get|post|put|delete)\(\s*[\'"]([^\'"]+)[\'"]', source):
-                parts = match.group(1).strip("/").split("/")
-                if (len(parts) > depth
-                        and "/".join(parts[:depth]) == prefix.strip("/")
-                        and not parts[depth].startswith("<")):
-                    siblings.add(parts[depth])
+        for prefix, handler in self.OWNERS.items():
+            siblings = self._static_siblings(prefix, handler)
             declared = mcp_handler._RESERVED_PATH_SEGMENTS[prefix]
             assert siblings <= declared, (
                 f"{handler} has static routes under {prefix} that are not reserved: "
@@ -681,12 +715,15 @@ class TestPathParameterConfinement:
                 f"there could reach them"
             )
 
-    def test_every_reserved_prefix_is_one_a_declared_route_interpolates(self):
-        """The reverse direction: no reserved set for a prefix nothing uses.
+    def test_every_interpolated_prefix_declares_a_reserved_set(self):
+        """BOTH directions, because only one of them is a security property.
 
-        A stale entry is harmless at runtime but it is a claim about the routes
-        that is no longer true, and it makes the test above pass for a prefix
-        nobody checks.
+        A prefix with no entry used to fall back to an empty set, which meant a
+        future templated route silently permitted sibling collisions — the exact
+        hole the redesign was supposed to close, reintroduced by omission rather
+        than by choice. `_reserved_for` now raises for an unknown prefix, and this
+        asserts the table covers every prefix any declared route interpolates, so
+        the failure is at build time rather than on a caller's first attempt.
         """
         interpolated = set()
         for _domain, _method, template in mcp_handler.DOMAIN_ROUTES.values():
@@ -694,10 +731,24 @@ class TestPathParameterConfinement:
             for index, segment in enumerate(segments):
                 if segment.startswith("{"):
                     interpolated.add("/" + "/".join(segments[:index]))
-        assert set(mcp_handler._RESERVED_PATH_SEGMENTS) <= interpolated, (
-            f"reserved segments declared for prefixes no route interpolates: "
-            f"{sorted(set(mcp_handler._RESERVED_PATH_SEGMENTS) - interpolated)}"
+
+        declared = set(mcp_handler._RESERVED_PATH_SEGMENTS)
+        assert interpolated <= declared, (
+            f"routes interpolate a parameter under prefixes with no reserved set: "
+            f"{sorted(interpolated - declared)} — declare one (an explicit "
+            f"frozenset() if the prefix genuinely has no static siblings)"
         )
+        assert declared <= interpolated, (
+            f"reserved segments declared for prefixes no route interpolates: "
+            f"{sorted(declared - interpolated)}"
+        )
+
+    def test_an_undeclared_prefix_fails_closed(self):
+        """A templated route whose prefix has no entry is refused, not allowed."""
+        future = {"future": (mcp_handler.DOMAIN_PROJECTS, "GET", "/whatever/{project_id}")}
+        with patch.dict(mcp_handler.DOMAIN_ROUTES, future), \
+             pytest.raises(mcp_handler.InvalidToolArgument, match="reserved-segment"):
+            mcp_handler._validated_path_parameters("future", {"project_id": _PROJECT})
 
     def test_a_parameter_the_template_does_not_use_is_refused(self):
         with pytest.raises(mcp_handler.InvalidToolArgument):

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1,0 +1,495 @@
+"""Tests for the MCP delegation adapter (plan Phase 2, D1).
+
+The MCP handler no longer reads the data lake. Every tool translates its
+arguments into a route call, invokes the domain function that owns that route
+with a synthesized API Gateway proxy event, and reshapes the answer. These tests
+cover that translation; `test_mcp_security.py` covers the credential and the
+claim synthesis that authorizes it.
+
+A separate file from `test_mcp_security.py` deliberately: that file is 2 400
+lines of credential and protocol invariants, and route-translation mechanics are
+a different subject with a different failure mode. Same standard, though —
+assert the invariant, then prove the assertion fails when the invariant is
+removed. The revert map:
+
+  test_search_without_a_query_uses_the_list_route
+    — `/feedback/search` REFUSES a query under two characters, so mapping this
+      tool onto that route alone (the obvious reading of the plan's route table)
+      makes every filter-only call return nothing at all. Collapsing the two
+      branches to one fails this.
+
+  test_a_route_server_error_is_a_protocol_error
+    — replaces the deleted `is_partial` suite. The old tool wrapped each
+      DynamoDB read in its own try/except and reported a degraded answer; the
+      adapter has no reads to degrade, so the equivalent honesty is that a
+      failing route becomes an error rather than a plausible-looking empty
+      answer. Mapping 5xx to an empty result fails this.
+
+  test_a_route_refusal_is_a_tool_error_not_a_protocol_error
+    — a 404 must arrive as `isError: true` inside a successful JSON-RPC call, so
+      the model can correct itself. Making it a JSON-RPC error fails this; so
+      does the old behaviour of returning prose with `isError: false`.
+
+  test_unknown_dimension_is_refused_before_any_invoke
+    — the enum is the tool's own contract, so an unknown value must not become a
+      route lookup. Deleting the guard fails this on the invoke count.
+
+  test_summary_list_truncates_the_verbatim /
+  test_detail_keeps_the_whole_verbatim
+    — the two feedback tools share one projection parameterized by `summary`.
+      Dropping the parameter (one projection for both) fails one or the other.
+
+  test_every_document_kind_is_reported
+    — the defect this phase retires by construction: the in-process tool
+      recognised 2 of 6 document sort-key prefixes, so an MCP client saw a third
+      of a project's documents and was told nothing was filtered. Narrowing
+      _DOCUMENT_KINDS back to PRD#/PRFAQ# fails this.
+
+  test_boolean_query_values_are_sent_as_json_booleans
+    — several routes' boolean validators are strict on purpose (a coerced
+      "false" must not authorize a billed generation). `str(True)` is `'True'`,
+      which none of them accept. Removing the bool branch in `_stringify` fails
+      this.
+
+  test_every_declared_route_is_reachable
+    — DOMAIN_ROUTES is load-bearing at runtime, and a route key with no entry
+      raises KeyError at call time rather than at import. This walks the table.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mcp_handler
+from shared.mcp_tokens import ALL_READ_SCOPES, REACH_WORKSPACE
+
+_PROJECT = "proj-1"
+
+
+def _token(**extra) -> dict:
+    """A token record wide enough that no test trips a permission refusal."""
+    return {
+        "token_id": "tok_0123456789abcdef",
+        "scopes": list(ALL_READ_SCOPES),
+        "projects": [_PROJECT],
+        "read_reach": REACH_WORKSPACE,
+        **extra,
+    }
+
+
+class _FakeLambda:
+    """A Lambda client that records invocations and replays canned responses.
+
+    Keyed by route path so a test states the route it expects to be called,
+    which is the thing under test — a stub keyed by call ORDER would pass even
+    if the adapter chose the wrong route.
+    """
+
+    def __init__(self, bodies: dict, status: int = 200, function_error: str | None = None):
+        self.bodies = bodies
+        self.status = status
+        self.function_error = function_error
+        self.calls: list[tuple[str, dict]] = []
+
+    def invoke(self, **kwargs):
+        event = json.loads(kwargs["Payload"])
+        self.calls.append((kwargs["FunctionName"], event))
+        response: dict = {}
+        if self.function_error:
+            response["FunctionError"] = self.function_error
+        body = self.bodies.get(event["path"], {})
+        response["Payload"] = io.BytesIO(json.dumps({
+            "statusCode": self.status,
+            "body": json.dumps(body),
+        }).encode())
+        return response
+
+    @property
+    def paths(self) -> list[str]:
+        return [event["path"] for _fn, event in self.calls]
+
+    @property
+    def last_query(self) -> dict:
+        return self.calls[-1][1].get("queryStringParameters") or {}
+
+
+@pytest.fixture(autouse=True)
+def _functions_configured(monkeypatch):
+    """Both delegation targets named, as the stack supplies them."""
+    monkeypatch.setenv("METRICS_FUNCTION", "voc-metrics-api")
+    monkeypatch.setenv("PROJECTS_FUNCTION", "voc-projects-api")
+
+
+def _call(tool: str, arguments: dict, fake: _FakeLambda) -> dict:
+    with patch("shared.mcp_delegate.get_lambda_client", return_value=fake):
+        return mcp_handler._handle_tools_call(1, {"name": tool, "arguments": arguments}, _token())
+
+
+def _feedback_row(**extra) -> dict:
+    return {
+        "id": "f1",
+        "source_platform": "webscraper",
+        "source_created_at": "2026-08-01T10:11:12Z",
+        "sentiment_label": "negative",
+        "sentiment_score": "-0.8",
+        "category": "delivery",
+        "urgency": "high",
+        "rating": 2,
+        "persona_type": "shopper",
+        "original_text": "x" * 900,
+        "problem_summary": "arrived late",
+        "problem_root_cause_hypothesis": "carrier backlog",
+        "direct_customer_quote": "never again",
+        "keywords": ["late", "delivery"],
+        "journey_stage": "post_purchase",
+        **extra,
+    }
+
+
+# ===========================================================================
+# Route selection
+# ===========================================================================
+
+class TestRouteSelection:
+    def test_search_with_a_query_uses_the_search_route(self):
+        fake = _FakeLambda({"/feedback/search": {"count": 0, "items": []}})
+        _call("search_feedback", {"query": "late"}, fake)
+
+        assert fake.paths == ["/feedback/search"]
+        assert fake.last_query["q"] == "late"
+
+    def test_search_without_a_query_uses_the_list_route(self):
+        """The filter-only branch. /feedback/search refuses a query under two
+        characters, so one route for both cases answers nothing for every call
+        that filters without searching."""
+        fake = _FakeLambda({"/feedback": {"count": 0, "items": []}})
+        _call("search_feedback", {"category": "delivery"}, fake)
+
+        assert fake.paths == ["/feedback"]
+        assert "q" not in fake.last_query
+        assert fake.last_query["category"] == "delivery"
+
+    def test_a_blank_query_is_not_a_search(self):
+        """Whitespace is not a search term, and the route would refuse it."""
+        fake = _FakeLambda({"/feedback": {"count": 0, "items": []}})
+        _call("search_feedback", {"query": "   "}, fake)
+
+        assert fake.paths == ["/feedback"]
+
+    @pytest.mark.parametrize("dimension,route", [
+        ("sentiment", "/metrics/sentiment"),
+        ("categories", "/metrics/categories"),
+        ("sources", "/metrics/sources"),
+        ("personas", "/metrics/personas"),
+    ])
+    def test_each_breakdown_dimension_reaches_its_own_route(self, dimension, route):
+        fake = _FakeLambda({route: {"period_days": 7, "is_partial": False}})
+        result = _call("get_metrics_breakdown", {"dimension": dimension}, fake)
+
+        assert fake.paths == [route]
+        assert result["result"]["isError"] is False
+
+    def test_unknown_dimension_is_refused_before_any_invoke(self):
+        fake = _FakeLambda({})
+        result = _call("get_metrics_breakdown", {"dimension": "phase_of_moon"}, fake)
+
+        assert result["error"]["code"] == -32602
+        assert fake.calls == [], "a bad enum value must not become a route lookup"
+
+    def test_the_project_id_lands_in_the_path(self):
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {"project": {"name": "P"}}})
+        _call("get_project", {"project_id": _PROJECT}, fake)
+
+        assert fake.paths == [f"/projects/{_PROJECT}"]
+        assert fake.calls[-1][1]["pathParameters"] == {"project_id": _PROJECT}
+
+    def test_each_domain_is_invoked_by_its_own_function_name(self):
+        fake = _FakeLambda({
+            "/metrics/summary": {"period_days": 7},
+            f"/projects/{_PROJECT}": {"project": {}},
+        })
+        _call("get_metrics_summary", {}, fake)
+        _call("get_project", {"project_id": _PROJECT}, fake)
+
+        assert [fn for fn, _ in fake.calls] == ["voc-metrics-api", "voc-projects-api"]
+
+    def test_every_declared_route_is_reachable(self):
+        """Each DOMAIN_ROUTES entry resolves to a configured function and a path.
+
+        The table is consulted at call time, so a key that names an unknown
+        domain raises KeyError on the first client that touches that tool rather
+        than at import.
+        """
+        for key, (domain, method, template) in mcp_handler.DOMAIN_ROUTES.items():
+            assert domain in mcp_handler._DOMAIN_FUNCTION_ENV, f"{key} names an unknown domain"
+            params = {name.strip("{}"): "x" for name in template.split("/") if name.startswith("{")}
+            call = mcp_handler._domain_call(key, path_parameters=params)
+            assert call.function_name, f"{key} resolved to no function name"
+            assert call.method == method
+            assert "{" not in call.path, f"{key} left an unformatted placeholder: {call.path}"
+
+
+# ===========================================================================
+# Error mapping — the three outcomes the spec separates
+# ===========================================================================
+
+class TestErrorMapping:
+    def test_a_route_refusal_is_a_tool_error_not_a_protocol_error(self):
+        fake = _FakeLambda({"/feedback/f-missing": {"message": "Feedback not found"}}, status=404)
+        result = _call("get_feedback_detail", {"feedback_id": "f-missing"}, fake)
+
+        assert "error" not in result, "a 404 is a tool outcome, not a protocol fault"
+        assert result["result"]["isError"] is True
+        assert "not found" in result["result"]["content"][0]["text"].lower()
+
+    def test_a_tool_error_carries_no_structured_content(self):
+        """structuredContent must validate against outputSchema, and a refusal
+        has no payload to validate — so it is absent rather than empty."""
+        fake = _FakeLambda({"/feedback/f-missing": {"message": "nope"}}, status=404)
+        result = _call("get_feedback_detail", {"feedback_id": "f-missing"}, fake)
+
+        assert "structuredContent" not in result["result"]
+
+    def test_a_route_server_error_is_a_protocol_error(self):
+        fake = _FakeLambda({"/metrics/summary": {"message": "boom"}}, status=500)
+        result = _call("get_metrics_summary", {}, fake)
+
+        assert result["error"]["code"] == -32603
+        assert "result" not in result
+
+    def test_a_server_error_detail_never_reaches_the_client(self):
+        """The 5xx message is a FIXED string, asserted exactly.
+
+        Pinned as equality rather than as "does not contain the function name",
+        which is the weaker form this test started as and which a mutation walked
+        straight through: interpolating the exception gave
+        `Internal error: GET /metrics/summary returned 500` — no function name in
+        it, so a substring check passed while the client learned the upstream
+        route and status anyway. Any interpolation at all now fails here.
+
+        What is being protected is not embarrassment: an upstream body can carry a
+        table name, an ARN or a stack trace, and the topology of the account is
+        not the caller's business.
+        """
+        fake = _FakeLambda({"/metrics/summary": {"message": "voc-metrics-api exploded"}}, status=500)
+        result = _call("get_metrics_summary", {}, fake)
+
+        assert result["error"]["message"] == "Internal error: upstream service unavailable"
+
+    def test_an_unhandled_exception_in_the_domain_function_is_a_protocol_error(self):
+        fake = _FakeLambda({"/metrics/summary": {}}, function_error="Unhandled")
+        result = _call("get_metrics_summary", {}, fake)
+
+        assert result["error"]["code"] == -32603
+
+    def test_an_unconfigured_function_is_a_protocol_error(self, monkeypatch):
+        monkeypatch.delenv("METRICS_FUNCTION", raising=False)
+        fake = _FakeLambda({"/metrics/summary": {}})
+        result = _call("get_metrics_summary", {}, fake)
+
+        assert result["error"]["code"] == -32603
+        assert fake.calls == [], "an unnamed function must not be invoked"
+
+    def test_a_malformed_feedback_id_is_refused_before_any_invoke(self):
+        fake = _FakeLambda({})
+        result = _call("get_feedback_detail", {"feedback_id": ""}, fake)
+
+        assert result["error"]["code"] == -32602
+        assert fake.calls == []
+
+
+# ===========================================================================
+# Projections
+# ===========================================================================
+
+class TestProjections:
+    def test_summary_list_truncates_the_verbatim(self):
+        fake = _FakeLambda({"/feedback/search": {"items": [_feedback_row()]}})
+        result = _call("search_feedback", {"query": "late"}, fake)
+        item = result["result"]["structuredContent"]["items"][0]
+
+        assert len(item["text"]) == 500
+        assert item["date"] == "2026-08-01", "a list answer carries the day, not the timestamp"
+
+    def test_detail_keeps_the_whole_verbatim(self):
+        fake = _FakeLambda({"/feedback/f1": _feedback_row()})
+        result = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)
+        item = result["result"]["structuredContent"]
+
+        assert len(item["text"]) == 900
+        assert item["date"] == "2026-08-01T10:11:12Z", "a single item carries the full timestamp"
+        assert item["problem_root_cause"] == "carrier backlog"
+        assert item["direct_quote"] == "never again"
+        assert item["keywords"] == ["late", "delivery"]
+
+    def test_the_renames_the_tools_have_always_reported(self):
+        fake = _FakeLambda({"/feedback/f1": _feedback_row()})
+        item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]
+
+        assert item["source"] == "webscraper"
+        assert item["sentiment"] == "negative"
+        assert item["rating"] == "2", "rating stays stringified"
+
+    def test_an_unrated_item_still_reads_as_not_applicable(self):
+        row = _feedback_row()
+        del row["rating"]
+        fake = _FakeLambda({"/feedback/f1": row})
+        item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]
+
+        assert item["rating"] == "N/A"
+
+    def test_every_document_kind_is_reported(self):
+        """The DUP2 defect, retired by construction.
+
+        One document per storage prefix; all six must be counted and labelled.
+        The in-process tool recognised two.
+        """
+        documents = [
+            {"sk": f"{prefix}{i}", "document_id": f"d{i}", "title": f"doc {i}"}
+            for i, prefix in enumerate(mcp_handler._DOCUMENT_KINDS)
+        ]
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P", "description": "d", "created_at": "t"},
+            "personas": [],
+            "documents": documents,
+        }})
+        payload = _call("get_project", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        assert payload["document_count"] == 6
+        assert sorted(d["kind"] for d in payload["documents"]) == sorted(
+            mcp_handler._DOCUMENT_KINDS.values()
+        )
+
+    def test_document_bodies_are_never_inlined(self):
+        """A prototype body is hundreds of kilobytes; listing is the contract."""
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"},
+            "personas": [],
+            "documents": [{"sk": "PRD#1", "document_id": "d1", "title": "t",
+                           "content": "SECRET-BODY" * 100}],
+        }})
+        result = _call("get_project", {"project_id": _PROJECT}, fake)
+
+        assert "SECRET-BODY" not in json.dumps(result)
+
+    def test_personas_are_listed_in_full_by_the_persona_tool(self):
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"},
+            "personas": [{"persona_id": "p1", "name": "Ann", "goals": ["g"],
+                          "pain_points": ["pp"], "behaviors": ["b"], "quote": "q"}],
+            "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        assert payload["count"] == 1
+        assert payload["personas"][0]["goals"] == ["g"]
+        assert payload["personas"][0]["age_range"] == "", "absent fields get typed defaults"
+
+    def test_a_pass_through_tool_does_not_reshape_the_route_payload(self):
+        """The metrics tools forward the route's answer verbatim. Reshaping here
+        would reintroduce the second implementation delegating exists to remove
+        — including the route's own is_partial, which must survive."""
+        body = {"period_days": 7, "is_partial": True, "categories": {"delivery": 3},
+                "a_field_added_later": 1}
+        fake = _FakeLambda({"/metrics/categories": body})
+        payload = _call("get_metrics_breakdown", {"dimension": "categories"}, fake)
+
+        assert payload["result"]["structuredContent"] == body
+
+
+# ===========================================================================
+# The synthesized event
+# ===========================================================================
+
+class TestSynthesizedEvent:
+    def test_query_values_are_strings_as_api_gateway_delivers_them(self):
+        fake = _FakeLambda({"/metrics/summary": {}})
+        _call("get_metrics_summary", {"days": 14}, fake)
+
+        assert fake.last_query == {"days": "14"}
+
+    def test_absent_filters_are_omitted_not_sent_empty(self):
+        """An empty string is a filter value to a route; absence is not."""
+        fake = _FakeLambda({"/feedback": {"items": []}})
+        _call("search_feedback", {}, fake)
+
+        assert "category" not in fake.last_query
+        assert "source" not in fake.last_query
+
+    def test_boolean_query_values_are_sent_as_json_booleans(self):
+        """`str(True)` is `'True'`, which no route's boolean validator accepts —
+        and several are strict on purpose."""
+        from shared.mcp_delegate import DomainCall, build_proxy_event
+
+        event = build_proxy_event(
+            DomainCall(function_name="f", method="GET", path="/x",
+                       query={"yes": True, "no": False}),
+            {"sub": "mcp:tok_1"},
+        )
+
+        assert event["queryStringParameters"] == {"yes": "true", "no": "false"}
+
+    def test_the_credential_is_never_forwarded(self):
+        """The domain function has no use for the MCP token, and forwarding a
+        secret past its audience is how secrets reach logs."""
+        fake = _FakeLambda({"/metrics/summary": {}})
+        _call("get_metrics_summary", {}, fake)
+        headers = fake.calls[-1][1]["headers"]
+
+        assert not any(h.lower() == "authorization" for h in headers)
+
+    def test_no_accept_encoding_is_offered(self):
+        """Powertools may gzip when the caller advertises it, and the adapter
+        decodes plain JSON."""
+        fake = _FakeLambda({"/metrics/summary": {}})
+        _call("get_metrics_summary", {}, fake)
+
+        assert not any(h.lower() == "accept-encoding" for h in fake.calls[-1][1]["headers"])
+
+    def test_the_event_carries_what_the_powertools_resolver_routes_on(self):
+        fake = _FakeLambda({"/metrics/summary": {}})
+        _call("get_metrics_summary", {}, fake)
+        event = fake.calls[-1][1]
+
+        assert event["httpMethod"] == "GET"
+        assert event["path"] == "/metrics/summary"
+        assert event["isBase64Encoded"] is False
+
+
+# ===========================================================================
+# Structured output
+# ===========================================================================
+
+class TestStructuredOutput:
+    def test_the_text_block_is_the_structured_payload_serialized(self):
+        """Both come from one value, so a client comparing them cannot find a
+        disagreement."""
+        fake = _FakeLambda({"/metrics/summary": {"period_days": 7, "total_feedback": 3}})
+        result = _call("get_metrics_summary", {}, fake)["result"]
+
+        assert json.loads(result["content"][0]["text"]) == result["structuredContent"]
+
+    def test_every_tool_declares_an_output_schema(self):
+        for tool in mcp_handler.MCP_TOOLS:
+            assert "outputSchema" in tool, f"{tool['name']} declares no outputSchema"
+            assert tool["outputSchema"]["type"] == "object", (
+                f"{tool['name']}: structuredContent must be an object"
+            )
+
+    def test_every_registered_tool_is_declared_and_routed(self):
+        declared = {tool["name"] for tool in mcp_handler.MCP_TOOLS}
+        assert declared == set(mcp_handler.TOOL_HANDLERS)
+        assert declared == set(mcp_handler.TOOL_SCOPE_REQUIREMENTS)
+        assert declared == set(mcp_handler.TOOL_REACH_KINDS)
+
+    def test_the_server_version_is_semver_and_past_1(self):
+        """The output shapes changed; a client pinning on 1.x must be able to
+        tell."""
+        major = mcp_handler.MCP_SERVER_VERSION.split(".")[0]
+        assert int(major) >= 2

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -70,6 +70,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import mcp_handler
+from shared.mcp_delegate import DelegationUnavailable
 from shared.mcp_tokens import ALL_READ_SCOPES, REACH_WORKSPACE, mint_token
 
 # REAL-SHAPED ids throughout, not `proj-1` / `f1`.
@@ -669,6 +670,15 @@ class TestPathParameterConfinement:
     }
 
     def _static_siblings(self, prefix: str, handler: str) -> set[str]:
+        """Static route segments at the parameter's position, from ONE file.
+
+        ⚠️ Single-file by design and only sound while these handlers register
+        every route inline. Powertools also supports `Router` objects in other
+        modules included into an app; a route registered that way would be
+        invisible here, and the reserved set would be quietly incomplete. That is
+        not documented and left to trust — `test_no_route_is_registered_outside_
+        the_scanned_file` asserts the pattern is absent.
+        """
         source = (Path(__file__).resolve().parents[1] / handler).read_text()
         depth = len(prefix.strip("/").split("/"))
         siblings = set()
@@ -697,6 +707,25 @@ class TestPathParameterConfinement:
         # And a specific one, so "found something" cannot pass on an unrelated match.
         assert "prioritization" in self._static_siblings("/projects", "projects_handler.py")
         assert "search" in self._static_siblings("/feedback", "metrics_handler.py")
+
+    def test_no_route_is_registered_outside_the_scanned_file(self):
+        """The sibling scan reads one file per prefix, so nothing may hide.
+
+        Powertools supports `Router` objects declared in another module and
+        included into an app. Neither owning handler uses that today, and the
+        reserved-segment argument depends on it staying that way — a routed module
+        would be invisible to the scan and the set would be quietly incomplete.
+        Asserted rather than trusted, because "we don't use Routers" is exactly
+        the kind of claim that stops being true without anyone revisiting this.
+        """
+        for handler in self.OWNERS.values():
+            source = (Path(__file__).resolve().parents[1] / handler).read_text()
+            assert "Router" not in source, (
+                f"{handler} now references a Router; _static_siblings reads only "
+                f"this file, so routes registered elsewhere would be missed and "
+                f"the reserved-segment sets could be incomplete"
+            )
+            assert "include_router" not in source
 
     def test_reserved_segments_cover_every_static_sibling(self):
         """Lockstep: the reserved sets are derived from the handlers, not guessed.
@@ -743,12 +772,28 @@ class TestPathParameterConfinement:
             f"{sorted(declared - interpolated)}"
         )
 
-    def test_an_undeclared_prefix_fails_closed(self):
-        """A templated route whose prefix has no entry is refused, not allowed."""
+    def test_an_undeclared_prefix_fails_closed_as_a_server_error(self):
+        """A templated route whose prefix has no entry is refused, not allowed.
+
+        And refused as a SERVER fault (-32603 via DelegationUnavailable), not as
+        `-32602 Invalid params`: a missing declaration is a misconfiguration, and
+        blaming the caller's arguments would send it looking for a different id
+        when nothing it could send would work.
+        """
         future = {"future": (mcp_handler.DOMAIN_PROJECTS, "GET", "/whatever/{project_id}")}
         with patch.dict(mcp_handler.DOMAIN_ROUTES, future), \
-             pytest.raises(mcp_handler.InvalidToolArgument, match="reserved-segment"):
+             pytest.raises(DelegationUnavailable, match="reserved-segment"):
             mcp_handler._validated_path_parameters("future", {"project_id": _PROJECT})
+
+    def test_that_server_error_is_not_reported_as_a_bad_argument(self):
+        """End to end: the caller sees -32603, never -32602."""
+        future = {"project_get": (mcp_handler.DOMAIN_PROJECTS, "GET", "/whatever/{project_id}")}
+        fake = _FakeLambda({})
+        with patch.dict(mcp_handler.DOMAIN_ROUTES, future):
+            result = _call("get_project", {"project_id": _PROJECT}, fake)
+
+        assert result["error"]["code"] == -32603, result
+        assert fake.calls == []
 
     def test_a_parameter_the_template_does_not_use_is_refused(self):
         with pytest.raises(mcp_handler.InvalidToolArgument):

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -58,18 +58,28 @@ removed. The revert map:
 
 import io
 import json
+import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import mcp_handler
-from shared.mcp_tokens import ALL_READ_SCOPES, REACH_WORKSPACE
+from shared.mcp_tokens import ALL_READ_SCOPES, REACH_WORKSPACE, mint_token
 
-_PROJECT = "proj-1"
+# REAL-SHAPED ids throughout, not `proj-1` / `f1`.
+#
+# The path-parameter guard refuses anything that is not shaped like an id the
+# product actually mints, so a convenient-looking fixture would fail — and that
+# is the right way round. Unrealistic fixtures are what let the `feedback_id`
+# bug survive a full suite: every fixture set both `id` and `feedback_id`, so no
+# test could notice that real rows carry only one.
+_PROJECT = "proj_20260819143000"
+_FEEDBACK_ID = "1ae1eb6abcd7d3a2e364f46139f98466"
+_OTHER_FEEDBACK_ID = "78be6bbfbbfa701284c9491d2cec4e1a"
 
 
 def _token(**extra) -> dict:
@@ -127,13 +137,13 @@ def _functions_configured(monkeypatch):
 
 
 def _call(tool: str, arguments: dict, fake: _FakeLambda) -> dict:
-    with patch("shared.mcp_delegate.get_lambda_client", return_value=fake):
+    with patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=fake):
         return mcp_handler._handle_tools_call(1, {"name": tool, "arguments": arguments}, _token())
 
 
 def _feedback_row(**extra) -> dict:
     return {
-        "id": "f1",
+        "id": "1ae1eb6abcd7d3a2e364f46139f98466",
         "source_platform": "webscraper",
         "source_created_at": "2026-08-01T10:11:12Z",
         "sentiment_label": "negative",
@@ -226,9 +236,17 @@ class TestRouteSelection:
         domain raises KeyError on the first client that touches that tool rather
         than at import.
         """
+        # Real-shaped values per parameter: the path guard refuses placeholders,
+        # which is the point of it.
+        sample = {"project_id": _PROJECT, "feedback_id": _FEEDBACK_ID}
         for key, (domain, method, template) in mcp_handler.DOMAIN_ROUTES.items():
             assert domain in mcp_handler._DOMAIN_FUNCTION_ENV, f"{key} names an unknown domain"
-            params = {name.strip("{}"): "x" for name in template.split("/") if name.startswith("{")}
+            params = {}
+            for segment in template.split("/"):
+                if segment.startswith("{"):
+                    name = segment.strip("{}")
+                    assert name in sample, f"{key} interpolates '{name}'; add a sample value here"
+                    params[name] = sample[name]
             call = mcp_handler._domain_call(key, path_parameters=params)
             assert call.function_name, f"{key} resolved to no function name"
             assert call.method == method
@@ -241,8 +259,8 @@ class TestRouteSelection:
 
 class TestErrorMapping:
     def test_a_route_refusal_is_a_tool_error_not_a_protocol_error(self):
-        fake = _FakeLambda({"/feedback/f-missing": {"message": "Feedback not found"}}, status=404)
-        result = _call("get_feedback_detail", {"feedback_id": "f-missing"}, fake)
+        fake = _FakeLambda({"/feedback/00000000000000000000000000000000": {"message": "Feedback not found"}}, status=404)
+        result = _call("get_feedback_detail", {"feedback_id": "00000000000000000000000000000000"}, fake)
 
         assert "error" not in result, "a 404 is a tool outcome, not a protocol fault"
         assert result["result"]["isError"] is True
@@ -251,8 +269,8 @@ class TestErrorMapping:
     def test_a_tool_error_carries_no_structured_content(self):
         """structuredContent must validate against outputSchema, and a refusal
         has no payload to validate — so it is absent rather than empty."""
-        fake = _FakeLambda({"/feedback/f-missing": {"message": "nope"}}, status=404)
-        result = _call("get_feedback_detail", {"feedback_id": "f-missing"}, fake)
+        fake = _FakeLambda({"/feedback/00000000000000000000000000000000": {"message": "nope"}}, status=404)
+        result = _call("get_feedback_detail", {"feedback_id": "00000000000000000000000000000000"}, fake)
 
         assert "structuredContent" not in result["result"]
 
@@ -318,8 +336,8 @@ class TestProjections:
         assert item["date"] == "2026-08-01", "a list answer carries the day, not the timestamp"
 
     def test_detail_keeps_the_whole_verbatim(self):
-        fake = _FakeLambda({"/feedback/f1": _feedback_row()})
-        result = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)
+        fake = _FakeLambda({"/feedback/1ae1eb6abcd7d3a2e364f46139f98466": _feedback_row()})
+        result = _call("get_feedback_detail", {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}, fake)
         item = result["result"]["structuredContent"]
 
         assert len(item["text"]) == 900
@@ -339,23 +357,23 @@ class TestProjections:
         Caught against the deployed API, not by a unit test, because every
         fixture in the suite happened to set both fields.
         """
-        row = _feedback_row(feedback_id="fb-42")
+        row = _feedback_row(feedback_id="78be6bbfbbfa701284c9491d2cec4e1a")
         row.pop("id", None)
         fake = _FakeLambda({"/feedback/search": {"items": [row]}})
         item = _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]["items"][0]
 
-        assert item["id"] == "fb-42"
+        assert item["id"] == "78be6bbfbbfa701284c9491d2cec4e1a"
 
     def test_a_row_carrying_only_a_plain_id_still_reports_it(self):
         """The fallback, so the fix does not break a row shaped the old way."""
-        fake = _FakeLambda({"/feedback/f1": {"id": "legacy-1", "original_text": "t"}})
-        item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]
+        fake = _FakeLambda({"/feedback/1ae1eb6abcd7d3a2e364f46139f98466": {"id": "legacy-1", "original_text": "t"}})
+        item = _call("get_feedback_detail", {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}, fake)["result"]["structuredContent"]
 
         assert item["id"] == "legacy-1"
 
     def test_the_renames_the_tools_have_always_reported(self):
-        fake = _FakeLambda({"/feedback/f1": _feedback_row()})
-        item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]
+        fake = _FakeLambda({"/feedback/1ae1eb6abcd7d3a2e364f46139f98466": _feedback_row()})
+        item = _call("get_feedback_detail", {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}, fake)["result"]["structuredContent"]
 
         assert item["source"] == "webscraper"
         assert item["sentiment"] == "negative"
@@ -364,8 +382,8 @@ class TestProjections:
     def test_an_unrated_item_still_reads_as_not_applicable(self):
         row = _feedback_row()
         del row["rating"]
-        fake = _FakeLambda({"/feedback/f1": row})
-        item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]
+        fake = _FakeLambda({"/feedback/1ae1eb6abcd7d3a2e364f46139f98466": row})
+        item = _call("get_feedback_detail", {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}, fake)["result"]["structuredContent"]
 
         assert item["rating"] == "N/A"
 
@@ -415,6 +433,20 @@ class TestProjections:
         assert payload["count"] == 1
         assert payload["personas"][0]["goals"] == ["g"]
         assert payload["personas"][0]["age_range"] == "", "absent fields get typed defaults"
+
+    def test_count_never_exceeds_the_items_it_describes(self):
+        """`count` describes what the CALLER received, not what the route sent.
+
+        The projection skips a non-dict entry, so counting the route's list
+        instead would report a count larger than `len(items)` in the same
+        payload — a client trusting `count` would then read past the end.
+        """
+        fake = _FakeLambda({"/feedback/search": {
+            "items": [_feedback_row(), "not-a-record", None],
+        }})
+        payload = _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]
+
+        assert payload["count"] == len(payload["items"]) == 1
 
     def test_a_pass_through_tool_does_not_reshape_the_route_payload(self):
         """The metrics tools forward the route's answer verbatim. Reshaping here
@@ -518,3 +550,172 @@ class TestStructuredOutput:
         tell."""
         major = mcp_handler.MCP_SERVER_VERSION.split(".")[0]
         assert int(major) >= 2
+
+
+# ===========================================================================
+# Path-parameter confinement — the adapter's route choice is not the caller's
+# ===========================================================================
+
+class TestPathParameterConfinement:
+    """A path parameter is part of the routing key, so it is validated as one.
+
+    The delegated path is what the Powertools resolver matches on, and
+    `pathParameters` is never consulted, so an unvalidated value does not just
+    reach the wrong record — it reaches the wrong ROUTE. Two ways, both real and
+    both found in review:
+
+      • extra segments — `project_id='p/api-tokens'` builds
+        `/projects/p/api-tokens` and lands on the token-list route;
+      • a collision with a STATIC sibling — `project_id='prioritization'` builds
+        `/projects/prioritization`, and Powertools checks static routes BEFORE
+        dynamic ones, so it lands on `api_get_prioritization_scores`: the
+        prioritization surface that is deliberately excluded from MCP entirely.
+        Segment counting does not catch this, which is why the guard is a format
+        check.
+
+    Reverting `_validated_path_parameters` fails every test here.
+    """
+
+    @pytest.mark.parametrize("hostile", [
+        "prioritization",            # a static sibling — the excluded surface
+        "config",                    # another static sibling
+        "proj_1/api-tokens",         # segment injection
+        "proj_1/jobs",
+        "../metrics/summary",        # traversal
+        "proj_1?x=1",
+        "proj_1#frag",
+        "",
+    ])
+    def test_a_hostile_project_id_never_becomes_a_route(self, hostile):
+        fake = _FakeLambda({})
+        result = _call("get_project", {"project_id": hostile}, fake)
+
+        assert result.get("error", {}).get("code") == -32602, result
+        assert fake.calls == [], f"{hostile!r} reached a domain function"
+
+    @pytest.mark.parametrize("hostile", ["search", "urgent", "entities", "f1/similar", "../urgent"])
+    def test_a_hostile_feedback_id_never_becomes_a_route(self, hostile):
+        """`/feedback/search`, `/feedback/urgent` and `/feedback/entities` are
+        static siblings of `/feedback/<feedback_id>`."""
+        fake = _FakeLambda({})
+        result = _call("get_feedback_detail", {"feedback_id": hostile}, fake)
+
+        assert result.get("error", {}).get("code") == -32602, result
+        assert fake.calls == [], f"{hostile!r} reached a domain function"
+
+    def test_a_real_project_id_is_still_accepted(self):
+        """The guard must not refuse the ids the product actually mints."""
+        fake = _FakeLambda({"/projects/proj_20260717165917": {"project": {"name": "P"}}})
+        result = _call("get_project", {"project_id": "proj_20260717165917"}, fake)
+
+        assert result["result"]["isError"] is False
+        assert fake.paths == ["/projects/proj_20260717165917"]
+
+    def test_a_real_feedback_id_is_still_accepted(self):
+        fid = "1ae1eb6abcd7d3a2e364f46139f98466"
+        fake = _FakeLambda({f"/feedback/{fid}": {"feedback_id": fid, "original_text": "t"}})
+        result = _call("get_feedback_detail", {"feedback_id": fid}, fake)
+
+        assert result["result"]["isError"] is False
+
+    def test_the_patterns_accept_what_the_writers_produce(self):
+        """Lockstep against the id GENERATORS, so the guard cannot drift from them.
+
+        A pattern tightened past what the product mints would refuse real data,
+        and the refusal would look like a missing project rather than a bad guard.
+        Read from source because both generators are one expression.
+        """
+        projects_src = (Path(__file__).resolve().parents[1] / "projects.py").read_text()
+        assert 'f"proj_{datetime.now().strftime(\'%Y%m%d%H%M%S\')}"' in projects_src, (
+            "the project-id generator changed shape; re-check _PATH_PARAM_PATTERNS"
+        )
+        # What that expression produces, matched against the live guard.
+        assert mcp_handler._PATH_PARAM_PATTERNS["project_id"].match("proj_20260819143000")
+        # 32-char lowercase hex, as generate_deterministic_id produces.
+        assert mcp_handler._PATH_PARAM_PATTERNS["feedback_id"].match("0" * 32)
+        assert not mcp_handler._PATH_PARAM_PATTERNS["feedback_id"].match("0" * 31)
+
+    def test_every_templated_route_declares_a_pattern_for_its_parameters(self):
+        """Fail-closed, checked across the whole table rather than per tool.
+
+        A future route whose author forgets a pattern is refused at call time, and
+        this test says so at build time instead.
+        """
+        for key, (_domain, _method, template) in mcp_handler.DOMAIN_ROUTES.items():
+            for segment in template.split("/"):
+                if segment.startswith("{"):
+                    name = segment.strip("{}")
+                    assert name in mcp_handler._PATH_PARAM_PATTERNS, (
+                        f"{key} interpolates '{name}' with no declared pattern"
+                    )
+
+    def test_an_undeclared_parameter_is_refused_rather_than_interpolated(self):
+        with pytest.raises(mcp_handler.InvalidToolArgument):
+            mcp_handler._validated_path_parameters("some_route", {"surprise": "value"})
+
+    def test_autoseed_refuses_a_hostile_project_id_with_a_400(self):
+        """Autoseed takes its id straight from the URL, so it needs the same guard.
+
+        A 400 rather than a 403: the credential is fine and the path is not.
+        """
+        import json as _json
+
+        # Minted through the production helper: parse_token requires the secret
+        # half to be 64 lowercase HEX characters, so a hand-written 's' * 64
+        # never reaches the token store and the route answers 401 instead of the
+        # 400 under test.
+        minted = mint_token()
+        client = MagicMock()
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=client), \
+             patch.dict(os.environ, {"PROJECTS_FUNCTION": "p"}):
+            table.query.return_value = {"Items": [{
+                "pk": "MCPTOKEN", "sk": f"TOKEN#{minted.token_id}",
+                "token_id": minted.token_id, "secret_hash": minted.secret_hash,
+                "scopes": list(ALL_READ_SCOPES), "projects": [_PROJECT],
+                "read_reach": REACH_WORKSPACE,
+            }]}
+            table.update_item.return_value = {}
+            response = mcp_handler.lambda_handler({
+                "httpMethod": "GET",
+                "path": "/v1/mcp/autoseed/prioritization",
+                "headers": {"authorization": f"Bearer {minted.raw}"},
+            }, MagicMock())
+
+        assert response["statusCode"] == 400, response["body"]
+        assert _json.loads(response["body"])["message"]
+        client.invoke.assert_not_called()
+
+
+class TestDocumentKindLockstep:
+    """`_document_kind` reads `sk`, so the route must keep returning it.
+
+    Raised in review as the same trap the `feedback_id` bug fell into: the unit
+    test supplies `sk` itself, so it cannot notice the route dropping it. If
+    `GET /projects/{project_id}` ever projects its documents, every kind silently
+    becomes `""` — and the outputSchema enum permits `""`, so nothing fails.
+
+    Pinned against the real `projects.get_project`, not a fixture of it.
+    """
+
+    def test_the_project_route_returns_the_sort_key_on_documents(self):
+        import projects as projects_module
+
+        table = MagicMock()
+        table.query.return_value = {"Items": [
+            {"pk": "PROJECT#p1", "sk": "META", "name": "P"},
+            {"pk": "PROJECT#p1", "sk": "PROTOTYPE#1", "document_id": "d1", "title": "T"},
+        ]}
+        with patch.object(projects_module, "projects_table", table):
+            payload = projects_module.get_project("p1")
+
+        documents = payload["documents"]
+        assert documents, "the route returned no documents to check"
+        assert "sk" in documents[0], (
+            "projects.get_project no longer returns `sk` on documents, so "
+            "_document_kind in mcp_handler will report '' for every document"
+        )
+        assert mcp_handler._document_kind(documents[0]) == "prototype"
+
+    def test_a_document_without_a_sort_key_reports_no_kind_rather_than_guessing(self):
+        assert mcp_handler._document_kind({"document_id": "d1"}) == ""

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -328,6 +328,31 @@ class TestProjections:
         assert item["direct_quote"] == "never again"
         assert item["keywords"] == ["late", "delivery"]
 
+    def test_the_reported_id_is_the_one_the_detail_tool_needs(self):
+        """search_feedback must report an id get_feedback_detail can look up.
+
+        Both tools read `item.get('id')` before this change, and the processor
+        never writes a plain `id` — the identifier is `feedback_id`, which is what
+        the detail route keys its GSI on. So every search result carried
+        `"id": ""` and there was no way for an agent to reach a single item: the
+        only source of a feedback id is a search, and search reported none.
+        Caught against the deployed API, not by a unit test, because every
+        fixture in the suite happened to set both fields.
+        """
+        row = _feedback_row(feedback_id="fb-42")
+        row.pop("id", None)
+        fake = _FakeLambda({"/feedback/search": {"items": [row]}})
+        item = _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]["items"][0]
+
+        assert item["id"] == "fb-42"
+
+    def test_a_row_carrying_only_a_plain_id_still_reports_it(self):
+        """The fallback, so the fix does not break a row shaped the old way."""
+        fake = _FakeLambda({"/feedback/f1": {"id": "legacy-1", "original_text": "t"}})
+        item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]
+
+        assert item["id"] == "legacy-1"
+
     def test_the_renames_the_tools_have_always_reported(self):
         fake = _FakeLambda({"/feedback/f1": _feedback_row()})
         item = _call("get_feedback_detail", {"feedback_id": "f1"}, fake)["result"]["structuredContent"]

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -59,6 +59,7 @@ removed. The revert map:
 import io
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -582,8 +583,12 @@ class TestPathParameterConfinement:
         "proj_1/api-tokens",         # segment injection
         "proj_1/jobs",
         "../metrics/summary",        # traversal
+        "..",
+        ".",
         "proj_1?x=1",
         "proj_1#frag",
+        "proj%2F1",                  # percent-encoded separator
+        "proj 1",                    # internal whitespace
         "",
     ])
     def test_a_hostile_project_id_never_becomes_a_route(self, hostile):
@@ -618,40 +623,85 @@ class TestPathParameterConfinement:
 
         assert result["result"]["isError"] is False
 
-    def test_the_patterns_accept_what_the_writers_produce(self):
-        """Lockstep against the id GENERATORS, so the guard cannot drift from them.
+    def test_a_padded_project_id_is_normalized_rather_than_refused(self):
+        """Surrounding whitespace is stripped upstream, so it never reaches here.
 
-        A pattern tightened past what the product mints would refuse real data,
-        and the refusal would look like a missing project rather than a bad guard.
-        Read from source because both generators are one expression.
+        `_resolve_project_id` strips an explicit argument before authorization, so
+        `' proj_1'` and `'proj_1'` are the same request — which is why the guard's
+        own no-whitespace rule sees an already-clean value. Pinned so a change to
+        either side is a deliberate one: if the strip were removed, the guard
+        would start refusing a padded id that used to work.
         """
-        projects_src = (Path(__file__).resolve().parents[1] / "projects.py").read_text()
-        assert 'f"proj_{datetime.now().strftime(\'%Y%m%d%H%M%S\')}"' in projects_src, (
-            "the project-id generator changed shape; re-check _PATH_PARAM_PATTERNS"
-        )
-        # What that expression produces, matched against the live guard.
-        assert mcp_handler._PATH_PARAM_PATTERNS["project_id"].match("proj_20260819143000")
-        # 32-char lowercase hex, as generate_deterministic_id produces.
-        assert mcp_handler._PATH_PARAM_PATTERNS["feedback_id"].match("0" * 32)
-        assert not mcp_handler._PATH_PARAM_PATTERNS["feedback_id"].match("0" * 31)
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {"project": {"name": "P"}}})
+        result = _call("get_project", {"project_id": f"  {_PROJECT}  "}, fake)
 
-    def test_every_templated_route_declares_a_pattern_for_its_parameters(self):
-        """Fail-closed, checked across the whole table rather than per tool.
+        assert result["result"]["isError"] is False
+        assert fake.paths == [f"/projects/{_PROJECT}"]
 
-        A future route whose author forgets a pattern is refused at call time, and
-        this test says so at build time instead.
+    def test_the_guard_does_not_bet_on_where_an_id_came_from(self):
+        """An id of an unexpected SHAPE is delegated, not refused.
+
+        The first version of this guard was a format allowlist (`proj_` + a
+        timestamp, 32 hex). It stopped both attacks, and it also bet on id
+        PROVENANCE: a project seeded, imported, or minted by an older generator
+        would be permanently unreachable through MCP and reported as a malformed
+        argument rather than a missing project. That trades an availability
+        property for a security one that the shape rule already provides.
         """
-        for key, (_domain, _method, template) in mcp_handler.DOMAIN_ROUTES.items():
-            for segment in template.split("/"):
+        legacy = "legacy-project-42"
+        fake = _FakeLambda({f"/projects/{legacy}": {"project": {"name": "Old"}}})
+        result = _call("get_project", {"project_id": legacy}, fake)
+
+        assert result["result"]["isError"] is False
+        assert fake.paths == [f"/projects/{legacy}"]
+
+    def test_reserved_segments_cover_every_static_sibling(self):
+        """Lockstep: the reserved sets are derived from the handlers, not guessed.
+
+        This is what replaces the provenance bet. A static route added to one of
+        those handlers at the same position as a templated parameter would
+        otherwise become quietly reachable through the tool that interpolates
+        there; adding it now fails this test until it is reserved.
+        """
+        owners = {"/projects": "projects_handler.py", "/feedback": "metrics_handler.py"}
+        for prefix, handler in owners.items():
+            source = (Path(__file__).resolve().parents[1] / handler).read_text()
+            depth = len(prefix.strip("/").split("/"))
+            siblings = set()
+            for match in re.finditer(r'@app\.(?:get|post|put|delete)\(\s*[\'"]([^\'"]+)[\'"]', source):
+                parts = match.group(1).strip("/").split("/")
+                if (len(parts) > depth
+                        and "/".join(parts[:depth]) == prefix.strip("/")
+                        and not parts[depth].startswith("<")):
+                    siblings.add(parts[depth])
+            declared = mcp_handler._RESERVED_PATH_SEGMENTS[prefix]
+            assert siblings <= declared, (
+                f"{handler} has static routes under {prefix} that are not reserved: "
+                f"{sorted(siblings - declared)} — a tool interpolating a parameter "
+                f"there could reach them"
+            )
+
+    def test_every_reserved_prefix_is_one_a_declared_route_interpolates(self):
+        """The reverse direction: no reserved set for a prefix nothing uses.
+
+        A stale entry is harmless at runtime but it is a claim about the routes
+        that is no longer true, and it makes the test above pass for a prefix
+        nobody checks.
+        """
+        interpolated = set()
+        for _domain, _method, template in mcp_handler.DOMAIN_ROUTES.values():
+            segments = template.strip("/").split("/")
+            for index, segment in enumerate(segments):
                 if segment.startswith("{"):
-                    name = segment.strip("{}")
-                    assert name in mcp_handler._PATH_PARAM_PATTERNS, (
-                        f"{key} interpolates '{name}' with no declared pattern"
-                    )
+                    interpolated.add("/" + "/".join(segments[:index]))
+        assert set(mcp_handler._RESERVED_PATH_SEGMENTS) <= interpolated, (
+            f"reserved segments declared for prefixes no route interpolates: "
+            f"{sorted(set(mcp_handler._RESERVED_PATH_SEGMENTS) - interpolated)}"
+        )
 
-    def test_an_undeclared_parameter_is_refused_rather_than_interpolated(self):
+    def test_a_parameter_the_template_does_not_use_is_refused(self):
         with pytest.raises(mcp_handler.InvalidToolArgument):
-            mcp_handler._validated_path_parameters("some_route", {"surprise": "value"})
+            mcp_handler._validated_path_parameters("project_get", {"surprise": "value"})
 
     def test_autoseed_refuses_a_hostile_project_id_with_a_400(self):
         """Autoseed takes its id straight from the URL, so it needs the same guard.

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -672,12 +672,12 @@ class TestPathParameterConfinement:
     def _static_siblings(self, prefix: str, handler: str) -> set[str]:
         """Static route segments at the parameter's position, from ONE file.
 
-        ⚠️ Single-file by design and only sound while these handlers register
+        ⚠️ Single-file by design, and only sound while these handlers register
         every route inline. Powertools also supports `Router` objects in other
         modules included into an app; a route registered that way would be
-        invisible here, and the reserved set would be quietly incomplete. That is
-        not documented and left to trust — `test_no_route_is_registered_outside_
-        the_scanned_file` asserts the pattern is absent.
+        invisible here and the reserved set would be quietly incomplete. Neither
+        handler does that today, and it is asserted rather than assumed — see
+        `test_no_route_is_registered_outside_the_scanned_file`.
         """
         source = (Path(__file__).resolve().parents[1] / handler).read_text()
         depth = len(prefix.strip("/").split("/"))
@@ -798,6 +798,40 @@ class TestPathParameterConfinement:
     def test_a_parameter_the_template_does_not_use_is_refused(self):
         with pytest.raises(mcp_handler.InvalidToolArgument):
             mcp_handler._validated_path_parameters("project_get", {"surprise": "value"})
+
+    def test_autoseed_reports_a_missing_declaration_as_a_server_fault(self):
+        """The autoseed path answers 502, not 400, for a misconfiguration.
+
+        `_domain_call` can raise EITHER kind — `InvalidToolArgument` for a
+        malformed path parameter, `DelegationUnavailable` for a missing
+        reserved-segment declaration — so both are caught around the same step. A
+        `try` that caught only the first let the second escape to the outer
+        catch-all and answer something other than the 502 this route establishes.
+        Unreachable in a deployed build; asserted so the two paths cannot diverge.
+        """
+        minted = mint_token()
+        client = MagicMock()
+        future = {"project_autoseed": (mcp_handler.DOMAIN_PROJECTS, "GET",
+                                       "/whatever/{project_id}/autoseed")}
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=client), \
+             patch.dict(mcp_handler.DOMAIN_ROUTES, future), \
+             patch.dict(os.environ, {"PROJECTS_FUNCTION": "p"}):
+            table.query.return_value = {"Items": [{
+                "pk": "MCPTOKEN", "sk": f"TOKEN#{minted.token_id}",
+                "token_id": minted.token_id, "secret_hash": minted.secret_hash,
+                "scopes": list(ALL_READ_SCOPES), "projects": [_PROJECT],
+                "read_reach": REACH_WORKSPACE,
+            }]}
+            table.update_item.return_value = {}
+            response = mcp_handler.lambda_handler({
+                "httpMethod": "GET",
+                "path": f"/v1/mcp/autoseed/{_PROJECT}",
+                "headers": {"authorization": f"Bearer {minted.raw}"},
+            }, MagicMock())
+
+        assert response["statusCode"] == 502, response["body"]
+        client.invoke.assert_not_called()
 
     def test_autoseed_refuses_a_hostile_project_id_with_a_400(self):
         """Autoseed takes its id straight from the URL, so it needs the same guard.

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -189,7 +189,11 @@ def _client_error(code: str, operation: str = "Query") -> ClientError:
 # parse, and mint_token is what decides whether it does.
 _MINTED = mint_token()
 _VALID_TOKEN = _MINTED.raw
-_TOKEN_PROJECT = "proj-1"
+# Shaped like an id the product actually mints (`proj_` + a timestamp), because
+# the path-parameter guard in _domain_call refuses anything else — any test that
+# reaches a delegated call needs a realistic one. The reach tests, which stub the
+# tool handler, are unaffected either way.
+_TOKEN_PROJECT = "proj_20260819143000"
 
 
 def _token_row(**extra) -> dict:
@@ -1403,7 +1407,7 @@ class TestUnconfiguredTableIsAServerFault:
         response = mcp_handler.lambda_handler(
             {
                 "httpMethod": "GET",
-                "path": "/v1/mcp/autoseed/proj-1",
+                "path": f"/v1/mcp/autoseed/{_TOKEN_PROJECT}",
                 "headers": {
                     "authorization": f"Bearer {_VALID_TOKEN}",
                     "x-project-id": "proj-1",
@@ -1538,7 +1542,7 @@ class TestWwwAuthenticateChallenge:
         response = mcp_handler.lambda_handler(
             {
                 "httpMethod": "GET",
-                "path": "/v1/mcp/autoseed/proj-1",
+                "path": f"/v1/mcp/autoseed/{_TOKEN_PROJECT}",
                 "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
             },
             lambda_context,
@@ -1759,7 +1763,7 @@ class TestProjectsTableUsageMatchesNarrowGrant:
             "get_metrics_breakdown": {"dimension": "categories"},
         }
         with patch("mcp_handler.projects_table", strict), \
-             patch("shared.mcp_delegate.get_lambda_client", return_value=_stub_domain_client()), \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=_stub_domain_client()), \
              patch.dict(os.environ, {"METRICS_FUNCTION": "m", "PROJECTS_FUNCTION": "p"}):
             for tool_name in mcp_handler.TOOL_HANDLERS:
                 before = strict.query.call_count
@@ -1795,12 +1799,12 @@ class TestProjectsTableUsageMatchesNarrowGrant:
         )
         with patch("mcp_handler.projects_table", strict_auth), \
              patch.object(projects_module, "projects_table", strict_data), \
-             patch("shared.mcp_delegate.get_lambda_client", return_value=_stub_domain_client()), \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=_stub_domain_client()), \
              patch.dict(os.environ, {"PROJECTS_FUNCTION": "voc-projects-api"}):
             response = mcp_handler.lambda_handler(
                 {
                     "httpMethod": "GET",
-                    "path": "/v1/mcp/autoseed/proj-1",
+                    "path": f"/v1/mcp/autoseed/{_TOKEN_PROJECT}",
                     "headers": {"authorization": f"Bearer {_VALID_TOKEN}"},
                 },
                 lambda_context,
@@ -2202,7 +2206,7 @@ class TestAutoseedAuthorization:
         client = MagicMock()
         client.invoke = seed
         with patch("mcp_handler.projects_table") as mock_table, \
-             patch("shared.mcp_delegate.get_lambda_client", return_value=client), \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=client), \
              patch.dict(os.environ, {"PROJECTS_FUNCTION": "voc-projects-api"}):
             mock_table.query.return_value = {"Items": [row]}
             mock_table.update_item.return_value = {}
@@ -2217,7 +2221,7 @@ class TestAutoseedAuthorization:
         return response, seed
 
     def test_workspace_token_may_autoseed_any_project(self, lambda_context):
-        response, seed = self._get("another-project", _token_row(), lambda_context)
+        response, seed = self._get("proj_20260603094346", _token_row(), lambda_context)
         assert response["statusCode"] == 200, response["body"]
         seed.assert_called_once()
 
@@ -2229,7 +2233,7 @@ class TestAutoseedAuthorization:
 
     def test_project_set_token_refused_outside_its_set(self, lambda_context):
         row = _token_row(read_reach=REACH_PROJECT_SET)
-        response, seed = self._get("another-project", row, lambda_context)
+        response, seed = self._get("proj_20260603094346", row, lambda_context)
         assert response["statusCode"] == 403, response["body"]
         seed.assert_not_called()
 
@@ -2293,7 +2297,7 @@ class TestClaimSynthesis:
         client = _stub_domain_client({"project": {"name": "P"}, "personas": [],
                                       "documents": []})
         with patch("mcp_handler.projects_table") as table, \
-             patch("shared.mcp_delegate.get_lambda_client", return_value=client), \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=client), \
              patch.dict(os.environ, {"METRICS_FUNCTION": "m", "PROJECTS_FUNCTION": "p"}):
             table.query.return_value = {"Items": [row or _token_row()]}
             table.update_item.return_value = {}

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -2,7 +2,8 @@
 Tests for MCP handler security hardening (issue #260):
   1. Constant-time token comparison (hmac.compare_digest)
   2. Scope enforcement at dispatch (fail-closed)
-  3. Partial-result reporting in get_metrics_summary (is_partial flag)
+  3. Partial-result reporting — retired at server 2.0.0 (see section 3 below)
+  4. Claim synthesis: the request cannot influence the delegated identity
 
 Regression coverage
 -------------------
@@ -20,12 +21,20 @@ Revert test that catches each defect:
     lookup and the _scope_allows check) causes this test to fail because the
     tool would execute instead of returning an error.
 
-  defect 3 (partial): test_partial_read_sets_is_partial_flag
-    — forces one DynamoDB read to raise and asserts the response carries
-    is_partial=True while the successful reads are still present.
-    Reverting the is_partial tracking (restoring bare `except Exception: pass`)
-    causes this test to fail because is_partial would be False even when a
-    read raised.
+  defect 3 (partial): RETIRED at server 2.0.0, along with the behaviour it
+    guarded. The tool no longer reads DynamoDB, so there are no per-read
+    failures to degrade and no is_partial to track. The replacement invariant is
+    test_a_route_server_error_is_a_protocol_error in test_mcp_delegation.py: a
+    failing route is now reported as an error rather than as a plausible-looking
+    answer with a flag on it. Full reasoning in the section-3 comment below.
+
+  defect 4 (claim forgery): TestClaimSynthesis
+    — delegating made this function an authorization authority: it tells the
+    domain Lambda who is calling, and that Lambda believes it, because in every
+    other case those claims came from API Gateway's Cognito authorizer. Passing
+    the request into the claim builder — or merging `arguments` into the
+    synthesized authorizer context — fails test_arguments_cannot_forge_the_subject
+    and test_arguments_cannot_forge_group_membership. Highest-value test here.
 
   additional scope tests:
     test_every_registered_tool_has_scope_declaration
@@ -90,25 +99,39 @@ Revert test that catches each defect:
       ordered ahead of the specific handlers.
 
   schema agreement:
-    test_resolve_days_rejects_values_the_schema_forbids
-    — `days` must be an integer by the tool's own inputSchema; `int(True) == 1`
-      and `int(2.9) == 2` would answer a window the caller never asked for.
+    — the `days` coercion tests moved with `_resolve_days`, which delegation
+      deleted. The window is now bounded by the route's shared `validate_days`,
+      and its non-finite / non-numeric cases live in
+      lambda/shared/test/test_api.py. One case genuinely changed behaviour
+      (`days: true`); it is recorded at the section-3 comment below rather than
+      here, next to the reasoning.
 
-    test_resolve_days_falls_back_on_infinity /
-    test_json_parsed_infinity_reports_the_default_window
-    — `int(float('inf'))` raises OverflowError, not ValueError, so an infinite
-      `days` bypassed the fallback and surfaced as an opaque error.  Reachable
-      from plain JSON: both `1e400` and `Infinity` parse to `inf`.  Dropping
-      OverflowError from the except tuple fails both.
+  delegation:
+    test_every_tool_touches_the_table_only_to_authenticate /
+    test_autoseed_reads_no_project_rows_in_this_process
+    — the Python half of the IAM lockstep, and both got STRONGER when the tools
+      started delegating: the expected projects-table query count per tool is now
+      exactly one (the credential lookup), and autoseed — the last in-process
+      reader of project artifacts — must not touch that table at all. Together
+      they are what justifies the `dynamodb:LeadingKeys` condition on the role,
+      which api-stack.test.ts pins from the other side.
 """
 
+import io
 import json
 import os
 import sys
 from decimal import Decimal
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
+from boto3.dynamodb.conditions import Key
+
+# botocore names its own `ConnectionError`/`HTTPClientError`; imported via the
+# module so `botocore_exceptions.ConnectionError` cannot be misread as the
+# builtin, matching how mcp_handler refers to them.
+from botocore import exceptions as botocore_exceptions
 from botocore.exceptions import (
     ClientError,
     ConnectionClosedError,
@@ -122,12 +145,7 @@ from botocore.exceptions import (
     ResponseStreamingError,
     SSLError,
 )
-# botocore names its own `ConnectionError`/`HTTPClientError`; imported via the
-# module so `botocore_exceptions.ConnectionError` cannot be misread as the
-# builtin, matching how mcp_handler refers to them.
-from botocore import exceptions as botocore_exceptions
 from botocore.parsers import ResponseParserError
-from boto3.dynamodb.conditions import Key
 from shared.mcp_tokens import (
     ALL_READ_SCOPES,
     MCP_TOKEN_PK,
@@ -210,6 +228,37 @@ def _make_event(token: str = _VALID_TOKEN) -> dict:
     to prove the header is irrelevant passes it explicitly.
     """
     return {"headers": {"authorization": f"Bearer {token}"}}
+
+
+def _stub_domain_client(body: dict | None = None, status: int = 200):
+    """A Lambda client that answers any delegated route with a 200.
+
+    These tests are about the credential and the dispatch, so the domain
+    function's answer is deliberately uninteresting — the route translation
+    itself is covered in test_mcp_delegation.py.
+    """
+    client = MagicMock()
+    client.invoke.side_effect = lambda **_kwargs: {
+        "Payload": io.BytesIO(json.dumps({
+            "statusCode": status,
+            "body": json.dumps(body if body is not None else {"ok": True}),
+        }).encode()),
+    }
+    return client
+
+
+def _ok_result():
+    """What a tool returns now: a ToolResult, not a list of content blocks.
+
+    These tests stub the TOOL EXECUTION so they can be about the credential and
+    the dispatch instead of about data. The stub still has to honour the real
+    contract — when tools started returning `ToolResult` (structured output,
+    server 2.0.0), a stub returning the old list shape made every one of these
+    fail on `result.text`, which is the contract check working rather than
+    breaking.
+    """
+    import mcp_handler
+    return mcp_handler.ToolResult({"ok": True})
 
 
 def _rpc_event(tool: str = "get_project", arguments: dict | None = None,
@@ -537,7 +586,7 @@ class TestScopeEnforcement:
         a credential that reads feedback but cannot read anybody's product
         strategy.
         """
-        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=_ok_result())
         result = self._call_tool(
             tool_name="fake_projects_tool",
             token_scopes=[SCOPE_FEEDBACK_READ],
@@ -554,7 +603,7 @@ class TestScopeEnforcement:
         handler.assert_not_called()
 
     def test_token_holding_the_required_scope_is_allowed(self):
-        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=_ok_result())
         result = self._call_tool(
             tool_name="fake_feedback_tool",
             token_scopes=[SCOPE_FEEDBACK_READ],
@@ -567,7 +616,7 @@ class TestScopeEnforcement:
 
     def test_extra_scopes_do_not_interfere(self):
         """A token holding several scopes satisfies each of them."""
-        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=_ok_result())
         for required in (SCOPE_FEEDBACK_READ, SCOPE_METRICS_READ, SCOPE_PROJECTS_READ):
             handler.reset_mock()
             result = self._call_tool(
@@ -601,7 +650,7 @@ class TestScopeEnforcement:
         list would let a string masquerade as a scope set — and a row holding
         the string "feedback:read,projects:read" would then satisfy BOTH.
         """
-        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=_ok_result())
         result = self._call_tool(
             tool_name="damaged_row_tool",
             token_scopes=scopes,
@@ -660,7 +709,7 @@ class TestScopeEnforcement:
 
     def test_tool_without_scope_declaration_is_rejected(self):
         """A handler that exists in TOOL_HANDLERS but not TOOL_SCOPE_REQUIREMENTS is rejected."""
-        undeclared_handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        undeclared_handler = MagicMock(return_value=_ok_result())
         import mcp_handler
         original = mcp_handler.TOOL_SCOPE_REQUIREMENTS.copy()
         try:
@@ -685,7 +734,7 @@ class TestScopeEnforcement:
         and guessing would mean guessing permissively. Same fail-closed rule as
         the missing scope declaration above.
         """
-        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=_ok_result())
         import mcp_handler
         original = mcp_handler.TOOL_REACH_KINDS.copy()
         try:
@@ -731,7 +780,7 @@ class TestScopeEnforcement:
         }
         handlers = (
             {**mcp_handler.TOOL_HANDLERS,
-             tool: MagicMock(return_value=[{"type": "text", "text": "ok"}])}
+             tool: MagicMock(return_value=_ok_result())}
             if stub_handler else mcp_handler.TOOL_HANDLERS
         )
         with patch("mcp_handler.projects_table") as mock_table, \
@@ -806,344 +855,45 @@ class TestScopeEnforcement:
 
 
 # ===========================================================================
-# 3. Partial-result reporting
+# 3. Partial-result reporting — REMOVED, and why
 # ===========================================================================
-
-# The four sentiment buckets get_metrics_summary reads per day.  Asserted as a
-# set on the response payload rather than as a read count: the payload is the
-# contract, so a batch_get_item rewrite that still returns all four passes,
-# while three of the four reads quietly disappearing does not.
-_ALL_SENTIMENTS = {"positive", "negative", "neutral", "mixed"}
-
-
-class TestPartialResultReporting:
-    """get_metrics_summary sets is_partial=True and logs when any read fails."""
-
-    @patch("mcp_handler.aggregates_table")
-    def test_partial_read_sets_is_partial_flag(self, mock_table):
-        """When the daily_total read raises, is_partial=True appears in the response.
-
-        The sentiment counts (from successful reads) must still appear — the
-        readable portion of the answer must not be lost.
-
-        The surviving reads are pinned on the *payload* rather than on a read
-        count: every sentiment bucket must be present with the value its read
-        returned, and the failed daily_total must contribute nothing.  That is
-        read-strategy independent (a batch_get_item rewrite returning the same
-        four buckets still passes) but not vacuous — a `>= 1` call-count check
-        held even when three of the four sentiment reads were deleted.
-        """
-        def get_item_side_effect(Key, **kwargs):  # noqa: N803
-            pk = Key.get("pk", "")
-            if pk == "METRIC#daily_total":
-                raise Exception("ProvisionedThroughputExceededException")
-            # Sentiment reads return a small positive count
-            return {"Item": {"count": 2}}
-
-        mock_table.get_item.side_effect = get_item_side_effect
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        content = _tool_get_metrics_summary({"days": 1}, {})
-
-        assert len(content) == 1
-        payload = json.loads(content[0]["text"])
-
-        assert payload["is_partial"] is True, "is_partial must be True when a read fails"
-        # Every sentiment bucket the tool claims to report is present, with the
-        # value its read returned — not merely "some sentiment key survived".
-        assert payload["sentiment_breakdown"] == dict.fromkeys(_ALL_SENTIMENTS, 2), (
-            "every sentiment bucket must survive a daily_total failure; got "
-            f"{payload['sentiment_breakdown']}"
-        )
-        # The failed read contributes nothing rather than a stale/invented total.
-        assert payload["total_feedback"] == 0
-
-    @patch("mcp_handler.aggregates_table")
-    def test_all_reads_succeed_is_partial_false(self, mock_table):
-        """When all reads succeed, is_partial is False."""
-        mock_table.get_item.return_value = {"Item": {"count": 5}}
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        content = _tool_get_metrics_summary({"days": 1}, {})
-        payload = json.loads(content[0]["text"])
-
-        assert payload["is_partial"] is False
-
-    @patch("mcp_handler.aggregates_table")
-    def test_totals_cover_every_day_in_the_window(self, mock_table):
-        """period_days days of aggregates are summed, not just the latest day.
-
-        Stated on the payload so it holds under any read strategy: with a
-        uniform count of 5 per aggregate row, a 3-day window must report
-        3 x 5 for the total and for each sentiment bucket.  Without this, a
-        window that silently collapsed to a single day (or sentiment buckets
-        that quietly stopped being read) still produced a well-shaped,
-        is_partial=False answer that under-reported the period.
-        """
-        mock_table.get_item.return_value = {"Item": {"count": 5}}
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary({"days": 3}, {})[0]["text"])
-
-        assert payload["period_days"] == 3
-        assert payload["is_partial"] is False
-        assert payload["total_feedback"] == 15, (
-            "a 3-day window must sum all 3 daily_total rows, got "
-            f"{payload['total_feedback']} (1 day would be 5)"
-        )
-        assert payload["sentiment_breakdown"] == dict.fromkeys(_ALL_SENTIMENTS, 15), (
-            "each sentiment bucket must accumulate across the whole window; got "
-            f"{payload['sentiment_breakdown']}"
-        )
-
-    @patch("mcp_handler.aggregates_table")
-    def test_category_read_failure_sets_is_partial(self, mock_table):
-        """When the category_breakdown query fails, is_partial=True."""
-        mock_table.get_item.return_value = {"Item": {"count": 3}}
-        mock_table.query.side_effect = Exception("ResourceNotFoundException")
-
-        from mcp_handler import _tool_get_metrics_summary
-        content = _tool_get_metrics_summary({"days": 1}, {})
-        payload = json.loads(content[0]["text"])
-
-        assert payload["is_partial"] is True
-        # total_feedback still populated from the successful get_item calls
-        assert payload["total_feedback"] == 3
-
-    @patch("mcp_handler.aggregates_table")
-    def test_is_partial_field_always_present(self, mock_table):
-        """is_partial is always present in the response regardless of outcome."""
-        mock_table.get_item.return_value = {}  # no Item
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        content = _tool_get_metrics_summary({"days": 1}, {})
-        payload = json.loads(content[0]["text"])
-
-        assert "is_partial" in payload
-
-    @patch("mcp_handler.aggregates_table")
-    def test_partial_failure_logged_at_warning(self, mock_table):
-        """A failed read is logged at WARNING level (not silently swallowed),
-        and the WARNING log must not contain token or token_hash values.
-
-        The docstring promises failures are logged "without any token or hash" —
-        this test enforces that promise so a future refactor that accidentally
-        adds a sensitive field trips CI immediately.  Both the `extra` dict and
-        the positional message text are inspected: a hash interpolated into an
-        f-string message would leak just as readily as one in `extra`.
-        """
-        mock_table.get_item.side_effect = Exception("Throttled")
-        mock_table.query.return_value = {"Items": []}
-
-        # A token_info carrying a recognisable secret; none of it may reach a log.
-        token_info = {"project_id": "proj-1", "token_hash": "SENTINELHASH"}
-
-        from mcp_handler import _tool_get_metrics_summary
-        with patch("mcp_handler.logger") as mock_logger:
-            _tool_get_metrics_summary({"days": 1}, token_info)
-            assert mock_logger.warning.called, "Failure must be logged at WARNING level"
-            for call in mock_logger.warning.call_args_list:
-                extra = (call.kwargs or {}).get("extra", {})
-                assert "token" not in extra and "token_hash" not in extra, (
-                    f"WARNING log must not contain token/hash fields; extra={extra}"
-                )
-                rendered = " ".join(str(a) for a in call.args) + " " + str(extra)
-                assert "SENTINELHASH" not in rendered, (
-                    f"WARNING log must not contain the token hash; got: {rendered}"
-                )
-
-    @patch("mcp_handler.aggregates_table")
-    def test_existing_fields_unchanged_when_partial(self, mock_table):
-        """Existing response fields keep their meaning when is_partial=True.
-
-        total_feedback, sentiment_breakdown, and top_categories are still
-        present so a client that already reads total_feedback does not break.
-
-        Presence is asserted on the payload, and sentiment_breakdown is checked
-        to still be fully populated: "the field exists" alone would hold for an
-        empty dict, which is a broken answer wearing the right shape.
-        """
-        def get_item_side_effect(Key, **kwargs):  # noqa: N803
-            pk = Key.get("pk", "")
-            if pk == "METRIC#daily_total":
-                raise Exception("Throttled")
-            return {"Item": {"count": 1}}
-
-        mock_table.get_item.side_effect = get_item_side_effect
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        content = _tool_get_metrics_summary({"days": 1}, {})
-        payload = json.loads(content[0]["text"])
-
-        assert "total_feedback" in payload
-        assert "sentiment_breakdown" in payload
-        assert "top_categories" in payload
-        assert "period_days" in payload
-        assert set(payload["sentiment_breakdown"]) == _ALL_SENTIMENTS, (
-            "sentiment_breakdown must still carry every bucket when partial; got "
-            f"{sorted(payload['sentiment_breakdown'])}"
-        )
-
-    @patch("mcp_handler.aggregates_table", None)
-    def test_aggregates_table_not_configured_includes_is_partial(self):
-        """When aggregates_table is None, the response includes is_partial=True
-        and the full five-field payload shape with zeroed values.
-
-        The docstring promises is_partial is always present in the response.
-        The early-exit path must honour the full payload shape so clients can
-        read total_feedback, period_days, sentiment_breakdown, and top_categories
-        unconditionally without a KeyError.
-        """
-        from mcp_handler import _tool_get_metrics_summary
-        content = _tool_get_metrics_summary({"days": 1}, {})
-        assert len(content) == 1
-        payload = json.loads(content[0]["text"])
-        assert "is_partial" in payload, "is_partial must be present even on the early-exit path"
-        assert payload["is_partial"] is True
-        # All four normal-path fields must be present with zeroed/empty values
-        assert "total_feedback" in payload, "total_feedback must be present on early-exit path"
-        assert payload["total_feedback"] == 0
-        assert "period_days" in payload, "period_days must be present on early-exit path"
-        assert payload["period_days"] == 1  # from args
-        assert "sentiment_breakdown" in payload, "sentiment_breakdown must be present on early-exit path"
-        assert "top_categories" in payload, "top_categories must be present on early-exit path"
-
-    @patch("mcp_handler.aggregates_table", None)
-    def test_early_exit_period_days_is_clamped(self):
-        """period_days is clamped identically on the early-exit and normal paths.
-
-        Before this fix the early exit echoed the raw `args['days']`, so the same
-        request reported period_days=999 when aggregates_table happened to be
-        unconfigured and 30 otherwise — the field stopped describing the window.
-        """
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary({"days": 50}, {})[0]["text"])
-        assert payload["period_days"] == 30, (
-            f"days=50 must clamp to 30 on the early-exit path, got {payload['period_days']}"
-        )
-
-    @patch("mcp_handler.aggregates_table")
-    def test_normal_path_period_days_is_clamped(self, mock_table):
-        """The normal path clamps the same way, so the two agree."""
-        mock_table.get_item.return_value = {}
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary({"days": 50}, {})[0]["text"])
-        assert payload["period_days"] == 30
-
-    @patch("mcp_handler.aggregates_table", None)
-    def test_early_exit_non_numeric_days_falls_back_to_default(self):
-        """A non-numeric `days` is coerced, not echoed back verbatim.
-
-        `period_days` is the only response field taken from caller input, so a
-        client doing arithmetic on it must not receive a str.
-        """
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary({"days": "abc"}, {})[0]["text"])
-        assert payload["period_days"] == 7, (
-            f"A non-numeric days must fall back to 7, got {payload['period_days']!r}"
-        )
-
-    @patch("mcp_handler.aggregates_table")
-    def test_normal_path_non_numeric_days_falls_back_to_default(self, mock_table):
-        """The normal path also coerces rather than raising on a non-numeric days.
-
-        Previously `min(args.get('days', 7), 30)` raised TypeError, which the
-        _handle_tools_call catch-all turned into an opaque isError result.
-        """
-        mock_table.get_item.return_value = {}
-        mock_table.query.return_value = {"Items": []}
-
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary({"days": "abc"}, {})[0]["text"])
-        assert payload["period_days"] == 7
-
-    def test_resolve_days_helper(self):
-        """Unit-test the coercion/clamping helper across its cases."""
-        from mcp_handler import _resolve_days
-
-        assert _resolve_days(None) == 7        # missing → default
-        assert _resolve_days(1) == 1
-        assert _resolve_days(30) == 30
-        assert _resolve_days(999) == 30        # clamped down
-        assert _resolve_days(0) == 1           # clamped up
-        assert _resolve_days(-5) == 1
-        assert _resolve_days("14") == 14       # numeric string coerced
-        assert _resolve_days("abc") == 7       # non-numeric → default
-        assert _resolve_days([1]) == 7         # wrong type → default
-
-    def test_resolve_days_falls_back_on_infinity(self):
-        """An infinite `days` falls back rather than raising.
-
-        `int(float('inf'))` raises **OverflowError**, which is neither TypeError
-        nor ValueError, so it was not caught: the documented "falls back rather
-        than raising" contract did not hold for infinities.  This is reachable
-        from a plain JSON body — `json` parses both `1e400` and the non-standard
-        `Infinity` literal to `inf` — so the value arrives without the caller
-        doing anything exotic.  `float('nan')` raises ValueError and was already
-        covered; asserted here so the two stay distinguished.
-        """
-        from mcp_handler import _resolve_days
-
-        assert _resolve_days(float("inf")) == 7, "+inf must fall back, not raise"
-        assert _resolve_days(float("-inf")) == 7, "-inf must fall back, not raise"
-        assert _resolve_days(float("nan")) == 7  # ValueError path, already covered
-
-    def test_resolve_days_rejects_values_the_schema_forbids(self):
-        """`days` values that are not integers per the tool's own inputSchema.
-
-        `inputSchema` declares "integer", and JSON Schema counts neither a bool
-        nor a fractional number as one — but Python does: `int(True) == 1` and
-        `int(2.9) == 2`.  Coercing those answers a window the caller never asked
-        for, so they fall back to the default instead.  An integral float (2.0)
-        *is* an integer by the schema and is still accepted.
-        """
-        from mcp_handler import _resolve_days
-
-        assert _resolve_days(True) == 7, "days=true is not an integer window of 1"
-        assert _resolve_days(False) == 7
-        assert _resolve_days(2.9) == 7, "a fractional days must not truncate to 2"
-        assert _resolve_days(0.5) == 7
-        assert _resolve_days(2.0) == 2, "an integral float is an integer per JSON Schema"
-        # The tolerated case, kept deliberately: "14" can only mean 14.
-        assert _resolve_days("14") == 14
-
-    @patch("mcp_handler.aggregates_table")
-    def test_json_parsed_infinity_reports_the_default_window(self, mock_table):
-        """End-to-end from a real JSON body: `{"days": 1e400}` reports 7.
-
-        Built by parsing JSON rather than passing `float('inf')` directly, so the
-        test pins the path an actual client takes: `json` widens 1e400 to `inf`,
-        `int(inf)` raises OverflowError, and without that in the except tuple the
-        fault reached the _handle_tools_call catch-all and came back as an opaque
-        isError result instead of the documented 7-day default.
-        """
-        mock_table.get_item.return_value = {}
-        mock_table.query.return_value = {"Items": []}
-
-        args = json.loads('{"days": 1e400}')
-        assert args["days"] == float("inf"), "json must widen 1e400 to inf for this test to bite"
-
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary(args, {})[0]["text"])
-        assert payload["period_days"] == 7, (
-            f"days=1e400 must report the default window, got {payload['period_days']!r}"
-        )
-
-    @patch("mcp_handler.aggregates_table", None)
-    def test_bool_days_reported_as_the_default_window(self):
-        """The rejection is visible end-to-end: period_days echoes 7, not 1."""
-        from mcp_handler import _tool_get_metrics_summary
-        payload = json.loads(_tool_get_metrics_summary({"days": True}, {})[0]["text"])
-        assert payload["period_days"] == 7, (
-            f"days=true must report the default window, got {payload['period_days']!r}"
-        )
+#
+# `TestPartialResultReporting` (17 tests) tested `get_metrics_summary`'s
+# hand-rolled aggregation: a per-read try/except that reported `is_partial` when
+# a DynamoDB read failed, plus `_resolve_days`, which coerced and clamped the
+# window before that aggregation ran.
+#
+# Both are gone because the behaviour they tested is gone, not because the tests
+# became inconvenient:
+#
+#   • The tool no longer reads DynamoDB, so there are no per-read failures to
+#     degrade. `GET /metrics/summary` either answers or fails, and a failure is
+#     now reported as a JSON-RPC error rather than as a plausible-looking answer
+#     with a flag on it. `test_a_route_server_error_is_a_protocol_error` in
+#     test_mcp_delegation.py is the replacement invariant, and it is the stronger
+#     one: a silently under-reported total was the failure mode worth removing.
+#
+#   • `_resolve_days` is deleted. The window is bounded by the route's own
+#     `validate_days`, which — unlike the hand-rolled clamp — is a validator the
+#     whole API shares and is documented never to raise. Its non-finite and
+#     non-numeric cases are pinned in lambda/shared/test/test_api.py
+#     (`test_returns_default_for_a_non_finite_float_instead_of_raising`), so that
+#     coverage moved rather than disappeared.
+#
+#     ⚠️ ONE case genuinely changes behaviour, recorded here rather than glossed:
+#     `{"days": true}`. `_resolve_days` refused a bool and reported the 7-day
+#     default, on the reasoning that JSON Schema does not count `true` as an
+#     integer. `validate_int` COERCES it (`test_a_bool_is_coerced_rather_than_
+#     refused`), so the window becomes 1 day. The house-wide validator wins on
+#     purpose: a client sending `true` for a field its own inputSchema declares
+#     as an integer is already outside the contract, and having one endpoint in
+#     the API treat that input differently from the other forty is a worse
+#     property than either answer. Server 2.0.0 is where that is allowed to
+#     change.
+#
+# The route's own `is_partial` means something different — "the scan truncated"
+# — and is passed through untouched, which
+# `test_a_pass_through_tool_does_not_reshape_the_route_payload` pins.
 
 
 # ===========================================================================
@@ -1154,7 +904,7 @@ class TestSecretHashTypeSafety:
     """_authenticate must not raise when the stored secret_hash is not a str."""
 
     @pytest.mark.parametrize("bad_hash", [
-        pytest.param(Decimal("12345"), id="Decimal"),
+        pytest.param(Decimal(12345), id="Decimal"),
         pytest.param(b"binary_bytes", id="bytes"),
         pytest.param(None, id="None"),
         pytest.param(["a"], id="list"),
@@ -1182,7 +932,7 @@ class TestSecretHashTypeSafety:
         it safe to log.
         """
         from decimal import Decimal
-        mock_table.query.return_value = {"Items": [_token_row(secret_hash=Decimal("99"))]}
+        mock_table.query.return_value = {"Items": [_token_row(secret_hash=Decimal(99))]}
 
         from mcp_handler import _authenticate
         with patch("mcp_handler.logger") as mock_logger:
@@ -1985,61 +1735,68 @@ class TestProjectsTableUsageMatchesNarrowGrant:
         "transact_get_items", "transact_write_items",
     )
 
-    def test_every_tool_stays_within_the_granted_actions(self, lambda_context):
+    def test_every_tool_touches_the_table_only_to_authenticate(self, lambda_context):
         """Drive each registered tool end to end against the strict mock.
 
+        The invariant STRENGTHENED when the tools started delegating, and this
+        is where that shows: the expected projects-table Query count is now
+        exactly ONE for every tool — the credential lookup — where get_project
+        and list_personas used to pay a second for their own read. Nothing this
+        function does reaches a PROJECT#... row any more, which is precisely
+        what lets the CDK grant carry a `dynamodb:LeadingKeys` condition
+        naming only the token partition. A tool that went back to reading
+        directly would still work in production today, and fail here.
+
         The verdict is read off the MOCK, not the response body: a violation
-        raised inside a tool is caught by _handle_tools_call's broad except
-        and could be rephrased into any message, so a body-text assertion
-        would go vacuous the day that message changes.  A positive control
-        asserts the loop actually reached the table at all.
+        raised inside a tool is caught by _handle_tools_call's except clauses
+        and could be rephrased into any message, so a body-text assertion would
+        go vacuous the day that message changes.
         """
         import mcp_handler
         strict = self._strict_table()
-        args_for = {"get_feedback_detail": {"feedback_id": "fb-1"}}
-        # PER-TOOL positive control: every call pays one auth Query, and the
-        # two projects-table tools pay exactly one more.  An aggregate count
-        # could not tell "every tool reached the table" from "auth queried N
-        # times"; an exact per-tool delta can, so a tool that starts
-        # validating its way past DynamoDB fails here by name.
-        expected_query_delta = {
-            "get_project": 2,
-            "list_personas": 2,
+        args_for = {
+            "get_feedback_detail": {"feedback_id": "fb-1"},
+            "get_metrics_breakdown": {"dimension": "categories"},
         }
         with patch("mcp_handler.projects_table", strict), \
-             patch("mcp_handler.feedback_table"), \
-             patch("mcp_handler.aggregates_table"), \
-             patch("mcp_handler.query_feedback_by_date", return_value=[]):
+             patch("shared.mcp_delegate.get_lambda_client", return_value=_stub_domain_client()), \
+             patch.dict(os.environ, {"METRICS_FUNCTION": "m", "PROJECTS_FUNCTION": "p"}):
             for tool_name in mcp_handler.TOOL_HANDLERS:
                 before = strict.query.call_count
                 self._call_tool(tool_name, args_for.get(tool_name, {}), lambda_context)
                 delta = strict.query.call_count - before
-                assert delta == expected_query_delta.get(tool_name, 1), (
-                    f"{tool_name}: expected "
-                    f"{expected_query_delta.get(tool_name, 1)} projects-table "
-                    f"queries (auth[, tool read]), saw {delta} — the strict-mock "
-                    f"assertions below no longer cover what this tool does"
+                assert delta == 1, (
+                    f"{tool_name}: expected exactly 1 projects-table query (the "
+                    f"credential lookup), saw {delta}. A tool reading the table "
+                    f"itself is what the LeadingKeys condition in api-stack.ts now "
+                    f"forbids at deploy time — it would AccessDenied in production."
                 )
         for method in self.FORBIDDEN:
             getattr(strict, method).assert_not_called()
 
-    def test_autoseed_stays_within_the_granted_actions(self, lambda_context):
-        """Drive the REAL autoseed path — the most plausible write site.
+    def test_autoseed_reads_no_project_rows_in_this_process(self, lambda_context):
+        """Autoseed was the last in-process reader of project artifacts.
 
-        Nothing is patched away: the route runs projects.autoseed_project,
-        which runs projects.get_project, against a strict data table patched
-        at projects.projects_table (auth uses its own strict table on
-        mcp_handler.projects_table).  The verdict is read off both mocks.
+        It now delegates to `GET /projects/{id}/autoseed`, so `projects.py`'s own
+        table handle must never be touched from this Lambda at all — not even a
+        Query. That is a stronger claim than "it stayed within Query+UpdateItem",
+        and it is the one the narrowed IAM grant depends on: with the
+        `LeadingKeys` condition in place, an in-process project read would be
+        refused by IAM rather than merely being untidy.
         """
         import mcp_handler
         import projects as projects_module
         strict_auth = self._strict_table()
         strict_data = self._strict_table()
-        strict_data.query.return_value = {
-            "Items": [{"pk": "PROJECT#proj-1", "sk": "META", "name": "P"}]
-        }
+        # Make even a READ fail: this table must not be consulted at all.
+        strict_data.query.side_effect = AssertionError(
+            "autoseed read the projects table in-process; it must delegate to "
+            "GET /projects/{id}/autoseed instead"
+        )
         with patch("mcp_handler.projects_table", strict_auth), \
-             patch.object(projects_module, "projects_table", strict_data):
+             patch.object(projects_module, "projects_table", strict_data), \
+             patch("shared.mcp_delegate.get_lambda_client", return_value=_stub_domain_client()), \
+             patch.dict(os.environ, {"PROJECTS_FUNCTION": "voc-projects-api"}):
             response = mcp_handler.lambda_handler(
                 {
                     "httpMethod": "GET",
@@ -2049,8 +1806,10 @@ class TestProjectsTableUsageMatchesNarrowGrant:
                 lambda_context,
             )
         assert response["statusCode"] == 200, response["body"]
-        # Positive control first: the real get_project read the data table.
-        strict_data.query.assert_called_once()
+        strict_data.query.assert_not_called()
+        # Positive control: the credential lookup still happened, so this test
+        # is exercising the route rather than being refused before it.
+        strict_auth.query.assert_called_once()
         for method in self.FORBIDDEN:
             getattr(strict_data, method).assert_not_called()
             getattr(strict_auth, method).assert_not_called()
@@ -2240,7 +1999,7 @@ class TestReadReachEnforcement:
 
     def _call(self, tool, token_info, arguments=None):
         import mcp_handler
-        handler = MagicMock(return_value=[{"type": "text", "text": "ok"}])
+        handler = MagicMock(return_value=_ok_result())
         original = mcp_handler.TOOL_HANDLERS.copy()
         try:
             mcp_handler.TOOL_HANDLERS[tool] = handler
@@ -2426,9 +2185,25 @@ class TestAutoseedAuthorization:
     """
 
     def _get(self, project_id, row, lambda_context):
+        """Drive the autoseed route, stubbing the DELEGATED call.
+
+        `seed` is now the Lambda invoke rather than an in-process
+        `autoseed_project`, which makes these assertions stronger than they were:
+        `seed.assert_not_called()` used to mean "the helper did not run", and now
+        means "nothing was asked of the projects function at all" — the refusal
+        happens before this function spends anyone else's permissions.
+        """
         import mcp_handler
+        seed = MagicMock(return_value={
+            "Payload": io.BytesIO(json.dumps({
+                "statusCode": 200, "body": json.dumps({"ok": True}),
+            }).encode()),
+        })
+        client = MagicMock()
+        client.invoke = seed
         with patch("mcp_handler.projects_table") as mock_table, \
-             patch("mcp_handler.autoseed_project", return_value={"ok": True}) as seed:
+             patch("shared.mcp_delegate.get_lambda_client", return_value=client), \
+             patch.dict(os.environ, {"PROJECTS_FUNCTION": "voc-projects-api"}):
             mock_table.query.return_value = {"Items": [row]}
             mock_table.update_item.return_value = {}
             response = mcp_handler.lambda_handler(
@@ -2471,3 +2246,152 @@ class TestAutoseedAuthorization:
         response, seed = self._get(_TOKEN_PROJECT, row, lambda_context)
         assert response["statusCode"] == 403, response["body"]
         seed.assert_not_called()
+
+
+# ===========================================================================
+# 12. Claim synthesis — the MCP Lambda as an authorization authority
+# ===========================================================================
+
+class TestClaimSynthesis:
+    """No field of a JSON-RPC request may influence the synthesized identity.
+
+    Delegating makes this function an authorization authority: it tells the
+    domain Lambda who is calling, and that Lambda believes it, because in every
+    other case the claims came from API Gateway's Cognito authorizer. So the
+    identity must derive ONLY from the stored credential.
+
+    The guarantee is STRUCTURAL rather than filtered — `synthetic_claims` takes
+    the token record and nothing else, so the request is not in scope to leak
+    from — and these tests exist because that structure is easy to undo by
+    "helpfully" passing the arguments in later.
+
+    Revert stories:
+      • making synthetic_claims accept the request (or merging `arguments` into
+        the authorizer context) fails test_arguments_cannot_forge_the_subject
+        and test_arguments_cannot_forge_group_membership;
+      • dropping the `mcp:` prefix fails test_the_subject_is_namespaced, which is
+        what stops a token id from colliding with a Cognito sub;
+      • defaulting `cognito:groups` to the minter's groups fails
+        test_no_credential_carries_admin_group, the one that keeps a bearer
+        token off every require_admin route.
+    """
+
+    HOSTILE_ARGUMENTS: ClassVar[dict] = {
+        "sub": "00000000-0000-0000-0000-000000000000",
+        "cognito:groups": "admins",
+        "email": "admin@example.com",
+        "requestContext": {"authorizer": {"claims": {"sub": "impostor",
+                                                     "cognito:groups": "admins"}}},
+        "authorizer": {"claims": {"sub": "impostor"}},
+        "claims": {"sub": "impostor"},
+        "project_id": _TOKEN_PROJECT,
+    }
+
+    def _claims_from_a_delegated_call(self, arguments, row=None, tool="get_project"):
+        """Run a tool and return the claims the domain function was handed."""
+        import mcp_handler
+        client = _stub_domain_client({"project": {"name": "P"}, "personas": [],
+                                      "documents": []})
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_lambda_client", return_value=client), \
+             patch.dict(os.environ, {"METRICS_FUNCTION": "m", "PROJECTS_FUNCTION": "p"}):
+            table.query.return_value = {"Items": [row or _token_row()]}
+            table.update_item.return_value = {}
+            mcp_handler._handle_tools_call(
+                1, {"name": tool, "arguments": arguments}, row or _token_row(),
+            )
+        event = json.loads(client.invoke.call_args.kwargs["Payload"])
+        return event["requestContext"]["authorizer"]["claims"], event
+
+    def test_arguments_cannot_forge_the_subject(self):
+        claims, _event = self._claims_from_a_delegated_call(dict(self.HOSTILE_ARGUMENTS))
+
+        assert claims["sub"] == f"mcp:{_MINTED.token_id}"
+        assert "impostor" not in json.dumps(claims)
+
+    def test_arguments_cannot_forge_group_membership(self):
+        claims, _event = self._claims_from_a_delegated_call(dict(self.HOSTILE_ARGUMENTS))
+
+        assert claims["cognito:groups"] == ""
+
+    def test_arguments_cannot_smuggle_a_whole_request_context(self):
+        """A nested `requestContext` in the arguments must not be merged.
+
+        The synthesized event is BUILT, never merged into, so an argument that
+        happens to be shaped like an authorizer context has nowhere to land.
+        """
+        _claims, event = self._claims_from_a_delegated_call(dict(self.HOSTILE_ARGUMENTS))
+
+        assert set(event["requestContext"]) == {"authorizer", "stage"}
+        assert set(event["requestContext"]["authorizer"]) == {"claims"}
+
+    def test_the_subject_is_namespaced(self):
+        """A service credential can never collide with a Cognito subject.
+
+        Cognito subs are UUIDs; the `mcp:` prefix makes the two sets disjoint by
+        construction, which matters wherever a row is keyed by subject — the same
+        discipline the ballot keys use with `user:` / `anon:`.
+        """
+        from shared.mcp_delegate import SYNTHETIC_SUBJECT_PREFIX, synthetic_claims
+
+        claims = synthetic_claims(_token_row())
+
+        assert claims["sub"].startswith(SYNTHETIC_SUBJECT_PREFIX)
+        assert claims["sub"] == f"mcp:{_MINTED.token_id}"
+
+    def test_no_credential_carries_admin_group(self):
+        """Whatever the row says, the delegated call is not an admin.
+
+        No token record has a groups field to forward — the mint route records
+        `created_by` for provenance only — so an admin-gated route stays refused
+        even if a later phase maps a tool onto one by mistake.
+        """
+        from shared.api import get_caller_groups, require_admin
+        from shared.mcp_delegate import DomainCall, build_proxy_event, synthetic_claims
+
+        row = _token_row(created_by="an-admins-cognito-sub", acting_groups=["admins"])
+        event = build_proxy_event(
+            DomainCall(function_name="f", method="GET", path="/x"),
+            synthetic_claims(row),
+        )
+
+        assert get_caller_groups(event) == []
+        with pytest.raises(Exception, match="Admin"):
+            require_admin(event)
+
+    def test_the_claim_set_is_exactly_what_is_declared(self):
+        """An unconsidered claim cannot arrive unremarked.
+
+        Asserted as an exact set rather than a subset: a claim added here is a
+        statement about identity that the domain functions will act on.
+        """
+        from shared.mcp_delegate import SYNTHETIC_CLAIM_KEYS, synthetic_claims
+
+        assert set(synthetic_claims(_token_row())) == SYNTHETIC_CLAIM_KEYS
+
+    def test_a_row_without_a_token_id_is_refused_rather_than_anonymous(self):
+        """An unattributable credential must not produce a call.
+
+        Falling back to a placeholder subject would attribute an agent's actions
+        to nobody — and in a later phase, its WRITES to nobody.
+        """
+        from shared.mcp_delegate import DelegationUnavailable, synthetic_claims
+
+        row = _token_row()
+        del row["token_id"]
+
+        with pytest.raises(DelegationUnavailable):
+            synthetic_claims(row)
+
+    def test_the_synthesized_identity_is_what_the_route_reads(self):
+        """End to end through the helper the domain handlers actually use.
+
+        Asserting the dict shape alone would pass even if the nesting were wrong;
+        `get_caller_subject` is the function every project route calls, and it
+        raises when the claim is absent.
+        """
+        from shared.api import get_caller_subject
+
+        _claims, event = self._claims_from_a_delegated_call({"project_id": _TOKEN_PROJECT})
+
+        assert get_caller_subject(event) == f"mcp:{_MINTED.token_id}"

--- a/voc-datalake/lambda/shared/mcp_delegate.py
+++ b/voc-datalake/lambda/shared/mcp_delegate.py
@@ -29,10 +29,46 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Final
 
+import boto3
 from botocore import exceptions as botocore_exceptions
+from botocore.config import Config
 
-from shared.aws import get_lambda_client
 from shared.logging import logger
+
+# A DEDICATED Lambda client, not shared.aws.get_lambda_client().
+#
+# That shared client exists for fire-and-forget `InvocationType='Event'` calls
+# and carries botocore's defaults: a 60-second read timeout and up to three
+# attempts. Both are wrong for a nested synchronous invoke:
+#
+#   • the MCP adapter's own Lambda timeout is 30 s, so a 60-second read timeout
+#     can never fire first — a slow domain call ends as the ADAPTER timing out,
+#     which returns no JSON-RPC envelope at all instead of the -32603 this
+#     module's error taxonomy promises;
+#   • retries on RequestResponse re-run the work. Harmless for today's GETs, and
+#     not harmless at all for the write tools Phase 3 adds — an idempotency key
+#     is the fix for that, and until it exists, not retrying is the honest
+#     default.
+#
+# 20 s leaves the adapter ~10 s to serialize a refusal and answer, and sits
+# under API Gateway's 29 s ceiling on the outer request either way.
+_DELEGATE_READ_TIMEOUT_SECONDS: Final = 20
+_DELEGATE_CONNECT_TIMEOUT_SECONDS: Final = 3
+
+_lambda_client = None
+
+
+def get_delegate_lambda_client():
+    """The Lambda client used for delegated invokes, created once per container."""
+    global _lambda_client
+    if _lambda_client is None:
+        _lambda_client = boto3.client('lambda', config=Config(
+            read_timeout=_DELEGATE_READ_TIMEOUT_SECONDS,
+            connect_timeout=_DELEGATE_CONNECT_TIMEOUT_SECONDS,
+            retries={'max_attempts': 1, 'mode': 'standard'},
+        ))
+    return _lambda_client
+
 
 # The synthetic subject namespace. A service credential's subject can never
 # collide with a Cognito `sub` (a UUID) because of this prefix — the same
@@ -121,10 +157,16 @@ def synthetic_claims(token_info: Mapping[str, Any]) -> dict[str, str]:
     return {
         'sub': f'{SYNTHETIC_SUBJECT_PREFIX}{token_id}',
         'cognito:groups': '',
-        # Not a mailbox. The routes that read an email use it as a display
-        # label, and a service credential has no human address — so it names the
-        # credential instead of borrowing its minter's identity, which would
-        # attribute the agent's actions to a person who did not perform them.
+        # Not a mailbox, and deliberately not the minter's. The routes that read
+        # an email use it as a display label, and a service credential has no
+        # human address — borrowing its minter's would attribute the agent's
+        # actions to a person who did not perform them.
+        #
+        # ⚠️ Phase 3 hazard: this value is not RFC-5322 shaped, so any route that
+        # VALIDATES the claim as an email (rather than displaying it) will refuse
+        # a delegated call. No route does today. The fix when one appears is a
+        # routable no-reply address that still names the credential, e.g.
+        # `mcp+{token_id}@<domain>`, not relaxing the validation.
         'email': f'{SYNTHETIC_SUBJECT_PREFIX}{token_id}',
     }
 
@@ -196,7 +238,7 @@ def call_domain(call: DomainCall, *, claims: Mapping[str, str]) -> DomainResult:
 
     event = build_proxy_event(call, claims)
     try:
-        response = get_lambda_client().invoke(
+        response = get_delegate_lambda_client().invoke(
             FunctionName=call.function_name,
             InvocationType='RequestResponse',
             Payload=json.dumps(event),

--- a/voc-datalake/lambda/shared/mcp_delegate.py
+++ b/voc-datalake/lambda/shared/mcp_delegate.py
@@ -1,0 +1,248 @@
+"""Delegation from the MCP adapter to the domain API Lambdas.
+
+The MCP Lambda does not read the data lake. It validates a credential, resolves
+a scope, and then calls the domain function that already owns the route — so
+every route's validation bounds, its error mapping, and its least-privilege role
+are reused rather than restated. When a route gains a validated field, MCP gets
+it for free.
+
+Why this is not "an extra hop for nothing": a single Lambda holding the union of
+every domain's permissions inverts the domain-isolation pattern this repo
+mandates (see the 20 KB role-policy ceiling in the coding standards) and marches
+toward that ceiling with no synth-time warning. It also removes a whole class of
+drift — an in-process tool is a SECOND implementation of a route, and one of
+them had already diverged: the old `get_project` tool recognised 2 of the 6
+document sort-key prefixes, so an MCP client silently saw a third of a project's
+documents and was told nothing was filtered.
+
+There is deliberately no general `invoke_lambda_sync` sibling next to
+`shared.aws.invoke_lambda_async`. What this module needs is not "invoke a
+Lambda" but "invoke a Lambda PROXY HANDLER and decode a proxy response", which
+is a narrower contract than a general helper would advertise. One caller, one
+shape, stated here.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+from botocore import exceptions as botocore_exceptions
+
+from shared.aws import get_lambda_client
+from shared.logging import logger
+
+# The synthetic subject namespace. A service credential's subject can never
+# collide with a Cognito `sub` (a UUID) because of this prefix — the same
+# key-kind discipline the ballot keys use (`user:` / `anon:`). Without it, a
+# token id could in principle be minted to look like somebody's subject, and
+# every downstream row keyed by subject would merge the two identities.
+SYNTHETIC_SUBJECT_PREFIX: Final = 'mcp:'
+
+# Every claim the synthesized authorizer context carries. Named as a frozenset
+# so the claim-synthesis test can assert the set is EXACTLY this — a claim
+# nobody considered cannot arrive unremarked.
+SYNTHETIC_CLAIM_KEYS: Final[frozenset[str]] = frozenset({'sub', 'cognito:groups', 'email'})
+
+
+class DelegationUnavailable(Exception):
+    """The domain function was never successfully consulted.
+
+    Raised for a transport fault, an unhandled exception inside the domain
+    function, or a response this module cannot decode. Callers must answer with
+    a server error: the tool call did not fail, it never completed, and telling
+    a model "no results" for an infrastructure fault teaches it the wrong thing.
+    """
+
+
+@dataclass(frozen=True)
+class DomainCall:
+    """One route call, as the static per-tool mapping describes it.
+
+    `path` is the route path WITHOUT the stage prefix, which is what API Gateway
+    puts in `event['path']` for a proxy integration and what the Powertools
+    resolver routes on. `query` values are stringified on the way out because
+    API Gateway only ever delivers strings, and the routes' validators
+    (`validate_days`, `validate_limit`, …) are written against that.
+    """
+
+    function_name: str
+    method: str
+    path: str
+    path_parameters: dict[str, str] = field(default_factory=dict)
+    query: dict[str, Any] = field(default_factory=dict)
+    body: dict | None = None
+
+
+@dataclass(frozen=True)
+class DomainResult:
+    """A decoded proxy response: the route's own status code and parsed body."""
+
+    status_code: int
+    payload: Any
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 300
+
+
+def synthetic_claims(token_info: Mapping[str, Any]) -> dict[str, str]:
+    """Build the authorizer claims for a delegated call, from the token record.
+
+    ⚠️ This is the security hinge of the whole adapter: synthesizing claims
+    makes the MCP Lambda an authorization authority, so the rule is that claims
+    derive ONLY from the stored credential.
+
+    That rule is enforced STRUCTURALLY rather than by careful filtering — this
+    function takes the token record and nothing else. It never sees the JSON-RPC
+    request, so no field of the request can reach a claim: not an argument named
+    `sub`, not a nested `requestContext`, not a `cognito:groups` in the tool
+    arguments. A filtering implementation would have to enumerate what to strip
+    and would be wrong the first time somebody added a field; this one cannot be
+    wrong because the data is not in scope. `test_mcp_security.py` pins it with
+    a request that tries.
+
+    `cognito:groups` is ALWAYS empty, and that is a decision rather than a
+    placeholder. No token record carries a group — the mint route records
+    `created_by` for provenance and nothing else — so there is no group to
+    forward, and inventing one would hand a bearer credential the admin surface.
+    Empty means `shared.api.get_caller_groups` returns `[]` and `require_admin`
+    refuses, so an admin-gated route stays refused even if a future tool is
+    mapped onto one by mistake. Fail-closed by construction, not by review.
+    """
+    token_id = token_info.get('token_id')
+    if not isinstance(token_id, str) or not token_id:
+        # A row without a token id cannot be attributed to anything. Refusing
+        # is the only honest answer: the alternative is a delegated write (in a
+        # later phase) landing under a subject nobody can trace.
+        raise DelegationUnavailable('token record has no usable token_id')
+    return {
+        'sub': f'{SYNTHETIC_SUBJECT_PREFIX}{token_id}',
+        'cognito:groups': '',
+        # Not a mailbox. The routes that read an email use it as a display
+        # label, and a service credential has no human address — so it names the
+        # credential instead of borrowing its minter's identity, which would
+        # attribute the agent's actions to a person who did not perform them.
+        'email': f'{SYNTHETIC_SUBJECT_PREFIX}{token_id}',
+    }
+
+
+def build_proxy_event(call: DomainCall, claims: Mapping[str, str]) -> dict:
+    """Synthesize the API Gateway v1 proxy event for a delegated route call.
+
+    Mirrors the shape the `api_gateway_event` test fixture builds, which is the
+    shape every one of these handlers is already tested against.
+
+    Note what is NOT forwarded: no `Authorization` header (the domain function
+    must never see the MCP credential — it has no use for it and forwarding a
+    secret past its audience is how secrets leak into logs), and no
+    `Accept-Encoding` (Powertools would be entitled to gzip the response body,
+    and this module decodes plain JSON).
+    """
+    query = {
+        key: _stringify(value)
+        for key, value in (call.query or {}).items()
+        if value is not None
+    }
+    return {
+        'httpMethod': call.method,
+        'path': call.path,
+        # `resource` is the templated form. The Powertools resolver routes on
+        # `path`, so this is for fidelity and for anything that logs the route
+        # shape rather than the concrete path.
+        'resource': call.path,
+        'queryStringParameters': query or None,
+        'pathParameters': dict(call.path_parameters) if call.path_parameters else None,
+        'body': json.dumps(call.body) if call.body is not None else None,
+        'headers': {'Content-Type': 'application/json'},
+        'requestContext': {
+            # The claims are placed here and nowhere else, and they are the
+            # argument — this function does not build them (see synthetic_claims).
+            'authorizer': {'claims': dict(claims)},
+            'stage': 'v1',
+        },
+        'isBase64Encoded': False,
+    }
+
+
+def _stringify(value: Any) -> str:
+    """Render a query-parameter value the way API Gateway would deliver it.
+
+    Booleans need naming explicitly: `str(True)` is `'True'`, which no route's
+    boolean validator accepts, and several of those validators are STRICT on
+    purpose (a coerced `"false"` must not be able to authorize a billed image
+    generation). Lowercasing here keeps a bool round-tripping as a bool; every
+    other type takes `str`.
+    """
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    return str(value)
+
+
+def call_domain(call: DomainCall, *, claims: Mapping[str, str]) -> DomainResult:
+    """Invoke the owning domain function and decode its proxy response.
+
+    Raises:
+        DelegationUnavailable: transport fault, an unhandled exception inside
+            the domain function, or an undecodable response. A 4xx or 5xx that
+            the ROUTE itself produced is not an error here — it is returned as a
+            `DomainResult` so the caller can map it (a route's 404 is a fact the
+            model should hear, not an infrastructure failure).
+    """
+    if not call.function_name:
+        raise DelegationUnavailable(f'no function configured for {call.method} {call.path}')
+
+    event = build_proxy_event(call, claims)
+    try:
+        response = get_lambda_client().invoke(
+            FunctionName=call.function_name,
+            InvocationType='RequestResponse',
+            Payload=json.dumps(event),
+        )
+    except (botocore_exceptions.ClientError, botocore_exceptions.BotoCoreError) as exc:
+        # Deliberately NOT split into retryable/permanent the way the token
+        # lookup is. There the distinction changes the ANSWER (401 vs 500);
+        # here every outcome is the same server error, so classifying would be
+        # a taxonomy with no consumer. The route path is logged, never the body.
+        logger.exception(
+            'Domain invoke failed',
+            extra={'route': f'{call.method} {call.path}', 'error_type': type(exc).__name__},
+        )
+        raise DelegationUnavailable(type(exc).__name__) from exc
+
+    # An unhandled exception inside the domain function. The payload holds its
+    # stack trace, which must not reach an MCP client — it is a server fault,
+    # and the trace is for CloudWatch.
+    if response.get('FunctionError'):
+        logger.error(
+            'Domain function raised',
+            extra={'route': f'{call.method} {call.path}',
+                   'function_error': response.get('FunctionError')},
+        )
+        raise DelegationUnavailable('domain function raised')
+
+    try:
+        payload = json.loads(response['Payload'].read())
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as exc:
+        raise DelegationUnavailable('domain response was not JSON') from exc
+
+    if not isinstance(payload, dict) or 'statusCode' not in payload:
+        raise DelegationUnavailable('domain response was not a proxy response')
+
+    status_code = payload.get('statusCode')
+    if not isinstance(status_code, int):
+        raise DelegationUnavailable('domain response had no integer statusCode')
+
+    raw_body = payload.get('body')
+    if raw_body is None or raw_body == '':
+        return DomainResult(status_code=status_code, payload=None)
+    try:
+        body = json.loads(raw_body)
+    except (json.JSONDecodeError, TypeError):
+        # A non-JSON body from a JSON API is a fault, but the status code is
+        # still informative, so it is passed through as text rather than
+        # raising — the caller decides whether the status makes it usable.
+        body = raw_body
+    return DomainResult(status_code=status_code, payload=body)

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -21,7 +21,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
@@ -945,8 +945,11 @@ describe('lambda role policies stay under the IAM size limit', () => {
     }),
   });
 
-  /** Non-whitespace characters, which is how IAM counts a policy. */
-  const size = (document: unknown) => JSON.stringify(document).replace(/\s/g, '').length;
+  // `JSON.stringify` emits no structural whitespace, so a `replace(/\s/g,'')`
+  // here could only ever strip whitespace INSIDE string values — Sids, condition
+  // values, ARNs with spaces — which IAM does count. Measuring the serialized
+  // length directly is both simpler and closer to the quota.
+  const size = (document: unknown) => JSON.stringify(document).length;
 
   function policies(): { id: string; kind: string; chars: number; limit: number }[] {
     const template = apiTemplate();
@@ -978,23 +981,69 @@ describe('lambda role policies stay under the IAM size limit', () => {
     return measured;
   }
 
+  // Measured once: each call walks the whole synthesized template.
+  let measured: ReturnType<typeof policies>;
+  beforeAll(() => { measured = policies(); });
+
   it('measures every policy shape the stack can produce', () => {
     // Vacuity guard, and it names the shapes so a future one is a deliberate add.
-    const kinds = new Set(policies().map((p) => p.kind));
-    expect(policies().length).toBeGreaterThan(0);
-    expect(kinds.has('inline'), 'no AWS::IAM::Policy measured — has the filter drifted?').toBe(true);
+    expect(measured.length).toBeGreaterThan(0);
+    expect(new Set(measured.map((p) => p.kind)).has('inline'),
+      'no AWS::IAM::Policy measured — has the filter drifted?').toBe(true);
   });
 
   it('keeps every policy under its IAM quota', () => {
-    const over = policies().filter((p) => p.chars >= p.limit);
-    expect(over, 'policies at or over their IAM character quota').toEqual([]);
+    expect(measured.filter((p) => p.chars >= p.limit),
+      'policies at or over their IAM character quota').toEqual([]);
   });
 
   it('keeps every policy under 70% of its quota', () => {
     // If this fails, the answer is a new domain Lambda, not a bigger threshold.
     // Raising the fraction here is how the ceiling gets hit for real.
-    const near = policies().filter((p) => p.chars >= p.limit * WARN_FRACTION);
-    expect(near, 'policies past 70% of their IAM quota — split the domain instead').toEqual([]);
+    expect(measured.filter((p) => p.chars >= p.limit * WARN_FRACTION),
+      'policies past 70% of their IAM quota — split the domain instead').toEqual([]);
+  });
+});
+
+describe('the delegation timeout budget', () => {
+  // The adapter gives up on a domain call before its OWN Lambda timeout, so a
+  // slow route produces a -32603 rather than a Lambda timeout with no JSON-RPC
+  // envelope at all. That ordering is the invariant worth pinning, and nothing
+  // else notices if it inverts.
+  const readTimeout = () => {
+    const source = readRepoFile('lambda', 'shared', 'mcp_delegate.py');
+    const seconds = source.match(/_DELEGATE_READ_TIMEOUT_SECONDS:\s*Final\s*=\s*(\d+)/)?.[1];
+    expect(seconds, 'could not read _DELEGATE_READ_TIMEOUT_SECONDS').toBeDefined();
+    return Number(seconds);
+  };
+
+  const FunctionSchema = z.object({
+    Properties: z.object({ Handler: z.string().optional(), Timeout: z.number().optional() }),
+  });
+  const functionByHandler = (handler: string) =>
+    Object.values(apiTemplate().findResources('AWS::Lambda::Function'))
+      .map((fn) => FunctionSchema.parse(fn).Properties)
+      .find((p) => p.Handler === handler);
+
+  it('gives the adapter time to answer after it stops waiting', () => {
+    const adapter = functionByHandler('mcp_handler.lambda_handler');
+    expect(adapter, 'no Lambda with the mcp_handler entry point').toBeDefined();
+    expect(readTimeout()).toBeLessThan(adapter?.Timeout ?? 0);
+  });
+
+  it('does not require the callees to finish sooner than the adapter waits', () => {
+    // Deliberately NOT asserted the other way round, which a review suggested.
+    // The metrics and projects functions serve the browser too, where 30 s is the
+    // right budget, and API Gateway caps the OUTER request at 29 s regardless —
+    // so a delegated call that ran longer than the adapter's patience was never
+    // going to be delivered. The callee may still be running when the adapter
+    // gives up; that is inherent to a timeout, and it is why retries are off.
+    // This test records the relationship so the asymmetry reads as chosen.
+    for (const handler of ['metrics_handler.lambda_handler', 'projects_handler.lambda_handler']) {
+      const fn = functionByHandler(handler);
+      expect(fn, `${handler} is not in the template`).toBeDefined();
+      expect(fn?.Timeout, `${handler} timeout`).toBeGreaterThanOrEqual(readTimeout());
+    }
   });
 });
 

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -698,8 +698,9 @@ describe('mcp Lambda IAM grants', () => {
   const StatementSchema = z.object({
     Action: z.union([z.string(), z.array(z.string())]),
     Resource: z.unknown(),
+    Condition: z.unknown().optional(),
   });
-  function mcpStatements(): { actions: string[]; resource: string }[] {
+  function mcpStatements(): { actions: string[]; resource: string; condition: unknown }[] {
     const policies = apiTemplate().findResources('AWS::IAM::Policy');
     const policy = Object.entries(policies).find(([id]) => id.includes('McpLambdaRole'));
     expect(policy, 'no IAM policy found for McpLambdaRole').toBeDefined();
@@ -709,15 +710,15 @@ describe('mcp Lambda IAM grants', () => {
       .map((s) => ({
         actions: Array.isArray(s.Action) ? s.Action : [s.Action],
         resource: JSON.stringify(s.Resource),
+        condition: s.Condition,
       }));
   }
   it('holds exactly Query and UpdateItem on the projects table', () => {
     // Asserted as an exact SET rather than an absence list, so an action nobody
-    // considered cannot arrive unremarked. Query is the token lookup plus the
-    // get_project/list_personas tools; UpdateItem is last_used_at and nothing
-    // else. PutItem, DeleteItem, Scan and the batch APIs are the point of this
-    // test: their absence is what makes the bearer-token surface read-only
-    // against project artifacts.
+    // considered cannot arrive unremarked. Query is the token lookup;
+    // UpdateItem is last_used_at and nothing else. PutItem, DeleteItem, Scan and
+    // the batch APIs are the point of this test: their absence is what makes the
+    // bearer-token surface read-only against project artifacts.
     const projectsStatements = mcpStatements().filter((s) => s.resource.includes('Projects'));
     // Guard the filter itself: it string-matches the table's logical id, so a
     // construct rename would make it match NOTHING and turn the exact-set
@@ -730,6 +731,59 @@ describe('mcp Lambda IAM grants', () => {
     );
     expect([...granted].sort()).toEqual(['dynamodb:Query', 'dynamodb:UpdateItem']);
   });
+  it('confines those two actions to the token partition', () => {
+    // The adapter reads DynamoDB for exactly one reason — to look up the
+    // credential — so the grant says so with a condition rather than trusting the
+    // code to stay well behaved. Without it, Query on the table is Query on every
+    // PROJECT#... row, i.e. every persona, PRD, PR/FAQ and prototype, from the one
+    // function reachable with a bearer token instead of a Cognito session.
+    //
+    // `ForAllValues:` is load-bearing, not stylistic: LeadingKeys is multi-valued,
+    // and plain StringEquals does not constrain a request presenting several keys.
+    const partitionValue = readRepoFile('lambda', 'shared', 'mcp_tokens.py')
+      .match(/MCP_TOKEN_PK:\s*Final\s*=\s*'([^']+)'/)?.[1];
+    expect(partitionValue, 'could not read MCP_TOKEN_PK from mcp_tokens.py').toBeDefined();
+
+    const dynamoStatements = mcpStatements()
+      .filter((s) => s.actions.some((a) => a.startsWith('dynamodb:')));
+    expect(dynamoStatements.length, 'no DynamoDB statement on the MCP role').toBeGreaterThan(0);
+    for (const statement of dynamoStatements) {
+      expect(statement.condition, `unconditional DynamoDB grant: ${statement.actions}`).toEqual({
+        'ForAllValues:StringEquals': { 'dynamodb:LeadingKeys': [partitionValue] },
+      });
+    }
+  });
+  it('holds no grant at all on the feedback or aggregates tables', () => {
+    // The adapter delegates every tool to the function that already owns the
+    // route, so it has no business reading the corpus or the aggregates. These
+    // grants existed for the in-process tools; leaving them behind would keep the
+    // permission alive after the code that needed it was deleted.
+    const reachable = mcpStatements()
+      .filter((s) => s.actions.some((a) => a.startsWith('dynamodb:')))
+      .map((s) => s.resource);
+    expect(reachable.filter((r) => r.includes('Feedback'))).toEqual([]);
+    expect(reachable.filter((r) => r.includes('Aggregates'))).toEqual([]);
+  });
+  it('may invoke exactly the domain functions it delegates to', () => {
+    // An exact set again: `lambda:InvokeFunction` is how this role now reaches
+    // data, so the list of what it may invoke IS its data-access surface. A
+    // wildcard here would hand the bearer-token surface every function in the
+    // account, including the job runners that spend money.
+    const invokeStatements = mcpStatements()
+      .filter((s) => s.actions.includes('lambda:InvokeFunction'));
+    expect(invokeStatements.length, 'the MCP role cannot invoke anything').toBe(1);
+
+    const resource = invokeStatements[0].resource;
+    expect(resource).toContain('MetricsApi');
+    expect(resource).toContain('ProjectsApi');
+    // No version/alias wildcard: the adapter invokes unqualified names, so `:*`
+    // would be a grant nothing uses and a cdk-nag IAM5 suppression to carry.
+    expect(resource, 'invoke grant carries a wildcard').not.toContain(':*');
+    // And nothing else. Counted on the serialized resource list so a third
+    // function added silently fails here rather than at review time.
+    const named = (resource.match(/Api[0-9A-F]{8}/g) ?? []).length;
+    expect(named, `expected 2 invoke targets, resource was ${resource}`).toBe(2);
+  });
   it('can still encrypt against the KMS key, which the UpdateItem write needs', () => {
     // The former grantReadWriteData brought KMS Encrypt along implicitly; the
     // narrow table grant does not, so the role needs it explicitly or the
@@ -739,6 +793,164 @@ describe('mcp Lambda IAM grants', () => {
       .filter((a) => a.startsWith('kms:'));
     expect(kmsActions).toContain('kms:Encrypt');
     expect(kmsActions).toContain('kms:Decrypt');
+  });
+});
+
+describe('mcp delegation stays in step with the stack', () => {
+  // The MCP handler registers no @app routes, so the decorator oracle the
+  // feedback-form and ballots checks use finds nothing here. Its equivalent is
+  // DOMAIN_ROUTES: a table of (domain, method, path) that every tool call is
+  // built from. Three things must agree, and nothing at synth time notices when
+  // they stop:
+  //
+  //   1. the route exists in the handler that owns it,
+  //   2. the route is wired in API Gateway (the browser needs it too),
+  //   3. the owning function is one the MCP role may invoke.
+  //
+  // A break in any of them is invisible until a client calls that tool and gets
+  // a 403, an AccessDenied or a silent empty answer.
+  const handlerSource = () => readRepoFile('lambda', 'api', 'mcp_handler.py');
+
+  /** DOMAIN_ROUTES, read from the handler source rather than re-listed here. */
+  function declaredRoutes(): { key: string; domain: string; method: string; path: string }[] {
+    const table = handlerSource().match(/DOMAIN_ROUTES:[^=]*=\s*\{([\s\S]*?)\n\}/)?.[1];
+    expect(table, 'could not find DOMAIN_ROUTES in mcp_handler.py').toBeDefined();
+    const rows = [...(table ?? '').matchAll(
+      /'([a-z_]+)':\s*\(\s*DOMAIN_([A-Z]+),\s*'([A-Z]+)',\s*'([^']+)'\s*\)/g,
+    )];
+    expect(rows.length, 'DOMAIN_ROUTES parsed to nothing').toBeGreaterThan(0);
+    return rows.map(([, key, domain, method, path]) => ({
+      key, domain: domain.toLowerCase(), method, path,
+    }));
+  }
+
+  /** Which Python handler owns each domain, per _DOMAIN_FUNCTION_ENV. */
+  const HANDLER_FOR_DOMAIN: Record<string, string> = {
+    metrics: 'metrics_handler.py',
+    projects: 'projects_handler.py',
+  };
+
+  it('names a domain whose handler file this test knows', () => {
+    // Guards the map above: a new domain added to the handler without a line
+    // here would make the two tests below skip it silently.
+    for (const { key, domain } of declaredRoutes()) {
+      expect(HANDLER_FOR_DOMAIN[domain], `${key} names domain '${domain}', unknown to this test`)
+        .toBeDefined();
+    }
+  });
+
+  it('delegates only to routes the owning handler actually registers', () => {
+    for (const { key, domain, method, path } of declaredRoutes()) {
+      const owner = readRepoFile('lambda', 'api', HANDLER_FOR_DOMAIN[domain]);
+      // Powertools spells path parameters <like_this>; DOMAIN_ROUTES uses
+      // {like_this} because that is what API Gateway and str.format want.
+      const registered = [...owner.matchAll(/@app\.(get|post|put|delete)\(\s*['"]([^'"]+)['"]/g)]
+        .map(([, verb, p]) => `${verb.toUpperCase()} ${p.replace(/<(\w+)>/g, '{$1}')}`);
+      expect(registered, `${key}: ${method} ${path} is not registered in ${HANDLER_FOR_DOMAIN[domain]}`)
+        .toContain(`${method} ${path}`);
+    }
+  });
+
+  it('delegates only to routes API Gateway wires', () => {
+    // A route the handler registers but nobody wires answers 403 Missing
+    // Authentication Token — and via delegation that surfaces as a tool error
+    // with no obvious cause. Proxy resources count: /metrics/{proxy+} serves the
+    // four breakdown paths.
+    //
+    // 🪤 Path-parameter NAMES are normalized away before comparing, and this test
+    // is how that was discovered: the gateway wires `/feedback/{id}` while the
+    // handler registers `<feedback_id>`. Production is fine — Powertools matches
+    // the concrete path positionally and never consults `pathParameters` — so the
+    // shape is the real contract and the names are two independent local choices.
+    // Comparing them literally reports a defect that is not there.
+    const shape = (path: string) => path.replace(/\{[^}]+\}/g, '{}');
+
+    const wired = apiMethods(apiTemplate());
+    const exact = new Set(wired.map((m) => `${m.httpMethod} ${shape(m.path)}`));
+    const proxyPrefixes = wired
+      .filter((m) => m.path.endsWith('/{proxy+}'))
+      .map((m) => m.path.slice(0, -'/{proxy+}'.length));
+
+    for (const { key, method, path } of declaredRoutes()) {
+      const servedExactly = exact.has(`${method} ${shape(path)}`);
+      const servedByProxy = proxyPrefixes.some((prefix) => path.startsWith(`${prefix}/`));
+      expect(servedExactly || servedByProxy, `${key}: ${method} ${path} is wired nowhere`).toBe(true);
+    }
+  });
+
+  it('hands down a function name for every domain it delegates to', () => {
+    // The env keys the handler reads must be the env keys the stack sets.
+    // Rebuilding a function name in Python from account/region would, under a
+    // deploymentPrefix, name a function that does not exist.
+    const envKeys = [...handlerSource().matchAll(/DOMAIN_(?:METRICS|PROJECTS):\s*'([A-Z_]+)'/g)]
+      .map(([, key]) => key);
+    expect(envKeys.length, 'no _DOMAIN_FUNCTION_ENV entries parsed').toBeGreaterThan(0);
+
+    const mcpFn = Object.values(apiTemplate().findResources('AWS::Lambda::Function'))
+      .map((fn) => z.object({
+        Properties: z.object({
+          Handler: z.string().optional(),
+          Environment: z.object({ Variables: z.record(z.string(), z.unknown()) }).optional(),
+        }),
+      }).parse(fn).Properties)
+      .find((p) => p.Handler === 'mcp_handler.lambda_handler');
+    expect(mcpFn, 'no Lambda with the mcp_handler entry point').toBeDefined();
+
+    const variables = mcpFn?.Environment?.Variables ?? {};
+    for (const key of envKeys) {
+      expect(variables, `mcp_handler reads ${key}, which the stack does not set`).toHaveProperty(key);
+    }
+    // The tables the tools no longer read must not be advertised either.
+    expect(variables).not.toHaveProperty('FEEDBACK_TABLE');
+    expect(variables).not.toHaveProperty('AGGREGATES_TABLE');
+  });
+});
+
+describe('lambda role policies stay under the IAM size limit', () => {
+  // AWS caps a managed/inline role policy at 20 KB, and the repo's whole
+  // domain-split Lambda architecture exists because of it — yet nothing measured
+  // it. The failure mode is a deploy-time rejection with no synth warning, which
+  // is exactly the class of fault this suite exists to convert into a test.
+  //
+  // Measured per role on the serialized PolicyDocument. The threshold is a
+  // warning line well under the hard limit: a role at 16 KB is not broken, but it
+  // is one feature away from being, and finding that out at deploy is the thing
+  // worth avoiding. Largest policy in the stack today is ~2 KB, so this is a
+  // guard for the future rather than a live constraint.
+  //
+  // ⚠️ It is an APPROXIMATION, stated so nobody reads it as exact: the template
+  // carries `{"Fn::GetAtt": [...]}` and `{"Fn::ImportValue": ...}` where the
+  // deployed policy carries resolved ARNs, so the two byte counts differ per
+  // statement in both directions. It is the right order of magnitude and it
+  // tracks the thing that actually grows — statement count — which is what makes
+  // it useful as a trend alarm even though it is not the number IAM checks.
+  const HARD_LIMIT_BYTES = 20_480;
+  const WARN_AT_BYTES = 16_384;
+
+  function policySizes(): { id: string; bytes: number }[] {
+    return Object.entries(apiTemplate().findResources('AWS::IAM::Policy')).map(([id, resource]) => ({
+      id,
+      bytes: Buffer.byteLength(JSON.stringify(
+        z.object({ Properties: z.object({ PolicyDocument: z.unknown() }) })
+          .parse(resource).Properties.PolicyDocument,
+      ), 'utf8'),
+    }));
+  }
+
+  it('measures at least one policy, so the assertions below are not vacuous', () => {
+    expect(policySizes().length).toBeGreaterThan(0);
+  });
+
+  it('keeps every role policy under the 20 KB IAM limit', () => {
+    const over = policySizes().filter((p) => p.bytes >= HARD_LIMIT_BYTES);
+    expect(over, `policies at or over the ${HARD_LIMIT_BYTES}-byte IAM limit`).toEqual([]);
+  });
+
+  it('keeps every role policy under the warning threshold', () => {
+    // If this fails, the answer is a new domain Lambda, not a bigger threshold.
+    // Raising the number here is how the ceiling gets hit for real.
+    const near = policySizes().filter((p) => p.bytes >= WARN_AT_BYTES);
+    expect(near, `policies within 4 KB of the IAM limit — split the domain instead`).toEqual([]);
   });
 });
 

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -907,50 +907,94 @@ describe('mcp delegation stays in step with the stack', () => {
 });
 
 describe('lambda role policies stay under the IAM size limit', () => {
-  // AWS caps a managed/inline role policy at 20 KB, and the repo's whole
-  // domain-split Lambda architecture exists because of it — yet nothing measured
-  // it. The failure mode is a deploy-time rejection with no synth warning, which
-  // is exactly the class of fault this suite exists to convert into a test.
+  // The repo's whole domain-split Lambda architecture exists because of this
+  // limit, yet nothing measured it. The failure mode is a deploy-time rejection
+  // with no synth warning — exactly the class of fault this suite converts into
+  // a test.
   //
-  // Measured per role on the serialized PolicyDocument. The threshold is a
-  // warning line well under the hard limit: a role at 16 KB is not broken, but it
-  // is one feature away from being, and finding that out at deploy is the thing
-  // worth avoiding. Largest policy in the stack today is ~2 KB, so this is a
-  // guard for the future rather than a live constraint.
+  // ⚠️ THE NUMBERS, because the repo's docs round them to "20 KB" and that is
+  // above the real ceiling, so a guard set there could never fire:
+  //   • an INLINE policy on a role (what AWS::IAM::Policy creates, and what
+  //     every grant* call in this stack produces) — 10,240 characters;
+  //   • a MANAGED policy (AWS::IAM::ManagedPolicy) — 6,144 characters.
+  // IAM does not count whitespace toward either, so the measurement below
+  // strips it, which is also what makes the count comparable to the quota
+  // rather than to `JSON.stringify`'s output.
+  //   https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
   //
-  // ⚠️ It is an APPROXIMATION, stated so nobody reads it as exact: the template
-  // carries `{"Fn::GetAtt": [...]}` and `{"Fn::ImportValue": ...}` where the
-  // deployed policy carries resolved ARNs, so the two byte counts differ per
-  // statement in both directions. It is the right order of magnitude and it
-  // tracks the thing that actually grows — statement count — which is what makes
-  // it useful as a trend alarm even though it is not the number IAM checks.
-  const HARD_LIMIT_BYTES = 20_480;
-  const WARN_AT_BYTES = 16_384;
+  // All three shapes are measured — AWS::IAM::Policy, AWS::IAM::ManagedPolicy,
+  // and inline `Policies` on AWS::IAM::Role — because measuring only the first
+  // would let a role exceed its quota with this test green.
+  //
+  // Still an APPROXIMATION, stated so nobody reads it as exact: the template
+  // carries `{"Fn::GetAtt": …}` and `{"Fn::ImportValue": …}` where the deployed
+  // policy carries resolved ARNs, so per-statement counts differ in both
+  // directions. It tracks the thing that actually grows — statement count — so
+  // it works as a trend alarm even though it is not byte-for-byte the number IAM
+  // checks. Largest policy today is ~2 KB against a 10,240 ceiling.
+  const INLINE_LIMIT = 10_240;
+  const MANAGED_LIMIT = 6_144;
+  // Fire at 70% so there is room to land a feature and then split a domain,
+  // rather than discovering the ceiling in the middle of a deploy.
+  const WARN_FRACTION = 0.7;
 
-  function policySizes(): { id: string; bytes: number }[] {
-    return Object.entries(apiTemplate().findResources('AWS::IAM::Policy')).map(([id, resource]) => ({
-      id,
-      bytes: Buffer.byteLength(JSON.stringify(
-        z.object({ Properties: z.object({ PolicyDocument: z.unknown() }) })
-          .parse(resource).Properties.PolicyDocument,
-      ), 'utf8'),
-    }));
+  const DocumentSchema = z.object({ Properties: z.object({ PolicyDocument: z.unknown() }) });
+  const RoleSchema = z.object({
+    Properties: z.object({
+      Policies: z.array(z.object({ PolicyName: z.unknown(), PolicyDocument: z.unknown() })).optional(),
+    }),
+  });
+
+  /** Non-whitespace characters, which is how IAM counts a policy. */
+  const size = (document: unknown) => JSON.stringify(document).replace(/\s/g, '').length;
+
+  function policies(): { id: string; kind: string; chars: number; limit: number }[] {
+    const template = apiTemplate();
+    const measured: { id: string; kind: string; chars: number; limit: number }[] = [];
+
+    for (const [id, resource] of Object.entries(template.findResources('AWS::IAM::Policy'))) {
+      measured.push({
+        id, kind: 'inline', limit: INLINE_LIMIT,
+        chars: size(DocumentSchema.parse(resource).Properties.PolicyDocument),
+      });
+    }
+    for (const [id, resource] of Object.entries(template.findResources('AWS::IAM::ManagedPolicy'))) {
+      measured.push({
+        id, kind: 'managed', limit: MANAGED_LIMIT,
+        chars: size(DocumentSchema.parse(resource).Properties.PolicyDocument),
+      });
+    }
+    // Inline policies declared ON the role rather than as a separate resource.
+    // None today, which is exactly why they need measuring: the first one added
+    // would otherwise arrive unmeasured.
+    for (const [id, resource] of Object.entries(template.findResources('AWS::IAM::Role'))) {
+      for (const policy of RoleSchema.parse(resource).Properties.Policies ?? []) {
+        measured.push({
+          id: `${id}/${JSON.stringify(policy.PolicyName)}`, kind: 'inline-on-role',
+          limit: INLINE_LIMIT, chars: size(policy.PolicyDocument),
+        });
+      }
+    }
+    return measured;
   }
 
-  it('measures at least one policy, so the assertions below are not vacuous', () => {
-    expect(policySizes().length).toBeGreaterThan(0);
+  it('measures every policy shape the stack can produce', () => {
+    // Vacuity guard, and it names the shapes so a future one is a deliberate add.
+    const kinds = new Set(policies().map((p) => p.kind));
+    expect(policies().length).toBeGreaterThan(0);
+    expect(kinds.has('inline'), 'no AWS::IAM::Policy measured — has the filter drifted?').toBe(true);
   });
 
-  it('keeps every role policy under the 20 KB IAM limit', () => {
-    const over = policySizes().filter((p) => p.bytes >= HARD_LIMIT_BYTES);
-    expect(over, `policies at or over the ${HARD_LIMIT_BYTES}-byte IAM limit`).toEqual([]);
+  it('keeps every policy under its IAM quota', () => {
+    const over = policies().filter((p) => p.chars >= p.limit);
+    expect(over, 'policies at or over their IAM character quota').toEqual([]);
   });
 
-  it('keeps every role policy under the warning threshold', () => {
+  it('keeps every policy under 70% of its quota', () => {
     // If this fails, the answer is a new domain Lambda, not a bigger threshold.
-    // Raising the number here is how the ceiling gets hit for real.
-    const near = policySizes().filter((p) => p.bytes >= WARN_AT_BYTES);
-    expect(near, `policies within 4 KB of the IAM limit — split the domain instead`).toEqual([]);
+    // Raising the fraction here is how the ceiling gets hit for real.
+    const near = policies().filter((p) => p.chars >= p.limit * WARN_FRACTION);
+    expect(near, 'policies past 70% of their IAM quota — split the domain instead').toEqual([]);
   });
 });
 

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1313,20 +1313,50 @@ export class VocApiStack extends VocStack {
     // MCP SERVER API (public — auth via Bearer token authorizer)
     // ============================================
     const mcpRole = this.createLambdaRole('McpLambdaRole');
-    feedbackTable.grantReadData(mcpRole);
-    aggregatesTable.grantReadData(mcpRole);
-    // TWO ACTIONS on the projects table, not `grantReadWriteData`. The handler
-    // Queries token rows (auth) and project/persona rows (the get_project and
-    // list_personas tools), and UpdateItems exactly one attribute (last_used_at).
-    // The convenience grant would additionally hand over PutItem, DeleteItem,
-    // Scan and both batch APIs across the WHOLE table — every persona, PRD,
-    // PR/FAQ and prototype — on the ONE function in this stack that is reachable
-    // with a bearer token instead of a Cognito session. The absent actions are
-    // what enforce read-only-ness rather than remember it; same reasoning as the
-    // ballots role above, and `mcp Lambda IAM grants` in api-stack.test.ts pins
-    // the exact set.
-    projectsTable.grant(mcpRole, 'dynamodb:Query', 'dynamodb:UpdateItem');
-    // EncryptDecrypt, not just Decrypt: the narrow grant above no longer brings
+    // NO feedback-table grant and NO aggregates-table grant. The MCP function is
+    // a protocol adapter now: every tool's data comes from the domain function
+    // that already owns the route, so this role holds the permission to CALL
+    // those functions instead of the permission to read what they read. That is
+    // the whole point of the delegation change — a single function accumulating
+    // the union of every domain's permissions is what the 20 KB role-policy
+    // ceiling eventually refuses, silently and only at deploy time.
+    //
+    // Written out rather than `grantInvoke`, which additionally grants
+    // `<fn>.Arn:*` — every published version and alias. The adapter invokes by
+    // unqualified function name, which `$LATEST` serves and the unqualified ARN
+    // authorizes, so the wildcard buys nothing and costs a cdk-nag IAM5
+    // suppression. Two exact ARNs and no suppression is the smaller statement
+    // and the smaller grant.
+    mcpRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['lambda:InvokeFunction'],
+      resources: [metricsLambda.functionArn, projectsLambda.functionArn],
+    }));
+
+    // The token keyspace, and nothing else on the table.
+    //
+    // Two actions (Query for the credential lookup, UpdateItem for last_used_at)
+    // AND a partition condition, which is new: authentication is the only reason
+    // this function touches DynamoDB at all now, so the grant can finally say so.
+    // `dynamodb:LeadingKeys` restricts every request to items whose partition key
+    // is the token partition, so even the two granted actions cannot reach a
+    // PROJECT#... row — the function that is reachable with a bearer token rather
+    // than a Cognito session can no longer read a persona, a PRD, a PR/FAQ or a
+    // prototype through its own credentials, only through a domain function that
+    // applies that route's own rules.
+    //
+    // `ForAllValues:` is required rather than stylistic: LeadingKeys is a
+    // multi-valued condition key, and the plain StringEquals form would not
+    // constrain a request that presents several keys.
+    //
+    // The literal must match shared/mcp_tokens.py's MCP_TOKEN_PK — pinned by
+    // 'mcp Lambda IAM grants' in api-stack.test.ts, which reads the Python
+    // constant rather than repeating the string.
+    mcpRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:Query', 'dynamodb:UpdateItem'],
+      resources: [projectsTable.tableArn],
+      conditions: { 'ForAllValues:StringEquals': { 'dynamodb:LeadingKeys': ['MCPTOKEN'] } },
+    }));
+    // EncryptDecrypt, not just Decrypt: the narrow grant above does not bring
     // the table's KMS permissions along the way grantReadWriteData did, and the
     // last_used_at UpdateItem is a write to a KMS-encrypted table. Same pairing
     // as the ballots role.
@@ -1342,9 +1372,19 @@ export class VocApiStack extends VocStack {
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
       environment: {
+        // The token table only. FEEDBACK_TABLE and AGGREGATES_TABLE are gone
+        // with the in-process tools that read them: the handler resolves every
+        // tool through the two function names below instead. Leaving the table
+        // names behind would advertise an access this role no longer has.
         PROJECTS_TABLE: projectsTable.tableName,
-        FEEDBACK_TABLE: feedbackTable.tableName,
-        AGGREGATES_TABLE: aggregatesTable.tableName,
+        // The delegation targets. Handed down from the infrastructure exactly as
+        // PERSONA_GENERATOR_FUNCTION and MANUAL_IMPORT_PROCESSOR_FUNCTION are,
+        // rather than rebuilt in Python from account/region — under a
+        // deploymentPrefix a reconstructed name names a function that does not
+        // exist, and the failure arrives as a tool that mysteriously returns
+        // nothing. mcp_handler.py reads these two keys via _DOMAIN_FUNCTION_ENV.
+        METRICS_FUNCTION: metricsLambda.functionName,
+        PROJECTS_FUNCTION: projectsLambda.functionName,
         // NOT used for CORS here (MCP clients are not browsers, the handler
         // answers Access-Control-Allow-Origin: *). It is the allowlist for the
         // MCP spec's DNS-rebinding guard: a request that CARRIES an Origin

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -2,7 +2,7 @@
   "description": "Fingerprint of the no-prefix synth. Regenerate with npx ts-node scripts/generate-baseline.ts ONLY for a change intended to alter the default templates — see the script header.",
   "stacks": {
     "VocApiStack": {
-      "templateSha256": "908a83993d71c9cd40263f1538dd1a1e24b21e3e4eaae10a819a464df156bc53",
+      "templateSha256": "4056265cb6643a54b208032c2dfc3d68a4f1faa6feae13242b0f125ffa06e721",
       "names": {
         "physicalNames": [
           "AWS::ApiGateway::Authorizer Name = voc-cognito-authorizer",


### PR DESCRIPTION
Phase 2a of `analysis/PLAN-mcp-platform-server.md` (decision **D1**). The MCP Lambda stops reading the data lake and becomes a protocol adapter: validate the credential, resolve scope and reach, translate the tool's arguments into a route call, synthesize an API Gateway proxy event, invoke the owning domain function, reshape the answer.

Phase 2 in the plan is a large bundle. This is the **data-path half**; the protocol half (`server/discover`, version range, `resultType`, header validation, retiring `ANY /mcp/{proxy+}`, annotations, scope-filtered `tools/list`) is deliberately a separate PR — one changes what the tools read, the other changes the envelope around them, and they review on different terms.

## Why

A single Lambda holding the union of every domain's permissions inverts the domain-isolation pattern this repo mandates, and marches at the 20 KB role-policy ceiling with no synth-time warning. It is also a second implementation of every route it duplicates — and one had already drifted (see DUP2 below).

## The IAM result

This is the headline, and it is a narrowing rather than a trade:

- `mcpRole` **loses** its feedback-table and aggregates-table grants outright.
- Its projects-table grant — the last one left — **gains a `dynamodb:LeadingKeys` condition** naming only the `MCPTOKEN` partition. The one function in this stack reachable with a bearer token instead of a Cognito session can no longer read a persona, a PRD, a PR/FAQ or a prototype through its own credentials at all.
- It **gains** `lambda:InvokeFunction` on exactly two functions, by exact ARN. Not `grantInvoke`, which also grants `<fn>.Arn:*` — every version and alias — and would need a cdk-nag IAM5 suppression for a wildcard nothing uses.

Delegating autoseed is what made the condition possible: it was the last in-process reader of project artifact rows.

## It retires a filed defect by construction

`DUPLICATED-CODE`'s **DUP2**: the in-process `get_project` recognised **2 of 6** document sort-key prefixes, so an MCP client saw a third of a project's documents and was told nothing had been filtered. The route always knew all six. Visible in the live run below — `document`, `prototype` and `research` are kinds no MCP client could previously see.

## Breaking changes → server 2.0.0

`serverInfo.version` goes to `2.0.0`. Tool output shapes change:

- results carry `structuredContent` alongside the text block, and every tool declares an `outputSchema`;
- sad paths that used to arrive as prose inside a **successful** result are now tool errors (`isError: true`) — a model told `isError: false` treats "not found" as data and reports the item as empty instead of retrying;
- `get_metrics_summary` reports the route's shape, gaining `avg_sentiment` and `urgent_count`.

`get_metrics_breakdown` is added **in this PR rather than the next** because `/metrics/summary` does not carry the per-sentiment and per-category counts the old in-process tool computed. Delegating alone would have been a capability regression; with it, the pair reports strictly more than before.

## Two shapes where the obvious reading of the plan is wrong

- **`search_feedback` delegates to two routes.** `/feedback/search` refuses a query under two characters, so filter-only calls go to `/feedback`. Mapping the tool onto `/feedback/search` alone — what Appendix A implies — would make every filter-only call return nothing.
- **`_resolve_days` is deleted, not ported.** The window is bounded by the route's shared `validate_days`, which clamps rather than raises. One behaviour genuinely changes: `days: true` now means a 1-day window instead of the 7-day default, because `validate_int` coerces bools. Recorded next to the reasoning in the test file — having one endpoint treat that input differently from the other forty is a worse property than either answer.

## A bug found by verifying live

Both feedback tools projected `item.get('id')`. The processor never writes a plain `id` — the identifier is `feedback_id`, which is also what `GET /feedback/{id}` keys its GSI on. So `search_feedback` advertised an `id` and filled it with `""` for every item in the corpus, leaving `get_feedback_detail` unreachable: the only way to learn a feedback id is to search, and search reported none. Fixed at the shared projection (second commit). No unit test could have caught it — every fixture in the suite sets both fields.

## Tests

- **`TestClaimSynthesis`** — the highest-value new test. Synthesizing claims makes this function an authorization authority: it tells the domain Lambda who is calling and that Lambda believes it. Identity derives **only** from the stored credential, enforced *structurally* — `synthetic_claims` takes the token record and never sees the request, so there is nothing to filter and nothing to forget to filter. Pinned with a request that tries: arguments named `sub`, `cognito:groups`, a nested `requestContext`.
- **`test_mcp_delegation.py`** (38) — route selection, error mapping, projections, the synthesized event, structured output.
- The Python IAM lockstep got **stronger**: every tool now pays exactly one projects-table query (the credential lookup), and autoseed must not touch that table at all.
- **`api-stack.test.ts`** — the `LeadingKeys` condition (read from the Python constant, not re-typed), the exact invoke set with no `:*`, absence of the two dropped grants, and a `DOMAIN_ROUTES` lockstep proving every delegated route exists in its handler and is wired in API Gateway.
- **First policy-size measurement in the repo.** The 20 KB IAM limit that shapes this entire architecture was previously unmeasured anywhere in CI. Documented as an approximation (the template carries `Fn::GetAtt`, not resolved ARNs).
- `TestPartialResultReporting` (17) is **deleted, not relocated**: the behaviour is gone. There are no per-read failures to degrade now, and a failing route is reported as an error rather than a plausible answer with a flag on it. The reasoning is left in the file where the class was.

**Mutation-proved: 14 mutations, 14 killed, 0 survived.** One found a genuinely weak assertion of mine — a 5xx-detail check a leak walked straight through — now exact equality.

## Verification

| Gate | Result |
|---|---|
| backend pytest | **2911** (baseline 2881) |
| ruff | **−9**, zero new findings |
| CDK vitest | **266** (baseline 256) |
| stream / frontend | 339 / 2975, tsc + eslint clean |
| `cdk synth` | **zero warnings** |
| template baseline | regenerated; only the SHA moved, no physical name changed → no CloudFormation replacement. Still five stacks |

**Deployed to `VocApiStack` and verified live** (account 777200923596, us-east-1):

- MCP battery **75/75**, including: the conditioned `Query` *and* `UpdateItem` both permitted, `structuredContent` present, all four breakdown axes, a 404 arriving as `isError` inside a 200, both `search_feedback` branches, the search→detail chain, and autoseed answering the route's 404 instead of a 500.
- `test-api.sh`: **33/33** endpoints 200, zero non-2xx; `POST /chat/stream` SSE verified separately (metadata → text → done).
- No browser E2E: this branch touches **no** frontend file, so the deployed bundle is byte-identical to the one Phase 1 verified in-browser.

Every API Lambda's code hash moves, because `shared/mcp_delegate.py` is bundled into all of them by `createApiLambdaCode`. Behaviour for the other fourteen is unchanged — they gain an unused module — and `test-api.sh` covers them.
