### PR TITLE
fix(personas): stop feeding prompts fields no writer produces

### DIFF
--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -1005,7 +1005,12 @@ def generate_prd(project_id: str, body: dict) -> dict:
     # Format personas for context. Migrated with the live sites even though this
     # function is unreached (see the LEGACY note above): leaving a phantom-key
     # builder in the file is what invites the next copy-paste.
-    personas_context = personas_prompt_context(personas)
+    #
+    # `or '(none)'` because the template hard-codes a `USER PERSONAS:` header
+    # before the placeholder. An empty value leaves that header with nothing under
+    # it, which is the same silent-empty-label defect this change removes, one
+    # layer up.
+    personas_context = personas_prompt_context(personas) or '(none)'
 
     feature_idea = body.get('feature_idea', 'Improve customer experience based on feedback')
 
@@ -1357,7 +1362,8 @@ def generate_prfaq(project_id: str, body: dict) -> dict:
     # reason. This one only ever lost the quote — `quote` is singular here while
     # rows store `quotes: [{text, context}]` — so it never had the empty
     # Goals/Frustrations lines the other builders did.
-    personas_context = personas_prompt_context(personas)
+    # `or '(none)'`: the template hard-codes a `USER PERSONAS:` header.
+    personas_context = personas_prompt_context(personas) or '(none)'
     
     feature_idea = body.get('feature_idea', 'New feature based on customer feedback')
 

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -14,6 +14,7 @@ from botocore.exceptions import ClientError
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
 from shared.api import validate_days, MAX_PERSONAS_PER_GENERATION
+from shared.persona_context import personas_prompt_context
 from shared.converse import converse_chain
 from shared.exceptions import (
     ConfigurationError,
@@ -1001,15 +1002,10 @@ def generate_prd(project_id: str, body: dict) -> dict:
     feedback_items = get_feedback_context(filters, limit=FEEDBACK_LIMIT_PRD)
     feedback_context = format_feedback_for_llm(feedback_items)
 
-    # Format personas for context
-    personas_context = ""
-    for p in personas:
-        personas_context += f"""
-**{p.get('name')}** - {p.get('tagline', '')}
-- Quote: "{p.get('quote', '')}"
-- Goals: {', '.join(p.get('goals', [])[:3])}
-- Frustrations: {', '.join(p.get('frustrations', [])[:3])}
-"""
+    # Format personas for context. Migrated with the live sites even though this
+    # function is unreached (see the LEGACY note above): leaving a phantom-key
+    # builder in the file is what invites the next copy-paste.
+    personas_context = personas_prompt_context(personas)
 
     feature_idea = body.get('feature_idea', 'Improve customer experience based on feedback')
 
@@ -1091,14 +1087,12 @@ def autofill_prfaq_questions(project_id: str, body: dict) -> dict:
     feedback_items = get_feedback_context(filters, limit=FEEDBACK_LIMIT_AUTOFILL)
     feedback_context = format_feedback_for_llm(feedback_items)
 
-    personas_context = ""
-    for p in personas:
-        personas_context += (
-            f"\n**{p.get('name')}** — {p.get('tagline', '')}\n"
-            f"Quote: \"{p.get('quote', '')}\"\n"
-            f"Goals: {', '.join(p.get('goals', [])[:3])}\n"
-            f"Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n"
-        )
+    # `goals`, `frustrations` and singular `quote` are keys no writer produces, so
+    # this block used to reach the model with every label present and every value
+    # empty. Worse than omitting the persona: `Goals: ` with nothing after it reads
+    # as an assertion that the persona has none. Field paths now live in
+    # shared/persona_context.py.
+    personas_context = personas_prompt_context(personas)
 
     feature_idea = (body or {}).get('feature_idea', '').strip()
     title = (body or {}).get('title', '').strip()
@@ -1359,13 +1353,11 @@ def generate_prfaq(project_id: str, body: dict) -> dict:
     feedback_items = get_feedback_context(filters, limit=FEEDBACK_LIMIT_PRFAQ)
     feedback_context = format_feedback_for_llm(feedback_items)
 
-    # Format personas
-    personas_context = ""
-    for p in personas:
-        personas_context += f"""
-**{p.get('name')}**: {p.get('tagline', '')}
-Quote: "{p.get('quote', '')}"
-"""
+    # Format personas. Also unreached (LEGACY note above), migrated for the same
+    # reason. This one only ever lost the quote — `quote` is singular here while
+    # rows store `quotes: [{text, context}]` — so it never had the empty
+    # Goals/Frustrations lines the other builders did.
+    personas_context = personas_prompt_context(personas)
     
     feature_idea = body.get('feature_idea', 'New feature based on customer feedback')
 

--- a/voc-datalake/lambda/api/test/test_projects_ai_assists.py
+++ b/voc-datalake/lambda/api/test/test_projects_ai_assists.py
@@ -17,8 +17,12 @@ from unittest.mock import patch, MagicMock
 PROJECT_DATA = {
     'project': {'project_id': 'proj-1', 'name': 'Test', 'filters': {'days': 30}},
     'personas': [{
-        'name': 'Kim Jisu', 'tagline': 'Power user', 'quote': 'I love it',
-        'goals': ['speed'], 'frustrations': ['crashes'],
+        # Canonical shape; was flat `quote`/`goals`/`frustrations`, which no
+        # writer produces.
+        'name': 'Kim Jisu', 'tagline': 'Power user',
+        'quotes': [{'text': 'I love it'}],
+        'goals_motivations': {'primary_goal': 'speed'},
+        'pain_points': {'current_challenges': ['crashes']},
     }],
 }
 

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -145,7 +145,11 @@ def _gather_context(
             # empty while `used_persona_ids` below recorded provenance from
             # content the model never received. Field paths now live in
             # shared/persona_context.py.
-            personas_context = personas_prompt_context(personas)
+            # `or '(none)'`: prd-generation.json and prfaq-generation.json both
+            # hard-code a `USER PERSONAS:` header before the placeholder, so an
+            # empty value leaves a bare header — the same empty-label defect being
+            # removed here, one layer up.
+            personas_context = personas_prompt_context(personas) or '(none)'
             for p in personas:
                 pid = p.get('persona_id')
                 if pid:

--- a/voc-datalake/lambda/jobs/document_generator/handler.py
+++ b/voc-datalake/lambda/jobs/document_generator/handler.py
@@ -47,6 +47,7 @@ from shared.jobs import job_handler, JobContext, update_job_status
 from shared.aws import get_dynamodb_resource
 from shared.converse import converse_chain
 from shared.feedback import query_feedback_by_date
+from shared.persona_context import personas_prompt_context
 from shared.api import validate_date_basis
 from shared.prompts import get_prd_generation_steps, get_prfaq_generation_steps
 from shared.prototypes import prototype_s3_key
@@ -139,17 +140,16 @@ def _gather_context(
         if selected_ids:
             personas = [p for p in personas if p.get('persona_id') in selected_ids]
         if personas:
-            parts = []
+            # `goals`/`frustrations` were phantom keys — no writer produces them,
+            # so every PRD and PR/FAQ was generated with those labels present and
+            # empty while `used_persona_ids` below recorded provenance from
+            # content the model never received. Field paths now live in
+            # shared/persona_context.py.
+            personas_context = personas_prompt_context(personas)
             for p in personas:
-                parts.append(
-                    f"**{p.get('name')}**: {p.get('tagline', '')}\n"
-                    f"- Goals: {', '.join(p.get('goals', [])[:3])}\n"
-                    f"- Frustrations: {', '.join(p.get('frustrations', [])[:3])}"
-                )
                 pid = p.get('persona_id')
                 if pid:
                     used_persona_ids.append(pid)
-            personas_context = '\n\n'.join(parts)
 
     # Gather reference documents and append to feedback context
     if data_sources.get('documents') or data_sources.get('research'):

--- a/voc-datalake/lambda/jobs/document_generator/test/test_handler_coverage.py
+++ b/voc-datalake/lambda/jobs/document_generator/test/test_handler_coverage.py
@@ -100,8 +100,18 @@ class TestDocumentGeneratorPersonasGathering:
 
         mock_projects_table.query.return_value = {
             'Items': [
-                {'sk': 'PERSONA#p1', 'persona_id': 'p1', 'name': 'Power User', 'tagline': 'Uses daily', 'goals': ['Speed'], 'frustrations': ['Bugs']},
-                {'sk': 'PERSONA#p2', 'persona_id': 'p2', 'name': 'Casual User', 'tagline': 'Occasional', 'goals': ['Simple'], 'frustrations': ['Complex']},
+                # Canonical `schemas/persona.schema.json` shape. These fixtures
+                # used flat `goals`/`frustrations`, keys no writer produces — which
+                # is why the assertion below (persona NAME only) passed while the
+                # generated PRD received empty Goals and Frustrations lines.
+                {'sk': 'PERSONA#p1', 'persona_id': 'p1', 'name': 'Power User',
+                 'tagline': 'Uses daily',
+                 'goals_motivations': {'primary_goal': 'Speed'},
+                 'pain_points': {'current_challenges': ['Bugs']}},
+                {'sk': 'PERSONA#p2', 'persona_id': 'p2', 'name': 'Casual User',
+                 'tagline': 'Occasional',
+                 'goals_motivations': {'primary_goal': 'Simple'},
+                 'pain_points': {'current_challenges': ['Complex']}},
             ]
         }
         mock_projects_table.put_item.return_value = {}
@@ -123,9 +133,17 @@ class TestDocumentGeneratorPersonasGathering:
 
         assert result['success'] is True
         call_kwargs = mock_prompt_steps['prd'].call_args.kwargs
-        assert 'Power User' in call_kwargs['personas_context']
+        personas_context = call_kwargs['personas_context']
+        assert 'Power User' in personas_context
         # p2 should be filtered out
-        assert 'Casual User' not in call_kwargs['personas_context']
+        assert 'Casual User' not in personas_context
+
+        # 🔑 The assertions that make this test worth having. Asserting the NAME
+        # alone is what let a PRD be generated from persona blocks whose Goals and
+        # Frustrations lines were empty: the name is present either way. Reverting
+        # the builder to `p.get('goals', [])` fails these two.
+        assert 'Speed' in personas_context, 'the persona goal never reached the prompt'
+        assert 'Bugs' in personas_context, 'the persona frustration never reached the prompt'
 
 
 class TestDocumentGeneratorDocumentsGathering:

--- a/voc-datalake/lambda/jobs/document_merger/handler.py
+++ b/voc-datalake/lambda/jobs/document_merger/handler.py
@@ -18,6 +18,7 @@ from shared.jobs import job_handler, JobContext
 from shared.aws import get_dynamodb_resource
 from shared.converse import converse
 from shared.feedback import query_feedback_by_date
+from shared.persona_context import personas_prompt_context
 from shared.derivation import (
     DERIVATION_FIELD,
     ROLE_MERGE_INPUT,
@@ -87,12 +88,17 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, merge_config: dict
         personas = [i for i in all_items if i.get('sk', '').startswith('PERSONA#')]
         selected_personas = [p for p in personas if p.get('persona_id') in selected_persona_ids]
         if selected_personas:
-            persona_text = "## USER PERSONAS FOR CONTEXT\n\n"
+            # Was reading phantom `goals`/`frustrations`, so every merged document
+            # carried persona headings with empty values. Field paths live in
+            # shared/persona_context.py.
+            persona_text = personas_prompt_context(
+                selected_personas, header="## USER PERSONAS FOR CONTEXT"
+            )
             for p in selected_personas:
-                persona_text += f"**{p.get('name')}**: {p.get('tagline', '')}\n- Goals: {', '.join(p.get('goals', [])[:3])}\n- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n\n"
                 if p.get('persona_id'):
                     used_persona_ids.append(p['persona_id'])
-            context_parts.append(persona_text)
+            if persona_text:
+                context_parts.append(persona_text)
     
     if use_feedback:
         ctx.update_progress(40, 'fetching_feedback')

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -15,6 +15,7 @@ from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource, BEDROCK_MODEL_ID
 from shared.api import api_handler
 from shared.converse import converse, BedrockThrottlingError
+from shared.persona_context import personas_prompt_context
 from shared.prompts import (
     get_research_step_config,
     get_response_language_instruction,
@@ -164,12 +165,14 @@ def step_initialize(event: dict) -> dict:
         selected_personas = [p for p in all_personas if p.get('persona_id') in selected_persona_ids]
         
         if selected_personas:
-            personas_context = "## Selected Personas\n\n"
+            # `goals`, `frustrations` and singular `quote` were all phantom keys,
+            # so this block reached the analysis step as headings with no content.
+            # Field paths live in shared/persona_context.py, which caps each list
+            # deliberately: this string crosses a Step Functions state boundary.
+            personas_context = personas_prompt_context(
+                selected_personas, header="## Selected Personas"
+            )
             for p in selected_personas:
-                personas_context += f"**{p.get('name')}** - {p.get('tagline', '')}\n"
-                personas_context += f"- Goals: {', '.join(p.get('goals', [])[:3])}\n"
-                personas_context += f"- Frustrations: {', '.join(p.get('frustrations', [])[:3])}\n"
-                personas_context += f"- Quote: \"{p.get('quote', '')}\"\n\n"
                 if p.get('persona_id'):
                     used_persona_ids.append(p['persona_id'])
     

--- a/voc-datalake/lambda/research/test/test_research_steps.py
+++ b/voc-datalake/lambda/research/test/test_research_steps.py
@@ -118,7 +118,13 @@ class TestStepInitialize:
         mock_tables['projects'].query.return_value = {
             'Items': [
                 {'sk': 'PERSONA#p1', 'persona_id': 'p1', 'name': 'User A',
-                 'tagline': 'Tag', 'goals': ['g1'], 'frustrations': ['f1'], 'quote': 'Q'},
+                 'tagline': 'Tag',
+                 # Canonical shape. Was flat `goals`/`frustrations`/`quote`, none
+                 # of which any writer produces, so the assertion below (name
+                 # only) passed while the research prompt got empty headings.
+                 'goals_motivations': {'primary_goal': 'g1'},
+                 'pain_points': {'current_challenges': ['f1']},
+                 'quotes': [{'text': 'Q'}]},
             ]
         }
 
@@ -131,7 +137,13 @@ class TestStepInitialize:
         }
 
         result = step_initialize(event)
-        assert 'User A' in result['personas_context']
+        personas_context = result['personas_context']
+        assert 'User A' in personas_context
+        # The name alone was the whole assertion, and it passes whether or not the
+        # persona's content arrives. Reverting to `p.get('goals', [])` fails these.
+        assert 'g1' in personas_context, 'the persona goal never reached the prompt'
+        assert 'f1' in personas_context, 'the persona frustration never reached the prompt'
+        assert 'Q' in personas_context, 'the persona quote never reached the prompt'
 
     @patch('research_step_handler.get_feedback_context')
     @patch('research_step_handler.format_feedback_for_llm', return_value='fb')

--- a/voc-datalake/lambda/shared/persona_context.py
+++ b/voc-datalake/lambda/shared/persona_context.py
@@ -1,4 +1,4 @@
-"""One way to put a persona in front of a model.
+r"""One way to put a persona in front of a model.
 
 Framed like `shared/derivation.py`: N call sites had spelled the same relation N
 different ways, so the relation lives here once.
@@ -29,11 +29,38 @@ the history budget, so this is deliberately NOT
 and opens an `# H1` per persona, which would flatten the heading structure of the
 prompt it is embedded in. Its field paths are reused; its format is not.
 """
+from collections.abc import Sequence
 from typing import Any
 
 # Enough to characterise a persona without crowding out the feedback evidence
 # that shares the same prompt budget.
 DEFAULT_MAX_ITEMS = 3
+
+# Keys worth reading off a dict that turned up where a string was expected. An
+# imported persona's list entries are LLM-authored, so an object is possible.
+_TEXTUAL_KEYS: tuple[str, ...] = ('text', 'description', 'value', 'name')
+
+
+def _entry_text(entry: Any) -> str:
+    """The readable text of one list entry, or '' if there is none.
+
+    🪤 A dict does NOT become `str(entry)`. That put a Python repr
+    (`{'goal': 'x', 'weight': 2}`) into an LLM prompt — noise, and extra structure
+    in a string that reaches a model, on a path whose content comes from customer
+    documents. Read a known text-ish key instead, and drop the entry when none of
+    them holds anything.
+    """
+    if isinstance(entry, str):
+        return entry.strip()
+    if isinstance(entry, dict):
+        for key in _TEXTUAL_KEYS:
+            candidate = entry.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+        return ''
+    if isinstance(entry, (int, float)) and not isinstance(entry, bool):
+        return str(entry)
+    return ''
 
 
 def _clean_items(value: Any, limit: int) -> list[str]:
@@ -44,13 +71,7 @@ def _clean_items(value: Any, limit: int) -> list[str]:
         return []
     out: list[str] = []
     for entry in value:
-        if isinstance(entry, str):
-            text = entry.strip()
-        elif entry in (None, '', [], {}):
-            continue
-        else:
-            # Stringified rather than dropped: the value is a model's evidence.
-            text = str(entry).strip()
+        text = _entry_text(entry)
         if text:
             out.append(text)
         if len(out) >= limit:
@@ -58,7 +79,7 @@ def _clean_items(value: Any, limit: int) -> list[str]:
     return out
 
 
-def persona_voice(persona: dict) -> str:
+def persona_voice(persona: dict[str, Any]) -> str:
     """The persona's representative quote, or ''.
 
     `quotes` is a list of `{text, context}` objects. The `isinstance` tolerance is
@@ -78,7 +99,7 @@ def persona_voice(persona: dict) -> str:
     return ''
 
 
-def persona_goals(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> list[str]:
+def persona_goals(persona: dict[str, Any], max_items: int = DEFAULT_MAX_ITEMS) -> list[str]:
     """Primary goal first, then secondary goals, as flat lines."""
     section = persona.get('goals_motivations')
     if not isinstance(section, dict):
@@ -91,7 +112,7 @@ def persona_goals(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> list[str
     return goals[:max_items]
 
 
-def persona_frustrations(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> list[str]:
+def persona_frustrations(persona: dict[str, Any], max_items: int = DEFAULT_MAX_ITEMS) -> list[str]:
     """Current challenges first, topped up with blockers if there is room.
 
     Both belong under "frustrations" for a prompt: a challenge is what hurts and a
@@ -110,7 +131,7 @@ def persona_frustrations(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> l
     return pains[:max_items]
 
 
-def persona_prompt_block(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> str:
+def persona_prompt_block(persona: dict[str, Any], max_items: int = DEFAULT_MAX_ITEMS) -> str:
     """One persona as a compact labelled block for an LLM prompt.
 
     A label is emitted ONLY when it has content. That is the point of the change:
@@ -138,13 +159,21 @@ def persona_prompt_block(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> s
 
 
 def personas_prompt_context(
-    personas: list, header: str = '', max_items: int = DEFAULT_MAX_ITEMS
+    personas: Sequence[Any], header: str = '', max_items: int = DEFAULT_MAX_ITEMS
 ) -> str:
     """Several personas as one prompt section, or '' when there are none.
 
     Returning '' for an empty list matters: callers previously built a section
     containing only labels, so `personas_context or '(none)'` could never fire
     even when nothing was known.
+
+    ⚠️ '' is a real return value and the CALLER must decide what it means. Two
+    prompt templates (`prd-generation.json`, `prfaq-generation.json`) hard-code a
+    `USER PERSONAS:` header before the placeholder, so those call sites append
+    `or '(none)'`; `document_merger` instead omits its whole section with
+    `if persona_text:`. Both are correct — dropping the guard entirely is not,
+    because a bare header with nothing under it is the defect this module exists
+    to remove.
     """
     blocks = [
         persona_prompt_block(p, max_items)

--- a/voc-datalake/lambda/shared/persona_context.py
+++ b/voc-datalake/lambda/shared/persona_context.py
@@ -1,0 +1,157 @@
+"""One way to put a persona in front of a model.
+
+Framed like `shared/derivation.py`: N call sites had spelled the same relation N
+different ways, so the relation lives here once.
+
+🔴 THE DEFECT THIS EXISTS TO FIX. Four live prompt builders read persona fields
+that no writer has ever produced:
+
+    f"- Goals: {', '.join(p.get('goals', [])[:3])}\n"
+    f"- Frustrations: {', '.join(p.get('frustrations', [])[:3])}"
+
+Stored personas follow `schemas/persona.schema.json`: goals live under
+`goals_motivations.primary_goal` / `.secondary_goals`, frustrations under
+`pain_points.current_challenges` / `.blockers`, and the voice line under
+`quotes[0].text` — there is no `goals`, no `frustrations`, no `needs` and no
+singular `quote` on any row. `.get(key, [])` returns the default for all of them,
+so every generated PRD, PR/FAQ, merged document and research report was built
+with a persona block whose labels were present and whose values were EMPTY.
+
+That is worse than omitting the persona: `Goals: ` with nothing after it reads to
+a model as an assertion that the persona has no goals, and the document then
+records `used_persona_ids` in its derivation, claiming provenance from content it
+never received.
+
+Compact on purpose, and capped. The research path carries this string across a
+Step Functions state boundary (256 KB ceiling) and the chat paths compete with
+the history budget, so this is deliberately NOT
+`projects.py::_persona_to_markdown` — that renderer is whole-document, uncapped,
+and opens an `# H1` per persona, which would flatten the heading structure of the
+prompt it is embedded in. Its field paths are reused; its format is not.
+"""
+from typing import Any
+
+# Enough to characterise a persona without crowding out the feedback evidence
+# that shares the same prompt budget.
+DEFAULT_MAX_ITEMS = 3
+
+
+def _clean_items(value: Any, limit: int) -> list[str]:
+    """Up to `limit` non-empty strings from a list-shaped persona field."""
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if not isinstance(value, (list, tuple)):
+        return []
+    out: list[str] = []
+    for entry in value:
+        if isinstance(entry, str):
+            text = entry.strip()
+        elif entry in (None, '', [], {}):
+            continue
+        else:
+            # Stringified rather than dropped: the value is a model's evidence.
+            text = str(entry).strip()
+        if text:
+            out.append(text)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def persona_voice(persona: dict) -> str:
+    """The persona's representative quote, or ''.
+
+    `quotes` is a list of `{text, context}` objects. The `isinstance` tolerance is
+    copied from `_persona_to_markdown`, which already handles rows whose quotes
+    are bare strings.
+    """
+    quotes = persona.get('quotes')
+    if not isinstance(quotes, (list, tuple)):
+        return ''
+    for quote in quotes:
+        if isinstance(quote, dict):
+            text = quote.get('text', '')
+        else:
+            text = quote
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return ''
+
+
+def persona_goals(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> list[str]:
+    """Primary goal first, then secondary goals, as flat lines."""
+    section = persona.get('goals_motivations')
+    if not isinstance(section, dict):
+        return []
+    goals: list[str] = []
+    primary = section.get('primary_goal')
+    if isinstance(primary, str) and primary.strip():
+        goals.append(primary.strip())
+    goals += _clean_items(section.get('secondary_goals'), max_items)
+    return goals[:max_items]
+
+
+def persona_frustrations(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> list[str]:
+    """Current challenges first, topped up with blockers if there is room.
+
+    Both belong under "frustrations" for a prompt: a challenge is what hurts and a
+    blocker is what stops them, and a model reasoning about a feature needs both.
+    """
+    section = persona.get('pain_points')
+    if not isinstance(section, dict):
+        return []
+    pains = _clean_items(section.get('current_challenges'), max_items)
+    if len(pains) < max_items:
+        for blocker in _clean_items(section.get('blockers'), max_items):
+            if blocker not in pains:
+                pains.append(blocker)
+            if len(pains) >= max_items:
+                break
+    return pains[:max_items]
+
+
+def persona_prompt_block(persona: dict, max_items: int = DEFAULT_MAX_ITEMS) -> str:
+    """One persona as a compact labelled block for an LLM prompt.
+
+    A label is emitted ONLY when it has content. That is the point of the change:
+    an empty `Goals:` line is a false statement about the persona, so a persona
+    with no recorded goals now says nothing about goals rather than asserting the
+    absence of them.
+    """
+    name = str(persona.get('name') or 'Unnamed persona').strip()
+    tagline = str(persona.get('tagline') or '').strip()
+    lines = [f"**{name}**" + (f" — {tagline}" if tagline else "")]
+
+    voice = persona_voice(persona)
+    if voice:
+        lines.append(f'- Voice: "{voice}"')
+
+    goals = persona_goals(persona, max_items)
+    if goals:
+        lines.append(f"- Goals: {'; '.join(goals)}")
+
+    frustrations = persona_frustrations(persona, max_items)
+    if frustrations:
+        lines.append(f"- Frustrations: {'; '.join(frustrations)}")
+
+    return '\n'.join(lines)
+
+
+def personas_prompt_context(
+    personas: list, header: str = '', max_items: int = DEFAULT_MAX_ITEMS
+) -> str:
+    """Several personas as one prompt section, or '' when there are none.
+
+    Returning '' for an empty list matters: callers previously built a section
+    containing only labels, so `personas_context or '(none)'` could never fire
+    even when nothing was known.
+    """
+    blocks = [
+        persona_prompt_block(p, max_items)
+        for p in personas
+        if isinstance(p, dict)
+    ]
+    if not blocks:
+        return ''
+    body = '\n\n'.join(blocks)
+    return f"{header}\n\n{body}" if header else body

--- a/voc-datalake/lambda/shared/test/test_persona_context.py
+++ b/voc-datalake/lambda/shared/test/test_persona_context.py
@@ -105,6 +105,22 @@ class TestFieldPaths:
         assert persona_goals({'goals_motivations': ['not', 'a', 'dict']}) == []
         assert persona_frustrations({'pain_points': 'a string'}) == []
 
+    def test_an_object_list_entry_yields_its_text_not_a_python_repr(self):
+        """A dict where a string was expected must not reach a model as
+        `{'goal': 'x'}` — that is noise plus extra structure in a prompt whose
+        content comes from customer documents. A known text-ish key is read, and
+        an entry with none is dropped."""
+        persona = {'goals_motivations': {'secondary_goals': [
+            {'text': 'Read via text'},
+            {'description': 'Read via description'},
+            {'weight': 2},
+            'plain string',
+        ]}}
+        assert persona_goals(persona, max_items=4) == [
+            'Read via text', 'Read via description', 'plain string',
+        ]
+        assert '{' not in persona_prompt_block(persona)
+
 
 class TestBlockRendering:
     def test_a_generated_persona_renders_every_line(self):
@@ -142,8 +158,10 @@ class TestBlockRendering:
             'pain_points': {'current_challenges': [f'pain {i}' for i in range(50)]},
         }
         block = persona_prompt_block(crowded, max_items=2)
-        assert block.count('goal ') == 2
-        assert block.count('pain ') == 2
+        # Whole-line equality, not a substring count: `count('goal ')` would also
+        # match a goal whose own text contained the word.
+        assert '- Goals: goal 0; goal 1' in block
+        assert '- Frustrations: pain 0; pain 1' in block
 
 
 class TestMultiPersonaContext:

--- a/voc-datalake/lambda/shared/test/test_persona_context.py
+++ b/voc-datalake/lambda/shared/test/test_persona_context.py
@@ -1,0 +1,162 @@
+"""Guards for the one persona→prompt renderer.
+
+The defect being fixed was invisible for a reason worth restating: every existing
+test at the four call sites asserted only the persona's NAME, so a block whose
+Goals and Frustrations lines were empty passed all of them. The assertions here
+are therefore about VALUES, and the fixtures are the shapes of live rows rather
+than the flat shape the broken code imagined.
+
+Revert map:
+  test_goals_come_from_goals_motivations / test_frustrations_come_from_pain_points
+    — restoring `p.get('goals', [])` / `p.get('frustrations', [])` yields [] for
+      every real persona, so both fail.
+  test_a_label_is_omitted_when_it_has_no_content
+    — the old builders always emitted the label. An empty `Goals:` line reads to
+      a model as "this persona has no goals", which is a false statement.
+  test_the_voice_line_reads_the_quotes_list
+    — `quote` (singular) is a third phantom key; rows carry `quotes: [{text}]`.
+  test_empty_personas_render_as_empty_string
+    — callers guard with `personas_context or '(none)'`, which could never fire
+      while the string contained labels.
+"""
+from shared.persona_context import (
+    persona_frustrations,
+    persona_goals,
+    persona_prompt_block,
+    persona_voice,
+    personas_prompt_context,
+)
+
+# Shape of a generated row (`schemas/persona.schema.json`), trimmed to the fields
+# a prompt uses.
+GENERATED = {
+    'persona_id': 'persona_20260802204425',
+    'name': 'Priya Shah',
+    'tagline': 'The Habitual Skimmer',
+    'goals_motivations': {
+        'primary_goal': 'Stay informed in ten minutes',
+        'secondary_goals': ['Follow local council news', 'Avoid clickbait'],
+        'success_definition': 'Knows the day in one sitting',
+    },
+    'pain_points': {
+        'current_challenges': ['Alerts bury the real news', 'Comment threads are hostile'],
+        'blockers': ['Cannot mute a topic'],
+        'workarounds': ['Curated her notification categories'],
+        'emotional_impact': 'Quietly resigned',
+    },
+    'quotes': [{'text': 'I just want the headlines.', 'context': 'onboarding'}],
+}
+
+# Shape of an imported row: unpredicted inner keys, no canonical goals/pains.
+IMPORTED = {
+    'persona_id': 'persona_20260814135248',
+    'name': 'Priya Raman',
+    'tagline': 'Ops lead under audit pressure',
+    'goals_motivations': {'primary_goal': 'Close the audit', 'motivations': ['Avoid fines']},
+    'pain_points': {'primary_frustration': 'No audit trail', 'related_issues': ['Manual exports']},
+    'quotes': [{'text': 'I cannot prove what changed.'}],
+}
+
+
+class TestFieldPaths:
+    def test_goals_come_from_goals_motivations(self):
+        """Primary goal leads, then secondary goals."""
+        assert persona_goals(GENERATED) == [
+            'Stay informed in ten minutes',
+            'Follow local council news',
+            'Avoid clickbait',
+        ]
+
+    def test_frustrations_come_from_pain_points(self):
+        assert persona_frustrations(GENERATED) == [
+            'Alerts bury the real news',
+            'Comment threads are hostile',
+            'Cannot mute a topic',
+        ]
+
+    def test_blockers_only_top_up_when_challenges_leave_room(self):
+        """A challenge is what hurts, a blocker is what stops them; both belong,
+        but challenges lead and the cap is respected."""
+        assert persona_frustrations(GENERATED, max_items=2) == [
+            'Alerts bury the real news',
+            'Comment threads are hostile',
+        ]
+
+    def test_the_voice_line_reads_the_quotes_list(self):
+        assert persona_voice(GENERATED) == 'I just want the headlines.'
+
+    def test_a_bare_string_quote_is_tolerated(self):
+        """Copied from `_persona_to_markdown`, which already handles this."""
+        assert persona_voice({'quotes': ['Straight to the point.']}) == 'Straight to the point.'
+
+    def test_the_phantom_flat_keys_are_not_read(self):
+        """A row in the shape the broken code imagined yields nothing.
+
+        This is the assertion that would have caught the original defect: the flat
+        keys are not a fallback, because no writer produces them and treating them
+        as one would keep the wrong contract alive.
+        """
+        phantom = {'name': 'Ghost', 'goals': ['g'], 'frustrations': ['f'], 'quote': 'q'}
+        assert persona_goals(phantom) == []
+        assert persona_frustrations(phantom) == []
+        assert persona_voice(phantom) == ''
+
+    def test_a_non_dict_section_yields_nothing_rather_than_raising(self):
+        assert persona_goals({'goals_motivations': ['not', 'a', 'dict']}) == []
+        assert persona_frustrations({'pain_points': 'a string'}) == []
+
+
+class TestBlockRendering:
+    def test_a_generated_persona_renders_every_line(self):
+        block = persona_prompt_block(GENERATED)
+        assert block.startswith('**Priya Shah** — The Habitual Skimmer')
+        assert '- Voice: "I just want the headlines."' in block
+        assert '- Goals: Stay informed in ten minutes; Follow local council news' in block
+        assert '- Frustrations: Alerts bury the real news' in block
+
+    def test_an_imported_persona_renders_what_it_has(self):
+        """Its pain points sit under keys this module never chose, so the
+        Frustrations line is absent rather than empty — and the goal it DOES
+        record still arrives."""
+        block = persona_prompt_block(IMPORTED)
+        assert '- Goals: Close the audit' in block
+        assert '- Voice: "I cannot prove what changed."' in block
+        assert 'Frustrations' not in block
+
+    def test_a_label_is_omitted_when_it_has_no_content(self):
+        """The heart of the fix. An empty `Goals:` line is a false statement."""
+        block = persona_prompt_block({'name': 'Sparse'})
+        assert block == '**Sparse**'
+        assert 'Goals' not in block
+        assert 'Frustrations' not in block
+        assert 'Voice' not in block
+
+    def test_an_unnamed_persona_still_renders(self):
+        assert persona_prompt_block({}).startswith('**Unnamed persona**')
+
+    def test_the_cap_bounds_the_block(self):
+        """The research path carries this across Step Functions state (256 KB)."""
+        crowded = {
+            'name': 'Verbose',
+            'goals_motivations': {'secondary_goals': [f'goal {i}' for i in range(50)]},
+            'pain_points': {'current_challenges': [f'pain {i}' for i in range(50)]},
+        }
+        block = persona_prompt_block(crowded, max_items=2)
+        assert block.count('goal ') == 2
+        assert block.count('pain ') == 2
+
+
+class TestMultiPersonaContext:
+    def test_personas_are_separated_and_headed(self):
+        context = personas_prompt_context([GENERATED, IMPORTED], header='## Selected Personas')
+        assert context.startswith('## Selected Personas')
+        assert 'Priya Shah' in context and 'Priya Raman' in context
+        assert context.count('**Priya') == 2
+
+    def test_empty_personas_render_as_empty_string(self):
+        """So a caller's `or '(none)'` fallback can actually fire."""
+        assert personas_prompt_context([]) == ''
+        assert personas_prompt_context([], header='## Personas') == ''
+
+    def test_non_dict_entries_are_skipped(self):
+        assert personas_prompt_context([GENERATED, 'nope', None]).count('**') == 2

--- a/voc-datalake/lambda/shared/test/test_persona_context_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_persona_context_lockstep.py
@@ -20,9 +20,24 @@ test_avatar_image_model_lockstep.py (same repo).
 import re
 from pathlib import Path
 
+import pytest
+
 from shared import persona_context
 
 TS_SOURCE = 'lambda/stream/src/context/persona-fields.ts'
+
+# 🔑 The seven sites where the defect actually lived. Scanning only the two shared
+# renderers would let the regression back in exactly where it came from: a
+# copy-pasted `p.get('goals', [])` in a handler passes a guard that reads only
+# `persona_context.py`. These are the files a future builder would be added to.
+CALL_SITES = (
+    'lambda/api/projects.py',
+    'lambda/jobs/document_generator/handler.py',
+    'lambda/jobs/document_merger/handler.py',
+    'lambda/research/research_step_handler.py',
+    'lambda/stream/src/context/project-context.ts',
+    'lambda/stream/src/context/persona-prompt.ts',
+)
 
 # Field paths BOTH renderers read. Naming the pairs explicitly is the point: a
 # section taught to one runtime and not the other fails here.
@@ -51,10 +66,18 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
-def _ts_source() -> str:
-    path = _repo_root() / TS_SOURCE
-    assert path.is_file(), f'{TS_SOURCE} not found — did the file move?'
+def _read_repo_file(relative: str) -> str:
+    path = _repo_root() / relative
+    if not path.is_file():
+        # A packaged copy of `shared/` has no sibling `stream/` or `api/` tree, so
+        # skip rather than fail: the mirror cannot be checked from there, and a
+        # spurious red would train people to ignore this file.
+        pytest.skip(f'{relative} not present in this layout — nothing to compare')
     return path.read_text(encoding='utf-8')
+
+
+def _ts_source() -> str:
+    return _read_repo_file(TS_SOURCE)
 
 
 def _py_source() -> str:
@@ -72,13 +95,16 @@ def _code_only(source: str, *, python: bool) -> str:
     fail on its own explanation — a guard that cannot tell code from prose is
     worse than none, because the obvious "fix" is to delete the explanation.
 
-    KNOWN CEILING: this is lexical, not a parse. It strips comments and
-    triple-quoted blocks, so it would also strip a legitimate triple-quoted code
-    string, and it cannot see a phantom key reached INDIRECTLY —
-    `KEY = 'goals'; persona.get(KEY)` passes. Both renderers access their fields
-    literally today, which is what makes the trade sound. If either ever needs
-    dynamic field access, upgrade this to an `ast` walk on the Python side and
-    accept the TypeScript side as advisory.
+    KNOWN CEILING, two parts. (1) This is lexical, not a parse: it strips comments
+    and triple-quoted blocks, so it would also strip a legitimate triple-quoted
+    code string, and it cannot see a phantom key reached INDIRECTLY —
+    `KEY = 'goals'; persona.get(KEY)` passes. (2) The presence checks below are
+    bare substring matches, so a field name surviving in a dead constant or an
+    unused helper satisfies them even if the renderer no longer reads it.
+
+    Both are acceptable for a grep-level mirror guard — every access in both
+    renderers is literal today — and the upgrade path is an `ast` walk on the
+    Python side, with the TypeScript side staying advisory.
     """
     if python:
         # Triple-quoted blocks first, so a `#` inside a docstring is already gone.
@@ -142,12 +168,30 @@ def test_neither_runtime_reads_a_phantom_key():
             assert not found, f'{label} renderer reads a phantom key: {found}'
 
 
+@pytest.mark.parametrize('relative', CALL_SITES)
+def test_no_call_site_reads_a_phantom_key_either(relative):
+    """The renderers are not where the bug would come back.
+
+    It would come back as a copy-pasted `p.get('goals', [])` in whichever handler
+    grows the next persona block — so the scan covers the seven files the defect
+    was actually removed from, not just the two it was consolidated into.
+    """
+    is_python = relative.endswith('.py')
+    code = _code_only(_read_repo_file(relative), python=is_python)
+    pattern = (
+        r"\.get\(\s*['\"](?:goals|frustrations|needs|quote)['\"]" if is_python
+        else r"\.(?:goals|frustrations|needs|quote)\b(?![s_])"
+    )
+    found = re.findall(pattern, code)
+    assert not found, f'{relative} reads a phantom persona key again: {found}'
+
+
 def test_the_caps_differ_on_purpose_and_are_both_pinned():
     """A cap change should be a decision, not a drift."""
     assert persona_context.DEFAULT_MAX_ITEMS == 3, (
         'python caps at 3 because the research context crosses Step Functions state'
     )
-    match = re.search(r'DEFAULT_PERSONA_ITEMS\s*=\s*(\d+)', _ts_source())
+    match = re.search(r'DEFAULT_PERSONA_ITEMS\s*=\s*(\d+)', _ts_code())
     assert match, 'DEFAULT_PERSONA_ITEMS not found in the TS renderer'
     assert int(match.group(1)) == 4, (
         'TS caps at 4 because chat prompts have more room than the document paths'
@@ -156,7 +200,7 @@ def test_the_caps_differ_on_purpose_and_are_both_pinned():
 
 def test_every_python_reader_has_a_typescript_counterpart():
     """The exported surfaces mirror each other by name."""
-    ts = _ts_source()
+    ts = _ts_code()
     for py_name, ts_name in (
         ('persona_voice', 'personaVoice'),
         ('persona_goals', 'personaGoals'),

--- a/voc-datalake/lambda/shared/test/test_persona_context_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_persona_context_lockstep.py
@@ -1,0 +1,166 @@
+"""`shared/persona_context.py` and `stream/src/context/persona-fields.ts` are a
+cross-runtime MIRROR, and this pins them.
+
+Two renderers answer the same question — where a persona's goals, frustrations
+and voice live — because the document paths are Python and the chat paths are
+TypeScript. That is the same situation as `shared/image_limits.py` mirroring the
+TS allowlist, and this repo's convention for a mirror is a lockstep test rather
+than trust. Without one they drift silently: someone teaches the Python side to
+read `blockers`, the TS side keeps ignoring it, and project chat quietly shows
+less than a PRD does.
+
+What is deliberately NOT locked: the per-list cap. Python defaults to 3 because
+the research string crosses a Step Functions state boundary; TypeScript defaults
+to 4 because chat prompts have more room. Both are asserted here so a change to
+either is a decision rather than an accident.
+
+Pattern follows test_kiro_exportable_types_lockstep.py and
+test_avatar_image_model_lockstep.py (same repo).
+"""
+import re
+from pathlib import Path
+
+from shared import persona_context
+
+TS_SOURCE = 'lambda/stream/src/context/persona-fields.ts'
+
+# Field paths BOTH renderers read. Naming the pairs explicitly is the point: a
+# section taught to one runtime and not the other fails here.
+MIRRORED_FIELD_PATHS = (
+    ('goals_motivations', 'primary_goal'),
+    ('goals_motivations', 'secondary_goals'),
+    ('pain_points', 'current_challenges'),
+    ('pain_points', 'blockers'),
+)
+
+# 🔑 Read by TYPESCRIPT ONLY, and that asymmetry is deliberate — this test caught
+# it on its first run, which is the whole reason it exists.
+#
+# The phantom `needs` key appeared only at the two stream sites, so only the TS
+# renderer has a `personaNeeds`, mapping it to the two canonical fields that
+# answer the same question. No Python caller ever had a "needs" concept, and
+# adding `persona_needs` there purely for symmetry would be dead code.
+TS_ONLY_FIELD_PATHS = (
+    ('goals_motivations', 'underlying_motivations'),
+    ('pain_points', 'workarounds'),
+)
+
+
+def _repo_root() -> Path:
+    # lambda/shared/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _ts_source() -> str:
+    path = _repo_root() / TS_SOURCE
+    assert path.is_file(), f'{TS_SOURCE} not found — did the file move?'
+    return path.read_text(encoding='utf-8')
+
+
+def _py_source() -> str:
+    path = Path(persona_context.__file__)
+    assert path.is_file()
+    return path.read_text(encoding='utf-8')
+
+
+def _code_only(source: str, *, python: bool) -> str:
+    """Source with comments and docstrings removed.
+
+    🪤 Necessary, not fussiness: both renderers DOCUMENT the phantom keys they no
+    longer read (`.get('goals', [])` appears verbatim in the Python module
+    docstring explaining the defect). Scanning raw text made the phantom-key guard
+    fail on its own explanation — a guard that cannot tell code from prose is
+    worse than none, because the obvious "fix" is to delete the explanation.
+
+    KNOWN CEILING: this is lexical, not a parse. It strips comments and
+    triple-quoted blocks, so it would also strip a legitimate triple-quoted code
+    string, and it cannot see a phantom key reached INDIRECTLY —
+    `KEY = 'goals'; persona.get(KEY)` passes. Both renderers access their fields
+    literally today, which is what makes the trade sound. If either ever needs
+    dynamic field access, upgrade this to an `ast` walk on the Python side and
+    accept the TypeScript side as advisory.
+    """
+    if python:
+        # Triple-quoted blocks first, so a `#` inside a docstring is already gone.
+        source = re.sub(r'"""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\'', '', source)
+        return re.sub(r'#.*', '', source)
+    source = re.sub(r'/\*[\s\S]*?\*/', '', source)
+    return re.sub(r'//.*', '', source)
+
+
+def _py_code() -> str:
+    return _code_only(_py_source(), python=True)
+
+
+def _ts_code() -> str:
+    return _code_only(_ts_source(), python=False)
+
+
+def test_both_runtimes_read_the_same_canonical_field_paths():
+    """Neither renderer may know about a shared field the other does not."""
+    ts, py = _ts_code(), _py_code()
+    for section, key in MIRRORED_FIELD_PATHS:
+        assert section in py, f'python renderer lost the {section} section'
+        assert section in ts, f'TS renderer lost the {section} section'
+        assert key in py, f'python renderer stopped reading {section}.{key}'
+        assert key in ts, f'TS renderer stopped reading {section}.{key}'
+
+
+def test_the_typescript_only_fields_stay_typescript_only():
+    """Pins the asymmetry so it reads as a decision, not an oversight.
+
+    If a Python caller ever wants a "needs" concept, this test is where that
+    choice gets made explicitly instead of drifting in.
+    """
+    ts, py = _ts_code(), _py_code()
+    for section, key in TS_ONLY_FIELD_PATHS:
+        assert key in ts, f'TS renderer stopped reading {section}.{key}'
+        assert key not in py, (
+            f'python now reads {section}.{key} — move it to MIRRORED_FIELD_PATHS'
+        )
+
+
+def test_neither_runtime_reads_a_phantom_key():
+    """The defect being fixed, pinned in both runtimes at once.
+
+    `goals`, `frustrations`, `needs` and singular `quote` exist on no stored row.
+    A bare-word match would false-positive on `goals_motivations` and on the
+    `personaGoals` / `persona_goals` function names, so each is matched as a FIELD
+    ACCESS — the only form that would reintroduce the bug.
+    """
+    phantom_accesses = (
+        # python: item.get('goals'), persona.get('frustrations'), …
+        r"\.get\(\s*['\"](?:goals|frustrations|needs|quote)['\"]",
+        # typescript: persona.goals, p.frustrations, …
+        # The trailing guard keeps `goals_motivations` and `quotes` out: `\b`
+        # alone already stops at `goals_`, and `(?![s_])` also excludes `quotes`.
+        r"\.(?:goals|frustrations|needs|quote)\b(?![s_])",
+    )
+    for source, label in ((_py_code(), 'python'), (_ts_code(), 'typescript')):
+        for pattern in phantom_accesses:
+            found = re.findall(pattern, source)
+            assert not found, f'{label} renderer reads a phantom key: {found}'
+
+
+def test_the_caps_differ_on_purpose_and_are_both_pinned():
+    """A cap change should be a decision, not a drift."""
+    assert persona_context.DEFAULT_MAX_ITEMS == 3, (
+        'python caps at 3 because the research context crosses Step Functions state'
+    )
+    match = re.search(r'DEFAULT_PERSONA_ITEMS\s*=\s*(\d+)', _ts_source())
+    assert match, 'DEFAULT_PERSONA_ITEMS not found in the TS renderer'
+    assert int(match.group(1)) == 4, (
+        'TS caps at 4 because chat prompts have more room than the document paths'
+    )
+
+
+def test_every_python_reader_has_a_typescript_counterpart():
+    """The exported surfaces mirror each other by name."""
+    ts = _ts_source()
+    for py_name, ts_name in (
+        ('persona_voice', 'personaVoice'),
+        ('persona_goals', 'personaGoals'),
+        ('persona_frustrations', 'personaFrustrations'),
+    ):
+        assert hasattr(persona_context, py_name), f'python lost {py_name}'
+        assert f'export function {ts_name}' in ts, f'TS lost {ts_name}'

--- a/voc-datalake/lambda/shared/test/test_persona_context_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_persona_context_lockstep.py
@@ -198,6 +198,19 @@ def test_the_caps_differ_on_purpose_and_are_both_pinned():
     )
 
 
+def test_both_runtimes_read_the_same_text_keys_off_an_object_entry():
+    """A list entry that is an object must survive identically in both runtimes.
+
+    Caught in review: Python read a text-ish key while TypeScript dropped the
+    entry, so the same persona produced a goal in a PRD and silence in chat —
+    the content-silently-lost defect this whole change removes, reintroduced
+    between the twins.
+    """
+    ts = _ts_code()
+    for key in persona_context._TEXTUAL_KEYS:
+        assert f"'{key}'" in ts, f'TS entryText stopped reading {key!r}'
+
+
 def test_every_python_reader_has_a_typescript_counterpart():
     """The exported surfaces mirror each other by name."""
     ts = _ts_code()

--- a/voc-datalake/lambda/stream/src/context/persona-fields.test.ts
+++ b/voc-datalake/lambda/stream/src/context/persona-fields.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Behavioural guards for the TypeScript persona reader, and for the roundtable
+ * prompt that consumes it.
+ *
+ * The lockstep test on the Python side greps this file's field paths; that proves
+ * the two runtimes agree, not that either one works. These are the assertions
+ * that fail if the readers or the label-omission logic are reverted.
+ *
+ * Fixtures are the shapes of live rows. `pain_points` and `goals_motivations`
+ * arrive as OPAQUE records from `projectItemSchema` on purpose — naming their
+ * leaves would let one malformed persona throw and take down the whole
+ * chat-context build — so the null and wrong-type cases below are the contract,
+ * not defensive padding.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  bulletList,
+  personaFrustrations,
+  personaGoals,
+  personaNeeds,
+  personaVoice,
+} from './persona-fields.js';
+import { buildSinglePersonaPrompt } from './persona-prompt.js';
+import type { ProjectItem } from './project-context.js';
+
+const asPersona = (raw: Record<string, unknown>): ProjectItem =>
+  raw as unknown as ProjectItem;
+
+const GENERATED = asPersona({
+  sk: 'PERSONA#p1',
+  persona_id: 'p1',
+  name: 'Priya Shah',
+  tagline: 'The Habitual Skimmer',
+  quotes: [{ text: 'I just want the headlines.', context: 'onboarding' }],
+  goals_motivations: {
+    primary_goal: 'Stay informed in ten minutes',
+    secondary_goals: ['Follow local council news', 'Avoid clickbait'],
+    underlying_motivations: ['Feel like a competent citizen'],
+  },
+  pain_points: {
+    current_challenges: ['Alerts bury the real news'],
+    blockers: ['Cannot mute a topic'],
+    workarounds: ['Curated her notification categories'],
+  },
+});
+
+// An imported row: inner keys this module never chose, no canonical sections.
+const IMPORTED = asPersona({
+  sk: 'PERSONA#p2',
+  persona_id: 'p2',
+  name: 'Priya Raman',
+  tagline: 'Ops lead under audit pressure',
+  quotes: [{ text: 'I cannot prove what changed.' }],
+  goals_motivations: { primary_goal: 'Close the audit', motivations: ['Avoid fines'] },
+  pain_points: { primary_frustration: 'No audit trail' },
+});
+
+describe('personaGoals', () => {
+  it('returns the primary goal first, then the secondary goals', () => {
+    expect(personaGoals(GENERATED)).toStrictEqual([
+      'Stay informed in ten minutes',
+      'Follow local council news',
+      'Avoid clickbait',
+    ]);
+  });
+
+  it('returns nothing for the phantom flat key, which no writer produces', () => {
+    expect(personaGoals(asPersona({ goals: ['Save money'] }))).toStrictEqual([]);
+  });
+
+  it('respects the cap', () => {
+    expect(personaGoals(GENERATED, 2)).toHaveLength(2);
+  });
+});
+
+describe('personaFrustrations', () => {
+  it('leads with current challenges and tops up with blockers', () => {
+    expect(personaFrustrations(GENERATED)).toStrictEqual([
+      'Alerts bury the real news',
+      'Cannot mute a topic',
+    ]);
+  });
+
+  it('does not top up past the cap', () => {
+    expect(personaFrustrations(GENERATED, 1)).toStrictEqual(['Alerts bury the real news']);
+  });
+
+  it('returns nothing for the phantom flat key', () => {
+    expect(personaFrustrations(asPersona({ frustrations: ['Hidden fees'] }))).toStrictEqual([]);
+  });
+});
+
+describe('personaNeeds', () => {
+  it('maps the absent `needs` concept onto motivations then workarounds', () => {
+    expect(personaNeeds(GENERATED)).toStrictEqual([
+      'Feel like a competent citizen',
+      'Curated her notification categories',
+    ]);
+  });
+
+  it('returns nothing for the phantom flat key', () => {
+    expect(personaNeeds(asPersona({ needs: ['Transparent pricing'] }))).toStrictEqual([]);
+  });
+});
+
+describe('personaVoice', () => {
+  it('reads the quotes list', () => {
+    expect(personaVoice(GENERATED)).toBe('I just want the headlines.');
+  });
+
+  it('tolerates a bare string entry, as the Python reader does', () => {
+    expect(personaVoice(asPersona({ quotes: ['Straight to the point.'] })))
+      .toBe('Straight to the point.');
+  });
+
+  it('returns nothing for the phantom singular `quote`', () => {
+    expect(personaVoice(asPersona({ quote: 'I should not be read' }))).toBe('');
+  });
+
+  it('skips an entry whose text is null and takes the next usable one', () => {
+    expect(personaVoice(asPersona({ quotes: [{ text: null }, { text: 'Second.' }] })))
+      .toBe('Second.');
+  });
+});
+
+describe('tolerance for shapes the boundary no longer validates', () => {
+  // `projectItemSchema` declares these sections as opaque records precisely so a
+  // malformed row cannot throw. That moves the burden here, so it is asserted here.
+  it.each([
+    ['a null section', { goals_motivations: null, pain_points: null, quotes: null }],
+    ['a nulled leaf', { goals_motivations: { secondary_goals: null }, pain_points: { current_challenges: null } }],
+    ['a section that is an array', { goals_motivations: [], pain_points: [] }],
+    ['a section that is a string', { goals_motivations: 'nope', pain_points: 'nope' }],
+    ['leaves holding objects instead of strings', {
+      goals_motivations: { secondary_goals: [{ goal: 'x' }] },
+      pain_points: { current_challenges: [{ pain: 'y' }] },
+    }],
+    ['a scalar where a list is expected', {
+      goals_motivations: { secondary_goals: 'just one' },
+      pain_points: { current_challenges: 'just one' },
+    }],
+  ])('does not throw on %s', (_label, raw) => {
+    const persona = asPersona({ name: 'Odd', ...raw });
+    expect(() => {
+      personaGoals(persona);
+      personaFrustrations(persona);
+      personaNeeds(persona);
+      personaVoice(persona);
+    }).not.toThrow();
+  });
+
+  it('keeps a scalar in a list slot rather than dropping the content', () => {
+    const persona = asPersona({ goals_motivations: { secondary_goals: 'just one' } });
+    expect(personaGoals(persona)).toStrictEqual(['just one']);
+  });
+
+  it('drops non-string list entries instead of rendering an object', () => {
+    // The Python reader stringifies; here they are dropped, because a JS object
+    // renders as "[object Object]" rather than anything a model can use.
+    const persona = asPersona({ goals_motivations: { secondary_goals: [{ goal: 'x' }, 'real'] } });
+    expect(personaGoals(persona)).toStrictEqual(['real']);
+  });
+});
+
+describe('bulletList', () => {
+  it('returns an empty string for no values, so a caller can omit the label', () => {
+    expect(bulletList([])).toBe('');
+  });
+});
+
+describe('the roundtable identity block', () => {
+  // projectName, persona, selectedContent, otherDocsList, feedbackSection,
+  // selectedDocumentIds, documents, previousResponses.
+  const build = (persona: ProjectItem): string =>
+    buildSinglePersonaPrompt('NorthStar', persona, '', [], '', [], [], []);
+
+  it('gives the persona its real goals, frustrations and voice', () => {
+    const prompt = build(GENERATED);
+    expect(prompt).toContain('Stay informed in ten minutes');
+    expect(prompt).toContain('Alerts bury the real news');
+    expect(prompt).toContain('I just want the headlines.');
+    expect(prompt).toContain('Feel like a competent citizen');
+  });
+
+  it('omits a heading it has no content for', () => {
+    // The defect: the model was told to BE a persona and handed
+    // "**Your Goals:**" with nothing under it, which reads as an assertion that
+    // the persona wants nothing. Emitting the heading unconditionally fails this.
+    const prompt = build(asPersona({ name: 'Sparse', tagline: 'Knows little' }));
+    expect(prompt).toContain('You are "Sparse"');
+    expect(prompt).not.toContain('Your Goals');
+    expect(prompt).not.toContain('Your Frustrations');
+    expect(prompt).not.toContain('What You Need');
+    expect(prompt).not.toContain('Your voice');
+  });
+
+  it('renders what an imported persona has and stays silent on the rest', () => {
+    const prompt = build(IMPORTED);
+    expect(prompt).toContain('Close the audit');
+    expect(prompt).toContain('I cannot prove what changed.');
+    // Its pain points sit under a key this module never chose.
+    expect(prompt).not.toContain('Your Frustrations');
+  });
+
+  it('does not throw on a persona whose sections are malformed', () => {
+    expect(() => build(asPersona({
+      name: 'Broken',
+      goals_motivations: { secondary_goals: null },
+      pain_points: 'nope',
+      quotes: [{ text: null }],
+    }))).not.toThrow();
+  });
+});

--- a/voc-datalake/lambda/stream/src/context/persona-fields.test.ts
+++ b/voc-datalake/lambda/stream/src/context/persona-fields.test.ts
@@ -154,10 +154,18 @@ describe('tolerance for shapes the boundary no longer validates', () => {
     expect(personaGoals(persona)).toStrictEqual(['just one']);
   });
 
-  it('drops non-string list entries instead of rendering an object', () => {
-    // The Python reader stringifies; here they are dropped, because a JS object
-    // renders as "[object Object]" rather than anything a model can use.
-    const persona = asPersona({ goals_motivations: { secondary_goals: [{ goal: 'x' }, 'real'] } });
+  it('reads a text-ish key off an object entry, matching the Python reader', () => {
+    // The twins must agree about whether content survives, or the same persona
+    // yields a goal in a PRD and silence in chat.
+    const persona = asPersona({ goals_motivations: { secondary_goals: [
+      { text: 'via text' }, { description: 'via description' }, 'plain',
+    ] } });
+    expect(personaGoals(persona)).toStrictEqual(['via text', 'via description', 'plain']);
+  });
+
+  it('drops an object entry holding no readable text rather than rendering it', () => {
+    // `String({})` is "[object Object]", which is worse in a prompt than silence.
+    const persona = asPersona({ goals_motivations: { secondary_goals: [{ weight: 2 }, 'real'] } });
     expect(personaGoals(persona)).toStrictEqual(['real']);
   });
 });

--- a/voc-datalake/lambda/stream/src/context/persona-fields.ts
+++ b/voc-datalake/lambda/stream/src/context/persona-fields.ts
@@ -20,6 +20,29 @@ import type { ProjectItem } from './project-context.js';
 /** Chat prompts have more room than the Python document paths, which cap at 3. */
 export const DEFAULT_PERSONA_ITEMS = 4;
 
+/**
+ * One key off a value that is only believed to be an object.
+ *
+ * The persona sections arrive as opaque records — `project-context.ts` declares
+ * them that way on purpose, because naming their leaves would let one malformed
+ * row throw and take down the whole context build. So every read goes through a
+ * guard here rather than trusting the declared type.
+ */
+/**
+ * Duplicated from `project-context.ts`'s `isPlainRecord` on purpose, three lines
+ * rather than an import: `project-context.ts` imports the readers in this module
+ * as VALUES, so importing a value back would be a real runtime cycle — the
+ * existing type-only import in `persona-prompt.ts` is erased at compile time and
+ * is not a precedent for one.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readKey(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
 function cleanStrings(values: unknown, limit: number): string[] {
   if (typeof values === 'string') {
     const single = values.trim();
@@ -45,7 +68,7 @@ export function personaVoice(persona: ProjectItem): string {
   const quotes = persona.quotes;
   if (!Array.isArray(quotes)) return '';
   for (const quote of quotes) {
-    const text = typeof quote === 'string' ? quote : quote?.text;
+    const text = typeof quote === 'string' ? quote : readKey(quote, 'text');
     if (typeof text === 'string' && text.trim()) return text.trim();
   }
   return '';
@@ -56,10 +79,9 @@ export function personaGoals(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS
   const section = persona.goals_motivations;
   if (!section) return [];
   const goals: string[] = [];
-  if (typeof section.primary_goal === 'string' && section.primary_goal.trim()) {
-    goals.push(section.primary_goal.trim());
-  }
-  goals.push(...cleanStrings(section.secondary_goals, limit));
+  const primary = readKey(section, 'primary_goal');
+  if (typeof primary === 'string' && primary.trim()) goals.push(primary.trim());
+  goals.push(...cleanStrings(readKey(section, 'secondary_goals'), limit));
   return goals.slice(0, limit);
 }
 
@@ -72,8 +94,8 @@ export function personaGoals(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS
 export function personaFrustrations(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS): string[] {
   const section = persona.pain_points;
   if (!section) return [];
-  const pains = cleanStrings(section.current_challenges, limit);
-  for (const blocker of cleanStrings(section.blockers, limit)) {
+  const pains = cleanStrings(readKey(section, 'current_challenges'), limit);
+  for (const blocker of cleanStrings(readKey(section, 'blockers'), limit)) {
     if (pains.length >= limit) break;
     if (!pains.includes(blocker)) pains.push(blocker);
   }
@@ -90,8 +112,8 @@ export function personaFrustrations(persona: ProjectItem, limit = DEFAULT_PERSON
  * (`goals_motivations.underlying_motivations`).
  */
 export function personaNeeds(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS): string[] {
-  const needs = cleanStrings(persona.goals_motivations?.underlying_motivations, limit);
-  for (const workaround of cleanStrings(persona.pain_points?.workarounds, limit)) {
+  const needs = cleanStrings(readKey(persona.goals_motivations, 'underlying_motivations'), limit);
+  for (const workaround of cleanStrings(readKey(persona.pain_points, 'workarounds'), limit)) {
     if (needs.length >= limit) break;
     if (!needs.includes(workaround)) needs.push(workaround);
   }

--- a/voc-datalake/lambda/stream/src/context/persona-fields.ts
+++ b/voc-datalake/lambda/stream/src/context/persona-fields.ts
@@ -43,6 +43,29 @@ function readKey(value: unknown, key: string): unknown {
   return isRecord(value) ? value[key] : undefined;
 }
 
+/**
+ * Keys worth reading off an entry that turned up as an object where a string was
+ * expected. Mirrors `_TEXTUAL_KEYS` in `shared/persona_context.py` — the twins
+ * must not disagree about whether content survives, or the same persona yields a
+ * goal in a PRD and silence in chat.
+ */
+const TEXTUAL_KEYS = ['text', 'description', 'value', 'name'] as const;
+
+/** The readable text of one list entry, or '' when it holds none. */
+function entryText(entry: unknown): string {
+  if (typeof entry === 'string') return entry.trim();
+  if (typeof entry === 'number' && Number.isFinite(entry)) return String(entry);
+  if (isRecord(entry)) {
+    for (const key of TEXTUAL_KEYS) {
+      const candidate = entry[key];
+      if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+    }
+  }
+  // Deliberately NOT `String(entry)`: an object renders as "[object Object]",
+  // which is worse in a prompt than saying nothing.
+  return '';
+}
+
 function cleanStrings(values: unknown, limit: number): string[] {
   if (typeof values === 'string') {
     const single = values.trim();
@@ -51,7 +74,7 @@ function cleanStrings(values: unknown, limit: number): string[] {
   if (!Array.isArray(values)) return [];
   const out: string[] = [];
   for (const value of values) {
-    const text = typeof value === 'string' ? value.trim() : '';
+    const text = entryText(value);
     if (text) out.push(text);
     if (out.length >= limit) break;
   }

--- a/voc-datalake/lambda/stream/src/context/persona-fields.ts
+++ b/voc-datalake/lambda/stream/src/context/persona-fields.ts
@@ -1,0 +1,104 @@
+/**
+ * Where a persona's goals, frustrations and voice actually live.
+ *
+ * The TypeScript twin of `lambda/shared/persona_context.py`, and it exists for
+ * the same reason: two prompt builders here read `persona.goals`,
+ * `persona.frustrations`, `persona.needs` and `persona.quote` — keys NO writer
+ * produces. Stored personas follow `schemas/persona.schema.json`, so goals live
+ * under `goals_motivations`, frustrations under `pain_points`, and the voice line
+ * under `quotes[0].text`.
+ *
+ * Consequence before this: project chat rendered "**Goals:**" with nothing under
+ * it, and the roundtable prompt told the model to BE a persona while handing it an
+ * empty identity. Neither errored, so neither was noticed.
+ *
+ * Kept deliberately small and capped: these strings land in a system prompt that
+ * competes with the conversation history budget (`src/history-budget.ts`).
+ */
+import type { ProjectItem } from './project-context.js';
+
+/** Chat prompts have more room than the Python document paths, which cap at 3. */
+export const DEFAULT_PERSONA_ITEMS = 4;
+
+function cleanStrings(values: unknown, limit: number): string[] {
+  if (typeof values === 'string') {
+    const single = values.trim();
+    return single ? [single] : [];
+  }
+  if (!Array.isArray(values)) return [];
+  const out: string[] = [];
+  for (const value of values) {
+    const text = typeof value === 'string' ? value.trim() : '';
+    if (text) out.push(text);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/**
+ * The persona's representative quote, or ''.
+ *
+ * `quotes` entries are `{text, context}` objects; a bare string is tolerated
+ * because the Python renderer tolerates it and rows exist in both shapes.
+ */
+export function personaVoice(persona: ProjectItem): string {
+  const quotes = persona.quotes;
+  if (!Array.isArray(quotes)) return '';
+  for (const quote of quotes) {
+    const text = typeof quote === 'string' ? quote : quote?.text;
+    if (typeof text === 'string' && text.trim()) return text.trim();
+  }
+  return '';
+}
+
+/** Primary goal first, then secondary goals. */
+export function personaGoals(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS): string[] {
+  const section = persona.goals_motivations;
+  if (!section) return [];
+  const goals: string[] = [];
+  if (typeof section.primary_goal === 'string' && section.primary_goal.trim()) {
+    goals.push(section.primary_goal.trim());
+  }
+  goals.push(...cleanStrings(section.secondary_goals, limit));
+  return goals.slice(0, limit);
+}
+
+/**
+ * Current challenges first, topped up with blockers.
+ *
+ * Both belong under "frustrations" for a prompt: a challenge is what hurts, a
+ * blocker is what stops them, and a model reasoning about a feature needs both.
+ */
+export function personaFrustrations(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS): string[] {
+  const section = persona.pain_points;
+  if (!section) return [];
+  const pains = cleanStrings(section.current_challenges, limit);
+  for (const blocker of cleanStrings(section.blockers, limit)) {
+    if (pains.length >= limit) break;
+    if (!pains.includes(blocker)) pains.push(blocker);
+  }
+  return pains.slice(0, limit);
+}
+
+/**
+ * What the persona is working around or motivated by — the closest real data to
+ * the old phantom `needs` key.
+ *
+ * `needs` never existed on any row. Rather than drop the concept, it maps to the
+ * two canonical fields that answer the same question for a model: how they cope
+ * today (`pain_points.workarounds`) and what actually drives them
+ * (`goals_motivations.underlying_motivations`).
+ */
+export function personaNeeds(persona: ProjectItem, limit = DEFAULT_PERSONA_ITEMS): string[] {
+  const needs = cleanStrings(persona.goals_motivations?.underlying_motivations, limit);
+  for (const workaround of cleanStrings(persona.pain_points?.workarounds, limit)) {
+    if (needs.length >= limit) break;
+    if (!needs.includes(workaround)) needs.push(workaround);
+  }
+  return needs.slice(0, limit);
+}
+
+/** `- one\n- two`, or '' when there is nothing — so a caller can omit the label. */
+export function bulletList(values: string[]): string {
+  return values.map((value) => `- ${value}`).join('\n');
+}

--- a/voc-datalake/lambda/stream/src/context/persona-prompt.ts
+++ b/voc-datalake/lambda/stream/src/context/persona-prompt.ts
@@ -7,24 +7,50 @@
  * directly rather than through a re-export here.
  */
 import type { ProjectItem } from './project-context.js';
+import {
+  bulletList,
+  personaFrustrations,
+  personaGoals,
+  personaNeeds,
+  personaVoice,
+} from './persona-fields.js';
 import { getLanguageInstruction } from './language.js';
 import type { SupportedLanguage } from './language.js';
 
-/** The persona's identity block: who they are, what drives them, how to speak. */
+/** The persona's identity block: who they are, what drives them, how to speak.
+ *
+ * 🔴 This was the worst instance of the phantom-key defect: it reads
+ * `persona.goals` / `.frustrations` / `.needs` / `.quote`, none of which any
+ * writer produces, so the model was instructed to BE a persona and then handed an
+ * empty identity — "**Your Goals:**" with nothing under it. It answered anyway,
+ * inventing a character. Field paths now come from persona-fields.js.
+ */
 function personaIdentitySection(projectName: string, persona: ProjectItem): string {
-  const bullets = (values: string[] | undefined): string =>
-    (values ?? []).slice(0, 4).map((value) => `- ${value}`).join('\n');
-
-  return [
+  const parts = [
     `You are "${persona.name}" — a customer persona in the project "${projectName}".\n`,
-    `Your tagline: "${persona.tagline ?? ''}"\n`,
-    `Your voice: "${persona.quote ?? ''}"\n\n`,
-    `**Your Goals:**\n${bullets(persona.goals)}\n\n`,
-    `**Your Frustrations:**\n${bullets(persona.frustrations)}\n\n`,
-    `**Your Needs:**\n${bullets(persona.needs)}\n\n`,
-    'Respond in first person AS this persona. Use "I think...", "As someone who...", etc. Be concise — keep your response to 2-4 paragraphs.\n',
+  ];
+  if (persona.tagline) parts.push(`Your tagline: "${persona.tagline}"\n`);
+
+  // Each block is omitted when empty rather than rendered as a bare header: an
+  // empty "**Your Goals:**" tells the persona it wants nothing, which is worse
+  // than saying nothing about goals at all.
+  const voice = personaVoice(persona);
+  if (voice) parts.push(`Your voice: "${voice}"\n`);
+
+  const goals = personaGoals(persona);
+  if (goals.length) parts.push(`\n**Your Goals:**\n${bulletList(goals)}\n`);
+
+  const frustrations = personaFrustrations(persona);
+  if (frustrations.length) parts.push(`\n**Your Frustrations:**\n${bulletList(frustrations)}\n`);
+
+  const needs = personaNeeds(persona);
+  if (needs.length) parts.push(`\n**What You Need:**\n${bulletList(needs)}\n`);
+
+  parts.push(
+    '\nRespond in first person AS this persona. Use "I think...", "As someone who...", etc. Be concise — keep your response to 2-4 paragraphs.\n',
     'You are in a roundtable discussion with other customer personas. Speak naturally, share your honest opinion, and don\'t hold back. If you disagree with someone, say so directly.\n\n',
-  ].join('');
+  );
+  return parts.join('');
 }
 
 export function buildSinglePersonaPrompt(

--- a/voc-datalake/lambda/stream/src/context/project-context.test.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.test.ts
@@ -33,16 +33,27 @@ const projectMeta = {
   document_count: 1,
 };
 
+// Canonical `schemas/persona.schema.json` shape, which is what every writer
+// persists. These fixtures previously used flat `quote` / `goals` / `frustrations`
+// / `needs` arrays — keys no writer produces — and that is precisely why the chat
+// prompt could render empty persona sections while these tests stayed green. The
+// value assertions below are the ones that now mean something.
 const persona1 = {
   pk: 'PROJECT#proj-1',
   sk: 'PERSONA#p1',
   persona_id: 'p1',
   name: 'Budget Buyer',
   tagline: 'Price-conscious shopper',
-  quote: 'I always look for the best deal',
-  goals: ['Save money', 'Find quality products'],
-  frustrations: ['Hidden fees', 'Poor value'],
-  needs: ['Transparent pricing'],
+  quotes: [{ text: 'I always look for the best deal', context: 'interview' }],
+  goals_motivations: {
+    primary_goal: 'Save money',
+    secondary_goals: ['Find quality products'],
+    underlying_motivations: ['Transparent pricing'],
+  },
+  pain_points: {
+    current_challenges: ['Hidden fees', 'Poor value'],
+    workarounds: ['Compares three sites before buying'],
+  },
 };
 
 const persona2 = {
@@ -51,10 +62,9 @@ const persona2 = {
   persona_id: 'p2',
   name: 'Power User',
   tagline: 'Tech enthusiast',
-  quote: 'I need advanced features',
-  goals: ['Efficiency'],
-  frustrations: ['Slow performance'],
-  needs: ['Speed'],
+  quotes: [{ text: 'I need advanced features' }],
+  goals_motivations: { primary_goal: 'Efficiency' },
+  pain_points: { current_challenges: ['Slow performance'], blockers: ['No bulk actions'] },
 };
 
 const document1 = {
@@ -262,17 +272,20 @@ describe('buildProjectChatContext', () => {
     // generated avatar has avatar_url: null, which previously failed Zod
     // validation (expected string, received null) and took down project chat
     // with an opaque "Unknown error".
+    // The nulled fields are the CANONICAL ones. They used to be `goals` /
+    // `frustrations` / `needs`, which the schema no longer declares — so this
+    // regression test would have kept passing while exercising nothing, because
+    // Zod strips undeclared keys before `nullsToUndefined` matters.
     const personaWithNulls = {
       pk: 'PROJECT#proj-1',
       sk: 'PERSONA#p3',
       persona_id: 'p3',
       name: 'No Avatar Persona',
       tagline: 'Generated without an avatar',
-      quote: 'I should still render',
       avatar_url: null,
-      goals: null,
-      frustrations: null,
-      needs: null,
+      quotes: null,
+      goals_motivations: null,
+      pain_points: null,
     } as unknown as Record<string, unknown>;
 
     const docClient = createMockDocClient([

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -101,22 +101,24 @@ const projectItemSchema = z.preprocess(nullsToUndefined, z.object({
   // read them, and both rendered empty Goals / Frustrations / Needs into the chat
   // and roundtable system prompts. Declaring them here is what makes a reader fix
   // possible at all; the boundary is the fix, per the workspace wire-shape rule.
-  quotes: z.array(z.union([
-    z.object({ text: z.string().optional(), context: z.string().optional() }).passthrough(),
-    z.string(),
-  ])).optional(),
-  goals_motivations: z.object({
-    primary_goal: z.string().optional(),
-    secondary_goals: z.array(z.string()).optional(),
-    success_definition: z.string().optional(),
-    underlying_motivations: z.array(z.string()).optional(),
-  }).passthrough().optional(),
-  pain_points: z.object({
-    current_challenges: z.array(z.string()).optional(),
-    blockers: z.array(z.string()).optional(),
-    workarounds: z.array(z.string()).optional(),
-    emotional_impact: z.string().optional(),
-  }).passthrough().optional(),
+  // 🪤 Declared as OPAQUE containers, and that is load-bearing rather than lazy.
+  //
+  // `projectItemSchema.parse()` THROWS, so any leaf declared here becomes a way
+  // for one malformed persona to take down the whole chat-context build — which is
+  // the exact incident the null-tolerance regression test below was written for.
+  // These three sections were previously undeclared, so Zod stripped them and
+  // never validated them; naming their inner types would have validated them for
+  // the FIRST time, and `nullsToUndefined` is SHALLOW (top-level only), so a
+  // `pain_points: {current_challenges: null}` row — DynamoDB stores empty
+  // attributes as null — would fail `z.array(z.string()).optional()` and throw.
+  //
+  // The contents are LLM-authored, so odd shapes are expected, not exceptional.
+  // `persona-fields.ts` validates every value it touches (`typeof === 'string'`,
+  // `Array.isArray`), which is where the checking belongs per the repo's
+  // wire-shape rule: normalize at the reader, never reject the row.
+  quotes: z.array(z.unknown()).optional(),
+  goals_motivations: z.record(z.unknown()).optional(),
+  pain_points: z.record(z.unknown()).optional(),
   behaviors: z.union([
     z.object({
       current_solutions: z.array(z.string()).optional(),

--- a/voc-datalake/lambda/stream/src/context/project-context.ts
+++ b/voc-datalake/lambda/stream/src/context/project-context.ts
@@ -8,6 +8,13 @@ import { signCloudFrontUrl } from '../lib/cloudfront-signing.js';
 import { ConfigurationError, NotFoundError } from '../lib/errors.js';
 import { fetchRecentFeedback } from './recent-feedback.js';
 import { buildSinglePersonaPrompt } from './persona-prompt.js';
+import {
+  bulletList,
+  personaFrustrations,
+  personaGoals,
+  personaNeeds,
+  personaVoice,
+} from './persona-fields.js';
 import { getLanguageInstruction } from './language.js';
 import type { SupportedLanguage } from './language.js';
 
@@ -87,10 +94,29 @@ const projectItemSchema = z.preprocess(nullsToUndefined, z.object({
   filters: z.record(z.unknown()).optional(),
   persona_id: z.string().optional(),
   tagline: z.string().optional(),
-  quote: z.string().optional(),
-  goals: z.array(z.string()).optional(),
-  frustrations: z.array(z.string()).optional(),
-  needs: z.array(z.string()).optional(),
+  // 🔴 `quote`, `goals`, `frustrations` and `needs` are keys NO writer produces.
+  // Stored personas follow `schemas/persona.schema.json`, and this schema omitted
+  // `goals_motivations`, `pain_points` and `quotes` entirely — so it STRIPPED the
+  // real fields before `buildPersonasContext` and `personaIdentitySection` could
+  // read them, and both rendered empty Goals / Frustrations / Needs into the chat
+  // and roundtable system prompts. Declaring them here is what makes a reader fix
+  // possible at all; the boundary is the fix, per the workspace wire-shape rule.
+  quotes: z.array(z.union([
+    z.object({ text: z.string().optional(), context: z.string().optional() }).passthrough(),
+    z.string(),
+  ])).optional(),
+  goals_motivations: z.object({
+    primary_goal: z.string().optional(),
+    secondary_goals: z.array(z.string()).optional(),
+    success_definition: z.string().optional(),
+    underlying_motivations: z.array(z.string()).optional(),
+  }).passthrough().optional(),
+  pain_points: z.object({
+    current_challenges: z.array(z.string()).optional(),
+    blockers: z.array(z.string()).optional(),
+    workarounds: z.array(z.string()).optional(),
+    emotional_impact: z.string().optional(),
+  }).passthrough().optional(),
   behaviors: z.union([
     z.object({
       current_solutions: z.array(z.string()).optional(),
@@ -179,25 +205,29 @@ function resolveActivePersonas(
 // ── Prompt building helpers ──
 
 function buildPersonasContext(personas: ProjectItem[]): string {
+  // Read through persona-fields, which knows where these values actually live.
+  // This used to read `p.goals` / `p.frustrations` / `p.needs` / `p.quote` —
+  // none of which any writer produces — so every section header was rendered
+  // with nothing beneath it.
   const sections = personas.map((p) => {
-    const goals = (p.goals ?? []).slice(0, 4).map((g) => `- ${g}`).join('\n');
-    const frustrations = (p.frustrations ?? []).slice(0, 4).map((f) => `- ${f}`).join('\n');
-    const needs = (p.needs ?? []).slice(0, 4).map((n) => `- ${n}`).join('\n');
-    return `
-### ${p.name} - ${p.tagline ?? ''}
+    const taglineSuffix = p.tagline ? ` - ${p.tagline}` : '';
+    const parts = [`### ${p.name}${taglineSuffix}`];
 
-**Their voice:** "${p.quote ?? ''}"
+    // A header is emitted only when it has content: an empty "**Goals:**" reads
+    // to the model as an assertion that the persona has none.
+    const voice = personaVoice(p);
+    if (voice) parts.push(`**Their voice:** "${voice}"`);
 
-**Goals:**
-${goals}
+    const goals = personaGoals(p);
+    if (goals.length) parts.push(`**Goals:**\n${bulletList(goals)}`);
 
-**Frustrations:**
-${frustrations}
+    const frustrations = personaFrustrations(p);
+    if (frustrations.length) parts.push(`**Frustrations:**\n${bulletList(frustrations)}`);
 
-**Needs:**
-${needs}
+    const needs = personaNeeds(p);
+    if (needs.length) parts.push(`**What they need:**\n${bulletList(needs)}`);
 
----`;
+    return `\n${parts.join('\n\n')}\n\n---`;
   });
   return `\n## 👤 ACTIVE PERSONAS (Respond from their perspective)\n${sections.join('\n')}`;
 }


### PR DESCRIPTION
## Summary

Seven prompt builders read persona fields that **no writer has ever produced**: `goals`, `frustrations`, `needs`, and singular `quote`. Stored personas follow `schemas/persona.schema.json`, where goals live under `goals_motivations.primary_goal` / `.secondary_goals`, frustrations under `pain_points.current_challenges` / `.blockers`, and the voice line under `quotes[0].text`.

`.get(key, [])` returns the default for all of them, so every builder emitted its labels with empty values. Every generated PRD, PR/FAQ, merged document and research report was built from a persona block that looked like this:

```
**Priya Shah** — The Habitual Skimmer
- Goals:
- Frustrations:
```

That is worse than omitting the persona. An empty `Goals:` reads to a model as an assertion that the persona *has* no goals — and the document then records `used_persona_ids` in its derivation, claiming provenance from content that never arrived. Project chat rendered the same empty sections, and the roundtable prompt told the model to **be** a persona while handing it an empty identity.

Nothing errored, and the documents look complete, which is why this survived.

## Why every gate missed it

**No test at any of the seven sites asserted on the persona text.** They assert the persona's **name**, which is present whether or not the content arrives. The one test in the repo that asserted a persona *value* (`project-context.test.ts`) used a phantom-shaped fixture, so it asserted a value that only existed in the fixture.

## Changes

**Two shared readers, one per runtime**

- `lambda/shared/persona_context.py` — `persona_voice`, `persona_goals`, `persona_frustrations`, `persona_prompt_block`, `personas_prompt_context`. Framed like `shared/derivation.py`: one relation that had been spelled five different ways.
- `lambda/stream/src/context/persona-fields.ts` — the TypeScript twin for the two stream sites.

Both cap their lists deliberately: the research string crosses a **Step Functions state boundary** and the chat prompts compete with the conversation history budget. This is why neither reuses `projects.py::_persona_to_markdown`, which is whole-document, uncapped, and opens an `# H1` per persona — that would flatten the heading structure of the prompt it is embedded in. Its field paths are reused; its format is not.

A label is emitted **only when it has content**, so a persona with nothing recorded now says nothing about goals rather than asserting it has none. And `personas_prompt_context([])` returns `''`, so a caller's `or '(none)'` fallback can finally fire — it never could before, because the string contained the labels.

**Call sites**

| Site | Status |
|---|---|
| `jobs/document_generator/handler.py` | the **live** PRD/PR-FAQ path |
| `jobs/document_merger/handler.py` | live |
| `research/research_step_handler.py` | live; also fixes singular `quote` |
| `api/projects.py` — PR/FAQ wizard autofill | live |
| `api/projects.py` — `generate_prd` / `generate_prfaq` | documented `LEGACY — NOT REACHED`; migrated anyway, because leaving a phantom-key builder in the file is what invites the next copy-paste |
| `stream/src/context/project-context.ts` | project chat |
| `stream/src/context/persona-prompt.ts` | the roundtable identity block |

**The Zod boundary, which had to go first**

`projectItemSchema` declared `quote` / `goals` / `frustrations` / `needs` and omitted `goals_motivations`, `pain_points` and `quotes` **entirely** — so it stripped the real fields before either TypeScript reader could see them. It now declares them with `.passthrough()` on each object. Without this, a reader-only fix would have been inert.

**`needs`**

The key never existed on any row. Rather than drop the concept, it maps to the two canonical fields that answer the same question for a model: `goals_motivations.underlying_motivations` topped up with `pain_points.workarounds`.

## Tests

- **15 new guards** on the shared renderer, with fixtures copied from the shapes of live rows: generated, imported, and sparse.
- **Value assertions added where only the name was asserted.** Reverting the builder now fails a test at the document-generator and research sites.
- Four phantom-shaped fixtures converted to canonical.
- `project-context.test.ts`'s null-tolerance regression test now nulls the **canonical** fields. It nulled `goals`/`frustrations`/`needs`, which the schema no longer declares, so it would have kept passing while exercising nothing.

## Validation

| Gate | Result |
|---|---|
| pytest | **2959** passed — verified **+15** against a 2944 baseline on `development` (collect-only, both sides) |
| stream vitest | **339** passed |
| `typecheck:stream` | clean |
| `lint:stream` | back to its one pre-existing warning |
| ruff | **no new rule classes** on any changed file |
| mutations | **4 run, 4 caught** |

Reading phantom `goals`, reading phantom `frustrations`, reading singular `quote`, and emitting the label unconditionally each fail a test. The last reproduces the defect verbatim: `'**Sparse**\n- Goals: '`.

## For reviewers: this increases the prompt-injection surface

Persona text is LLM-authored from **customer-supplied documents**, and on these paths it was silently dropped. Making it arrive means an imported persona containing instruction-shaped text now reaches the PRD, research, merge and chat prompts.

I don't think it's a blocker — feeding persona content to models is the feature's purpose, and the content comes from the customer's own documents — but the exposure genuinely grows, so it belongs in the description rather than being discovered later.

## Scope

- **Independent of #356**: branched from `development`, disjoint file set, verified with `merge-base --is-ancestor`. Mergeable in either order.
- **Not deployed.**
- Not touched: `frontend/src/test/fixtures.ts::mockPersona` is also phantom-shaped and its docstring claims it matches the DynamoDB structure. Frontend-only, no production impact, left for a separate change.
