### PR TITLE
fix(personas): make list_personas callable and fix the import prompt

### DIFF
--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -683,17 +683,104 @@ _DOCUMENT_KINDS: dict[str, str] = {
     'PROTOTYPE#': 'prototype',
 }
 
+_STRING_LIST: dict[str, Any] = {"type": "array", "items": {"type": "string"}}
+
+# The persona shape, mirroring `schemas/persona.schema.json` — which is the
+# repo's canonical declaration, what both writers persist, and what the frontend
+# `ProjectPersona` type already describes.
+#
+# 🔴 It did NOT mirror it before, and that is what made `list_personas`
+# uncallable: it declared a pre-8-section shape (`goals`, `age_range`,
+# `occupation`, `quote`, `journey_stage`, `type` at the top level, with
+# `pain_points`/`behaviors` as `array<string>`). Six of those ten keys exist on
+# no stored row, and the two that do are OBJECTS. A client validates
+# `structuredContent` against this schema, so every call failed `-32602` while
+# raw JSON-RPC returned the data — which is why a curl battery never saw it.
+#
+# `additionalProperties` is deliberately OPEN on each section. These values are
+# LLM-authored: the generation prompt pins the canonical keys, but the import
+# path does not, and live rows carry `primary_frustration`, `frustration`,
+# `tooling`, `current_practices`, `related_issues`. Declaring `false` would make
+# the tool fail on its own product; declaring the known keys and permitting the
+# rest is the honest contract. The variance belongs to the WRITER and is fixed
+# there, not laundered here.
+_PERSONA_SECTIONS: dict[str, dict[str, Any]] = {
+    # Section 1 — Identity & Demographics.
+    "identity": {
+        "age_range": {"type": "string"},
+        "location": {"type": "string"},
+        "occupation": {"type": "string"},
+        "income_bracket": {"type": "string"},
+        "education": {"type": "string"},
+        "family_status": {"type": "string"},
+        "bio": {"type": "string"},
+    },
+    # Section 2 — Goals & Motivations.
+    "goals_motivations": {
+        "primary_goal": {"type": "string"},
+        "secondary_goals": _STRING_LIST,
+        "success_definition": {"type": "string"},
+        "underlying_motivations": _STRING_LIST,
+    },
+    # Section 3 — Pain Points & Frustrations.
+    "pain_points": {
+        "current_challenges": _STRING_LIST,
+        "blockers": _STRING_LIST,
+        "workarounds": _STRING_LIST,
+        "emotional_impact": {"type": "string"},
+    },
+    # Section 4 — Behaviors & Habits.
+    "behaviors": {
+        "current_solutions": _STRING_LIST,
+        "tools_used": _STRING_LIST,
+        "activity_frequency": {"type": "string"},
+        "tech_savviness": {"type": "string"},
+        "decision_style": {"type": "string"},
+    },
+}
+
 _PERSONA_PROPERTIES: dict[str, Any] = {
     "persona_id": {"type": "string"},
     "name": {"type": "string"},
-    "type": {"type": "string"},
-    "age_range": {"type": "string"},
-    "occupation": {"type": "string"},
-    "goals": {"type": "array", "items": {"type": "string"}},
-    "pain_points": {"type": "array", "items": {"type": "string"}},
-    "behaviors": {"type": "array", "items": {"type": "string"}},
-    "quote": {"type": "string"},
-    "journey_stage": {"type": "string"},
+    # `tagline` is the persona's one-line characterisation and is REQUIRED by the
+    # canonical schema. It replaces the old `type`, which no row has ever carried.
+    "tagline": {"type": "string"},
+    "confidence": {"type": "string"},
+    "feedback_count": {"type": "integer"},
+    **{
+        section: {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": True,
+        }
+        for section, properties in _PERSONA_SECTIONS.items()
+    },
+    # Section 6 — Representative Quotes. Objects on the row, not strings, and the
+    # old single `quote` key never existed.
+    "quotes": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string"},
+                "context": {"type": "string"},
+            },
+            "additionalProperties": True,
+        },
+    },
+}
+
+# Which declared keys are arrays, so the projection can coerce a scalar the
+# writer left unwrapped. Derived from the declarations above by VALUE, not by
+# identity with `_STRING_LIST`: an author who inlines the literal instead of
+# reusing the constant must still get coercion, or this derivation would have
+# exactly the silent-omission hole it exists to close.
+_PERSONA_LIST_KEYS: dict[str, frozenset[str]] = {
+    section: frozenset(
+        key for key, declared in properties.items()
+        if declared.get("type") == "array"
+    )
+    for section, properties in _PERSONA_SECTIONS.items()
 }
 
 # A window argument, stated once. `maximum` is the route's real ceiling
@@ -869,7 +956,10 @@ MCP_TOOLS = [
                         "properties": {
                             "persona_id": {"type": "string"},
                             "name": {"type": "string"},
-                            "type": {"type": "string"},
+                            # `tagline`, not `type`: no stored persona has ever
+                            # carried a `type`, so this summary reported an empty
+                            # string for every persona in every project.
+                            "tagline": {"type": "string"},
                         },
                         "additionalProperties": False,
                     },
@@ -1124,26 +1214,89 @@ def _document_kind(item: dict) -> str:
     return ''
 
 
-def _project_persona(item: dict) -> dict:
-    """The persona fields the tools report, with typed defaults.
+def _as_string_list(value: Any) -> list[str]:
+    """Coerce a declared-array persona field to the list of strings it promises.
 
-    Shared by both project-shaped tools so a persona reads the same either way.
-    Everything else on the row — avatar keys, source feedback ids, notes,
-    timestamps — is dropped: a project's personas are the answer, not its
-    storage layout.
+    A writer that leaves a single value unwrapped (`workarounds` is a string on
+    some imported rows and a list on generated ones) must not make the payload
+    contradict its own schema, so the boundary coerces instead of passing the
+    scalar through. Non-string entries are stringified rather than dropped: the
+    value is a model's evidence, and silently losing it is worse than reporting
+    it in the declared type.
     """
+    if value is None or value == '':
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [v if isinstance(v, str) else str(v) for v in value if v not in (None, '')]
+    return [str(value)]
+
+
+def _persona_section(value: Any, list_keys: frozenset[str]) -> dict:
+    """One canonical persona section, coerced to its declared types.
+
+    Unrecognised keys are PRESERVED, not dropped. The section's declared keys
+    are what the generation prompt pins; the import path pins nothing, so real
+    rows also carry `primary_frustration`, `tooling`, `related_issues`. Dropping
+    those would make the tool answer "this persona has no pain points" about a
+    persona whose pain points are simply under a key this file did not predict —
+    the same class of silent under-report the surface is being fixed for.
+    """
+    if not isinstance(value, dict):
+        # Absent, or a shape no writer produces. Every writer persists an object
+        # (both use a `{}` default), and all five live rows are objects, so there
+        # is no flat-list case to salvage — and guessing a destination key would
+        # file content under a misleading heading (`sorted()` would pick
+        # `blockers` for a list of pain points).
+        return {}
     return {
+        key: _as_string_list(inner) if key in list_keys else inner
+        for key, inner in value.items()
+    }
+
+
+def _project_persona(item: dict) -> dict:
+    """One persona in the canonical shape of `schemas/persona.schema.json`.
+
+    Used ONLY by `list_personas`. `get_project` deliberately renders a two-field
+    summary of its own — an earlier version of this docstring claimed the two
+    shared a projection, which was never true and is why the schema mismatch
+    below went unnoticed for so long.
+
+    🔑 The bug this replaces: every field was read with `item.get(key, default)`,
+    which fires only when a key is ABSENT and cannot correct a value of the wrong
+    TYPE. `pain_points` and `behaviors` are objects on every stored row while the
+    schema declared `array<string>`, so the dicts travelled unchanged and a
+    schema-validating client rejected the whole result. Six other declared keys
+    (`goals`, `age_range`, `occupation`, `quote`, `journey_stage`, `type`) exist
+    on no row at all and were reported as empty forever.
+
+    Everything not declared — avatar keys, source feedback ids, research notes,
+    timestamps, llm metadata — is still dropped: a project's personas are the
+    answer, not its storage layout.
+    """
+    projected: dict[str, Any] = {
         "persona_id": item.get('persona_id', ''),
         "name": item.get('name', ''),
-        "type": item.get('type', ''),
-        "age_range": item.get('age_range', ''),
-        "occupation": item.get('occupation', ''),
-        "goals": item.get('goals', []),
-        "pain_points": item.get('pain_points', []),
-        "behaviors": item.get('behaviors', []),
-        "quote": item.get('quote', ''),
-        "journey_stage": item.get('journey_stage', ''),
+        "tagline": item.get('tagline', ''),
+        "confidence": item.get('confidence', ''),
     }
+
+    # `feedback_count` is declared an integer, so a missing or unparseable value
+    # must not become `''` — that would violate the schema exactly as the old
+    # string defaults did.
+    try:
+        projected["feedback_count"] = int(item.get('feedback_count') or 0)
+    except (TypeError, ValueError):
+        projected["feedback_count"] = 0
+
+    for section, list_keys in _PERSONA_LIST_KEYS.items():
+        projected[section] = _persona_section(item.get(section), list_keys)
+
+    quotes = item.get('quotes')
+    projected["quotes"] = [q for q in quotes if isinstance(q, dict)] if isinstance(quotes, list) else []
+    return projected
 
 
 def _get_project_payload(token_info: dict) -> tuple[dict, list[dict], list[dict]]:
@@ -1190,7 +1343,7 @@ def _tool_get_project(args: dict, token_info: dict) -> ToolResult:
         "document_count": len(documents),
         "personas": [
             {"persona_id": p.get('persona_id', ''), "name": p.get('name', ''),
-             "type": p.get('type', '')}
+             "tagline": p.get('tagline', '')}
             for p in personas
         ],
         "documents": [

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -12,6 +12,7 @@ from the Authorization header against SHA-256 hashes in the projects table.
 import json
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -75,12 +76,23 @@ projects_table = get_projects_table()
 # meant two breaking output changes instead of one.
 MCP_PROTOCOL_VERSION = "2024-11-05"
 
-# Semver on the SERVER, independent of the protocol revision above. 2.0.0
-# because tool output shapes changed: results now carry `structuredContent`
-# alongside the text block, sad paths that used to arrive as prose in a
-# successful result are now tool errors, and `get_project` reports the
-# documents it previously dropped.
-MCP_SERVER_VERSION = "2.0.0"
+# Semver on the SERVER, independent of the protocol revision above, and the only
+# signal a client gets that a tool's output shape moved — it is advertised in
+# `serverInfo` on every `initialize`.
+#
+# 2.0.0 carried `structuredContent` alongside the text block, turned sad paths
+# that used to arrive as prose in a successful result into tool errors, and made
+# `get_project` report the documents it had been dropping.
+#
+# 3.0.0 changes the persona shape both persona-reporting tools publish:
+# `list_personas` now mirrors `schemas/persona.schema.json` and no longer
+# declares `goals`, `age_range`, `occupation`, `quote`, `journey_stage` or
+# `type`, and `get_project`'s persona summary reports `tagline` in place of
+# `type`. Those six keys existed on no stored row and `list_personas` was
+# uncallable against real data, so nothing could have consumed them — but a
+# client coded against the NAMES loses them, which is a major bump by this
+# file's own rule rather than a judgement about how many clients exist.
+MCP_SERVER_VERSION = "3.0.0"
 
 
 # ============================================
@@ -685,25 +697,22 @@ _DOCUMENT_KINDS: dict[str, str] = {
 
 _STRING_LIST: dict[str, Any] = {"type": "array", "items": {"type": "string"}}
 
-# The persona shape, mirroring `schemas/persona.schema.json` — which is the
-# repo's canonical declaration, what both writers persist, and what the frontend
-# `ProjectPersona` type already describes.
-#
-# 🔴 It did NOT mirror it before, and that is what made `list_personas`
-# uncallable: it declared a pre-8-section shape (`goals`, `age_range`,
-# `occupation`, `quote`, `journey_stage`, `type` at the top level, with
-# `pain_points`/`behaviors` as `array<string>`). Six of those ten keys exist on
-# no stored row, and the two that do are OBJECTS. A client validates
-# `structuredContent` against this schema, so every call failed `-32602` while
-# raw JSON-RPC returned the data — which is why a curl battery never saw it.
+# The persona, mirroring `schemas/persona.schema.json` — the repo's canonical
+# declaration, what both writers persist, and what the frontend
+# `ProjectPersona` type already describes. Section numbers below are the
+# canonical schema's own: 1-5 and 7 are objects and are declared here, 6
+# (`quotes`) is an array declared under `_QUOTE_PROPERTIES`, and 8
+# (`research_notes`) is researcher annotation rather than persona content and is
+# deliberately not reported. That division is enforced against the schema file
+# by `test_every_canonical_persona_section_is_reported_or_excluded`, so a ninth
+# section cannot go missing here the way 5 and 7 first did.
 #
 # `additionalProperties` is deliberately OPEN on each section. These values are
-# LLM-authored: the generation prompt pins the canonical keys, but the import
-# path does not, and live rows carry `primary_frustration`, `frustration`,
-# `tooling`, `current_practices`, `related_issues`. Declaring `false` would make
-# the tool fail on its own product; declaring the known keys and permitting the
-# rest is the honest contract. The variance belongs to the WRITER and is fixed
-# there, not laundered here.
+# LLM-authored, and a prompt is a request rather than enforcement: live rows
+# carry `primary_frustration`, `frustration`, `tooling`, `current_practices`,
+# `related_issues`. Declaring `false` would make the tool fail on its own
+# product; declaring the known keys and permitting the rest is the honest
+# contract, and the variance belongs to the writer.
 _PERSONA_SECTIONS: dict[str, dict[str, Any]] = {
     # Section 1 — Identity & Demographics.
     "identity": {
@@ -737,6 +746,35 @@ _PERSONA_SECTIONS: dict[str, dict[str, Any]] = {
         "tech_savviness": {"type": "string"},
         "decision_style": {"type": "string"},
     },
+    # Section 5 — Context & Environment.
+    "context_environment": {
+        "usage_context": {"type": "string"},
+        "devices": _STRING_LIST,
+        "time_constraints": {"type": "string"},
+        "social_context": {"type": "string"},
+        "influencers": _STRING_LIST,
+    },
+    # Section 7 — Scenario / User Story.
+    "scenario": {
+        "title": {"type": "string"},
+        "narrative": {"type": "string"},
+        "trigger": {"type": "string"},
+        "outcome": {"type": "string"},
+    },
+}
+
+# Section 6 — Representative Quotes. Objects on the row, not strings, and the
+# old single `quote` key never existed. Named separately from the sections above
+# because it is an array, so it needs its own projection.
+#
+# `source_feedback_id` is the quote's own citation and is declared, unlike the
+# persona's top-level `source_feedback_ids`, which is dropped: one is where this
+# sentence came from and is the id `get_feedback_detail` takes, the other is the
+# row's provenance list.
+_QUOTE_PROPERTIES: dict[str, Any] = {
+    "text": {"type": "string"},
+    "context": {"type": "string"},
+    "source_feedback_id": {"type": "string"},
 }
 
 _PERSONA_PROPERTIES: dict[str, Any] = {
@@ -755,32 +793,45 @@ _PERSONA_PROPERTIES: dict[str, Any] = {
         }
         for section, properties in _PERSONA_SECTIONS.items()
     },
-    # Section 6 — Representative Quotes. Objects on the row, not strings, and the
-    # old single `quote` key never existed.
     "quotes": {
         "type": "array",
         "items": {
             "type": "object",
-            "properties": {
-                "text": {"type": "string"},
-                "context": {"type": "string"},
-            },
+            "properties": _QUOTE_PROPERTIES,
             "additionalProperties": True,
         },
     },
 }
 
-# Which declared keys are arrays, so the projection can coerce a scalar the
-# writer left unwrapped. Derived from the declarations above by VALUE, not by
-# identity with `_STRING_LIST`: an author who inlines the literal instead of
-# reusing the constant must still get coercion, or this derivation would have
-# exactly the silent-omission hole it exists to close.
-_PERSONA_LIST_KEYS: dict[str, frozenset[str]] = {
-    section: frozenset(
-        key for key, declared in properties.items()
-        if declared.get("type") == "array"
-    )
+
+def _declared_types(properties: dict[str, Any]) -> dict[str, str]:
+    """The declared JSON type of each property, so the projection can coerce to it.
+
+    Read off the declarations by VALUE rather than by identity with
+    `_STRING_LIST`: an author who inlines a literal instead of reusing the
+    constant must still get coercion, or this derivation would have exactly the
+    silent-omission hole it exists to close. Deriving EVERY type rather than
+    only the arrays is what stops the next declared field from being the one
+    nobody coerces — `confidence` was that field.
+    """
+    return {
+        key: declared["type"]
+        for key, declared in properties.items()
+        if isinstance(declared.get("type"), str)
+    }
+
+
+_PERSONA_SECTION_TYPES: dict[str, dict[str, str]] = {
+    section: _declared_types(properties)
     for section, properties in _PERSONA_SECTIONS.items()
+}
+_QUOTE_TYPES: dict[str, str] = _declared_types(_QUOTE_PROPERTIES)
+# The top-level scalars only: the sections and `quotes` are objects and arrays of
+# objects, each with its own projection below.
+_PERSONA_SCALAR_TYPES: dict[str, str] = {
+    key: declared_type
+    for key, declared_type in _declared_types(_PERSONA_PROPERTIES).items()
+    if declared_type not in ("object", "array")
 }
 
 # A window argument, stated once. `maximum` is the route's real ceiling
@@ -989,8 +1040,10 @@ MCP_TOOLS = [
     {
         "name": "list_personas",
         "description": (
-            "List all personas for a project with their demographics, "
-            "pain points, goals, and behavioral traits."
+            "List all personas for a project: identity and demographics, goals "
+            "and motivations, pain points, behaviors, context and environment, "
+            "representative quotes, and scenario. Researcher notes are not "
+            "included."
         ),
         "inputSchema": {
             "type": "object",
@@ -1214,6 +1267,39 @@ def _document_kind(item: dict) -> str:
     return ''
 
 
+def _as_string(value: Any) -> str:
+    """Coerce a declared-string persona field to the string it promises.
+
+    A list is joined rather than passed through: `emotional_impact` and
+    `primary_goal` are declared strings, and a list arriving in either would
+    reproduce the defect this schema fix is about — a payload contradicting its
+    own declaration. A dict becomes JSON rather than a Python `repr`, because
+    the reader is a model and `{'a': 'x'}` is not machine-readable.
+    """
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, tuple)):
+        return '; '.join(_as_string(v) for v in value if v not in (None, ''))
+    if isinstance(value, dict):
+        return json.dumps(value, cls=DecimalEncoder)
+    return str(value)
+
+
+def _as_int(value: Any) -> int:
+    """Coerce a declared-integer persona field, defaulting rather than lying.
+
+    `feedback_count` arrives from DynamoDB as a `Decimal`, and not at all on
+    rows that predate it. An unparseable value becomes 0 instead of travelling
+    as the string it was.
+    """
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _as_string_list(value: Any) -> list[str]:
     """Coerce a declared-array persona field to the list of strings it promises.
 
@@ -1226,34 +1312,80 @@ def _as_string_list(value: Any) -> list[str]:
     """
     if value is None or value == '':
         return []
-    if isinstance(value, str):
-        return [value]
     if isinstance(value, (list, tuple)):
-        return [v if isinstance(v, str) else str(v) for v in value if v not in (None, '')]
-    return [str(value)]
+        return [_as_string(v) for v in value if v not in (None, '')]
+    return [_as_string(value)]
 
 
-def _persona_section(value: Any, list_keys: frozenset[str]) -> dict:
+# One coercion per JSON type the persona schema declares. Objects are absent on
+# purpose: the sections and quotes have their own projections, which is also why
+# `_PERSONA_SCALAR_TYPES` excludes them.
+_COERCIONS: dict[str, Callable[[Any], Any]] = {
+    "string": _as_string,
+    "integer": _as_int,
+    "array": _as_string_list,
+}
+
+
+def _coerce_declared(value: Any, declared_type: str) -> Any:
+    """Coerce one value to the JSON type its own schema declares.
+
+    A type with no coercion passes through unchanged, so an undeclared key keeps
+    whatever the row holds — `additionalProperties: true` permits it and
+    rewriting it would claim a structure the row does not have.
+    """
+    coerce = _COERCIONS.get(declared_type)
+    return coerce(value) if coerce else value
+
+
+def _persona_section(name: str, value: Any, declared: dict[str, str]) -> dict:
     """One canonical persona section, coerced to its declared types.
 
     Unrecognised keys are PRESERVED, not dropped. The section's declared keys
-    are what the generation prompt pins; the import path pins nothing, so real
-    rows also carry `primary_frustration`, `tooling`, `related_issues`. Dropping
-    those would make the tool answer "this persona has no pain points" about a
-    persona whose pain points are simply under a key this file did not predict —
-    the same class of silent under-report the surface is being fixed for.
+    are what the prompts pin; a prompt is a request, so real rows also carry
+    `primary_frustration`, `tooling`, `related_issues`. Dropping those would
+    make the tool answer "this persona has no pain points" about a persona whose
+    pain points are simply under a key this file did not predict — the same
+    class of silent under-report the surface is being fixed for.
     """
     if not isinstance(value, dict):
-        # Absent, or a shape no writer produces. Every writer persists an object
-        # (both use a `{}` default), and all five live rows are objects, so there
-        # is no flat-list case to salvage — and guessing a destination key would
+        # Absent, or a shape no writer produces. Both writers persist an object
+        # (both default to `{}`) and all five live rows are objects, so there is
+        # no flat-list case to salvage — and guessing a destination key would
         # file content under a misleading heading (`sorted()` would pick
-        # `blockers` for a list of pain points).
+        # `blockers` for a list of pain points). An absent section is normal and
+        # silent; anything else is logged, because a section that cannot be
+        # reported should be visible rather than invisible. The value itself is
+        # never logged: it is customer-derived text.
+        if value not in (None, '', [], {}):
+            logger.warning(
+                "Persona section not reported: not an object",
+                extra={"section": name, "arrived_as": type(value).__name__},
+            )
         return {}
     return {
-        key: _as_string_list(inner) if key in list_keys else inner
+        key: _coerce_declared(inner, declared[key]) if key in declared else inner
         for key, inner in value.items()
     }
+
+
+def _as_quote(value: Any) -> dict | None:
+    """One representative quote, as the object the schema declares.
+
+    A bare string entry used to be filtered out, which answered "this persona
+    has no quotes" about a persona who had them — the same silent under-report
+    this file argues against everywhere else. These entries are LLM-authored on
+    a path that pinned nothing until now, so `quotes: ["…"]` is a plausible
+    stored shape and it becomes `{"text": …}`. `None` means the entry carried no
+    content, not that content was discarded.
+    """
+    if isinstance(value, dict):
+        return {
+            key: _coerce_declared(inner, _QUOTE_TYPES[key]) if key in _QUOTE_TYPES else inner
+            for key, inner in value.items()
+        }
+    text = _as_string(value)
+    return {"text": text} if text else None
 
 
 def _project_persona(item: dict) -> dict:
@@ -1262,40 +1394,31 @@ def _project_persona(item: dict) -> dict:
     Used ONLY by `list_personas`. `get_project` deliberately renders a two-field
     summary of its own — an earlier version of this docstring claimed the two
     shared a projection, which was never true and is why the schema mismatch
-    below went unnoticed for so long.
+    went unnoticed for so long.
 
-    🔑 The bug this replaces: every field was read with `item.get(key, default)`,
-    which fires only when a key is ABSENT and cannot correct a value of the wrong
-    TYPE. `pain_points` and `behaviors` are objects on every stored row while the
-    schema declared `array<string>`, so the dicts travelled unchanged and a
-    schema-validating client rejected the whole result. Six other declared keys
-    (`goals`, `age_range`, `occupation`, `quote`, `journey_stage`, `type`) exist
-    on no row at all and were reported as empty forever.
+    Every field is coerced to the type it is DECLARED as, driven by the
+    declarations rather than written out field by field. The bug this replaces
+    read each field with `item.get(key, default)`, and a default fires only when
+    a key is ABSENT: it cannot correct a value of the wrong TYPE, so the object
+    `pain_points` travelled unchanged under a schema declaring `array<string>`
+    and a validating client rejected the whole result. Driving it from the
+    declarations is the second half of that lesson — the field-by-field version
+    of this function guarded `feedback_count` and left `confidence` unchecked.
 
-    Everything not declared — avatar keys, source feedback ids, research notes,
-    timestamps, llm metadata — is still dropped: a project's personas are the
-    answer, not its storage layout.
+    Everything not declared — avatar keys, source feedback ids, researcher
+    notes, timestamps, llm metadata — is still dropped: a project's personas are
+    the answer, not its storage layout.
     """
     projected: dict[str, Any] = {
-        "persona_id": item.get('persona_id', ''),
-        "name": item.get('name', ''),
-        "tagline": item.get('tagline', ''),
-        "confidence": item.get('confidence', ''),
+        key: _coerce_declared(item.get(key), declared_type)
+        for key, declared_type in _PERSONA_SCALAR_TYPES.items()
     }
-
-    # `feedback_count` is declared an integer, so a missing or unparseable value
-    # must not become `''` — that would violate the schema exactly as the old
-    # string defaults did.
-    try:
-        projected["feedback_count"] = int(item.get('feedback_count') or 0)
-    except (TypeError, ValueError):
-        projected["feedback_count"] = 0
-
-    for section, list_keys in _PERSONA_LIST_KEYS.items():
-        projected[section] = _persona_section(item.get(section), list_keys)
+    for section, declared in _PERSONA_SECTION_TYPES.items():
+        projected[section] = _persona_section(section, item.get(section), declared)
 
     quotes = item.get('quotes')
-    projected["quotes"] = [q for q in quotes if isinstance(q, dict)] if isinstance(quotes, list) else []
+    entries = quotes if isinstance(quotes, (list, tuple)) else [quotes]
+    projected["quotes"] = [q for q in map(_as_quote, entries) if q is not None]
     return projected
 
 
@@ -1334,21 +1457,27 @@ def _tool_get_project(args: dict, token_info: dict) -> ToolResult:
     Bodies become resources in a later phase.
     """
     meta, personas, documents = _get_project_payload(token_info)
+    # Every field below is declared a string in this tool's own `outputSchema`, so
+    # every one is coerced. `.get(key, '')` defaults on an ABSENT key and cannot
+    # correct a value of the wrong TYPE — the mechanism behind `list_personas`
+    # being uncallable, and this tool reports a persona `tagline` from the same
+    # LLM-authored rows. Well-formed rows are unaffected: `_as_string` returns a
+    # string unchanged.
     return ToolResult({
         "project_id": token_info['project_id'],
-        "name": meta.get('name', ''),
-        "description": meta.get('description', ''),
-        "created_at": meta.get('created_at', ''),
+        "name": _as_string(meta.get('name')),
+        "description": _as_string(meta.get('description')),
+        "created_at": _as_string(meta.get('created_at')),
         "persona_count": len(personas),
         "document_count": len(documents),
         "personas": [
-            {"persona_id": p.get('persona_id', ''), "name": p.get('name', ''),
-             "tagline": p.get('tagline', '')}
+            {"persona_id": _as_string(p.get('persona_id')), "name": _as_string(p.get('name')),
+             "tagline": _as_string(p.get('tagline'))}
             for p in personas
         ],
         "documents": [
-            {"document_id": d.get('document_id', ''), "title": d.get('title', ''),
-             "type": d.get('type', ''), "kind": _document_kind(d)}
+            {"document_id": _as_string(d.get('document_id')), "title": _as_string(d.get('title')),
+             "type": _as_string(d.get('type')), "kind": _document_kind(d)}
             for d in documents
         ],
     })

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -174,12 +174,29 @@ _GENERATED_PERSONA: dict = {
         "tech_savviness": "medium-high",
         "decision_style": "Research-heavy at setup, habitual after",
     },
+    "context_environment": {
+        "usage_context": "First coffee of the day",
+        "devices": ["iPhone", "iPad"],
+        "time_constraints": "Ten minutes before the school run",
+    },
+    "scenario": {
+        "title": "The morning catch-up",
+        "narrative": "She opens the app while the kettle boils and wants the day in one screen.",
+        "trigger": "A push notification she did not ask for",
+        "outcome": "Knows what matters before she leaves the house",
+    },
     # Avatar keys, source ids and notes are present on real rows and must be
     # dropped by the projection — asserted in test_storage_layout_is_not_exposed.
     "avatar_url": "s3://bucket/avatars/p.png",
     "source_feedback_ids": ["1ae1eb6abcd7d3a2e364f46139f98466"],
     "research_notes": [{"note_id": "n1", "text": "seen twice", "created_at": "t"}],
-    "quotes": [{"text": "I just want the headlines.", "context": "onboarding"}],
+    "quotes": [{
+        "text": "I just want the headlines.",
+        "context": "onboarding",
+        # The quote's own citation, which IS reported: it is the id
+        # `get_feedback_detail` takes, unlike the row's `source_feedback_ids`.
+        "source_feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466",
+    }],
 }
 
 # `imported_from` rows: unpredictable keys, and `workarounds` is a STRING here
@@ -222,6 +239,35 @@ def _tool_output_schema(name: str) -> dict:
         if tool["name"] == name:
             return tool["outputSchema"]
     raise AssertionError(f"no tool named {name}")
+
+
+# The canonical persona declaration, read from the repo rather than restated, for
+# the same reason as `_tool_output_schema` above.
+_CANONICAL_PERSONA_SCHEMA = Path(__file__).resolve().parents[3] / "schemas" / "persona.schema.json"
+
+# The one canonical section `list_personas` deliberately does not report, with the
+# reason it does not. `research_notes` is researcher annotation added through
+# `/personas/{id}/notes` after the fact — a human's working notes about the
+# persona, not the persona — and it is asserted absent by
+# `test_storage_layout_is_not_exposed`.
+_UNREPORTED_SECTIONS = frozenset({"research_notes"})
+
+
+def _canonical_persona_sections() -> dict[str, str]:
+    """The canonical schema's own numbered sections, read from the schema file.
+
+    Keyed off the `Section N:` marker the schema itself writes in each
+    description, so this cannot drift from the file and a ninth section added
+    there fails this suite instead of quietly never reaching a client — which is
+    exactly how sections 5 and 7 went missing from the first version of the
+    projection.
+    """
+    schema = json.loads(_CANONICAL_PERSONA_SCHEMA.read_text(encoding="utf-8"))
+    return {
+        key: declared["description"]
+        for key, declared in schema["properties"].items()
+        if str(declared.get("description", "")).startswith("Section ")
+    }
 
 
 _JSON_TYPES: dict[str, type | tuple[type, ...]] = {
@@ -556,14 +602,19 @@ class TestProjections:
 
         assert "SECRET-BODY" not in json.dumps(result)
 
-    def test_personas_are_listed_in_full_by_the_persona_tool(self):
-        """The canonical 8-section shape, which is what every writer persists.
+    def test_every_reported_persona_section_carries_its_content(self):
+        """The seven content sections of `schemas/persona.schema.json`.
 
         The fixture this replaced was `{"goals": ["g"], "pain_points": ["pp"],
         "behaviors": ["b"], "quote": "q"}` — flat string lists and a `quote`
         string. No writer has ever produced that, and believing it is precisely
         what made `list_personas` uncallable against real data while this test
         passed.
+
+        One assertion per section, so a section that is declared but never
+        populated fails here. The first version of this projection declared
+        neither `context_environment` nor `scenario`, and a test that sampled
+        only some sections is what let that pass.
         """
         fake = _FakeLambda({f"/projects/{_PROJECT}": {
             "project": {"name": "P"},
@@ -579,7 +630,52 @@ class TestProjections:
         assert persona["goals_motivations"]["primary_goal"] == "Stay informed in ten minutes"
         assert persona["pain_points"]["current_challenges"] == ["Alerts bury the real news"]
         assert persona["behaviors"]["tech_savviness"] == "medium-high"
+        assert persona["context_environment"]["usage_context"] == "First coffee of the day"
+        assert persona["context_environment"]["devices"] == ["iPhone", "iPad"]
+        assert persona["scenario"]["title"] == "The morning catch-up"
         assert persona["quotes"][0]["text"] == "I just want the headlines."
+        assert persona["quotes"][0]["source_feedback_id"] == _FEEDBACK_ID
+
+    def test_every_canonical_persona_section_is_reported_or_excluded(self):
+        """The completeness claim, enforced against the schema instead of asserted.
+
+        `context_environment` and `scenario` are persisted by BOTH writers and
+        were declared by neither the tool's schema nor its projection, so a
+        client could not reach them while the docstrings claimed the canonical
+        shape. Prose cannot fail; this can. A ninth section added to
+        `persona.schema.json` now fails here until it is either reported or
+        listed as an exclusion with a reason.
+        """
+        sections = _canonical_persona_sections()
+        # The schema's own title says eight, so a marker that stopped matching
+        # would otherwise make this test vacuously true.
+        assert len(sections) == 8, f"expected 8 numbered sections, found {sorted(sections)}"
+
+        declared = set(mcp_handler._PERSONA_PROPERTIES)
+        missing = set(sections) - declared - _UNREPORTED_SECTIONS
+        assert not missing, f"canonical sections neither reported nor excluded: {sorted(missing)}"
+
+        # The exclusion list is not a dumping ground: every name in it must be a
+        # section that really exists, and must really not be reported.
+        assert _UNREPORTED_SECTIONS <= set(sections)
+        assert not _UNREPORTED_SECTIONS & declared
+
+    def test_a_quote_declares_every_field_the_canonical_schema_gives_it(self):
+        """Section 6's own fields, checked against the schema for the same reason.
+
+        An undeclared key still travels — the quote object is
+        `additionalProperties: true` — so the cost of leaving one out is not lost
+        data but a client that cannot rely on the citation being there.
+        `source_feedback_id` is the id `get_feedback_detail` takes, which makes it
+        the one worth relying on.
+        """
+        canonical = json.loads(_CANONICAL_PERSONA_SCHEMA.read_text(encoding="utf-8"))
+        quote_fields = set(canonical["properties"]["quotes"]["items"]["properties"])
+
+        assert quote_fields, "the canonical quote item declares no fields; marker moved?"
+        assert quote_fields <= set(mcp_handler._QUOTE_PROPERTIES), (
+            f"canonical quote fields not declared: {sorted(quote_fields - set(mcp_handler._QUOTE_PROPERTIES))}"
+        )
 
     def test_storage_layout_is_not_exposed(self):
         """Avatar keys, source ids and notes are dropped; the persona is the answer."""
@@ -657,6 +753,137 @@ class TestProjections:
         assert projected["pain_points"]["current_challenges"] == ["Just the one"]
         assert _schema_errors(payload, _tool_output_schema("list_personas")) == []
 
+    def test_a_list_in_a_DECLARED_STRING_slot_is_coerced(self):
+        """The mirror image, and the hole the first version of this fix left.
+
+        Coercing only the declared ARRAYS meant a list arriving in a declared
+        string — `emotional_impact`, `primary_goal`, or top-level `confidence` —
+        reproduced M1 exactly: a payload contradicting its own `outputSchema`.
+        Every one of these values is LLM-authored, so the boundary coerces
+        whatever type it declared, not the subset that happened to be listed.
+        """
+        persona = {
+            **_SPARSE_PERSONA,
+            "confidence": ["high"],
+            "feedback_count": "42",
+            "pain_points": {"emotional_impact": ["Tired", "Resigned"]},
+            "scenario": {"narrative": {"step": "Opens the app"}},
+        }
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [persona], "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        projected = payload["personas"][0]
+        assert projected["confidence"] == "high"
+        assert projected["feedback_count"] == 42
+        assert projected["pain_points"]["emotional_impact"] == "Tired; Resigned"
+        # A dict in a string slot is JSON, not a Python repr: the reader is a
+        # model, and `{'step': 'Opens the app'}` is not machine-readable.
+        assert projected["scenario"]["narrative"] == '{"step": "Opens the app"}'
+        assert _schema_errors(payload, _tool_output_schema("list_personas")) == []
+
+    def test_a_quote_stored_as_a_bare_string_still_reaches_the_client(self):
+        """`quotes` entries were filtered by `isinstance(q, dict)`.
+
+        That answered "this persona has no quotes" about a persona who had them.
+        The shape is not hypothetical: the import path's own test fixture models
+        the model returning `quotes: ["I spend too much time in meetings"]`, and
+        until this change nothing pinned the schema it was asked for.
+        """
+        persona = {**_SPARSE_PERSONA, "quotes": ["I cannot prove what changed.", ""]}
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [persona], "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        quotes = payload["personas"][0]["quotes"]
+        # The empty entry carried no content, so it is not reported as a quote.
+        assert quotes == [{"text": "I cannot prove what changed."}]
+        assert _schema_errors(payload, _tool_output_schema("list_personas")) == []
+
+    def test_a_section_that_cannot_be_reported_is_logged_not_swallowed(self):
+        """An absent section is normal; a section of the wrong shape is not.
+
+        No writer produces a non-object section and all five live rows are
+        objects, so there is nothing to salvage and guessing a destination key
+        would file content under a misleading heading. Dropping it silently is
+        still the wrong half of that: the operator gets a warning, and the
+        persona's own text is never logged because it is customer-derived.
+        """
+        persona = {**_SPARSE_PERSONA, "behaviors": ["Checks the app twice a day"]}
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [persona], "documents": [],
+        }})
+        with patch.object(mcp_handler.logger, "warning") as warned:
+            payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        assert payload["personas"][0]["behaviors"] == {}
+        assert warned.call_count == 1
+        logged = json.dumps(warned.call_args.kwargs.get("extra", {}))
+        assert "behaviors" in logged
+        assert "Checks the app twice a day" not in logged
+
+    def test_every_declared_persona_type_has_a_coercion(self):
+        """A declared type with no coercion is M1 waiting to happen again.
+
+        The projection coerces by DECLARED TYPE, so adding a `boolean` or
+        `number` field to the persona schema without teaching `_COERCIONS` about
+        it would publish a type the boundary does not enforce. This is the
+        structural version of the finding that `confidence` went uncoerced while
+        `feedback_count` was guarded.
+        """
+        declared = set(mcp_handler._PERSONA_SCALAR_TYPES.values())
+        declared |= set(mcp_handler._QUOTE_TYPES.values())
+        for section in mcp_handler._PERSONA_SECTION_TYPES.values():
+            declared |= set(section.values())
+
+        uncoerced = declared - set(mcp_handler._COERCIONS)
+        assert not uncoerced, f"declared but never coerced: {sorted(uncoerced)}"
+
+        # The array coercion produces a list of STRINGS, so a declared array of
+        # objects would be flattened into JSON strings — the same contradiction
+        # one level down. `quotes` is the only array of objects and it has its own
+        # projection, so every array declared INSIDE a section must be strings.
+        for section, properties in mcp_handler._PERSONA_SECTIONS.items():
+            for key, declared_property in properties.items():
+                if declared_property.get("type") == "array":
+                    assert declared_property.get("items") == {"type": "string"}, (
+                        f"{section}.{key} declares array items that "
+                        "_as_string_list would flatten into strings"
+                    )
+
+    def test_the_project_summary_coerces_the_persona_fields_it_declares(self):
+        """`get_project` reads the same LLM-authored rows and declares strings.
+
+        It is the tool that WAS callable, so this is the live half of the same
+        defect: `tagline` is new to this summary and comes from the writer that
+        pinned nothing, and `p.get('tagline', '')` cannot correct a list.
+        """
+        persona = {**_SPARSE_PERSONA, "tagline": ["Night-shift", "supervisor"]}
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [persona], "documents": [],
+        }})
+        payload = _call("get_project", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        assert payload["personas"][0]["tagline"] == "Night-shift; supervisor"
+        assert _schema_errors(payload, _tool_output_schema("get_project")) == []
+
+    def test_an_absent_section_is_not_logged(self):
+        """The positive control for the warning above.
+
+        Most live rows omit some sections entirely — the sparse row omits three —
+        so warning on absence would make the log useless and the previous test
+        would pass for the wrong reason.
+        """
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [_SPARSE_PERSONA], "documents": [],
+        }})
+        with patch.object(mcp_handler.logger, "warning") as warned:
+            _call("list_personas", {"project_id": _PROJECT}, fake)
+
+        assert warned.call_count == 0
+
     def test_unpredicted_section_keys_are_preserved(self):
         """An imported persona's pain points live under keys this file never chose.
 
@@ -698,6 +925,12 @@ class TestProjections:
             broken(pain_points={"current_challenges": {"a": 1}}), schema)
         assert _schema_errors(broken(feedback_count="42"), schema)
         assert _schema_errors(broken(tagline=["not", "a", "string"]), schema)
+        # A list in a declared STRING slot, nested and top-level: the violation the
+        # scalar coercion prevents. Without these two the checker would pass a
+        # payload the string coercion is the only thing stopping.
+        assert _schema_errors(broken(confidence=["high"]), schema)
+        assert _schema_errors(
+            broken(pain_points={"emotional_impact": ["tired", "resigned"]}), schema)
         assert _schema_errors(broken(journey_stage="undeclared"), schema)
         assert _schema_errors({"count": "1", "personas": []}, schema)
 

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -56,6 +56,7 @@ removed. The revert map:
       raises KeyError at call time rather than at import. This walks the table.
 """
 
+import hashlib
 import io
 import json
 import os
@@ -253,6 +254,11 @@ _CANONICAL_PERSONA_SCHEMA = Path(__file__).resolve().parents[3] / "schemas" / "p
 _UNREPORTED_SECTIONS = frozenset({"research_notes"})
 
 
+def _canonical_persona_properties() -> dict:
+    """The canonical persona declaration's `properties`, read from the schema file."""
+    return json.loads(_CANONICAL_PERSONA_SCHEMA.read_text(encoding="utf-8"))["properties"]
+
+
 def _canonical_persona_sections() -> dict[str, str]:
     """The canonical schema's own numbered sections, read from the schema file.
 
@@ -262,10 +268,9 @@ def _canonical_persona_sections() -> dict[str, str]:
     exactly how sections 5 and 7 went missing from the first version of the
     projection.
     """
-    schema = json.loads(_CANONICAL_PERSONA_SCHEMA.read_text(encoding="utf-8"))
     return {
         key: declared["description"]
-        for key, declared in schema["properties"].items()
+        for key, declared in _canonical_persona_properties().items()
         if str(declared.get("description", "")).startswith("Section ")
     }
 
@@ -647,9 +652,12 @@ class TestProjections:
         listed as an exclusion with a reason.
         """
         sections = _canonical_persona_sections()
-        # The schema's own title says eight, so a marker that stopped matching
-        # would otherwise make this test vacuously true.
-        assert len(sections) == 8, f"expected 8 numbered sections, found {sorted(sections)}"
+        # Anti-vacuity only: the schema's own title says eight sections, so a
+        # marker that stopped matching must fail rather than pass with an empty
+        # set. Deliberately `>=`, not `==` — a ninth section that IS correctly
+        # reported has to fail on the reporting check below, with a message that
+        # names it, rather than on a count that misdirects.
+        assert len(sections) >= 8, f"expected at least 8 numbered sections, found {sorted(sections)}"
 
         declared = set(mcp_handler._PERSONA_PROPERTIES)
         missing = set(sections) - declared - _UNREPORTED_SECTIONS
@@ -669,8 +677,7 @@ class TestProjections:
         `source_feedback_id` is the id `get_feedback_detail` takes, which makes it
         the one worth relying on.
         """
-        canonical = json.loads(_CANONICAL_PERSONA_SCHEMA.read_text(encoding="utf-8"))
-        quote_fields = set(canonical["properties"]["quotes"]["items"]["properties"])
+        quote_fields = set(_canonical_persona_properties()["quotes"]["items"]["properties"])
 
         assert quote_fields, "the canonical quote item declares no fields; marker moved?"
         assert quote_fields <= set(mcp_handler._QUOTE_PROPERTIES), (
@@ -1050,6 +1057,33 @@ class TestStructuredOutput:
         tell."""
         major = mcp_handler.MCP_SERVER_VERSION.split(".")[0]
         assert int(major) >= 2
+
+    def test_a_changed_tool_output_shape_moves_the_server_version(self):
+        """`serverInfo.version` is the only signal a client gets, so it is pinned
+        to the shapes it describes.
+
+        The check above (`major >= 2`) passes forever, which means it would have
+        let this PR's own persona-shape change ship under the version that
+        described the previous one. Fingerprinting the declared `outputSchema`s in
+        lockstep makes any edit to a published shape fail here until the version
+        is reconsidered — the repo's lockstep pattern, applied to the one contract
+        that leaves the account.
+
+        Key order does not count (`sort_keys`), so reordering a declaration is
+        free and only content moves the fingerprint.
+        """
+        shapes = json.dumps(
+            {tool["name"]: tool["outputSchema"] for tool in mcp_handler.MCP_TOOLS},
+            sort_keys=True,
+        )
+        fingerprint = hashlib.sha256(shapes.encode("utf-8")).hexdigest()[:16]
+
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.0.0", "6b78edcc4fed0723"), (
+            "a tool's declared output shape changed. Move MCP_SERVER_VERSION — minor "
+            "for an added field, MAJOR for a removal or a retype, because a client "
+            "validates structuredContent against these schemas — then update the "
+            "fingerprint here in the same commit."
+        )
 
 
 # ===========================================================================

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -144,6 +144,138 @@ def _call(tool: str, arguments: dict, fake: _FakeLambda) -> dict:
         return mcp_handler._handle_tools_call(1, {"name": tool, "arguments": arguments}, _token())
 
 
+# Persona fixtures copied from the SHAPES OF LIVE ROWS, not invented.
+#
+# Two writers exist and they do not agree. `projects.py` generation follows
+# `schemas/persona.schema.json`; `jobs/persona_importer` does not constrain the
+# model, so imported rows carry keys this file cannot predict and sometimes a
+# scalar where the schema says array. Both are represented here, because a
+# fixture that only covered the tidy writer is exactly what hid the defect.
+_GENERATED_PERSONA: dict = {
+    "persona_id": "persona_20260802204425",
+    "name": "Priya Shah",
+    "tagline": "The Habitual Skimmer",
+    "confidence": "high",
+    "feedback_count": 42,
+    "identity": {"age_range": "35-44", "occupation": "Solicitor", "location": "Leeds, UK"},
+    "goals_motivations": {
+        "primary_goal": "Stay informed in ten minutes",
+        "secondary_goals": ["Follow local council news"],
+    },
+    "pain_points": {
+        "current_challenges": ["Alerts bury the real news"],
+        "blockers": ["Nothing blocking her today"],
+        "workarounds": ["Curated her notification categories"],
+        "emotional_impact": "Calm but quietly resigned",
+    },
+    "behaviors": {
+        "current_solutions": ["Home-screen widget"],
+        "tools_used": ["iOS app"],
+        "tech_savviness": "medium-high",
+        "decision_style": "Research-heavy at setup, habitual after",
+    },
+    # Avatar keys, source ids and notes are present on real rows and must be
+    # dropped by the projection — asserted in test_storage_layout_is_not_exposed.
+    "avatar_url": "s3://bucket/avatars/p.png",
+    "source_feedback_ids": ["1ae1eb6abcd7d3a2e364f46139f98466"],
+    "research_notes": [{"note_id": "n1", "text": "seen twice", "created_at": "t"}],
+    "quotes": [{"text": "I just want the headlines.", "context": "onboarding"}],
+}
+
+# `imported_from` rows: unpredictable keys, and `workarounds` is a STRING here
+# while it is a list above. Same key, two types, both live.
+_IMPORTED_PERSONA: dict = {
+    "persona_id": "persona_20260814135248",
+    "name": "Priya Raman",
+    "tagline": "Ops lead under audit pressure",
+    "imported_from": "text",
+    "identity": {"role": "Ops Lead", "industry": "Logistics", "company_size": "200-500"},
+    "goals_motivations": {"primary_goal": "Close the audit", "motivations": ["Avoid fines"]},
+    "pain_points": {"primary_frustration": "No audit trail", "related_issues": ["Manual exports"]},
+    "behaviors": {"workarounds": "Keeps a private spreadsheet", "current_practices": "Weekly review"},
+    "quotes": [{"text": "I cannot prove what changed."}],
+}
+
+# The thinnest live row: one key per section, no quotes, no confidence.
+_SPARSE_PERSONA: dict = {
+    "persona_id": "persona_20260815121940",
+    "name": "Tobias Krenzler",
+    "tagline": "Night-shift supervisor",
+    "identity": {"location": "Hamburg"},
+    "goals_motivations": {"primary_goal": "Finish the handover"},
+    "pain_points": {"frustration": "Shift notes get lost"},
+    "behaviors": {},
+}
+
+_LIVE_PERSONA_SHAPES: tuple[dict, ...] = (
+    _GENERATED_PERSONA, _IMPORTED_PERSONA, _SPARSE_PERSONA,
+)
+
+
+def _tool_output_schema(name: str) -> dict:
+    """The tool's OWN declared `outputSchema`, read from the live registry.
+
+    Read rather than restated so the check cannot drift from what the server
+    publishes — a copy in this file would keep passing after the schema changed.
+    """
+    for tool in mcp_handler.MCP_TOOLS:
+        if tool["name"] == name:
+            return tool["outputSchema"]
+    raise AssertionError(f"no tool named {name}")
+
+
+_JSON_TYPES: dict[str, type | tuple[type, ...]] = {
+    "object": dict,
+    "array": (list, tuple),
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+}
+
+
+def _schema_errors(value, schema: dict, path: str = "") -> list[str]:
+    """Validate against the JSON Schema subset these tool schemas actually use.
+
+    Deliberately NOT a general implementation, and deliberately not a new
+    dependency: `jsonschema` is not installed in this suite, and a hand-rolled
+    general validator is the kind of thing that passes for the wrong reason. This
+    covers exactly `type`, `properties`, `items`, `required`, `enum` and
+    `additionalProperties: false` — every construct present in `MCP_TOOLS` — and
+    `test_the_schema_checker_itself_rejects_a_bad_payload` is its positive
+    control.
+    """
+    declared = schema.get("type")
+    expected = _JSON_TYPES.get(declared) if declared else None
+    if expected is not None:
+        # bool is a subclass of int in Python; an integer field must not accept it.
+        if declared in ("integer", "number") and isinstance(value, bool):
+            return [f"{path or '<root>'}: bool where {declared} declared"]
+        if not isinstance(value, expected):
+            return [f"{path or '<root>'}: {type(value).__name__} where {declared} declared"]
+
+    if "enum" in schema and value not in schema["enum"]:
+        return [f"{path or '<root>'}: {value!r} not in enum"]
+
+    errors: list[str] = []
+    if declared == "object" and isinstance(value, dict):
+        properties = schema.get("properties", {})
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append(f"{path}.{key}: required but absent")
+        if schema.get("additionalProperties") is False:
+            for key in value:
+                if key not in properties:
+                    errors.append(f"{path}.{key}: not declared (additionalProperties is false)")
+        for key, inner in value.items():
+            if key in properties:
+                errors += _schema_errors(inner, properties[key], f"{path}.{key}")
+    elif declared == "array" and isinstance(value, (list, tuple)) and "items" in schema:
+        for i, entry in enumerate(value):
+            errors += _schema_errors(entry, schema["items"], f"{path}[{i}]")
+    return errors
+
+
 def _feedback_row(**extra) -> dict:
     return {
         "id": "1ae1eb6abcd7d3a2e364f46139f98466",
@@ -425,17 +557,149 @@ class TestProjections:
         assert "SECRET-BODY" not in json.dumps(result)
 
     def test_personas_are_listed_in_full_by_the_persona_tool(self):
+        """The canonical 8-section shape, which is what every writer persists.
+
+        The fixture this replaced was `{"goals": ["g"], "pain_points": ["pp"],
+        "behaviors": ["b"], "quote": "q"}` — flat string lists and a `quote`
+        string. No writer has ever produced that, and believing it is precisely
+        what made `list_personas` uncallable against real data while this test
+        passed.
+        """
         fake = _FakeLambda({f"/projects/{_PROJECT}": {
             "project": {"name": "P"},
-            "personas": [{"persona_id": "p1", "name": "Ann", "goals": ["g"],
-                          "pain_points": ["pp"], "behaviors": ["b"], "quote": "q"}],
+            "personas": [_GENERATED_PERSONA],
             "documents": [],
         }})
         payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
 
         assert payload["count"] == 1
-        assert payload["personas"][0]["goals"] == ["g"]
-        assert payload["personas"][0]["age_range"] == "", "absent fields get typed defaults"
+        persona = payload["personas"][0]
+        assert persona["tagline"] == "The Habitual Skimmer"
+        assert persona["identity"]["age_range"] == "35-44"
+        assert persona["goals_motivations"]["primary_goal"] == "Stay informed in ten minutes"
+        assert persona["pain_points"]["current_challenges"] == ["Alerts bury the real news"]
+        assert persona["behaviors"]["tech_savviness"] == "medium-high"
+        assert persona["quotes"][0]["text"] == "I just want the headlines."
+
+    def test_storage_layout_is_not_exposed(self):
+        """Avatar keys, source ids and notes are dropped; the persona is the answer."""
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [_GENERATED_PERSONA], "documents": [],
+        }})
+        result = _call("list_personas", {"project_id": _PROJECT}, fake)
+
+        for leaked in ("avatar_url", "source_feedback_ids", "research_notes"):
+            assert leaked not in json.dumps(result), f"{leaked} reached the client"
+
+    @pytest.mark.parametrize(
+        "persona", _LIVE_PERSONA_SHAPES, ids=["generated", "imported", "sparse"]
+    )
+    def test_every_live_persona_shape_satisfies_the_declared_output_schema(self, persona):
+        """The gate that did not exist, and its absence is the whole defect.
+
+        `list_personas` declared `pain_points`/`behaviors` as `array<string>`
+        while every stored row holds an OBJECT. The declaration was published as
+        a contract and never checked against real data, so 2 944 pytest cases,
+        268 CDK cases and an 84/84 live curl battery all passed while a
+        schema-validating client — the official MCP SDK, by default — rejected
+        every call with `-32602`.
+
+        Reverting the projection to `item.get('pain_points', [])` fails this,
+        because a `.get` default fires only on an ABSENT key and cannot correct a
+        value of the wrong TYPE.
+        """
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [persona], "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        errors = _schema_errors(payload, _tool_output_schema("list_personas"))
+        assert errors == [], f"payload violates its own outputSchema: {errors}"
+
+    def test_an_undeclared_key_keeps_its_own_type(self):
+        """Live shape: the imported row files `workarounds` under `behaviors`.
+
+        `workarounds` is a declared array under `pain_points` and undeclared under
+        `behaviors`, so here it is neither coerced nor dropped — it is preserved
+        as the string it is, which `additionalProperties: true` permits. Coercing
+        by key NAME regardless of section would fail this and would also make the
+        answer claim a structure the row does not have.
+        """
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [_IMPORTED_PERSONA], "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        assert payload["personas"][0]["behaviors"]["workarounds"] == "Keeps a private spreadsheet"
+
+    def test_a_scalar_in_a_DECLARED_array_slot_is_coerced(self):
+        """Defensive, and the reason is a trust boundary, not a known bad row.
+
+        No live row currently holds a scalar in a declared array slot, but every
+        one of these values is LLM-authored and the live rows already prove the
+        shape varies per writer. A scalar arriving in `secondary_goals` would
+        reproduce M1 exactly — a payload contradicting its own schema — so the
+        boundary coerces. Deleting the list branch of `_as_string_list` fails this
+        AND the conformance test above.
+        """
+        persona = {
+            **_SPARSE_PERSONA,
+            "goals_motivations": {"primary_goal": "Ship", "secondary_goals": "Only one"},
+            "pain_points": {"current_challenges": "Just the one"},
+        }
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [persona], "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        projected = payload["personas"][0]
+        assert projected["goals_motivations"]["secondary_goals"] == ["Only one"]
+        assert projected["pain_points"]["current_challenges"] == ["Just the one"]
+        assert _schema_errors(payload, _tool_output_schema("list_personas")) == []
+
+    def test_unpredicted_section_keys_are_preserved(self):
+        """An imported persona's pain points live under keys this file never chose.
+
+        Dropping them would answer "this persona has no pain points" about a
+        persona whose pain points are simply filed elsewhere — the same silent
+        under-report the surface is being fixed for. Restricting the projection to
+        the declared keys fails this.
+        """
+        fake = _FakeLambda({f"/projects/{_PROJECT}": {
+            "project": {"name": "P"}, "personas": [_IMPORTED_PERSONA], "documents": [],
+        }})
+        payload = _call("list_personas", {"project_id": _PROJECT}, fake)["result"]["structuredContent"]
+
+        pains = payload["personas"][0]["pain_points"]
+        assert pains["primary_frustration"] == "No audit trail"
+        assert pains["related_issues"] == ["Manual exports"]
+
+    def test_the_schema_checker_itself_rejects_a_bad_payload(self):
+        """Positive control. A conformance test that cannot fail proves nothing.
+
+        Every violation the real defect produced must be caught: a dict where an
+        array is declared, a scalar where an array is declared, a string where an
+        integer is declared, and an undeclared top-level key.
+        """
+        schema = _tool_output_schema("list_personas")
+        good = {"count": 1, "personas": [{
+            "persona_id": "p", "name": "n", "tagline": "t", "confidence": "high",
+            "feedback_count": 1, "identity": {}, "goals_motivations": {},
+            "pain_points": {}, "behaviors": {}, "quotes": [],
+        }]}
+        assert _schema_errors(good, schema) == []
+
+        def broken(**changes):
+            persona = {**good["personas"][0], **changes}
+            return {"count": 1, "personas": [persona]}
+
+        # The exact shape of the live defect: an object where array was declared.
+        assert _schema_errors(
+            broken(pain_points={"current_challenges": {"a": 1}}), schema)
+        assert _schema_errors(broken(feedback_count="42"), schema)
+        assert _schema_errors(broken(tagline=["not", "a", "string"]), schema)
+        assert _schema_errors(broken(journey_stage="undeclared"), schema)
+        assert _schema_errors({"count": "1", "personas": []}, schema)
 
     def test_count_never_exceeds_the_items_it_describes(self):
         """`count` describes what the CALLER received, not what the route sent.

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1069,14 +1069,22 @@ class TestStructuredOutput:
         is reconsidered — the repo's lockstep pattern, applied to the one contract
         that leaves the account.
 
-        Key order does not count (`sort_keys`), so reordering a declaration is
-        free and only content moves the fingerprint.
+        OBJECT key order does not count (`sort_keys`), so reformatting a
+        declaration is free. LIST order does count, and `required` and `enum` are
+        lists: reordering their entries is semantically identical but will move
+        the fingerprint, so treat such a failure as a prompt to restore the order
+        rather than to bump the version.
         """
-        shapes = json.dumps(
-            {tool["name"]: tool["outputSchema"] for tool in mcp_handler.MCP_TOOLS},
-            sort_keys=True,
-        )
-        fingerprint = hashlib.sha256(shapes.encode("utf-8")).hexdigest()[:16]
+        shapes = {}
+        for tool in mcp_handler.MCP_TOOLS:
+            # Named rather than a KeyError from inside the fingerprint: presence is
+            # `test_every_tool_declares_an_output_schema`'s claim, and this test
+            # should say which tool broke it, not where it noticed.
+            assert "outputSchema" in tool, f"{tool['name']} declares no output shape"
+            shapes[tool["name"]] = tool["outputSchema"]
+
+        serialized = json.dumps(shapes, sort_keys=True)
+        fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
         assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.0.0", "6b78edcc4fed0723"), (
             "a tool's declared output shape changed. Move MCP_SERVER_VERSION — minor "

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -68,23 +68,16 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, import_config: dic
 
     logger.info(f"[IMPORT_PERSONA_JOB] Starting import from {input_type} for project {project_id}")
 
-    # 🔴 ROOT-CAUSE FIX: this handler used to hand-build its own prompt inline,
-    # with a schema string whose every section was the literal `{...}`:
+    # The prompt comes from `persona-import.json`, which carries the canonical key
+    # set with example values that pin the TYPES (`"workarounds": ["Workaround 1"]`)
+    # and enums (`low|medium|high`). It replaces a schema string built here whose
+    # every section was the literal `{...}`, which named the sections and nothing
+    # about their contents — so the model invented inner keys per document and
+    # `.get(k, {})` below persisted whatever came back.
     #
-    #   '{"identity": {...}, "goals_motivations": {...}, "pain_points": {...}, …}'
-    #
-    # so the model was told the SECTION names and nothing about their contents. It
-    # complied, inventing inner keys per document (`primary_frustration`,
-    # `frustration`, `tooling`, `current_practices`), and `.get(k, {})` below
-    # persisted whatever came back. That is why imported personas do not match
-    # `schemas/persona.schema.json` while generated ones do — the writer never
-    # asked them to.
-    #
-    # `persona-import.json` has carried the full canonical key set, with example
-    # values that also pin the TYPES (`"workarounds": ["Workaround 1"]`) and enums
-    # (`low|medium|high`), the whole time — and nothing loaded it. It is already
-    # packaged into this bundle: `createJobLambdaCode` copies `api/prompts` to the
-    # bundle root, so `get_prompts_dir()` resolves `/var/task/prompts` first.
+    # The template needs no bundling change: `createJobLambdaCode` copies
+    # `api/prompts` to the bundle root, so `get_prompts_dir()` resolves
+    # `/var/task/prompts` first.
     prompt_config = load_prompt_file(PERSONA_IMPORT_PROMPTS)
     system_prompt = prompt_config['system_prompt']
     # Dumped from the template rather than restated here, so the schema the model

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from shared.logging import logger, tracer, metrics
 from shared.jobs import job_handler, JobContext
 from shared.persona_import import validate_import_config
+from shared.prompts import PERSONA_IMPORT_PROMPTS, format_prompt, load_prompt_file
 from shared.image_limits import converse_image_format
 from shared.aws import get_dynamodb_resource, get_bedrock_client
 from shared.model_config import get_active_model_id
@@ -66,13 +67,31 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, import_config: dic
     )
 
     logger.info(f"[IMPORT_PERSONA_JOB] Starting import from {input_type} for project {project_id}")
-    
-    system_prompt = """You are a UX researcher expert at extracting persona information from documents and images.
-Extract persona data from the provided input and output a structured JSON object.
-CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
 
-    json_schema = '{"name": "Full Name", "tagline": "One sentence", "confidence": "high", "identity": {...}, "goals_motivations": {...}, "pain_points": {...}, "behaviors": {...}, "context_environment": {...}, "quotes": [...], "scenario": {...}}'
-    
+    # 🔴 ROOT-CAUSE FIX: this handler used to hand-build its own prompt inline,
+    # with a schema string whose every section was the literal `{...}`:
+    #
+    #   '{"identity": {...}, "goals_motivations": {...}, "pain_points": {...}, …}'
+    #
+    # so the model was told the SECTION names and nothing about their contents. It
+    # complied, inventing inner keys per document (`primary_frustration`,
+    # `frustration`, `tooling`, `current_practices`), and `.get(k, {})` below
+    # persisted whatever came back. That is why imported personas do not match
+    # `schemas/persona.schema.json` while generated ones do — the writer never
+    # asked them to.
+    #
+    # `persona-import.json` has carried the full canonical key set, with example
+    # values that also pin the TYPES (`"workarounds": ["Workaround 1"]`) and enums
+    # (`low|medium|high`), the whole time — and nothing loaded it. It is already
+    # packaged into this bundle: `createJobLambdaCode` copies `api/prompts` to the
+    # bundle root, so `get_prompts_dir()` resolves `/var/task/prompts` first.
+    prompt_config = load_prompt_file(PERSONA_IMPORT_PROMPTS)
+    system_prompt = prompt_config['system_prompt']
+    # Dumped from the template rather than restated here, so the schema the model
+    # is shown cannot drift from the schema the file declares.
+    json_schema = json.dumps(prompt_config['output_schema'], indent=2)
+    user_prompts = prompt_config['user_prompts']
+
     # Build converse content
     converse_content = []
     if input_type == 'image':
@@ -86,13 +105,18 @@ CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
             }
         })
         converse_content.append({
-            'text': f"Extract the persona information from this image.\n\nOutput a JSON object with this structure:\n{json_schema}\n\nOutput ONLY the JSON object."
+            'text': f"{user_prompts['image']}\n\nSchema:\n{json_schema}"
         })
     else:
         # `input_type` is 'text' here — the guard above left no other possibility,
         # so there is no fallback content to substitute and nothing to invent.
+        #
+        # The template's `pdf` prompt is deliberately NOT wired: `pdf` is in
+        # `DEFERRED_INPUT_TYPES` and `validate_import_config` refuses it upstream,
+        # so a branch for it here would be unreachable code advertising a
+        # capability the product declines.
         converse_content.append({
-            'text': f"Extract the persona information from this text:\n\n---\n{content}\n---\n\nOutput a JSON object with this structure:\n{json_schema}\n\nOutput ONLY the JSON object."
+            'text': f"{format_prompt(user_prompts['text'], content=content)}\n\nSchema:\n{json_schema}"
         })
     
     ctx.update_progress(30, 'calling_ai')
@@ -108,7 +132,10 @@ CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
         modelId=model_id,
         system=[{'text': system_prompt}],
         messages=[{'role': 'user', 'content': converse_content}],
-        inferenceConfig={'maxTokens': 4096}
+        # From the template too, so the budget lives beside the schema it has to
+        # produce rather than as a literal here that nobody updates when the
+        # schema grows.
+        inferenceConfig={'maxTokens': prompt_config['max_tokens']}
     )
     
     response_text = response.get('output', {}).get('message', {}).get('content', [{}])[0].get('text', '')
@@ -146,6 +173,14 @@ CRITICAL: Output ONLY valid JSON, no markdown, no explanation."""
         'scenario': persona_data.get('scenario', {}),
         'research_notes': [],
         'imported_from': input_type,
+        # Attributability, matching what the generation path already records. An
+        # imported persona previously carried no prompt version at all, so a row
+        # with odd inner keys could not be traced to the prompt that produced it —
+        # which is exactly the diagnosis this fix had to reconstruct by hand.
+        'llm_metadata': {
+            'model': model_id,
+            'prompt_version': prompt_config['version'],
+        },
         'created_at': now,
         'updated_at': now,
     }

--- a/voc-datalake/lambda/jobs/persona_importer/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/test/test_handler.py
@@ -195,10 +195,13 @@ class TestImportPromptComesFromTheTemplate:
         lambda_handler(text_import_event, lambda_context)
         prompt = self._prompt_text(mock_bedrock)
 
-        # One inner key per canonical section — the four sections MCP reports.
+        # One inner key per canonical section, covering every section
+        # `list_personas` reports: what the reader publishes, the writer must ask
+        # for, or the schema is honest about a shape nothing produces.
         for inner_key in ('age_range', 'primary_goal', 'current_challenges',
                           'blockers', 'workarounds', 'emotional_impact',
-                          'current_solutions', 'tech_savviness'):
+                          'current_solutions', 'tech_savviness',
+                          'usage_context', 'devices', 'narrative', 'trigger'):
             assert inner_key in prompt, f"the model was never told about {inner_key}"
 
         assert '{...}' not in prompt, "the inline placeholder schema is back"
@@ -248,13 +251,20 @@ class TestImportPromptComesFromTheTemplate:
 
         `validate_import_config` refuses it upstream, so a branch for it here would
         be unreachable code advertising a capability the product declines.
+
+        Asserted against the template's own `pdf` prompt rather than a phrase
+        copied out of it, so rewording the template cannot turn this green for a
+        reason that has nothing to do with wiring.
         """
         mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        from shared.prompts import PERSONA_IMPORT_PROMPTS, load_prompt_file
+
         from jobs.persona_importer.handler import lambda_handler
 
         lambda_handler(text_import_event, lambda_context)
 
-        assert 'PDF document' not in self._prompt_text(mock_bedrock)
+        pdf_prompt = load_prompt_file(PERSONA_IMPORT_PROMPTS)['user_prompts']['pdf']
+        assert pdf_prompt not in self._prompt_text(mock_bedrock)
 
     def test_the_template_carries_every_key_the_handler_consumes(self):
         """The handler subscripts the template directly, so a dropped key must be

--- a/voc-datalake/lambda/jobs/persona_importer/test/test_handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/test/test_handler.py
@@ -149,3 +149,155 @@ class TestPersonaImporterHandler:
         # Verify update_item was called to increment persona_count
         update_calls = [c for c in mock_dynamodb['table'].update_item.call_args_list]
         assert any('persona_count' in str(c) for c in update_calls)
+
+
+class TestImportPromptComesFromTheTemplate:
+    """The root cause of the persona-shape divergence, and its guard.
+
+    This handler used to hand-build its prompt inline with a schema string whose
+    every section was the literal `{...}`:
+
+        '{"identity": {...}, "goals_motivations": {...}, "pain_points": {...}, …}'
+
+    so the model was told the section NAMES and nothing about their contents. It
+    complied — imported personas carry `primary_frustration`, `frustration`,
+    `tooling`, `current_practices` where generated ones carry the canonical keys —
+    and the persist block's `.get(k, {})` stored whatever came back.
+
+    `api/prompts/persona-import.json` has held the full canonical key set the whole
+    time, with example values that pin the TYPES and enums, and nothing loaded it.
+
+    Revert map: restoring the inline `{...}` schema fails
+    `test_the_prompt_names_the_canonical_inner_keys`; dropping the template's
+    example values fails `test_the_schema_shown_pins_types_not_just_key_names`.
+    """
+
+    @staticmethod
+    def _prompt_text(mock_bedrock) -> str:
+        """Everything the model was actually shown, system prompt included."""
+        kwargs = mock_bedrock.converse.call_args.kwargs
+        blocks = [
+            block.get('text', '')
+            for message in kwargs.get('messages', [])
+            for block in message.get('content', [])
+        ]
+        system = [s.get('text', '') for s in kwargs.get('system', [])]
+        return '\n'.join(system + blocks)
+
+    def test_the_prompt_names_the_canonical_inner_keys(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response, lambda_context
+    ):
+        """Section names alone are what produced the divergence."""
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        from jobs.persona_importer.handler import lambda_handler
+
+        lambda_handler(text_import_event, lambda_context)
+        prompt = self._prompt_text(mock_bedrock)
+
+        # One inner key per canonical section — the four sections MCP reports.
+        for inner_key in ('age_range', 'primary_goal', 'current_challenges',
+                          'blockers', 'workarounds', 'emotional_impact',
+                          'current_solutions', 'tech_savviness'):
+            assert inner_key in prompt, f"the model was never told about {inner_key}"
+
+        assert '{...}' not in prompt, "the inline placeholder schema is back"
+
+    def test_the_schema_shown_pins_types_not_just_key_names(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response, lambda_context
+    ):
+        """`workarounds` was a STRING on one live row and a LIST on another.
+
+        The example values are the type specification, so they have to reach the
+        model: a bare key list would leave the same ambiguity that produced the
+        mixed types.
+        """
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        from jobs.persona_importer.handler import lambda_handler
+
+        lambda_handler(text_import_event, lambda_context)
+        prompt = self._prompt_text(mock_bedrock)
+
+        assert '"workarounds": [' in prompt, "array-ness of workarounds not shown"
+        assert 'low|medium|high' in prompt, "the tech_savviness enum not shown"
+
+    def test_the_text_prompt_interpolates_the_content(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response, lambda_context
+    ):
+        """The template's text prompt carries a `{content}` placeholder.
+
+        Sending it unformatted would ask the model to extract a persona from the
+        literal word `{content}` — the same class of defect as the hardcoded
+        placeholder sentence this handler was already fixed for once.
+        """
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        from jobs.persona_importer.handler import lambda_handler
+
+        lambda_handler(text_import_event, lambda_context)
+        prompt = self._prompt_text(mock_bedrock)
+
+        assert '{content}' not in prompt
+
+    def test_the_pdf_prompt_is_not_wired(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response, lambda_context
+    ):
+        """The template has a `pdf` user prompt; `pdf` is a DEFERRED input type.
+
+        `validate_import_config` refuses it upstream, so a branch for it here would
+        be unreachable code advertising a capability the product declines.
+        """
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        from jobs.persona_importer.handler import lambda_handler
+
+        lambda_handler(text_import_event, lambda_context)
+
+        assert 'PDF document' not in self._prompt_text(mock_bedrock)
+
+    def test_the_template_carries_every_key_the_handler_consumes(self):
+        """The handler subscripts the template directly, so a dropped key must be
+        caught HERE rather than at runtime.
+
+        Why not `.get()` with fallbacks: a fallback would silently send a degraded
+        prompt, which is the exact defect this whole change removes. And why it
+        matters that it fails in CI — `shared/jobs.py::job_handler` writes `str(e)`
+        into the job record as a USER-FACING message, so an unguarded `KeyError`
+        would show someone `KeyError: 'output_schema'`. A red test here makes that
+        runtime path unreachable, which is cheaper than a runtime guard for a
+        condition CI already prevents.
+        """
+        from shared.prompts import PERSONA_IMPORT_PROMPTS, load_prompt_file
+
+        config = load_prompt_file(PERSONA_IMPORT_PROMPTS)
+        for key in ('system_prompt', 'output_schema', 'user_prompts', 'max_tokens', 'version'):
+            assert key in config, f"the handler reads config[{key!r}] and it is gone"
+
+        # Only the input types the product actually accepts need a user prompt;
+        # `pdf` is deferred and its prompt is deliberately unwired.
+        for input_type in ('text', 'image'):
+            assert input_type in config['user_prompts']
+        assert '{content}' in config['user_prompts']['text'], (
+            "the text prompt lost its placeholder, so content would never be interpolated"
+        )
+
+    def test_the_persisted_prompt_version_matches_the_template(
+        self, mock_dynamodb, mock_jobs_table, mock_bedrock,
+        mock_avatar_generation, text_import_event, mock_bedrock_persona_response, lambda_context
+    ):
+        """Lockstep, copying the `persona-generation.json` precedent.
+
+        An imported persona used to record no prompt version at all, so a row with
+        odd inner keys could not be attributed to the prompt that produced it —
+        which is precisely the diagnosis that had to be reconstructed by hand.
+        """
+        mock_bedrock.converse.return_value = mock_bedrock_persona_response
+        from shared.prompts import PERSONA_IMPORT_PROMPTS, load_prompt_file
+        from jobs.persona_importer.handler import lambda_handler
+
+        lambda_handler(text_import_event, lambda_context)
+
+        item = mock_dynamodb['table'].put_item.call_args.kwargs.get('Item', {})
+        expected = load_prompt_file(PERSONA_IMPORT_PROMPTS)['version']
+        assert item['llm_metadata']['prompt_version'] == expected

--- a/voc-datalake/lambda/shared/prompts.py
+++ b/voc-datalake/lambda/shared/prompts.py
@@ -36,6 +36,7 @@ PERSONA_GENERATION_PROMPTS = 'persona-generation.json'
 # personas get thrown away.
 PERSONA_SYNTHESIS_STEP = 'persona_synthesis'
 PERSONA_CHAIN_STEPS = ('research_analysis', PERSONA_SYNTHESIS_STEP)
+PERSONA_IMPORT_PROMPTS = 'persona-import.json'
 PRD_GENERATION_PROMPTS = 'prd-generation.json'
 PRFAQ_GENERATION_PROMPTS = 'prfaq-generation.json'
 RESEARCH_ANALYSIS_PROMPTS = 'research-analysis.json'


### PR DESCRIPTION
## Summary

`list_personas` could not be called at all, and tracing why led to the writer that caused it.

The tool declared `pain_points` and `behaviors` as `array<string>` while every stored persona holds objects. Clients validate `structuredContent` against the schema a tool publishes — the official MCP SDK does so by default — so **every call failed with `-32602`** and the model received nothing. Raw JSON-RPC returned the data, which is why 2 944 pytest cases, 268 CDK cases and an 84/84 live HTTP battery all passed: the schema was published as a contract and never checked against data that exists.

Found by connecting a real MCP client to the deployed server for the first time. Full write-up of this and seven sibling findings is in `analysis/BUG-mcp-tool-truthfulness-GITHUB-ISSUE.md` (M1 here; M2–M8 not addressed).

## Why the shapes disagreed

`persona_importer` built its prompt inline with a schema string whose every section was the literal `{...}`:

```
'{"identity": {...}, "goals_motivations": {...}, "pain_points": {...}, "behaviors": {...}, …}'
```

The model was told the section **names** and nothing about their **contents**, and it complied — imported personas carry `primary_frustration`, `frustration`, `tooling`, `current_practices` where generated ones carry the canonical keys. So the imported rows are not malformed; they are the correct response to a prompt that asked for nothing in particular.

Meanwhile `api/prompts/persona-import.json` has carried the full canonical key set — with example values that pin types and enums — the whole time, and **nothing loaded it**. `shared/prompts.py` declares constants for five templates and had none for it.

## Changes

**Reader** — `lambda/api/mcp_handler.py`

- `_PERSONA_SECTIONS` + `_QUOTE_PROPERTIES` mirror `schemas/persona.schema.json`. All seven content sections are reported: identity, goals & motivations, pain points, behaviors, context & environment, quotes, scenario. Section 8, `research_notes`, is researcher annotation rather than persona content and is the one deliberate exclusion.
- Six declared keys that exist on no stored row and reported empty forever are gone: `goals`, `age_range`, `occupation`, `quote`, `journey_stage`, `type`.
- `get_project`'s persona summary reports `tagline` instead of `type`.
- **Every field is coerced to the type its own schema declares**, derived from the declarations (`_declared_types` → `_COERCIONS`) rather than written out field by field. `_project_persona` used to read each field with `item.get(key, default)`, which fires only on an absent key and cannot correct a value of the wrong type — the mechanism that laundered the mismatch. Deriving the coercion is the other half of that lesson: a hand-kept list of "which keys are arrays" left `confidence` unchecked beside a defensively `int()`-wrapped `feedback_count`.
- A scalar in a declared array slot is wrapped; a list in a declared string slot is joined; a dict is JSON rather than a Python `repr`. `workarounds` is a string on one live row and a list on another.
- `get_project` coerces the declared strings in its own projection too. It is the tool that **was** callable, so it is the live half of the same defect, and it reads `tagline` from the writer that pinned nothing.
- Sections keep `additionalProperties: true` and unrecognised keys are preserved. Declaring `false` would make the tool fail on its own product; dropping the keys would answer *"this persona has no pain points"* about a persona whose pain points sit under an unforeseen key. A section that arrives as something other than an object is logged rather than discarded in silence — without its content, which is customer-derived text.
- `MCP_SERVER_VERSION` → **3.0.0**. The constant's own rule is that a changed tool output shape is a major bump, and it is what a client reads from `serverInfo`. Nothing could have consumed the removed keys — they were always empty and the tool was uncallable — but a client coded against the names loses them.

**Writer** — `lambda/jobs/persona_importer/handler.py`, `lambda/shared/prompts.py`

- Loads the template via `load_prompt_file` behind a new `PERSONA_IMPORT_PROMPTS` constant, taking `system_prompt`, `output_schema` (JSON-dumped, so what the model sees cannot drift from what the file declares), `user_prompts[input_type]` and `max_tokens` from it.
- Records `llm_metadata.prompt_version`; imported personas carried none, so a row with odd keys could not be attributed to the prompt that produced it.
- The template's `pdf` prompt is deliberately **not** wired — `pdf` is in `DEFERRED_INPUT_TYPES` and refused upstream, so a branch would be unreachable code advertising a declined capability.

**No CDK or bundling change.** `createJobLambdaCode` already copies `api/prompts` to the bundle root and `get_prompts_dir()` resolves `/var/task/prompts` first, so the template was already deployed beside the code ignoring it. Verified before wiring, because `load_prompt_file` would otherwise have raised `FileNotFoundError` at runtime and no test would have caught it — tests resolve the repo layout.

## What this does not do

Fixing the prompt does **not** make `additionalProperties: true` removable, and that is design rather than a leftover. A prompt is a request, not schema enforcement, so the model can still deviate; and discarding a field genuinely extracted from a customer's own document (`industry`, `role`, `segment` off a persona card) is data loss rather than tidiness. What changes is that variance goes from **systematic** — guaranteed, because the prompt asked for `{...}` — to **incidental**.

Write-side validation of the parsed output was considered and left out: the template's example values pin the types, so type variance is addressed at source, and a second normalizer before measuring whether variance persists would be speculative. If it recurs, the enforcement point is `persona_importer` before `put_item`.

## Tests

- Replaced the fixture that let this through — flat string lists and a `quote` string, a shape no writer has ever produced.
- New fixtures copy the shapes of **live rows**: generated, imported, sparse.
- **A schema-conformance gate that did not exist anywhere in this repo**: it reads each tool's own `outputSchema` from `MCP_TOOLS` so it cannot drift, and it has a positive control, because a conformance test that cannot fail proves nothing.
- **The completeness claim is enforced, not asserted.** A docstring saying "the canonical 8-section shape" is what let two persisted sections go unreported. The check now reads `schemas/persona.schema.json` and keys off the `Section N:` marker the schema itself writes, so a ninth section fails CI until it is either reported or named in an exclusion set — and the exclusion set is checked for being a dumping ground.
- **Every declared type must have a coercion**, and every array declared inside a section must declare string items, since the array coercion would otherwise flatten object items. Both guards have their own mutation as a control.
- **The declared output shapes are pinned to `MCP_SERVER_VERSION`.** The previous guard (`major >= 2`) passes forever and would have allowed this PR's own shape change to ship under the version describing the previous one.
- Prompt-provenance guards: the prompt names the canonical inner keys of every section the reader reports, shows types rather than key names alone, interpolates `{content}`, leaves the `pdf` prompt unwired (compared against the template's own text, not a phrase copied out of it), and pins the persisted version to the template's. One further test asserts the template still carries every key the handler subscripts, so a dropped key fails CI rather than reaching a user as a `KeyError` through `job_handler`'s user-facing error text.

## Validation

| Gate | Result |
|---|---|
| pytest | **2967** passed (from 2952) |
| CDK vitest | **268** passed |
| ruff | **delta zero** on every file touched — same findings, same rule histogram |
| mutations | **15 run, 15 caught** on the reader; **9 run, 8 caught** on the writer |
| real data | the projection run against the **five live persona rows** conforms, empties no populated section, emits no phantom field |

The one writer mutation **not** caught is recorded rather than hidden: reverting `max_tokens` to the literal `4096` equals the template's current value, so it is behaviour-neutral and no test can distinguish it.

Worth noting for reviewers who mutation-test: reverting the *projection* alone does **not** trip the conformance gate, because with the schema corrected a dict is now valid. The mutation that proves that gate earns its keep is reverting the **schema**. Testing one side only would have claimed coverage that did not exist.

## Not deployed

The shared slot is contended and this is unmerged. `list_personas` still fails against the live server until this ships.

## Follow-ons, deliberately not bundled

- **`_project_feedback` has the same `.get(key, '')`-under-a-declared-string pattern** for `source`, `sentiment`, `category`, `urgency`, `persona_type` and the text fields. Same class, different writer, its own tests, shipped in #355 and untouched by this diff — and no live counter-example is known, where the persona case had five rows in four shapes. Folding it in would put a second contract into a PR about the persona one.
- **Three existing persona rows stay in their non-canonical shape by decision**, not by omission: the reader handles both shapes, and this PR fixes the import path rather than the data. No stored data is touched.
- **Seven prompt builders read phantom keys** (`p.get('goals')`, `p.get('frustrations')`, singular `quote`) in `jobs/document_generator`, `jobs/document_merger`, `research/research_step_handler`, `projects.py` autofill and its two legacy builders, plus `project-context.ts` and `persona-prompt.ts`. Every generated PRD, PR/FAQ, merged document, research report and roundtable prompt is therefore built with blank persona goals and frustrations. Arguably higher product impact than this PR, and it changes LLM inputs, so it is its own change — in flight on `fix/personas-reach-prompts`, which shares no file with this branch.
