### PR TITLE
fix(mcp): make three declared contracts actually hold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ voc-datalake/Workshop/*
 .kiro/memory/
 .kiro/sessions/
 .kiro/NEW_SESSION_PROMPT.md
+# MCP client config — carries a live bearer token inline in headers.Authorization.
+# .kiro/settings/ is otherwise tracked (context-rules.json), so without this line
+# sharing an MCP config with the team publishes a working credential to a PUBLIC repo.
+.kiro/settings/mcp.json

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -1790,10 +1790,9 @@ describe('searchFeedback trims the query at the boundary', () => {
   // present-but-too-short term with a 400. Trimming here means the string that
   // is SENT is the string the route measures, whatever a caller passed in.
   //
-  // Asserted on the REQUEST URL rather than on the source text of client.ts. A
-  // sibling guard used to assert the literal substring `q: params.q.trim()`,
-  // which a Prettier reflow or an extracted local would break with no behaviour
-  // change — pinning characters instead of behaviour.
+  // Asserted on the REQUEST URL, not on the source text of client.ts. Matching a
+  // literal like `q: params.q.trim()` would pin characters rather than behaviour,
+  // and break on a reformat or an extracted local with nothing having changed.
   beforeEach(() => {
     ;(useConfigStore.getState as ReturnType<typeof vi.fn>).mockReturnValue(DEFAULT_STORE_STATE)
     ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -1784,3 +1784,57 @@ describe('getDateRangeParams', () => {
     })
   })
 })
+
+describe('searchFeedback trims the query at the boundary', () => {
+  // `/feedback/search` trims `q` before applying its minimum and refuses a
+  // present-but-too-short term with a 400. Trimming here means the string that
+  // is SENT is the string the route measures, whatever a caller passed in.
+  //
+  // Asserted on the REQUEST URL rather than on the source text of client.ts. A
+  // sibling guard used to assert the literal substring `q: params.q.trim()`,
+  // which a Prettier reflow or an extracted local would break with no behaviour
+  // change — pinning characters instead of behaviour.
+  beforeEach(() => {
+    ;(useConfigStore.getState as ReturnType<typeof vi.fn>).mockReturnValue(DEFAULT_STORE_STATE)
+    ;(authService.refreshSession as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const okOnce = (body: unknown) =>
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(body),
+    })
+
+  const requestedUrl = () =>
+    String((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0])
+
+  it('sends the trimmed term when the caller passes surrounding whitespace', async () => {
+    okOnce({ count: 0, items: [], entities: {}, query: 'delivery' })
+
+    await api.searchFeedback({ q: '  delivery  ' })
+
+    expect(requestedUrl()).toContain('q=delivery')
+  })
+
+  it('preserves interior spaces, which are part of the term', async () => {
+    okOnce({ count: 0, items: [], entities: {}, query: 'slow delivery' })
+
+    await api.searchFeedback({ q: '  slow delivery  ' })
+
+    // URLSearchParams encodes the space; what matters is that it survives.
+    expect(decodeURIComponent(requestedUrl().replace(/\+/g, ' '))).toContain('q=slow delivery')
+  })
+
+  it('surfaces the truncation flag the route reports', async () => {
+    okOnce({ count: 1, items: [{ feedback_id: '1' }], entities: {}, query: 'x', is_partial_window: true })
+
+    const result = await api.searchFeedback({ q: 'delivery' })
+
+    expect(result.is_partial_window).toBe(true)
+  })
+})

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -189,15 +189,25 @@ export const api = {
   },
   
   searchFeedback: async (params: { q: string; days?: number; date_basis?: DateBasis; limit?: number; source?: string; sentiment?: string; category?: string }) => {
-    // `q` trimmed HERE, at the single boundary every caller goes through, rather
-    // than in each caller's gate.
+    // `q` trimmed HERE, at the single boundary every caller goes through, so the
+    // string that is SENT is the string the route measures.
     //
     // `/feedback/search` trims before applying `SEARCH_QUERY_MIN_LENGTH` and
-    // REFUSES a present-but-too-short term with a 400, so any caller comparing
-    // raw `.length` could ship `"a "` — two characters here, one there — and
-    // surface a server error from ordinary typing. Trimming at the boundary makes
-    // every caller agree with the route by construction; a caller's own gate then
-    // only decides WHETHER to search, not what counts as long enough.
+    // refuses a present-but-too-short term with a 400, so a caller passing `"a "`
+    // through untrimmed would have the server measure something different from
+    // what the caller measured.
+    //
+    // ⚠️ Precisely what this does and does not buy: it normalises the VALUE, not
+    // the DECISION. A caller that gates on raw `.length` will still let `"a "`
+    // past its own gate, and this boundary will faithfully send `q=a` and get a
+    // 400. Only a caller's own TRIMMED gate prevents that — `useFeedbackListData`
+    // has one, and `test_search_minimum_lockstep.py` pins its constant to the
+    // route's.
+    //
+    // Deliberately NOT short-circuiting a too-short term into an empty result
+    // here, which was the reviewer's alternative: returning `count: 0` for a
+    // search that never ran is exactly the ambiguity the route was just fixed to
+    // stop producing. Better a loud 400 than a quiet zero.
     const searchParams = buildSearchParams({ ...params, q: params.q.trim() })
     // `is_partial_window` declared, not merely surviving the spread below: the
     // route sets it when the candidate scan stops on its soft cap, and

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -204,10 +204,10 @@ export const api = {
     // has one, and `test_search_minimum_lockstep.py` pins its constant to the
     // route's.
     //
-    // Deliberately NOT short-circuiting a too-short term into an empty result
-    // here, which was the reviewer's alternative: returning `count: 0` for a
-    // search that never ran is exactly the ambiguity the route was just fixed to
-    // stop producing. Better a loud 400 than a quiet zero.
+    // A too-short term is deliberately NOT short-circuited into an empty result
+    // here, because returning `count: 0` for a search that never ran is the same
+    // ambiguity the route was fixed to stop producing — moving it from the server
+    // to the client would not make it honest. A loud 400 beats a quiet zero.
     const searchParams = buildSearchParams({ ...params, q: params.q.trim() })
     // `is_partial_window` declared, not merely surviving the spread below: the
     // route sets it when the candidate scan stops on its soft cap, and

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -190,7 +190,12 @@ export const api = {
   
   searchFeedback: async (params: { q: string; days?: number; date_basis?: DateBasis; limit?: number; source?: string; sentiment?: string; category?: string }) => {
     const searchParams = buildSearchParams(params)
-    const res = await fetchApi<{ count: number; items: FeedbackItem[]; entities: EntitiesResponse['entities']; query: string }>(`/feedback/search?${searchParams}`)
+    // `is_partial_window` declared, not merely surviving the spread below: the
+    // route sets it when the candidate scan stops on its soft cap, and
+    // `extractTotals` already reads that key for the search branch, so the "N+"
+    // display works either way. Declaring it is what tells the next reader the
+    // field is real rather than incidental.
+    const res = await fetchApi<{ count: number; items: FeedbackItem[]; entities: EntitiesResponse['entities']; query: string; is_partial_window?: boolean }>(`/feedback/search?${searchParams}`)
     return { ...res, items: normalizeFeedbackItems(res.items) }
   },
   

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -189,13 +189,23 @@ export const api = {
   },
   
   searchFeedback: async (params: { q: string; days?: number; date_basis?: DateBasis; limit?: number; source?: string; sentiment?: string; category?: string }) => {
-    const searchParams = buildSearchParams(params)
+    // `q` trimmed HERE, at the single boundary every caller goes through, rather
+    // than in each caller's gate.
+    //
+    // `/feedback/search` trims before applying `SEARCH_QUERY_MIN_LENGTH` and
+    // REFUSES a present-but-too-short term with a 400, so any caller comparing
+    // raw `.length` could ship `"a "` — two characters here, one there — and
+    // surface a server error from ordinary typing. Trimming at the boundary makes
+    // every caller agree with the route by construction; a caller's own gate then
+    // only decides WHETHER to search, not what counts as long enough.
+    const searchParams = buildSearchParams({ ...params, q: params.q.trim() })
     // `is_partial_window` declared, not merely surviving the spread below: the
     // route sets it when the candidate scan stops on its soft cap, and
     // `extractTotals` already reads that key for the search branch, so the "N+"
     // display works either way. Declaring it is what tells the next reader the
     // field is real rather than incidental.
     const res = await fetchApi<{ count: number; items: FeedbackItem[]; entities: EntitiesResponse['entities']; query: string; is_partial_window?: boolean }>(`/feedback/search?${searchParams}`)
+
     return { ...res, items: normalizeFeedbackItems(res.items) }
   },
   

--- a/voc-datalake/frontend/src/pages/Categories/useFeedbackListData.test.tsx
+++ b/voc-datalake/frontend/src/pages/Categories/useFeedbackListData.test.tsx
@@ -262,3 +262,65 @@ describe('useFeedbackListData', () => {
     })
   })
 })
+
+describe('the search gate measures what the server measures', () => {
+  it('does not search when the term trims below the minimum', async () => {
+    // `/feedback/search` trims `q` and now REFUSES a present-but-too-short term
+    // with a 400 instead of answering an empty success. Gating on raw `.length`
+    // made `"a "` two characters here and one there, so an ordinary typing
+    // sequence produced a server error. Nothing should leave the client.
+    const { result } = renderData({ ...baseFilters, searchText: 'a ' })
+
+    await waitFor(() => expect(result.current.isSearching).toBe(false))
+    expect(mockSearchFeedback).not.toHaveBeenCalled()
+  })
+
+  it('sends the trimmed term so the client and the route agree on its length', async () => {
+    renderData({ ...baseFilters, searchText: '  delivery  ' })
+
+    await waitFor(() => expect(mockSearchFeedback).toHaveBeenCalled())
+    expect(mockSearchFeedback.mock.calls[0][0]).toMatchObject({ q: 'delivery' })
+  })
+
+  it('still searches when only the interior has spaces', async () => {
+    renderData({ ...baseFilters, searchText: 'slow delivery' })
+
+    await waitFor(() => expect(mockSearchFeedback).toHaveBeenCalled())
+    expect(mockSearchFeedback.mock.calls[0][0]).toMatchObject({ q: 'slow delivery' })
+  })
+})
+
+describe('a truncated search window reaches the display', () => {
+  it('reports isPartialWindow from the search response', async () => {
+    // The route sets `is_partial_window` when the candidate scan stops on its
+    // soft cap. Without this the dashboard would show a bare count for a
+    // truncated scan — the same ambiguity the MCP tool was fixed for.
+    mockSearchFeedback.mockResolvedValue({
+      count: 1, items: [makeItem()], is_partial_window: true,
+    })
+
+    const { result } = renderData({ ...baseFilters, searchText: 'delivery' })
+
+    await waitFor(() => expect(result.current.isPartialWindow).toBe(true))
+  })
+
+  it('reports a complete search window as complete', async () => {
+    mockSearchFeedback.mockResolvedValue({
+      count: 1, items: [makeItem()], is_partial_window: false,
+    })
+
+    const { result } = renderData({ ...baseFilters, searchText: 'delivery' })
+
+    await waitFor(() => expect(result.current.filteredFeedback).toHaveLength(1))
+    expect(result.current.isPartialWindow).toBe(false)
+  })
+
+  it('treats a route that omits the flag as complete', async () => {
+    mockSearchFeedback.mockResolvedValue({ count: 1, items: [makeItem()] })
+
+    const { result } = renderData({ ...baseFilters, searchText: 'delivery' })
+
+    await waitFor(() => expect(result.current.filteredFeedback).toHaveLength(1))
+    expect(result.current.isPartialWindow).toBe(false)
+  })
+})

--- a/voc-datalake/frontend/src/pages/Categories/useFeedbackListData.ts
+++ b/voc-datalake/frontend/src/pages/Categories/useFeedbackListData.ts
@@ -92,13 +92,21 @@ export function useFeedbackListData(
   filters: CategoryFiltersState,
   apiEndpoint: string
 ): FeedbackListData {
-  const isSearching = filters.searchText.length >= SEARCH_MIN_CHARS
+  // TRIMMED, and measured on the same string the server measures.
+  //
+  // `/feedback/search` trims `q` before applying its own minimum and now REFUSES
+  // a present-but-too-short term instead of answering an empty success. Gating on
+  // raw `.length` would send `"a "` — two characters here, one there — and the
+  // user would see an error from an ordinary typing sequence. Sending the trimmed
+  // value too keeps the cache key, the request and the server's view identical.
+  const searchText = filters.searchText.trim()
+  const isSearching = searchText.length >= SEARCH_MIN_CHARS
   const enabled = computeEnabledQueries(apiEndpoint, isSearching, filters.showUrgentOnly)
   const commonParams = buildCommonParams(dateParams, filters)
 
   const searchQuery = useQuery({
-    queryKey: ['categories-feedback-search', filters.searchText, commonParams],
-    queryFn: () => api.searchFeedback({ q: filters.searchText, ...commonParams }),
+    queryKey: ['categories-feedback-search', searchText, commonParams],
+    queryFn: () => api.searchFeedback({ q: searchText, ...commonParams }),
     enabled: enabled.search,
   })
 

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -919,8 +919,7 @@ MCP_TOOLS = [
                     # treats a blank query as "no query" and answers from
                     # `/feedback`. That tolerance is tested rather than incidental:
                     # `test_mcp_delegation.py::TestRouteSelection`
-                    # ::test_a_blank_query_is_not_a_search (a pre-existing test,
-                    # which is why it appears in no diff that adds this comment).
+                    # `::test_a_blank_query_is_not_a_search`.
                     #
                     # That asymmetry is safe in the direction it runs. A schema
                     # says what a caller MAY send, and a client that sends `""`

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -908,6 +908,21 @@ MCP_TOOLS = [
                     # `SEARCH_QUERY_MIN_LENGTH`, so the prose cannot drift from the
                     # rule the route actually enforces.
                     "minLength": SEARCH_QUERY_MIN_LENGTH,
+                    # ⚖️ The declaration is STRICTER than the server, on purpose.
+                    #
+                    # `minLength` forbids `""`, while `_tool_search_feedback` still
+                    # treats a blank query as "no query" and answers from
+                    # `/feedback` — pinned by `test_a_blank_query_is_not_a_search`,
+                    # so the tolerance is tested rather than incidental.
+                    #
+                    # That asymmetry is safe in the direction it runs. A schema
+                    # says what a caller MAY send, and a client that sends `""`
+                    # instead of omitting gets told to omit, which is the
+                    # documented spelling. The defect this file keeps fixing is
+                    # the OPPOSITE shape — a declaration LOOSER than reality, or a
+                    # promise reality ignores — because that one yields a WRONG
+                    # ANSWER. Being tolerant of an input the schema discourages
+                    # yields the right answer by another spelling.
                     "description": (
                         "Text to match in the verbatim, title or problem summary. "
                         f"Must be at least {SEARCH_QUERY_MIN_LENGTH} characters. "

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -917,9 +917,8 @@ MCP_TOOLS = [
                     #
                     # `minLength` forbids `""`, while `_tool_search_feedback` still
                     # treats a blank query as "no query" and answers from
-                    # `/feedback`. That tolerance is tested rather than incidental:
-                    # `test_mcp_delegation.py::TestRouteSelection`
-                    # `::test_a_blank_query_is_not_a_search`.
+                    # `/feedback`. That tolerance is tested rather than incidental,
+                    # by `test_mcp_delegation.py::TestRouteSelection::test_a_blank_query_is_not_a_search`.
                     #
                     # That asymmetry is safe in the direction it runs. A schema
                     # says what a caller MAY send, and a client that sends `""`

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -22,7 +22,7 @@ from boto3.dynamodb.conditions import Key
 # Imported as a module because botocore's own `ConnectionError` would shadow the builtin.
 from botocore import exceptions as botocore_exceptions
 
-from shared.api import DecimalEncoder
+from shared.api import DecimalEncoder, SEARCH_QUERY_MIN_LENGTH
 from shared.mcp_delegate import (
     DelegationUnavailable,
     DomainCall,
@@ -92,7 +92,14 @@ MCP_PROTOCOL_VERSION = "2024-11-05"
 # uncallable against real data, so nothing could have consumed them — but a
 # client coded against the NAMES loses them, which is a major bump by this
 # file's own rule rather than a judgement about how many clients exist.
-MCP_SERVER_VERSION = "3.0.0"
+#
+# 3.1.0 ADDS `is_partial` to `search_feedback`'s output — an added field, which
+# is a minor bump by the rule above. ⚠️ Minor does not mean invisible: these
+# output shapes carry `additionalProperties: false` and a client validates
+# against the `tools/list` it cached at CONNECT, so a session that predates the
+# deploy rejects the new field until it reconnects. The server honestly declares
+# `tools.listChanged: false`, so there is no notification path to tell it.
+MCP_SERVER_VERSION = "3.1.0"
 
 
 # ============================================
@@ -834,6 +841,40 @@ _PERSONA_SCALAR_TYPES: dict[str, str] = {
     if declared_type not in ("object", "array")
 }
 
+# Each projected feedback key, mapped to the row keys it reads — first non-empty
+# wins.
+#
+# 🔑 This map exists so the feedback projection can be driven by its own
+# declarations, exactly as `_project_persona` is. It could not simply iterate the
+# declared properties against the row, because this projection RENAMES
+# (`source_platform`→`source`, `original_text`→`text`,
+# `problem_root_cause_hypothesis`→`problem_root_cause`), so the declared key is
+# not the key to read. Stating the mapping once is what lets EVERY declared field
+# be coerced instead of the handful someone remembered to wrap in `str()`.
+#
+# `id` is the only multi-key entry, preserving the existing fallback: the
+# processor writes `feedback_id`, and a row that happens to carry a plain `id` is
+# not worth breaking to make a point.
+_FEEDBACK_SOURCE_KEYS: dict[str, tuple[str, ...]] = {
+    "id": ('feedback_id', 'id'),
+    "source": ('source_platform',),
+    "date": ('source_created_at',),
+    "sentiment": ('sentiment_label',),
+    "sentiment_score": ('sentiment_score',),
+    "category": ('category',),
+    "urgency": ('urgency',),
+    "rating": ('rating',),
+    "persona_type": ('persona_type',),
+    "text": ('original_text',),
+    "problem_summary": ('problem_summary',),
+    "journey_stage": ('journey_stage',),
+    "problem_root_cause": ('problem_root_cause_hypothesis',),
+    "direct_quote": ('direct_customer_quote',),
+    "keywords": ('keywords',),
+}
+_FEEDBACK_SUMMARY_TYPES: dict[str, str] = _declared_types(_FEEDBACK_SUMMARY_PROPERTIES)
+_FEEDBACK_DETAIL_TYPES: dict[str, str] = _declared_types(_FEEDBACK_DETAIL_PROPERTIES)
+
 # A window argument, stated once. `maximum` is the route's real ceiling
 # (`validate_days` bounds to 365) rather than a tighter number restated here:
 # the adapter no longer clamps, so a limit this file invented would be a
@@ -859,9 +900,18 @@ MCP_TOOLS = [
             "properties": {
                 "query": {
                     "type": "string",
+                    # DECLARED, not just described. The sentence below always said
+                    # "at least 2 characters" while the schema accepted "a", so a
+                    # validating client had nothing to check against and the route
+                    # answered a one-character search with `{'count': 0}` and no
+                    # error. Both the constraint and the sentence now read from
+                    # `SEARCH_QUERY_MIN_LENGTH`, so the prose cannot drift from the
+                    # rule the route actually enforces.
+                    "minLength": SEARCH_QUERY_MIN_LENGTH,
                     "description": (
                         "Text to match in the verbatim, title or problem summary. "
-                        "Must be at least 2 characters. Omit to list by filters alone."
+                        f"Must be at least {SEARCH_QUERY_MIN_LENGTH} characters. "
+                        "Omit to list by filters alone."
                     ),
                 },
                 "days": _DAYS_ARG,
@@ -903,6 +953,21 @@ MCP_TOOLS = [
             "properties": {
                 "count": {"type": "integer", "description": "Items returned"},
                 "query": {"type": "string", "description": "The text matched, empty when filtering only"},
+                # The tool most likely to truncate was the only one that hid it.
+                # `get_metrics_breakdown` has always published `is_partial`; this
+                # one collected the same flag from the route and threw it away, so
+                # `count: 0` could mean "nothing matches in your window" or "the
+                # scan stopped before reaching the end of it" and a caller had no
+                # way to tell. REQUIRED, because a flag that is sometimes missing
+                # is read as absence of truncation — the same mistake as asserting
+                # it false.
+                "is_partial": {
+                    "type": "boolean",
+                    "description": (
+                        "True when the candidate scan stopped on its soft cap before "
+                        "covering the whole window, so results are a sample of it"
+                    ),
+                },
                 "items": {
                     "type": "array",
                     "items": {
@@ -912,7 +977,7 @@ MCP_TOOLS = [
                     },
                 },
             },
-            "required": ["count", "query", "items"],
+            "required": ["count", "query", "is_partial", "items"],
             "additionalProperties": False,
         },
     },
@@ -1099,6 +1164,20 @@ MCP_TOOLS = [
 # MCP Tool implementations
 # ============================================
 
+def _row_value(item: dict, keys: tuple[str, ...]) -> Any:
+    """The first present value among `keys`, or None.
+
+    Presence is "not absent and not empty string" rather than truthiness, so a
+    `rating` or `sentiment_score` of 0 counts as present and reports as `'0'`.
+    Testing truthiness here would report a zero rating as unrated.
+    """
+    for key in keys:
+        value = item.get(key)
+        if value is not None and value != '':
+            return value
+    return None
+
+
 def _project_feedback(item: dict, *, summary: bool) -> dict:
     """Reshape one raw feedback record for a model to read.
 
@@ -1116,45 +1195,51 @@ def _project_feedback(item: dict, *, summary: bool) -> dict:
     `sentiment_score` and `rating` are stringified, preserving the existing
     contract: both are DynamoDB Decimals, and a client that pattern-matched on
     `"rating": "N/A"` for an unrated item still sees it.
+
+    Every field is coerced to the type it is DECLARED as, driven by
+    `_FEEDBACK_SOURCE_KEYS` and the declarations rather than field by field. The
+    version this replaces read each field with `item.get(key, default)`, and a
+    default fires only when a key is ABSENT — it cannot correct a value of the
+    wrong TYPE. That is the same defect that made `list_personas` uncallable, and
+    here it was worse than a schema violation: `date` and `text` are SLICED
+    (`[:10]`, `[:_SUMMARY_TEXT_LIMIT]`), so a row storing either as a number or a
+    dict raised `TypeError` inside the projection and took down the whole tool
+    call. Coercing first makes both slices safe by construction.
+
+    Only `id` and `rating` keep behaviour that the declarations cannot express:
+    `id` falls back across two row keys, and an absent `rating` reports the
+    documented `'N/A'` rather than an empty string.
     """
+    # `feedback_id` FIRST, and this is a bug fix rather than a rename.
+    #
+    # Both feedback tools reported `item.get('id')`, and the processor that
+    # writes these rows never sets a plain `id` — the identifier is
+    # `feedback_id`, which is also the key `GET /feedback/{id}` looks up on its
+    # GSI. So `search_feedback` advertised an `id` field and filled it with `""`
+    # for every item in the corpus, which made `get_feedback_detail` unreachable
+    # for an agent: the only way to learn a feedback id is to search, and search
+    # reported none. Verified live against the deployed API before fixing.
+    declared = _FEEDBACK_SUMMARY_TYPES if summary else _FEEDBACK_DETAIL_TYPES
     projected = {
-        # `feedback_id` FIRST, and this is a bug fix rather than a rename.
-        #
-        # Both feedback tools reported `item.get('id')`, and the processor that
-        # writes these rows never sets a plain `id` — the identifier is
-        # `feedback_id`, which is also the key `GET /feedback/{id}` looks up on
-        # its GSI. So `search_feedback` advertised an `id` field and filled it
-        # with `""` for every item in the corpus, which made
-        # `get_feedback_detail` unreachable for an agent: the only way to learn a
-        # feedback id is to search, and search reported none. Verified live
-        # against the deployed API before fixing.
-        #
-        # `item.get('id')` is kept as the fallback rather than dropped, because a
-        # row that does carry one is not worth breaking to make a point.
-        "id": item.get('feedback_id') or item.get('id', ''),
-        "source": item.get('source_platform', ''),
-        "date": item.get('source_created_at', '') or '',
-        "sentiment": item.get('sentiment_label', ''),
-        "sentiment_score": str(item.get('sentiment_score', '')),
-        "category": item.get('category', ''),
-        "urgency": item.get('urgency', ''),
-        "rating": str(item.get('rating', 'N/A')),
-        "persona_type": item.get('persona_type', ''),
-        "text": item.get('original_text', '') or '',
-        "problem_summary": item.get('problem_summary', ''),
+        # `.get(key, (key,))` rather than `[key]`: a declared property with no
+        # entry in the map reads the row key of its own name instead of raising
+        # `KeyError` and killing the tool call — the M1 failure mode. The
+        # omission is still a CI failure, pinned by
+        # `test_source_key_map_covers_every_declared_field`; this only decides
+        # whether the symptom is a red test or a dead tool in production.
+        key: _coerce_declared(_row_value(item, _FEEDBACK_SOURCE_KEYS.get(key, (key,))), declared_type)
+        for key, declared_type in declared.items()
     }
+    # An unrated item reads `'N/A'`, not `''`. Applied after coercion so a stored
+    # `None` reports `'N/A'` too — `str(None)` used to put the literal `'None'`
+    # in front of a model, which reads as a value rather than as an absence.
+    if not projected["rating"]:
+        projected["rating"] = 'N/A'
     if summary:
         # A list answer carries the date as a plain day and clips the verbatim;
         # the single-item answer carries both in full.
         projected["date"] = projected["date"][:10]
         projected["text"] = projected["text"][:_SUMMARY_TEXT_LIMIT]
-        return projected
-    projected.update({
-        "journey_stage": item.get('journey_stage', ''),
-        "problem_root_cause": item.get('problem_root_cause_hypothesis', ''),
-        "direct_quote": item.get('direct_customer_quote', ''),
-        "keywords": item.get('keywords', []),
-    })
     return projected
 
 
@@ -1192,9 +1277,15 @@ def _tool_search_feedback(args: dict, token_info: dict) -> ToolResult:
     # `count` exceed `len(items)` in the same payload.
     items = [_project_feedback(item, summary=True) for item in raw_items
              if isinstance(item, dict)]
+    # Both routes publish the flag under the same name, so one read covers the
+    # search branch and the filter-only branch. Coerced with `bool()` rather than
+    # passed through: the declaration says boolean, and a route that answered
+    # `null` would otherwise reproduce M1 in the field added to fix M5.
+    truncated = bool(body.get('is_partial_window')) if isinstance(body, dict) else False
     return ToolResult({
         "count": len(items),
         "query": query,
+        "is_partial": truncated,
         "items": items,
     })
 

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -22,7 +22,7 @@ from boto3.dynamodb.conditions import Key
 # Imported as a module because botocore's own `ConnectionError` would shadow the builtin.
 from botocore import exceptions as botocore_exceptions
 
-from shared.api import DecimalEncoder, SEARCH_QUERY_MIN_LENGTH
+from shared.api import DecimalEncoder, MAX_FEEDBACK_WINDOW_DAYS, SEARCH_QUERY_MIN_LENGTH
 from shared.mcp_delegate import (
     DelegationUnavailable,
     DomainCall,
@@ -875,17 +875,22 @@ _FEEDBACK_SOURCE_KEYS: dict[str, tuple[str, ...]] = {
 _FEEDBACK_SUMMARY_TYPES: dict[str, str] = _declared_types(_FEEDBACK_SUMMARY_PROPERTIES)
 _FEEDBACK_DETAIL_TYPES: dict[str, str] = _declared_types(_FEEDBACK_DETAIL_PROPERTIES)
 
-# A window argument, stated once. `maximum` is the route's real ceiling
-# (`validate_days` bounds to 365) rather than a tighter number restated here:
-# the adapter no longer clamps, so a limit this file invented would be a
-# promise nothing keeps. The route CLAMPS rather than refuses, which is why an
-# out-of-range value is not an error.
+# A window argument, stated once. `maximum` is the route's real ceiling rather
+# than a tighter number restated here: the adapter no longer clamps, so a limit
+# this file invented would be a promise nothing keeps. The route CLAMPS rather
+# than refuses, which is why an out-of-range value is not an error.
+#
+# 🔑 IMPORTED from `MAX_FEEDBACK_WINDOW_DAYS`, not written as `365`. It was the
+# literal, with the real bound named only in this comment — which is precisely
+# the declaration-vs-enforcement drift the rest of this file exists to remove,
+# sitting in the file that removes it. A comment cannot fail CI; an import
+# cannot disagree.
 _DAYS_ARG: dict[str, Any] = {
     "type": "integer",
     "description": "Days to look back (default 7). Values above the route's ceiling are clamped, not refused.",
     "default": 7,
     "minimum": 1,
-    "maximum": 365,
+    "maximum": MAX_FEEDBACK_WINDOW_DAYS,
 }
 
 MCP_TOOLS = [
@@ -912,8 +917,10 @@ MCP_TOOLS = [
                     #
                     # `minLength` forbids `""`, while `_tool_search_feedback` still
                     # treats a blank query as "no query" and answers from
-                    # `/feedback` — pinned by `test_a_blank_query_is_not_a_search`,
-                    # so the tolerance is tested rather than incidental.
+                    # `/feedback`. That tolerance is tested rather than incidental:
+                    # `test_mcp_delegation.py::TestRouteSelection`
+                    # ::test_a_blank_query_is_not_a_search (a pre-existing test,
+                    # which is why it appears in no diff that adds this comment).
                     #
                     # That asymmetry is safe in the direction it runs. A schema
                     # says what a caller MAY send, and a client that sends `""`

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -1164,7 +1164,7 @@ MCP_TOOLS = [
 # MCP Tool implementations
 # ============================================
 
-def _row_value(item: dict, keys: tuple[str, ...]) -> Any:
+def _row_value(item: dict[str, Any], keys: tuple[str, ...]) -> Any:
     """The first present value among `keys`, or None.
 
     Presence is "not absent and not empty string" rather than truthiness, so a

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -15,9 +15,10 @@ from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource
 from shared.api import (
     create_api_resolver, validate_days, validate_limit, validate_int,
-    validate_date_basis, DATE_BASIS_REVIEW,
+    validate_date_basis, DATE_BASIS_REVIEW, SEARCH_QUERY_MIN_LENGTH,
     get_configured_categories, api_handler, DEFAULT_CATEGORIES
 )
+from shared.exceptions import ValidationError
 from shared.feedback import basis_date, window_cutoff
 from shared.indexes import (
     AGGREGATES_BY_METRIC_TYPE_INDEX,
@@ -547,8 +548,22 @@ def search_feedback():
     params = app.current_event.query_string_parameters or {}
     
     query = params.get('q', '').strip().lower()
-    if not query or len(query) < 2:
+    # No search term at all is not an error: `q` absent or blank means the caller
+    # is not searching, and the filter-only answer belongs to `/feedback` (which
+    # is where MCP's adapter routes such a call). An empty result is the honest
+    # answer to an empty question.
+    if not query:
         return {'count': 0, 'items': [], 'entities': {}, 'query': query}
+    # A term that IS present but too short used to return the same empty success,
+    # which is a very different claim: it reports "nothing in the corpus matches"
+    # about a search that was never run. On the dashboard a human sees their own
+    # one-character box and infers it; through MCP a model receives
+    # `{'count': 0}` with no error and reports "no customer mentioned that".
+    if len(query) < SEARCH_QUERY_MIN_LENGTH:
+        raise ValidationError(
+            f"Search query must be at least {SEARCH_QUERY_MIN_LENGTH} characters "
+            f"after trimming; received {len(query)}."
+        )
     
     days = validate_days(params.get('days'), default=30)
     limit = validate_limit(params.get('limit'), default=50, max_val=100)
@@ -561,10 +576,22 @@ def search_feedback():
     # /feedback and /metrics/*). Previously spanned days+1 calendar days.
     cutoff_date = window_cutoff(days)
     
-    candidates, _ = _scan_recent_items(
-        # Sampling scan: search text-matches within a bounded recent sample,
-        # so it keeps the smaller legacy budget rather than the full window.
-        min(days, 30), per_day_limit=300, soft_cap=CANDIDATES_SOFT_CAP,
+    # The REQUESTED window, not a second undocumented one.
+    #
+    # This read `min(days, 30)` while `cutoff_date` above was computed from the
+    # caller's full `days`, so the two disagreed: at `days=365` the filter admitted
+    # a year of items and the candidate set held thirty days of them. Every item
+    # older than a month was unreachable by text search at ANY `days` value, and
+    # the answer was a plain `count: 0` — a claim about the corpus standing in for
+    # the boundary of a scan. On the corpus this was found on, a 5,240-item import
+    # sits 37 days back, so roughly 84% of it could not be searched.
+    #
+    # `is_partial` is now KEPT rather than discarded (`candidates, _ =`). That is
+    # the load-bearing half: the soft cap still bounds how many candidates are
+    # collected, so widening the window without saying when the scan stopped early
+    # would only make an incomplete answer slower and no more honest.
+    candidates, window_truncated = _scan_recent_items(
+        days, per_day_limit=300, soft_cap=CANDIDATES_SOFT_CAP,
         source=source_filter,
     )
     
@@ -606,7 +633,17 @@ def search_feedback():
             'sources': dict(sorted(source_counts.items(), key=lambda x: x[1], reverse=True)),
             'sentiments': dict(sorted(sentiment_counts.items(), key=lambda x: x[1], reverse=True)),
         },
-        'query': query
+        'query': query,
+        # Named as `/feedback` names it, because it means the same thing and a
+        # second name for one concept is how the two drift. True when the
+        # candidate scan stopped on the soft cap, so `count: 0` can be told apart
+        # from "the scan gave up before it reached the end of the window" — which
+        # is the distinction the caller could not previously make at all.
+        #
+        # Hitting `limit` is deliberately NOT truncation here, matching
+        # `/feedback`: a caller that asked for N and received N can see that for
+        # itself, whereas a scan that stopped early is invisible without this.
+        'is_partial_window': window_truncated,
     }
 
 

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1533,11 +1533,21 @@ class TestFeedbackDeclaredTypes:
         under-report class. The runtime fallback keeps it from being a dead tool;
         this test is what keeps it from being invisible.
         """
-        declared = set(mcp_handler._FEEDBACK_DETAIL_TYPES)
+        detail = set(mcp_handler._FEEDBACK_DETAIL_TYPES)
+        summary = set(mcp_handler._FEEDBACK_SUMMARY_TYPES)
         mapped = set(mcp_handler._FEEDBACK_SOURCE_KEYS)
 
-        assert declared - mapped == set(), "declared but unmapped: reads its own name"
-        assert mapped - declared == set(), "mapped but undeclared: dead entry"
+        assert detail - mapped == set(), "declared but unmapped: reads its own name"
+        assert mapped - detail == set(), "mapped but undeclared: dead entry"
+        # BOTH declaration sets, asserted separately. Detail is built as
+        # `{**summary, ...}` so it is a superset today and covering it covers
+        # summary — but that is an implementation detail of one dict literal, and
+        # if it ever stops holding, a summary-only property would fall through to
+        # the `.get(key, (key,))` self-name read with nothing failing. The
+        # superset relation is asserted too, so the redundancy is visible rather
+        # than accidental.
+        assert summary <= detail, "detail is expected to extend summary"
+        assert summary - mapped == set(), "summary-only declaration would read its own name"
 
 
 class TestSearchQueryMinimumIsDeclared:

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1086,7 +1086,7 @@ class TestStructuredOutput:
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.0.0", "6b78edcc4fed0723"), (
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.1.0", "95dc5ca05354367b"), (
             "a tool's declared output shape changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
             "validates structuredContent against these schemas — then update the "
@@ -1438,3 +1438,218 @@ class TestDocumentKindLockstep:
 
     def test_a_document_without_a_sort_key_reports_no_kind_rather_than_guessing(self):
         assert mcp_handler._document_kind({"document_id": "d1"}) == ""
+
+
+# ===========================================================================
+# The feedback projection's declared types — the M1 class, second instance
+# ===========================================================================
+
+_DETAIL_ROUTE = "/feedback/1ae1eb6abcd7d3a2e364f46139f98466"
+_DETAIL_ARGS = {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}
+
+
+def _detail(row: dict) -> dict:
+    fake = _FakeLambda({_DETAIL_ROUTE: row})
+    return _call("get_feedback_detail", _DETAIL_ARGS, fake)["result"]["structuredContent"]
+
+
+def _summary(row: dict) -> dict:
+    fake = _FakeLambda({"/feedback/search": {"items": [row]}})
+    return _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]["items"][0]
+
+
+class TestFeedbackDeclaredTypes:
+    """`_project_feedback` read every field with `item.get(key, default)`.
+
+    A default fires only when a key is ABSENT — it cannot correct a value of the
+    WRONG TYPE. That is precisely the defect that made `list_personas` uncallable
+    (M1), living a second time in the feedback projection, and #356's PR body
+    named it as the owed follow-on.
+    """
+
+    def test_a_dict_where_a_string_is_declared_does_not_kill_the_tool(self):
+        """The sharp end: `date` and `text` are SLICED, so a wrong type RAISED.
+
+        A list answer clips `date[:10]` and `text[:_SUMMARY_TEXT_LIMIT]`. Read
+        with `item.get(key, '') or ''`, a dict or a number passes straight
+        through and the slice then raises `TypeError` — which is not one bad
+        field in one entry, it is the whole `search_feedback` call failing on
+        account of a single malformed row. Coercing first makes both slices safe
+        by construction. Reverting the coercion fails this test.
+        """
+        item = _summary(_feedback_row(source_created_at={"S": "2026-08-01"}, original_text=12345))
+
+        assert isinstance(item["date"], str), "a dict in a declared-string field must not survive"
+        assert isinstance(item["text"], str)
+        assert item["text"] == "12345"
+
+    def test_a_number_in_a_declared_string_field_is_stringified(self):
+        item = _detail(_feedback_row(category=7, problem_summary=42))
+
+        assert item["category"] == "7"
+        assert item["problem_summary"] == "42"
+
+    def test_a_bare_string_in_the_declared_keywords_array_becomes_a_list(self):
+        """`keywords` is the one declared array, and a writer may leave it flat."""
+        item = _detail(_feedback_row(keywords="late"))
+
+        assert item["keywords"] == ["late"]
+
+    def test_a_zero_rating_reports_as_zero_rather_than_as_unrated(self):
+        """Presence, not truthiness: 0 is a rating a customer actually gave.
+
+        `_row_value` tests `is not None and != ''` for exactly this reason. A
+        truthiness test here would report a zero rating as `'N/A'`.
+        """
+        assert _detail(_feedback_row(rating=0))["rating"] == "0"
+
+    def test_a_stored_null_rating_reads_as_not_applicable(self):
+        """`str(None)` used to put the literal `'None'` in front of a model.
+
+        DynamoDB stores nulls, so this is a live shape, and `'None'` reads as a
+        value rather than as an absence.
+        """
+        assert _detail(_feedback_row(rating=None))["rating"] == "N/A"
+
+    def test_a_row_of_entirely_wrong_types_still_conforms_to_its_own_schema(self):
+        """The M1 assertion, applied to feedback: no payload may contradict its
+        own declaration, whatever the row holds."""
+        hostile = _feedback_row(
+            source_platform=["webscraper"], source_created_at={"S": "x"},
+            sentiment_label=None, sentiment_score={"N": "-0.8"}, category=7,
+            urgency=["high"], persona_type={"a": "b"}, original_text=12345,
+            problem_summary=[1, 2], journey_stage=9,
+            problem_root_cause_hypothesis={"k": "v"}, direct_customer_quote=3.5,
+            keywords="late",
+        )
+        payload = _detail(hostile)
+
+        errors = _schema_errors(payload, _tool_output_schema("get_feedback_detail"))
+        assert errors == [], f"payload violates its own outputSchema: {errors}"
+
+    def test_source_key_map_covers_every_declared_field(self):
+        """A declared property with no entry in the map reads the row key of its
+        own name — a silent wrong-key read, which is the same silent
+        under-report class. The runtime fallback keeps it from being a dead tool;
+        this test is what keeps it from being invisible.
+        """
+        declared = set(mcp_handler._FEEDBACK_DETAIL_TYPES)
+        mapped = set(mcp_handler._FEEDBACK_SOURCE_KEYS)
+
+        assert declared - mapped == set(), "declared but unmapped: reads its own name"
+        assert mapped - declared == set(), "mapped but undeclared: dead entry"
+
+
+class TestSearchQueryMinimumIsDeclared:
+    """M2: the tool's description promised a minimum its schema did not declare.
+
+    The sentence "Must be at least 2 characters" has always been in the tool
+    description, so a model reading the catalogue was told the rule — while the
+    `inputSchema` accepted `"a"`, the route answered it with `{'count': 0}`, and
+    nothing anywhere failed. A prose promise cannot fail CI.
+    """
+
+    @staticmethod
+    def _query_schema() -> dict:
+        """The tool's OWN declared `query` argument, read from the live registry
+        for the same reason `_tool_output_schema` is."""
+        for tool in mcp_handler.MCP_TOOLS:
+            if tool["name"] == "search_feedback":
+                return tool["inputSchema"]["properties"]["query"]
+        raise AssertionError("no search_feedback tool")
+
+    def test_the_query_argument_declares_the_minimum_the_route_enforces(self):
+        """Lockstep: one constant, read by the schema and by the route.
+
+        Read from `shared.api` rather than restated as `2`, so a change to the
+        bound cannot leave the declaration behind.
+        """
+        from shared.api import SEARCH_QUERY_MIN_LENGTH
+
+        assert self._query_schema()["minLength"] == SEARCH_QUERY_MIN_LENGTH
+
+    def test_the_description_states_the_same_minimum_it_declares(self):
+        """The prose and the constraint are generated from one value, so this
+        pins that they cannot disagree again."""
+        schema = self._query_schema()
+
+        assert f"at least {schema['minLength']} characters" in schema["description"]
+
+    def test_a_short_query_reaches_the_model_as_an_error_not_as_no_matches(self):
+        """The harm, end to end.
+
+        A non-validating client can still send `"a"`. The route refuses, and the
+        adapter must surface that refusal as an MCP error carrying the route's
+        own message — NOT as a successful `count: 0`, which a model reports as
+        "no customer mentioned that". The body shape is the one
+        `shared.exceptions.ValidationError` actually produces.
+        """
+        fake = _FakeLambda(
+            {"/feedback/search": {
+                "success": False,
+                "error": "Search query must be at least 2 characters after trimming; received 1.",
+            }},
+            status=400,
+        )
+
+        result = _call("search_feedback", {"query": "a"}, fake)["result"]
+
+        assert result["isError"] is True, "a refused search must not read as empty"
+        assert "at least 2 characters" in result["content"][0]["text"]
+        assert "structuredContent" not in result, "a refusal carries no count to misread"
+
+
+class TestSearchReportsItsTruncation:
+    """M5: the tool most likely to truncate was the only one hiding it.
+
+    `get_metrics_breakdown` has always published `is_partial`. `search_feedback`
+    collected the same flag from the route and discarded it (`candidates, _ =`),
+    so a caller could not tell "nothing in your window matches" from "the scan
+    stopped before it reached the end of your window".
+    """
+
+    def test_a_truncated_search_reports_is_partial(self):
+        fake = _FakeLambda({"/feedback/search": {
+            "items": [_feedback_row()], "is_partial_window": True,
+        }})
+
+        payload = _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]
+
+        assert payload["is_partial"] is True
+
+    def test_a_complete_search_reports_is_partial_false(self):
+        fake = _FakeLambda({"/feedback/search": {
+            "items": [_feedback_row()], "is_partial_window": False,
+        }})
+
+        payload = _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]
+
+        assert payload["is_partial"] is False
+
+    def test_the_filter_only_branch_reports_it_too(self):
+        """`/feedback` publishes the same flag under the same name, so the
+        no-query branch is covered by the same read."""
+        fake = _FakeLambda({"/feedback": {
+            "items": [_feedback_row()], "is_partial_window": True,
+        }})
+
+        payload = _call("search_feedback", {"days": 7}, fake)["result"]["structuredContent"]
+
+        assert payload["is_partial"] is True
+
+    def test_a_route_that_omits_the_flag_reports_false_rather_than_null(self):
+        """The declaration says boolean and it is REQUIRED, so a missing flag has
+        to become `False` — a `null` here would reproduce M1 inside the field
+        added to fix M5."""
+        fake = _FakeLambda({"/feedback/search": {"items": [_feedback_row()]}})
+
+        payload = _call("search_feedback", {"query": "late"}, fake)["result"]["structuredContent"]
+
+        assert payload["is_partial"] is False
+        assert _schema_errors(payload, _tool_output_schema("search_feedback")) == []
+
+    def test_the_flag_is_declared_required_so_absence_cannot_read_as_complete(self):
+        schema = _tool_output_schema("search_feedback")
+
+        assert "is_partial" in schema["required"]
+        assert schema["properties"]["is_partial"]["type"] == "boolean"

--- a/voc-datalake/lambda/api/test/test_metrics_handler.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler.py
@@ -1026,6 +1026,12 @@ class TestSearchScansTheRequestedWindow:
         answer slower. `count: 0` and "the scan gave up" must be distinguishable.
         """
         from metrics_handler import CANDIDATES_SOFT_CAP
+        # `date` is OMITTED on purpose, and that is load-bearing: the default
+        # `imported` basis reads `item['date']`, so `basis_date` returns `''`,
+        # every row falls below the cutoff, and `count` is 0 for a reason that has
+        # nothing to do with the search term. That is exactly the state under test
+        # — zero matches out of a scan that also truncated. Adding `date` here
+        # would make the rows pass the cutoff and test something else.
         dense_day = [
             {'feedback_id': f'f{i}', 'original_text': 'nothing to match here',
              'source_created_at': '2026-08-01T00:00:00Z'}

--- a/voc-datalake/lambda/api/test/test_metrics_handler.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler.py
@@ -839,3 +839,210 @@ class TestMetricsRequestCountIsIndependentOfWindow:
         body = json.loads(response['body'])
 
         assert body['urgent_count'] == 12
+
+
+class TestSearchQueryMinimumLength:
+    """GET /feedback/search and a query shorter than the documented minimum.
+
+    The route answered `{'count': 0, 'items': []}` with HTTP 200, which is a
+    claim about the CORPUS ("nothing matches") standing in for a fact about the
+    REQUEST ("that search was never run"). A human typing in a search box infers
+    the difference from their own one-character input; a model calling the MCP
+    tool receives a successful empty result and reports that no customer
+    mentioned the thing.
+    """
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_one_character_query_is_refused_rather_than_answered_empty(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(path='/feedback/search', query_params={'q': 'a'})
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert json.loads(response['body'])['success'] is False
+        assert mock_fb.query.call_count == 0, "a refused search must not scan the corpus"
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_refusal_states_the_minimum_so_a_caller_can_correct_itself(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The adapter relays this message verbatim to the model, so it has to
+        say what the rule is rather than merely that a rule was broken."""
+        from metrics_handler import lambda_handler
+        from shared.api import SEARCH_QUERY_MIN_LENGTH
+        event = api_gateway_event(path='/feedback/search', query_params={'q': 'a'})
+
+        error = json.loads(lambda_handler(event, lambda_context)['body'])['error']
+
+        assert str(SEARCH_QUERY_MIN_LENGTH) in error
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_whitespace_that_trims_below_the_minimum_is_refused(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The route trims before measuring, so `' a '` is one character.
+
+        This is the case the frontend can actually produce: its own gate counts
+        raw `.length`, so two typed spaces around one letter passes the client
+        check and arrives here as a single character.
+        """
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(path='/feedback/search', query_params={'q': '  a  '})
+
+        assert lambda_handler(event, lambda_context)['statusCode'] == 400
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_blank_query_is_still_a_successful_empty_answer(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """Deliberately NOT an error: no search term means no search was asked
+        for, and the filter-only answer belongs to `/feedback` — which is where
+        the MCP adapter routes such a call. Only a term that is PRESENT and too
+        short is a refusal.
+        """
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(path='/feedback/search', query_params={'q': '   '})
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['count'] == 0
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_query_at_the_minimum_is_accepted(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The boundary itself, so the guard cannot drift into off-by-one."""
+        from metrics_handler import lambda_handler
+        from shared.api import SEARCH_QUERY_MIN_LENGTH
+        mock_fb.query.return_value = {'Items': []}
+        event = api_gateway_event(
+            path='/feedback/search',
+            query_params={'q': 'a' * SEARCH_QUERY_MIN_LENGTH, 'days': '1'},
+        )
+
+        assert lambda_handler(event, lambda_context)['statusCode'] == 200
+
+
+class TestSearchScansTheRequestedWindow:
+    """GET /feedback/search read `min(days, 30)` while its cutoff used `days`.
+
+    The two disagreed, so at `days=365` the filter admitted a year of items and
+    the candidate set only ever held thirty days of them. Anything older was
+    unreachable by text search at ANY `days` value, and the answer was a plain
+    `count: 0` — indistinguishable from "no customer said that".
+    """
+
+    @staticmethod
+    def _day_partitions(mock_fb):
+        """The `DATE#` partitions the route actually queried, in order."""
+        return [
+            call.kwargs['KeyConditionExpression']._values[1]
+            for call in mock_fb.query.call_args_list
+        ]
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_match_older_than_thirty_days_is_now_reachable(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The reported symptom, as a test: on the corpus this was found on, a
+        5,240-item import sat 37 days back and no text search could see it."""
+        old_day = (datetime.now(timezone.utc) - timedelta(days=37)).strftime('%Y-%m-%d')
+
+        def by_day(**kwargs):
+            queried = kwargs['KeyConditionExpression']._values[1]
+            if queried == f'DATE#{old_day}':
+                return {'Items': [{
+                    'feedback_id': 'old-hit', 'original_text': 'slow delivery',
+                    # `date` is the import date and mirrors the gsi1 partition, so
+                    # a row living in `DATE#{old_day}` carries that same day. It is
+                    # what the default `imported` basis filters on — omitting it
+                    # makes `basis_date` return `''`, which is below every cutoff.
+                    'date': old_day,
+                    'source_created_at': f'{old_day}T00:00:00Z', 'category': 'delivery',
+                }]}
+            return {'Items': []}
+
+        mock_fb.query.side_effect = by_day
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            path='/feedback/search', query_params={'q': 'delivery', 'days': '90'}
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert [i['feedback_id'] for i in body['items']] == ['old-hit']
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_scan_covers_every_requested_day_not_thirty(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """Asserted on the PARTITIONS queried rather than on a call count, so it
+        says which window was read instead of merely how many reads happened."""
+        mock_fb.query.return_value = {'Items': []}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            path='/feedback/search', query_params={'q': 'delivery', 'days': '60'}
+        )
+
+        lambda_handler(event, lambda_context)
+
+        assert len(self._day_partitions(mock_fb)) == 60, "the requested window, not a hidden 30"
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_complete_scan_reports_itself_as_complete(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        mock_fb.query.return_value = {'Items': []}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            path='/feedback/search', query_params={'q': 'delivery', 'days': '7'}
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial_window'] is False
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_scan_that_stops_on_the_soft_cap_says_so(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The load-bearing half of the fix.
+
+        The soft cap still bounds how many candidates are collected, so widening
+        the window without reporting an early stop would only make an incomplete
+        answer slower. `count: 0` and "the scan gave up" must be distinguishable.
+        """
+        from metrics_handler import CANDIDATES_SOFT_CAP
+        dense_day = [
+            {'feedback_id': f'f{i}', 'original_text': 'nothing to match here',
+             'source_created_at': '2026-08-01T00:00:00Z'}
+            for i in range(300)
+        ]
+        mock_fb.query.return_value = {'Items': dense_day}
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            path='/feedback/search', query_params={'q': 'delivery', 'days': '365'}
+        )
+
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['count'] == 0, "no item contains the term"
+        assert body['is_partial_window'] is True, (
+            "zero matches out of a truncated scan must not read as zero matches in the window"
+        )
+        assert len(self._day_partitions(mock_fb)) < 365, (
+            f"the soft cap of {CANDIDATES_SOFT_CAP} should have stopped the scan early"
+        )

--- a/voc-datalake/lambda/shared/api.py
+++ b/voc-datalake/lambda/shared/api.py
@@ -66,12 +66,23 @@ MAX_PERSONAS_PER_GENERATION = 10
 # mentioned this". A prose promise cannot fail CI.
 SEARCH_QUERY_MIN_LENGTH = 2
 
+# The longest window any route will honour, and `validate_days`' ceiling.
+#
+# Named rather than left as a bare default in the signature because it is now
+# COUPLED to infrastructure: `/feedback/search` walks one DynamoDB query per day
+# partition (gsi1-by-date is partitioned BY DAY), so the widest window a caller
+# can ask for decides the worst-case duration of that route — and therefore
+# whether the metrics Lambda's timeout and API Gateway's 29 s integration limit
+# still cover it. `api-stack.test.ts` § "the search fan-out fits the metrics
+# timeout" READS this value and fails if raising it outgrows the budget.
+MAX_FEEDBACK_WINDOW_DAYS = 365
+
 
 def validate_days(
     value: str | int | None,
     default: int = 7,
     min_val: int = 1,
-    max_val: int = 365
+    max_val: int = MAX_FEEDBACK_WINDOW_DAYS
 ) -> int:
     """Validate and bound days parameter. Convenience wrapper around validate_int."""
     return validate_int(value, default=default, min_val=min_val, max_val=max_val)

--- a/voc-datalake/lambda/shared/api.py
+++ b/voc-datalake/lambda/shared/api.py
@@ -53,6 +53,19 @@ def decimal_default(obj):
 # raising this ceiling used to silently halve the fan-out benefit while every test passed.
 MAX_PERSONAS_PER_GENERATION = 10
 
+# The shortest text search `/feedback/search` will run. Lives here, beside
+# MAX_PERSONAS_PER_GENERATION and for the same reason, because THREE places size
+# themselves against it and two of them are in other files: the route that
+# enforces it, the MCP tool's `inputSchema.minLength` plus the sentence in its
+# description that states it, and the frontend's own `SEARCH_MIN_CHARS` gate.
+#
+# 🔑 The bound was previously the bare literal `2` in the route and a claim in
+# English in the MCP tool description, with nothing declaring it — so the tool
+# advertised "must be at least 2 characters" while its schema accepted `"a"`, the
+# route answered `{'count': 0}` to it, and a model read that as "no customer
+# mentioned this". A prose promise cannot fail CI.
+SEARCH_QUERY_MIN_LENGTH = 2
+
 
 def validate_days(
     value: str | int | None,

--- a/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
@@ -39,13 +39,17 @@ def _frontend_minimum() -> int | None:
 
 
 class TestSearchMinimumMirror:
-    """The positive control stays LOUD; the comparison SKIPS when the tree is gone.
+    """The comparison SKIPS when the frontend tree is gone; the control does not.
 
     A checkout without `frontend/` (a backend-only sparse checkout, say) should
-    not report a mirror mismatch it cannot possibly have measured — that is a
-    `FileNotFoundError` masquerading as a finding. The control below is the one
-    test that must still fail in a normal checkout, so it is not skipped on the
-    file's contents, only on its absence.
+    not report a mirror mismatch it never measured — that is a
+    `FileNotFoundError` masquerading as a finding, so the equality test carries a
+    `skipif`.
+
+    `test_the_frontend_constant_is_findable` carries NO skip marker on purpose: it
+    asserts the file exists and the constant parses, which is exactly the check
+    that has to run. Skipping it would leave the equality test able to pass while
+    comparing against nothing.
     """
 
     def test_the_frontend_constant_is_findable(self):

--- a/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
@@ -1,0 +1,69 @@
+"""Guard test for the search-query minimum, mirrored in Python and TypeScript.
+
+`shared/api.py` owns `SEARCH_QUERY_MIN_LENGTH`: the route enforces it and the MCP
+tool declares it as `inputSchema.minLength`. The frontend has its own
+`SEARCH_MIN_CHARS`, which decides whether to issue a search at all.
+
+Nothing tied the two together, so the frontend could gate at a different number
+than the route refuses at — and the failure is user-visible rather than loud: the
+client lets a term through and the user gets an HTTP 400 from a search box. That
+is how the two halves of this bound drifted in the first place.
+
+Same pattern as `test_indexes.py` (CDK ↔ Python GSI names) and the model-allowlist
+TS ↔ Python mirror: parse the other language's source and assert equality, so a
+change on either side fails CI instead of the live UI.
+"""
+import re
+from pathlib import Path
+
+from shared.api import SEARCH_QUERY_MIN_LENGTH
+
+
+def _repo_root() -> Path:
+    # lambda/shared/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+_GATE_SOURCE = _repo_root() / 'frontend' / 'src' / 'pages' / 'Categories' / 'useFeedbackListData.ts'
+
+
+def _frontend_minimum() -> int | None:
+    """`SEARCH_MIN_CHARS` as declared in the hook, or None if not found."""
+    match = re.search(
+        r'export\s+const\s+SEARCH_MIN_CHARS\s*=\s*(\d+)',
+        _GATE_SOURCE.read_text(),
+    )
+    return int(match.group(1)) if match else None
+
+
+class TestSearchMinimumMirror:
+    def test_the_frontend_constant_is_findable(self):
+        """The positive control.
+
+        Without it, a rename to `SEARCH_MIN_CHARACTERS` would make the parser
+        return None and the equality test below would be comparing against
+        nothing — a green result meaning "did not check", which is the failure
+        mode this file exists to prevent, applied to itself.
+        """
+        assert _GATE_SOURCE.exists(), f'gate source moved: {_GATE_SOURCE}'
+        assert _frontend_minimum() is not None, (
+            'parsed no SEARCH_MIN_CHARS from useFeedbackListData.ts — parser drift?'
+        )
+
+    def test_both_languages_agree_on_the_minimum(self):
+        """Equality, so raising the bound on one side fails here rather than
+        turning an ordinary keystroke into a 400."""
+        assert _frontend_minimum() == SEARCH_QUERY_MIN_LENGTH, (
+            f'frontend gates at {_frontend_minimum()} while the route enforces '
+            f'{SEARCH_QUERY_MIN_LENGTH}'
+        )
+
+    def test_the_client_trims_before_measuring_against_the_route(self):
+        """The route trims `q` before applying the minimum, so the client has to
+        compare the same string. This pins the trim at the API boundary, where it
+        covers every caller, rather than in one hook's gate."""
+        client = (_repo_root() / 'frontend' / 'src' / 'api' / 'client.ts').read_text()
+
+        assert 'q: params.q.trim()' in client, (
+            'api.searchFeedback must trim `q` so every caller agrees with the route'
+        )

--- a/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
@@ -74,16 +74,11 @@ class TestSearchMinimumMirror:
             f'{SEARCH_QUERY_MIN_LENGTH}'
         )
 
-    # The client's trim is NOT asserted here any more.
+    # The client's TRIM is deliberately not asserted here.
     #
-    # It used to be, as the literal substring `q: params.q.trim()` in client.ts —
-    # which pins CHARACTERS, not behaviour: a Prettier reflow or an extracted
-    # local would have failed a green test with no change in what the code does.
-    # That is the "assert on structure, not text" rule this repo already learned
-    # elsewhere, and grepping another language's source for an expression was the
-    # weakest available form of it.
-    #
-    # The behaviour is pinned where it can be observed instead — `client.test.ts`
-    # § "searchFeedback trims the query at the boundary" asserts the trimmed term
-    # in the REQUEST URL. This file keeps only what genuinely needs cross-language
-    # parsing: the shared CONSTANT.
+    # Grepping another language's source for an expression pins CHARACTERS rather
+    # than behaviour: a reformat or an extracted local breaks such a test with no
+    # change in what the code does. This file keeps only what genuinely requires
+    # cross-language parsing — the shared CONSTANT — and the trim is pinned where
+    # it can be observed, in `client.test.ts` § "searchFeedback trims the query at
+    # the boundary", which asserts the trimmed term in the REQUEST URL.

--- a/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_search_minimum_lockstep.py
@@ -16,6 +16,8 @@ change on either side fails CI instead of the live UI.
 import re
 from pathlib import Path
 
+import pytest
+
 from shared.api import SEARCH_QUERY_MIN_LENGTH
 
 
@@ -37,6 +39,15 @@ def _frontend_minimum() -> int | None:
 
 
 class TestSearchMinimumMirror:
+    """The positive control stays LOUD; the comparison SKIPS when the tree is gone.
+
+    A checkout without `frontend/` (a backend-only sparse checkout, say) should
+    not report a mirror mismatch it cannot possibly have measured — that is a
+    `FileNotFoundError` masquerading as a finding. The control below is the one
+    test that must still fail in a normal checkout, so it is not skipped on the
+    file's contents, only on its absence.
+    """
+
     def test_the_frontend_constant_is_findable(self):
         """The positive control.
 
@@ -50,6 +61,7 @@ class TestSearchMinimumMirror:
             'parsed no SEARCH_MIN_CHARS from useFeedbackListData.ts — parser drift?'
         )
 
+    @pytest.mark.skipif(not _GATE_SOURCE.exists(), reason='frontend tree absent from this checkout')
     def test_both_languages_agree_on_the_minimum(self):
         """Equality, so raising the bound on one side fails here rather than
         turning an ordinary keystroke into a 400."""
@@ -58,12 +70,16 @@ class TestSearchMinimumMirror:
             f'{SEARCH_QUERY_MIN_LENGTH}'
         )
 
-    def test_the_client_trims_before_measuring_against_the_route(self):
-        """The route trims `q` before applying the minimum, so the client has to
-        compare the same string. This pins the trim at the API boundary, where it
-        covers every caller, rather than in one hook's gate."""
-        client = (_repo_root() / 'frontend' / 'src' / 'api' / 'client.ts').read_text()
-
-        assert 'q: params.q.trim()' in client, (
-            'api.searchFeedback must trim `q` so every caller agrees with the route'
-        )
+    # The client's trim is NOT asserted here any more.
+    #
+    # It used to be, as the literal substring `q: params.q.trim()` in client.ts —
+    # which pins CHARACTERS, not behaviour: a Prettier reflow or an extracted
+    # local would have failed a green test with no change in what the code does.
+    # That is the "assert on structure, not text" rule this repo already learned
+    # elsewhere, and grepping another language's source for an expression was the
+    # weakest available form of it.
+    #
+    # The behaviour is pinned where it can be observed instead — `client.test.ts`
+    # § "searchFeedback trims the query at the boundary" asserts the trimmed term
+    # in the REQUEST URL. This file keeps only what genuinely needs cross-language
+    # parsing: the shared CONSTANT.

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1047,6 +1047,66 @@ describe('the delegation timeout budget', () => {
   });
 });
 
+describe('the search fan-out fits the metrics timeout', () => {
+  // `/feedback/search` walks ONE DynamoDB query per day partition, because
+  // gsi1-by-date is partitioned BY DAY (`gsi1pk = DATE#YYYY-MM-DD`) and no index
+  // supports a bounded multi-day query with a usable projection. Removing the old
+  // undocumented `min(days, 30)` cap — which made most of the corpus unreachable
+  // by text search — means the loop can now run for the FULL validated window.
+  //
+  // So the window ceiling and the Lambda timeout became coupled, and nothing said
+  // so. This pins the arithmetic: raising `validate_days`' maximum, or lowering
+  // the metrics timeout, fails here instead of producing 502s on a year-long
+  // search. The measured cost is ~10-15 ms per day partition (p50, sparse days),
+  // so the upper bound is used.
+  const MEASURED_MS_PER_DAY = 15;
+  const SAFETY_FACTOR = 2;
+  // API Gateway hard-caps a REST integration at 29 s regardless of the Lambda's
+  // own timeout, so a budget above this is unreachable however it is configured.
+  const API_GATEWAY_INTEGRATION_CEILING_SECONDS = 29;
+
+  const maxWindowDays = () => {
+    const source = readRepoFile('lambda', 'shared', 'api.py');
+    // `validate_days`' own ceiling, read rather than restated — a copy here would
+    // keep passing after the real bound moved, which is the whole failure mode.
+    const block = source.match(/def validate_days\([\s\S]*?\)\s*->\s*int:/)?.[0];
+    expect(block, 'could not locate validate_days signature').toBeDefined();
+    const maxVal = block?.match(/max_val:\s*int\s*=\s*(\d+)/)?.[1];
+    expect(maxVal, 'could not read validate_days max_val').toBeDefined();
+    return Number(maxVal);
+  };
+
+  const metricsTimeout = () => {
+    const fn = Object.values(apiTemplate().findResources('AWS::Lambda::Function'))
+      .map((f) => z.object({
+        Properties: z.object({ Handler: z.string().optional(), Timeout: z.number().optional() }),
+      }).parse(f).Properties)
+      .find((p) => p.Handler === 'metrics_handler.lambda_handler');
+    expect(fn, 'no Lambda with the metrics_handler entry point').toBeDefined();
+    return fn?.Timeout ?? 0;
+  };
+
+  it('leaves the metrics function time for a full-window search', () => {
+    const worstCaseSeconds = (maxWindowDays() * MEASURED_MS_PER_DAY) / 1000;
+
+    expect(
+      metricsTimeout(),
+      `a ${maxWindowDays()}-day search projects to ~${worstCaseSeconds.toFixed(1)}s ` +
+      `at ${MEASURED_MS_PER_DAY}ms/day; the metrics timeout must cover that with margin`,
+    ).toBeGreaterThanOrEqual(worstCaseSeconds * SAFETY_FACTOR);
+  });
+
+  it('keeps the budget inside what API Gateway will actually wait for', () => {
+    // Not redundant with the assertion above: that one could be satisfied by
+    // raising the Lambda timeout past the point where the caller still receives
+    // the response, which would trade a 502 for a slower 504.
+    const worstCaseSeconds = (maxWindowDays() * MEASURED_MS_PER_DAY) / 1000;
+
+    expect(worstCaseSeconds).toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
+    expect(metricsTimeout()).toBeLessThanOrEqual(API_GATEWAY_INTEGRATION_CEILING_SECONDS + 1);
+  });
+});
+
 describe('mcp endpoint throttling', () => {
   // The former McpUsagePlan never bound: a usage plan's throttle applies per
   // API KEY and no MCP client sends one (SEC-10's fourth sub-claim, open since

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1088,44 +1088,41 @@ describe('the search fan-out fits the metrics timeout', () => {
   };
 
   it('leaves the metrics function time for a full-window search', () => {
-    const worstCaseSeconds = (maxWindowDays() * MEASURED_MS_PER_DAY) / 1000;
+    const days = maxWindowDays();
+    const worstCaseSeconds = (days * MEASURED_MS_PER_DAY) / 1000;
+    const budget =
+      `a ${days}-day search projects to ~${worstCaseSeconds.toFixed(1)}s at ` +
+      `${MEASURED_MS_PER_DAY}ms/day`;
 
-    expect(
-      metricsTimeout(),
-      `a ${maxWindowDays()}-day search projects to ~${worstCaseSeconds.toFixed(1)}s ` +
-      `at ${MEASURED_MS_PER_DAY}ms/day; the metrics timeout must cover that with margin`,
-    ).toBeGreaterThanOrEqual(worstCaseSeconds * SAFETY_FACTOR);
+    // ONE guard, because there is one thing to guard: the projection has to fit
+    // inside both budgets. A separate test for the API Gateway ceiling was split
+    // out at first, but once the Lambda-config half of it was removed as
+    // misleading it reduced to arithmetic over two constants in this file and no
+    // longer touched infrastructure at all — a guard in name only. Folded back in
+    // as a second bound on the same number.
+    expect(metricsTimeout(), `${budget}; the metrics timeout must cover it with margin`)
+      .toBeGreaterThanOrEqual(worstCaseSeconds * SAFETY_FACTOR);
+
+    // And the caller's own ceiling, which no Lambda timeout can rescue a request
+    // from once API Gateway has abandoned it.
+    expect(worstCaseSeconds, `${budget}; API Gateway stops waiting at ${API_GATEWAY_INTEGRATION_CEILING_SECONDS}s`)
+      .toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
   });
 
-  it('keeps the projected worst case inside what API Gateway will wait for', () => {
-    // Asserted on the PROJECTION only, deliberately — NOT on the Lambda timeout.
-    //
-    // An earlier version of this test also asserted
-    // `metricsTimeout() <= CEILING + 1`, under a name claiming it kept the budget
-    // inside the integration limit. That `+1` existed solely to accommodate the
-    // current 30 s config, so the assertion permitted the very 30 > 29 case its
-    // own name said it prevented: an assertion shaped around the value it was
-    // supposed to constrain, which cannot fail for the reason it claims.
-    //
-    // The 30 s Lambda outliving the 29 s integration is CHOSEN, not an oversight.
-    // `MetricsApi` serves the browser across every `/metrics/*` and `/feedback/*`
-    // route, where 30 s is the right budget, and the sibling suite above records
-    // the same asymmetry for the delegation path. A Lambda that outlives the
-    // integration wastes tail compute on a response nobody receives; one that
-    // dies sooner turns a slow-but-valid answer into a 502. The second is worse,
-    // so the asymmetry stays and this test does not pretend otherwise.
-    //
-    // What genuinely must hold is that a full-window search is nowhere near the
-    // ceiling the CALLER is bounded by, since no Lambda timeout can rescue a
-    // request API Gateway has already abandoned.
-    const worstCaseSeconds = (maxWindowDays() * MEASURED_MS_PER_DAY) / 1000;
-
-    expect(
-      worstCaseSeconds,
-      `a ${maxWindowDays()}-day search projects to ~${worstCaseSeconds.toFixed(1)}s, ` +
-      `which must stay under API Gateway's ${API_GATEWAY_INTEGRATION_CEILING_SECONDS}s ceiling`,
-    ).toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
-  });
+  // 🔑 The Lambda timeout is NOT asserted against the API Gateway ceiling, and
+  // that omission is deliberate. An earlier version asserted
+  // `metricsTimeout() <= CEILING + 1` under a name claiming it kept the budget
+  // inside the integration limit — but the `+1` existed solely to fit the current
+  // 30 s config, so it permitted the very 30 > 29 case its own name said it
+  // prevented. An assertion shaped around the value it is meant to constrain
+  // cannot fail for the reason it advertises.
+  //
+  // The 30 s Lambda outliving the 29 s integration is CHOSEN. `MetricsApi` serves
+  // the browser across every `/metrics/*` and `/feedback/*` route where 30 s is
+  // the right budget, and the sibling suite above records the same asymmetry for
+  // the delegation path. A Lambda that outlives the integration wastes tail
+  // compute on a response nobody receives; one that dies sooner turns a
+  // slow-but-valid answer into a 502. The second is worse.
 });
 
 describe('mcp endpoint throttling', () => {

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1066,13 +1066,14 @@ describe('the search fan-out fits the metrics timeout', () => {
   const API_GATEWAY_INTEGRATION_CEILING_SECONDS = 29;
 
   const maxWindowDays = () => {
+    // Read from the NAMED constant, not from `validate_days`' signature default.
+    // The earlier two-step regex walked into the signature to find
+    // `max_val: int = 365`, which would have silently stopped matching the moment
+    // the ceiling moved to a constant or the parameter was renamed. It is a named
+    // declaration now precisely so this parse has something stable to aim at.
     const source = readRepoFile('lambda', 'shared', 'api.py');
-    // `validate_days`' own ceiling, read rather than restated — a copy here would
-    // keep passing after the real bound moved, which is the whole failure mode.
-    const block = source.match(/def validate_days\([\s\S]*?\)\s*->\s*int:/)?.[0];
-    expect(block, 'could not locate validate_days signature').toBeDefined();
-    const maxVal = block?.match(/max_val:\s*int\s*=\s*(\d+)/)?.[1];
-    expect(maxVal, 'could not read validate_days max_val').toBeDefined();
+    const maxVal = source.match(/^MAX_FEEDBACK_WINDOW_DAYS\s*=\s*(\d+)/m)?.[1];
+    expect(maxVal, 'could not read MAX_FEEDBACK_WINDOW_DAYS from shared/api.py').toBeDefined();
     return Number(maxVal);
   };
 
@@ -1096,14 +1097,34 @@ describe('the search fan-out fits the metrics timeout', () => {
     ).toBeGreaterThanOrEqual(worstCaseSeconds * SAFETY_FACTOR);
   });
 
-  it('keeps the budget inside what API Gateway will actually wait for', () => {
-    // Not redundant with the assertion above: that one could be satisfied by
-    // raising the Lambda timeout past the point where the caller still receives
-    // the response, which would trade a 502 for a slower 504.
+  it('keeps the projected worst case inside what API Gateway will wait for', () => {
+    // Asserted on the PROJECTION only, deliberately — NOT on the Lambda timeout.
+    //
+    // An earlier version of this test also asserted
+    // `metricsTimeout() <= CEILING + 1`, under a name claiming it kept the budget
+    // inside the integration limit. That `+1` existed solely to accommodate the
+    // current 30 s config, so the assertion permitted the very 30 > 29 case its
+    // own name said it prevented: an assertion shaped around the value it was
+    // supposed to constrain, which cannot fail for the reason it claims.
+    //
+    // The 30 s Lambda outliving the 29 s integration is CHOSEN, not an oversight.
+    // `MetricsApi` serves the browser across every `/metrics/*` and `/feedback/*`
+    // route, where 30 s is the right budget, and the sibling suite above records
+    // the same asymmetry for the delegation path. A Lambda that outlives the
+    // integration wastes tail compute on a response nobody receives; one that
+    // dies sooner turns a slow-but-valid answer into a 502. The second is worse,
+    // so the asymmetry stays and this test does not pretend otherwise.
+    //
+    // What genuinely must hold is that a full-window search is nowhere near the
+    // ceiling the CALLER is bounded by, since no Lambda timeout can rescue a
+    // request API Gateway has already abandoned.
     const worstCaseSeconds = (maxWindowDays() * MEASURED_MS_PER_DAY) / 1000;
 
-    expect(worstCaseSeconds).toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
-    expect(metricsTimeout()).toBeLessThanOrEqual(API_GATEWAY_INTEGRATION_CEILING_SECONDS + 1);
+    expect(
+      worstCaseSeconds,
+      `a ${maxWindowDays()}-day search projects to ~${worstCaseSeconds.toFixed(1)}s, ` +
+      `which must stay under API Gateway's ${API_GATEWAY_INTEGRATION_CEILING_SECONDS}s ceiling`,
+    ).toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
   });
 });
 

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1054,11 +1054,20 @@ describe('the search fan-out fits the metrics timeout', () => {
   // undocumented `min(days, 30)` cap — which made most of the corpus unreachable
   // by text search — means the loop can now run for the FULL validated window.
   //
-  // So the window ceiling and the Lambda timeout became coupled, and nothing said
-  // so. This pins the arithmetic: raising `validate_days`' maximum, or lowering
-  // the metrics timeout, fails here instead of producing 502s on a year-long
-  // search. The measured cost is ~10-15 ms per day partition (p50, sparse days),
-  // so the upper bound is used.
+  // So the window ceiling and the Lambda timeout are coupled. This pins the
+  // arithmetic: raising the window maximum, or lowering the metrics timeout, fails
+  // here instead of producing 502s on a year-long search. The measured cost is
+  // ~10-15 ms per day partition (p50, sparse days), so the upper bound is used.
+  // Note this bounds a PROJECTION, not live latency — it guards config drift.
+  //
+  // 🔑 The Lambda timeout is deliberately NOT asserted against the API Gateway
+  // ceiling. `MetricsApi` serves the browser across every `/metrics/*` and
+  // `/feedback/*` route, where 30 s is the right budget, and the sibling suite
+  // above records the same asymmetry for the delegation path. A Lambda outliving
+  // the 29 s integration wastes tail compute on a response nobody receives; one
+  // that dies sooner turns a slow-but-valid answer into a 502, which is worse. Any
+  // assertion tying the two would have to be widened to fit the config it claims
+  // to constrain, and could then never fail for the reason it advertises.
   const MEASURED_MS_PER_DAY = 15;
   const SAFETY_FACTOR = 2;
   // API Gateway hard-caps a REST integration at 29 s regardless of the Lambda's
@@ -1066,11 +1075,10 @@ describe('the search fan-out fits the metrics timeout', () => {
   const API_GATEWAY_INTEGRATION_CEILING_SECONDS = 29;
 
   const maxWindowDays = () => {
-    // Read from the NAMED constant, not from `validate_days`' signature default.
-    // The earlier two-step regex walked into the signature to find
-    // `max_val: int = 365`, which would have silently stopped matching the moment
-    // the ceiling moved to a constant or the parameter was renamed. It is a named
-    // declaration now precisely so this parse has something stable to aim at.
+    // Aimed at the NAMED constant rather than at a function's parameter default,
+    // which a rename or a moved default would silently stop matching. The
+    // `toBeDefined` below turns any such drift into a loud failure rather than a
+    // vacuous pass.
     const source = readRepoFile('lambda', 'shared', 'api.py');
     const maxVal = source.match(/^MAX_FEEDBACK_WINDOW_DAYS\s*=\s*(\d+)/m)?.[1];
     expect(maxVal, 'could not read MAX_FEEDBACK_WINDOW_DAYS from shared/api.py').toBeDefined();
@@ -1094,12 +1102,8 @@ describe('the search fan-out fits the metrics timeout', () => {
       `a ${days}-day search projects to ~${worstCaseSeconds.toFixed(1)}s at ` +
       `${MEASURED_MS_PER_DAY}ms/day`;
 
-    // ONE guard, because there is one thing to guard: the projection has to fit
-    // inside both budgets. A separate test for the API Gateway ceiling was split
-    // out at first, but once the Lambda-config half of it was removed as
-    // misleading it reduced to arithmetic over two constants in this file and no
-    // longer touched infrastructure at all — a guard in name only. Folded back in
-    // as a second bound on the same number.
+    // One guard, two bounds on the same projected number: it must fit the Lambda's
+    // own budget with margin, and it must fit the ceiling the caller is bounded by.
     expect(metricsTimeout(), `${budget}; the metrics timeout must cover it with margin`)
       .toBeGreaterThanOrEqual(worstCaseSeconds * SAFETY_FACTOR);
 
@@ -1109,20 +1113,6 @@ describe('the search fan-out fits the metrics timeout', () => {
       .toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
   });
 
-  // 🔑 The Lambda timeout is NOT asserted against the API Gateway ceiling, and
-  // that omission is deliberate. An earlier version asserted
-  // `metricsTimeout() <= CEILING + 1` under a name claiming it kept the budget
-  // inside the integration limit — but the `+1` existed solely to fit the current
-  // 30 s config, so it permitted the very 30 > 29 case its own name said it
-  // prevented. An assertion shaped around the value it is meant to constrain
-  // cannot fail for the reason it advertises.
-  //
-  // The 30 s Lambda outliving the 29 s integration is CHOSEN. `MetricsApi` serves
-  // the browser across every `/metrics/*` and `/feedback/*` route where 30 s is
-  // the right budget, and the sibling suite above records the same asymmetry for
-  // the delegation path. A Lambda that outlives the integration wastes tail
-  // compute on a response nobody receives; one that dies sooner turns a
-  // slow-but-valid answer into a 502. The second is worse.
 });
 
 describe('mcp endpoint throttling', () => {

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1112,7 +1112,6 @@ describe('the search fan-out fits the metrics timeout', () => {
     expect(worstCaseSeconds, `${budget}; API Gateway stops waiting at ${API_GATEWAY_INTEGRATION_CEILING_SECONDS}s`)
       .toBeLessThan(API_GATEWAY_INTEGRATION_CEILING_SECONDS);
   });
-
 });
 
 describe('mcp endpoint throttling', () => {


### PR DESCRIPTION
Three findings from the MCP client audit. All the same shape: something the server **declares** was not what it did, and the gap was invisible because the wrong answer came back with `isError: false`.

That last part is why these matter more through MCP than on the dashboard. A human sees `total_feedback: 6239` and a 99-item chart on one screen and notices. **A model calls one tool and reports the answer, with no second number to cross-check.**

## M1-class — `_project_feedback` now coerces by declared type

The follow-on named in #356's own PR body. Every field was read with `item.get(key, default)`, and a default fires only when a key is **absent** — it cannot correct a value of the wrong **type**. That is the defect that made `list_personas` uncallable, living a second time in the feedback projection.

Sharper here than in the persona case: `date` and `text` are **sliced** (`[:10]`, `[:_SUMMARY_TEXT_LIMIT]`), so a row storing either as a number or a dict raised `TypeError` inside the projection. One malformed row failed the **entire** `search_feedback` call, not just its own entry. Coercing first makes both slices safe by construction.

Driven by the declarations through the existing `_declared_types` / `_coerce_declared` rather than field by field — the second half of #356's lesson, where the hand-written version guarded `feedback_count` and left `confidence` unchecked. A new `_FEEDBACK_SOURCE_KEYS` states the renames once, since the projection renames and so the declared key is not the key to read.

Looked up with `.get(key, (key,))` rather than `[key]` on purpose: an unmapped declared property must not raise and kill the tool, which is the M1 failure mode itself. A test pins the map against the declarations, so the omission is still red in CI — the fallback only decides whether the symptom is a failing test or a dead tool in production.

## M2 — a query under the documented minimum was an empty *success*

The tool description has always said "at least 2 characters" while its `inputSchema` accepted `"a"` and the route answered `{'count': 0}` with HTTP 200. A claim about the **corpus** standing in for a fact about the **request**.

New `SEARCH_QUERY_MIN_LENGTH` in `shared/api.py`, beside `MAX_PERSONAS_PER_GENERATION` and for the reason recorded there: three places size themselves against this bound, and a prose promise cannot fail CI. The route now raises `ValidationError`; the schema **declares** `minLength` and builds its own description from the same constant.

The split is deliberate. A blank `q` is still a successful empty answer, because no search term means no search was asked for, and the filter-only answer belongs to `/feedback` — which is where the adapter already routes such a call. Only a term that is **present and too short** is a refusal.

The adapter needed no new validation: `_delegate` already maps a 4xx to `ToolRouteError` carrying the route's own message, so the model reads the real reason. Route owns the rule, adapter declares it.

## M3 + M5 — search read 30 days whatever you asked for, and never said so

`search_feedback` called `_scan_recent_items(min(days, 30), …)` while its `cutoff_date` came from the caller's full `days`. The two disagreed: at `days=365` the filter admitted a year of items and the candidate set only ever held thirty days of them, so anything older was unreachable by text search at **any** `days` value. On the corpus this was found on, a 5,240-item import sits 37 days back.

Both halves ship together, because the audit is explicit that the first alone moves the lie rather than fixing it — *"raising it without M5's truncation signal makes a wrong answer slower"*:

- the scan reads the **requested** window;
- `is_partial` is **kept** rather than discarded (`candidates, _ =`) and reported, so `count: 0` can be told apart from "the scan stopped early". The soft cap still bounds candidate collection, which is precisely why the signal is needed.

Named `is_partial_window` on the route as `/feedback` names it, and projected to `is_partial` to match its sibling tool `get_metrics_breakdown`. **Required** in the schema, because a flag that is sometimes missing reads as absence of truncation — the same mistake as asserting it false. Coerced with `bool()`, since a route answering `null` would otherwise reproduce M1 inside the very field added to fix M5.

### ⚠️ Existing MCP clients need one reconnect

`MCP_SERVER_VERSION` goes 3.0.0 → 3.1.0 — minor for an added field, by this repo's own rule — with the output fingerprint updated in the same commit as its test demands.

Minor is not invisible. These output shapes carry `additionalProperties: false`, and a client validates against the `tools/list` it cached at **connect**, so a session predating the deploy will reject the new field. The server honestly declares `tools.listChanged: false`, so there is no notification path to tell it. This is the deploy-only finding from #356, recurring exactly as recorded.

## Deliberately not in scope

- **The TypeScript twin** `Math.min(days, 30)` in the streaming chat tool. Same idea, third runtime, tracked by `BUG-chat-30-day-search-window`. Worth knowing: it is currently pinned by **no test at all**.
- **Parallelising the day fan-out.** The loop is forced by the schema — `gsi1pk = DATE#YYYY-MM-DD`, one partition per day, and no index supports a bounded multi-day Query with a usable projection. 365 sequential days measures ~4–5.5 s against a 20 s delegated-read timeout, and batching would change early-break semantics for six other `_scan_window_items` callers.
- **Pushing the text match into a `FilterExpression`.** DynamoDB `contains()` is case-**sensitive** while this route lowercases both sides, so a push-down would silently **drop** valid matches. Doing it properly needs a lowercased attribute written by the processor plus a backfill of the existing corpus — a separate change with a data migration.

## Verification

| Gate | Result |
|---|---|
| pytest (backend) | **3019**, up from 2995 — +24, matching the collected count exactly |
| ruff | delta **zero** on the changed files, identical rule distribution |
| `typecheck:all` | clean |
| CDK | 268 |
| stream | 365 |
| frontend | 3048 |

Mutation checks, **all caught**: restore the 30-day cap · assert `is_partial` false instead of computing it · drop the refusal · undeclare `minLength` · pass a null flag through.

One mutant **survived**, recorded rather than hidden: swapping `.get(key, (key,))` back to `[key]` is defensive only — the map is complete, so no test can distinguish it.

Two process notes, since both produced false confidence before being caught:

- `command -v ruff` finds nothing here (ruff is not on `PATH`), so a check invoked that way returns **empty with exit 1** — a clean result that actually means "did not run". The correct invocation is `voc-datalake/.venv/bin/python -m ruff`, as `npm run lint:python` does, and the harness now carries a positive control.
- The mutation anchor `'is_partial_window': window_truncated,` matched **twice**, because `list_feedback` publishes the same key from a same-named local. The harness reported anchor rot instead of a false "caught".

`npm run lint` still exits 1 on a pre-existing 514-error ruff baseline across `lambda/` and `plugins/`. Not from this change — six files are touched and their delta is zero.

## Also here

One unrelated four-line commit, kept separate: `.kiro/settings/mcp.json` stores its bearer token inline, the repo's own `.kiro/settings/` is tracked, and `git check-ignore` matched no rule for it — so sharing an MCP config with the team by moving it into the repo would have published a working credential to a public repo. Verified narrow: the target is now ignored, the tracked sibling is not, and the index is unchanged. No real credential is committed anywhere; a scan for token-shaped strings matches only synthetic fixtures.

## Follow-ups this leaves open

M4 (`is_partial: false` asserted unconditionally on the aggregate path) and M6 (`get_metrics_summary` and `search_feedback` contradicting each other, because `aggregator/handler.py` is INSERT-only so REMOVE never decrements) are **platform** defects that the adapter relays faithfully. M6 has a backfill question attached. Different size, different owner, not adapter work.

M7 (the persona dimension reading a field nothing populates) and M8 (a revoked credential completing the full handshake, which Phase 2b's version work touches anyway) remain open.

---

## Review rounds

**Round 1 — both blockers were real.** The first was one I documented and then failed to act on: `/feedback/search` trims `q` before applying its minimum while the frontend gate counted raw `.length`, so `"a "` was two characters on the client and one on the server, and a debounced search box could surface an HTTP 400 from ordinary typing. My own test docstring named that case and I left the client alone. Fixed, with the trim now at the API boundary every caller passes through.

The second blocker asked what happens to the new `is_partial_window` key at the frontend boundary. Checked rather than assumed: `searchFeedback` uses `fetchApi<T>`, a type assertion with no Zod there, so it cannot break at runtime — and it is not dropped either, because `pickActiveSource` → `toSimpleSource` → `extractTotals` already reads that key and `FeedbackPage` already declares it. What was missing was the declaration on the response type, now added with three tests covering true / false / omitted.

**Round 2** took the follow-up findings, and the reviewer's version of the main one is better than mine — I had patched one caller's gate instead of the shared boundary, and the body overclaimed that the frontend "sizes itself against" the Python constant when `SEARCH_MIN_CHARS` was an unpinned TS literal. Both remedies are in: the trim moved to `api.searchFeedback`, and a new `test_search_minimum_lockstep.py` parses the TS constant and asserts equality with `SEARCH_QUERY_MIN_LENGTH`, following `test_indexes.py` and carrying its positive control (a rename makes the parser return `None`, and without the control the equality check would pass while comparing against nothing — verified by mutation).

### Answers to the two items flagged as unconfirmed

These were answered in commit messages rather than here, which is why they read as open.

**Does the timeout cover `days=365` on the direct dashboard path?** Yes, with room. `api-stack.ts` gives `MetricsApi` a **30 s** timeout at 512 MB, against API Gateway's 29 s integration limit, and the measured worst case for a 365-day scan is **~4–5.5 s** — roughly 5× headroom. Result size stays bounded by `per_day_limit=300` and the 1,000-candidate soft cap; only the *query count* scales with `days`, and an empty day partition is ~0.5 RCU, so a 365-day scan of a sparse corpus is ~180 RCU on on-demand billing. The dashboard's own search default is `days=30`, so interactive latency is unchanged unless someone picks a custom year-long range.

**`query: ""` is schema-invalid for behaviour the route supports.** Confirmed the adapter performs no generic `inputSchema` argument validation, so nothing regresses server-side: a blank query still takes the filter-only branch. What remains is a strict schema over a lenient server, which is the safe direction — it produces no wrong answer, unlike the strict-claim/lenient-reality mismatches this PR fixes. The argument description already says "Omit to list by filters alone". Left as is deliberately; happy to relax it if you would rather the declaration mirror the tolerance exactly.

### Residual risk, stated rather than papered over

The lockstep pins the two **constants**, not the comparison. A future caller that gates on raw `.length` can still fire a request whose trimmed term is too short, because trimming at the boundary normalises what is sent without repairing a bad gate. An exported `isSearchable(text)` predicate would close it. I have deliberately not added one — there is exactly one caller today, so it would be an abstraction for a hypothetical second. Your call.

### Rounds 3–8

Converged. Findings decayed from blockers to formatting, and the substantive ones are all closed:

| Round | Substance |
|---|---|
| 3 | The `client.ts` comment overstated the boundary trim (it normalises the VALUE, not the DECISION); a guard pinned CHARACTERS not behaviour; a lockstep read raised `FileNotFoundError` instead of skipping |
| 4 | An assertion that could not fail for its stated reason — `metricsTimeout() <= 29 + 1` permitted exactly the 30 > 29 case its name claimed to prevent |
| 5 | `_DAYS_ARG.maximum` was still the literal `365` with the bound named only in prose — this PR's own defect class, in this PR's own file |
| 6–8 | Review narration in comments, a bodyless trailer, backticks, a blank line |

Two of those deserve calling out because they were mine and they were the same mistake this PR is about.

**The `+1` fudge.** I added a CDK guard named "keeps the budget inside what API Gateway will actually wait for" and then wrote `<= CEILING + 1` so it would pass against the current 30 s config. An assertion shaped around the value it is meant to constrain cannot fail for the reason it advertises. Resolved by dropping the pretence rather than widening it: the 30 s Lambda outliving the 29 s integration is a choice (`MetricsApi` serves every `/metrics/*` and `/feedback/*` route; a Lambda that dies sooner turns a slow-but-valid answer into a 502), so the test now asserts only what must hold and the reasoning sits in the `describe` header.

**`_DAYS_ARG` declared `365` as a literal** with the real ceiling named only in the comment above it — declaration-vs-enforcement drift, in the file whose purpose here is removing exactly that. Now imported from the new `MAX_FEEDBACK_WINDOW_DAYS`, which `validate_days` also takes its default from and which the CDK guard parses. Value-preserving, so the output fingerprint does not move.

### The two standing questions, answered with evidence

**"Grep to confirm the cited test name before merge."** Discharged by construction rather than assertion — the qualified name is extracted *from the comment* and handed to pytest as a node id:

```
CITED=$(grep -oE 'test_mcp_delegation\.py::TestRouteSelection::test_a_blank_query_is_not_a_search' \
        voc-datalake/lambda/api/mcp_handler.py)
.venv/bin/python -m pytest "lambda/api/test/$CITED"   # 1 passed
```

It resolves and passes, at `test_mcp_delegation.py:374`. It is pre-existing, which is why it appears in no diff.

**"The merged citation line is ~105 chars — confirm ruff is still clean."** It is 106, and it is not a violation: the project's `ruff.toml` does not select E501. Forcing `--select E501` reports **40** pre-existing long lines in that file alone, so line length is deliberately unenforced here. Consistent with the measured delta:

```
ruff on the changed files — HEAD=28  WORKING=28  delta=0   (identical rule distribution)
```

### Final gate state

pytest **3021** · frontend **3057** · CDK **269** · stream **365** · `typecheck:all` clean · eslint `--max-warnings 0` clean · ruff delta **zero**.

Mutation-verified rather than assumed, across the whole change: restore the 30-day cap · assert `is_partial` false instead of computing it · drop the query refusal · undeclare `minLength` · pass a null flag through · drop the type coercion · swap presence for truthiness · revert the client trim · diverge the two language constants · rename the TS constant (fails the positive control first) · raise the window ceiling to 3650 (fails the fan-out budget with `expected 30 to be greater than or equal to 109.5`). One survivor recorded rather than hidden: `.get(key, (key,))` → `[key]` is defensive only, since the map is complete.
