### PR TITLE
feat(mcp): bring the protocol envelope up to the spec it claims to speak

### DIFF
--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -416,13 +416,31 @@ ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 #     made resolving it per resource (`GET` on the autoseed path, not `POST`)
 #     invisible to exactly the client class the expose list exists for.
 #
-# ⚠️ MINOR, decided by the rule at 3.3.0, and this entry is the easiest of the recent
-# ones: every part of it turns a refusal into an answer or ADDS a header name. Nothing
-# a client could hold is renamed or removed. The `Access-Control-Expose-Headers` value
-# GAINS an entry, which a client reads as more of its own answer becoming readable.
-# The one behaviour that changes for a message that used to be answered is the posted
-# response — from a 404 instructing a session teardown to the 202 the transport
-# mandates — and a client that was told to re-initialize was told wrongly.
+# Two more refusals join it, and both are the fail-closed reading applied where the
+# permissive one was picking between two things a caller said:
+#   • A HEADER SENT MORE THAN ONCE with different values is `-32020`. The reader saw
+#     one value — it read `headers` and never `multiValueHeaders`, and returned on the
+#     first case-insensitive match — so a request carrying two `Mcp-Method` values was
+#     answered according to dict order, which is the two-hops-disagree case the
+#     mismatch refusal exists for, reached through a duplicate. A duplicated `Origin`
+#     is a 403 (a rebinding guard must not pick one of two claimed origins) and a
+#     duplicated `Authorization` is a 401 (two credentials are not one). Two IDENTICAL
+#     values are still one value.
+#   • AN ID-LESS message on a non-notification method is `-32600` with the `id`
+#     OMITTED. This was the last place a RESULT carrying `id: null` was sent to a
+#     message that carries no id: `{"jsonrpc": "2.0", "method": "ping"}` got a 200 and
+#     a full result. By JSON-RPC's definition that message is a notification, so no
+#     reply may be sent; by MCP's it is nothing, since no id-less `ping` exists. Not a
+#     202 either — an id-less `tools/call` is a request a client is waiting on.
+#
+# ⚠️ MINOR, decided by the rule at 3.3.0. Nothing a client could hold is renamed or
+# removed: the `Access-Control-Expose-Headers` value GAINS an entry, which a client
+# reads as more of its own answer becoming readable, and every other part turns a
+# refusal into an answer or an ill-formed answer into a refusal. Three message shapes
+# that used to be answered are answered differently, and in each case what they got
+# was wrong under the revision they negotiated — a 404 instructing a session teardown
+# for a posted response, a result with a null id for an id-less request, and one of
+# two contradictory header values served as though the caller had sent one.
 #
 # No published tool declaration moved, so the fingerprinted catalogue is untouched a
 # third time.
@@ -920,6 +938,53 @@ def _accepted_no_content() -> dict:
     }
 
 
+def _header_values(event: dict, name: str) -> list[str]:
+    """EVERY value the request carries for one header, deduplicated, in order.
+
+    Both places a REST proxy event puts them are read, and reading only the first
+    was the gap this closes:
+
+      • `headers` keeps ONE value per header — API Gateway collapses duplicates
+        last-wins — but a DIRECT invoke can carry two keys that fold to the same
+        name (`Mcp-Method` and `mcp-method`), and a reader returning on the first
+        match then answered whichever key came first in the dict. The same wire
+        request got two different answers depending on how the event was built.
+      • `multiValueHeaders` keeps ALL of them, and nothing here looked at it. A
+        request with two `Mcp-Method` values was compared against one of them and
+        the other was never seen — which is exactly the two-hops-disagree case the
+        `-32020` refusal exists for, reached through a duplicate rather than
+        through a header/body disagreement.
+
+    Deduplicated, so two IDENTICAL values are one value: a client (or an
+    intermediary) restating the same thing twice has not contradicted itself, and
+    refusing that would refuse requests for no gain.
+
+    A non-dict `headers` or `multiValueHeaders` reads as absence rather than
+    raising: a Lambda proxy event always delivers a dict or null, so this needs a
+    direct invoke to reach, and `.get` on a list raised `AttributeError` from the
+    one caller that runs before the handler's try/except — a 502 with no JSON-RPC
+    envelope and no CORS headers.
+    """
+    values: list[str] = []
+    for source_key in ('headers', 'multiValueHeaders'):
+        source = event.get(source_key) or {}
+        if not isinstance(source, dict):
+            continue
+        for key, raw in source.items():
+            if not isinstance(key, str) or key.lower() != name:
+                continue
+            # A `multiValueHeaders` entry is a list; a `headers` entry is a scalar.
+            # A non-string value reads as the empty string for the reason
+            # `_request_header` documents: a header that arrived carrying something
+            # unusable said something, and it is not a valid value here.
+            candidates = raw if isinstance(raw, list) else [raw]
+            for candidate in candidates:
+                value = candidate if isinstance(candidate, str) else ''
+                if value not in values:
+                    values.append(value)
+    return values
+
+
 def _request_header(event: dict, name: str) -> str | None:
     """One header, matched case-insensitively, or None when absent.
 
@@ -928,6 +993,22 @@ def _request_header(event: dict, name: str) -> str | None:
     invoke (a test, a local driver) does not, and a guard has to hold for both.
     An empty value is NOT absence: a client that sent a header empty said
     something, and what it said is not a valid value for any header read here.
+
+    ⚠️ A header carrying TWO DIFFERENT VALUES RAISES rather than resolving to one
+    of them, and that is the fail-closed reading this module applies everywhere
+    else. It is the same fault `_validate_routing_headers` refuses — an
+    intermediary routing on the first `Mcp-Method` while this server acts on the
+    last is two hops serving different requests — and that guard's own words cover
+    it: "there is no way to know which of the two statements was the caller's
+    intent", which is as true of two headers as of a header and a body. Reported as
+    `-32020 HeaderMismatch` for the same reason.
+
+    Every caller must be able to answer the raise, and each answers in its own
+    currency rather than being made to speak JSON-RPC: `_origin_allowed` refuses
+    403 (a rebinding guard must not pick one of two claimed origins), the
+    credential read refuses 401 (two different credentials are not one credential),
+    and the transport headers reach the `InvalidTransportHeader` catch in
+    `lambda_handler` and become the spec's 400.
 
     A non-dict `headers` reads as absence. A Lambda proxy event always delivers a
     dict or null, so this needs a direct invoke or a non-API-Gateway trigger to
@@ -941,13 +1022,17 @@ def _request_header(event: dict, name: str) -> str | None:
     used to match `'origin'` and `'Origin'` by hand, so `ORIGIN:` or `oRigin:`
     walked past the DNS-rebinding guard on a direct invoke.
     """
-    headers = event.get('headers') or {}
-    if not isinstance(headers, dict):
+    values = _header_values(event, name)
+    if not values:
         return None
-    for key, value in headers.items():
-        if isinstance(key, str) and key.lower() == name:
-            return value if isinstance(value, str) else ''
-    return None
+    if len(values) > 1:
+        raise InvalidTransportHeader(
+            f'{_canonical_header_name(name)} was sent more than once with different '
+            f'values ({", ".join(repr(v) for v in values)}); there is no way to know '
+            f'which one was meant',
+            code=JSONRPC_HEADER_MISMATCH,
+        )
+    return values[0]
 
 
 def _origin_allowed(event: dict) -> bool:
@@ -969,8 +1054,20 @@ def _origin_allowed(event: dict) -> bool:
     `AttributeError`. This function runs FIRST in `lambda_handler`, outside its
     try/except, so that raise was a 502 with no JSON-RPC envelope and no CORS
     headers — the exact shape the `BotoCoreError` clause exists to avoid.
+
+    ⚠️ TWO DIFFERENT ORIGINS IS A REFUSAL, not a choice between them. `Origin` is
+    what this guard exists to compare, so picking one of two claimed origins is the
+    one thing a rebinding guard must not do: an intermediary that forwarded the
+    victim's origin alongside the attacker's would have this function compare
+    whichever it happened to read. The raise is CAUGHT here rather than propagated,
+    because this function's contract is a boolean and its caller's answer is a 403 —
+    which is the right status for a browser-presented Origin this server will not
+    serve, however many were presented.
     """
-    origin = _request_header(event, 'origin') or ''
+    try:
+        origin = _request_header(event, 'origin') or ''
+    except InvalidTransportHeader:
+        return False
     if not origin:
         return True
     if ALLOWED_ORIGIN == '*':
@@ -1436,7 +1533,18 @@ def _authenticate(event: dict, *, touch: bool = True) -> dict | None:
     # form this replaces missed `AUTHORIZATION` and every other casing, which on
     # the liveness check below would have let a dead credential through the very
     # gate it was added to close.
-    auth_header = _request_header(event, 'authorization') or ''
+    #
+    # TWO DIFFERENT `Authorization` values authenticate NOTHING, and this is the
+    # fail-closed reading rather than a tidy-up: two credentials are not one
+    # credential, and comparing whichever was read first would let a caller present
+    # a good token alongside a revoked one — or probe the store with two per
+    # request. Reported as this function's ordinary "no usable credential", which
+    # every caller already answers with a 401, because from here that is what it is.
+    try:
+        auth_header = _request_header(event, 'authorization') or ''
+    except InvalidTransportHeader:
+        logger.info("Authorization presented more than once with different values")
+        return None
 
     if not auth_header.startswith('Bearer '):
         return None
@@ -3617,6 +3725,19 @@ def _is_notification(body: Any, method: str) -> bool:
     `id` — a bare `[]`, a string, a number — is not promoted to a notification and
     accepted, which is what an id-only test would have done to precisely the input
     that used to crash this handler.
+
+    ⚠️ THE PREFIX HALF DRAWS A LINE, and what falls on the other side of it is
+    stated here rather than left to be discovered. An id-less message on a method
+    that is NOT `notifications/`-prefixed — `{"jsonrpc": "2.0", "method": "ping"}` —
+    is a notification by JSON-RPC's definition and nothing at all by MCP's, which
+    defines no id-less `ping`. This predicate says False for it, deliberately, and
+    `lambda_handler` refuses it `-32600` with the `id` member OMITTED rather than
+    doing either of the things that look adjacent: it used to be answered with a
+    RESULT carrying `id: null`, which replies to a message that gets no reply and
+    does it ill-formedly, and accepting it 202 would silently drop an id-less
+    `tools/call` that a client is waiting on. The argument in full is at that
+    branch; the boundary is recorded here because this is where a reader asks about
+    it.
     """
     if not isinstance(body, dict) or 'id' in body:
         return False
@@ -3982,6 +4103,50 @@ def lambda_handler(event: dict, context: Any) -> dict:
         logger.info(f"MCP notification accepted: method={method}")
         return _accepted_no_content()
 
+    # An ID-LESS message on a method that is NOT a notification is refused, with the
+    # `id` member OMITTED — and this is the last place a result carrying `id: null`
+    # was sent to a message that carries no id.
+    #
+    # ⚠️ Why it is not accepted 202 like a notification, and not answered like a
+    # request either. By JSON-RPC's own definition ("a Request object without an id
+    # member") this IS a notification, so a reply is forbidden; by MCP's, it is
+    # nothing at all, because MCP defines no id-less `ping` or `initialize`. Those
+    # two readings disagree, and the answer has to satisfy both:
+    #
+    #   • a RESULT is wrong under both. `{"id": null, "result": …}` — which is what
+    #     an id-less `ping`, `initialize` and `server/discover` used to get — replies
+    #     to a message JSON-RPC says gets no reply, and does it with an envelope
+    #     whose id must not be null. Exactly the pair of faults the 202 fix removed
+    #     from the notification path and the `_NO_ID` fix removed from the refusals;
+    #   • a 202 would be wrong too, and this is the half that decides it. 202 says
+    #     "accepted", and `_accepted_no_content` is reserved for a message this
+    #     server can honestly accept and drop. An id-less `tools/call` is a request
+    #     a client is WAITING on (which is why
+    #     test_a_non_notification_method_without_an_id_is_not_accepted pins it), and
+    #     answering silence to a caller expecting a result is the worse failure. The
+    #     shape cannot be decided per method without inventing an id-less variant of
+    #     each.
+    #
+    # So: `-32600 Invalid Request`, the code for a message that is not a well-formed
+    # request, with NO `id` — the transport's own allowance for a refusal whose
+    # subject carries none, and the same envelope a refused notification now gets.
+    # A client that meant a notification is not replied to in any way it correlates;
+    # a client that forgot an id learns the request was not served.
+    #
+    # Placed after the notification branch and before the dispatch, so a real
+    # notification still reaches its 202 and no handler is ever called without an id.
+    if isinstance(body, dict) and 'id' not in body:
+        logger.info(f"MCP id-less non-notification refused: method={method}")
+        return _cors_response(
+            _jsonrpc_error(
+                _NO_ID, JSONRPC_INVALID_REQUEST,
+                f'A request must carry an id: {method!r} is not a notification, and '
+                f'this server defines no id-less form of it. Send an id, or send one '
+                f'of the notifications/* methods.',
+            ),
+            status_code=400,
+        )
+
     # Handle the methods that need no credential (initialize, ping,
     # server/discover).
     if method in MCP_METHODS:
@@ -4127,8 +4292,21 @@ def _refuse_a_dead_credential(event: dict, req_id: Any, method: str) -> dict | N
     # Case-insensitive, via the same helper the transport headers use: a spelling
     # this failed to match would read as "no credential presented" and skip the
     # check entirely, which is the one way this guard can silently not run.
-    auth_header = _request_header(event, 'authorization') or ''
-    if not auth_header.startswith('Bearer '):
+    #
+    # A DUPLICATED `Authorization` is a credential that was presented and cannot be
+    # used, so it belongs on the refusing side of this branch rather than on the
+    # "nothing was presented" side. Falling through to `_authenticate` would reach
+    # the same 401, but only after this function had decided the caller presented
+    # nothing — and the raise would escape here, outside the transport-header catch,
+    # as a 502 with no JSON-RPC envelope.
+    try:
+        auth_header = _request_header(event, 'authorization') or ''
+    except InvalidTransportHeader:
+        auth_header = ''
+        presented = True
+    else:
+        presented = auth_header.startswith('Bearer ')
+    if not presented:
         return None
 
     try:

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -130,7 +130,23 @@ PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
 # a session that cached `tools/list` before this deploy holds a catalogue with no
 # annotations and no cost classes, and `listChanged: false` means nothing will
 # tell it. Connected clients must reconnect.
-MCP_SERVER_VERSION = "3.2.0"
+#
+# 3.3.0 makes the envelope's field NAMES the spec's own, and the rename is why this
+# is a version bump rather than a patch: 3.2.0 published a local vocabulary in
+# spec-owned places, which a conforming client of the newest advertised revision had
+# to reject outright.
+#   • `resultType` now carries the spec's `"complete"`; the local shape vocabulary
+#     moved to `_meta['com.amazonaws.voc-datalake/resultShape']`.
+#   • `_meta.costClass` on each published tool became the vendor-prefixed key, and
+#     each tool gained the top-level `title` the current revision defines.
+#   • `tools/list` and `server/discover` carry the spec's `ttlMs`/`cacheScope`
+#     instead of a locally invented `_meta.cacheHints`.
+#   • `server/discover` answers `supportedVersions` and puts `serverInfo` under the
+#     spec's reserved `_meta` key.
+# Minor rather than major because no declared tool INPUT or OUTPUT shape moved: a
+# client validating `structuredContent` against a cached `outputSchema` is
+# unaffected. The reconnect caveat above applies with the same force.
+MCP_SERVER_VERSION = "3.3.0"
 
 
 # ============================================
@@ -396,20 +412,55 @@ TRANSPORT_HEADERS: tuple[str, ...] = (
 )
 
 
+# The wire spelling of each transport header, as the SPEC spells it. Not derivable
+# from the lowercase form by one rule, because the spec is not internally
+# consistent about it: `MCP-Protocol-Version` carries the acronym in caps while
+# `Mcp-Method` and `Mcp-Name` title-case it. An earlier version of this module
+# applied a single `MCP` rule to all three and published `MCP-Method` — harmless
+# on the wire (HTTP header names are case-insensitive, and this module matches
+# case-insensitively) but a discovery answer and a CORS allowlist stating a
+# spelling the spec does not use is a contract that quietly disagrees with it.
+#
+# Declared as a table rather than computed so the exception is visible, and
+# asserted against TRANSPORT_HEADERS below so the two cannot drift.
+_CANONICAL_HEADER_NAMES: dict[str, str] = {
+    PROTOCOL_VERSION_HEADER: 'MCP-Protocol-Version',
+    METHOD_HEADER: 'Mcp-Method',
+    NAME_HEADER: 'Mcp-Name',
+}
+
+
 def _canonical_header_name(header: str) -> str:
     """The wire spelling of a header this module reads in lowercase.
 
-    Derived rather than declared twice: the lowercase forms above exist only
-    because API Gateway normalises what it delivers, while a CORS allowlist and a
-    discovery answer are read by clients that spell headers the canonical way. Two
-    hand-written lists is how one gains a header the other does not.
+    Looked up rather than declared twice at each use: the lowercase forms exist
+    only because API Gateway normalises what it delivers, while a CORS allowlist,
+    a discovery answer and an error message are read by clients that spell headers
+    the way the spec does. Two hand-written lists is how one gains a header the
+    other does not.
 
-    `MCP` keeps its acronym casing; every other segment title-cases, which is what
-    makes `MCP-Protocol-Version`.
+    Unknown headers fall back to plain title-casing. Nothing reaches that path
+    today — the assertion below pins every declared transport header to the table
+    — and it exists so a future caller passing some other header name gets a
+    reasonable spelling rather than a KeyError.
     """
-    return '-'.join(
-        'MCP' if part == 'mcp' else part.capitalize()
-        for part in header.split('-')
+    known = _CANONICAL_HEADER_NAMES.get(header)
+    if known is not None:
+        return known
+    return '-'.join(part.capitalize() for part in header.split('-'))
+
+
+# Every transport header has a declared wire spelling. A header added above
+# without a spelling here would otherwise be published title-cased by the
+# fallback, silently, which is the drift the table exists to prevent.
+#
+# `raise` rather than `assert`, which this tree requires: a bare `assert` is
+# stripped under `python -O`, so the invariant would go unchecked exactly where it
+# matters, and an AssertionError bypasses this tree's logging.
+if set(_CANONICAL_HEADER_NAMES) != set(TRANSPORT_HEADERS):
+    raise RuntimeError(
+        'transport headers and their canonical spellings disagree: '
+        f'{sorted(set(TRANSPORT_HEADERS) ^ set(_CANONICAL_HEADER_NAMES))}'
     )
 
 
@@ -456,21 +507,41 @@ CORS_HEADERS = {
 _WWW_AUTHENTICATE_401 = 'Bearer error="invalid_token"'
 
 
-def _cors_response(body: dict, status_code: int = 200) -> dict:
+# What each endpoint of this function actually serves, which is what RFC 9110
+# §15.5.6 defines `Allow` to mean: "the set of methods supported by the TARGET
+# RESOURCE".
+#
+# ⚠️ This is per-resource and cannot be derived from `Access-Control-Allow-Methods`,
+# which the first draft of this change did. That header answers a different
+# question — "what may a browser preflight against this Lambda" — and it is one
+# constant for the whole function, so a `DELETE /v1/mcp/autoseed/p1` was refused
+# with `Allow: POST, OPTIONS`: an advertised set omitting the one method that
+# resource actually serves, sending a client to retry with `POST` on a path that
+# only handles `GET`. Deriving one from the other bought consistency at the cost of
+# being wrong.
+_ALLOW_JSONRPC: tuple[str, ...] = ('POST', 'OPTIONS')
+_ALLOW_AUTOSEED: tuple[str, ...] = ('GET', 'OPTIONS')
+
+
+def _cors_response(body: dict, status_code: int = 200,
+                   allow: tuple[str, ...] = _ALLOW_JSONRPC) -> dict:
     """Return a Lambda proxy response with CORS headers.
 
-    Every 401 gains the RFC 6750 challenge here, and every 405 gains the
-    `Allow` header RFC 9110 §15.5.6 REQUIRES, at the one choke point all
-    responses pass through, so no future path of either kind can forget it.
+    Every 401 gains the RFC 6750 challenge here, and every 405 gains the `Allow`
+    header RFC 9110 §15.5.6 REQUIRES, at the one choke point all responses pass
+    through, so no future path of either kind can forget it.
+
+    `allow` defaults to the JSON-RPC endpoint's set because that is what nearly
+    every caller is answering for; the autoseed path passes its own. The default
+    is safe to get wrong in only one direction — a caller that forgets it on a 405
+    for some future resource publishes the JSON-RPC set — so the two 405 call sites
+    are pinned by tests naming both paths.
     """
     headers = {**CORS_HEADERS, 'Content-Type': 'application/json'}
     if status_code == 401:
         headers['WWW-Authenticate'] = _WWW_AUTHENTICATE_401
     if status_code == 405:
-        # Derived from the CORS declaration rather than written out again: the
-        # two say the same thing to two audiences (a browser preflight and a
-        # 405), and a hand-written second copy is how they come to disagree.
-        headers['Allow'] = CORS_HEADERS['Access-Control-Allow-Methods'].replace(',', ', ')
+        headers['Allow'] = ', '.join(allow)
     return {
         'statusCode': status_code,
         'headers': headers,
@@ -529,13 +600,60 @@ def _origin_allowed(event: dict) -> bool:
 _ENCODED_WORD = re.compile(r'\A=\?base64\?(.*)\?=\Z', re.DOTALL)
 
 
+# The spec's own codes for the two transport faults this server can report.
+# `-32020`–`-32099` is reserved for spec-defined codes, so these are used with
+# EXACTLY the spec's meaning and no neighbour in the range is invented:
+#
+#   -32020 HeaderMismatch            — a routing header contradicts the body.
+#   -32022 UnsupportedProtocolVersion — with `data.supported` / `data.requested`.
+#
+# (-32021 MissingRequiredClientCapability is the third in the range and is not
+# used here: this server requires no client capability.)
+JSONRPC_HEADER_MISMATCH = -32020
+JSONRPC_UNSUPPORTED_PROTOCOL_VERSION = -32022
+
+# JSON-RPC's own code for a method this server does not implement. Paired with
+# HTTP 404 by the Streamable HTTP transport, which is what lets a client tell this
+# apart from the 404 of a legacy HTTP+SSE server that does not host the endpoint.
+JSONRPC_METHOD_NOT_FOUND = -32601
+
+# `-32600 Invalid Request` for a malformed transport that is neither of the two
+# spec-defined faults — a sentinel that claims base64 and does not decode. The
+# BODY may be perfectly well formed, and it is the REQUEST as a whole that is not;
+# `-32602 Invalid params` would send the caller looking at its arguments.
+JSONRPC_INVALID_REQUEST = -32600
+
+
 class InvalidTransportHeader(Exception):
     """A transport header is absent-or-fine, or it is malformed. Never ignored.
 
-    Reported as `-32600 Invalid Request` with HTTP 400: the JSON-RPC body may be
-    perfectly well formed, and it is the REQUEST — body plus transport — that is
-    not. `-32602 Invalid params` would send the caller looking at its arguments.
+    Carries the JSON-RPC code and `data` payload the SPEC defines for the fault,
+    rather than being flattened to one generic code at the handler. The first
+    draft of this change reported every one of these as `-32600` with the detail
+    only in the human-readable message, which broke two things:
+
+      • A client could not machine-read the recovery path. The spec's own rule for
+        an unsupported version is "select a mutually supported version from the
+        `supported` list and retry" — with the list only in an English sentence,
+        retrying means parsing prose.
+      • ERA DETECTION. The Streamable HTTP backward-compatibility rules say a
+        dual-era client sends a modern request and, on a 400, inspects the body: a
+        RECOGNIZED modern error means "modern server, retry with a supported
+        version", anything else means "legacy server, fall back to `initialize`".
+        `-32600` is not a recognized modern error, so a client that guessed the
+        version wrong concluded this server was legacy — while the server was
+        advertising a modern revision.
+
+    The HTTP status travels too, because the spec pins it per fault (400 for both
+    spec-defined codes here) and the status is half of what the era probe reads.
     """
+
+    def __init__(self, message: str, code: int = JSONRPC_INVALID_REQUEST,
+                 data: Any = None, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.code = code
+        self.data = data
+        self.status_code = status_code
 
 
 def _request_header(event: dict, name: str) -> str | None:
@@ -587,6 +705,20 @@ def _decoded_header(raw: str, name: str) -> str:
     return decoded
 
 
+def _header_mismatch_message(header: str, header_value: Any, body_value: Any) -> str:
+    """A header/body disagreement, worded the way the spec's own example words it.
+
+    `Header mismatch: Mcp-Name header value 'foo' does not match body value 'bar'`.
+    Matching the spec's phrasing is not cosmetic: it is the sentence an operator
+    reading two implementations' logs side by side has to recognize as the same
+    fault, and the canonical header spelling is what the client actually sent.
+    """
+    return (
+        f'Header mismatch: {_canonical_header_name(header)} header value '
+        f'{header_value!r} does not match body value {body_value!r}'
+    )
+
+
 def _negotiate_protocol_version(requested: Any) -> str:
     """The revision this session will speak.
 
@@ -621,14 +753,28 @@ def _validated_protocol_version(event: dict) -> str:
     version = _decoded_header(raw, PROTOCOL_VERSION_HEADER)
     if version not in SUPPORTED_PROTOCOL_VERSIONS:
         raise InvalidTransportHeader(
-            f'Unsupported MCP protocol version {version!r}. This server speaks: '
-            f'{", ".join(SUPPORTED_PROTOCOL_VERSIONS)}'
+            f'Unsupported protocol version {version!r}. This server speaks: '
+            f'{", ".join(SUPPORTED_PROTOCOL_VERSIONS)}',
+            code=JSONRPC_UNSUPPORTED_PROTOCOL_VERSION,
+            # The machine-readable half, and the reason this error has a `data`
+            # payload at all: `supported` is what the spec tells the client to
+            # retry with, and `requested` echoes the rejected value so a client
+            # with several in flight knows which request this answers.
+            data={
+                "supported": list(SUPPORTED_PROTOCOL_VERSIONS),
+                "requested": version,
+            },
         )
     return version
 
 
 def _validate_routing_headers(event: dict, method: str, params: Any) -> None:
     """Refuse a routing echo that contradicts the body it travels with.
+
+    Reported as `-32020 HeaderMismatch`, which is the spec's code for exactly this
+    and carries the spec's own rationale: a load balancer routes on the header
+    while the server executes on the body, so the two hops would be serving
+    different requests.
 
     Both headers are OPTIONAL, so absence is silent. A present one is compared
     against the body, and the comparison is exact: these are protocol tokens, not
@@ -644,8 +790,8 @@ def _validate_routing_headers(event: dict, method: str, params: Any) -> None:
         declared = _decoded_header(raw_method, METHOD_HEADER)
         if declared != method:
             raise InvalidTransportHeader(
-                f'{METHOD_HEADER} says {declared!r} but the request body calls '
-                f'{method!r}'
+                _header_mismatch_message(METHOD_HEADER, declared, method),
+                code=JSONRPC_HEADER_MISMATCH,
             )
 
     raw_name = _request_header(event, NAME_HEADER)
@@ -654,14 +800,15 @@ def _validate_routing_headers(event: dict, method: str, params: Any) -> None:
     declared_name = _decoded_header(raw_name, NAME_HEADER)
     if method != 'tools/call':
         raise InvalidTransportHeader(
-            f'{NAME_HEADER} names a tool, which is meaningful only on tools/call, '
-            f'not on {method!r}'
+            f'{_canonical_header_name(NAME_HEADER)} names a tool, which is meaningful '
+            f'only on tools/call, not on {method!r}',
+            code=JSONRPC_HEADER_MISMATCH,
         )
     body_name = params.get('name') if isinstance(params, dict) else None
     if declared_name != body_name:
         raise InvalidTransportHeader(
-            f'{NAME_HEADER} says {declared_name!r} but the request body calls '
-            f'{body_name!r}'
+            _header_mismatch_message(NAME_HEADER, declared_name, body_name),
+            code=JSONRPC_HEADER_MISMATCH,
         )
 
 
@@ -743,21 +890,31 @@ class AuthBackendUnavailable(Exception):
 
 
 @tracer.capture_method
-def _authenticate(event: dict) -> dict | None:
+def _authenticate(event: dict, *, touch: bool = True) -> dict | None:
     """
     Validate Bearer token from Authorization header.
 
     Returns the token DynamoDB item (with project_id, scope, etc.) on success,
     or None if authentication fails.
 
+    `touch=False` skips the `last_used_at` write. It exists for the pre-dispatch
+    liveness check on the unauthenticated methods: "last used" is a fact about
+    when a credential was USED to read something, and stamping it from a `ping`
+    would turn a keepalive loop into "last used: continuously" on the MCP Access
+    tab — a field an operator reads to decide whether a token is still wanted.
+
     Raises:
         AuthBackendUnavailable: the token store could not be consulted because
             of a permanent server-side fault.  Callers must answer with a
             server error, not a 401 — the credential was never checked.
     """
-    headers = event.get('headers', {})
-    # API Gateway lowercases header names in proxy mode
-    auth_header = headers.get('authorization') or headers.get('Authorization') or ''
+    # Matched case-insensitively rather than by trying two spellings: API Gateway
+    # lowercases in proxy mode and a direct invoke does not, and `Authorization`
+    # is no more exempt from that than the transport headers are. The two-spelling
+    # form this replaces missed `AUTHORIZATION` and every other casing, which on
+    # the liveness check below would have let a dead credential through the very
+    # gate it was added to close.
+    auth_header = _request_header(event, 'authorization') or ''
 
     if not auth_header.startswith('Bearer '):
         return None
@@ -870,14 +1027,15 @@ def _authenticate(event: dict) -> dict | None:
     if _credential_expired(item):
         return None
 
-    try:
-        projects_table.update_item(
-            Key={'pk': MCP_TOKEN_PK, 'sk': item['sk']},
-            UpdateExpression='SET last_used_at = :now',
-            ExpressionAttributeValues={':now': datetime.now(timezone.utc).isoformat()},
-        )
-    except Exception as e:
-        logger.warning(f"Failed to update last_used_at: {e}")
+    if touch:
+        try:
+            projects_table.update_item(
+                Key={'pk': MCP_TOKEN_PK, 'sk': item['sk']},
+                UpdateExpression='SET last_used_at = :now',
+                ExpressionAttributeValues={':now': datetime.now(timezone.utc).isoformat()},
+            )
+        except Exception as e:
+            logger.warning(f"Failed to update last_used_at: {e}")
 
     return item
 
@@ -1153,6 +1311,25 @@ _DAYS_ARG: dict[str, Any] = {
 }
 
 # ---------------------------------------------------------------------------
+# The vendor `_meta` prefix
+# ---------------------------------------------------------------------------
+#
+# Every non-spec field this server publishes travels under `_meta` behind this
+# prefix. `_meta` is the spec's own extension point, and the prefix is what keeps
+# a local field from colliding with a future spec field of the same name — a
+# collision that is free to avoid now and awkward to fix once a client has cached
+# the declaration carrying it.
+#
+# Legal precisely because the second label is `amazonaws`: the spec reserves any
+# prefix whose second label is `modelcontextprotocol` or `mcp`.
+VENDOR_META_PREFIX = 'com.amazonaws.voc-datalake/'
+
+# The `_meta` keys this server publishes. Named rather than spelled at each use so
+# a test can read them, and so the prefix is applied in one place.
+COST_CLASS_KEY = f'{VENDOR_META_PREFIX}costClass'
+RESULT_SHAPE_KEY = f'{VENDOR_META_PREFIX}resultShape'
+
+# ---------------------------------------------------------------------------
 # Cost classes
 # ---------------------------------------------------------------------------
 #
@@ -1256,12 +1433,24 @@ def _published_tool(declaration: dict) -> dict:
         raise ValueError(f'{name} declares undeclared cost class {cost_class!r}')
     return {
         **declaration,
+        # BOTH spellings of the title, which is the compatible choice and costs one
+        # line. `title` is where the current revision defines it — a client written
+        # against that revision reads the top level and would otherwise show the raw
+        # `name` in its permission prompt, the exact failure `TOOL_TITLES` exists to
+        # prevent. `annotations.title` is the pre-2026 spelling and is what older
+        # clients read. One source value, so the two cannot disagree.
+        "title": TOOL_TITLES[name],
         "annotations": _tool_annotations(name),
-        # `_meta` is the spec's own extension point, which is where a
-        # non-standard signal belongs: a client that does not know `costClass`
-        # ignores `_meta` wholesale rather than failing to validate a tool
-        # declaration carrying a field its schema does not define.
-        "_meta": {"costClass": cost_class},
+        # `_meta` is the spec's own extension point, which is where a non-standard
+        # signal belongs: a client that does not know the key ignores `_meta`
+        # wholesale rather than failing to validate a tool declaration carrying a
+        # field its schema does not define.
+        #
+        # VENDOR-PREFIXED rather than a bare `costClass`. Bare is legal today, but it
+        # is also the name a future revision could take for the same idea with
+        # different semantics — and a prefix is free to adopt now and awkward once a
+        # client has cached the entry.
+        "_meta": {COST_CLASS_KEY: cost_class},
     }
 
 
@@ -1556,16 +1745,47 @@ _TOOL_DECLARATIONS = [
 # first client that asks for the catalogue.
 MCP_TOOLS = [_published_tool(declaration) for declaration in _TOOL_DECLARATIONS]
 
-# How long a client may reuse a cached `tools/list`, in seconds. Five minutes,
-# matching the MCP authorizer's own `resultsCacheTtl` in api-stack.ts — not
-# because the two caches interact, but because a client holding a catalogue longer
-# than the credential's authorization decision lives is holding the older of two
-# facts about the same token.
+# ---------------------------------------------------------------------------
+# Cache hints
+# ---------------------------------------------------------------------------
+#
+# The spec's own two fields, `ttlMs` and `cacheScope`, and it REQUIRES them on
+# every `resultType: "complete"` result from `server/discover` and `tools/list`.
+#
+# ⚠️ The first draft of this change invented a parallel `_meta.cacheHints` object
+# with `maxAgeSeconds` and `scope: "credential"`. The SEMANTICS were right and the
+# encoding was a reinvention, with two consequences: a spec-reading client found no
+# `ttlMs`, defaulted it to 0 (immediately stale) and cached nothing; and — the
+# safety-relevant half — with no `cacheScope`, nothing told a gateway cache it must
+# not serve one token's catalogue to another.
+#
+# `private` is the spec's own encoding of exactly the property the credential
+# filter makes load-bearing: "Cached responses MAY be reused for the same
+# authorization context. Caches MUST NOT be shared across authorization contexts."
+CACHE_SCOPE_PUBLIC = 'public'
+CACHE_SCOPE_PRIVATE = 'private'
+
+# How long a client may reuse a cached `tools/list`. Five minutes, matching the MCP
+# authorizer's own `resultsCacheTtl` in api-stack.ts — not because the two caches
+# interact, but because a client holding a catalogue longer than the credential's
+# authorization decision lives is holding the older of two facts about the same
+# token.
 #
 # It is a HINT, and the etag beside it is what makes staleness detectable rather
 # than merely time-bounded: `listChanged: false` means no notification is coming,
 # so the honest contract is "re-ask, compare the etag, and reconnect if it moved".
 _TOOL_LIST_MAX_AGE_SECONDS = 300
+
+# The same duration in the unit the spec's field uses. Converted here, at the one
+# boundary, rather than by writing `300000` next to `300` and trusting the two to
+# stay in step — the unit is the whole reason the reinvented `maxAgeSeconds` could
+# not simply be renamed.
+_TOOL_LIST_TTL_MS = _TOOL_LIST_MAX_AGE_SECONDS * 1000
+
+# Discovery is cacheable for longer than the catalogue, and for a different reason:
+# it is a function of the DEPLOYED BUILD (versions, methods, headers), not of any
+# credential, so the only thing that invalidates it is a deploy.
+_DISCOVER_TTL_MS = 3_600_000
 
 
 # ============================================
@@ -2082,72 +2302,125 @@ TOOL_REACH_KINDS: dict[str, str] = {
 # MCP JSON-RPC protocol handling
 # ============================================
 
-# The `resultType` vocabulary — one discriminator per SHAPE of result this server
-# returns.
+# `resultType` — the SPEC's field, carrying the spec's own value.
 #
-# 🔑 Why a discriminator rather than "look at which keys are present": every
-# result here is a bare JSON object, and telling them apart by key inference is
-# guesswork that gets worse as shapes grow. `{}` is both a `ping` answer and a
-# notification acknowledgement; a tool result and a tool ERROR differ only by a
-# boolean and by whether `structuredContent` happens to be there. A client
-# switching on inferred shape re-derives that table from scratch, gets it subtly
-# wrong, and the failure lands in the client rather than here.
+# ⚠️ This was the defect the first draft of this change shipped: the seven local
+# shape names below travelled in `resultType` itself. That field's value space is
+# owned by the spec, which defines `complete` and `input_required` (the MRTR
+# interim result) and says a value the client does not recognize "MUST be
+# considered invalid" — extension values are legal only when advertised through a
+# capability-declared extension, and this server declares none. So a strict
+# 2026-07-28 client had to reject EVERY result from this server, which made the
+# newest advertised revision less interoperable than the pinned 2024-11-05 it
+# replaced (where the field is absent and an absent value reads as `complete`).
 #
-# `toolError` is a distinct type rather than "a toolResult with isError" ON
-# PURPOSE, and `isError` is still sent: the flag is what the spec defines, the
-# type is what says the payload has no `structuredContent` to validate.
-RESULT_TYPE_INITIALIZE = 'initialize'
-RESULT_TYPE_DISCOVERY = 'discovery'
-RESULT_TYPE_TOOL_LIST = 'toolList'
-RESULT_TYPE_TOOL_RESULT = 'toolResult'
-RESULT_TYPE_TOOL_ERROR = 'toolError'
-RESULT_TYPE_PONG = 'pong'
-RESULT_TYPE_ACK = 'ack'
+# `complete` on every result here is the whole vocabulary this server needs:
+# `input_required` belongs to multi-round-trip requests, and no tool asks the
+# caller for more input mid-call.
+RESULT_TYPE_KEY = 'resultType'
+RESULT_TYPE_COMPLETE = 'complete'
 
-RESULT_TYPES: frozenset[str] = frozenset({
-    RESULT_TYPE_INITIALIZE,
-    RESULT_TYPE_DISCOVERY,
-    RESULT_TYPE_TOOL_LIST,
-    RESULT_TYPE_TOOL_RESULT,
-    RESULT_TYPE_TOOL_ERROR,
-    RESULT_TYPE_PONG,
-    RESULT_TYPE_ACK,
+# The local shape discriminator travels under `RESULT_SHAPE_KEY` (declared with the
+# other vendor `_meta` keys, above the tool catalogue) rather than in the spec's
+# field. Same reasoning the cost class already followed: a client that does not
+# know the key ignores `_meta` wholesale, instead of failing to validate a result
+# carrying a field its schema does not define.
+#
+# 🔑 Why a discriminator at all, rather than "look at which keys are present":
+# every result here is a bare JSON object, and telling them apart by key
+# inference is guesswork that gets worse as shapes grow. `{}` is both a `ping`
+# answer and a notification acknowledgement; a tool result and a tool ERROR
+# differ only by a boolean and by whether `structuredContent` happens to be
+# there. A client switching on inferred shape re-derives that table from scratch,
+# gets it subtly wrong, and the failure lands in the client rather than here.
+#
+# `toolError` is a distinct shape rather than "a toolResult with isError" ON
+# PURPOSE, and `isError` is still sent: the flag is what the spec defines, the
+# shape is what says the payload has no `structuredContent` to validate.
+RESULT_SHAPE_INITIALIZE = 'initialize'
+RESULT_SHAPE_DISCOVERY = 'discovery'
+RESULT_SHAPE_TOOL_LIST = 'toolList'
+RESULT_SHAPE_TOOL_RESULT = 'toolResult'
+RESULT_SHAPE_TOOL_ERROR = 'toolError'
+RESULT_SHAPE_PONG = 'pong'
+RESULT_SHAPE_ACK = 'ack'
+
+RESULT_SHAPES: frozenset[str] = frozenset({
+    RESULT_SHAPE_INITIALIZE,
+    RESULT_SHAPE_DISCOVERY,
+    RESULT_SHAPE_TOOL_LIST,
+    RESULT_SHAPE_TOOL_RESULT,
+    RESULT_SHAPE_TOOL_ERROR,
+    RESULT_SHAPE_PONG,
+    RESULT_SHAPE_ACK,
 })
 
-# The key the discriminator travels under. Named so a test can read it rather
-# than restate the string, and so the one-line change to namespace it later
-# touches one place.
-RESULT_TYPE_KEY = 'resultType'
 
+def _jsonrpc_error(req_id: Any, code: int, message: str, data: Any = None) -> dict:
+    """Build a JSON-RPC error response, optionally carrying machine-readable data.
 
-def _jsonrpc_error(req_id: Any, code: int, message: str) -> dict:
-    """Build a JSON-RPC error response."""
+    `data` is omitted entirely when absent rather than sent as `null`: the spec
+    makes the member optional, and a present-but-null member is a third state a
+    client has to handle for no gain.
+
+    It exists because two of the spec's own errors put the caller's recovery path
+    in `data` rather than in prose — `-32022` lists the versions this server does
+    speak, which is what the client retries with. Prose is not a recovery path.
+    """
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
     return {
         "jsonrpc": "2.0",
         "id": req_id,
-        "error": {"code": code, "message": message},
+        "error": error,
     }
 
 
-def _jsonrpc_result(req_id: Any, result_type: str, result: dict) -> dict:
-    """Build a JSON-RPC success response, discriminated by its shape.
+def _jsonrpc_result(req_id: Any, result_shape: str, result: dict) -> dict:
+    """Build a JSON-RPC success response: spec `resultType`, local shape in `_meta`.
 
-    The discriminator is a REQUIRED positional argument rather than an optional
-    keyword, which is the whole design: every result this server returns is built
-    here, so a new result shape cannot ship without naming itself. An optional
-    parameter would have made the discriminator a thing authors remember, which is
-    the same class of defect as a declaration nothing checks.
+    The shape is a REQUIRED positional argument rather than an optional keyword,
+    which is the whole design: every result this server returns is built here, so
+    a new result shape cannot ship without naming itself. An optional parameter
+    would have made the discriminator a thing authors remember, which is the same
+    class of defect as a declaration nothing checks.
 
-    An undeclared type raises rather than travelling: a client switching on the
+    An undeclared shape raises rather than travelling: a client switching on the
     value cannot switch on a typo, and finding out at the client is finding out
     too late.
+
+    A payload that already carries either key ALSO raises. Ordering the spread so
+    the injected value wins would have been the one-character fix, but silently
+    overwriting a caller's value is the same defect in the other direction — and
+    the earlier `{KEY: value, **result}` form let a payload replace the validated
+    discriminator outright, which is exactly the guarantee this function exists to
+    provide.
+
+    `_meta` is MERGED rather than replaced, because a caller's `_meta` (the cache
+    hints on `tools/list`, the cost class on a tool result) has to survive
+    alongside the shape.
     """
-    if result_type not in RESULT_TYPES:
-        raise ValueError(f'undeclared resultType {result_type!r}')
+    if result_shape not in RESULT_SHAPES:
+        raise ValueError(f'undeclared result shape {result_shape!r}')
+    if RESULT_TYPE_KEY in result:
+        raise ValueError(
+            f'result already carries {RESULT_TYPE_KEY!r}; it is set here, not by callers'
+        )
+    caller_meta = result.get('_meta') or {}
+    if RESULT_SHAPE_KEY in caller_meta:
+        raise ValueError(
+            f'result _meta already carries {RESULT_SHAPE_KEY!r}; it is set here, '
+            f'not by callers'
+        )
     return {
         "jsonrpc": "2.0",
         "id": req_id,
-        "result": {RESULT_TYPE_KEY: result_type, **result},
+        "result": {
+            **result,
+            RESULT_TYPE_KEY: RESULT_TYPE_COMPLETE,
+            "_meta": {**caller_meta, RESULT_SHAPE_KEY: result_shape},
+        },
     }
 
 
@@ -2174,7 +2447,7 @@ def _handle_initialize(req_id: Any, params: dict) -> dict:
     the same whatever was asked — a handshake in shape only.
     """
     requested = params.get('protocolVersion') if isinstance(params, dict) else None
-    return _jsonrpc_result(req_id, RESULT_TYPE_INITIALIZE, {
+    return _jsonrpc_result(req_id, RESULT_SHAPE_INITIALIZE, {
         "protocolVersion": _negotiate_protocol_version(requested),
         "capabilities": _server_capabilities(),
         "serverInfo": {
@@ -2201,29 +2474,60 @@ def _handle_discover(req_id: Any, _params: dict) -> dict:
     Deliberately does NOT list tools. `tools/list` does that, and it varies by
     credential — repeating a credential-shaped answer on an unauthenticated
     method would either leak the catalogue or contradict the other method.
+
+    ⚠️ The field names here are the SPEC's `DiscoverResult`, not this module's own
+    vocabulary. The first draft published `protocolVersions` and a top-level
+    `serverInfo`, which meant a client calling this method precisely to learn the
+    supported versions read `supportedVersions`, found it absent, and was no better
+    off than if the method did not exist. The extra facts this server can report
+    are still reported — under a vendor-prefixed `_meta` key, which is where the
+    cost class already lives and for the same reason.
     """
-    return _jsonrpc_result(req_id, RESULT_TYPE_DISCOVERY, {
-        "serverInfo": {
-            "name": "voc-datalake",
-            "version": MCP_SERVER_VERSION,
-        },
-        "protocolVersions": list(SUPPORTED_PROTOCOL_VERSIONS),
-        "preferredProtocolVersion": PREFERRED_PROTOCOL_VERSION,
+    return _jsonrpc_result(req_id, RESULT_SHAPE_DISCOVERY, {
+        # The spec's name for this list, and the one field a client calls this
+        # method to read.
+        "supportedVersions": list(SUPPORTED_PROTOCOL_VERSIONS),
         "capabilities": _server_capabilities(),
-        # Sorted, because this is a set rather than a sequence and a client
-        # diffing two discoveries should see a change only when one happened.
-        "methods": sorted({*MCP_METHODS, *MCP_AUTH_METHODS}),
-        "authenticatedMethods": sorted(MCP_AUTH_METHODS),
-        # In the spelling a client SENDS, not the lowercase form this module reads
-        # after API Gateway has normalised it. Reporting the internal spelling
-        # would document an implementation detail as a contract.
-        "transportHeaders": list(CANONICAL_TRANSPORT_HEADERS),
-        "resultTypes": sorted(RESULT_TYPES),
-        "costClasses": list(COST_CLASSES),
-        # The list varies by credential, so a client cannot conclude "these are
-        # the tools" from an unauthenticated discovery. Saying so is cheaper than
-        # letting it find out by calling one it was never granted.
-        "toolsVaryByCredential": True,
+        # `server/discover` is in the spec's cacheable-results list, so the hints
+        # are REQUIRED rather than a nicety. `public` is honest here: this answer
+        # names no project, no tool and no data, so a shared cache serving it to
+        # another caller reveals nothing that caller could not ask for itself.
+        "ttlMs": _DISCOVER_TTL_MS,
+        "cacheScope": CACHE_SCOPE_PUBLIC,
+        "_meta": {
+            # The spec's reserved key for server identity — self-reported, and the
+            # spec says clients SHOULD NOT make security decisions on it.
+            'io.modelcontextprotocol/serverInfo': {
+                "name": "voc-datalake",
+                "version": MCP_SERVER_VERSION,
+            },
+            # Everything below is this server's own reporting, not the spec's, so
+            # it travels under a vendor prefix: a client that does not know these
+            # keys ignores them, instead of failing to validate a `DiscoverResult`
+            # carrying fields its schema does not define.
+            f'{VENDOR_META_PREFIX}serverDetail': {
+                "preferredProtocolVersion": PREFERRED_PROTOCOL_VERSION,
+                # Sorted, because this is a set rather than a sequence and a client
+                # diffing two discoveries should see a change only when one happened.
+                "methods": sorted({*MCP_METHODS, *MCP_AUTH_METHODS}),
+                "authenticatedMethods": sorted(MCP_AUTH_METHODS),
+                # In the spelling a client SENDS, not the lowercase form this
+                # module reads after API Gateway has normalised it. Reporting the
+                # internal spelling would document an implementation detail as a
+                # contract.
+                "transportHeaders": list(CANONICAL_TRANSPORT_HEADERS),
+                # Named `resultShapes`, NOT `resultTypes`: the spec owns the
+                # `resultType` vocabulary and this is not it. Publishing this list
+                # as `resultTypes` would have claimed otherwise.
+                "resultShapes": sorted(RESULT_SHAPES),
+                "costClasses": list(COST_CLASSES),
+                # The list varies by credential, so a client cannot conclude "these
+                # are the tools" from an unauthenticated discovery. Saying so is
+                # cheaper than letting it find out by calling one it was never
+                # granted.
+                "toolsVaryByCredential": True,
+            },
+        },
     })
 
 
@@ -2233,6 +2537,29 @@ def _handle_discover(req_id: Any, _params: dict) -> dict:
 # never becomes a path. Named rather than inlined so that is legible at the one
 # place it is read.
 _ANY_PROJECT = 'any-project'
+
+
+def _token_projects(token_info: dict) -> list[str]:
+    """The project ids on this credential: usable strings only, junk dropped.
+
+    Read through one helper at every site that consults `projects`, because the
+    value is STORED data and every caller of it is deciding reach. Two shapes are
+    dropped here rather than downstream:
+
+      • Entries that are not non-empty strings. A `None`, a `7` or a `{}` names no
+        project, and counting one as a project would let a damaged row widen what
+        a `project-set` token reaches.
+      • A `projects` that is not a list at all — notably a bare STRING. `"proj1"`
+        is iterable, so the per-entry filter above happily yielded `'p'`, `'r'`,
+        `'o'`, … and the first of them passed as a project id; `reach_allows` then
+        compared it with `in`, which against a string is a substring test, so the
+        listing and the dispatch AGREED and both were wrong. `reach_allows` is
+        hardened too — this is the fail-closed reading applied at both ends.
+    """
+    projects = token_info.get('projects')
+    if not isinstance(projects, (list, tuple)):
+        return []
+    return [p for p in projects if isinstance(p, str) and p]
 
 
 def _tool_is_authorized(tool_name: str, token_info: dict) -> bool:
@@ -2256,7 +2583,7 @@ def _tool_is_authorized(tool_name: str, token_info: dict) -> bool:
     if not _scope_allows(token_info.get('scopes'), required_scope):
         return False
 
-    token_projects = token_info.get('projects') or []
+    token_projects = _token_projects(token_info)
     read_reach = token_info.get('read_reach') or DEFAULT_READ_REACH
     # `reach_allows` decides on a CONCRETE project, and a listing has none, so a
     # project-shaped tool is asked about a representative one. A project from the
@@ -2267,9 +2594,7 @@ def _tool_is_authorized(tool_name: str, token_info: dict) -> bool:
     # and `reach_allows` refuses it, which is right — it can reach no project.
     representative = None
     if tool_reach_kind == REACH_KIND_PROJECT:
-        representative = next(
-            (p for p in token_projects if isinstance(p, str) and p), None,
-        )
+        representative = next(iter(token_projects), None)
         if representative is None and read_reach == REACH_WORKSPACE:
             representative = _ANY_PROJECT
 
@@ -2323,20 +2648,26 @@ def _handle_tools_list(req_id: Any, _params: dict, token_info: dict) -> dict:
     caller cannot call is a catalogue that has to be tried to be believed.
 
     Cache hints travel with the answer because `listChanged: false` means the
-    client is on its own: nothing will tell it the list moved. `scope: credential`
-    is the load-bearing one — a shared cache keyed on the endpoint alone would
-    serve one token's catalogue to another token.
+    client is on its own: nothing will tell it the list moved. `cacheScope:
+    private` is the load-bearing one — a shared cache keyed on the endpoint alone
+    would serve one token's catalogue to another token, which only became possible
+    the moment the list started varying.
     """
     tools = _tools_for(token_info)
-    return _jsonrpc_result(req_id, RESULT_TYPE_TOOL_LIST, {
+    return _jsonrpc_result(req_id, RESULT_SHAPE_TOOL_LIST, {
         "tools": tools,
+        # The spec's caching fields, at the top level where a spec-reading client
+        # looks for them. `private` because this answer is a function of the
+        # CREDENTIAL rather than of the endpoint — the spec names this exact case
+        # ("filtered list results that vary per user").
+        "ttlMs": _TOOL_LIST_TTL_MS,
+        "cacheScope": CACHE_SCOPE_PRIVATE,
         "_meta": {
-            "cacheHints": {
-                # Cacheable, and the qualifier matters more than the flag: this
-                # answer is a function of the CREDENTIAL, not of the endpoint.
-                "cacheable": True,
-                "scope": "credential",
-                "maxAgeSeconds": _TOOL_LIST_MAX_AGE_SECONDS,
+            # Not spec fields, so vendor-prefixed. The etag is what makes staleness
+            # DETECTABLE rather than merely time-bounded, which matters more here
+            # than for most caches: `listChanged: false` means no notification is
+            # coming, so "re-ask and compare" is the only path a client has.
+            f'{VENDOR_META_PREFIX}catalogue': {
                 "etag": _tools_list_etag(tools),
                 "serverVersion": MCP_SERVER_VERSION,
                 # Stated rather than implied by the capability: a client reading
@@ -2409,10 +2740,13 @@ def _resolve_project_id(args: dict, token_info: dict) -> str | None:
                 f'{type(explicit).__name__}'
             )
         return explicit.strip()
-    token_projects = token_info.get('projects')
-    if isinstance(token_projects, (list, tuple)) and len(token_projects) == 1:
-        only = token_projects[0]
-        return only if isinstance(only, str) and only else None
+    # One usable project on the credential is an unambiguous default; anything
+    # else (none, or several) is not, and returns None rather than picking. The
+    # shape filtering lives in `_token_projects`, so a `projects` stored as a bare
+    # string cannot present its first character as "the only project".
+    token_projects = _token_projects(token_info)
+    if len(token_projects) == 1:
+        return token_projects[0]
     return None
 
 
@@ -2478,7 +2812,7 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
     # of data a token may read, reach says HOW FAR. A token can hold
     # `projects:read` and still be refused a particular project.
     read_reach = token_info.get('read_reach') or DEFAULT_READ_REACH
-    token_projects = token_info.get('projects') or []
+    token_projects = _token_projects(token_info)
     project_id = None
     if tool_reach_kind == REACH_KIND_PROJECT:
         try:
@@ -2556,7 +2890,7 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         logger.exception(f"Tool execution error: {tool_name}")
         return _tool_error(req_id, f"Error: {str(e)}")
 
-    return _jsonrpc_result(req_id, RESULT_TYPE_TOOL_RESULT, {
+    return _jsonrpc_result(req_id, RESULT_SHAPE_TOOL_RESULT, {
         "content": [{"type": "text", "text": result.text}],
         # Structured output alongside the text block, not instead of it: the
         # spec says a tool SHOULD keep sending the serialized form for clients
@@ -2574,7 +2908,9 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         # failure (`_published_tool` refuses to build the catalogue, and the
         # declaration tables are asserted to agree), so this decides only whether
         # the symptom is a red test or a dead tool.
-        **({"_meta": {"costClass": TOOL_COST_CLASSES[tool_name]}}
+        # Same vendor-prefixed key the catalogue publishes, so a client reading the
+        # class off a result and off the declaration reads one name.
+        **({"_meta": {COST_CLASS_KEY: TOOL_COST_CLASSES[tool_name]}}
            if tool_name in TOOL_COST_CLASSES else {}),
     })
 
@@ -2587,7 +2923,7 @@ def _tool_error(req_id: Any, message: str) -> dict:
     `structuredContent` to validate against the tool's `outputSchema`. A client
     switching on the type knows that without having to test for the key.
     """
-    return _jsonrpc_result(req_id, RESULT_TYPE_TOOL_ERROR, {
+    return _jsonrpc_result(req_id, RESULT_SHAPE_TOOL_ERROR, {
         "content": [{"type": "text", "text": message}],
         "isError": True,
     })
@@ -2595,7 +2931,7 @@ def _tool_error(req_id: Any, message: str) -> dict:
 
 def _handle_ping(req_id: Any, _params: dict) -> dict:
     """Handle MCP ping request."""
-    return _jsonrpc_result(req_id, RESULT_TYPE_PONG, {})
+    return _jsonrpc_result(req_id, RESULT_SHAPE_PONG, {})
 
 
 # Method → handler mapping.
@@ -2652,7 +2988,7 @@ def _handle_autoseed(event: dict) -> dict:
         )
     if not reach_allows(
         read_reach=token_info.get('read_reach') or DEFAULT_READ_REACH,
-        token_projects=token_info.get('projects') or [],
+        token_projects=_token_projects(token_info),
         tool_reach_kind=REACH_KIND_PROJECT,
         project_id=project_id,
     ):
@@ -2737,10 +3073,18 @@ def lambda_handler(event: dict, context: Any) -> dict:
     # `_cors_response`) naming what IS allowed, which is what tells a client to
     # stop trying rather than to retry differently. Everything else that is not
     # POST lands here too, for the same reason and with the same answer.
+    #
+    # The allowed set is the one belonging to the RESOURCE being refused, not to
+    # this Lambda: a non-GET verb on the autoseed path is refused with `GET,
+    # OPTIONS`, because that is what that path serves. `autoseed_match` has already
+    # been evaluated above, so the two answers cannot disagree about which path
+    # this is.
     if http_method != 'POST':
         return _cors_response(
-            _jsonrpc_error(None, -32600, f"Method not allowed: {http_method or 'unknown'}"),
+            _jsonrpc_error(None, JSONRPC_INVALID_REQUEST,
+                           f"Method not allowed: {http_method or 'unknown'}"),
             status_code=405,
+            allow=_ALLOW_AUTOSEED if autoseed_match else _ALLOW_JSONRPC,
         )
 
     # Parse JSON-RPC request
@@ -2773,28 +3117,36 @@ def lambda_handler(event: dict, context: Any) -> dict:
         _validated_protocol_version(event)
         _validate_routing_headers(event, method, params)
     except InvalidTransportHeader as exc:
+        # The code, the `data` payload and the status all come from the exception
+        # rather than being decided here: the spec pins a different code per fault
+        # (-32022 with the supported-version list, -32020 for a header/body
+        # disagreement), and a single generic code at this one catch site is how the
+        # first draft of this change lost both the client's recovery path and the
+        # era-detection signal.
         return _cors_response(
-            _jsonrpc_error(req_id, -32600, str(exc)),
-            status_code=400,
+            _jsonrpc_error(req_id, exc.code, str(exc), exc.data),
+            status_code=exc.status_code,
         )
 
     # Handle the methods that need no credential (initialize, ping,
     # server/discover, notifications).
     if method in MCP_METHODS:
-        # A PRESENTED credential is checked even here, and this is the honesty fix
-        # this envelope owes: a revoked or expired token used to complete the whole
-        # handshake and fail only at the first `tools/call`, so a dead credential
-        # presented as a connected server and whoever was debugging went looking
-        # at the tools. An ABSENT credential still passes — a client is entitled to
-        # ask what this server is before deciding what to present — so this
-        # refuses only a credential that was offered and does not work.
-        refusal = _refuse_a_dead_credential(event, req_id)
+        # A PRESENTED credential is checked on the methods a client uses to decide
+        # it is CONNECTED, and this is the honesty fix this envelope owes: a revoked
+        # or expired token used to complete the whole handshake and fail only at the
+        # first `tools/call`, so a dead credential presented as a connected server
+        # and whoever was debugging went looking at the tools. An ABSENT credential
+        # still passes — a client is entitled to ask what this server is before
+        # deciding what to present — so this refuses only a credential that was
+        # offered and does not work. The method is passed because the check is
+        # scoped: `ping` and the notifications are out (see the constant).
+        refusal = _refuse_a_dead_credential(event, req_id, method)
         if refusal is not None:
             return refusal
         handler = MCP_METHODS[method]
         if handler is None:
             # Notification — no response needed, but HTTP requires a body
-            return _cors_response(_jsonrpc_result(req_id, RESULT_TYPE_ACK, {}))
+            return _cors_response(_jsonrpc_result(req_id, RESULT_SHAPE_ACK, {}))
         return _cors_response(handler(req_id, params))
 
     # All other methods require authentication
@@ -2826,12 +3178,47 @@ def lambda_handler(event: dict, context: Any) -> dict:
     # probing for a method this server might have needs to be able to tell
     # "no such method here" from a refusal it could fix. `server/discover` exists
     # so the probe is unnecessary in the first place.
+    #
+    # HTTP 404 alongside it, which the Streamable HTTP transport REQUIRES and which
+    # is not merely decorative: it is what a dual-era client's fallback probe reads,
+    # and the JSON-RPC body is what distinguishes this 404 from the 404 of a legacy
+    # HTTP+SSE server that does not host the modern endpoint at all. Answering 200
+    # here — as this did — left the status saying "your request was fine" about a
+    # method that does not exist, while the 405 path in this same module already
+    # set a status for the same class of "this server does not do that".
     return _cors_response(
-        _jsonrpc_error(req_id, -32601, f"Method not found: {method}"),
+        _jsonrpc_error(req_id, JSONRPC_METHOD_NOT_FOUND, f"Method not found: {method}"),
+        status_code=404,
     )
 
 
-def _refuse_a_dead_credential(event: dict, req_id: Any) -> dict | None:
+# The unauthenticated methods where a dead credential must be reported, and the
+# rule is "which method does a client use to decide it is CONNECTED":
+#
+#   • `initialize` — the handshake. A client that completes it believes it has a
+#     working session.
+#   • `server/discover` — the same decision without the handshake, for a client
+#     that starts here.
+#
+# `ping` and the notifications are deliberately NOT here. Two reasons, and the
+# second is the stronger one:
+#
+#   • Cost. `ping` is a keepalive, so checking it put a DynamoDB Query (and, before
+#     `touch=False`, an UpdateItem) on every heartbeat of every session — on a route
+#     throttled at 20 rps whose authorizer caches for 300 s, so a single valid-shaped
+#     token could drive that stream straight past the cache. `ping` previously
+#     touched nothing.
+#   • A NOTIFICATION CARRIES NO ID. JSON-RPC says a notification gets no response at
+#     all, so answering one with a 401 replies to a message that must not be replied
+#     to. The honesty defect was never about notifications anyway: nobody concludes
+#     "connected" from an un-refused notification.
+_LIVENESS_CHECKED_METHODS: frozenset[str] = frozenset({
+    'initialize',
+    'server/discover',
+})
+
+
+def _refuse_a_dead_credential(event: dict, req_id: Any, method: str) -> dict | None:
     """401 when a credential was presented and does not authenticate, else None.
 
     🔑 The honesty defect this closes: `initialize` needs no credential, so a
@@ -2839,6 +3226,10 @@ def _refuse_a_dead_credential(event: dict, req_id: Any) -> dict | None:
     the first `tools/call` was the first refusal. A client shows that as a
     connected server with failing tools, which sends whoever is debugging at the
     tools, at the scopes, at the routes — anywhere but the credential.
+
+    Scoped to `_LIVENESS_CHECKED_METHODS` — the methods a client uses to decide it
+    is connected — rather than to every unauthenticated method. See that constant
+    for why `ping` and the notifications are out.
 
     Only a PRESENTED credential is checked. No `Authorization` header is not a
     dead credential, it is no credential, and an unauthenticated `initialize` or
@@ -2848,15 +3239,20 @@ def _refuse_a_dead_credential(event: dict, req_id: Any) -> dict | None:
     "your token is invalid" for a table nobody could read sends an operator to
     re-mint a credential that was never compared.
     """
-    headers = event.get('headers') or {}
-    auth_header = ''
-    if isinstance(headers, dict):
-        auth_header = headers.get('authorization') or headers.get('Authorization') or ''
-    if not isinstance(auth_header, str) or not auth_header.startswith('Bearer '):
+    if method not in _LIVENESS_CHECKED_METHODS:
+        return None
+
+    # Case-insensitive, via the same helper the transport headers use: a spelling
+    # this failed to match would read as "no credential presented" and skip the
+    # check entirely, which is the one way this guard can silently not run.
+    auth_header = _request_header(event, 'authorization') or ''
+    if not auth_header.startswith('Bearer '):
         return None
 
     try:
-        token_info = _authenticate(event)
+        # `touch=False`: this is a liveness probe, not a use. Stamping
+        # `last_used_at` here would make the field mean "last pinged".
+        token_info = _authenticate(event, touch=False)
     except AuthBackendUnavailable:
         return _cors_response(
             _jsonrpc_error(req_id, -32603, "Internal error: token store unavailable"),

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -127,6 +127,84 @@ PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
 # did — silently upgrades exactly the clients that cannot be upgraded.
 ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 
+# 🔑 THE NEGOTIATED VERSION IS A GATE, NOT A MODE — and this is a deliberate
+# decision rather than an unfinished one, recorded here because the alternative is
+# a reader hunting for a consumer that does not exist.
+#
+# `_validated_protocol_version` is called for its EXCEPTION: nothing reads its
+# return value, and nothing reads `ASSUMED_PROTOCOL_VERSION` beyond it.
+# `_handle_initialize` puts the negotiated version in its answer and no later
+# request consults what was negotiated. So the version decides whether a request is
+# SERVED, never what it is served.
+#
+# That is honest as long as the envelope is revision-invariant, which it is: every
+# revision in the range above is handshake-based, none of them differs in a way
+# this server exercises, and the same fields go out whichever one was negotiated.
+# The transport's stated purpose for the header — "allowing the MCP server to
+# respond based on the MCP protocol version" — is therefore satisfied vacuously
+# rather than ignored.
+#
+# Per-revision response SHAPING is the next phase's work, and it arrives with
+# 2026-07-28 rather than before it: that is the revision that actually defines
+# fields the older ones do not (see the provenance note below), so it is the first
+# one where "which revision is this" changes what should be sent. Threading the
+# validated version into the dispatch now would add a parameter every handler
+# ignores, which is a seam that looks load-bearing and is not.
+#
+# ---------------------------------------------------------------------------
+# ⚠️ PROVENANCE: what this envelope sends that the advertised range does not define
+# ---------------------------------------------------------------------------
+#
+# Several envelope constructs here are defined by 2026-07-28 — the revision this
+# server deliberately does NOT advertise. Recorded once, and referenced from each
+# declaration, so the next reader can tell a deliberate forward-compatibility bet
+# from a mistake:
+#
+#   • `resultType` (`RESULT_TYPE_KEY`, value `complete`)
+#   • `ttlMs` and `cacheScope` (`CACHE_SCOPE_*`, `_TOOL_LIST_TTL_MS`,
+#     `_DISCOVER_TTL_MS`)
+#   • `-32020 HeaderMismatch` and `-32022 UnsupportedProtocolVersion`
+#   • the `server/discover` method and its `DiscoverResult` field names
+#
+# None of these appears in 2025-11-25 or earlier. They are sent anyway, and it is
+# safe because it is ADDITIVE: those revisions' `Result` is
+# `additionalProperties: {}` and `ListToolsResult` sets no
+# `additionalProperties: false`, so a conforming client of an advertised revision
+# IGNORES a member it does not know rather than rejecting the message. No field
+# any advertised revision defines is replaced or retyped — `_additive_only` in the
+# envelope tests pins that half, which is the half that could break a client.
+#
+# The alternative was to hold these back until 2026-07-28 is negotiable, which
+# would mean shipping a locally-invented equivalent in the meantime and renaming it
+# later — the exact defect the previous round removed.
+#
+# THE ERROR CODES ARE THE ONE JUDGEMENT CALL, so it is stated rather than implied.
+# 2026-07-28 reserves -32020..-32099 for the specification and says an
+# implementation "MUST NOT emit any code from this sub-range that is not defined by
+# this specification". Read literally, that rule is satisfied: -32020 and -32022
+# ARE defined by that specification and are used with exactly its meaning, and no
+# neighbour in the range is invented. Read from a 2025-11-25 client's seat, the
+# sub-range has no definitions at all, so the code is one that client cannot
+# interpret. Both readings were weighed and the codes are KEPT:
+#
+#   • the fallback, `-32600`, is actively worse for the client this matters to. The
+#     transport's backward-compatibility rules have a dual-era client read a 400
+#     body for a RECOGNIZED modern error to conclude "modern server, retry with a
+#     supported version", and anything else to conclude "legacy server". `-32600`
+#     sent a client that merely guessed a version wrong into legacy fallback
+#     against a server advertising a modern revision. That was the earlier finding
+#     these codes exist to answer.
+#   • an unrecognized error CODE is not a validation failure the way an
+#     unrecognized `resultType` value is. There is no schema rule obliging a client
+#     to reject it, the human-readable `message` is unaffected, and the recovery
+#     path travels in `data.supported`, which a client reads without knowing the
+#     code at all.
+#
+# When 2026-07-28 becomes negotiable, none of this changes shape — it stops being
+# early. What changes is that these constructs become REQUIRED rather than
+# additive, and the reserved-range question stops having two readings.
+# ---------------------------------------------------------------------------
+
 # Semver on the SERVER, independent of the protocol revision above, and the only
 # signal a client gets that a tool's output shape moved — it is advertised in
 # `serverInfo` on every `initialize`.
@@ -184,7 +262,49 @@ ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 # Minor rather than major because no declared tool INPUT or OUTPUT shape moved: a
 # client validating `structuredContent` against a cached `outputSchema` is
 # unaffected. The reconnect caveat above applies with the same force.
-MCP_SERVER_VERSION = "3.3.0"
+#
+# ⚠️ Minor for a RENAME needs the argument the 3.0.0 entry above implies, because
+# by that entry's own rule — "a client coded against the NAMES loses them, which is
+# a major bump by this file's own rule rather than a judgement about how many
+# clients exist" — renaming a published field reads like the major case. What makes
+# it minor here is not the count of affected clients but that there can be none:
+# every field 3.3.0 renames was INTRODUCED IN 3.2.0, and 3.2.0 was never deployed.
+# No client can hold a catalogue or a cached result containing `_meta.cacheHints`,
+# a local `resultType` value or a bare `costClass`, because no build that published
+# them ever left the account. Measured against the last DEPLOYED version, 3.1.0,
+# every part of 3.3.0 is an addition.
+#
+# So the rule stands and is worth restating sharply: renaming a field a DEPLOYED
+# version published is a MAJOR bump. Renaming one introduced and superseded between
+# two deploys is bookkeeping. The distinction is "could a client have cached it",
+# not "is the diff large".
+#
+# 3.4.0 fixes what the envelope does with a message it must not answer, and with a
+# status that means something else on the revisions it advertises:
+#   • A NOTIFICATION is now `202 Accepted` with no body, which every advertised
+#     revision states as a MUST. It was answered `200` with a JSON-RPC result
+#     carrying `id: null` — a reply to a message that gets no reply, and an
+#     ill-formed one, since a result's id must not be null.
+#   • The notifications this server does NOT dispatch — `notifications/cancelled`
+#     above all — were answered `404`, and on the advertised revisions a 404 on this
+#     endpoint means the session was terminated and the client MUST re-initialize.
+#     Routine cancellation traffic was tearing down live sessions. An unknown
+#     REQUEST is still 404 with -32601.
+#   • `initialize` no longer refuses an `MCP-Protocol-Version` naming a revision
+#     this server does not implement; it counter-offers, which is what a
+#     current-generation client's very first request needs (it must send its own
+#     revision and has nothing else to send). Every other method still refuses.
+#   • `RESULT_SHAPE_ACK` is GONE, because the response it described must not be
+#     sent. This is the only REMOVAL, and it is why this entry is not a patch.
+#
+# Minor rather than major, and the rule above is what decides it: no published tool
+# declaration moved, so the fingerprinted catalogue is untouched, and the removed
+# `ack` shape was introduced in 3.3.0 — undeployed — so no client can have seen it.
+# What DOES change for a deployed 3.1.0 client is the notification path, and that
+# change is from an ill-formed answer to the one the spec mandates: a client
+# ignoring the ack (the only correct thing to do with it) is unaffected, and one
+# parsing it was parsing a response it should never have received.
+MCP_SERVER_VERSION = "3.4.0"
 
 
 # ============================================
@@ -587,6 +707,65 @@ def _cors_response(body: dict, status_code: int = 200,
     }
 
 
+def _accepted_no_content() -> dict:
+    """202 Accepted with NO body — the transport's answer to a notification.
+
+    Every revision this server advertises states the rule in identical words
+    (Streamable HTTP, *Sending Messages to the Server*): "If the input is a
+    JSON-RPC response or notification: If the server accepts the input, the server
+    MUST return HTTP status code 202 Accepted with no body."
+
+    ⚠️ What this replaces was not merely untidy. A notification used to be answered
+    with `200` and a full JSON-RPC result carrying `id: null`, which breaks the rule
+    twice over: it REPLIES to a message JSON-RPC says gets no reply, and the reply
+    it sends is ill-formed, because a result's `id` must not be null and a client
+    correlating responses by id holds one matching no request it ever made.
+
+    A separate function from `_cors_response` because the difference is the absence
+    of a body, and threading a "no body" flag through the builder every other
+    answer uses would have made an empty body a thing a caller can produce by
+    accident. CORS headers still travel — a browser-based client must be able to
+    read the 202 — while `Content-Type` deliberately does not: there is no content
+    to describe, and announcing `application/json` for an empty body is the sort of
+    small lie a strict client is entitled to complain about.
+    """
+    return {
+        'statusCode': 202,
+        'headers': dict(CORS_HEADERS),
+        'body': '',
+    }
+
+
+def _request_header(event: dict, name: str) -> str | None:
+    """One header, matched case-insensitively, or None when absent.
+
+    `name` is the LOWERCASE spelling; every key on the event is folded before
+    comparison. API Gateway lowercases header names in proxy mode, but a direct
+    invoke (a test, a local driver) does not, and a guard has to hold for both.
+    An empty value is NOT absence: a client that sent a header empty said
+    something, and what it said is not a valid value for any header read here.
+
+    A non-dict `headers` reads as absence. A Lambda proxy event always delivers a
+    dict or null, so this needs a direct invoke or a non-API-Gateway trigger to
+    reach — but the alternative is an `AttributeError` from `.get`, and the one
+    caller that ran before the handler's try/except turned that into a 502 with no
+    JSON-RPC envelope and no CORS headers.
+
+    ⚠️ Shared by `_origin_allowed`, the transport headers and the credential read,
+    which is the point: it is the only header reader in this module, so a casing
+    or a shape that would bypass one guard bypasses none of them. `_origin_allowed`
+    used to match `'origin'` and `'Origin'` by hand, so `ORIGIN:` or `oRigin:`
+    walked past the DNS-rebinding guard on a direct invoke.
+    """
+    headers = event.get('headers') or {}
+    if not isinstance(headers, dict):
+        return None
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == name:
+            return value if isinstance(value, str) else ''
+    return None
+
+
 def _origin_allowed(event: dict) -> bool:
     """DNS-rebinding guard: reject a browser-presented Origin that is not ours.
 
@@ -598,9 +777,16 @@ def _origin_allowed(event: dict) -> bool:
     '*' (dev deployments) passes everything. Comparison is exact-string on the
     scheme+host+port tuple the browser sends — no normalisation, mirroring the
     strictness the MCP auth spec demands for issuer comparison.
+
+    The header is read through `_request_header`, the shared reader, which closes
+    two gaps this function had while it read `event['headers']` by hand: it matched
+    only `'origin'` and `'Origin'`, so `ORIGIN:` or `oRigin:` bypassed the guard
+    entirely on a direct invoke, and `.get` on a non-dict `headers` raised
+    `AttributeError`. This function runs FIRST in `lambda_handler`, outside its
+    try/except, so that raise was a 502 with no JSON-RPC envelope and no CORS
+    headers — the exact shape the `BotoCoreError` clause exists to avoid.
     """
-    headers = event.get('headers') or {}
-    origin = headers.get('origin') or headers.get('Origin') or ''
+    origin = _request_header(event, 'origin') or ''
     if not origin:
         return True
     if ALLOWED_ORIGIN == '*':
@@ -647,12 +833,28 @@ _ENCODED_WORD = re.compile(r'\A=\?base64\?(.*)\?=\Z', re.DOTALL)
 #
 # (-32021 MissingRequiredClientCapability is the third in the range and is not
 # used here: this server requires no client capability.)
+#
+# ⚠️ WHICH spec: BOTH CODES ARE DEFINED BY 2026-07-28 ONLY, and no advertised
+# revision defines any code in that sub-range. So every client this server actually
+# talks to receives a code its own revision does not define. That is the one
+# genuine judgement call in the provenance note at `ASSUMED_PROTOCOL_VERSION`, and
+# it is argued in full there: kept because the fallback (-32600) actively misleads
+# a dual-era client's era probe into legacy fallback, and because an unrecognized
+# error CODE — unlike an unrecognized `resultType` VALUE — obliges a client to
+# reject nothing, while the recovery path travels in `data.supported`, which is
+# readable without knowing the code.
 JSONRPC_HEADER_MISMATCH = -32020
 JSONRPC_UNSUPPORTED_PROTOCOL_VERSION = -32022
 
-# JSON-RPC's own code for a method this server does not implement. Paired with
-# HTTP 404 by the Streamable HTTP transport, which is what lets a client tell this
-# apart from the 404 of a legacy HTTP+SSE server that does not host the endpoint.
+# JSON-RPC's own code for a method this server does not implement — from JSON-RPC
+# 2.0 itself, so unlike the two above every revision knows it.
+#
+# Paired with HTTP 404 by the Streamable HTTP transport, which is what lets a client
+# tell this apart from the 404 of a legacy HTTP+SSE server that does not host the
+# endpoint. ⚠️ That PAIRING is 2026-07-28's rule, and on the advertised revisions a
+# 404 here also carries a session meaning — which is why only a REQUEST is answered
+# with it and a notification is answered 202. See the unknown-method branch in
+# `lambda_handler`.
 JSONRPC_METHOD_NOT_FOUND = -32601
 
 # `-32600 Invalid Request` for a malformed transport that is neither of the two
@@ -694,24 +896,6 @@ class InvalidTransportHeader(Exception):
         self.status_code = status_code
 
 
-def _request_header(event: dict, name: str) -> str | None:
-    """One header, matched case-insensitively, or None when absent.
-
-    API Gateway lowercases header names in proxy mode, but a direct invoke (a
-    test, a local driver) does not, and the guard has to hold for both — the same
-    lesson `_origin_allowed` records for `Origin`. An empty value is NOT absence:
-    a client that sent the header empty said something, and what it said is not a
-    valid value for any of the three.
-    """
-    headers = event.get('headers') or {}
-    if not isinstance(headers, dict):
-        return None
-    for key, value in headers.items():
-        if isinstance(key, str) and key.lower() == name:
-            return value if isinstance(value, str) else ''
-    return None
-
-
 def _decoded_header(raw: str, name: str) -> str:
     """A header value with the encoded-word sentinel resolved.
 
@@ -721,6 +905,22 @@ def _decoded_header(raw: str, name: str) -> str:
     compared literally: treating `=?base64?not-base64?=` as a version string
     would report "unsupported protocol version =?base64?…?=", which sends the
     caller after a version number when the fault is the encoding.
+
+    Accepted on `MCP-Protocol-Version` too, which is WIDER than the spec asks: the
+    sentinel is defined for `Mcp-Name` and `Mcp-Param-{Name}`, and a date string is
+    always header-safe so a conforming client has no reason to encode one. Kept
+    deliberately — decoding is not permitting, and the version rule survives the
+    spelling — rather than refusing a decodable value on the grounds that nobody
+    should have sent it.
+
+    ⚠️ CONSTRAINT ON FUTURE CALLERS. `validate=True` rejects non-alphabet
+    characters in the payload, but the DECODED UTF-8 may still carry control
+    characters — a CR or an LF is exactly what an encoded-word smuggles past a
+    header parser. Every value this returns today is compared against a body value
+    and then discarded, so nothing is injected anywhere; that is a property of the
+    three call sites, NOT of this function. A caller that logs a decoded value or
+    forwards it into a downstream header or path needs a CR/LF guard first, and
+    that is the moment to add one here rather than at the new call site.
     """
     match = _ENCODED_WORD.match(raw)
     if not match:
@@ -768,15 +968,15 @@ def _negotiate_protocol_version(requested: Any) -> str:
     with the counter-offer closes the connection, which is its decision to make.
 
     Contrast the HEADER (`_validated_protocol_version` below), where an
-    unsupported value IS refused: by then the handshake has happened, so a
-    version this server never offered can only be a client contradicting itself.
+    unsupported value IS refused — for every method EXCEPT this one. See that
+    function for why the handshake is the exception.
     """
     if isinstance(requested, str) and requested in SUPPORTED_PROTOCOL_VERSIONS:
         return requested
     return PREFERRED_PROTOCOL_VERSION
 
 
-def _validated_protocol_version(event: dict) -> str:
+def _validated_protocol_version(event: dict, method: str = '') -> str:
     """The revision named by the transport header, refusing one we cannot speak.
 
     An ABSENT header reads as `ASSUMED_PROTOCOL_VERSION` (2025-03-26), which is
@@ -786,12 +986,50 @@ def _validated_protocol_version(event: dict) -> str:
     those clients; reading it as the NEWEST supported revision — as this did —
     silently upgrades precisely the clients that cannot be upgraded. A client that
     DOES send the header has made a claim this server can check.
+
+    ⚠️ `initialize` IS EXEMPT from the refusal, and this is the asymmetry the
+    docstring above points at. The earlier reading — "by then the handshake has
+    happened, so a version this server never offered can only be a client
+    contradicting itself" — is true of request N and false of request 1. A client
+    whose newest revision is 2026-07-28 MUST send that value on its very first
+    POST: that revision requires the header on every request and has no handshake
+    to learn a different value from. Refusing it here meant a current-generation
+    SDK's first contact was a hard 400 and `_negotiate_protocol_version` — the
+    counter-offer that exists for exactly this client — was unreachable, because
+    validation runs before dispatch and `initialize` never ran.
+
+    So on the handshake an unsupported header value falls THROUGH to
+    `_handle_initialize`, which counter-offers the newest revision this server
+    speaks, and the client learns in one round trip what it would otherwise have
+    had to parse out of an error. A 400 on first contact is also what a dual-era
+    client reads as "possibly a legacy server", so the refusal cost a round trip
+    and risked an era misdetection to enforce a rule the handshake already handles.
+
+    Every other method keeps the refusal, `ping` and `server/discover` included:
+    past the handshake a client has a negotiated value to send, and one this server
+    never offered is the client contradicting itself.
+
+    The exemption is narrow: it covers a well-formed value naming a revision this
+    server does not implement, which is the case a counter-offer answers. Two
+    faults are still refused on `initialize`:
+
+      • a malformed encoded-word sentinel, which raises from `_decoded_header`
+        before this function compares anything — there is nothing to counter-offer
+        about a value that does not decode, and the fault is the encoding;
+      • an EMPTY value, refused just below. A client that sent the header empty has
+        not named a revision, so there is no claim to negotiate against; treating
+        it as an unsupported version would answer a version question nobody asked.
     """
     raw = _request_header(event, PROTOCOL_VERSION_HEADER)
     if raw is None:
         return ASSUMED_PROTOCOL_VERSION
     version = _decoded_header(raw, PROTOCOL_VERSION_HEADER)
     if version not in SUPPORTED_PROTOCOL_VERSIONS:
+        if method == 'initialize' and version:
+            # Not an error, and not the client's value either: the session speaks
+            # what the handshake negotiates, which is `PREFERRED_PROTOCOL_VERSION`
+            # for a header naming a revision this server does not implement.
+            return PREFERRED_PROTOCOL_VERSION
         raise InvalidTransportHeader(
             f'Unsupported protocol version {version!r}. This server speaks: '
             f'{", ".join(SUPPORTED_PROTOCOL_VERSIONS)}',
@@ -1802,6 +2040,13 @@ MCP_TOOLS = [_published_tool(declaration) for declaration in _TOOL_DECLARATIONS]
 # `private` is the spec's own encoding of exactly the property the credential
 # filter makes load-bearing: "Cached responses MAY be reused for the same
 # authorization context. Caches MUST NOT be shared across authorization contexts."
+#
+# ⚠️ BOTH FIELDS ARE DEFINED BY 2026-07-28, which this server does not advertise —
+# so "it REQUIRES them" above is that revision's requirement, and under the
+# advertised range they are additive extras a client may ignore. Sending them early
+# is the deliberate bet recorded in the PROVENANCE block at
+# `ASSUMED_PROTOCOL_VERSION`; the alternative was the locally-invented
+# `_meta.cacheHints` this replaced, renamed later.
 CACHE_SCOPE_PUBLIC = 'public'
 CACHE_SCOPE_PRIVATE = 'private'
 
@@ -2357,6 +2602,11 @@ TOOL_REACH_KINDS: dict[str, str] = {
 # `complete` on every result here is the whole vocabulary this server needs:
 # `input_required` belongs to multi-round-trip requests, and no tool asks the
 # caller for more input mid-call.
+#
+# ⚠️ DEFINED BY 2026-07-28, which this server does not advertise. Sent anyway
+# because it is additive under every advertised revision's permissive `Result`
+# schema; see the PROVENANCE block at `ASSUMED_PROTOCOL_VERSION` for the full
+# argument and for what changes when that revision becomes negotiable.
 RESULT_TYPE_KEY = 'resultType'
 RESULT_TYPE_COMPLETE = 'complete'
 
@@ -2368,22 +2618,29 @@ RESULT_TYPE_COMPLETE = 'complete'
 #
 # 🔑 Why a discriminator at all, rather than "look at which keys are present":
 # every result here is a bare JSON object, and telling them apart by key
-# inference is guesswork that gets worse as shapes grow. `{}` is both a `ping`
-# answer and a notification acknowledgement; a tool result and a tool ERROR
-# differ only by a boolean and by whether `structuredContent` happens to be
-# there. A client switching on inferred shape re-derives that table from scratch,
-# gets it subtly wrong, and the failure lands in the client rather than here.
+# inference is guesswork that gets worse as shapes grow. A tool result and a tool
+# ERROR differ only by a boolean and by whether `structuredContent` happens to be
+# there; `ping` answers a bare `{}`. A client switching on inferred shape
+# re-derives that table from scratch, gets it subtly wrong, and the failure lands
+# in the client rather than here.
 #
 # `toolError` is a distinct shape rather than "a toolResult with isError" ON
 # PURPOSE, and `isError` is still sent: the flag is what the spec defines, the
 # shape is what says the payload has no `structuredContent` to validate.
+#
+# ⚠️ There is NO `ack` shape, and its absence is load-bearing rather than an
+# omission. It existed to describe the answer to a notification — and a
+# notification gets 202 Accepted with no body, which every advertised revision
+# states as a MUST, so there is no result to name. Adding one back would be
+# describing a response the transport says must not be sent; the pong/ack pair
+# that half-justified this discriminator was a pair of answers to a message that
+# should have had one.
 RESULT_SHAPE_INITIALIZE = 'initialize'
 RESULT_SHAPE_DISCOVERY = 'discovery'
 RESULT_SHAPE_TOOL_LIST = 'toolList'
 RESULT_SHAPE_TOOL_RESULT = 'toolResult'
 RESULT_SHAPE_TOOL_ERROR = 'toolError'
 RESULT_SHAPE_PONG = 'pong'
-RESULT_SHAPE_ACK = 'ack'
 
 RESULT_SHAPES: frozenset[str] = frozenset({
     RESULT_SHAPE_INITIALIZE,
@@ -2392,7 +2649,6 @@ RESULT_SHAPES: frozenset[str] = frozenset({
     RESULT_SHAPE_TOOL_RESULT,
     RESULT_SHAPE_TOOL_ERROR,
     RESULT_SHAPE_PONG,
-    RESULT_SHAPE_ACK,
 })
 
 
@@ -2522,6 +2778,14 @@ def _handle_discover(req_id: Any, _params: dict) -> dict:
     off than if the method did not exist. The extra facts this server can report
     are still reported — under a vendor-prefixed `_meta` key, which is where the
     cost class already lives and for the same reason.
+
+    ⚠️ THE METHOD ITSELF, and `DiscoverResult` with it, is defined by 2026-07-28 —
+    the revision this server does not advertise. It is offered under the advertised
+    range as an extra method a client is free never to call, which is additive in
+    the strongest sense: a client that does not know it asks for `initialize`
+    instead and loses nothing, and one that does know it gets the spec's own field
+    names rather than a local approximation it would have to unlearn. See the
+    PROVENANCE block at `ASSUMED_PROTOCOL_VERSION`.
     """
     return _jsonrpc_result(req_id, RESULT_SHAPE_DISCOVERY, {
         # The spec's name for this list, and the one field a client calls this
@@ -2985,7 +3249,9 @@ MCP_METHODS = {
     "initialize": _handle_initialize,
     "ping": _handle_ping,
     "server/discover": _handle_discover,
-    "notifications/initialized": None,  # notification, no response needed
+    # `None` means "this method produces no result": it is answered with 202 and
+    # no body, not with a result carrying `id: null`. See `_is_notification`.
+    "notifications/initialized": None,
 }
 
 # Methods that require authentication
@@ -2993,6 +3259,40 @@ MCP_AUTH_METHODS = {
     "tools/list": _handle_tools_list,
     "tools/call": _handle_tools_call,
 }
+
+
+# The prefix MCP gives every notification method it defines. Used to tell a
+# fire-and-forget message from a request WITHOUT a table of them, which matters
+# because the notifications this server does not implement are the ones that need
+# recognising: `notifications/cancelled`, `notifications/progress` and
+# `notifications/roots/list_changed` are all methods a conforming client may send
+# and none of them is dispatched here.
+_NOTIFICATION_METHOD_PREFIX = 'notifications/'
+
+
+def _is_notification(body: Any, method: str) -> bool:
+    """True when this message is a JSON-RPC notification: no reply may be sent.
+
+    Two conditions, and BOTH are required:
+
+      • no `id` MEMBER in the body — JSON-RPC's own definition of a notification
+        is "a Request object without an id member". Tested with `not in` rather
+        than by truthiness, because `"id": 0` and `"id": null` are present members
+        and only one of the three is a notification;
+      • a `notifications/`-prefixed method — MCP's naming convention for the whole
+        class of them.
+
+    Requiring both keeps two things straight that a single test would confuse. An
+    `id` PRESENT on a `notifications/` method makes it a request by JSON-RPC's
+    definition, so it is answered like one (`-32601` for a method that is not
+    dispatched) instead of being silently accepted; and a malformed body with no
+    `id` — a bare `[]`, a string, a number — is not promoted to a notification and
+    accepted, which is what an id-only test would have done to precisely the input
+    that used to crash this handler.
+    """
+    if not isinstance(body, dict) or 'id' in body:
+        return False
+    return method.startswith(_NOTIFICATION_METHOD_PREFIX)
 
 
 @tracer.capture_method
@@ -3149,12 +3449,14 @@ def lambda_handler(event: dict, context: Any) -> dict:
     # authentication for the same reason `_origin_allowed` is — a malformed
     # request should not buy a probe of the token store.
     #
-    # The protocol version is validated even for `initialize`, which is not a
-    # contradiction: the HEADER is the transport's version, the handshake's
-    # `params.protocolVersion` is the session's, and a client may state a
-    # transport version it cannot be served on its very first request.
+    # The METHOD is passed to the version check because the handshake is exempt
+    # from the refusal: a current-generation client MUST send its own revision in
+    # the header on its very first request and has no negotiated value to send
+    # instead, so refusing there made `_handle_initialize`'s counter-offer
+    # unreachable for exactly the clients it exists for. Every other method keeps
+    # the refusal. The reasoning is at `_validated_protocol_version`.
     try:
-        _validated_protocol_version(event)
+        _validated_protocol_version(event, method)
         _validate_routing_headers(event, method, params)
     except InvalidTransportHeader as exc:
         # The code, the `data` payload and the status all come from the exception
@@ -3168,8 +3470,37 @@ def lambda_handler(event: dict, context: Any) -> dict:
             status_code=exc.status_code,
         )
 
+    # A NOTIFICATION is answered 202 with no body and nothing else — before the
+    # dispatch tables are consulted, because the answer is the same whether or not
+    # this server implements the notification in question.
+    #
+    # Every advertised revision states it as a MUST: "If the input is a JSON-RPC
+    # response or notification: If the server accepts the input, the server MUST
+    # return HTTP status code 202 Accepted with no body." Two defects lived here:
+    #
+    #   • `notifications/initialized` was answered with a 200 and a full JSON-RPC
+    #     result carrying `id: null` — a reply to a message that gets no reply, and
+    #     an ill-formed one, since a result's id must not be null;
+    #   • every OTHER notification fell through to the unknown-method branch and
+    #     was answered `404`. On this endpoint a 404 has a specific meaning in the
+    #     advertised revisions — the session was terminated, and a client receiving
+    #     one "MUST start a new session by sending a new InitializeRequest". So a
+    #     client sending `notifications/cancelled`, which is the transport's own
+    #     cancellation mechanism, was told by the revision it negotiated to tear
+    #     down its session and re-initialize. The 404-for-an-unknown-method rule is
+    #     2026-07-28's, and that revision is deliberately not advertised here.
+    #
+    # ACCEPTED rather than refused, for the notifications this server does not
+    # implement as much as for the one it does: a notification carries no
+    # obligation to act, so accepting and ignoring one is what a server with no
+    # cancellation semantics honestly does. Refusing would report a failure to a
+    # sender that is not listening for one.
+    if _is_notification(body, method):
+        logger.info(f"MCP notification accepted: method={method}")
+        return _accepted_no_content()
+
     # Handle the methods that need no credential (initialize, ping,
-    # server/discover, notifications).
+    # server/discover).
     if method in MCP_METHODS:
         # A PRESENTED credential is checked on the methods a client uses to decide
         # it is CONNECTED, and this is the honesty fix this envelope owes: a revoked
@@ -3185,8 +3516,17 @@ def lambda_handler(event: dict, context: Any) -> dict:
             return refusal
         handler = MCP_METHODS[method]
         if handler is None:
-            # Notification — no response needed, but HTTP requires a body
-            return _cors_response(_jsonrpc_result(req_id, RESULT_SHAPE_ACK, {}))
+            # A `None` handler is a method that produces no result, which is only
+            # ever a notification — and one carrying an `id` reached here rather
+            # than the 202 above, so it is a REQUEST naming a notification method.
+            # JSON-RPC says the id makes it a request, and this server implements
+            # no request by that name, so it gets the request answer.
+            return _cors_response(
+                _jsonrpc_error(req_id, JSONRPC_METHOD_NOT_FOUND,
+                               f"Method not found: {method} is a notification and "
+                               f"takes no id"),
+                status_code=404,
+            )
         return _cors_response(handler(req_id, params))
 
     # All other methods require authentication
@@ -3214,18 +3554,34 @@ def lambda_handler(event: dict, context: Any) -> dict:
         # wrong arguments without anything saying so.
         return _cors_response(MCP_AUTH_METHODS[method](req_id, params, token_info))
 
-    # An unknown method is JSON-RPC's own -32601, and nothing else: a client
+    # An unknown REQUEST is JSON-RPC's own -32601, and nothing else: a client
     # probing for a method this server might have needs to be able to tell
     # "no such method here" from a refusal it could fix. `server/discover` exists
     # so the probe is unnecessary in the first place.
     #
-    # HTTP 404 alongside it, which the Streamable HTTP transport REQUIRES and which
-    # is not merely decorative: it is what a dual-era client's fallback probe reads,
-    # and the JSON-RPC body is what distinguishes this 404 from the 404 of a legacy
-    # HTTP+SSE server that does not host the modern endpoint at all. Answering 200
-    # here — as this did — left the status saying "your request was fine" about a
-    # method that does not exist, while the 405 path in this same module already
-    # set a status for the same class of "this server does not do that".
+    # Only a request reaches here. A notification was answered 202 above, which is
+    # the distinction this branch used to miss: `notifications/cancelled` and its
+    # siblings are not dispatched by this server, so they landed here and were told
+    # 404 — see that comment for why that is worse than untidy.
+    #
+    # HTTP 404 alongside the code, which the Streamable HTTP transport REQUIRES and
+    # which is not merely decorative: it is what a dual-era client's fallback probe
+    # reads, and the JSON-RPC body is what distinguishes this 404 from the 404 of a
+    # legacy HTTP+SSE server that does not host the modern endpoint at all.
+    # Answering 200 — as this did — left the status saying "your request was fine"
+    # about a method that does not exist, while the 405 path in this same module
+    # already set a status for the same class of "this server does not do that".
+    #
+    # ⚠️ The 404 is OVERLOADED on this endpoint, and the overload is why it is
+    # confined to requests. The dedicated 404-for-an-unknown-method rule is
+    # 2026-07-28's; in the revisions this server actually advertises, a 404 on the
+    # MCP endpoint means the SESSION was terminated and a client receiving one
+    # "MUST start a new session by sending a new InitializeRequest". A client that
+    # asked for a method this server does not implement re-initializing is a wasted
+    # round trip and no worse — it re-establishes a session that still works and
+    # the method is still absent. A client whose CANCELLATION was answered that way
+    # tore down a live session over routine traffic, which is why notifications
+    # never reach this line.
     return _cors_response(
         _jsonrpc_error(req_id, JSONRPC_METHOD_NOT_FOUND, f"Method not found: {method}"),
         status_code=404,
@@ -3251,7 +3607,10 @@ def lambda_handler(event: dict, context: Any) -> dict:
 #   • A NOTIFICATION CARRIES NO ID. JSON-RPC says a notification gets no response at
 #     all, so answering one with a 401 replies to a message that must not be replied
 #     to. The honesty defect was never about notifications anyway: nobody concludes
-#     "connected" from an un-refused notification.
+#     "connected" from an un-refused notification. This is now structural rather
+#     than a matter of this set's contents — a notification is answered 202 before
+#     the dispatch is reached, so it cannot arrive here — and the entry stays out
+#     for the same reason it was never in.
 _LIVENESS_CHECKED_METHODS: frozenset[str] = frozenset({
     'initialize',
     'server/discover',

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -955,9 +955,29 @@ def _header_values(event: dict, name: str) -> list[str]:
         `-32020` refusal exists for, reached through a duplicate rather than
         through a header/body disagreement.
 
-    Deduplicated, so two IDENTICAL values are one value: a client (or an
-    intermediary) restating the same thing twice has not contradicted itself, and
-    refusing that would refuse requests for no gain.
+    Deduplicated ON THE RAW CANDIDATE, so two IDENTICAL values are one value: a
+    client (or an intermediary) restating the same thing twice has not
+    contradicted itself, and refusing that would refuse requests for no gain.
+    Raw, not coerced, and the ordering is the point: coercing non-strings to `''`
+    BEFORE the dedup collapsed two DIFFERENT unusable values into one, so
+    `multiValueHeaders={'origin': [None, 42]}` reached `_request_header` as a
+    single `''` and never hit its `len(values) > 1` refusal — and `''` is how this
+    module spells ABSENT, so the DNS-rebinding guard read two contradictory
+    origins as no origin at all and served the request. Two distinct unusable
+    values now stay two values and are refused as a duplicate (their coerced
+    reprs may coincide as `'', ''` in the message, which is honest: what was sent
+    twice is two things, neither of them a usable value).
+    `test_two_unusable_values_for_one_header_are_still_a_duplicate` and
+    `test_two_unusable_origins_are_refused_not_read_as_absent` fail if the
+    coercion moves back inside the dedup.
+
+    ⚠️ The guard's REACH is tied to the REST proxy event shape read here. An
+    HTTP API (payload 2.0) event carries no `multiValueHeaders` at all and
+    comma-joins duplicated headers into one `headers` value, so the ambiguity
+    this refuses would arrive pre-collapsed as a single value and be served.
+    This endpoint is declared on a REST API in `api-stack.ts`, so that shape
+    does not reach it today — but a migration to an HTTP API must revisit this
+    reader, because none of the duplicate refusals downstream of it would fire.
 
     A non-dict `headers` or `multiValueHeaders` reads as absence rather than
     raising: a Lambda proxy event always delivers a dict or null, so this needs a
@@ -966,6 +986,12 @@ def _header_values(event: dict, name: str) -> list[str]:
     envelope and no CORS headers.
     """
     values: list[str] = []
+    # The raw candidates already seen, kept SEPARATELY from the coerced values:
+    # identity is decided on what the request actually carried, and only the
+    # answer is coerced. `list` rather than `set` because a direct-invoke
+    # candidate need not be hashable, and `in` on a list compares by equality,
+    # which is the identity a duplicate check wants.
+    seen: list[Any] = []
     for source_key in ('headers', 'multiValueHeaders'):
         source = event.get(source_key) or {}
         if not isinstance(source, dict):
@@ -976,12 +1002,16 @@ def _header_values(event: dict, name: str) -> list[str]:
             # A `multiValueHeaders` entry is a list; a `headers` entry is a scalar.
             # A non-string value reads as the empty string for the reason
             # `_request_header` documents: a header that arrived carrying something
-            # unusable said something, and it is not a valid value here.
+            # unusable said something, and it is not a valid value here. The
+            # coercion runs AFTER the dedup — coercing first erased the identity
+            # of two DIFFERENT unusable values, and `_origin_allowed` read the
+            # resulting single `''` as an absent Origin (see the docstring).
             candidates = raw if isinstance(raw, list) else [raw]
             for candidate in candidates:
-                value = candidate if isinstance(candidate, str) else ''
-                if value not in values:
-                    values.append(value)
+                if candidate in seen:
+                    continue
+                seen.append(candidate)
+                values.append(candidate if isinstance(candidate, str) else '')
     return values
 
 
@@ -1209,8 +1239,13 @@ def _decoded_header(raw: str, name: str) -> str:
     try:
         decoded = base64.b64decode(match.group(1), validate=True).decode('utf-8')
     except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
+        # `_canonical_header_name`, as in every neighbouring refusal: `name` is
+        # the lowercase form API Gateway normalisation forced on this module, and
+        # interpolating it told a client about a header it never sent. The
+        # fallback branch covers callers passing a non-transport name.
         raise InvalidTransportHeader(
-            f'{name} is in encoded-word form but its payload is not base64-encoded UTF-8'
+            f'{_canonical_header_name(name)} is in encoded-word form but its '
+            f'payload is not base64-encoded UTF-8'
         ) from exc
     if not decoded:
         # `=?base64??=` is well-formed base64 of nothing. Refused HERE, with the
@@ -1219,7 +1254,8 @@ def _decoded_header(raw: str, name: str) -> str:
         # through would report "unsupported protocol version ''" — an answer about
         # a version, for a fault in the encoding.
         raise InvalidTransportHeader(
-            f'{name} is in encoded-word form but its base64 payload is empty'
+            f'{_canonical_header_name(name)} is in encoded-word form but its '
+            f'base64 payload is empty'
         )
     return decoded
 
@@ -3062,6 +3098,25 @@ RESULT_SHAPES: frozenset[str] = frozenset({
 # So "no id at all" and "an id of null" are two different answers and cannot share
 # one spelling — which is the same distinction `_is_notification` turns on, one
 # layer down.
+#
+# ⚠️ THE RULE FOR WHICH REFUSALS USE WHICH, stated here because it was previously
+# only inferable from which call sites happened to be changed:
+#
+#   • `_NO_ID` — NO JSON-RPC message could have carried an id. A notification and
+#     an id-less request (their bodies carry no `id` member, by `_carries_no_id`);
+#     the Origin 403 (it runs before the body is parsed, and its subject may
+#     legitimately be a notification); and the 405 (a `GET` or `DELETE` typically
+#     carries no body — there is no message at all, so there is no id to have
+#     failed to detect).
+#   • `None`, i.e. `"id": null` — a message WAS claimed and its id could not be
+#     DETECTED. The parse error, the non-object body, and the batch (many
+#     messages, no single id): JSON-RPC's own rule for an undetectable id is
+#     `null`, and `test_a_non_object_body_is_not_a_crash` pins it deliberately.
+#
+# The discriminator is whether "there is an id, and what is it?" was a question
+# this server can honestly say it could not answer (null), or a question that has
+# no subject (omitted). A future refusal that runs before `json.loads` should ask
+# which of those two it is, not copy its nearest neighbour.
 _NO_ID = object()
 
 
@@ -3744,6 +3799,31 @@ def _is_notification(body: Any, method: str) -> bool:
     return method.startswith(_NOTIFICATION_METHOD_PREFIX)
 
 
+def _carries_no_id(body: Any) -> bool:
+    """True when the message body carries NO `id` member at all.
+
+    The condition the transport's no-id allowance actually turns on. A refusal's
+    envelope omits the `id` when its subject carries none — and that is true of a
+    notification AND of an id-less non-notification alike, which is why this is a
+    separate predicate from `_is_notification` rather than a call to it.
+
+    It exists because the transport-guard refusal used to ask the narrower
+    question: `_is_notification` is deliberately False for an id-less `ping`
+    (MCP defines no id-less form of it), so an id-less `ping` that tripped a
+    header guard was answered `id: null` — the exact defect the id-less `-32600`
+    branch removes, reached one guard earlier. The two branches were disagreeing
+    about the same message. Both now ask this predicate, so they cannot.
+
+    `not in` rather than truthiness, for the same reason `_is_notification`
+    documents: `"id": 0` and `"id": null` are PRESENT members, and a refusal must
+    echo them (`test_a_refused_request_still_carries_its_id` pins the echo).
+    A non-dict body answers False — its id is UNDETECTABLE rather than absent,
+    and JSON-RPC's own rule spells an undetectable id as `null`, not as omission
+    (the distinction `_NO_ID`'s comment records).
+    """
+    return isinstance(body, dict) and 'id' not in body
+
+
 def _is_batch(body: Any) -> bool:
     """True when the body is a JSON-RPC BATCH — an array of messages.
 
@@ -3928,9 +4008,16 @@ def lambda_handler(event: dict, context: Any) -> dict:
     # OPTIONS`, because that is what that path serves. `autoseed_match` has already
     # been evaluated above, so the two answers cannot disagree about which path
     # this is.
+    #
+    # `_NO_ID`, not `None`: a `GET` or a `DELETE` typically carries no body, so
+    # this is not a message whose id could not be detected — it is no JSON-RPC
+    # message at all, and `id: null` claimed an undetectable id for a request
+    # that never claimed to carry one. Same side of the rule at `_NO_ID` as the
+    # Origin 403; the parse error below stays `null`, because there a message WAS
+    # claimed and its id is genuinely undetectable.
     if http_method != 'POST':
         return _cors_response(
-            _jsonrpc_error(None, JSONRPC_INVALID_REQUEST,
+            _jsonrpc_error(_NO_ID, JSONRPC_INVALID_REQUEST,
                            f"Method not allowed: {http_method or 'unknown'}"),
             status_code=405,
             allow=_ALLOW_AUTOSEED if autoseed_match else _ALLOW_JSONRPC,
@@ -4056,19 +4143,31 @@ def lambda_handler(event: dict, context: Any) -> dict:
         # first draft of this change lost both the client's recovery path and the
         # era-detection signal.
         #
-        # ⚠️ The MESSAGE KIND is consulted here even though this runs before the
-        # notification branch, and it has to be: a notification that fails a guard is
-        # still a notification, and its refusal was the last place `id: null` was
-        # sent to a message that carries no id. The advertised revisions say a
-        # notification the server cannot accept gets an HTTP error status whose body
-        # "MAY comprise a JSON-RPC error response that has NO id" — so the STATUS and
-        # the code stay exactly as they were and only the envelope changes. This
-        # branch is not the notification's acceptance path (that is the 202 below,
-        # and it is deliberately still after the guards); it is the refusal path
-        # learning what it is refusing.
+        # ⚠️ WHETHER THE BODY CARRIES AN ID is consulted here even though this runs
+        # before the notification branch, and it has to be: a message that fails a
+        # guard still carries (or does not carry) whatever id it carried, and this
+        # refusal was the last place `id: null` was sent to a message that carries
+        # no id. The advertised revisions say a notification the server cannot
+        # accept gets an HTTP error status whose body "MAY comprise a JSON-RPC
+        # error response that has NO id" — so the STATUS and the code stay exactly
+        # as they were and only the envelope changes.
+        #
+        # `_carries_no_id`, NOT `_is_notification`: the condition the transport's
+        # allowance turns on is "the subject carries no id", and an id-less `ping`
+        # is exactly as id-less as a notification. Asking the narrower question
+        # here answered `id: null` to an id-less non-notification that tripped a
+        # header guard — the defect the id-less `-32600` branch below removes,
+        # reached one guard earlier — so the two branches disagreed about the same
+        # message. `test_an_idless_request_refused_by_a_transport_guard_omits_the_id`
+        # fails if `_is_notification` comes back;
+        # `test_a_refused_request_still_carries_its_id` fails if the id stops
+        # being echoed for a body that has one. This branch is not the
+        # notification's acceptance path (that is the 202 below, and it is
+        # deliberately still after the guards); it is the refusal path learning
+        # what it is refusing.
         return _cors_response(
             _jsonrpc_error(
-                _NO_ID if _is_notification(body, method) else req_id,
+                _NO_ID if _carries_no_id(body) else req_id,
                 exc.code, str(exc), exc.data,
             ),
             status_code=exc.status_code,
@@ -4135,7 +4234,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
     #
     # Placed after the notification branch and before the dispatch, so a real
     # notification still reaches its 202 and no handler is ever called without an id.
-    if isinstance(body, dict) and 'id' not in body:
+    if _carries_no_id(body):
         logger.info(f"MCP id-less non-notification refused: method={method}")
         return _cors_response(
             _jsonrpc_error(

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -85,13 +85,13 @@ SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
 # What an `initialize` that asks for nothing usable is answered with, and what a
 # request carrying no `MCP-Protocol-Version` header is read as. Derived rather
 # than restated so it cannot disagree with the tuple above.
+#
+# This replaces the `MCP_PROTOCOL_VERSION` constant outright rather than aliasing
+# it. An alias would have kept a name meaning "the only version this server
+# speaks" alive next to the tuple that makes that untrue — and nothing outside
+# this module read it, so keeping it would have been a second name for one fact,
+# maintained by nobody.
 PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
-
-# The name kept from the pinned-constant era, now meaning "the version this
-# server prefers" rather than "the only version it speaks". Kept because it is
-# the value `serverInfo`-adjacent tooling and the frontend docs refer to, and
-# because deleting it would be a rename with no behavioural content.
-MCP_PROTOCOL_VERSION = PREFERRED_PROTOCOL_VERSION
 
 # Semver on the SERVER, independent of the protocol revision above, and the only
 # signal a client gets that a tool's output shape moved — it is advertised in
@@ -395,6 +395,31 @@ TRANSPORT_HEADERS: tuple[str, ...] = (
     NAME_HEADER,
 )
 
+
+def _canonical_header_name(header: str) -> str:
+    """The wire spelling of a header this module reads in lowercase.
+
+    Derived rather than declared twice: the lowercase forms above exist only
+    because API Gateway normalises what it delivers, while a CORS allowlist and a
+    discovery answer are read by clients that spell headers the canonical way. Two
+    hand-written lists is how one gains a header the other does not.
+
+    `MCP` keeps its acronym casing; every other segment title-cases, which is what
+    makes `MCP-Protocol-Version`.
+    """
+    return '-'.join(
+        'MCP' if part == 'mcp' else part.capitalize()
+        for part in header.split('-')
+    )
+
+
+# Every transport header in the spelling a client sends, for the CORS allowlist and
+# for `server/discover`. Sorted so a client diffing two discoveries sees a change
+# only when one happened.
+CANONICAL_TRANSPORT_HEADERS: tuple[str, ...] = tuple(
+    sorted(_canonical_header_name(header) for header in TRANSPORT_HEADERS)
+)
+
 CORS_HEADERS = {
     'Access-Control-Allow-Origin': '*',
     # X-Project-Id is gone: the credential carries its own project reach, so a
@@ -405,14 +430,11 @@ CORS_HEADERS = {
     # that sends one would otherwise be stopped by its own preflight before this
     # function ever saw it — a header the server validates but a browser may not
     # send is a rule with no reachable subject. Derived from TRANSPORT_HEADERS so
-    # the two cannot drift; the canonical spelling is restored for the wire, since
-    # the lowercase forms above exist only to read API Gateway's own normalisation.
+    # the two cannot drift.
     'Access-Control-Allow-Headers': ','.join((
         'Content-Type',
         'Authorization',
-        *('-'.join(part.capitalize() if part != 'mcp' else 'MCP'
-                   for part in header.split('-'))
-          for header in TRANSPORT_HEADERS),
+        *CANONICAL_TRANSPORT_HEADERS,
     )),
     'Access-Control-Allow-Methods': 'POST,OPTIONS',
     # Without this a BROWSER-based MCP client can receive the 401 challenge but
@@ -2192,7 +2214,10 @@ def _handle_discover(req_id: Any, _params: dict) -> dict:
         # diffing two discoveries should see a change only when one happened.
         "methods": sorted({*MCP_METHODS, *MCP_AUTH_METHODS}),
         "authenticatedMethods": sorted(MCP_AUTH_METHODS),
-        "transportHeaders": sorted(TRANSPORT_HEADERS),
+        # In the spelling a client SENDS, not the lowercase form this module reads
+        # after API Gateway has normalised it. Reporting the internal spelling
+        # would document an implementation detail as a contract.
+        "transportHeaders": list(CANONICAL_TRANSPORT_HEADERS),
         "resultTypes": sorted(RESULT_TYPES),
         "costClasses": list(COST_CLASSES),
         # The list varies by credential, so a client cannot conclude "these are
@@ -2200,6 +2225,14 @@ def _handle_discover(req_id: Any, _params: dict) -> dict:
         # letting it find out by calling one it was never granted.
         "toolsVaryByCredential": True,
     })
+
+
+# The stand-in a LISTING uses when it must ask a project-shaped question without
+# a project. Only ever reached under `workspace` reach, which admits every project
+# without consulting the id — so this value is never compared against anything and
+# never becomes a path. Named rather than inlined so that is legible at the one
+# place it is read.
+_ANY_PROJECT = 'any-project'
 
 
 def _tool_is_authorized(tool_name: str, token_info: dict) -> bool:
@@ -2222,32 +2255,29 @@ def _tool_is_authorized(tool_name: str, token_info: dict) -> bool:
         return False
     if not _scope_allows(token_info.get('scopes'), required_scope):
         return False
+
     token_projects = token_info.get('projects') or []
     read_reach = token_info.get('read_reach') or DEFAULT_READ_REACH
+    # `reach_allows` decides on a CONCRETE project, and a listing has none, so a
+    # project-shaped tool is asked about a representative one. A project from the
+    # token's own set is the honest representative under every reach; only
+    # `workspace` reach has no such set to draw on, and it is also the one reach
+    # that does not consult the id at all, which is what makes the sentinel safe
+    # rather than a guess. A `project-set` token with an empty set gets None here
+    # and `reach_allows` refuses it, which is right — it can reach no project.
+    representative = None
     if tool_reach_kind == REACH_KIND_PROJECT:
-        # `reach_allows` needs a concrete project, and a listing has none. Any
-        # project in the token's set is representative: `project-set` reach admits
-        # exactly those, and `workspace` admits everything, so a token whose set is
-        # empty and whose reach is `project-set` correctly lists nothing.
-        candidate = next((p for p in token_projects if isinstance(p, str) and p), None)
-        if read_reach == REACH_WORKSPACE:
-            # A sentinel project, so this asks "may this credential reach a
-            # project at all" without inventing one it can reach — workspace reach
-            # does not consult the id, which `reach_allows` is what decides.
-            candidate = candidate or 'any'
-        if not candidate:
-            return False
-        return reach_allows(
-            read_reach=read_reach,
-            token_projects=token_projects,
-            tool_reach_kind=tool_reach_kind,
-            project_id=candidate,
+        representative = next(
+            (p for p in token_projects if isinstance(p, str) and p), None,
         )
+        if representative is None and read_reach == REACH_WORKSPACE:
+            representative = _ANY_PROJECT
+
     return reach_allows(
         read_reach=read_reach,
         token_projects=token_projects,
         tool_reach_kind=tool_reach_kind,
-        project_id=None,
+        project_id=representative,
     )
 
 

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -938,8 +938,15 @@ def _accepted_no_content() -> dict:
     }
 
 
-def _header_values(event: dict, name: str) -> list[str]:
+def _header_values(event: dict, name: str) -> list[tuple[str, str]]:
     """EVERY value the request carries for one header, deduplicated, in order.
+
+    Each entry is a `(value, display)` pair: the USABLE value (non-strings coerce
+    to `''`, the reading `_request_header` documents) and the `repr` of what the
+    request actually carried. The display exists because a refusal about two
+    values has to show the two values — building the message from the coerced
+    side produced `('', '')`, a sentence asserting the values differ while
+    displaying two identical ones.
 
     Both places a REST proxy event puts them are read, and reading only the first
     was the gap this closes:
@@ -955,21 +962,31 @@ def _header_values(event: dict, name: str) -> list[str]:
         `-32020` refusal exists for, reached through a duplicate rather than
         through a header/body disagreement.
 
-    Deduplicated ON THE RAW CANDIDATE, so two IDENTICAL values are one value: a
-    client (or an intermediary) restating the same thing twice has not
-    contradicted itself, and refusing that would refuse requests for no gain.
-    Raw, not coerced, and the ordering is the point: coercing non-strings to `''`
-    BEFORE the dedup collapsed two DIFFERENT unusable values into one, so
-    `multiValueHeaders={'origin': [None, 42]}` reached `_request_header` as a
-    single `''` and never hit its `len(values) > 1` refusal — and `''` is how this
-    module spells ABSENT, so the DNS-rebinding guard read two contradictory
-    origins as no origin at all and served the request. Two distinct unusable
-    values now stay two values and are refused as a duplicate (their coerced
-    reprs may coincide as `'', ''` in the message, which is honest: what was sent
-    twice is two things, neither of them a usable value).
+    Deduplicated ON THE DISPLAY — the `repr` of the raw candidate — so two
+    IDENTICAL values are one value: a client (or an intermediary) restating the
+    same thing twice has not contradicted itself, and refusing that would refuse
+    requests for no gain. Not on the coerced value, and not on the raw candidate
+    either, and each rejection has its own defect behind it:
+
+      • coercing non-strings to `''` BEFORE the dedup collapsed two DIFFERENT
+        unusable values into one, so `multiValueHeaders={'origin': [None, 42]}`
+        reached `_request_header` as a single `''` and never hit its
+        `len(values) > 1` refusal — and `''` is how this module spells ABSENT, so
+        the DNS-rebinding guard read two contradictory origins as no origin at
+        all and served the request;
+      • deduplicating on the raw candidate with `in` (i.e. `==`) refolded the
+        pairs Python equates across types — `True`/`1`, `False`/`0`, `1`/`1.0` —
+        so `multiValueHeaders={'origin': [True, 1]}` was the same fail-open one
+        equality quirk deeper. `repr` distinguishes exactly what a reader of the
+        refusal message can distinguish, which makes the dedup identity and the
+        displayed identity THE SAME FACT: the message can never again assert two
+        values differ while displaying two identical ones.
+
     `test_two_unusable_values_for_one_header_are_still_a_duplicate` and
     `test_two_unusable_origins_are_refused_not_read_as_absent` fail if the
-    coercion moves back inside the dedup.
+    coercion moves back inside the dedup;
+    `test_equatable_but_distinct_unusable_origins_are_still_two_values` fails if
+    the dedup key goes back to `==` on the raw candidate.
 
     ⚠️ The guard's REACH is tied to the REST proxy event shape read here. An
     HTTP API (payload 2.0) event carries no `multiValueHeaders` at all and
@@ -985,13 +1002,12 @@ def _header_values(event: dict, name: str) -> list[str]:
     one caller that runs before the handler's try/except — a 502 with no JSON-RPC
     envelope and no CORS headers.
     """
-    values: list[str] = []
-    # The raw candidates already seen, kept SEPARATELY from the coerced values:
-    # identity is decided on what the request actually carried, and only the
-    # answer is coerced. `list` rather than `set` because a direct-invoke
-    # candidate need not be hashable, and `in` on a list compares by equality,
-    # which is the identity a duplicate check wants.
-    seen: list[Any] = []
+    values: list[tuple[str, str]] = []
+    # The displays already seen. `repr` of the raw candidate, decided BEFORE any
+    # coercion: identity is what the request actually carried, and the repr is a
+    # plain string, so a `set` needs no hashability caveat and `==` on it has no
+    # cross-type equalities to fold (`repr(True) != repr(1)`, where `True == 1`).
+    seen: set[str] = set()
     for source_key in ('headers', 'multiValueHeaders'):
         source = event.get(source_key) or {}
         if not isinstance(source, dict):
@@ -1008,10 +1024,13 @@ def _header_values(event: dict, name: str) -> list[str]:
             # resulting single `''` as an absent Origin (see the docstring).
             candidates = raw if isinstance(raw, list) else [raw]
             for candidate in candidates:
-                if candidate in seen:
+                display = repr(candidate)
+                if display in seen:
                     continue
-                seen.append(candidate)
-                values.append(candidate if isinstance(candidate, str) else '')
+                seen.add(display)
+                values.append(
+                    (candidate if isinstance(candidate, str) else '', display)
+                )
     return values
 
 
@@ -1056,13 +1075,18 @@ def _request_header(event: dict, name: str) -> str | None:
     if not values:
         return None
     if len(values) > 1:
+        # The DISPLAY halves, not the coerced values: a message asserting two
+        # values differ has to show the two things that differ, and the coerced
+        # side of two unusable values reads `'', ''` — a sentence contradicting
+        # itself. The display is the dedup key, so what is shown as different is
+        # exactly what was judged different.
         raise InvalidTransportHeader(
             f'{_canonical_header_name(name)} was sent more than once with different '
-            f'values ({", ".join(repr(v) for v in values)}); there is no way to know '
-            f'which one was meant',
+            f'values ({", ".join(display for _value, display in values)}); there is '
+            f'no way to know which one was meant',
             code=JSONRPC_HEADER_MISMATCH,
         )
-    return values[0]
+    return values[0][0]
 
 
 def _origin_allowed(event: dict) -> bool:

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -977,10 +977,22 @@ def _header_values(event: dict, name: str) -> list[tuple[str, str]]:
       • deduplicating on the raw candidate with `in` (i.e. `==`) refolded the
         pairs Python equates across types — `True`/`1`, `False`/`0`, `1`/`1.0` —
         so `multiValueHeaders={'origin': [True, 1]}` was the same fail-open one
-        equality quirk deeper. `repr` distinguishes exactly what a reader of the
-        refusal message can distinguish, which makes the dedup identity and the
-        displayed identity THE SAME FACT: the message can never again assert two
-        values differ while displaying two identical ones.
+        equality quirk deeper. The dedup identity and the displayed identity are
+        now THE SAME FACT: the message can never again assert two values differ
+        while displaying two identical ones.
+
+    The precise claim, and its limit: `repr` never folds two values a reader
+    could tell apart IN THE MESSAGE. It does fold two values that merely compare
+    unequal while spelling the same — two `float('nan')` candidates
+    (`nan != nan`, identical repr) fold to one, coerce to `''`, and an
+    all-unusable `Origin` reads as absent. Accepted deliberately rather than
+    patched with an identity-based key: the ambiguity this guard refuses is two
+    DISTINGUISHABLE claims (an intermediary acting on one while this server acts
+    on the other), and two indistinguishable spellings of one unusable value are
+    the single-unusable-value case restated — which the anti-overreach tests pin
+    as keeping its existing empty-value reading. A refusal here would display
+    `nan, nan`: the self-contradicting message again, for values no reader and
+    no intermediary could route apart.
 
     `test_two_unusable_values_for_one_header_are_still_a_duplicate` and
     `test_two_unusable_origins_are_refused_not_read_as_absent` fail if the

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -72,19 +72,45 @@ projects_table = get_projects_table()
 # alone claims a conformance the envelope has to actually provide (`resultType`,
 # transport-header validation, `server/discover`), which is what this change adds.
 #
+# ⚠️ 2026-07-28 IS DELIBERATELY ABSENT, and this is the same argument the previous
+# `MCP_PROTOCOL_VERSION` comment used to defer the bump in the first place. That
+# revision REMOVES the `initialize` handshake and protocol-level sessions: every
+# request instead carries `io.modelcontextprotocol/protocolVersion` and
+# `clientCapabilities` in `_meta` as REQUIRED fields, a request missing them must
+# be refused with -32602, and the `MCP-Protocol-Version` header must match the
+# `_meta` value. This handler implements none of that — it reads the version from
+# the header alone, ignores request `_meta`, and still routes the handshake through
+# `initialize`, which the spec's own compatibility matrix calls a "legacy server"
+# and where it notes a modern client FAILS. Advertising it would have been the
+# exact dishonesty this range was created to end: a client that took the
+# counter-offer at face value and then sent modern requests would be served by a
+# handler ignoring the metadata it was told to trust.
+#
+# So this is the honest range: every revision here is handshake-based and is one
+# this envelope really implements. 2026-07-28 is the next phase's work, and it is
+# a real phase (per-request `_meta`, the -32602 refusal, the header/`_meta` match)
+# rather than an entry in this tuple.
+#
+# The two OLDEST entries are here for compatibility rather than because they
+# define anything this server needs, and leaving them out was a live client break:
+# the deployed handler pinned 2024-11-05, so every client that has completed a
+# handshake against it sends `MCP-Protocol-Version: 2024-11-05` on every
+# subsequent request — which a header validator that only knew the newer revisions
+# refused with a 400. Accepting a revision is not the same as preferring it.
+#
 # Ordered NEWEST FIRST, and that order is load-bearing: `_negotiate_protocol_version`
 # answers with the client's version when it is one of these, and otherwise with
 # the first entry — the newest this server speaks — which is what the spec's
 # initialize handshake tells a client to expect when its request cannot be met.
 SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
-    "2026-07-28",
     "2025-11-25",
     "2025-06-18",
+    "2025-03-26",
+    "2024-11-05",
 )
 
-# What an `initialize` that asks for nothing usable is answered with, and what a
-# request carrying no `MCP-Protocol-Version` header is read as. Derived rather
-# than restated so it cannot disagree with the tuple above.
+# What an `initialize` that asks for nothing usable is answered with. Derived
+# rather than restated so it cannot disagree with the tuple above.
 #
 # This replaces the `MCP_PROTOCOL_VERSION` constant outright rather than aliasing
 # it. An alias would have kept a name meaning "the only version this server
@@ -92,6 +118,14 @@ SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
 # this module read it, so keeping it would have been a second name for one fact,
 # maintained by nobody.
 PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+# What a request carrying NO `MCP-Protocol-Version` header is read as, which is
+# not the preferred version and is the spec's own backwards-compatibility rule:
+# the header was introduced in 2025-06-18, so a request without it comes from a
+# client written against an earlier revision, and 2025-03-26 is the value the spec
+# names for that case. Reading absence as the NEWEST supported revision — as this
+# did — silently upgrades exactly the clients that cannot be upgraded.
+ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 
 # Semver on the SERVER, independent of the protocol revision above, and the only
 # signal a client gets that a tool's output shape moved — it is advertised in
@@ -143,6 +177,10 @@ PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
 #     instead of a locally invented `_meta.cacheHints`.
 #   • `server/discover` answers `supportedVersions` and puts `serverInfo` under the
 #     spec's reserved `_meta` key.
+#   • The advertised protocol range became the revisions this envelope actually
+#     implements — the handshake-based ones — and REGAINED `2024-11-05` and
+#     `2025-03-26`, which the deployed build negotiated and which a header
+#     validator knowing only the newer revisions refused with a 400.
 # Minor rather than major because no declared tool INPUT or OUTPUT shape moved: a
 # client validating `structuredContent` against a cached `outputSchema` is
 # unaffected. The reconnect caveat above applies with the same force.
@@ -741,15 +779,17 @@ def _negotiate_protocol_version(requested: Any) -> str:
 def _validated_protocol_version(event: dict) -> str:
     """The revision named by the transport header, refusing one we cannot speak.
 
-    An ABSENT header reads as the preferred version. That is deliberate and it is
-    the spec's own backwards-compatibility rule: the header postdates the first
-    revisions of the transport, so requiring it would refuse every client written
-    against one of those — while a client that DOES send it has made a claim this
-    server can check.
+    An ABSENT header reads as `ASSUMED_PROTOCOL_VERSION` (2025-03-26), which is
+    the spec's own backwards-compatibility rule rather than a guess: the header
+    was introduced in 2025-06-18, so a request without it comes from a client
+    written against an earlier revision. Requiring it would refuse every one of
+    those clients; reading it as the NEWEST supported revision — as this did —
+    silently upgrades precisely the clients that cannot be upgraded. A client that
+    DOES send the header has made a claim this server can check.
     """
     raw = _request_header(event, PROTOCOL_VERSION_HEADER)
     if raw is None:
-        return PREFERRED_PROTOCOL_VERSION
+        return ASSUMED_PROTOCOL_VERSION
     version = _decoded_header(raw, PROTOCOL_VERSION_HEADER)
     if version not in SUPPORTED_PROTOCOL_VERSIONS:
         raise InvalidTransportHeader(

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -392,7 +392,41 @@ ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 #
 # No published tool declaration moved, so the fingerprinted catalogue is untouched
 # again.
-MCP_SERVER_VERSION = "3.5.0"
+#
+# 3.6.0 makes three things REACHABLE that this envelope already claimed. Each was a
+# claim a client could act on and then find unhonoured:
+#   • `server/discover` no longer refuses the header its own revision mandates. The
+#     method and its `DiscoverResult` are defined only by 2026-07-28, so the only
+#     client that can know the name is one obliged to send
+#     `MCP-Protocol-Version: 2026-07-28` — and the version refusal was exempt on
+#     `initialize` alone, so discovery answered 200 for a header-less request and 400
+#     for the conforming one. The answer whose purpose is "everything a client would
+#     otherwise learn from a failed call" was itself learnable only from a failed
+#     call. The exemption is now `_PRE_HANDSHAKE_METHODS`, named for the position
+#     rather than for its members; `ping` and both `tools/*` still refuse.
+#   • A POSTED JSON-RPC RESPONSE is `202 Accepted` with no body. The transport clause
+#     the notification path is built on has two subjects ("a JSON-RPC response or
+#     notification") and only the second was recognised: a response carries no
+#     `method`, so it fell through to the unknown-method branch and was answered
+#     `404 -32601`, which on every advertised revision means the session was
+#     terminated and the client MUST re-initialize. Third route to the defect the
+#     notification and batch branches each closed.
+#   • `Allow` is EXPOSED to a browser. It is not CORS-safelisted, so a browser
+#     received the 405 and hid the one header that said what to retry with — which
+#     made resolving it per resource (`GET` on the autoseed path, not `POST`)
+#     invisible to exactly the client class the expose list exists for.
+#
+# ⚠️ MINOR, decided by the rule at 3.3.0, and this entry is the easiest of the recent
+# ones: every part of it turns a refusal into an answer or ADDS a header name. Nothing
+# a client could hold is renamed or removed. The `Access-Control-Expose-Headers` value
+# GAINS an entry, which a client reads as more of its own answer becoming readable.
+# The one behaviour that changes for a message that used to be answered is the posted
+# response — from a 404 instructing a session teardown to the 202 the transport
+# mandates — and a client that was told to re-initialize was told wrongly.
+#
+# No published tool declaration moved, so the fingerprinted catalogue is untouched a
+# third time.
+MCP_SERVER_VERSION = "3.6.0"
 
 
 # ============================================
@@ -651,6 +685,14 @@ PROTOCOL_VERSION_HEADER = 'mcp-protocol-version'
 METHOD_HEADER = 'mcp-method'
 NAME_HEADER = 'mcp-name'
 
+# ⚠️ A vitest READS THIS DECLARATION by regex — 'mcp transport headers reach a
+# browser' in api-stack.test.ts — because the gateway's preflight allow-list has to
+# name every header this handler validates, and a browser that cannot SEND one is a
+# rule with no reachable subject. The coupling is to the spelling as well as to the
+# contents: dropping the `: tuple[str, ...]` annotation, or reformatting the tuple
+# so the entries are not one NAMED CONSTANT per line, breaks the parse. The test
+# fails loudly rather than silently (it asserts the recovered names match the
+# entries it can see), but the fix is here as much as there.
 TRANSPORT_HEADERS: tuple[str, ...] = (
     PROTOCOL_VERSION_HEADER,
     METHOD_HEADER,
@@ -743,7 +785,21 @@ CORS_HEADERS = {
     # so. Pinned in lockstep with the gateway's `exposeHeaders` by
     # api-stack.test.ts, because a gateway-GENERATED response (the authorizer's 401)
     # carries the gateway's list and not this one.
-    'Access-Control-Expose-Headers': 'WWW-Authenticate,Vary',
+    #
+    # `Allow` is the third, and it is the header that says WHAT TO RETRY WITH. Also
+    # not CORS-safelisted, so a browser received the 405 and hid the one header that
+    # made it actionable — which made the per-resource work below
+    # (`_ALLOW_JSONRPC` vs `_ALLOW_AUTOSEED`, so a `DELETE` on the autoseed path is
+    # told `GET` rather than `POST`) invisible to exactly the client class this list
+    # exists for. The status alone says "not this verb"; `Allow` says which one.
+    #
+    # ⚠️ A vitest READS THIS LITERAL by regex — 'mcp transport headers reach a
+    # browser' in api-stack.test.ts — to pin the gateway's own `exposeHeaders`
+    # against it. Reformatting the value (double quotes, or a `','.join((...))`
+    # expression like the allow-list above) breaks that test rather than the
+    # contract; add the header to `CORS_EXPOSE_HEADERS` in api-stack.ts in the same
+    # commit.
+    'Access-Control-Expose-Headers': 'WWW-Authenticate,Vary,Allow',
     # 🔑 The HTTP-layer counterpart of `cacheScope`, and it is needed because those
     # two words live in the JSON-RPC BODY while every cache likely to sit in front of
     # this endpoint — API Gateway, a CDN, a corporate proxy — reads headers and never
@@ -1104,6 +1160,41 @@ def _negotiate_protocol_version(requested: Any) -> str:
     return PREFERRED_PROTOCOL_VERSION
 
 
+# The methods a client calls BEFORE it has negotiated anything, and therefore the
+# methods where an `MCP-Protocol-Version` this server does not implement is
+# answered rather than refused. The rule is one question: has this client had the
+# chance to learn what to send?
+#
+#   • `initialize` — the handshake itself. A current-generation client MUST put its
+#     own revision in the header on its very first POST (2026-07-28 requires the
+#     header on every request and has no handshake to learn a different value
+#     from), so a refusal here is a refusal of first contact.
+#   • `server/discover` — the same position without the handshake. This one is the
+#     sharper case, because the method is defined ONLY by 2026-07-28: a client that
+#     knows the name is by construction a client of that revision, which is
+#     obliged to send `MCP-Protocol-Version: 2026-07-28`. Refusing it meant the one
+#     client class that would ever call this method was served only when it
+#     VIOLATED its own revision's header rule, and the answer whose whole purpose is
+#     "everything a client would otherwise learn from a failed call" was itself
+#     learnable only from a failed call.
+#
+# ⚠️ NOT derived from `_LIVENESS_CHECKED_METHODS`, which today holds the same two
+# entries. That set means "the response depends on the credential"; this one means
+# "the client has nothing negotiated to send". The coincidence is real and is not a
+# shared fact: `ping` is in neither for two unrelated reasons, and a future method
+# that is credential-gated but post-handshake would have to be in one and not the
+# other. `test_the_two_sets_are_not_the_same_fact` records that they are separate
+# claims that happen to name the same pair.
+#
+# `ping` and `tools/*` keep the refusal, and that is the asymmetry: past the
+# handshake a client HAS a negotiated value, so one this server never offered is
+# the client contradicting itself.
+_PRE_HANDSHAKE_METHODS: frozenset[str] = frozenset({
+    'initialize',
+    'server/discover',
+})
+
+
 def _validated_protocol_version(event: dict, method: str = '') -> str:
     """The revision named by the transport header, refusing one we cannot speak.
 
@@ -1115,16 +1206,17 @@ def _validated_protocol_version(event: dict, method: str = '') -> str:
     silently upgrades precisely the clients that cannot be upgraded. A client that
     DOES send the header has made a claim this server can check.
 
-    ⚠️ `initialize` IS EXEMPT from the refusal, and this is the asymmetry the
-    docstring above points at. The earlier reading — "by then the handshake has
-    happened, so a version this server never offered can only be a client
-    contradicting itself" — is true of request N and false of request 1. A client
-    whose newest revision is 2026-07-28 MUST send that value on its very first
-    POST: that revision requires the header on every request and has no handshake
-    to learn a different value from. Refusing it here meant a current-generation
-    SDK's first contact was a hard 400 and `_negotiate_protocol_version` — the
-    counter-offer that exists for exactly this client — was unreachable, because
-    validation runs before dispatch and `initialize` never ran.
+    ⚠️ THE PRE-HANDSHAKE METHODS ARE EXEMPT from the refusal, and this is the
+    asymmetry the docstring above points at. The earlier reading — "by then the
+    handshake has happened, so a version this server never offered can only be a
+    client contradicting itself" — is true of request N and false of request 1. A
+    client whose newest revision is 2026-07-28 MUST send that value on its very
+    first POST: that revision requires the header on every request and has no
+    handshake to learn a different value from. Refusing it here meant a
+    current-generation SDK's first contact was a hard 400 and
+    `_negotiate_protocol_version` — the counter-offer that exists for exactly this
+    client — was unreachable, because validation runs before dispatch and
+    `initialize` never ran.
 
     So on the handshake an unsupported header value falls THROUGH to
     `_handle_initialize`, which counter-offers the newest revision this server
@@ -1133,13 +1225,30 @@ def _validated_protocol_version(event: dict, method: str = '') -> str:
     client reads as "possibly a legacy server", so the refusal cost a round trip
     and risked an era misdetection to enforce a rule the handshake already handles.
 
-    Every other method keeps the refusal, `ping` and `server/discover` included:
-    past the handshake a client has a negotiated value to send, and one this server
-    never offered is the client contradicting itself.
+    ⚠️ `server/discover` IS EXEMPT TOO, and confining the exemption to
+    `initialize` — as the first version of it did — left this method unreachable by
+    the only clients that can know it exists. The method and its `DiscoverResult`
+    are defined ONLY by 2026-07-28, so a client that calls it is a client of that
+    revision, which its own rules oblige to send
+    `MCP-Protocol-Version: 2026-07-28` on every POST. The result was that discovery
+    answered 200 for a header-less or a downlevel request and 400 for the
+    conforming one: served only to a client violating its own revision, and refused
+    to the client it was written for. This docstring's own justification for the
+    handshake exemption covers it verbatim — a client that STARTS at discovery has
+    negotiated nothing, which is exactly why the liveness check calls that method
+    "the same decision without the handshake".
+
+    The exemption is not "these two methods are special": it is the pre-handshake
+    POSITION, which is why the set is named for that rather than for its members.
+    See `_PRE_HANDSHAKE_METHODS`.
+
+    Every other method keeps the refusal, `ping` and both `tools/*` included: past
+    the handshake a client has a negotiated value to send, and one this server never
+    offered is the client contradicting itself.
 
     The exemption is narrow: it covers a well-formed value naming a revision this
     server does not implement, which is the case a counter-offer answers. Two
-    faults are still refused on `initialize`:
+    faults are still refused on the exempt methods too:
 
       • a malformed encoded-word sentinel, which raises from `_decoded_header`
         before this function compares anything — there is nothing to counter-offer
@@ -1153,10 +1262,17 @@ def _validated_protocol_version(event: dict, method: str = '') -> str:
         return ASSUMED_PROTOCOL_VERSION
     version = _decoded_header(raw, PROTOCOL_VERSION_HEADER)
     if version not in SUPPORTED_PROTOCOL_VERSIONS:
-        if method == 'initialize' and version:
+        if method in _PRE_HANDSHAKE_METHODS and version:
             # Not an error, and not the client's value either: the session speaks
-            # what the handshake negotiates, which is `PREFERRED_PROTOCOL_VERSION`
-            # for a header naming a revision this server does not implement.
+            # what this server implements, which is `PREFERRED_PROTOCOL_VERSION`
+            # for a header naming a revision it does not. On `initialize` that
+            # value IS the counter-offer the client is told; on `server/discover`
+            # nothing reads it and the client reads `supportedVersions` out of the
+            # answer instead — which is the whole point of that method.
+            #
+            # `and version` keeps an EMPTY header refused on both: a client that
+            # sent the header empty named no revision, so there is nothing to
+            # counter-offer.
             return PREFERRED_PROTOCOL_VERSION
         raise InvalidTransportHeader(
             f'Unsupported protocol version {version!r}. This server speaks: '
@@ -3523,6 +3639,43 @@ def _is_batch(body: Any) -> bool:
     return isinstance(body, list)
 
 
+def _is_response(body: Any) -> bool:
+    """True when the body is a JSON-RPC RESPONSE rather than a request.
+
+    The transport clause the notification branch is built on has TWO subjects —
+    "If the input is a JSON-RPC response or notification" — and only the second
+    was recognised. A single response fell through: it is a dict with no `method`,
+    so `method` became `''`, `_is_notification` was False (an `id` is present) and
+    `_is_batch` was False, and it landed on the unknown-method branch and was
+    answered `404 -32601 "Method not found: "`. On every advertised revision that
+    404 means the SESSION was terminated and the client MUST re-initialize, which
+    is the third route to the same defect the notification and batch branches each
+    closed.
+
+    Three conditions, and each excludes something:
+
+      • a dict — an ARRAY of responses is a batch, and `_is_batch` runs first and
+        refuses it naming batching. Two shapes, two answers, decided by the shape
+        rather than by what is inside it;
+      • NO `method` member — a body carrying both `method` and `result` is a
+        request that also happens to have a `result` key, and it stays a request.
+        A predicate that ignored `method` would swallow one;
+      • a `result` or an `error` member — JSON-RPC's own definition of a response,
+        and it is what separates a response from the malformed bodies
+        (`{"jsonrpc": "2.0"}`, `{"id": 1}`) that must keep their -32601.
+
+    Reachable in practice rather than theoretical: a response is what a client
+    sends after the SERVER has issued a request to it (sampling, elicitation,
+    `roots/list`). This server issues none, so no correct client sends one — but a
+    client with a shared outbound queue, or a misconfigured proxy, sends one to the
+    wrong endpoint, and the answer must not instruct it to tear down a working
+    session.
+    """
+    if not isinstance(body, dict) or 'method' in body:
+        return False
+    return 'result' in body or 'error' in body
+
+
 @tracer.capture_method
 def _handle_autoseed(event: dict) -> dict:
     """Handle GET /mcp/autoseed/{project_id} with Bearer token auth.
@@ -3722,6 +3875,40 @@ def lambda_handler(event: dict, context: Any) -> dict:
             status_code=400,
         )
 
+    # A posted JSON-RPC RESPONSE is accepted 202 with no body, exactly as a
+    # notification is — and for the same reason, from the same clause. The transport
+    # rule the notification branch quotes has two subjects: "If the input is a
+    # JSON-RPC response or notification: If the server accepts the input, the server
+    # MUST return HTTP status code 202 Accepted with no body." Only the second was
+    # recognised.
+    #
+    # A single response fell through to the unknown-method branch — it is a dict with
+    # no `method`, so `method` became `''` — and was answered
+    # `404 -32601 "Method not found: "`. That is the third route to the defect the
+    # notification and the batch branches each closed: on every advertised revision a
+    # 404 on this endpoint means the SESSION was terminated and the client MUST
+    # re-initialize, so a stray response tore down a working session, and the empty
+    # method name in the message told the caller nothing about what it had sent.
+    #
+    # ACCEPTED rather than refused, and the clause makes accepting the honest answer
+    # here in a way it does not for a batch. A batch is a body grammar this server
+    # does not implement, so refusing names a real constraint the caller can act on.
+    # A response is a message this server has NOTHING TO DO WITH: it issues no
+    # requests to clients (no sampling, no elicitation, no `roots/list`), so it holds
+    # no outstanding request to correlate one against, and "accept and ignore" is
+    # precisely what a server with no such requests outstanding does. Refusing would
+    # report a failure to a sender that, like a notification's, is not listening for
+    # one.
+    #
+    # Before the transport-header guards, for the reason the batch branch is: a
+    # response carries no `method` for `Mcp-Method` to be compared against, so
+    # validating the routing echoes first reported a header/body mismatch against
+    # `''` — an answer about a header, for a message that is not a request at all. It
+    # buys no probe of the token store either.
+    if _is_response(body):
+        logger.info("MCP response body accepted and ignored: this server issues no requests")
+        return _accepted_no_content()
+
     # Transport-header validation, BEFORE dispatch and before authentication.
     #
     # Before dispatch because a request whose transport and body disagree has not
@@ -3729,12 +3916,14 @@ def lambda_handler(event: dict, context: Any) -> dict:
     # authentication for the same reason `_origin_allowed` is — a malformed
     # request should not buy a probe of the token store.
     #
-    # The METHOD is passed to the version check because the handshake is exempt
-    # from the refusal: a current-generation client MUST send its own revision in
-    # the header on its very first request and has no negotiated value to send
-    # instead, so refusing there made `_handle_initialize`'s counter-offer
-    # unreachable for exactly the clients it exists for. Every other method keeps
-    # the refusal. The reasoning is at `_validated_protocol_version`.
+    # The METHOD is passed to the version check because the PRE-HANDSHAKE methods
+    # are exempt from the refusal: a current-generation client MUST send its own
+    # revision in the header on its very first request and has no negotiated value
+    # to send instead, so refusing there made `_handle_initialize`'s counter-offer
+    # unreachable for exactly the clients it exists for — and made
+    # `server/discover`, a method only a 2026-07-28 client knows, unreachable by any
+    # client obeying that revision's header rule. Every other method keeps the
+    # refusal. The reasoning is at `_PRE_HANDSHAKE_METHODS`.
     try:
         _validated_protocol_version(event, method)
         _validate_routing_headers(event, method, params)

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -9,6 +9,9 @@ Public endpoint — no Cognito auth. Auth is handled by validating the Bearer to
 from the Authorization header against SHA-256 hashes in the projects table.
 """
 
+import base64
+import binascii
+import hashlib
 import json
 import os
 import re
@@ -36,6 +39,7 @@ from shared.mcp_tokens import (
     REACH_KIND_WORKSPACE,
     REACH_NONE,
     REACH_PROJECT_SET,
+    REACH_WORKSPACE,
     SCOPE_FEEDBACK_READ,
     SCOPE_METRICS_READ,
     SCOPE_PROJECTS_READ,
@@ -59,22 +63,35 @@ metrics = Metrics(namespace="VoC-MCP")
 # and its role no longer holds a grant on either.
 projects_table = get_projects_table()
 
-# MCP Protocol version
+# MCP protocol versions — a RANGE that is negotiated, not one pinned string.
 #
-# ⚠️ KNOWN SKEW, and it is temporary by plan rather than by oversight.
-# `structuredContent` and `outputSchema` (below) arrived in the 2025-06-18
-# revision, while this still advertises 2024-11-05 and `initialize` declares no
-# capability for them. The version range — negotiating 2026-07-28 / 2025-11-25 /
-# 2025-06-18 and answering `server/discover` — is the next phase of the plan, and
-# bumping the number here without that negotiation would claim conformance this
-# handler does not yet have (no `resultType`, no header validation).
+# The skew this replaces was real and was recorded here: `structuredContent` and
+# `outputSchema` arrived in the 2025-06-18 revision while the handler advertised
+# 2024-11-05, so it shipped fields the version it claimed does not define. The
+# honest fix is not to bump the number — it is to negotiate, because a number
+# alone claims a conformance the envelope has to actually provide (`resultType`,
+# transport-header validation, `server/discover`), which is what this change adds.
 #
-# Shipping the structured fields early is safe in the meantime because both are
-# ADDITIVE: a 2024-11-05 client reads `content[0].text`, which still carries the
-# same payload serialized, and JSON-RPC clients ignore result fields they do not
-# know. The reverse order — negotiate first, add the fields later — would have
-# meant two breaking output changes instead of one.
-MCP_PROTOCOL_VERSION = "2024-11-05"
+# Ordered NEWEST FIRST, and that order is load-bearing: `_negotiate_protocol_version`
+# answers with the client's version when it is one of these, and otherwise with
+# the first entry — the newest this server speaks — which is what the spec's
+# initialize handshake tells a client to expect when its request cannot be met.
+SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
+    "2026-07-28",
+    "2025-11-25",
+    "2025-06-18",
+)
+
+# What an `initialize` that asks for nothing usable is answered with, and what a
+# request carrying no `MCP-Protocol-Version` header is read as. Derived rather
+# than restated so it cannot disagree with the tuple above.
+PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+# The name kept from the pinned-constant era, now meaning "the version this
+# server prefers" rather than "the only version it speaks". Kept because it is
+# the value `serverInfo`-adjacent tooling and the frontend docs refer to, and
+# because deleting it would be a rename with no behavioural content.
+MCP_PROTOCOL_VERSION = PREFERRED_PROTOCOL_VERSION
 
 # Semver on the SERVER, independent of the protocol revision above, and the only
 # signal a client gets that a tool's output shape moved — it is advertised in
@@ -99,7 +116,21 @@ MCP_PROTOCOL_VERSION = "2024-11-05"
 # against the `tools/list` it cached at CONNECT, so a session that predates the
 # deploy rejects the new field until it reconnects. The server honestly declares
 # `tools.listChanged: false`, so there is no notification path to tell it.
-MCP_SERVER_VERSION = "3.1.0"
+#
+# 3.2.0 is the ENVELOPE change, and it is a minor bump for the same reason: every
+# part of it ADDS. Each published tool gains `annotations` and a `_meta.costClass`;
+# every result gains a `resultType`; `tools/list` gains a `_meta.cacheHints` and
+# is now FILTERED by the credential presented. No declared output shape moved, so
+# a client validating `structuredContent` is unaffected.
+#
+# ⚠️ The filtering is the part that is not merely additive from a caller's seat: a
+# credential holding one scope now sees fewer tools than it did, which is the
+# defect being fixed (it was shown tools it would be refused) rather than a
+# regression. And the same reconnect caveat as 3.1.0 applies with more force —
+# a session that cached `tools/list` before this deploy holds a catalogue with no
+# annotations and no cost classes, and `listChanged: false` means nothing will
+# tell it. Connected clients must reconnect.
+MCP_SERVER_VERSION = "3.2.0"
 
 
 # ============================================
@@ -343,12 +374,46 @@ ALLOWED_ORIGIN = os.environ.get('ALLOWED_ORIGIN', '')
 # CORS helpers
 # ============================================
 
+# The transport headers this server reads, spelled once and lowercased because
+# API Gateway lowercases header names in proxy mode.
+#
+# `MCP-Protocol-Version` is the transport's own version statement, sent on every
+# request AFTER the initialize handshake — the spec's answer to "the session
+# negotiated 2025-06-18 but this request assumes 2026-07-28". The other two are
+# ROUTING ECHOES: a client (or an intermediary) that names the method and the
+# tool in headers has stated the same thing twice, and the two statements must
+# agree or the request is ambiguous about what it is asking for. Serving the body
+# and ignoring a contradicting header is the shape that lets a proxy route on one
+# value while the server acts on the other.
+PROTOCOL_VERSION_HEADER = 'mcp-protocol-version'
+METHOD_HEADER = 'mcp-method'
+NAME_HEADER = 'mcp-name'
+
+TRANSPORT_HEADERS: tuple[str, ...] = (
+    PROTOCOL_VERSION_HEADER,
+    METHOD_HEADER,
+    NAME_HEADER,
+)
+
 CORS_HEADERS = {
     'Access-Control-Allow-Origin': '*',
     # X-Project-Id is gone: the credential carries its own project reach, so a
     # client has no reason to send it and allowing it would keep a dead contract
     # looking alive.
-    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+    #
+    # The three MCP transport headers ARE listed, because a browser-based client
+    # that sends one would otherwise be stopped by its own preflight before this
+    # function ever saw it — a header the server validates but a browser may not
+    # send is a rule with no reachable subject. Derived from TRANSPORT_HEADERS so
+    # the two cannot drift; the canonical spelling is restored for the wire, since
+    # the lowercase forms above exist only to read API Gateway's own normalisation.
+    'Access-Control-Allow-Headers': ','.join((
+        'Content-Type',
+        'Authorization',
+        *('-'.join(part.capitalize() if part != 'mcp' else 'MCP'
+                   for part in header.split('-'))
+          for header in TRANSPORT_HEADERS),
+    )),
     'Access-Control-Allow-Methods': 'POST,OPTIONS',
     # Without this a BROWSER-based MCP client can receive the 401 challenge but
     # never read it: WWW-Authenticate is not a CORS-safelisted response header.
@@ -372,12 +437,18 @@ _WWW_AUTHENTICATE_401 = 'Bearer error="invalid_token"'
 def _cors_response(body: dict, status_code: int = 200) -> dict:
     """Return a Lambda proxy response with CORS headers.
 
-    Every 401 gains the RFC 6750 challenge here, at the one choke point all
-    responses pass through, so no future 401 path can forget it.
+    Every 401 gains the RFC 6750 challenge here, and every 405 gains the
+    `Allow` header RFC 9110 §15.5.6 REQUIRES, at the one choke point all
+    responses pass through, so no future path of either kind can forget it.
     """
     headers = {**CORS_HEADERS, 'Content-Type': 'application/json'}
     if status_code == 401:
         headers['WWW-Authenticate'] = _WWW_AUTHENTICATE_401
+    if status_code == 405:
+        # Derived from the CORS declaration rather than written out again: the
+        # two say the same thing to two audiences (a browser preflight and a
+        # 405), and a hand-written second copy is how they come to disagree.
+        headers['Allow'] = CORS_HEADERS['Access-Control-Allow-Methods'].replace(',', ', ')
     return {
         'statusCode': status_code,
         'headers': headers,
@@ -404,6 +475,172 @@ def _origin_allowed(event: dict) -> bool:
     if ALLOWED_ORIGIN == '*':
         return True
     return origin == ALLOWED_ORIGIN
+
+
+# ============================================
+# Transport headers
+# ============================================
+#
+# The transport carries three statements ALONGSIDE the JSON-RPC body, and a
+# server that reads the body and ignores them is not speaking the same protocol
+# as the client that sent them:
+#
+#   • `MCP-Protocol-Version` says which revision this request is written against.
+#     Unvalidated, a client speaking a revision this server does not implement is
+#     answered as though it spoke one that it does — the failure then surfaces as
+#     a field the client cannot parse, several calls later.
+#   • `MCP-Method` and `MCP-Name` echo the method and the tool name. They exist so
+#     an intermediary can route without parsing a body, which means the header and
+#     the body can DISAGREE — and serving the body while a proxy routed on the
+#     header is how one hop's view of a request stops matching the next hop's.
+#     A disagreement is refused rather than resolved in either direction: there is
+#     no way to know which of the two statements was the caller's intent.
+#
+# Every one of them may arrive in the ENCODED-WORD sentinel form below.
+
+# `=?base64?<payload>?=` — the sentinel form a conforming client may use for any
+# of these values. A header value is a constrained token on the wire, so a client
+# that cannot be sure its value survives an intermediary base64s it and marks it.
+# DOTALL because the payload is opaque: a newline inside it is malformed base64,
+# which is refused BELOW with a message about the encoding rather than silently
+# not matching the pattern and being compared as literal text.
+_ENCODED_WORD = re.compile(r'\A=\?base64\?(.*)\?=\Z', re.DOTALL)
+
+
+class InvalidTransportHeader(Exception):
+    """A transport header is absent-or-fine, or it is malformed. Never ignored.
+
+    Reported as `-32600 Invalid Request` with HTTP 400: the JSON-RPC body may be
+    perfectly well formed, and it is the REQUEST — body plus transport — that is
+    not. `-32602 Invalid params` would send the caller looking at its arguments.
+    """
+
+
+def _request_header(event: dict, name: str) -> str | None:
+    """One header, matched case-insensitively, or None when absent.
+
+    API Gateway lowercases header names in proxy mode, but a direct invoke (a
+    test, a local driver) does not, and the guard has to hold for both — the same
+    lesson `_origin_allowed` records for `Origin`. An empty value is NOT absence:
+    a client that sent the header empty said something, and what it said is not a
+    valid value for any of the three.
+    """
+    headers = event.get('headers') or {}
+    if not isinstance(headers, dict):
+        return None
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == name:
+            return value if isinstance(value, str) else ''
+    return None
+
+
+def _decoded_header(raw: str, name: str) -> str:
+    """A header value with the encoded-word sentinel resolved.
+
+    A value that is not in sentinel form is returned unchanged — the sentinel is
+    optional, and a plain `2025-06-18` is the ordinary spelling. A value that
+    CLAIMS the sentinel form and then does not decode is refused rather than
+    compared literally: treating `=?base64?not-base64?=` as a version string
+    would report "unsupported protocol version =?base64?…?=", which sends the
+    caller after a version number when the fault is the encoding.
+    """
+    match = _ENCODED_WORD.match(raw)
+    if not match:
+        return raw
+    try:
+        decoded = base64.b64decode(match.group(1), validate=True).decode('utf-8')
+    except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
+        raise InvalidTransportHeader(
+            f'{name} is in encoded-word form but its payload is not base64-encoded UTF-8'
+        ) from exc
+    if not decoded:
+        # `=?base64??=` is well-formed base64 of nothing. Refused HERE, with the
+        # encoding named, rather than passed on as `''`: an empty payload is a
+        # client that meant to say something and encoded nothing, and letting it
+        # through would report "unsupported protocol version ''" — an answer about
+        # a version, for a fault in the encoding.
+        raise InvalidTransportHeader(
+            f'{name} is in encoded-word form but its base64 payload is empty'
+        )
+    return decoded
+
+
+def _negotiate_protocol_version(requested: Any) -> str:
+    """The revision this session will speak.
+
+    The client's own version when this server implements it, and otherwise the
+    NEWEST this server implements — which is what the spec's handshake defines,
+    and it is a counter-offer rather than a refusal: `initialize` is where a
+    client learns what it is talking to, so answering an unknown request with an
+    error would leave it with nothing to fall back to. A client that cannot live
+    with the counter-offer closes the connection, which is its decision to make.
+
+    Contrast the HEADER (`_validated_protocol_version` below), where an
+    unsupported value IS refused: by then the handshake has happened, so a
+    version this server never offered can only be a client contradicting itself.
+    """
+    if isinstance(requested, str) and requested in SUPPORTED_PROTOCOL_VERSIONS:
+        return requested
+    return PREFERRED_PROTOCOL_VERSION
+
+
+def _validated_protocol_version(event: dict) -> str:
+    """The revision named by the transport header, refusing one we cannot speak.
+
+    An ABSENT header reads as the preferred version. That is deliberate and it is
+    the spec's own backwards-compatibility rule: the header postdates the first
+    revisions of the transport, so requiring it would refuse every client written
+    against one of those — while a client that DOES send it has made a claim this
+    server can check.
+    """
+    raw = _request_header(event, PROTOCOL_VERSION_HEADER)
+    if raw is None:
+        return PREFERRED_PROTOCOL_VERSION
+    version = _decoded_header(raw, PROTOCOL_VERSION_HEADER)
+    if version not in SUPPORTED_PROTOCOL_VERSIONS:
+        raise InvalidTransportHeader(
+            f'Unsupported MCP protocol version {version!r}. This server speaks: '
+            f'{", ".join(SUPPORTED_PROTOCOL_VERSIONS)}'
+        )
+    return version
+
+
+def _validate_routing_headers(event: dict, method: str, params: Any) -> None:
+    """Refuse a routing echo that contradicts the body it travels with.
+
+    Both headers are OPTIONAL, so absence is silent. A present one is compared
+    against the body, and the comparison is exact: these are protocol tokens, not
+    prose, so there is no case folding or trimming to argue about.
+
+    `MCP-Name` names a TOOL, so it is meaningful only on `tools/call`. Sent with
+    any other method it is refused rather than ignored — a client that names a
+    tool on `tools/list` has asked for something this server cannot do, and
+    answering the list would be answering a different question.
+    """
+    raw_method = _request_header(event, METHOD_HEADER)
+    if raw_method is not None:
+        declared = _decoded_header(raw_method, METHOD_HEADER)
+        if declared != method:
+            raise InvalidTransportHeader(
+                f'{METHOD_HEADER} says {declared!r} but the request body calls '
+                f'{method!r}'
+            )
+
+    raw_name = _request_header(event, NAME_HEADER)
+    if raw_name is None:
+        return
+    declared_name = _decoded_header(raw_name, NAME_HEADER)
+    if method != 'tools/call':
+        raise InvalidTransportHeader(
+            f'{NAME_HEADER} names a tool, which is meaningful only on tools/call, '
+            f'not on {method!r}'
+        )
+    body_name = params.get('name') if isinstance(params, dict) else None
+    if declared_name != body_name:
+        raise InvalidTransportHeader(
+            f'{NAME_HEADER} says {declared_name!r} but the request body calls '
+            f'{body_name!r}'
+        )
 
 
 # ============================================
@@ -893,7 +1130,120 @@ _DAYS_ARG: dict[str, Any] = {
     "maximum": MAX_FEEDBACK_WINDOW_DAYS,
 }
 
-MCP_TOOLS = [
+# ---------------------------------------------------------------------------
+# Cost classes
+# ---------------------------------------------------------------------------
+#
+# What a call COSTS, so a model can choose between two tools that answer nearly
+# the same question without discovering the difference by waiting for one. The
+# axis is the shape of the underlying read, which is the thing a caller cannot
+# see and cannot infer from the tool's name:
+#
+#   cheap     — one keyed read. Bounded by the item, not by the window.
+#   moderate  — one Query over one partition, or a small set of aggregate rows.
+#               Bounded by the data the route already indexes for it.
+#   expensive — a candidate scan bounded by a soft cap rather than by an index,
+#               which is why `search_feedback` is the tool that can come back
+#               `is_partial`. Truncation IS the cost showing.
+#
+# Ordered cheapest first, and that order is the vocabulary's content: a client
+# comparing two classes needs to know which is which, and an unordered set of
+# adjectives does not say.
+COST_CHEAP = 'cheap'
+COST_MODERATE = 'moderate'
+COST_EXPENSIVE = 'expensive'
+
+COST_CLASSES: tuple[str, ...] = (COST_CHEAP, COST_MODERATE, COST_EXPENSIVE)
+
+# Per-tool, and fail-closed at publication time rather than defaulted: a tool
+# with no entry raises when the catalogue is built, because a MISSING cost class
+# would silently read as "cheap" to a model that expected every tool to carry one.
+TOOL_COST_CLASSES: dict[str, str] = {
+    # One GSI lookup by feedback id.
+    "get_feedback_detail": COST_CHEAP,
+    # One Query of the project's partition; personas and documents come back with
+    # the metadata, so listing personas costs the same read.
+    "get_project": COST_MODERATE,
+    "list_personas": COST_MODERATE,
+    # Pre-aggregated daily rows over the window.
+    "get_metrics_summary": COST_MODERATE,
+    "get_metrics_breakdown": COST_MODERATE,
+    # The candidate scan. Soft-capped, hence `is_partial`.
+    "search_feedback": COST_EXPENSIVE,
+}
+
+# A human-readable title per tool, which is what `annotations.title` is for: the
+# NAME is an identifier a model matches on, the title is what a client shows a
+# person in a permission prompt. Declared here rather than inline so the
+# annotation block below can be derived for every tool at once and no tool can
+# have one and not the other.
+TOOL_TITLES: dict[str, str] = {
+    "search_feedback": "Search customer feedback",
+    "get_feedback_detail": "Read one feedback item",
+    "get_metrics_summary": "Summarise feedback metrics",
+    "get_metrics_breakdown": "Break metrics down by one axis",
+    "get_project": "Read a project",
+    "list_personas": "List a project's personas",
+}
+
+
+def _tool_annotations(name: str) -> dict:
+    """The spec's behaviour hints for one tool.
+
+    Every tool in this server is a READ, and all four hints say so — which is
+    worth declaring rather than leaving to inference, because the hints are what a
+    client uses to decide whether a call needs a human's permission. A read-only
+    tool that does not declare itself read-only gets prompted for like a write.
+
+    ⚠️ These are HINTS, and the spec is explicit that a client must not treat them
+    as a security boundary. The enforcement is elsewhere and stays elsewhere: the
+    scope table, the reach axes, and the domain function's own rules. Phase 3's
+    first write tool must set `readOnlyHint: False` here AND require a write
+    scope; setting only the hint would be a label, and setting only the scope would
+    make a client prompt for a write as though it were a read.
+    """
+    return {
+        "title": TOOL_TITLES[name],
+        "readOnlyHint": True,
+        # No tool here deletes or overwrites anything. Meaningful only when
+        # `readOnlyHint` is false, and declared anyway so the block has one shape.
+        "destructiveHint": False,
+        # Same arguments, same answer — modulo the corpus changing underneath,
+        # which is true of any read and is not what this hint is about.
+        "idempotentHint": True,
+        # A closed world: every tool reads this workspace's own data lake. Nothing
+        # here reaches the internet, which is what a client would otherwise have
+        # to assume.
+        "openWorldHint": False,
+    }
+
+
+def _published_tool(declaration: dict) -> dict:
+    """One tool as `tools/list` publishes it: declaration plus envelope.
+
+    The annotations and the cost class are ADDED here rather than written into
+    each literal, so they cannot be forgotten for one tool out of six — the
+    failure mode a per-literal `annotations` block has, and the reason
+    `TOOL_COST_CLASSES` raises instead of defaulting.
+    """
+    name = declaration["name"]
+    if name not in TOOL_COST_CLASSES:
+        raise KeyError(f'{name} declares no cost class in TOOL_COST_CLASSES')
+    cost_class = TOOL_COST_CLASSES[name]
+    if cost_class not in COST_CLASSES:
+        raise ValueError(f'{name} declares undeclared cost class {cost_class!r}')
+    return {
+        **declaration,
+        "annotations": _tool_annotations(name),
+        # `_meta` is the spec's own extension point, which is where a
+        # non-standard signal belongs: a client that does not know `costClass`
+        # ignores `_meta` wholesale rather than failing to validate a tool
+        # declaration carrying a field its schema does not define.
+        "_meta": {"costClass": cost_class},
+    }
+
+
+_TOOL_DECLARATIONS = [
     {
         "name": "search_feedback",
         "description": (
@@ -1178,6 +1528,22 @@ MCP_TOOLS = [
         },
     },
 ]
+
+# What `tools/list` publishes: every declaration above, wrapped. Built at import
+# so a tool missing its cost class or its title fails the module rather than the
+# first client that asks for the catalogue.
+MCP_TOOLS = [_published_tool(declaration) for declaration in _TOOL_DECLARATIONS]
+
+# How long a client may reuse a cached `tools/list`, in seconds. Five minutes,
+# matching the MCP authorizer's own `resultsCacheTtl` in api-stack.ts — not
+# because the two caches interact, but because a client holding a catalogue longer
+# than the credential's authorization decision lives is holding the older of two
+# facts about the same token.
+#
+# It is a HINT, and the etag beside it is what makes staleness detectable rather
+# than merely time-bounded: `listChanged: false` means no notification is coming,
+# so the honest contract is "re-ask, compare the etag, and reconnect if it moved".
+_TOOL_LIST_MAX_AGE_SECONDS = 300
 
 
 # ============================================
@@ -1694,6 +2060,44 @@ TOOL_REACH_KINDS: dict[str, str] = {
 # MCP JSON-RPC protocol handling
 # ============================================
 
+# The `resultType` vocabulary — one discriminator per SHAPE of result this server
+# returns.
+#
+# 🔑 Why a discriminator rather than "look at which keys are present": every
+# result here is a bare JSON object, and telling them apart by key inference is
+# guesswork that gets worse as shapes grow. `{}` is both a `ping` answer and a
+# notification acknowledgement; a tool result and a tool ERROR differ only by a
+# boolean and by whether `structuredContent` happens to be there. A client
+# switching on inferred shape re-derives that table from scratch, gets it subtly
+# wrong, and the failure lands in the client rather than here.
+#
+# `toolError` is a distinct type rather than "a toolResult with isError" ON
+# PURPOSE, and `isError` is still sent: the flag is what the spec defines, the
+# type is what says the payload has no `structuredContent` to validate.
+RESULT_TYPE_INITIALIZE = 'initialize'
+RESULT_TYPE_DISCOVERY = 'discovery'
+RESULT_TYPE_TOOL_LIST = 'toolList'
+RESULT_TYPE_TOOL_RESULT = 'toolResult'
+RESULT_TYPE_TOOL_ERROR = 'toolError'
+RESULT_TYPE_PONG = 'pong'
+RESULT_TYPE_ACK = 'ack'
+
+RESULT_TYPES: frozenset[str] = frozenset({
+    RESULT_TYPE_INITIALIZE,
+    RESULT_TYPE_DISCOVERY,
+    RESULT_TYPE_TOOL_LIST,
+    RESULT_TYPE_TOOL_RESULT,
+    RESULT_TYPE_TOOL_ERROR,
+    RESULT_TYPE_PONG,
+    RESULT_TYPE_ACK,
+})
+
+# The key the discriminator travels under. Named so a test can read it rather
+# than restate the string, and so the one-line change to namespace it later
+# touches one place.
+RESULT_TYPE_KEY = 'resultType'
+
+
 def _jsonrpc_error(req_id: Any, code: int, message: str) -> dict:
     """Build a JSON-RPC error response."""
     return {
@@ -1703,22 +2107,54 @@ def _jsonrpc_error(req_id: Any, code: int, message: str) -> dict:
     }
 
 
-def _jsonrpc_result(req_id: Any, result: dict) -> dict:
-    """Build a JSON-RPC success response."""
+def _jsonrpc_result(req_id: Any, result_type: str, result: dict) -> dict:
+    """Build a JSON-RPC success response, discriminated by its shape.
+
+    The discriminator is a REQUIRED positional argument rather than an optional
+    keyword, which is the whole design: every result this server returns is built
+    here, so a new result shape cannot ship without naming itself. An optional
+    parameter would have made the discriminator a thing authors remember, which is
+    the same class of defect as a declaration nothing checks.
+
+    An undeclared type raises rather than travelling: a client switching on the
+    value cannot switch on a typo, and finding out at the client is finding out
+    too late.
+    """
+    if result_type not in RESULT_TYPES:
+        raise ValueError(f'undeclared resultType {result_type!r}')
     return {
         "jsonrpc": "2.0",
         "id": req_id,
-        "result": result,
+        "result": {RESULT_TYPE_KEY: result_type, **result},
     }
 
 
-def _handle_initialize(req_id: Any, _params: dict) -> dict:
-    """Handle MCP initialize request."""
-    return _jsonrpc_result(req_id, {
-        "protocolVersion": MCP_PROTOCOL_VERSION,
-        "capabilities": {
-            "tools": {"listChanged": False},
-        },
+def _server_capabilities() -> dict:
+    """What this server can do, stated once for `initialize` and `server/discover`.
+
+    `listChanged: false` is honest rather than lazy — there is no notification
+    path here, so a client that caches `tools/list` at connect holds it until it
+    reconnects. That is why an envelope change is a reconnect (see the
+    MCP_SERVER_VERSION notes) and why the list carries cache hints of its own.
+    """
+    return {
+        "tools": {"listChanged": False},
+    }
+
+
+def _handle_initialize(req_id: Any, params: dict) -> dict:
+    """Handle MCP initialize — the version handshake.
+
+    The client states the revision it wants in `params.protocolVersion` and this
+    answers with what the session will actually speak, which is the client's
+    version when this server implements it and the newest one it does implement
+    otherwise. Pinning a single string here, as this used to, meant the answer was
+    the same whatever was asked — a handshake in shape only.
+    """
+    requested = params.get('protocolVersion') if isinstance(params, dict) else None
+    return _jsonrpc_result(req_id, RESULT_TYPE_INITIALIZE, {
+        "protocolVersion": _negotiate_protocol_version(requested),
+        "capabilities": _server_capabilities(),
         "serverInfo": {
             "name": "voc-datalake",
             "version": MCP_SERVER_VERSION,
@@ -1726,9 +2162,160 @@ def _handle_initialize(req_id: Any, _params: dict) -> dict:
     })
 
 
-def _handle_tools_list(req_id: Any, _params: dict) -> dict:
-    """Handle MCP tools/list request."""
-    return _jsonrpc_result(req_id, {"tools": MCP_TOOLS})
+def _handle_discover(req_id: Any, _params: dict) -> dict:
+    """Handle `server/discover` — what this server supports, without guessing.
+
+    Everything a client would otherwise learn from a FAILED call: the protocol
+    revisions on offer, the methods that exist, the transport headers that are
+    read, the `resultType` vocabulary, and the cost classes tools are labelled
+    with. A client that has to discover a method by receiving -32601 for it cannot
+    tell "this server does not implement that" from "that method is spelled
+    differently here", and it pays a round trip per guess.
+
+    Every list is DERIVED from the registry that implements the thing, not
+    restated: a method added to the dispatch tables appears here, and one that is
+    only listed here cannot exist.
+
+    Deliberately does NOT list tools. `tools/list` does that, and it varies by
+    credential — repeating a credential-shaped answer on an unauthenticated
+    method would either leak the catalogue or contradict the other method.
+    """
+    return _jsonrpc_result(req_id, RESULT_TYPE_DISCOVERY, {
+        "serverInfo": {
+            "name": "voc-datalake",
+            "version": MCP_SERVER_VERSION,
+        },
+        "protocolVersions": list(SUPPORTED_PROTOCOL_VERSIONS),
+        "preferredProtocolVersion": PREFERRED_PROTOCOL_VERSION,
+        "capabilities": _server_capabilities(),
+        # Sorted, because this is a set rather than a sequence and a client
+        # diffing two discoveries should see a change only when one happened.
+        "methods": sorted({*MCP_METHODS, *MCP_AUTH_METHODS}),
+        "authenticatedMethods": sorted(MCP_AUTH_METHODS),
+        "transportHeaders": sorted(TRANSPORT_HEADERS),
+        "resultTypes": sorted(RESULT_TYPES),
+        "costClasses": list(COST_CLASSES),
+        # The list varies by credential, so a client cannot conclude "these are
+        # the tools" from an unauthenticated discovery. Saying so is cheaper than
+        # letting it find out by calling one it was never granted.
+        "toolsVaryByCredential": True,
+    })
+
+
+def _tool_is_authorized(tool_name: str, token_info: dict) -> bool:
+    """Whether this credential could actually call *tool_name*.
+
+    Both gates, in the same order `_handle_tools_call` applies them, and
+    fail-closed on a tool with no declaration for either — the listing must not
+    advertise a tool the dispatch would refuse as undeclared.
+
+    The reach half asks the question a LISTING can ask, which is weaker than the
+    per-call one by exactly one thing: a project-shaped tool is listed when the
+    credential can reach SOME project, not when it can reach the one a later call
+    will name. That is the honest bound — which project a call addresses is an
+    argument of that call — and it is why `_handle_tools_call` still checks reach
+    itself rather than trusting this.
+    """
+    required_scope = TOOL_SCOPE_REQUIREMENTS.get(tool_name)
+    tool_reach_kind = TOOL_REACH_KINDS.get(tool_name)
+    if required_scope is None or tool_reach_kind is None:
+        return False
+    if not _scope_allows(token_info.get('scopes'), required_scope):
+        return False
+    token_projects = token_info.get('projects') or []
+    read_reach = token_info.get('read_reach') or DEFAULT_READ_REACH
+    if tool_reach_kind == REACH_KIND_PROJECT:
+        # `reach_allows` needs a concrete project, and a listing has none. Any
+        # project in the token's set is representative: `project-set` reach admits
+        # exactly those, and `workspace` admits everything, so a token whose set is
+        # empty and whose reach is `project-set` correctly lists nothing.
+        candidate = next((p for p in token_projects if isinstance(p, str) and p), None)
+        if read_reach == REACH_WORKSPACE:
+            # A sentinel project, so this asks "may this credential reach a
+            # project at all" without inventing one it can reach — workspace reach
+            # does not consult the id, which `reach_allows` is what decides.
+            candidate = candidate or 'any'
+        if not candidate:
+            return False
+        return reach_allows(
+            read_reach=read_reach,
+            token_projects=token_projects,
+            tool_reach_kind=tool_reach_kind,
+            project_id=candidate,
+        )
+    return reach_allows(
+        read_reach=read_reach,
+        token_projects=token_projects,
+        tool_reach_kind=tool_reach_kind,
+        project_id=None,
+    )
+
+
+def _tools_for(token_info: dict) -> list[dict]:
+    """The tools this credential may call, in a deterministic order.
+
+    Sorted BY NAME rather than left in declaration order: the list is now
+    credential-shaped, so two callers see different subsets, and a stable order is
+    what makes a cached list comparable to a fresh one (and an `etag` over it
+    mean anything). Declaration order would make the answer depend on where
+    somebody inserted a literal.
+    """
+    return sorted(
+        (tool for tool in MCP_TOOLS if _tool_is_authorized(tool["name"], token_info)),
+        key=lambda tool: tool["name"],
+    )
+
+
+def _tools_list_etag(tools: list[dict]) -> str:
+    """A stable fingerprint of exactly what this answer published.
+
+    Over the SERIALIZED tools plus the server version, so it moves when a
+    declaration moves and also when the version does — a client comparing etags
+    is asking "is my cached catalogue still the one this server would send", and
+    the server version is part of that answer even for an unchanged shape.
+
+    `sort_keys` so reformatting a declaration is free, matching the convention the
+    published-shape fingerprint test states.
+    """
+    serialized = json.dumps(
+        {"version": MCP_SERVER_VERSION, "tools": tools}, sort_keys=True, cls=DecimalEncoder,
+    )
+    return hashlib.sha256(serialized.encode('utf-8')).hexdigest()[:32]
+
+
+def _handle_tools_list(req_id: Any, _params: dict, token_info: dict) -> dict:
+    """Handle MCP tools/list — filtered by the authorization actually presented.
+
+    The spec blesses a tool set that varies by credential, and until now every
+    caller saw every tool regardless of the scopes on its token: a
+    `metrics:read`-only credential was shown `search_feedback` and `get_project`,
+    called one, and was refused with -32003. A catalogue that lists what the
+    caller cannot call is a catalogue that has to be tried to be believed.
+
+    Cache hints travel with the answer because `listChanged: false` means the
+    client is on its own: nothing will tell it the list moved. `scope: credential`
+    is the load-bearing one — a shared cache keyed on the endpoint alone would
+    serve one token's catalogue to another token.
+    """
+    tools = _tools_for(token_info)
+    return _jsonrpc_result(req_id, RESULT_TYPE_TOOL_LIST, {
+        "tools": tools,
+        "_meta": {
+            "cacheHints": {
+                # Cacheable, and the qualifier matters more than the flag: this
+                # answer is a function of the CREDENTIAL, not of the endpoint.
+                "cacheable": True,
+                "scope": "credential",
+                "maxAgeSeconds": _TOOL_LIST_MAX_AGE_SECONDS,
+                "etag": _tools_list_etag(tools),
+                "serverVersion": MCP_SERVER_VERSION,
+                # Stated rather than implied by the capability: a client reading
+                # the hints should not have to also read `initialize` to learn
+                # that nothing will notify it.
+                "listChangedNotifications": False,
+            },
+        },
+    })
 
 
 def _scope_allows(token_scopes: Any, required_scope: str) -> bool:
@@ -1939,7 +2526,7 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         logger.exception(f"Tool execution error: {tool_name}")
         return _tool_error(req_id, f"Error: {str(e)}")
 
-    return _jsonrpc_result(req_id, {
+    return _jsonrpc_result(req_id, RESULT_TYPE_TOOL_RESULT, {
         "content": [{"type": "text", "text": result.text}],
         # Structured output alongside the text block, not instead of it: the
         # spec says a tool SHOULD keep sending the serialized form for clients
@@ -1947,12 +2534,30 @@ def _handle_tools_call(req_id: Any, params: dict, token_info: dict) -> dict:
         # they cannot disagree.
         "structuredContent": result.structured,
         "isError": False,
+        # The cost the call actually carried, which is the same class the
+        # catalogue advertised — read from one table so an advertised `cheap` and
+        # a billed `expensive` cannot be two different facts.
+        #
+        # `.get` rather than `[...]`, for the same reason `_FEEDBACK_SOURCE_KEYS`
+        # is read with a fallback: a tool with no declared class must not turn
+        # into a `KeyError` that kills a working call. The omission is still a CI
+        # failure (`_published_tool` refuses to build the catalogue, and the
+        # declaration tables are asserted to agree), so this decides only whether
+        # the symptom is a red test or a dead tool.
+        **({"_meta": {"costClass": TOOL_COST_CLASSES[tool_name]}}
+           if tool_name in TOOL_COST_CLASSES else {}),
     })
 
 
 def _tool_error(req_id: Any, message: str) -> dict:
-    """A tool EXECUTION error: a successful JSON-RPC call reporting a failure."""
-    return _jsonrpc_result(req_id, {
+    """A tool EXECUTION error: a successful JSON-RPC call reporting a failure.
+
+    Its own `resultType`, distinct from a successful tool result, because the
+    payloads differ in a way `isError` alone does not describe: there is no
+    `structuredContent` to validate against the tool's `outputSchema`. A client
+    switching on the type knows that without having to test for the key.
+    """
+    return _jsonrpc_result(req_id, RESULT_TYPE_TOOL_ERROR, {
         "content": [{"type": "text", "text": message}],
         "isError": True,
     })
@@ -1960,14 +2565,20 @@ def _tool_error(req_id: Any, message: str) -> dict:
 
 def _handle_ping(req_id: Any, _params: dict) -> dict:
     """Handle MCP ping request."""
-    return _jsonrpc_result(req_id, {})
+    return _jsonrpc_result(req_id, RESULT_TYPE_PONG, {})
 
 
-# Method → handler mapping
-# initialize and ping don't require auth
+# Method → handler mapping.
+#
+# `initialize`, `ping` and `server/discover` require no credential, and
+# `server/discover` is deliberately in this half: it answers what the SERVER
+# supports, which a client needs before it has decided which credential to
+# present — and it names no project, no tool and no data. `tools/list` is in the
+# other half precisely because its answer IS credential-shaped.
 MCP_METHODS = {
     "initialize": _handle_initialize,
     "ping": _handle_ping,
+    "server/discover": _handle_discover,
     "notifications/initialized": None,  # notification, no response needed
 }
 
@@ -2090,9 +2701,15 @@ def lambda_handler(event: dict, context: Any) -> dict:
         event['pathParameters']['project_id'] = autoseed_match.group(1)
         return _handle_autoseed(event)
 
+    # GET and DELETE are the two the Streamable HTTP transport defines and this
+    # server does not implement — GET opens an SSE stream, DELETE terminates a
+    # session — so they get 405 with an `Allow` header (attached in
+    # `_cors_response`) naming what IS allowed, which is what tells a client to
+    # stop trying rather than to retry differently. Everything else that is not
+    # POST lands here too, for the same reason and with the same answer.
     if http_method != 'POST':
         return _cors_response(
-            _jsonrpc_error(None, -32600, "Only POST is supported"),
+            _jsonrpc_error(None, -32600, f"Method not allowed: {http_method or 'unknown'}"),
             status_code=405,
         )
 
@@ -2105,18 +2722,49 @@ def lambda_handler(event: dict, context: Any) -> dict:
             status_code=400,
         )
 
-    req_id = body.get('id')
-    method = body.get('method', '')
-    params = body.get('params', {})
+    req_id = body.get('id') if isinstance(body, dict) else None
+    method = body.get('method', '') if isinstance(body, dict) else ''
+    params = body.get('params', {}) if isinstance(body, dict) else {}
 
     logger.info(f"MCP request: method={method}, id={req_id}")
 
-    # Handle non-auth methods (initialize, ping)
+    # Transport-header validation, BEFORE dispatch and before authentication.
+    #
+    # Before dispatch because a request whose transport and body disagree has not
+    # said what it wants, so there is nothing to dispatch to; before
+    # authentication for the same reason `_origin_allowed` is — a malformed
+    # request should not buy a probe of the token store.
+    #
+    # The protocol version is validated even for `initialize`, which is not a
+    # contradiction: the HEADER is the transport's version, the handshake's
+    # `params.protocolVersion` is the session's, and a client may state a
+    # transport version it cannot be served on its very first request.
+    try:
+        _validated_protocol_version(event)
+        _validate_routing_headers(event, method, params)
+    except InvalidTransportHeader as exc:
+        return _cors_response(
+            _jsonrpc_error(req_id, -32600, str(exc)),
+            status_code=400,
+        )
+
+    # Handle the methods that need no credential (initialize, ping,
+    # server/discover, notifications).
     if method in MCP_METHODS:
+        # A PRESENTED credential is checked even here, and this is the honesty fix
+        # this envelope owes: a revoked or expired token used to complete the whole
+        # handshake and fail only at the first `tools/call`, so a dead credential
+        # presented as a connected server and whoever was debugging went looking
+        # at the tools. An ABSENT credential still passes — a client is entitled to
+        # ask what this server is before deciding what to present — so this
+        # refuses only a credential that was offered and does not work.
+        refusal = _refuse_a_dead_credential(event, req_id)
+        if refusal is not None:
+            return refusal
         handler = MCP_METHODS[method]
         if handler is None:
             # Notification — no response needed, but HTTP requires a body
-            return _cors_response(_jsonrpc_result(req_id, {}))
+            return _cors_response(_jsonrpc_result(req_id, RESULT_TYPE_ACK, {}))
         return _cors_response(handler(req_id, params))
 
     # All other methods require authentication
@@ -2138,14 +2786,59 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 status_code=401,
             )
 
-        handler = MCP_AUTH_METHODS[method]
-        if method == 'tools/call':
-            result = handler(req_id, params, token_info)
-        else:
-            result = handler(req_id, params)
-        return _cors_response(result)
+        # Uniform arity across both authenticated methods: `tools/list` now needs
+        # the credential too, because the catalogue it publishes is filtered by it.
+        # The per-method branch this replaces was how a handler could be given the
+        # wrong arguments without anything saying so.
+        return _cors_response(MCP_AUTH_METHODS[method](req_id, params, token_info))
 
-    # Unknown method
+    # An unknown method is JSON-RPC's own -32601, and nothing else: a client
+    # probing for a method this server might have needs to be able to tell
+    # "no such method here" from a refusal it could fix. `server/discover` exists
+    # so the probe is unnecessary in the first place.
     return _cors_response(
         _jsonrpc_error(req_id, -32601, f"Method not found: {method}"),
+    )
+
+
+def _refuse_a_dead_credential(event: dict, req_id: Any) -> dict | None:
+    """401 when a credential was presented and does not authenticate, else None.
+
+    🔑 The honesty defect this closes: `initialize` needs no credential, so a
+    revoked or expired token completed the handshake, `tools/list` answered, and
+    the first `tools/call` was the first refusal. A client shows that as a
+    connected server with failing tools, which sends whoever is debugging at the
+    tools, at the scopes, at the routes — anywhere but the credential.
+
+    Only a PRESENTED credential is checked. No `Authorization` header is not a
+    dead credential, it is no credential, and an unauthenticated `initialize` or
+    `server/discover` is exactly how a client learns what to present.
+
+    A backend fault is a 500 here as it is on the authenticated path: reporting
+    "your token is invalid" for a table nobody could read sends an operator to
+    re-mint a credential that was never compared.
+    """
+    headers = event.get('headers') or {}
+    auth_header = ''
+    if isinstance(headers, dict):
+        auth_header = headers.get('authorization') or headers.get('Authorization') or ''
+    if not isinstance(auth_header, str) or not auth_header.startswith('Bearer '):
+        return None
+
+    try:
+        token_info = _authenticate(event)
+    except AuthBackendUnavailable:
+        return _cors_response(
+            _jsonrpc_error(req_id, -32603, "Internal error: token store unavailable"),
+            status_code=500,
+        )
+    if token_info:
+        return None
+    logger.info("Credential presented on an unauthenticated method does not authenticate")
+    return _cors_response(
+        _jsonrpc_error(
+            req_id, -32001,
+            "Unauthorized: the presented API token is invalid, revoked or expired",
+        ),
+        status_code=401,
     )

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -91,12 +91,36 @@ projects_table = get_projects_table()
 # a real phase (per-request `_meta`, the -32602 refusal, the header/`_meta` match)
 # rather than an entry in this tuple.
 #
-# The two OLDEST entries are here for compatibility rather than because they
-# define anything this server needs, and leaving them out was a live client break:
-# the deployed handler pinned 2024-11-05, so every client that has completed a
+# The OLDEST entry is here for compatibility rather than because it defines
+# anything this server needs, and leaving it out was a live client break: the
+# deployed handler pinned 2024-11-05, so every client that has completed a
 # handshake against it sends `MCP-Protocol-Version: 2024-11-05` on every
 # subsequent request — which a header validator that only knew the newer revisions
 # refused with a 400. Accepting a revision is not the same as preferring it.
+#
+# ⚠️ 2025-03-26 IS DELIBERATELY ABSENT TOO, and for the same class of reason as
+# 2026-07-28: it is the ONE revision that mandates JSON-RPC BATCHING, and this
+# handler implements none. That revision's *Sending Messages to the Server* says
+# the POST body MUST be a single message, "an array batching one or more requests
+# and/or notifications", or an array of responses — batching arrived in 2025-03-26
+# and was removed again in 2025-06-18, so it is a one-revision-wide obligation this
+# range happened to straddle. Advertising it while answering a legal batch body
+# with `404 -32601 "Method not found: "` was the same skew this tuple exists to
+# end, and the 404 was worse than the wrong code: on the advertised revisions a 404
+# on this endpoint means the SESSION was terminated and the client MUST
+# re-initialize, so a client batching its `initialized` notification was told to
+# tear down and try again — which got it there again.
+#
+# It SURVIVES as `ASSUMED_PROTOCOL_VERSION` below, which is not a contradiction:
+# the spec names 2025-03-26 as the READING for a request carrying no header at all,
+# and a fallback reading is not an advertisement. Nothing is offered on it, so no
+# client concludes from a counter-offer that its batches will be served. A client
+# whose own newest revision is 2025-03-26 and which sends the header now gets the
+# spec's -32022 with `data.supported` and retries on 2024-11-05 or 2025-06-18 —
+# one round trip, against a batch body being answered with a session teardown.
+#
+# A batch body is refused explicitly rather than left to fall through the dispatch:
+# see `_is_batch` and the `-32600` refusal in `lambda_handler`.
 #
 # Ordered NEWEST FIRST, and that order is load-bearing: `_negotiate_protocol_version`
 # answers with the client's version when it is one of these, and otherwise with
@@ -105,9 +129,26 @@ projects_table = get_projects_table()
 SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
     "2025-11-25",
     "2025-06-18",
-    "2025-03-26",
     "2024-11-05",
 )
+
+# The revisions whose TRANSPORT-LEVEL BODY GRAMMAR this handler does not accept, so
+# that "we advertise only what we implement" is checked rather than remembered.
+# 2025-03-26 requires an array body to be handled; this server refuses one.
+#
+# Declared beside the tuple it constrains, and asserted against it below, because
+# the way this went wrong was a revision being re-added for a good reason (a header
+# validator was refusing deployed clients) by someone reasoning about the header
+# and not about the body grammar.
+BODY_GRAMMAR_UNIMPLEMENTED_VERSIONS: frozenset[str] = frozenset({"2025-03-26"})
+
+# `raise` rather than `assert`, which this tree requires: a bare `assert` is
+# stripped under `python -O`.
+if set(SUPPORTED_PROTOCOL_VERSIONS) & BODY_GRAMMAR_UNIMPLEMENTED_VERSIONS:
+    raise RuntimeError(
+        'advertising a revision whose body grammar this handler does not accept: '
+        f'{sorted(set(SUPPORTED_PROTOCOL_VERSIONS) & BODY_GRAMMAR_UNIMPLEMENTED_VERSIONS)}'
+    )
 
 # What an `initialize` that asks for nothing usable is answered with. Derived
 # rather than restated so it cannot disagree with the tuple above.
@@ -125,6 +166,16 @@ PREFERRED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
 # client written against an earlier revision, and 2025-03-26 is the value the spec
 # names for that case. Reading absence as the NEWEST supported revision — as this
 # did — silently upgrades exactly the clients that cannot be upgraded.
+#
+# ⚠️ DELIBERATELY NOT IN `SUPPORTED_PROTOCOL_VERSIONS`, and the distinction is the
+# whole reason this is a separate constant rather than an index into that tuple. A
+# FALLBACK READING is what this server assumes about a client that said nothing; an
+# ADVERTISEMENT is what it offers a client that asked. 2025-03-26 mandates JSON-RPC
+# batching, which this handler does not implement (see the tuple's comment), so it
+# must not be offered — and it is exactly the value the spec tells a server to
+# assume for a header-less request, so it must not be dropped either. Nothing reads
+# this value beyond `_validated_protocol_version`, which is what makes assuming an
+# unadvertised revision harmless: the assumption gates nothing and shapes nothing.
 ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 
 # 🔑 THE NEGOTIATED VERSION IS A GATE, NOT A MODE — and this is a deliberate
@@ -304,7 +355,44 @@ ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 # change is from an ill-formed answer to the one the spec mandates: a client
 # ignoring the ack (the only correct thing to do with it) is unaffected, and one
 # parsing it was parsing a response it should never have received.
-MCP_SERVER_VERSION = "3.4.0"
+#
+# 3.5.0 stops claiming three things this envelope does not do, and each was a claim
+# a client could act on:
+#   • `2025-03-26` IS NO LONGER ADVERTISED. It is the one revision that mandates
+#     JSON-RPC batching and this handler implements none: a legal batch body was
+#     answered `404 -32601`, and on the advertised revisions that 404 means the
+#     session was terminated, so a client batching its `initialized` notification was
+#     told to tear down and re-initialize — which got it there again. A batch is now
+#     refused with `-32600` and a message naming batching, and the revision remains
+#     the reading for a HEADER-LESS request (`ASSUMED_PROTOCOL_VERSION`), which is a
+#     fallback rather than an offer.
+#   • `server/discover` DECLARES `cacheScope: private`, not `public`. The payload is
+#     credential-independent; the RESPONSE is not, because the method is liveness-
+#     checked — no credential is a 200 and a revoked one is a 401. `public` licenses a
+#     shared cache to serve that 200 across authorization contexts for an hour,
+#     including to the request that was owed the 401.
+#   • A refusal aimed at a message that is not a request OMITS the `id` member
+#     instead of sending `id: null`. The 202 path had fixed the accepted case; a
+#     notification failing a transport guard, and the Origin 403 (which runs before
+#     the body is parsed), still replied with an id matching no request the client
+#     sent.
+# Also `Vary: Authorization` and `Cache-Control: private` on every response — the
+# header-level form of `cacheScope`, for the intermediaries that never parse a body.
+#
+# ⚠️ MINOR, and the rule at 3.3.0 is what decides it, but this entry is the closest
+# call in this file's history. Dropping an advertised revision REMOVES something a
+# deployed client can hold: a client that handshook on 2025-03-26 against the 3.3.0
+# build and sends that header now gets `-32022` where it got a 200. It is minor
+# because no 3.x build advertising it was ever DEPLOYED — the deployed build pinned
+# 2024-11-05, which is still advertised — so the set of clients that can hold
+# 2025-03-26 from this server is empty. Were it non-empty, this would be major: the
+# distinction remains "could a client have cached it", and the refusal it gets now
+# carries `data.supported` and one retry, against a batch body being answered with a
+# session teardown.
+#
+# No published tool declaration moved, so the fingerprinted catalogue is untouched
+# again.
+MCP_SERVER_VERSION = "3.5.0"
 
 
 # ============================================
@@ -648,7 +736,47 @@ CORS_HEADERS = {
     'Access-Control-Allow-Methods': 'POST,OPTIONS',
     # Without this a BROWSER-based MCP client can receive the 401 challenge but
     # never read it: WWW-Authenticate is not a CORS-safelisted response header.
-    'Access-Control-Expose-Headers': 'WWW-Authenticate',
+    #
+    # `Vary` is exposed for the same reason. It is not CORS-safelisted either, so a
+    # browser-based client that wanted to reason about its own cache — or to notice
+    # that this endpoint varies by credential — could not read the header that says
+    # so. Pinned in lockstep with the gateway's `exposeHeaders` by
+    # api-stack.test.ts, because a gateway-GENERATED response (the authorizer's 401)
+    # carries the gateway's list and not this one.
+    'Access-Control-Expose-Headers': 'WWW-Authenticate,Vary',
+    # 🔑 The HTTP-layer counterpart of `cacheScope`, and it is needed because those
+    # two words live in the JSON-RPC BODY while every cache likely to sit in front of
+    # this endpoint — API Gateway, a CDN, a corporate proxy — reads headers and never
+    # parses a body. `tools/list` genuinely varies: a full credential lists six tools
+    # and a `metrics:read` one lists two, with different etags. Declaring
+    # `cacheScope: private` in a payload no intermediary reads is a mitigation that
+    # reaches only the clients that were never the risk.
+    #
+    # Sent UNCONDITIONALLY, from the one choke point, rather than on the responses
+    # that happen to vary today. Two reasons: the header costs nothing on an answer
+    # that does not vary (it forbids a cache hit that would have been correct, and
+    # nothing in the current path caches POST at all), while getting the condition
+    # wrong costs a cross-credential hit — so the asymmetry says do not have a
+    # condition. And `Allow`/`WWW-Authenticate` above are attached by STATUS, which
+    # is a fact about one response; "this endpoint's answers depend on the
+    # credential" is a fact about the endpoint.
+    #
+    # `Authorization` alone: `Access-Control-Allow-Origin` is the static `*` above,
+    # so the answer does not vary by `Origin` and naming it would forbid cache hits
+    # for no reason. The credential is the only axis.
+    'Vary': 'Authorization',
+    # And the statement a cache actually obeys. `Vary` says WHICH request header
+    # partitions the cache; `Cache-Control: private` says a SHARED cache must not
+    # store the response at all. Both, because they answer different questions and a
+    # cache may honour one and not the other — a proxy that ignores `Vary` and
+    # respects `private` still cannot serve one credential's catalogue to another.
+    #
+    # `private` alone, with no `no-store` and no `no-cache`: a client's OWN cache
+    # reusing its OWN answer for `ttlMs` is exactly what the hint invites, and
+    # `no-cache` would forbid at the HTTP layer the reuse the body asks for. The two
+    # statements have to agree, and the one they agree on is "yours to reuse, not to
+    # share".
+    'Cache-Control': 'private',
 }
 
 # RFC 6750 §3: a 401 for a protected resource carries a WWW-Authenticate
@@ -2041,12 +2169,37 @@ MCP_TOOLS = [_published_tool(declaration) for declaration in _TOOL_DECLARATIONS]
 # filter makes load-bearing: "Cached responses MAY be reused for the same
 # authorization context. Caches MUST NOT be shared across authorization contexts."
 #
+# 🔑 THE SCOPE DESCRIBES THE RESPONSE, NOT THE PAYLOAD, and getting that backwards
+# was a live hole. `server/discover` was declared `public` on the argument that its
+# CONTENT names no project, no tool and no data — true of the content, and beside
+# the point. `server/discover` is in `_LIVENESS_CHECKED_METHODS`, so whether there
+# is an answer at all is a function of the credential: no credential is a 200, a
+# revoked one is a 401. `public` says a shared cache MAY serve the response "across
+# authorization contexts", which licenses replaying that unauthenticated 200 for an
+# hour to the request carrying the dead token — defeating the liveness check on the
+# one method whose whole reason for being in that set is the client that STARTS at
+# discovery. Two changes each right on their own terms: the liveness check made
+# discovery credential-sensitive and the cache hints declared it
+# credential-insensitive.
+#
+# `public` is therefore reserved for a response whose EXISTENCE is credential-
+# independent, and no answer this server currently sends qualifies. The invariant is
+# checked rather than remembered: `test_no_public_answer_is_credential_gated` derives
+# both halves from the constants and fails if a method declaring `public` appears in
+# `_LIVENESS_CHECKED_METHODS`.
+#
 # ⚠️ BOTH FIELDS ARE DEFINED BY 2026-07-28, which this server does not advertise —
 # so "it REQUIRES them" above is that revision's requirement, and under the
 # advertised range they are additive extras a client may ignore. Sending them early
 # is the deliberate bet recorded in the PROVENANCE block at
 # `ASSUMED_PROTOCOL_VERSION`; the alternative was the locally-invented
 # `_meta.cacheHints` this replaced, renamed later.
+#
+# `CACHE_SCOPE_PUBLIC` is declared and currently SENT BY NOTHING, which is deliberate
+# rather than dead: it is half of the spec's vocabulary, it is what the invariant
+# above is stated in terms of, and the test that enforces that invariant needs the
+# value to compare against. Keeping the name is what lets the rule be written down;
+# deleting it would leave the rule expressible only as a string literal in a test.
 CACHE_SCOPE_PUBLIC = 'public'
 CACHE_SCOPE_PRIVATE = 'private'
 
@@ -2067,10 +2220,33 @@ _TOOL_LIST_MAX_AGE_SECONDS = 300
 # not simply be renamed.
 _TOOL_LIST_TTL_MS = _TOOL_LIST_MAX_AGE_SECONDS * 1000
 
-# Discovery is cacheable for longer than the catalogue, and for a different reason:
-# it is a function of the DEPLOYED BUILD (versions, methods, headers), not of any
-# credential, so the only thing that invalidates it is a deploy.
+# Discovery's CONTENT is cacheable for longer than the catalogue, and for a
+# different reason: it is a function of the DEPLOYED BUILD (versions, methods,
+# headers), not of any credential, so the only thing that invalidates the content is
+# a deploy.
+#
+# The hour stands even under `private`. A per-authorization-context cache can serve
+# a stale 200 to the holder of a credential revoked in the meantime, and that costs
+# nothing this server was protecting: the liveness check on discovery is an HONESTY
+# fix — it stops a dead credential presenting as a connected server — not a
+# confidentiality boundary, and this payload names no project, no tool and no data.
+# What `private` prevents is the case that IS a boundary: replaying it to a
+# DIFFERENT authorization context that was owed a 401.
 _DISCOVER_TTL_MS = 3_600_000
+
+# The two cacheable answers and the scope each declares, as ONE table rather than a
+# literal at each handler — because the invariant that binds it (`public` must not
+# be a credential-gated answer) spans this and `_LIVENESS_CHECKED_METHODS`, and an
+# invariant across two facts needs both to be readable in one place. The test
+# derives from this and from that set rather than restating either.
+METHOD_CACHE_SCOPES: dict[str, str] = {
+    # Credential-gated by `_LIVENESS_CHECKED_METHODS`, so not `public`. See the
+    # 🔑 note above `CACHE_SCOPE_PUBLIC`.
+    'server/discover': CACHE_SCOPE_PRIVATE,
+    # Credential-gated twice over: it requires a credential AND its content varies
+    # by one.
+    'tools/list': CACHE_SCOPE_PRIVATE,
+}
 
 
 # ============================================
@@ -2652,6 +2828,19 @@ RESULT_SHAPES: frozenset[str] = frozenset({
 })
 
 
+# The id of a message that HAS none — passed to `_jsonrpc_error` for a refusal
+# whose subject is not a request, where the `id` member is OMITTED rather than sent
+# as null.
+#
+# A sentinel object rather than `None`, because `None` is a legitimate id to echo:
+# JSON-RPC's own rule for a malformed body is that an id it could not detect is
+# reported as `null`, and `test_a_non_object_body_is_not_a_crash` pins exactly that.
+# So "no id at all" and "an id of null" are two different answers and cannot share
+# one spelling — which is the same distinction `_is_notification` turns on, one
+# layer down.
+_NO_ID = object()
+
+
 def _jsonrpc_error(req_id: Any, code: int, message: str, data: Any = None) -> dict:
     """Build a JSON-RPC error response, optionally carrying machine-readable data.
 
@@ -2662,15 +2851,29 @@ def _jsonrpc_error(req_id: Any, code: int, message: str, data: Any = None) -> di
     It exists because two of the spec's own errors put the caller's recovery path
     in `data` rather than in prose — `-32022` lists the versions this server does
     speak, which is what the client retries with. Prose is not a recovery path.
+
+    ⚠️ `req_id=_NO_ID` OMITS the `id` member, and that is not a cosmetic option. The
+    202 path stopped answering notifications with a result carrying `id: null`, but
+    the REFUSAL path still did: a notification failing a transport guard was answered
+    `400 {"id": null, "error": …}`. Every advertised revision says a notification the
+    server cannot accept gets an HTTP error status whose body "MAY comprise a
+    JSON-RPC error response that has NO id" — and `id: null` is a PRESENT member with
+    a null value, which this module already holds is not the same thing (see
+    `_is_notification`, and the 3.4.0 note recording that a result's id must not be
+    null). A client correlating by id held an error entry matching no request it sent.
+
+    Passing `None` still sends `"id": null`, which is what JSON-RPC requires for a
+    body whose id could not be detected at all — a parse error, a batch, a non-object.
+    The two cases are spelled differently because they are different answers.
     """
     error: dict[str, Any] = {"code": code, "message": message}
     if data is not None:
         error["data"] = data
-    return {
-        "jsonrpc": "2.0",
-        "id": req_id,
-        "error": error,
-    }
+    envelope: dict[str, Any] = {"jsonrpc": "2.0"}
+    if req_id is not _NO_ID:
+        envelope["id"] = req_id
+    envelope["error"] = error
+    return envelope
 
 
 def _jsonrpc_result(req_id: Any, result_shape: str, result: dict) -> dict:
@@ -2793,11 +2996,20 @@ def _handle_discover(req_id: Any, _params: dict) -> dict:
         "supportedVersions": list(SUPPORTED_PROTOCOL_VERSIONS),
         "capabilities": _server_capabilities(),
         # `server/discover` is in the spec's cacheable-results list, so the hints
-        # are REQUIRED rather than a nicety. `public` is honest here: this answer
-        # names no project, no tool and no data, so a shared cache serving it to
-        # another caller reveals nothing that caller could not ask for itself.
+        # are REQUIRED rather than a nicety.
+        #
+        # ⚠️ `private`, NOT `public`, and the earlier `public` was wrong for a reason
+        # worth stating at the site: the scope describes the RESPONSE, not the
+        # payload. This payload is genuinely credential-independent — it names no
+        # project, no tool and no data — but this method is in
+        # `_LIVENESS_CHECKED_METHODS`, so whether there is a 200 at all depends on
+        # the credential presented. `public` licenses an intermediary to serve the
+        # unauthenticated 200 "across authorization contexts" for the hour below,
+        # including to the request carrying a revoked token that was owed a 401 —
+        # defeating the liveness check on the one method that exists in that set for
+        # the client which starts here. Full argument at `CACHE_SCOPE_PUBLIC`.
         "ttlMs": _DISCOVER_TTL_MS,
-        "cacheScope": CACHE_SCOPE_PUBLIC,
+        "cacheScope": METHOD_CACHE_SCOPES['server/discover'],
         "_meta": {
             # The spec's reserved key for server identity — self-reported, and the
             # spec says clients SHOULD NOT make security decisions on it.
@@ -2965,7 +3177,7 @@ def _handle_tools_list(req_id: Any, _params: dict, token_info: dict) -> dict:
         # CREDENTIAL rather than of the endpoint — the spec names this exact case
         # ("filtered list results that vary per user").
         "ttlMs": _TOOL_LIST_TTL_MS,
-        "cacheScope": CACHE_SCOPE_PRIVATE,
+        "cacheScope": METHOD_CACHE_SCOPES['tools/list'],
         "_meta": {
             # Not spec fields, so vendor-prefixed. The etag is what makes staleness
             # DETECTABLE rather than merely time-bounded, which matters more here
@@ -3295,6 +3507,22 @@ def _is_notification(body: Any, method: str) -> bool:
     return method.startswith(_NOTIFICATION_METHOD_PREFIX)
 
 
+def _is_batch(body: Any) -> bool:
+    """True when the body is a JSON-RPC BATCH — an array of messages.
+
+    A list is the only shape this can be, and it is a shape only ONE revision ever
+    required: 2025-03-26 added batching to the transport and 2025-06-18 removed it
+    again. This server implements none of it, which is why that revision is not
+    advertised (see `SUPPORTED_PROTOCOL_VERSIONS`).
+
+    An EMPTY list counts, and deliberately: `[]` is not a legal batch under the
+    revision that defined them ("one or more"), but it is unambiguously an array
+    body, and the answer a caller needs is "this server does not do arrays" rather
+    than a count of the elements in the array it should not have sent.
+    """
+    return isinstance(body, list)
+
+
 @tracer.capture_method
 def _handle_autoseed(event: dict) -> dict:
     """Handle GET /mcp/autoseed/{project_id} with Bearer token auth.
@@ -3384,9 +3612,16 @@ def lambda_handler(event: dict, context: Any) -> dict:
     # including OPTIONS. The MCP transport spec requires 403 for a present,
     # invalid Origin; checking before _authenticate also means a rebound page
     # cannot use a victim's browser to probe the token store at all.
+    #
+    # `_NO_ID`, not `None`: this guard runs before the body is even parsed, so the
+    # message being refused may well be a notification — and the transport's own
+    # wording for this refusal is that the body "MAY comprise a JSON-RPC error
+    # response that has no `id`". Sending `id: null` handed a correlating client an
+    # entry matching no request it made, for a message that may have carried no id
+    # in the first place.
     if not _origin_allowed(event):
         return _cors_response(
-            _jsonrpc_error(None, -32600, "Forbidden: invalid Origin"),
+            _jsonrpc_error(_NO_ID, -32600, "Forbidden: invalid Origin"),
             status_code=403,
         )
 
@@ -3442,6 +3677,51 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
     logger.info(f"MCP request: method={method}, id={req_id}")
 
+    # A BATCH — an array body — is refused here, naming batching, rather than left
+    # to fall through the dispatch.
+    #
+    # It used to fall through: `body.get(...) if isinstance(body, dict)` made
+    # `method` the empty string, and a legal 2025-03-26 batch landed on the
+    # unknown-method branch and was answered `404 -32601 "Method not found: "`. Three
+    # things were wrong with that and only one of them was the code. The 404 means
+    # "the session was terminated, re-initialize" on the revisions this server
+    # advertises, so a client batching its `initialized` notification was told to
+    # tear down a working session — and re-initializing got it there again. And an
+    # empty method name in the message told a caller nothing about what it had
+    # actually done wrong.
+    #
+    # `-32600 Invalid Request`, not `-32601`: the fault is the SHAPE of the request,
+    # not a method that is missing — there is no method here to be found. The
+    # message names batching so the caller learns the actual constraint, and the
+    # `data` payload carries the machine-readable version of it.
+    #
+    # The honest fix upstream is that 2025-03-26 is no longer advertised (see
+    # `SUPPORTED_PROTOCOL_VERSIONS`), so no client is told this server accepts a
+    # shape it refuses. This branch is what makes the refusal legible to a client
+    # that sends one anyway.
+    #
+    # Before the transport-header guards, and that ordering is deliberate: a batch
+    # has no single `method` for `Mcp-Method` to be compared against, so validating
+    # the routing echoes first would report a header/body mismatch against `''` —
+    # an answer about a header, for a request whose whole shape this server does not
+    # accept. The batch refusal still buys no probe of the token store, which is the
+    # property the guard ordering exists for.
+    if _is_batch(body):
+        logger.info("MCP batch body refused: this server accepts one message per POST")
+        return _cors_response(
+            _jsonrpc_error(
+                None, JSONRPC_INVALID_REQUEST,
+                'Batched requests are not supported: send one JSON-RPC message per '
+                'POST. Batching is defined only by protocol revision 2025-03-26, '
+                'which this server does not advertise.',
+                data={
+                    "supported": list(SUPPORTED_PROTOCOL_VERSIONS),
+                    "batchingSupported": False,
+                },
+            ),
+            status_code=400,
+        )
+
     # Transport-header validation, BEFORE dispatch and before authentication.
     #
     # Before dispatch because a request whose transport and body disagree has not
@@ -3465,8 +3745,22 @@ def lambda_handler(event: dict, context: Any) -> dict:
         # disagreement), and a single generic code at this one catch site is how the
         # first draft of this change lost both the client's recovery path and the
         # era-detection signal.
+        #
+        # ⚠️ The MESSAGE KIND is consulted here even though this runs before the
+        # notification branch, and it has to be: a notification that fails a guard is
+        # still a notification, and its refusal was the last place `id: null` was
+        # sent to a message that carries no id. The advertised revisions say a
+        # notification the server cannot accept gets an HTTP error status whose body
+        # "MAY comprise a JSON-RPC error response that has NO id" — so the STATUS and
+        # the code stay exactly as they were and only the envelope changes. This
+        # branch is not the notification's acceptance path (that is the 202 below,
+        # and it is deliberately still after the guards); it is the refusal path
+        # learning what it is refusing.
         return _cors_response(
-            _jsonrpc_error(req_id, exc.code, str(exc), exc.data),
+            _jsonrpc_error(
+                _NO_ID if _is_notification(body, method) else req_id,
+                exc.code, str(exc), exc.data,
+            ),
             status_code=exc.status_code,
         )
 

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1058,16 +1058,23 @@ class TestStructuredOutput:
         major = mcp_handler.MCP_SERVER_VERSION.split(".")[0]
         assert int(major) >= 2
 
-    def test_a_changed_tool_output_shape_moves_the_server_version(self):
+    def test_a_changed_published_tool_shape_moves_the_server_version(self):
         """`serverInfo.version` is the only signal a client gets, so it is pinned
         to the shapes it describes.
 
         The check above (`major >= 2`) passes forever, which means it would have
-        let this PR's own persona-shape change ship under the version that
-        described the previous one. Fingerprinting the declared `outputSchema`s in
+        let #356's own persona-shape change ship under the version that described
+        the previous one. Fingerprinting the PUBLISHED tool declarations in
         lockstep makes any edit to a published shape fail here until the version
         is reconsidered — the repo's lockstep pattern, applied to the one contract
         that leaves the account.
+
+        The fingerprint covers the WHOLE published entry, not just `outputSchema`,
+        and that widening is deliberate: a client caches `tools/list` at connect,
+        so its `inputSchema`, its `annotations` and its `_meta` are as much of the
+        cached contract as the output shape is. Fingerprinting only the output half
+        let the envelope change (annotations, cost classes) move what clients cache
+        without moving the number that tells them to re-fetch it.
 
         OBJECT key order does not count (`sort_keys`), so reformatting a
         declaration is free. LIST order does count, and `required` and `enum` are
@@ -1081,16 +1088,17 @@ class TestStructuredOutput:
             # `test_every_tool_declares_an_output_schema`'s claim, and this test
             # should say which tool broke it, not where it noticed.
             assert "outputSchema" in tool, f"{tool['name']} declares no output shape"
-            shapes[tool["name"]] = tool["outputSchema"]
+            shapes[tool["name"]] = tool
 
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.1.0", "95dc5ca05354367b"), (
-            "a tool's declared output shape changed. Move MCP_SERVER_VERSION — minor "
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.2.0", "648e52b109dce9b8"), (
+            "a tool's published declaration changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
-            "validates structuredContent against these schemas — then update the "
-            "fingerprint here in the same commit."
+            "validates structuredContent against these schemas and caches the whole "
+            "declaration at connect — then update the fingerprint here in the same "
+            "commit."
         )
 
 

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1093,7 +1093,7 @@ class TestStructuredOutput:
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.4.0", "7131e9e21c26a1ed"), (
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.5.0", "7131e9e21c26a1ed"), (
             "a tool's published declaration changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
             "validates structuredContent against these schemas and caches the whole "

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1093,7 +1093,7 @@ class TestStructuredOutput:
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.2.0", "648e52b109dce9b8"), (
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.3.0", "7131e9e21c26a1ed"), (
             "a tool's published declaration changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
             "validates structuredContent against these schemas and caches the whole "

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1093,7 +1093,7 @@ class TestStructuredOutput:
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.3.0", "7131e9e21c26a1ed"), (
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.4.0", "7131e9e21c26a1ed"), (
             "a tool's published declaration changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
             "validates structuredContent against these schemas and caches the whole "

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1093,7 +1093,7 @@ class TestStructuredOutput:
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.5.0", "7131e9e21c26a1ed"), (
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.6.0", "7131e9e21c26a1ed"), (
             "a tool's published declaration changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
             "validates structuredContent against these schemas and caches the whole "

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -280,6 +280,17 @@ class TestServerDiscover:
         assert status == 200, body
         return body["result"]
 
+    def _detail(self) -> dict:
+        """The vendor-prefixed sub-object carrying this server's own reporting.
+
+        Everything the SPEC does not define lives here rather than at the top
+        level, which is the correction this class exercises: a `DiscoverResult`
+        carrying undefined top-level keys is one a strict client cannot validate.
+        """
+        return self._discover()["_meta"][
+            f"{mcp_handler.VENDOR_META_PREFIX}serverDetail"
+        ]
+
     def test_discover_needs_no_credential(self):
         """It answers what the SERVER supports, which a client needs before it has
         decided what to present. It names no project, no tool and no data."""
@@ -291,17 +302,23 @@ class TestServerDiscover:
     def test_it_reports_every_protocol_version_the_server_speaks(self):
         result = self._discover()
 
-        assert result["protocolVersions"] == list(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
-        assert result["preferredProtocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
+        # The SPEC's field name. A client calls this method precisely to learn the
+        # versions, so publishing them under a name of our own invention left it
+        # reading `supportedVersions`, finding nothing, and no better off than if
+        # the method did not exist.
+        assert result["supportedVersions"] == list(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+        assert self._detail()["preferredProtocolVersion"] == (
+            mcp_handler.PREFERRED_PROTOCOL_VERSION
+        )
 
     def test_it_reports_every_method_the_server_dispatches(self):
         """Derived from the dispatch tables, so a method that exists is listed and
         one that is only listed cannot exist."""
-        result = self._discover()
+        detail = self._detail()
         dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
 
-        assert set(result["methods"]) == dispatched
-        assert set(result["authenticatedMethods"]) == set(mcp_handler.MCP_AUTH_METHODS)
+        assert set(detail["methods"]) == dispatched
+        assert set(detail["authenticatedMethods"]) == set(mcp_handler.MCP_AUTH_METHODS)
         # And the split is real: an authenticated method is not also served
         # without a credential.
         assert not set(mcp_handler.MCP_AUTH_METHODS) & set(mcp_handler.MCP_METHODS)
@@ -314,9 +331,9 @@ class TestServerDiscover:
         client sends, the guard reads the form API Gateway delivers. Both must name
         the same set of headers.
         """
-        result = self._discover()
+        detail = self._detail()
 
-        assert {name.lower() for name in result["transportHeaders"]} == set(
+        assert {name.lower() for name in detail["transportHeaders"]} == set(
             mcp_handler.TRANSPORT_HEADERS
         )
 
@@ -324,30 +341,90 @@ class TestServerDiscover:
         """The internal lowercase form is an artefact of API Gateway's
         normalisation, and publishing it would document an implementation detail
         as a contract."""
-        result = self._discover()
+        published = self._detail()["transportHeaders"]
 
-        assert "MCP-Protocol-Version" in result["transportHeaders"]
-        assert result["transportHeaders"] == sorted(result["transportHeaders"])
+        # The spec's own spellings, which are NOT one rule: the version header
+        # carries the acronym in caps and the two routing echoes title-case it.
+        # A single `MCP` rule published `MCP-Method`, a spelling the spec does not
+        # use.
+        assert set(published) == {"MCP-Protocol-Version", "Mcp-Method", "Mcp-Name"}
+        assert published == sorted(published)
 
-    def test_it_reports_the_result_type_vocabulary(self):
-        result = self._discover()
+    def test_it_reports_the_result_shape_vocabulary_under_its_own_name(self):
+        """Named `resultShapes`, not `resultTypes`.
 
-        assert set(result["resultTypes"]) == set(mcp_handler.RESULT_TYPES)
+        The spec owns the `resultType` vocabulary and this list is not it, so
+        publishing it as `resultTypes` would have claimed otherwise — in the very
+        answer a client reads to learn what this server means.
+        """
+        detail = self._detail()
+
+        assert set(detail["resultShapes"]) == set(mcp_handler.RESULT_SHAPES)
+        assert "resultTypes" not in detail
 
     def test_it_reports_the_cost_class_vocabulary_in_order(self):
         """Cheapest first: an unordered set of adjectives does not say which of
         two classes is the expensive one."""
-        result = self._discover()
-
-        assert result["costClasses"] == list(mcp_handler.COST_CLASSES)
+        assert self._detail()["costClasses"] == list(mcp_handler.COST_CLASSES)
 
     def test_it_says_the_tool_list_varies_by_credential(self):
         """Cheaper than letting a client find out by calling a tool it was never
         granted — and it is why discovery does not list tools itself."""
         result = self._discover()
 
-        assert result["toolsVaryByCredential"] is True
+        assert self._detail()["toolsVaryByCredential"] is True
         assert "tools" not in result
+
+    def test_server_info_travels_under_the_spec_reserved_meta_key(self):
+        """`serverInfo` is a `_meta` field in this revision, not a top-level one.
+
+        Publishing it at the top level put a key the `DiscoverResult` schema does
+        not define into a result a strict client validates.
+        """
+        result = self._discover()
+
+        assert "serverInfo" not in result
+        info = result["_meta"]["io.modelcontextprotocol/serverInfo"]
+        assert info == {"name": "voc-datalake", "version": mcp_handler.MCP_SERVER_VERSION}
+
+    def test_discovery_carries_the_caching_hints_the_spec_requires(self):
+        """`server/discover` is in the spec's cacheable-results list, so the two
+        hints are REQUIRED rather than optional.
+
+        `ttlMs` is MILLISECONDS — asserted as a magnitude rather than against the
+        constant, because the unit was the actual defect: a seconds value in a
+        milliseconds field reads as 0.3s, and an absent one reads as 0 (immediately
+        stale) per the spec's own default.
+        """
+        result = self._discover()
+
+        assert isinstance(result["ttlMs"], int)
+        assert result["ttlMs"] >= 60_000, (
+            f"ttlMs={result['ttlMs']} looks like seconds, not milliseconds"
+        )
+        # `public` is honest for this answer specifically: it names no project, no
+        # tool and no data, so a shared cache reveals nothing credential-shaped.
+        assert result["cacheScope"] == "public"
+
+    def test_the_discovery_answer_carries_no_undefined_top_level_fields(self):
+        """The whole correction, stated once as a closed set.
+
+        A client validating a `DiscoverResult` rejects unknown top-level keys, so
+        every local field has to sit in `_meta`. Written as "nothing outside this
+        set" rather than as individual absences, so a future field added at the top
+        level fails here instead of being noticed by a client.
+        """
+        result = self._discover()
+
+        allowed = {
+            # Spec-defined members of DiscoverResult (`instructions` is optional
+            # and this server sends none).
+            "supportedVersions", "capabilities", "ttlMs", "cacheScope",
+            "resultType", "_meta",
+        }
+        assert set(result) <= allowed, (
+            f"undefined top-level fields in DiscoverResult: {sorted(set(result) - allowed)}"
+        )
 
     def test_the_declared_capabilities_match_the_handshake(self):
         """One statement of what this server can do, or the two answers disagree
@@ -389,18 +466,53 @@ class TestProtocolVersionHeader:
         assert "result" in body
 
     def test_an_unsupported_version_header_is_refused(self):
-        """400 and -32600, and the message names what the server does speak.
+        """400 and `-32022 UnsupportedProtocolVersion`, the spec's own code.
 
-        `-32600 Invalid Request` rather than `-32602 Invalid params`: the BODY may
-        be perfectly well formed, and it is the request as a whole that is not.
+        Not `-32600`: a generic invalid-request code makes the refusal
+        indistinguishable from a malformed body, and the transport's
+        backward-compatibility rules have a dual-era client read a 400 body for a
+        RECOGNIZED modern error to decide the server is modern. `-32600` there means
+        "legacy server", so the client falls back to `initialize` while this server
+        is advertising a modern revision.
         """
         status, body = _call(_event(
             "initialize", headers={"MCP-Protocol-Version": "1999-01-01"},
         ))
 
         assert status == 400
-        assert body["error"]["code"] == -32600
+        assert body["error"]["code"] == -32022
         assert mcp_handler.PREFERRED_PROTOCOL_VERSION in body["error"]["message"]
+
+    def test_the_refusal_carries_the_supported_list_a_client_can_retry_with(self):
+        """The spec's recovery path is "pick from `data.supported` and retry".
+
+        With the versions only in the prose message — as the first draft had them —
+        that recovery path requires parsing English.
+        """
+        _status, body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": "1999-01-01"},
+        ))
+
+        data = body["error"]["data"]
+        assert data["supported"] == list(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+        # Echoed so a client with several requests in flight knows which one this
+        # answers, and can tell "I sent a bad version" from "a proxy rewrote it".
+        assert data["requested"] == "1999-01-01"
+
+    def test_a_malformed_encoding_is_not_reported_as_a_version_problem(self):
+        """The two faults are different codes because they have different fixes.
+
+        A sentinel that does not decode is `-32600`: the caller's version may be
+        perfectly supported and the ENCODING is what failed, so answering -32022
+        with a supported-version list would send them to change a version number
+        that was never the problem.
+        """
+        _status, body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": "=?base64?not-base64!!?="},
+        ))
+
+        assert body["error"]["code"] == -32600
+        assert "data" not in body["error"]
 
     def test_an_absent_version_header_is_served(self):
         """The header postdates the first revisions of the transport, so requiring
@@ -418,7 +530,7 @@ class TestProtocolVersionHeader:
         ))
 
         assert status == 400
-        assert body["error"]["code"] == -32600
+        assert body["error"]["code"] == -32022
 
     def test_the_header_is_matched_case_insensitively(self):
         """API Gateway lowercases header names in proxy mode; a direct invoke does
@@ -453,7 +565,7 @@ class TestProtocolVersionHeader:
         ))
 
         assert status == 400
-        assert body["error"]["code"] == -32600
+        assert body["error"]["code"] == -32022
 
     def test_the_declared_headers_are_all_reachable_from_a_browser(self):
         """A header the server validates but a browser's preflight blocks is a
@@ -582,12 +694,37 @@ class TestRoutingHeaders:
         assert "result" in body
 
     def test_a_method_header_contradicting_the_body_is_refused(self):
-        status, body = _call(_event("ping", headers={"MCP-Method": "tools/call"}))
+        """400 and `-32020 HeaderMismatch`, which is the spec's code for exactly
+        this and carries the spec's own rationale: a load balancer routes on the
+        header while the server executes on the body. `-32600` made the refusal
+        indistinguishable, to a client, from a malformed JSON-RPC body."""
+        status, body = _call(_event("ping", headers={"Mcp-Method": "tools/call"}))
 
         assert status == 400
-        assert body["error"]["code"] == -32600
+        assert body["error"]["code"] == -32020
         assert "tools/call" in body["error"]["message"]
         assert "ping" in body["error"]["message"]
+
+    def test_the_refusal_is_worded_the_way_the_spec_words_it(self):
+        """`Header mismatch: Mcp-Name header value 'x' does not match body value 'y'`.
+
+        The spec gives this exact shape, and matching it is what lets an operator
+        reading two implementations' logs recognize one fault. It also pins the
+        canonical header SPELLING, which is the one the client actually sent.
+        """
+        _status, body = _call(_event(
+            "tools/call",
+            params={"name": "get_metrics_summary", "arguments": {}},
+            headers={"Mcp-Name": "search_feedback"},
+            token=_TOKEN,
+        ))
+
+        message = body["error"]["message"]
+        assert message.startswith("Header mismatch: Mcp-Name header value ")
+        assert "does not match body value" in message
+        # The spelling the spec uses, not the `MCP-Name` an over-general acronym
+        # rule produced.
+        assert "MCP-Name" not in message
 
     def test_an_absent_method_header_is_served(self):
         """Both echoes are optional; absence is silent."""
@@ -620,7 +757,7 @@ class TestRoutingHeaders:
             ), MagicMock())
 
         assert response["statusCode"] == 400, response["body"]
-        assert json.loads(response["body"])["error"]["code"] == -32600
+        assert json.loads(response["body"])["error"]["code"] == -32020
         client.assert_not_called()
 
     def test_a_name_header_on_a_method_that_names_no_tool_is_refused(self):
@@ -628,11 +765,11 @@ class TestRoutingHeaders:
         server cannot do — and answering the list would answer a different
         question."""
         status, body = _call(_event(
-            "tools/list", headers={"MCP-Name": "search_feedback"}, token=_TOKEN,
+            "tools/list", headers={"Mcp-Name": "search_feedback"}, token=_TOKEN,
         ))
 
         assert status == 400
-        assert body["error"]["code"] == -32600
+        assert body["error"]["code"] == -32020
         assert "tools/call" in body["error"]["message"]
 
     def test_a_name_header_with_no_name_in_the_body_is_refused(self):
@@ -641,20 +778,20 @@ class TestRoutingHeaders:
         read as agreement."""
         status, body = _call(_event(
             "tools/call", params={"arguments": {}},
-            headers={"MCP-Name": "search_feedback"}, token=_TOKEN,
+            headers={"Mcp-Name": "search_feedback"}, token=_TOKEN,
         ))
 
         assert status == 400
-        assert body["error"]["code"] == -32600
+        assert body["error"]["code"] == -32020
 
     def test_both_echoes_are_matched_case_insensitively(self):
-        for spelling in ("MCP-Method", "mcp-method"):
+        for spelling in ("Mcp-Method", "MCP-METHOD", "mcp-method"):
             status, _body = _call(_event("ping", headers={spelling: "tools/call"}))
             assert status == 400, f"{spelling} was not read"
 
 
 # ===========================================================================
-# The resultType discriminator
+# The result discriminator: spec resultType, local shape in _meta
 # ===========================================================================
 
 class TestResultDiscriminator:
@@ -665,6 +802,14 @@ class TestResultDiscriminator:
     happens to be present. A client switching on inferred shape re-derives that
     table from scratch and gets it subtly wrong — in the client, where nothing
     here can catch it.
+
+    The mechanism is split across two fields on purpose, and the split IS the
+    subject of this class: `resultType` carries the spec's `"complete"`, and the
+    local vocabulary lives in `_meta` under a vendor prefix. Putting the local
+    names in `resultType` — as the first draft did — obliged a conforming client
+    of the newest advertised revision to reject every result this server sends,
+    because the spec says an unrecognized `resultType` value MUST be considered
+    invalid and this server declares no capability-advertised extension.
     """
 
     # Every dispatchable method, with whatever it needs to reach an answer. Keyed
@@ -679,6 +824,56 @@ class TestResultDiscriminator:
         "tools/call": ({"name": "get_metrics_summary", "arguments": {}}, _TOKEN),
     }
 
+    def test_every_result_carries_the_spec_result_type(self):
+        """`complete` is the spec's value and the only one this server can mean.
+
+        Pinned as a literal rather than through the constant: the point is the
+        value a client on the wire sees, and a test that reads the constant would
+        keep passing if the constant were changed to something the spec does not
+        define.
+        """
+        for method, (params, token) in sorted(self.CASES.items()):
+            _status, body = _call(_event(method, params=params, token=token))
+            assert body["result"]["resultType"] == "complete", (
+                f"{method} answered resultType {body['result'].get('resultType')!r}"
+            )
+
+    def test_the_local_vocabulary_is_not_in_the_spec_field(self):
+        """The regression guard for the defect this class documents.
+
+        Every local shape name must be absent from `resultType` everywhere. Written
+        as a search over the whole vocabulary rather than one example, so a future
+        shape cannot be added straight back into the spec's field.
+        """
+        seen = set()
+        for method, (params, token) in sorted(self.CASES.items()):
+            _status, body = _call(_event(method, params=params, token=token))
+            seen.add(body["result"]["resultType"])
+
+        assert seen == {"complete"}
+        assert not (seen & mcp_handler.RESULT_SHAPES), (
+            f"local shape names are travelling in the spec's resultType field: "
+            f"{sorted(seen & mcp_handler.RESULT_SHAPES)}"
+        )
+
+    def test_the_vendor_prefix_is_not_one_the_spec_reserves(self):
+        """The prefix has to be legal, or the `_meta` move solves nothing.
+
+        The spec reserves any prefix whose SECOND LABEL is `modelcontextprotocol`
+        or `mcp`. Asserted as that property rather than by restating the literal,
+        so a future re-namespacing is still checked.
+        """
+        prefix = mcp_handler.VENDOR_META_PREFIX
+        assert prefix.endswith('/'), prefix
+        labels = prefix.rstrip('/').split('.')
+        assert len(labels) >= 2, f"a vendor prefix needs a second label: {prefix}"
+        assert labels[1] not in ('modelcontextprotocol', 'mcp'), (
+            f"{prefix} is reserved for MCP use"
+        )
+        # And every key this module publishes actually sits behind it.
+        for key in (mcp_handler.RESULT_SHAPE_KEY, mcp_handler.COST_CLASS_KEY):
+            assert key.startswith(prefix), key
+
     def test_every_dispatchable_method_is_covered(self):
         """Anti-vacuity for the parametrized test below."""
         dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
@@ -689,48 +884,86 @@ class TestResultDiscriminator:
         )
 
     @pytest.mark.parametrize("method", sorted(CASES))
-    def test_every_method_answers_with_a_declared_result_type(self, method):
+    def test_every_method_answers_with_a_declared_result_shape(self, method):
         params, token = self.CASES[method]
         status, body = _call(_event(method, params=params, token=token))
 
         assert status == 200, body
-        result = body["result"]
-        declared = result.get(mcp_handler.RESULT_TYPE_KEY)
-        assert declared in mcp_handler.RESULT_TYPES, (
-            f"{method} answered with resultType {declared!r}"
+        declared = body["result"]["_meta"].get(mcp_handler.RESULT_SHAPE_KEY)
+        assert declared in mcp_handler.RESULT_SHAPES, (
+            f"{method} answered with result shape {declared!r}"
         )
 
-    def test_the_types_a_client_cannot_otherwise_tell_apart_differ(self):
+    def test_the_shapes_a_client_cannot_otherwise_tell_apart_differ(self):
         """The pairs that motivated the discriminator.
 
         A pong and an acknowledgement are both `{}` on the wire; a tool result and
         a tool error are the same object with one flag flipped. If either pair
-        shared a type the discriminator would not be discriminating.
+        shared a shape the discriminator would not be discriminating.
         """
         _s, pong = _call(_event("ping"))
         _s, ack = _call(_event("notifications/initialized"))
 
-        assert pong["result"][mcp_handler.RESULT_TYPE_KEY] != (
-            ack["result"][mcp_handler.RESULT_TYPE_KEY]
+        assert pong["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY] != (
+            ack["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY]
         )
+        # …while both still say `complete` in the spec's field, which is the whole
+        # reason the local discriminator had to move out of it.
+        assert pong["result"]["resultType"] == ack["result"]["resultType"] == "complete"
 
-    def test_a_tool_error_is_a_different_type_from_a_tool_result(self):
-        """A refusal carries no `structuredContent` to validate, and the type says
+    def test_a_tool_error_is_a_different_shape_from_a_tool_result(self):
+        """A refusal carries no `structuredContent` to validate, and the shape says
         so without the client testing for the key."""
         ok = mcp_handler._jsonrpc_result(
-            1, mcp_handler.RESULT_TYPE_TOOL_RESULT, {"isError": False},
+            1, mcp_handler.RESULT_SHAPE_TOOL_RESULT, {"isError": False},
         )
         bad = mcp_handler._tool_error(1, "nope")
 
-        assert ok["result"][mcp_handler.RESULT_TYPE_KEY] == (
-            mcp_handler.RESULT_TYPE_TOOL_RESULT
+        assert ok["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY] == (
+            mcp_handler.RESULT_SHAPE_TOOL_RESULT
         )
-        assert bad["result"][mcp_handler.RESULT_TYPE_KEY] == (
-            mcp_handler.RESULT_TYPE_TOOL_ERROR
+        assert bad["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY] == (
+            mcp_handler.RESULT_SHAPE_TOOL_ERROR
         )
-        # And the flag the spec defines is still there: the type describes the
+        # And the flag the spec defines is still there: the shape describes the
         # payload, it does not replace `isError`.
         assert bad["result"]["isError"] is True
+
+    def test_a_callers_meta_survives_alongside_the_shape(self):
+        """`_meta` is MERGED, not replaced.
+
+        The shape is injected into the same object the caller uses for its own
+        `_meta` (cache hints on `tools/list`, the cost class on a tool result), so
+        an implementation that assigned rather than merged would silently drop
+        whichever of the two was written second.
+        """
+        built = mcp_handler._jsonrpc_result(
+            1, mcp_handler.RESULT_SHAPE_TOOL_RESULT,
+            {"isError": False, "_meta": {"com.example/own": "kept"}},
+        )
+
+        meta = built["result"]["_meta"]
+        assert meta["com.example/own"] == "kept"
+        assert meta[mcp_handler.RESULT_SHAPE_KEY] == mcp_handler.RESULT_SHAPE_TOOL_RESULT
+
+    def test_a_payload_cannot_overwrite_the_discriminator(self):
+        """Refused rather than resolved, in EITHER direction.
+
+        The earlier builder spread the payload last, so a `result` carrying
+        `resultType` replaced the validated value and the "an undeclared value
+        cannot travel" guarantee was bypassed. Ordering the spread the other way
+        would have silently discarded the caller's value instead, which is the same
+        defect wearing the opposite sign — so both are a `ValueError`.
+        """
+        with pytest.raises(ValueError, match="already carries"):
+            mcp_handler._jsonrpc_result(
+                1, mcp_handler.RESULT_SHAPE_PONG, {"resultType": "input_required"},
+            )
+        with pytest.raises(ValueError, match="already carries"):
+            mcp_handler._jsonrpc_result(
+                1, mcp_handler.RESULT_SHAPE_PONG,
+                {"_meta": {mcp_handler.RESULT_SHAPE_KEY: "toolResult"}},
+            )
 
     def test_a_delegated_refusal_still_carries_the_tool_error_type(self):
         """End to end, through the route error path rather than the builder."""
@@ -753,13 +986,15 @@ class TestResultDiscriminator:
             ), MagicMock())
 
         result = json.loads(response["body"])["result"]
-        assert result[mcp_handler.RESULT_TYPE_KEY] == mcp_handler.RESULT_TYPE_TOOL_ERROR
+        assert result["_meta"][mcp_handler.RESULT_SHAPE_KEY] == (
+            mcp_handler.RESULT_SHAPE_TOOL_ERROR
+        )
         assert result["isError"] is True
 
-    def test_an_undeclared_result_type_cannot_be_sent(self):
+    def test_an_undeclared_result_shape_cannot_be_sent(self):
         """A client cannot switch on a typo, and finding out at the client is
         finding out too late."""
-        with pytest.raises(ValueError, match="undeclared resultType"):
+        with pytest.raises(ValueError, match="undeclared result shape"):
             mcp_handler._jsonrpc_result(1, "toolresult", {})
 
     def test_the_discriminator_is_required_not_optional(self):
@@ -772,11 +1007,11 @@ class TestResultDiscriminator:
         names the design rather than an arbitrary TypeError.
         """
         parameters = inspect.signature(mcp_handler._jsonrpc_result).parameters
-        result_type = parameters.get("result_type")
+        result_shape = parameters.get("result_shape")
 
-        assert result_type is not None, "_jsonrpc_result no longer takes a result type"
-        assert result_type.default is inspect.Parameter.empty, (
-            "result_type has a default, so a result can ship without naming its shape"
+        assert result_shape is not None, "_jsonrpc_result no longer takes a result shape"
+        assert result_shape.default is inspect.Parameter.empty, (
+            "result_shape has a default, so a result can ship without naming its shape"
         )
 
     def test_no_result_is_built_outside_the_builder(self):
@@ -930,14 +1165,19 @@ class TestUnknownMethod:
     """An unknown JSON-RPC method is -32601 and nothing else."""
 
     def test_an_unknown_method_is_method_not_found(self):
+        """-32601 with HTTP 404, which the Streamable HTTP transport REQUIRES.
+
+        The 200 this used to answer was not merely untidy: the status is what a
+        dual-era client's fallback probe reads, and the JSON-RPC body is what
+        distinguishes this 404 from the 404 of a legacy HTTP+SSE server that does
+        not host the modern endpoint at all. A 200 said "your request was fine"
+        about a method that does not exist.
+        """
         status, body = _call(_event("tools/teleport"))
 
         assert body["error"]["code"] == -32601
         assert "tools/teleport" in body["error"]["message"]
-        assert status == 200, (
-            "JSON-RPC transports a method-not-found in a 200 HTTP response: the "
-            "HTTP layer delivered the request fine"
-        )
+        assert status == 404, body
 
     def test_an_unknown_method_never_reaches_the_token_store(self):
         """A method that does not exist cannot need a credential, so asking for
@@ -952,7 +1192,7 @@ class TestUnknownMethod:
             body=json.dumps({"jsonrpc": "2.0", "id": 1, "params": {}}),
         ))
 
-        assert status == 200
+        assert status == 404
         assert body["error"]["code"] == -32601
 
     @pytest.mark.parametrize("body_text", ["[]", '"a string"', "42", "null"])
@@ -963,7 +1203,7 @@ class TestUnknownMethod:
         catch-all exists to prevent."""
         status, body = _call(_event(body=body_text))
 
-        assert status == 200, body
+        assert status == 404, body
         assert body["error"]["code"] == -32601
         assert body["id"] is None
 
@@ -1115,34 +1355,70 @@ class TestToolCatalogueIsFilteredByAuthorization:
             "this assertion deliberately"
         )
 
-    def test_the_list_carries_its_own_cache_hints(self):
-        """`listChanged: false` means nothing will tell the client the list moved,
-        so the answer says how long to hold it and how to detect staleness."""
+    def test_the_list_carries_the_caching_hints_the_spec_requires(self):
+        """The spec's own two fields, at the TOP LEVEL where a client reads them.
+
+        `tools/list` is in the spec's cacheable-results list, so these are required.
+        The earlier `_meta.cacheHints` object had the right semantics in a shape
+        nothing reads: a spec-reading client found no `ttlMs`, applied the spec's
+        default of 0, and cached nothing.
+
+        `ttlMs` is asserted as a MAGNITUDE rather than against the constant, because
+        the unit is the point — 300 in a milliseconds field is 0.3 seconds.
+        """
         status, body = _call(_event("tools/list", token=_TOKEN))
         assert status == 200, body
-        hints = body["result"]["_meta"]["cacheHints"]
+        result = body["result"]
 
-        assert hints["cacheable"] is True
-        assert isinstance(hints["maxAgeSeconds"], int) and hints["maxAgeSeconds"] > 0
-        assert hints["etag"]
-        assert hints["serverVersion"] == mcp_handler.MCP_SERVER_VERSION
-        assert hints["listChangedNotifications"] is False
+        assert isinstance(result["ttlMs"], int)
+        assert result["ttlMs"] >= 60_000, (
+            f"ttlMs={result['ttlMs']} looks like seconds, not milliseconds"
+        )
+        # And it is the same duration the seconds-denominated constant states,
+        # converted rather than restated.
+        assert result["ttlMs"] == mcp_handler._TOOL_LIST_MAX_AGE_SECONDS * 1000
 
-    def test_the_cache_scope_is_the_credential_not_the_endpoint(self):
-        """The load-bearing hint. A shared cache keyed on the endpoint alone would
-        serve one token's catalogue to another token — which only became possible
-        the moment the list started varying by credential."""
+        catalogue = result["_meta"][f"{mcp_handler.VENDOR_META_PREFIX}catalogue"]
+        assert catalogue["etag"]
+        assert catalogue["serverVersion"] == mcp_handler.MCP_SERVER_VERSION
+        assert catalogue["listChangedNotifications"] is False
+
+    def test_the_cache_scope_is_private_because_the_list_varies_by_credential(self):
+        """The load-bearing hint, in the spec's own encoding of it.
+
+        `private` is defined as "MAY be reused for the same authorization context;
+        caches MUST NOT be shared across authorization contexts" — exactly the
+        property that became necessary the moment the list started varying. With no
+        `cacheScope` at all, nothing told a gateway cache not to serve one token's
+        catalogue to another, which is the safety-relevant half of this fix.
+        """
         _status, body = _call(_event("tools/list", token=_TOKEN))
 
-        assert body["result"]["_meta"]["cacheHints"]["scope"] == "credential"
+        assert body["result"]["cacheScope"] == "private"
+
+    def test_the_two_cacheable_answers_scope_differently(self):
+        """Anti-vacuity, and the distinction is the whole point of the field.
+
+        Discovery is `public` (it names no project, tool or data) and the catalogue
+        is `private` (it is a function of the credential). A change that hard-coded
+        one value for both would pass each test above on its own.
+        """
+        _s, discovery = _call(_event("server/discover"))
+        _s, listing = _call(_event("tools/list", token=_TOKEN))
+
+        assert discovery["result"]["cacheScope"] == "public"
+        assert listing["result"]["cacheScope"] == "private"
 
     def test_the_cache_hint_agrees_with_the_declared_capability(self):
         """Two statements about notifications, from one fact."""
         _status, initialize = _call(_event("initialize"))
         _status, listing = _call(_event("tools/list", token=_TOKEN))
 
+        catalogue = listing["result"]["_meta"][
+            f"{mcp_handler.VENDOR_META_PREFIX}catalogue"
+        ]
         assert (
-            listing["result"]["_meta"]["cacheHints"]["listChangedNotifications"]
+            catalogue["listChangedNotifications"]
             is initialize["result"]["capabilities"]["tools"]["listChanged"]
         )
 
@@ -1153,9 +1429,10 @@ class TestToolCatalogueIsFilteredByAuthorization:
         _s, narrow = _call(_event("tools/list", token=_TOKEN),
                            row=_token_row(scopes=[SCOPE_METRICS_READ]))
 
+        key = f"{mcp_handler.VENDOR_META_PREFIX}catalogue"
         assert (
-            full["result"]["_meta"]["cacheHints"]["etag"]
-            != narrow["result"]["_meta"]["cacheHints"]["etag"]
+            full["result"]["_meta"][key]["etag"]
+            != narrow["result"]["_meta"][key]["etag"]
         )
 
     def test_the_etag_is_stable_across_identical_requests(self):
@@ -1163,9 +1440,10 @@ class TestToolCatalogueIsFilteredByAuthorization:
         _s, first = _call(_event("tools/list", token=_TOKEN))
         _s, second = _call(_event("tools/list", token=_TOKEN))
 
+        key = f"{mcp_handler.VENDOR_META_PREFIX}catalogue"
         assert (
-            first["result"]["_meta"]["cacheHints"]["etag"]
-            == second["result"]["_meta"]["cacheHints"]["etag"]
+            first["result"]["_meta"][key]["etag"]
+            == second["result"]["_meta"][key]["etag"]
         )
 
     def test_the_list_still_requires_a_credential(self):
@@ -1218,7 +1496,7 @@ class TestAnnotationsAndCostClass:
 
     def test_every_published_tool_carries_a_cost_class_from_the_vocabulary(self):
         for tool in mcp_handler.MCP_TOOLS:
-            cost = tool["_meta"]["costClass"]
+            cost = tool["_meta"][mcp_handler.COST_CLASS_KEY]
             assert cost in mcp_handler.COST_CLASSES, f"{tool['name']}: {cost!r}"
 
     def test_the_cost_class_table_covers_exactly_the_registered_tools(self):
@@ -1252,7 +1530,7 @@ class TestAnnotationsAndCostClass:
         for tool in mcp_handler.MCP_TOOLS:
             declares_truncation = "is_partial" in tool["outputSchema"].get("required", [])
             if declares_truncation:
-                assert tool["_meta"]["costClass"] == mcp_handler.COST_EXPENSIVE, (
+                assert tool["_meta"][mcp_handler.COST_CLASS_KEY] == mcp_handler.COST_EXPENSIVE, (
                     f"{tool['name']} can report truncation but is not the "
                     f"expensive class"
                 )
@@ -1266,14 +1544,15 @@ class TestAnnotationsAndCostClass:
         ))
 
         assert status == 200, body
-        assert body["result"]["_meta"]["costClass"] == (
+        assert body["result"]["_meta"][mcp_handler.COST_CLASS_KEY] == (
             mcp_handler.TOOL_COST_CLASSES["search_feedback"]
         )
 
     def test_the_advertised_and_the_reported_class_are_the_same_value(self):
         """Across every tool, not just the one an example exercises."""
         published = {
-            tool["name"]: tool["_meta"]["costClass"] for tool in mcp_handler.MCP_TOOLS
+            tool["name"]: tool["_meta"][mcp_handler.COST_CLASS_KEY]
+            for tool in mcp_handler.MCP_TOOLS
         }
         for name, advertised in published.items():
             arguments = {"dimension": "categories"} if name == "get_metrics_breakdown" else {}
@@ -1283,7 +1562,7 @@ class TestAnnotationsAndCostClass:
                 "tools/call", params={"name": name, "arguments": arguments}, token=_TOKEN,
             ))
             assert status == 200, body
-            assert body["result"]["_meta"]["costClass"] == advertised, name
+            assert body["result"]["_meta"][mcp_handler.COST_CLASS_KEY] == advertised, name
 
     def test_a_tool_error_carries_no_cost_class_to_misread(self):
         """A refusal did not perform the read, so reporting its class would
@@ -1291,10 +1570,14 @@ class TestAnnotationsAndCostClass:
 
         Same reasoning as `structuredContent` being absent on a refusal rather
         than empty.
+
+        `_meta` itself is PRESENT — it carries the result shape now — so the
+        assertion is about the cost key specifically rather than about the whole
+        object, which is what it used to be able to say.
         """
         error = mcp_handler._tool_error(1, "nope")
 
-        assert "_meta" not in error["result"]
+        assert mcp_handler.COST_CLASS_KEY not in error["result"]["_meta"]
 
     def test_the_declaration_the_annotations_wrap_is_not_mutated(self):
         """`_published_tool` composes; it must not edit the literal in place.
@@ -1326,15 +1609,86 @@ class TestADeadCredentialFailsTheHandshake:
         past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
         return _token_row(expires_at=past)
 
-    @pytest.mark.parametrize("method", ["initialize", "ping", "server/discover",
-                                        "notifications/initialized"])
-    def test_an_expired_credential_is_refused_on_every_unauthenticated_method(self, method):
-        """Every method in the no-credential half, because a client may open with
-        any of them and each one would otherwise report a healthy server."""
+    @pytest.mark.parametrize("method", sorted(mcp_handler._LIVENESS_CHECKED_METHODS))
+    def test_an_expired_credential_is_refused_where_a_client_decides_it_connected(
+        self, method,
+    ):
+        """The methods a client uses to conclude it has a working session.
+
+        Parametrized over the live set rather than a restated list, so a method
+        added to it is covered here without an edit — and one that is listed but
+        not actually checked fails.
+        """
         status, body = _call(_event(method, token=_TOKEN), row=self._expired_row())
 
         assert status == 401, body
         assert body["error"]["code"] == -32001
+
+    def test_the_checked_set_is_the_handshake_shaped_methods_only(self):
+        """The scope of the check, stated as a property of the two halves.
+
+        It must be a strict subset of the unauthenticated methods — checking an
+        authenticated one would be redundant, and checking ALL of them is the
+        cost/notification problem below.
+        """
+        checked = set(mcp_handler._LIVENESS_CHECKED_METHODS)
+
+        assert checked < set(mcp_handler.MCP_METHODS), (
+            "the liveness check must cover unauthenticated methods, and not all of them"
+        )
+        assert not checked & set(mcp_handler.MCP_AUTH_METHODS)
+
+    @pytest.mark.parametrize("method", ["ping", "notifications/initialized"])
+    def test_a_keepalive_is_not_a_liveness_probe(self, method):
+        """`ping` and the notifications are deliberately NOT checked, and the
+        second reason is the stronger one.
+
+        Cost: `ping` is a keepalive, so checking it put a token-store read on every
+        heartbeat of every session — on a route throttled at 20 rps whose authorizer
+        caches for 300 s, which is how one valid-shaped token drives that stream
+        past the cache. Before this, `ping` touched nothing.
+
+        Protocol: a NOTIFICATION CARRIES NO ID, so a 401 to one is a response to a
+        message JSON-RPC says must not receive one. And nobody concludes "connected"
+        from an un-refused notification, so the honesty defect was never here.
+        """
+        status, body = _call(_event(method, token=_TOKEN), row=self._expired_row())
+
+        assert status == 200, body
+        assert "error" not in body
+
+    def test_the_liveness_check_never_stamps_last_used_at(self):
+        """"Last used" means "last used to read something".
+
+        Stamping it from a liveness probe would make a keepalive loop read as
+        "last used: continuously" on the MCP Access tab — a field an operator reads
+        to decide whether a credential is still wanted.
+        """
+        with patch("mcp_handler.projects_table") as table, \
+             patch.dict(os.environ, {"METRICS_FUNCTION": "m"}):
+            table.query.return_value = {"Items": [_token_row()]}
+            mcp_handler.lambda_handler(_event("initialize", token=_TOKEN), MagicMock())
+
+        table.update_item.assert_not_called()
+
+    def test_a_live_credential_reading_data_still_stamps_last_used_at(self):
+        """The positive control for the test above.
+
+        Without it, an `_authenticate` that never wrote `last_used_at` at all would
+        pass — and the field would silently stop meaning anything.
+        """
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_delegate_lambda_client",
+                   return_value=_stub_domain_client()), \
+             patch.dict(os.environ, {"METRICS_FUNCTION": "m"}):
+            table.query.return_value = {"Items": [_token_row()]}
+            mcp_handler.lambda_handler(_event(
+                "tools/call",
+                params={"name": "get_metrics_summary", "arguments": {}},
+                token=_TOKEN,
+            ), MagicMock())
+
+        table.update_item.assert_called_once()
 
     def test_a_revoked_credential_is_refused_at_initialize(self):
         """Revocation deletes the row, so the credential parses and matches

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -1077,6 +1077,66 @@ class TestEncodedWordHeaders:
         assert body["error"]["code"] == -32600
         assert "base64" in body["error"]["message"]
 
+    @pytest.mark.parametrize("lowercase", sorted(mcp_handler.TRANSPORT_HEADERS))
+    def test_a_sentinel_refusal_names_the_wire_spelling(self, lowercase):
+        """The refusal must name the header the CLIENT sent, not this module's
+        internal lowercase form.
+
+        `_decoded_header` interpolated `name` directly — the spelling API Gateway
+        normalisation forced on this module — so a client sending
+        `Mcp-Name: =?base64?!!!?=` was told about `mcp-name`, a header it never
+        sent. The module's own argument is two functions up at
+        `_canonical_header_name`: an error message is read by clients that spell
+        headers the way the spec does. Reverting `_decoded_header` to interpolate
+        `name` fails this test.
+
+        The event map is keyed by the derived parametrisation, so a transport
+        header added without a case here fails as a KeyError rather than passing
+        vacuously.
+        """
+        canonical = mcp_handler._canonical_header_name(lowercase)
+        # Positive control for the not-in assertion below: if the canonical and
+        # internal spellings ever coincided, `lowercase not in message` would be
+        # unsatisfiable and this test would be asserting nothing.
+        assert canonical != lowercase
+        bad = "=?base64?not-base64!!?="
+        events = {
+            "mcp-protocol-version": _event("initialize", headers={canonical: bad}),
+            "mcp-method": _event("ping", headers={canonical: bad}),
+            "mcp-name": _event(
+                "tools/call",
+                params={"name": "get_metrics_summary", "arguments": {}},
+                headers={canonical: bad},
+            ),
+        }
+
+        status, body = _call(events[lowercase])
+        message = body["error"]["message"]
+
+        assert status == 400, body
+        assert canonical in message, message
+        assert lowercase not in message, message
+
+    @pytest.mark.parametrize("payload", ["not-base64!!", ""])
+    def test_every_sentinel_refusal_names_the_canonical_spelling(self, payload):
+        """Unit-level and DERIVED from the tables rather than restating the names,
+        so a future refusal added to `_decoded_header` cannot reintroduce the
+        internal spelling for any header, present or future.
+
+        The two payloads reach the two refusals: one that does not decode, and the
+        well-formed encoding of nothing.
+        """
+        for lowercase in mcp_handler.TRANSPORT_HEADERS:
+            canonical = mcp_handler._canonical_header_name(lowercase)
+            assert canonical != lowercase  # the control the not-in below needs
+
+            with pytest.raises(mcp_handler.InvalidTransportHeader) as excinfo:
+                mcp_handler._decoded_header(f"=?base64?{payload}?=", lowercase)
+            message = str(excinfo.value)
+
+            assert canonical in message, (lowercase, message)
+            assert lowercase not in message, (lowercase, message)
+
     def test_a_plain_value_is_not_treated_as_encoded(self):
         """The sentinel is optional and a plain value is the ordinary spelling.
 
@@ -1268,6 +1328,49 @@ class TestADuplicatedHeaderIsRefused:
 
         assert status == 200, body
         assert "result" in body
+
+    def test_two_unusable_values_for_one_header_are_still_a_duplicate(self):
+        """Coercion must not erase the identity the dedup runs on.
+
+        `_header_values` reads a non-string candidate as `''` — and coercing BEFORE
+        deduplicating collapsed two DIFFERENT unusable values into one `''`, so this
+        request sailed past the duplicate refusal and was answered as a header/body
+        mismatch against `''` instead: a diagnostic about a value, for a fault that
+        is two values. Moving the coercion back inside the dedup fails this test.
+        The header was sent twice; that it was sent twice unusably does not make it
+        sent once.
+        """
+        event = _event("ping")
+        event["multiValueHeaders"] = {"mcp-method": [None, 42]}
+
+        status, body = _call(event)
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32020
+        assert "more than once" in body["error"]["message"], body["error"]["message"]
+        # The fault named is the duplication, not a mismatch against the coerced
+        # `''` — the diagnostic the coerce-first ordering used to produce.
+        assert "does not match body value" not in body["error"]["message"]
+
+    def test_a_single_unusable_value_still_reads_as_the_empty_value(self):
+        """Anti-overreach: the fix is about TWO values, not about non-strings.
+
+        One unusable value keeps its existing reading — the empty string, which for
+        a routing echo is a mismatch against the body's method. A fix that started
+        refusing single non-strings as duplicates would have changed a documented
+        answer this module already gives.
+        """
+        event = _event("ping")
+        event["multiValueHeaders"] = {"mcp-method": [None]}
+
+        status, body = _call(event)
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32020
+        assert "does not match body value" in body["error"]["message"], (
+            body["error"]["message"]
+        )
+        assert "more than once" not in body["error"]["message"]
 
     @pytest.mark.parametrize("order", [
         ("Mcp-Method", "mcp-method"),
@@ -1922,6 +2025,43 @@ class TestMethodNotAllowed:
         assert body["error"]["code"] == -32600
         assert response["headers"]["Access-Control-Allow-Origin"] == "*"
 
+    @pytest.mark.parametrize("http_method", ["GET", "DELETE", "PUT"])
+    def test_a_405_omits_the_id_member(self, http_method):
+        """A `GET` or a `DELETE` typically carries no body: there is no JSON-RPC
+        message at all, so there is no id to have failed to detect.
+
+        `id: null` is JSON-RPC's spelling for an id that COULD NOT BE DETECTED in a
+        message that was claimed — and the 405 sent it for a request that never
+        claimed to carry a message. The rule at `_NO_ID` puts the 405 on the same
+        side as the Origin 403 (no subject → member omitted); the test below pins
+        the other side so this fix cannot creep onto it.
+        """
+        response = mcp_handler.lambda_handler(
+            _event(http_method=http_method), MagicMock(),
+        )
+        body = json.loads(response["body"])
+
+        assert response["statusCode"] == 405
+        assert "id" not in body, body
+
+    def test_a_parse_error_still_reports_a_null_id(self):
+        """The boundary of the 405 fix, pinned deliberately: a body that does not
+        parse DID claim to be a message, and JSON-RPC's own rule reports an id it
+        could not detect as `null` — not as omission.
+
+        Lives here rather than with the parse tests because it exists to stop the
+        405's `_NO_ID` from creeping one branch down: the two refusals are
+        neighbours in `lambda_handler` and the rule at `_NO_ID` names them as
+        opposite cases.
+        """
+        response = mcp_handler.lambda_handler(_event(body="{oops"), MagicMock())
+        body = json.loads(response["body"])
+
+        assert response["statusCode"] == 400
+        assert body["error"]["code"] == -32700
+        assert "id" in body, body
+        assert body["id"] is None, body
+
     def test_a_405_never_reaches_the_token_store(self):
         with patch("mcp_handler.projects_table") as table:
             mcp_handler.lambda_handler(
@@ -2285,6 +2425,37 @@ class TestAnIdlessRequestIsRefused:
 
         assert response["statusCode"] != 202, response["body"]
 
+    @pytest.mark.parametrize("headers,code", [
+        ({"MCP-Protocol-Version": "2099-01-01"}, -32022),
+        ({"Mcp-Method": "tools/list"}, -32020),
+        ({"Mcp-Name": "get_metrics_summary"}, -32020),
+    ])
+    def test_an_idless_request_refused_by_a_transport_guard_omits_the_id(
+        self, headers, code,
+    ):
+        """The transport guards run BEFORE this class's branch, and they must give
+        the same answer about the same message.
+
+        The guard catch used to ask `_is_notification` — deliberately False for an
+        id-less `ping`, as its docstring records — so the same id-less message got
+        the `id` member OMITTED from a clean refusal and `id: null` from one that
+        also tripped a header guard: the exact defect this class exists to pin,
+        reached one guard earlier. Both branches now ask `_carries_no_id`, whose
+        subject is the only condition the transport's no-id allowance turns on.
+
+        Parametrised over the three faults that can refuse first: an unsupported
+        version, a routing echo contradicting the body, and a tool name on a
+        method that takes none. Reverting the catch to `_is_notification` fails
+        all three; `test_a_refused_request_still_carries_its_id` is the
+        anti-overreach guard (a body WITH an id keeps it, header fault or not).
+        """
+        response = _raw_call(_notification_event("ping", headers=headers))
+        body = json.loads(response["body"])
+
+        assert response["statusCode"] == 400, response["body"]
+        assert body["error"]["code"] == code, body
+        assert "id" not in body, body
+
     def test_a_real_notification_still_reaches_its_202(self):
         """Anti-overreach, and the ordering this branch depends on: it sits AFTER the
         notification check, so a `notifications/`-prefixed message is unaffected."""
@@ -2314,10 +2485,18 @@ class TestAnIdlessRequestIsRefused:
     def test_the_refusal_names_the_missing_id_rather_than_the_method(self):
         """A caller reading this needs to know what to change. `Method not found` —
         which an earlier shape of this path produced for some of these bodies — sends
-        it after a method name it spelled correctly."""
-        _status, body = _call(_notification_event("ping"))
+        it after a method name it spelled correctly.
 
-        assert "id" in body["error"]["message"].lower()
+        Asserted on the phrase, not on the substring `"id"`: `"id" in message`
+        was satisfied by the `id` inside "invalid", so the exact regression this
+        test claims to guard against — a message about the method, not the id —
+        could have passed it.
+        """
+        _status, body = _call(_notification_event("ping"))
+        message = body["error"]["message"].lower()
+
+        assert "must carry an id" in message, message
+        assert "method not found" not in message, message
 
 
 class TestUnknownMethod:

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -1,0 +1,1378 @@
+"""Tests for the MCP protocol ENVELOPE (plan Phase 2b).
+
+Phase 2a moved what the tools read — every tool delegates to the route that owns
+its data, covered by `test_mcp_delegation.py`. This file is the envelope around
+those tools: the version handshake, the transport headers, the result
+discriminator, the catalogue's shape, and what happens to a request this server
+cannot serve. A separate file from `test_mcp_security.py` and
+`test_mcp_delegation.py` for the reason those two are separate from each other —
+credential rules, data correctness and protocol conformance are three subjects
+with three failure modes, and one 4 000-line file about all three is a file
+nobody can navigate.
+
+Same standard as its siblings: assert the invariant, and be able to say which
+revert makes each assertion fail.
+
+  TestVersionNegotiation
+    — the handler pinned ONE protocol version and answered `initialize` with it
+      whatever was asked, which is a handshake in shape only. Replacing
+      `_negotiate_protocol_version` with a constant fails
+      test_each_supported_version_is_echoed_back.
+
+  TestProtocolVersionHeader
+    — a client speaking a revision this server does not implement used to be
+      answered as though it spoke one that it does; the failure then surfaced
+      several calls later as a field it could not parse. Deleting the header
+      check fails test_an_unsupported_version_header_is_refused.
+
+  TestEncodedWordHeaders
+    — the `=?base64?...?=` sentinel form is what a conforming client sends when
+      it cannot be sure a value survives an intermediary. Treating it as literal
+      text fails test_an_encoded_protocol_version_is_decoded, and — worse —
+      would report "unsupported version =?base64?…?=" for a version this server
+      does speak.
+
+  TestRoutingHeaders
+    — `MCP-Method` / `MCP-Name` let an intermediary route without parsing a body,
+      which means the header and the body can DISAGREE. Serving the body anyway
+      fails test_a_method_header_contradicting_the_body_is_refused: one hop
+      routed on a value the next hop ignored.
+
+  TestResultDiscriminator
+    — every result carried a bare object and a client had to infer its shape
+      from which keys were present (`{}` is both a pong and an ack; a tool error
+      differs from a tool result by a boolean). Making `resultType` optional in
+      `_jsonrpc_result` fails test_every_method_answers_with_a_declared_result_type,
+      and the AST check fails the moment a result is built outside the builder.
+
+  TestMethodNotAllowed / TestUnknownMethod
+    — GET and DELETE are transport methods this server does not implement, so
+      they are 405 with an `Allow` header; an unknown JSON-RPC method is -32601.
+      Answering either any other way fails these.
+
+  TestToolCatalogueIsFilteredByAuthorization
+    — the spec blesses a credential-shaped tool set, and every caller used to see
+      every tool regardless of its scopes: it was shown a tool, called it, and was
+      refused -32003. Reverting `_handle_tools_list` to `{"tools": MCP_TOOLS}`
+      fails test_a_single_scope_credential_sees_only_that_domains_tools.
+
+  TestAnnotationsAndCostClass
+    — a client cannot tell a keyed read from a capped scan by looking at a tool
+      name. Dropping the `_published_tool` wrapper fails every test here.
+
+  TestADeadCredentialFailsTheHandshake
+    — the honesty defect: a revoked or expired token completed `initialize` and
+      failed only at the first `tools/call`, so a dead credential presented as a
+      connected server. Deleting `_refuse_a_dead_credential` fails
+      test_an_expired_credential_is_refused_at_initialize, and reverting it to
+      refuse an ABSENT credential too fails
+      test_no_credential_at_all_still_initializes.
+"""
+
+import ast
+import base64
+import inspect
+import io
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mcp_handler
+from shared.mcp_tokens import (
+    ALL_READ_SCOPES,
+    MCP_TOKEN_PK,
+    REACH_NONE,
+    REACH_PROJECT_SET,
+    REACH_WORKSPACE,
+    SCOPE_FEEDBACK_READ,
+    SCOPE_METRICS_READ,
+    SCOPE_PROJECTS_READ,
+    mint_token,
+    token_sk,
+)
+
+# One real credential for the module, minted through the production helper for
+# the reason test_mcp_security.py states: a hand-written token would let these
+# tests keep passing after a format change that broke every real client.
+_MINTED = mint_token()
+_TOKEN = _MINTED.raw
+_PROJECT = "proj_20260819143000"
+
+
+def _token_row(**extra) -> dict:
+    """A stored row that authenticates `_TOKEN`, widest shape by default."""
+    return {
+        "pk": MCP_TOKEN_PK,
+        "sk": token_sk(_MINTED.token_id),
+        "token_id": _MINTED.token_id,
+        "name": "envelope test token",
+        "secret_hash": _MINTED.secret_hash,
+        "scopes": list(ALL_READ_SCOPES),
+        "projects": [_PROJECT],
+        "read_reach": REACH_WORKSPACE,
+        **extra,
+    }
+
+
+def _event(method: str = "initialize", *, params: dict | None = None,
+           headers: dict | None = None, token: str | None = None,
+           http_method: str = "POST", path: str = "/v1/mcp",
+           body: str | None = None) -> dict:
+    """A Lambda proxy event for one JSON-RPC request.
+
+    Header names are passed through as given rather than lowercased, because both
+    spellings are real: API Gateway lowercases in proxy mode, a direct invoke does
+    not, and the guard has to hold for both.
+    """
+    request_headers = dict(headers or {})
+    if token is not None:
+        request_headers["authorization"] = f"Bearer {token}"
+    return {
+        "httpMethod": http_method,
+        "path": path,
+        "headers": request_headers,
+        "body": body if body is not None else json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": method, "params": params or {},
+        }),
+    }
+
+
+def _stub_domain_client():
+    """A Lambda client answering any delegated route with an empty 200 payload."""
+    client = MagicMock()
+    client.invoke.side_effect = lambda **_kwargs: {
+        "Payload": io.BytesIO(json.dumps({
+            "statusCode": 200, "body": json.dumps({"items": [], "project": {}}),
+        }).encode()),
+    }
+    return client
+
+
+def _call(event: dict, *, row: dict | None = None) -> tuple[int, dict]:
+    """Drive `lambda_handler` end to end; return (status, parsed body).
+
+    The token store and the delegation client are stubbed because this file is
+    about the envelope: what the store holds is `test_mcp_security.py`'s subject
+    and what the routes answer is `test_mcp_delegation.py`'s.
+    """
+    with patch("mcp_handler.projects_table") as table, \
+         patch("shared.mcp_delegate.get_delegate_lambda_client",
+               return_value=_stub_domain_client()), \
+         patch.dict(os.environ, {"METRICS_FUNCTION": "m", "PROJECTS_FUNCTION": "p"}):
+        table.query.return_value = {"Items": [row] if row is not None else [_token_row()]}
+        table.update_item.return_value = {}
+        response = mcp_handler.lambda_handler(event, MagicMock())
+    return response["statusCode"], json.loads(response["body"])
+
+
+def _encoded(value: str) -> str:
+    """The encoded-word sentinel form of a header value."""
+    return f"=?base64?{base64.b64encode(value.encode()).decode()}?="
+
+
+# ===========================================================================
+# Version negotiation
+# ===========================================================================
+
+class TestVersionNegotiation:
+    """`initialize` answers with the version the SESSION will speak.
+
+    A single pinned constant answered the same string whatever the client asked
+    for, which is not negotiation — and bumping that constant without the rest of
+    this file would have claimed a conformance the envelope did not have.
+    """
+
+    def test_more_than_one_version_is_supported(self):
+        """Anti-vacuity: every test below is about a RANGE.
+
+        With one entry, echoing and falling back are the same answer and the
+        whole class would pass while negotiating nothing.
+        """
+        assert len(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS) >= 3, (
+            f"expected a range of revisions, found "
+            f"{mcp_handler.SUPPORTED_PROTOCOL_VERSIONS}"
+        )
+        assert len(set(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)) == len(
+            mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+        ), "a repeated revision would make the preference order meaningless"
+
+    def test_the_supported_versions_are_ordered_newest_first(self):
+        """The order is load-bearing: the first entry is the counter-offer.
+
+        Asserted as a property of the values (ISO dates sort lexically) rather
+        than by restating the list, so adding a revision cannot leave this test
+        agreeing with a stale copy of it.
+        """
+        versions = list(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+        assert versions == sorted(versions, reverse=True)
+        assert mcp_handler.PREFERRED_PROTOCOL_VERSION == versions[0]
+
+    @pytest.mark.parametrize("version", mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+    def test_each_supported_version_is_echoed_back(self, version):
+        """A client asking for a revision this server speaks gets that revision.
+
+        Parametrized over the live tuple, so a revision added to the server is
+        covered here without an edit — and one that is listed but not honoured
+        fails.
+        """
+        status, body = _call(_event("initialize", params={"protocolVersion": version}))
+
+        assert status == 200, body
+        assert body["result"]["protocolVersion"] == version
+
+    def test_an_unknown_requested_version_is_answered_with_the_newest(self):
+        """A counter-offer, not an error.
+
+        `initialize` is where a client learns what it is talking to, so refusing
+        an unknown request would leave it with nothing to fall back to. Declining
+        the counter-offer is the client's decision, made by closing the
+        connection.
+        """
+        status, body = _call(_event("initialize", params={"protocolVersion": "1999-01-01"}))
+
+        assert status == 200, body
+        assert body["result"]["protocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
+        assert "error" not in body
+
+    @pytest.mark.parametrize("requested", [None, "", 2025, ["2025-06-18"], {}])
+    def test_an_unusable_requested_version_still_negotiates(self, requested):
+        """`params.protocolVersion` is caller-controlled JSON and need not be a
+        string. A non-string must not become a 500 or an echo of itself."""
+        params = {} if requested is None else {"protocolVersion": requested}
+        status, body = _call(_event("initialize", params=params))
+
+        assert status == 200, body
+        assert body["result"]["protocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
+
+    def test_the_negotiated_version_is_one_the_server_declares(self):
+        """Whatever is asked, the answer is from the declared set.
+
+        The property that matters to a client: it can always validate the answer
+        against `server/discover`.
+        """
+        for requested in (*mcp_handler.SUPPORTED_PROTOCOL_VERSIONS, "nonsense", None):
+            negotiated = mcp_handler._negotiate_protocol_version(requested)
+            assert negotiated in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+
+
+# ===========================================================================
+# server/discover
+# ===========================================================================
+
+class TestServerDiscover:
+    """A client can learn what this server supports without a failed call.
+
+    Discovering a method by receiving -32601 for it cannot distinguish "not
+    implemented here" from "spelled differently here", and costs a round trip per
+    guess.
+    """
+
+    def _discover(self) -> dict:
+        status, body = _call(_event("server/discover"))
+        assert status == 200, body
+        return body["result"]
+
+    def test_discover_needs_no_credential(self):
+        """It answers what the SERVER supports, which a client needs before it has
+        decided what to present. It names no project, no tool and no data."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(_event("server/discover"), MagicMock())
+        assert response["statusCode"] == 200, response["body"]
+        table.query.assert_not_called()
+
+    def test_it_reports_every_protocol_version_the_server_speaks(self):
+        result = self._discover()
+
+        assert result["protocolVersions"] == list(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+        assert result["preferredProtocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
+
+    def test_it_reports_every_method_the_server_dispatches(self):
+        """Derived from the dispatch tables, so a method that exists is listed and
+        one that is only listed cannot exist."""
+        result = self._discover()
+        dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
+
+        assert set(result["methods"]) == dispatched
+        assert set(result["authenticatedMethods"]) == set(mcp_handler.MCP_AUTH_METHODS)
+        # And the split is real: an authenticated method is not also served
+        # without a credential.
+        assert not set(mcp_handler.MCP_AUTH_METHODS) & set(mcp_handler.MCP_METHODS)
+
+    def test_it_reports_the_transport_headers_it_validates(self):
+        """A client cannot conform to a rule it cannot discover."""
+        result = self._discover()
+
+        assert set(result["transportHeaders"]) == set(mcp_handler.TRANSPORT_HEADERS)
+
+    def test_it_reports_the_result_type_vocabulary(self):
+        result = self._discover()
+
+        assert set(result["resultTypes"]) == set(mcp_handler.RESULT_TYPES)
+
+    def test_it_reports_the_cost_class_vocabulary_in_order(self):
+        """Cheapest first: an unordered set of adjectives does not say which of
+        two classes is the expensive one."""
+        result = self._discover()
+
+        assert result["costClasses"] == list(mcp_handler.COST_CLASSES)
+
+    def test_it_says_the_tool_list_varies_by_credential(self):
+        """Cheaper than letting a client find out by calling a tool it was never
+        granted — and it is why discovery does not list tools itself."""
+        result = self._discover()
+
+        assert result["toolsVaryByCredential"] is True
+        assert "tools" not in result
+
+    def test_the_declared_capabilities_match_the_handshake(self):
+        """One statement of what this server can do, or the two answers disagree
+        about the same fact."""
+        result = self._discover()
+        _status, initialize = _call(_event("initialize"))
+
+        assert result["capabilities"] == initialize["result"]["capabilities"]
+
+    def test_a_disallowed_origin_is_refused_before_discovery_answers(self):
+        """The DNS-rebinding guard covers the new method too.
+
+        Discovery is unauthenticated and describes the server, which is exactly
+        the sort of endpoint that gets added after a guard and outside it.
+        """
+        with patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com"):
+            response = mcp_handler.lambda_handler(
+                _event("server/discover", headers={"Origin": "https://evil.example.net"}),
+                MagicMock(),
+            )
+
+        assert response["statusCode"] == 403, response["body"]
+
+
+# ===========================================================================
+# The MCP-Protocol-Version transport header
+# ===========================================================================
+
+class TestProtocolVersionHeader:
+    """The transport's own version statement, checked rather than assumed."""
+
+    @pytest.mark.parametrize("version", mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+    def test_a_supported_version_header_is_served(self, version):
+        status, body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": version},
+        ))
+
+        assert status == 200, body
+        assert "result" in body
+
+    def test_an_unsupported_version_header_is_refused(self):
+        """400 and -32600, and the message names what the server does speak.
+
+        `-32600 Invalid Request` rather than `-32602 Invalid params`: the BODY may
+        be perfectly well formed, and it is the request as a whole that is not.
+        """
+        status, body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": "1999-01-01"},
+        ))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+        assert mcp_handler.PREFERRED_PROTOCOL_VERSION in body["error"]["message"]
+
+    def test_an_absent_version_header_is_served(self):
+        """The header postdates the first revisions of the transport, so requiring
+        it would refuse every client written against one of those."""
+        status, body = _call(_event("initialize"))
+
+        assert status == 200, body
+
+    def test_an_empty_version_header_is_refused(self):
+        """A client that sent the header empty said something, and what it said is
+        not a version. Reading it as absence would let a client that MEANT to name
+        a version be served silently on another one."""
+        status, body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": ""},
+        ))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+
+    def test_the_header_is_matched_case_insensitively(self):
+        """API Gateway lowercases header names in proxy mode; a direct invoke does
+        not. The guard has to hold for both, which is the lesson `Origin` already
+        taught this handler."""
+        for spelling in ("MCP-Protocol-Version", "mcp-protocol-version",
+                         "Mcp-Protocol-Version"):
+            status, _body = _call(_event(
+                "initialize", headers={spelling: "1999-01-01"},
+            ))
+            assert status == 400, f"{spelling} was not read"
+
+    def test_a_bad_version_header_never_reaches_the_token_store(self):
+        """Header validation runs before authentication: a malformed request must
+        not buy a probe of the credential store, the same property the Origin
+        guard has."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(
+                _event("tools/list", headers={"MCP-Protocol-Version": "1999-01-01"},
+                       token=_TOKEN),
+                MagicMock(),
+            )
+
+        assert response["statusCode"] == 400
+        table.query.assert_not_called()
+
+    def test_the_header_is_validated_on_the_authenticated_path_too(self):
+        """Not only on the handshake: a session that drifts mid-stream is exactly
+        what the header exists to catch."""
+        status, body = _call(_event(
+            "tools/list", headers={"MCP-Protocol-Version": "1999-01-01"}, token=_TOKEN,
+        ))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+
+    def test_the_declared_headers_are_all_reachable_from_a_browser(self):
+        """A header the server validates but a browser's preflight blocks is a
+        rule with no reachable subject.
+
+        Compared case-insensitively because CORS header matching is, and because
+        the wire spelling and the read spelling are deliberately different.
+        """
+        allowed = {
+            name.strip().lower()
+            for name in mcp_handler.CORS_HEADERS['Access-Control-Allow-Headers'].split(',')
+        }
+        for header in mcp_handler.TRANSPORT_HEADERS:
+            assert header in allowed, (
+                f"{header} is validated but not allowed through a CORS preflight"
+            )
+
+
+# ===========================================================================
+# The encoded-word sentinel form
+# ===========================================================================
+
+class TestEncodedWordHeaders:
+    """`=?base64?<payload>?=` — what a conforming client sends when it cannot be
+    sure a header value survives an intermediary.
+
+    Treating it as literal text is not merely a missing feature: it reports
+    "unsupported version =?base64?…?=" for a version this server does speak,
+    sending the caller after a version number.
+    """
+
+    def test_an_encoded_protocol_version_is_decoded(self):
+        status, body = _call(_event("initialize", headers={
+            "MCP-Protocol-Version": _encoded(mcp_handler.PREFERRED_PROTOCOL_VERSION),
+        }))
+
+        assert status == 200, body
+
+    def test_an_encoded_unsupported_version_is_still_refused(self):
+        """Decoding is not permitting: the sentinel changes the spelling, not the
+        rule. The message names the DECODED value, which is what the caller can
+        act on."""
+        status, body = _call(_event("initialize", headers={
+            "MCP-Protocol-Version": _encoded("1999-01-01"),
+        }))
+
+        assert status == 400
+        assert "1999-01-01" in body["error"]["message"]
+        assert "=?base64?" not in body["error"]["message"]
+
+    def test_an_encoded_method_header_is_decoded(self):
+        status, body = _call(_event("ping", headers={
+            "MCP-Method": _encoded("ping"),
+        }))
+
+        assert status == 200, body
+
+    def test_an_encoded_name_header_is_decoded(self):
+        status, body = _call(_event(
+            "tools/call",
+            params={"name": "get_metrics_summary", "arguments": {}},
+            headers={"MCP-Name": _encoded("get_metrics_summary")},
+            token=_TOKEN,
+        ))
+
+        assert status == 200, body
+        assert "error" not in body, body
+
+    @pytest.mark.parametrize("payload", [
+        "not-base64!!",          # not base64 at all
+        "//////",                # decodes to bytes that are not UTF-8
+        "",                      # the sentinel with nothing in it
+        "aGVsbG8=extra",         # trailing junk after valid base64
+    ])
+    def test_a_malformed_sentinel_is_refused_as_an_encoding_fault(self, payload):
+        """Refused, and refused for the right REASON.
+
+        Comparing `=?base64?not-base64?=` literally against the version list
+        would report an unsupported-version error, which sends the caller looking
+        for a version number when the fault is the encoding. The message has to
+        name the encoding.
+        """
+        status, body = _call(_event("initialize", headers={
+            "MCP-Protocol-Version": f"=?base64?{payload}?=",
+        }))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+        assert "base64" in body["error"]["message"]
+
+    def test_a_plain_value_is_not_treated_as_encoded(self):
+        """The sentinel is optional and a plain value is the ordinary spelling.
+
+        Pinned so a decoder that got greedy — stripping `=` padding, say — cannot
+        start mangling ordinary values.
+        """
+        assert mcp_handler._decoded_header("2025-06-18", "x") == "2025-06-18"
+        # A value that merely CONTAINS the marker is not in sentinel form.
+        assert mcp_handler._decoded_header("x=?base64?y?=", "x") == "x=?base64?y?="
+
+    def test_a_decoded_value_is_compared_after_decoding_not_before(self):
+        """Unit-level, so the property holds for every header rather than for the
+        one an end-to-end test happens to exercise."""
+        for value in ("tools/call", "search_feedback", "2026-07-28"):
+            assert mcp_handler._decoded_header(_encoded(value), "x") == value
+
+
+# ===========================================================================
+# The MCP-Method and MCP-Name routing echoes
+# ===========================================================================
+
+class TestRoutingHeaders:
+    """A routing echo that contradicts its body has not said what it wants.
+
+    These headers exist so an intermediary can route without parsing a body,
+    which is exactly what makes a disagreement dangerous: one hop routes on the
+    header, the next acts on the body, and the two hops are serving different
+    requests. Refused rather than resolved in either direction — there is no way
+    to know which statement was the caller's intent.
+    """
+
+    def test_a_matching_method_header_is_served(self):
+        status, body = _call(_event("ping", headers={"MCP-Method": "ping"}))
+
+        assert status == 200, body
+        assert "result" in body
+
+    def test_a_method_header_contradicting_the_body_is_refused(self):
+        status, body = _call(_event("ping", headers={"MCP-Method": "tools/call"}))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+        assert "tools/call" in body["error"]["message"]
+        assert "ping" in body["error"]["message"]
+
+    def test_an_absent_method_header_is_served(self):
+        """Both echoes are optional; absence is silent."""
+        status, body = _call(_event("ping"))
+
+        assert status == 200, body
+
+    def test_a_matching_name_header_is_served(self):
+        status, body = _call(_event(
+            "tools/call",
+            params={"name": "get_metrics_summary", "arguments": {}},
+            headers={"MCP-Name": "get_metrics_summary"},
+            token=_TOKEN,
+        ))
+
+        assert status == 200, body
+        assert "error" not in body, body
+
+    def test_a_name_header_contradicting_the_body_is_refused(self):
+        """And refused BEFORE the tool runs: a header naming one tool while the
+        body calls another must not spend anyone's permissions on either."""
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_delegate_lambda_client") as client:
+            table.query.return_value = {"Items": [_token_row()]}
+            response = mcp_handler.lambda_handler(_event(
+                "tools/call",
+                params={"name": "get_metrics_summary", "arguments": {}},
+                headers={"MCP-Name": "search_feedback"},
+                token=_TOKEN,
+            ), MagicMock())
+
+        assert response["statusCode"] == 400, response["body"]
+        assert json.loads(response["body"])["error"]["code"] == -32600
+        client.assert_not_called()
+
+    def test_a_name_header_on_a_method_that_names_no_tool_is_refused(self):
+        """`MCP-Name` names a TOOL, so on `tools/list` it asks for something this
+        server cannot do — and answering the list would answer a different
+        question."""
+        status, body = _call(_event(
+            "tools/list", headers={"MCP-Name": "search_feedback"}, token=_TOKEN,
+        ))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+        assert "tools/call" in body["error"]["message"]
+
+    def test_a_name_header_with_no_name_in_the_body_is_refused(self):
+        """A `tools/call` with no `name` is malformed anyway, but a header naming
+        a tool while the body names none is the disagreement case: it must not be
+        read as agreement."""
+        status, body = _call(_event(
+            "tools/call", params={"arguments": {}},
+            headers={"MCP-Name": "search_feedback"}, token=_TOKEN,
+        ))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+
+    def test_both_echoes_are_matched_case_insensitively(self):
+        for spelling in ("MCP-Method", "mcp-method"):
+            status, _body = _call(_event("ping", headers={spelling: "tools/call"}))
+            assert status == 400, f"{spelling} was not read"
+
+
+# ===========================================================================
+# The resultType discriminator
+# ===========================================================================
+
+class TestResultDiscriminator:
+    """Every result says what SHAPE it is, rather than being inferred from keys.
+
+    `{}` is both a `ping` answer and a notification acknowledgement; a tool error
+    differs from a tool result by a boolean and by whether `structuredContent`
+    happens to be present. A client switching on inferred shape re-derives that
+    table from scratch and gets it subtly wrong — in the client, where nothing
+    here can catch it.
+    """
+
+    # Every dispatchable method, with whatever it needs to reach an answer. Keyed
+    # by method so a method added to the tables without a line here fails
+    # `test_every_dispatchable_method_is_covered` rather than going unchecked.
+    CASES: ClassVar[dict[str, tuple[dict, str | None]]] = {
+        "initialize": ({}, None),
+        "ping": ({}, None),
+        "server/discover": ({}, None),
+        "notifications/initialized": ({}, None),
+        "tools/list": ({}, _TOKEN),
+        "tools/call": ({"name": "get_metrics_summary", "arguments": {}}, _TOKEN),
+    }
+
+    def test_every_dispatchable_method_is_covered(self):
+        """Anti-vacuity for the parametrized test below."""
+        dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
+
+        assert set(self.CASES) == dispatched, (
+            f"uncovered methods: {sorted(dispatched - set(self.CASES))}; "
+            f"stale cases: {sorted(set(self.CASES) - dispatched)}"
+        )
+
+    @pytest.mark.parametrize("method", sorted(CASES))
+    def test_every_method_answers_with_a_declared_result_type(self, method):
+        params, token = self.CASES[method]
+        status, body = _call(_event(method, params=params, token=token))
+
+        assert status == 200, body
+        result = body["result"]
+        declared = result.get(mcp_handler.RESULT_TYPE_KEY)
+        assert declared in mcp_handler.RESULT_TYPES, (
+            f"{method} answered with resultType {declared!r}"
+        )
+
+    def test_the_types_a_client_cannot_otherwise_tell_apart_differ(self):
+        """The pairs that motivated the discriminator.
+
+        A pong and an acknowledgement are both `{}` on the wire; a tool result and
+        a tool error are the same object with one flag flipped. If either pair
+        shared a type the discriminator would not be discriminating.
+        """
+        _s, pong = _call(_event("ping"))
+        _s, ack = _call(_event("notifications/initialized"))
+
+        assert pong["result"][mcp_handler.RESULT_TYPE_KEY] != (
+            ack["result"][mcp_handler.RESULT_TYPE_KEY]
+        )
+
+    def test_a_tool_error_is_a_different_type_from_a_tool_result(self):
+        """A refusal carries no `structuredContent` to validate, and the type says
+        so without the client testing for the key."""
+        ok = mcp_handler._jsonrpc_result(
+            1, mcp_handler.RESULT_TYPE_TOOL_RESULT, {"isError": False},
+        )
+        bad = mcp_handler._tool_error(1, "nope")
+
+        assert ok["result"][mcp_handler.RESULT_TYPE_KEY] == (
+            mcp_handler.RESULT_TYPE_TOOL_RESULT
+        )
+        assert bad["result"][mcp_handler.RESULT_TYPE_KEY] == (
+            mcp_handler.RESULT_TYPE_TOOL_ERROR
+        )
+        # And the flag the spec defines is still there: the type describes the
+        # payload, it does not replace `isError`.
+        assert bad["result"]["isError"] is True
+
+    def test_a_delegated_refusal_still_carries_the_tool_error_type(self):
+        """End to end, through the route error path rather than the builder."""
+        client = MagicMock()
+        client.invoke.side_effect = lambda **_kwargs: {
+            "Payload": io.BytesIO(json.dumps({
+                "statusCode": 404, "body": json.dumps({"message": "Feedback not found"}),
+            }).encode()),
+        }
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_delegate_lambda_client", return_value=client), \
+             patch.dict(os.environ, {"METRICS_FUNCTION": "m"}):
+            table.query.return_value = {"Items": [_token_row()]}
+            table.update_item.return_value = {}
+            response = mcp_handler.lambda_handler(_event(
+                "tools/call",
+                params={"name": "get_feedback_detail",
+                        "arguments": {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}},
+                token=_TOKEN,
+            ), MagicMock())
+
+        result = json.loads(response["body"])["result"]
+        assert result[mcp_handler.RESULT_TYPE_KEY] == mcp_handler.RESULT_TYPE_TOOL_ERROR
+        assert result["isError"] is True
+
+    def test_an_undeclared_result_type_cannot_be_sent(self):
+        """A client cannot switch on a typo, and finding out at the client is
+        finding out too late."""
+        with pytest.raises(ValueError, match="undeclared resultType"):
+            mcp_handler._jsonrpc_result(1, "toolresult", {})
+
+    def test_the_discriminator_is_required_not_optional(self):
+        """The signature is the enforcement: a new result shape cannot ship
+        without naming itself.
+
+        An optional keyword would make the discriminator a thing authors
+        remember, which is the same class of defect as a declaration nothing
+        checks. Read off the SIGNATURE rather than by calling it, so the failure
+        names the design rather than an arbitrary TypeError.
+        """
+        parameters = inspect.signature(mcp_handler._jsonrpc_result).parameters
+        result_type = parameters.get("result_type")
+
+        assert result_type is not None, "_jsonrpc_result no longer takes a result type"
+        assert result_type.default is inspect.Parameter.empty, (
+            "result_type has a default, so a result can ship without naming its shape"
+        )
+
+    def test_no_result_is_built_outside_the_builder(self):
+        """Structural, via the AST, because a substring search cannot tell code
+        from a comment about code.
+
+        Every JSON-RPC envelope in this module must come from one of the two
+        builders — that is what makes "every result carries a resultType" a
+        property of the module rather than of the six call sites somebody
+        remembered. A seventh hand-rolled envelope fails here.
+        """
+        tree = ast.parse(inspect.getsource(mcp_handler))
+        builders = {"_jsonrpc_result", "_jsonrpc_error"}
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if not isinstance(inner, ast.Dict):
+                    continue
+                keys = {
+                    key.value for key in inner.keys
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                }
+                if "jsonrpc" in keys and node.name not in builders:
+                    offenders.append(node.name)
+        assert offenders == [], (
+            f"JSON-RPC envelopes built outside the builders, so their resultType "
+            f"is not enforced: {sorted(set(offenders))}"
+        )
+        # Positive control: the walker must actually see the builders' own
+        # literals, or the check above passes by finding nothing at all.
+        found = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and any(
+                isinstance(inner, ast.Dict)
+                and any(isinstance(k, ast.Constant) and k.value == "jsonrpc"
+                        for k in inner.keys)
+                for inner in ast.walk(node)
+            )
+        }
+        assert found == builders, f"the AST walk lost sight of the builders: {found}"
+
+
+# ===========================================================================
+# HTTP methods the transport defines and this server does not implement
+# ===========================================================================
+
+class TestMethodNotAllowed:
+    """GET and DELETE are transport methods, and 405 is how a client is told to
+    stop rather than to retry differently.
+
+    GET opens an SSE stream and DELETE terminates a session in the Streamable
+    HTTP transport; neither is implemented here.
+    """
+
+    @pytest.mark.parametrize("http_method", ["GET", "DELETE"])
+    def test_the_unimplemented_transport_methods_are_405(self, http_method):
+        response = mcp_handler.lambda_handler(
+            _event(http_method=http_method, path="/v1/mcp"), MagicMock(),
+        )
+
+        assert response["statusCode"] == 405, response["body"]
+
+    @pytest.mark.parametrize("http_method", ["GET", "DELETE", "PUT", "PATCH"])
+    def test_a_405_names_what_is_allowed(self, http_method):
+        """RFC 9110 §15.5.6 REQUIRES `Allow` on a 405, and it is the difference
+        between "not here" and "not like that".
+
+        The header is PARSED into methods rather than substring-searched: `PUT` is
+        not a substring of `POST` today, but a check that depends on that is a
+        check that breaks on an unrelated method name.
+        """
+        response = mcp_handler.lambda_handler(
+            _event(http_method=http_method, path="/v1/mcp"), MagicMock(),
+        )
+
+        assert response["statusCode"] == 405
+        allowed = {m.strip() for m in response["headers"]["Allow"].split(",")}
+        assert allowed == {"POST", "OPTIONS"}
+        assert http_method not in allowed
+
+    def test_the_allow_header_agrees_with_the_cors_declaration(self):
+        """One statement of which methods this endpoint serves, to two audiences.
+
+        A hand-written second copy is how a preflight and a 405 come to disagree
+        about the same endpoint.
+        """
+        response = mcp_handler.lambda_handler(
+            _event(http_method="PUT"), MagicMock(),
+        )
+        allowed = {
+            m.strip() for m in response["headers"]["Allow"].split(",")
+        }
+        declared = {
+            m.strip()
+            for m in mcp_handler.CORS_HEADERS["Access-Control-Allow-Methods"].split(",")
+        }
+
+        assert allowed == declared
+
+    def test_a_405_carries_a_json_rpc_envelope_and_cors_headers(self):
+        """Every answer from this endpoint is parseable by the client that asked,
+        including the refusals — the property the BotoCoreError clause records."""
+        response = mcp_handler.lambda_handler(_event(http_method="GET"), MagicMock())
+        body = json.loads(response["body"])
+
+        assert body["jsonrpc"] == "2.0"
+        assert body["error"]["code"] == -32600
+        assert response["headers"]["Access-Control-Allow-Origin"] == "*"
+
+    def test_a_405_never_reaches_the_token_store(self):
+        with patch("mcp_handler.projects_table") as table:
+            mcp_handler.lambda_handler(
+                _event(http_method="DELETE", token=_TOKEN), MagicMock(),
+            )
+        table.query.assert_not_called()
+
+    def test_the_autoseed_get_route_is_unaffected(self):
+        """The 405 is for the JSON-RPC endpoint, and autoseed is a GET by design.
+
+        Pinned because "GET is not allowed" is exactly the kind of rule that gets
+        applied one layer too early.
+        """
+        with patch("mcp_handler.projects_table") as table, \
+             patch("shared.mcp_delegate.get_delegate_lambda_client",
+                   return_value=_stub_domain_client()), \
+             patch.dict(os.environ, {"PROJECTS_FUNCTION": "p"}):
+            table.query.return_value = {"Items": [_token_row()]}
+            table.update_item.return_value = {}
+            response = mcp_handler.lambda_handler({
+                "httpMethod": "GET",
+                "path": f"/v1/mcp/autoseed/{_PROJECT}",
+                "headers": {"authorization": f"Bearer {_TOKEN}"},
+            }, MagicMock())
+
+        assert response["statusCode"] == 200, response["body"]
+
+    def test_options_still_preflights(self):
+        """A browser-based client's preflight is not a method refusal."""
+        response = mcp_handler.lambda_handler(
+            _event(http_method="OPTIONS"), MagicMock(),
+        )
+
+        assert response["statusCode"] == 200
+
+
+class TestUnknownMethod:
+    """An unknown JSON-RPC method is -32601 and nothing else."""
+
+    def test_an_unknown_method_is_method_not_found(self):
+        status, body = _call(_event("tools/teleport"))
+
+        assert body["error"]["code"] == -32601
+        assert "tools/teleport" in body["error"]["message"]
+        assert status == 200, (
+            "JSON-RPC transports a method-not-found in a 200 HTTP response: the "
+            "HTTP layer delivered the request fine"
+        )
+
+    def test_an_unknown_method_never_reaches_the_token_store(self):
+        """A method that does not exist cannot need a credential, so asking for
+        one would be a free probe of the auth path."""
+        with patch("mcp_handler.projects_table") as table:
+            mcp_handler.lambda_handler(_event("tools/teleport", token=_TOKEN), MagicMock())
+        table.query.assert_not_called()
+
+    def test_an_absent_method_is_also_method_not_found(self):
+        """A body with no `method` names no method, which is the same answer."""
+        status, body = _call(_event(
+            body=json.dumps({"jsonrpc": "2.0", "id": 1, "params": {}}),
+        ))
+
+        assert status == 200
+        assert body["error"]["code"] == -32601
+
+    @pytest.mark.parametrize("body_text", ["[]", '"a string"', "42", "null"])
+    def test_a_non_object_body_is_not_a_crash(self, body_text):
+        """The body is caller-controlled JSON and need not be an object. `[]`
+        used to reach `.get` on a list — an AttributeError, i.e. a 502 with no
+        envelope and no CORS headers, which is the failure mode the auth path's
+        catch-all exists to prevent."""
+        status, body = _call(_event(body=body_text))
+
+        assert status == 200, body
+        assert body["error"]["code"] == -32601
+        assert body["id"] is None
+
+
+# ===========================================================================
+# tools/list, filtered by the authorization actually presented
+# ===========================================================================
+
+class TestToolCatalogueIsFilteredByAuthorization:
+    """The spec blesses a credential-shaped tool set; this server had one shape.
+
+    Every caller saw every tool regardless of the scopes on its token, so a
+    `metrics:read` credential was shown `search_feedback`, called it, and was
+    refused -32003. A catalogue that has to be tried to be believed is not a
+    catalogue.
+    """
+
+    def _names(self, row: dict) -> list[str]:
+        status, body = _call(_event("tools/list", token=_TOKEN), row=row)
+        assert status == 200, body
+        return [tool["name"] for tool in body["result"]["tools"]]
+
+    def test_a_full_credential_sees_every_tool(self):
+        """The positive control. Without it, a filter that returned nothing at all
+        would pass every negative test below."""
+        assert set(self._names(_token_row())) == set(mcp_handler.TOOL_HANDLERS)
+
+    @pytest.mark.parametrize("scope", [
+        SCOPE_FEEDBACK_READ, SCOPE_METRICS_READ, SCOPE_PROJECTS_READ,
+    ])
+    def test_a_single_scope_credential_sees_only_that_domains_tools(self, scope):
+        """Derived from the scope table rather than restated, so a tool moved
+        between domains is covered without an edit here."""
+        listed = set(self._names(_token_row(scopes=[scope])))
+        expected = {
+            name for name, required in mcp_handler.TOOL_SCOPE_REQUIREMENTS.items()
+            if required == scope
+        }
+
+        assert expected, f"no tool requires {scope}; the table moved"
+        assert listed == expected
+
+    def test_a_project_set_credential_is_not_shown_the_workspace_tools(self):
+        """The load-bearing refusal, mirrored into the catalogue.
+
+        `voc-feedback` is keyed by source with no project dimension, so
+        `project-set` reach has nothing to narrow and those tools are refused at
+        call time. Listing them would advertise the refusal.
+        """
+        listed = set(self._names(_token_row(read_reach=REACH_PROJECT_SET)))
+        expected = {
+            name for name, kind in mcp_handler.TOOL_REACH_KINDS.items()
+            if kind != mcp_handler.REACH_KIND_WORKSPACE
+        }
+
+        assert listed == expected
+
+    def test_a_none_reach_credential_sees_no_tools(self):
+        """It can call nothing, so it is shown nothing — and an empty list is an
+        answer rather than an error, because the credential is valid."""
+        status, body = _call(_event("tools/list", token=_TOKEN),
+                             row=_token_row(read_reach=REACH_NONE))
+
+        assert status == 200, body
+        assert body["result"]["tools"] == []
+
+    def test_a_project_set_credential_with_no_projects_sees_no_project_tools(self):
+        """Sealed to a set that names nothing reaches nothing."""
+        listed = self._names(_token_row(read_reach=REACH_PROJECT_SET, projects=[]))
+
+        assert listed == []
+
+    def test_a_damaged_scope_set_lists_nothing_rather_than_everything(self):
+        """Fail-closed, matching the dispatch: a row whose `scopes` is unusable
+        grants nothing, so it must not be shown everything."""
+        for damaged in (None, "", "feedback:read", 7, {}):
+            listed = self._names(_token_row(scopes=damaged))
+            assert listed == [], f"scopes={damaged!r} listed {listed}"
+
+    def test_every_listed_tool_is_actually_callable_by_that_credential(self):
+        """The claim the filter makes, checked end to end.
+
+        A listing that included a tool the dispatch refuses would be the original
+        defect with extra steps; one that excluded a callable tool would be a new
+        one. Both directions are checked — the exclusion half against the
+        workspace tools a project-set token is refused.
+        """
+        row = _token_row(scopes=[SCOPE_METRICS_READ])
+        listed = set(self._names(row))
+        assert listed, "the positive half of this test needs a non-empty list"
+
+        for name in mcp_handler.TOOL_HANDLERS:
+            arguments = {"dimension": "categories"} if name == "get_metrics_breakdown" else {}
+            status, body = _call(
+                _event("tools/call", params={"name": name, "arguments": arguments},
+                       token=_TOKEN),
+                row=row,
+            )
+            assert status == 200, body
+            refused = body.get("error", {}).get("code") == -32003
+            assert refused == (name not in listed), (
+                f"{name}: listed={name in listed} but the dispatch "
+                f"{'refused' if refused else 'allowed'} it"
+            )
+
+    def test_the_order_is_deterministic_and_not_declaration_order(self):
+        """A cached list is comparable to a fresh one only if the order is stable,
+        and the etag over it means nothing otherwise. Declaration order would make
+        the answer depend on where somebody inserted a literal."""
+        names = self._names(_token_row())
+
+        assert names == sorted(names)
+        # Anti-vacuity: if the declarations happened to already be alphabetical,
+        # this test would pass without the sort. They are not.
+        declared = [tool["name"] for tool in mcp_handler.MCP_TOOLS]
+        assert declared != sorted(declared), (
+            "the declarations are now alphabetical, so this test no longer proves "
+            "the sort is what produces the order — reorder a declaration or drop "
+            "this assertion deliberately"
+        )
+
+    def test_the_list_carries_its_own_cache_hints(self):
+        """`listChanged: false` means nothing will tell the client the list moved,
+        so the answer says how long to hold it and how to detect staleness."""
+        status, body = _call(_event("tools/list", token=_TOKEN))
+        assert status == 200, body
+        hints = body["result"]["_meta"]["cacheHints"]
+
+        assert hints["cacheable"] is True
+        assert isinstance(hints["maxAgeSeconds"], int) and hints["maxAgeSeconds"] > 0
+        assert hints["etag"]
+        assert hints["serverVersion"] == mcp_handler.MCP_SERVER_VERSION
+        assert hints["listChangedNotifications"] is False
+
+    def test_the_cache_scope_is_the_credential_not_the_endpoint(self):
+        """The load-bearing hint. A shared cache keyed on the endpoint alone would
+        serve one token's catalogue to another token — which only became possible
+        the moment the list started varying by credential."""
+        _status, body = _call(_event("tools/list", token=_TOKEN))
+
+        assert body["result"]["_meta"]["cacheHints"]["scope"] == "credential"
+
+    def test_the_cache_hint_agrees_with_the_declared_capability(self):
+        """Two statements about notifications, from one fact."""
+        _status, initialize = _call(_event("initialize"))
+        _status, listing = _call(_event("tools/list", token=_TOKEN))
+
+        assert (
+            listing["result"]["_meta"]["cacheHints"]["listChangedNotifications"]
+            is initialize["result"]["capabilities"]["tools"]["listChanged"]
+        )
+
+    def test_two_credentials_with_different_reach_get_different_etags(self):
+        """An etag that did not move with the catalogue would let a client keep
+        serving a stale one — the failure the hint exists to prevent."""
+        _s, full = _call(_event("tools/list", token=_TOKEN), row=_token_row())
+        _s, narrow = _call(_event("tools/list", token=_TOKEN),
+                           row=_token_row(scopes=[SCOPE_METRICS_READ]))
+
+        assert (
+            full["result"]["_meta"]["cacheHints"]["etag"]
+            != narrow["result"]["_meta"]["cacheHints"]["etag"]
+        )
+
+    def test_the_etag_is_stable_across_identical_requests(self):
+        """Otherwise a client re-fetches forever and the hint is noise."""
+        _s, first = _call(_event("tools/list", token=_TOKEN))
+        _s, second = _call(_event("tools/list", token=_TOKEN))
+
+        assert (
+            first["result"]["_meta"]["cacheHints"]["etag"]
+            == second["result"]["_meta"]["cacheHints"]["etag"]
+        )
+
+    def test_the_list_still_requires_a_credential(self):
+        """Filtering by authorization presupposes authorization: an unauthenticated
+        `tools/list` must not fall back to "everything" or to "nothing"."""
+        response = mcp_handler.lambda_handler(_event("tools/list"), MagicMock())
+
+        assert response["statusCode"] == 401, response["body"]
+
+
+# ===========================================================================
+# Annotations and the cost class
+# ===========================================================================
+
+class TestAnnotationsAndCostClass:
+    """A client cannot tell a keyed read from a soft-capped scan by tool name.
+
+    The cost class is what lets a model choose between two tools that answer
+    nearly the same question before making the expensive call rather than after.
+    """
+
+    def test_every_published_tool_carries_annotations(self):
+        for tool in mcp_handler.MCP_TOOLS:
+            annotations = tool.get("annotations")
+            assert annotations, f"{tool['name']} publishes no annotations"
+            assert annotations["title"], f"{tool['name']} has no human-readable title"
+
+    def test_every_published_tool_declares_all_four_behaviour_hints(self):
+        """A read-only tool that does not SAY it is read-only gets prompted for
+        like a write, because a client that cannot tell assumes the worse case."""
+        expected = {"readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"}
+        for tool in mcp_handler.MCP_TOOLS:
+            hints = set(tool["annotations"]) - {"title"}
+            assert hints == expected, f"{tool['name']}: {sorted(hints)}"
+
+    def test_every_tool_in_this_phase_is_declared_read_only(self):
+        """True of every tool here, and the assertion that has to MOVE when the
+        first write tool lands — deliberately, in the same commit as its write
+        scope, because a hint alone is a label and a scope alone makes a client
+        prompt for a write as though it were a read."""
+        for tool in mcp_handler.MCP_TOOLS:
+            assert tool["annotations"]["readOnlyHint"] is True, tool["name"]
+            assert tool["annotations"]["destructiveHint"] is False, tool["name"]
+
+    def test_no_tool_claims_to_reach_the_open_world(self):
+        """Every tool reads this workspace's own data lake. A client would
+        otherwise have to assume the internet."""
+        for tool in mcp_handler.MCP_TOOLS:
+            assert tool["annotations"]["openWorldHint"] is False, tool["name"]
+
+    def test_every_published_tool_carries_a_cost_class_from_the_vocabulary(self):
+        for tool in mcp_handler.MCP_TOOLS:
+            cost = tool["_meta"]["costClass"]
+            assert cost in mcp_handler.COST_CLASSES, f"{tool['name']}: {cost!r}"
+
+    def test_the_cost_class_table_covers_exactly_the_registered_tools(self):
+        """Fail-closed at publication: a missing class would read as `cheap` to a
+        model that expected every tool to carry one, and a stale entry is a claim
+        about a tool that no longer exists."""
+        assert set(mcp_handler.TOOL_COST_CLASSES) == set(mcp_handler.TOOL_HANDLERS)
+        assert set(mcp_handler.TOOL_TITLES) == set(mcp_handler.TOOL_HANDLERS)
+
+    def test_a_tool_with_no_cost_class_cannot_be_published(self):
+        """The enforcement, exercised rather than asserted about.
+
+        Building the catalogue is what refuses, so the failure is at import in a
+        deployed build rather than at a client's first `tools/list`.
+        """
+        with pytest.raises(KeyError, match="cost class"):
+            mcp_handler._published_tool({"name": "unregistered_tool"})
+
+    def test_an_undeclared_cost_class_cannot_be_published(self):
+        with patch.dict(mcp_handler.TOOL_COST_CLASSES, {"search_feedback": "free"}), \
+             patch.dict(mcp_handler.TOOL_TITLES, {"search_feedback": "x"}), \
+             pytest.raises(ValueError, match="cost class"):
+            mcp_handler._published_tool({"name": "search_feedback"})
+
+    def test_the_expensive_class_is_the_tool_that_can_truncate(self):
+        """The class is about the SHAPE of the read, and `is_partial` is the same
+        fact surfacing at answer time: a candidate scan bounded by a soft cap
+        rather than by an index. Asserted against the declared output schema, so
+        the two cannot drift into disagreement.
+        """
+        for tool in mcp_handler.MCP_TOOLS:
+            declares_truncation = "is_partial" in tool["outputSchema"].get("required", [])
+            if declares_truncation:
+                assert tool["_meta"]["costClass"] == mcp_handler.COST_EXPENSIVE, (
+                    f"{tool['name']} can report truncation but is not the "
+                    f"expensive class"
+                )
+
+    def test_a_tool_result_reports_the_cost_it_actually_carried(self):
+        """The same class the catalogue advertised, read from one table, so an
+        advertised `cheap` and a billed `expensive` cannot be two facts."""
+        status, body = _call(_event(
+            "tools/call", params={"name": "search_feedback", "arguments": {"query": "late"}},
+            token=_TOKEN,
+        ))
+
+        assert status == 200, body
+        assert body["result"]["_meta"]["costClass"] == (
+            mcp_handler.TOOL_COST_CLASSES["search_feedback"]
+        )
+
+    def test_the_advertised_and_the_reported_class_are_the_same_value(self):
+        """Across every tool, not just the one an example exercises."""
+        published = {
+            tool["name"]: tool["_meta"]["costClass"] for tool in mcp_handler.MCP_TOOLS
+        }
+        for name, advertised in published.items():
+            arguments = {"dimension": "categories"} if name == "get_metrics_breakdown" else {}
+            if name == "get_feedback_detail":
+                arguments = {"feedback_id": "1ae1eb6abcd7d3a2e364f46139f98466"}
+            status, body = _call(_event(
+                "tools/call", params={"name": name, "arguments": arguments}, token=_TOKEN,
+            ))
+            assert status == 200, body
+            assert body["result"]["_meta"]["costClass"] == advertised, name
+
+    def test_a_tool_error_carries_no_cost_class_to_misread(self):
+        """A refusal did not perform the read, so reporting its class would
+        attribute a cost to a call that never paid it.
+
+        Same reasoning as `structuredContent` being absent on a refusal rather
+        than empty.
+        """
+        error = mcp_handler._tool_error(1, "nope")
+
+        assert "_meta" not in error["result"]
+
+    def test_the_declaration_the_annotations_wrap_is_not_mutated(self):
+        """`_published_tool` composes; it must not edit the literal in place.
+
+        A mutating implementation would work exactly once and then double-wrap on
+        any future rebuild, which is the kind of fault that shows up as a
+        fingerprint that moves without a diff.
+        """
+        for declaration in mcp_handler._TOOL_DECLARATIONS:
+            assert "annotations" not in declaration, declaration["name"]
+            assert "_meta" not in declaration, declaration["name"]
+
+
+# ===========================================================================
+# A dead credential must fail the handshake, not the first tool call
+# ===========================================================================
+
+class TestADeadCredentialFailsTheHandshake:
+    """The honesty defect this envelope owes.
+
+    `initialize` needs no credential, so a revoked or expired token completed the
+    whole handshake, `tools/list` answered, and the FIRST `tools/call` was the
+    first refusal. A client shows that as a connected server with failing tools,
+    which sends whoever is debugging at the tools, the scopes and the routes —
+    anywhere but the credential.
+    """
+
+    def _expired_row(self) -> dict:
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        return _token_row(expires_at=past)
+
+    @pytest.mark.parametrize("method", ["initialize", "ping", "server/discover",
+                                        "notifications/initialized"])
+    def test_an_expired_credential_is_refused_on_every_unauthenticated_method(self, method):
+        """Every method in the no-credential half, because a client may open with
+        any of them and each one would otherwise report a healthy server."""
+        status, body = _call(_event(method, token=_TOKEN), row=self._expired_row())
+
+        assert status == 401, body
+        assert body["error"]["code"] == -32001
+
+    def test_a_revoked_credential_is_refused_at_initialize(self):
+        """Revocation deletes the row, so the credential parses and matches
+        nothing — indistinguishable from a wrong secret, and equally dead."""
+        with patch("mcp_handler.projects_table") as table:
+            table.query.return_value = {"Items": []}
+            response = mcp_handler.lambda_handler(
+                _event("initialize", token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 401, response["body"]
+
+    def test_the_refusal_says_the_credential_is_the_problem(self):
+        """The whole point: the message has to send the reader at the token.
+
+        A generic "unauthorized" on a handshake that used to succeed is what made
+        this worth fixing.
+        """
+        _status, body = _call(_event("initialize", token=_TOKEN), row=self._expired_row())
+        message = body["error"]["message"].lower()
+
+        assert "token" in message
+        assert "revoked" in message or "expired" in message
+
+    def test_no_credential_at_all_still_initializes(self):
+        """Absence is not a dead credential, it is no credential — and an
+        unauthenticated handshake is exactly how a client learns what to present.
+        Refusing here would break every client that connects before it has a
+        token.
+        """
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(_event("initialize"), MagicMock())
+
+        assert response["statusCode"] == 200, response["body"]
+        table.query.assert_not_called()
+
+    def test_a_malformed_authorization_header_still_initializes(self):
+        """A header that is not a Bearer credential presents no credential.
+
+        Read strictly, so a `Basic` header or a bare word is not mistaken for a
+        dead token and reported as one.
+        """
+        for header in ("", "Basic abc", "Bearer", "bearer voc_x", "voc_x"):
+            with patch("mcp_handler.projects_table") as table:
+                response = mcp_handler.lambda_handler(
+                    _event("initialize", headers={"authorization": header}), MagicMock(),
+                )
+            assert response["statusCode"] == 200, f"{header!r}: {response['body']}"
+            table.query.assert_not_called()
+
+    def test_a_live_credential_still_initializes(self):
+        """The positive control. A check that refused every presented credential
+        would pass every test above and break every working client."""
+        status, body = _call(_event("initialize", token=_TOKEN))
+
+        assert status == 200, body
+        assert body["result"]["protocolVersion"] in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+
+    def test_a_token_store_fault_is_a_server_error_not_a_dead_credential(self):
+        """Reporting "your token is invalid" for a table nobody could read sends
+        an operator to re-mint a credential that was never compared — the same
+        distinction the authenticated path already draws."""
+        with patch("mcp_handler.projects_table", None):
+            response = mcp_handler.lambda_handler(
+                _event("initialize", token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 500, response["body"]
+        assert json.loads(response["body"])["error"]["code"] == -32603
+
+    def test_the_401_carries_the_bearer_challenge(self):
+        """Through the same choke point as every other 401 here, so this new path
+        cannot be the one that forgets RFC 6750."""
+        with patch("mcp_handler.projects_table") as table:
+            table.query.return_value = {"Items": [self._expired_row()]}
+            response = mcp_handler.lambda_handler(
+                _event("initialize", token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 401
+        assert response["headers"]["WWW-Authenticate"].startswith("Bearer ")
+
+    def test_the_handshake_is_refused_before_it_reports_a_version(self):
+        """A 401 that also carried a negotiated version would still look like a
+        connected server to a client that reads the body optimistically."""
+        _status, body = _call(_event("initialize", token=_TOKEN), row=self._expired_row())
+
+        assert "result" not in body

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -25,6 +25,14 @@ revert makes each assertion fail.
       several calls later as a field it could not parse. Deleting the header
       check fails test_an_unsupported_version_header_is_refused.
 
+  TestTheHandshakeIsExemptFromTheVersionRefusal
+    — and then the refusal met the handshake, where a current-generation client
+      MUST send its own revision and has nothing else to send: its first contact
+      was a 400 and the counter-offer was unreachable. Reverting the
+      `method == 'initialize'` exemption in `_validated_protocol_version` fails
+      test_a_current_generation_first_contact_is_counter_offered; widening it past
+      the handshake fails test_every_other_method_still_refuses_the_same_header.
+
   TestEncodedWordHeaders
     — the `=?base64?...?=` sentinel form is what a conforming client sends when
       it cannot be sure a value survives an intermediary. Treating it as literal
@@ -40,15 +48,26 @@ revert makes each assertion fail.
 
   TestResultDiscriminator
     — every result carried a bare object and a client had to infer its shape
-      from which keys were present (`{}` is both a pong and an ack; a tool error
-      differs from a tool result by a boolean). Making `resultType` optional in
-      `_jsonrpc_result` fails test_every_method_answers_with_a_declared_result_type,
+      from which keys were present (a tool error differs from a tool result by a
+      boolean; `ping` answers a bare `{}`). Making the shape optional in
+      `_jsonrpc_result` fails test_every_method_answers_with_a_declared_result_shape,
       and the AST check fails the moment a result is built outside the builder.
+
+  TestNotificationsAreAccepted
+    — a notification was answered 200 with a result carrying `id: null`, and every
+      notification this server does not dispatch was answered 404 — which on this
+      endpoint means "your session was terminated, re-initialize", so routine
+      `notifications/cancelled` traffic tore down live sessions. Deleting the
+      `_is_notification` branch in `lambda_handler` fails every test in that class;
+      answering a notification anywhere but 202-with-no-body fails
+      test_a_notification_is_202_with_an_empty_body.
 
   TestMethodNotAllowed / TestUnknownMethod
     — GET and DELETE are transport methods this server does not implement, so
-      they are 405 with an `Allow` header; an unknown JSON-RPC method is -32601.
-      Answering either any other way fails these.
+      they are 405 with an `Allow` header; an unknown JSON-RPC REQUEST is -32601
+      with a 404. Answering either any other way fails these, and collapsing the
+      request/notification split back into one answer fails
+      test_the_two_message_kinds_get_different_answers.
 
   TestToolCatalogueIsFilteredByAuthorization
     — the spec blesses a credential-shaped tool set, and every caller used to see
@@ -145,6 +164,29 @@ def _event(method: str = "initialize", *, params: dict | None = None,
     }
 
 
+def _notification_event(method: str, *, params: dict | None = None,
+                        headers: dict | None = None,
+                        token: str | None = None) -> dict:
+    """A Lambda proxy event for a JSON-RPC NOTIFICATION.
+
+    The `id` MEMBER is absent, which is JSON-RPC's own definition of a
+    notification — not `"id": null`, which is a present member and is a request
+    with a null id. `_event` cannot express this, because it always writes an id,
+    and the distinction is exactly what the 202 path turns on.
+    """
+    request_headers = dict(headers or {})
+    if token is not None:
+        request_headers["authorization"] = f"Bearer {token}"
+    return {
+        "httpMethod": "POST",
+        "path": "/v1/mcp",
+        "headers": request_headers,
+        "body": json.dumps({
+            "jsonrpc": "2.0", "method": method, "params": params or {},
+        }),
+    }
+
+
 def _stub_domain_client():
     """A Lambda client answering any delegated route with an empty 200 payload."""
     client = MagicMock()
@@ -156,12 +198,16 @@ def _stub_domain_client():
     return client
 
 
-def _call(event: dict, *, row: dict | None = None) -> tuple[int, dict]:
-    """Drive `lambda_handler` end to end; return (status, parsed body).
+def _raw_call(event: dict, *, row: dict | None = None) -> dict:
+    """Drive `lambda_handler` end to end; return the RAW proxy response.
 
     The token store and the delegation client are stubbed because this file is
     about the envelope: what the store holds is `test_mcp_security.py`'s subject
     and what the routes answer is `test_mcp_delegation.py`'s.
+
+    Separate from `_call` because a 202 carries no body to parse, and a helper that
+    always parses one cannot express "there is nothing here" — it raises
+    `JSONDecodeError` and the failure names the helper rather than the assertion.
     """
     with patch("mcp_handler.projects_table") as table, \
          patch("shared.mcp_delegate.get_delegate_lambda_client",
@@ -169,7 +215,12 @@ def _call(event: dict, *, row: dict | None = None) -> tuple[int, dict]:
          patch.dict(os.environ, {"METRICS_FUNCTION": "m", "PROJECTS_FUNCTION": "p"}):
         table.query.return_value = {"Items": [row] if row is not None else [_token_row()]}
         table.update_item.return_value = {}
-        response = mcp_handler.lambda_handler(event, MagicMock())
+        return mcp_handler.lambda_handler(event, MagicMock())
+
+
+def _call(event: dict, *, row: dict | None = None) -> tuple[int, dict]:
+    """Drive `lambda_handler` end to end; return (status, parsed body)."""
+    response = _raw_call(event, row=row)
     return response["statusCode"], json.loads(response["body"])
 
 
@@ -529,9 +580,15 @@ class TestProtocolVersionHeader:
         RECOGNIZED modern error to decide the server is modern. `-32600` there means
         "legacy server", so the client falls back to `initialize` while this server
         is advertising a modern revision.
+
+        On `ping` rather than `initialize`, and that is the subject of
+        `TestTheHandshakeIsExemptFromTheVersionRefusal` below: past the handshake a
+        client has a negotiated version to send, so one this server never offered is
+        the client contradicting itself. On the handshake it is a client that has not
+        been told yet.
         """
         status, body = _call(_event(
-            "initialize", headers={"MCP-Protocol-Version": "1999-01-01"},
+            "ping", headers={"MCP-Protocol-Version": "1999-01-01"},
         ))
 
         assert status == 400
@@ -545,7 +602,7 @@ class TestProtocolVersionHeader:
         that recovery path requires parsing English.
         """
         _status, body = _call(_event(
-            "initialize", headers={"MCP-Protocol-Version": "1999-01-01"},
+            "ping", headers={"MCP-Protocol-Version": "1999-01-01"},
         ))
 
         data = body["error"]["data"]
@@ -597,7 +654,13 @@ class TestProtocolVersionHeader:
     def test_an_empty_version_header_is_refused(self):
         """A client that sent the header empty said something, and what it said is
         not a version. Reading it as absence would let a client that MEANT to name
-        a version be served silently on another one."""
+        a version be served silently on another one.
+
+        Refused on `initialize` too, which the unsupported-version case is NOT: an
+        empty value names no revision, so there is no claim for the handshake to
+        counter-offer against. The exemption below is for a client that stated a
+        version this server does not implement, not for one that stated nothing.
+        """
         status, body = _call(_event(
             "initialize", headers={"MCP-Protocol-Version": ""},
         ))
@@ -612,7 +675,7 @@ class TestProtocolVersionHeader:
         for spelling in ("MCP-Protocol-Version", "mcp-protocol-version",
                          "Mcp-Protocol-Version"):
             status, _body = _call(_event(
-                "initialize", headers={spelling: "1999-01-01"},
+                "ping", headers={spelling: "1999-01-01"},
             ))
             assert status == 400, f"{spelling} was not read"
 
@@ -657,6 +720,118 @@ class TestProtocolVersionHeader:
             )
 
 
+class TestTheHandshakeIsExemptFromTheVersionRefusal:
+    """A client's FIRST request may name a revision this server does not have.
+
+    The header refusal and the `initialize` counter-offer are both right and they
+    met in a place that served neither: a client whose newest revision is
+    2026-07-28 must send that value in the header on its very first POST — that
+    revision requires the header on every request and has no handshake to learn a
+    different value from — and header validation runs before dispatch, so the
+    request was refused 400 and `_handle_initialize` never ran. The counter-offer
+    that exists for exactly this client was unreachable by it.
+
+    Reverting the `method == 'initialize'` exemption in
+    `_validated_protocol_version` fails
+    test_a_current_generation_first_contact_is_counter_offered.
+    """
+
+    # The revision this server deliberately does not advertise, which is precisely
+    # the value a current SDK puts in the header. Written as a literal rather than
+    # derived: the point is a version OUTSIDE the supported tuple, and deriving it
+    # from the tuple would make the test agree with whatever the tuple says.
+    _UNIMPLEMENTED = "2026-07-28"
+
+    def test_the_unimplemented_revision_really_is_unimplemented(self):
+        """Anti-vacuity. If this revision were added to the tuple, every test in
+        this class would pass by the ordinary supported-version path and would stop
+        testing the exemption at all."""
+        assert self._UNIMPLEMENTED not in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+
+    def test_a_current_generation_first_contact_is_counter_offered(self):
+        """The whole finding, end to end: 200 and a usable version, not a 400.
+
+        The client sends its newest revision in BOTH places, which is what a fresh
+        SDK does, and gets the newest revision this server speaks — one round trip,
+        no error to parse.
+        """
+        status, body = _call(_event(
+            "initialize",
+            params={"protocolVersion": self._UNIMPLEMENTED},
+            headers={"MCP-Protocol-Version": self._UNIMPLEMENTED},
+        ))
+
+        assert status == 200, body
+        assert "error" not in body, body
+        assert body["result"]["protocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
+
+    def test_the_exemption_covers_the_header_alone_as_well(self):
+        """A client may state the transport version and leave `params` empty; the
+        header must not refuse what the body would have been counter-offered."""
+        status, body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": self._UNIMPLEMENTED},
+        ))
+
+        assert status == 200, body
+        assert body["result"]["protocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
+
+    @pytest.mark.parametrize("method", ["ping", "server/discover", "tools/list"])
+    def test_every_other_method_still_refuses_the_same_header(self, method):
+        """The asymmetry is the point, and it is not "initialize is special".
+
+        Past the handshake a client HAS a negotiated value to send, so one this
+        server never offered is the client contradicting itself. Parametrized across
+        both halves of the dispatch so an exemption that leaked into the
+        unauthenticated methods generally, or into the authenticated path, fails.
+        """
+        status, body = _call(_event(
+            method, headers={"MCP-Protocol-Version": self._UNIMPLEMENTED},
+            token=_TOKEN,
+        ))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32022
+        assert body["error"]["data"]["requested"] == self._UNIMPLEMENTED
+
+    def test_the_exempted_handshake_still_negotiates_a_declared_version(self):
+        """Exempt from the REFUSAL, not from the rule.
+
+        The session must still speak something this server implements — an
+        exemption that returned the client's own unimplemented version would have
+        replaced a wrong refusal with a wrong promise.
+        """
+        negotiated = mcp_handler._validated_protocol_version(
+            _event("initialize", headers={"MCP-Protocol-Version": self._UNIMPLEMENTED}),
+            "initialize",
+        )
+
+        assert negotiated in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+
+    def test_a_malformed_sentinel_is_still_refused_on_the_handshake(self):
+        """The exemption is for an unsupported VERSION, not for a broken encoding.
+
+        There is nothing to counter-offer about a value that does not decode: the
+        fault is the encoding and no negotiation fixes it.
+        """
+        status, body = _call(_event("initialize", headers={
+            "MCP-Protocol-Version": "=?base64?not-base64!!?=",
+        }))
+
+        assert status == 400
+        assert body["error"]["code"] == -32600
+        assert "base64" in body["error"]["message"]
+
+    def test_a_contradicting_routing_header_is_still_refused_on_the_handshake(self):
+        """And the exemption is confined to the VERSION check, not to header
+        validation as a whole."""
+        status, body = _call(_event(
+            "initialize", headers={"MCP-Method": "tools/call"},
+        ))
+
+        assert status == 400
+        assert body["error"]["code"] == -32020
+
+
 # ===========================================================================
 # The encoded-word sentinel form
 # ===========================================================================
@@ -680,8 +855,13 @@ class TestEncodedWordHeaders:
     def test_an_encoded_unsupported_version_is_still_refused(self):
         """Decoding is not permitting: the sentinel changes the spelling, not the
         rule. The message names the DECODED value, which is what the caller can
-        act on."""
-        status, body = _call(_event("initialize", headers={
+        act on.
+
+        On `ping`, because the handshake counter-offers rather than refuses an
+        unsupported version — and the rule under test here is that the sentinel
+        does not change which rule applies.
+        """
+        status, body = _call(_event("ping", headers={
             "MCP-Protocol-Version": _encoded("1999-01-01"),
         }))
 
@@ -870,11 +1050,10 @@ class TestRoutingHeaders:
 class TestResultDiscriminator:
     """Every result says what SHAPE it is, rather than being inferred from keys.
 
-    `{}` is both a `ping` answer and a notification acknowledgement; a tool error
-    differs from a tool result by a boolean and by whether `structuredContent`
-    happens to be present. A client switching on inferred shape re-derives that
-    table from scratch and gets it subtly wrong — in the client, where nothing
-    here can catch it.
+    A tool error differs from a tool result by a boolean and by whether
+    `structuredContent` happens to be present, and `ping` answers a bare `{}`. A
+    client switching on inferred shape re-derives that table from scratch and gets
+    it subtly wrong — in the client, where nothing here can catch it.
 
     The mechanism is split across two fields on purpose, and the split IS the
     subject of this class: `resultType` carries the spec's `"complete"`, and the
@@ -883,16 +1062,21 @@ class TestResultDiscriminator:
     of the newest advertised revision to reject every result this server sends,
     because the spec says an unrecognized `resultType` value MUST be considered
     invalid and this server declares no capability-advertised extension.
+
+    ⚠️ Notifications are absent from `CASES`, and that is not an omission: a
+    notification is answered 202 with no body, so it has no result to discriminate.
+    `TestNotificationsAreAccepted` owns that path. An earlier version of this class
+    justified the discriminator partly on "`{}` is both a pong and an ack" — a pair
+    that only existed because a notification was being answered at all.
     """
 
-    # Every dispatchable method, with whatever it needs to reach an answer. Keyed
-    # by method so a method added to the tables without a line here fails
-    # `test_every_dispatchable_method_is_covered` rather than going unchecked.
+    # Every dispatchable method that RETURNS A RESULT, with whatever it needs to
+    # reach an answer. Keyed by method so a method added to the tables without a
+    # line here fails `test_every_dispatchable_method_is_covered`.
     CASES: ClassVar[dict[str, tuple[dict, str | None]]] = {
         "initialize": ({}, None),
         "ping": ({}, None),
         "server/discover": ({}, None),
-        "notifications/initialized": ({}, None),
         "tools/list": ({}, _TOKEN),
         "tools/call": ({"name": "get_metrics_summary", "arguments": {}}, _TOKEN),
     }
@@ -948,12 +1132,28 @@ class TestResultDiscriminator:
             assert key.startswith(prefix), key
 
     def test_every_dispatchable_method_is_covered(self):
-        """Anti-vacuity for the parametrized test below."""
-        dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
+        """Anti-vacuity for the parametrized test below.
 
-        assert set(self.CASES) == dispatched, (
-            f"uncovered methods: {sorted(dispatched - set(self.CASES))}; "
-            f"stale cases: {sorted(set(self.CASES) - dispatched)}"
+        The result-bearing methods are the dispatch tables MINUS the notifications,
+        and the subtraction is derived from the table (a `None` handler is a method
+        that produces no result) rather than by naming them here — so a notification
+        added to the dispatch does not silently become an uncovered case, and one
+        that gains a handler does not stay excluded.
+        """
+        dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
+        answers_with_a_result = {
+            method for method in dispatched
+            if mcp_handler.MCP_METHODS.get(method, 'authenticated') is not None
+        }
+
+        assert set(self.CASES) == answers_with_a_result, (
+            f"uncovered methods: {sorted(answers_with_a_result - set(self.CASES))}; "
+            f"stale cases: {sorted(set(self.CASES) - answers_with_a_result)}"
+        )
+        # Positive control: the subtraction must actually remove something, or this
+        # test is the old one with more code.
+        assert dispatched - answers_with_a_result, (
+            "no notification is dispatched, so the exclusion above is vacuous"
         )
 
     @pytest.mark.parametrize("method", sorted(CASES))
@@ -967,22 +1167,37 @@ class TestResultDiscriminator:
             f"{method} answered with result shape {declared!r}"
         )
 
-    def test_the_shapes_a_client_cannot_otherwise_tell_apart_differ(self):
-        """The pairs that motivated the discriminator.
+    def test_no_two_methods_share_a_shape(self):
+        """The discriminator has to DISCRIMINATE.
 
-        A pong and an acknowledgement are both `{}` on the wire; a tool result and
-        a tool error are the same object with one flag flipped. If either pair
-        shared a shape the discriminator would not be discriminating.
+        This replaces a pong/ack comparison, which compared two answers to two
+        messages only one of which should have been answered at all. The surviving
+        property is the general one and a stronger claim: every result-bearing
+        method names a shape no other method names, so a client switching on the
+        value never has to fall back to inferring from keys.
         """
-        _s, pong = _call(_event("ping"))
-        _s, ack = _call(_event("notifications/initialized"))
+        shapes = {}
+        for method, (params, token) in sorted(self.CASES.items()):
+            _status, body = _call(_event(method, params=params, token=token))
+            shapes[method] = body["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY]
 
-        assert pong["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY] != (
-            ack["result"]["_meta"][mcp_handler.RESULT_SHAPE_KEY]
-        )
-        # …while both still say `complete` in the spec's field, which is the whole
-        # reason the local discriminator had to move out of it.
-        assert pong["result"]["resultType"] == ack["result"]["resultType"] == "complete"
+        assert len(set(shapes.values())) == len(shapes), f"shared shapes: {shapes}"
+        # …while every one still says `complete` in the spec's field, which is the
+        # whole reason the local discriminator had to move out of it.
+        for method, (params, token) in sorted(self.CASES.items()):
+            _status, body = _call(_event(method, params=params, token=token))
+            assert body["result"]["resultType"] == "complete", method
+
+    def test_there_is_no_shape_for_a_notification(self):
+        """The `ack` shape is gone, and it must not come back.
+
+        It named the answer to a notification — and a notification is answered 202
+        with no body, which every advertised revision states as a MUST. A shape
+        describing that response describes a response that must not be sent, so its
+        absence is the invariant rather than a tidying.
+        """
+        assert 'ack' not in mcp_handler.RESULT_SHAPES
+        assert not hasattr(mcp_handler, 'RESULT_SHAPE_ACK')
 
     def test_a_tool_error_is_a_different_shape_from_a_tool_result(self):
         """A refusal carries no `structuredContent` to validate, and the shape says
@@ -1132,6 +1347,149 @@ class TestResultDiscriminator:
 
 
 # ===========================================================================
+# The envelope's forward-compatible extras are ADDITIVE
+# ===========================================================================
+
+class TestTheForwardCompatibleExtrasAreAdditive:
+    """This envelope sends 2026-07-28 constructs under a range that predates them.
+
+    `resultType`, `ttlMs`/`cacheScope`, `-32020`/`-32022` and `server/discover` are
+    all defined by 2026-07-28, and this server deliberately advertises only the
+    handshake-based revisions. That is a documented forward-compatibility bet (the
+    PROVENANCE block at `ASSUMED_PROTOCOL_VERSION`) and it is safe for exactly one
+    reason: those revisions' result schemas are permissive about members they do not
+    know, so an extra field is IGNORED rather than rejected.
+
+    This class pins the half of that argument which could break a client: the extras
+    only ever ADD. A field an advertised revision defines is never replaced, retyped
+    or renamed by them — because a client of an advertised revision reads those
+    fields, and no permissiveness rule protects it there.
+
+    Making any extra replace a spec-defined member fails these.
+    """
+
+    # What the advertised revisions define for the results this server sends, and
+    # what a client written against one of them therefore reads. Deliberately a
+    # LITERAL table rather than something derived from the handler: it is the other
+    # side of the contract, so deriving it from the code under test would let the
+    # code define its own obligations.
+    REQUIRED_MEMBERS: ClassVar[dict[str, dict[str, type | tuple[type, ...]]]] = {
+        "initialize": {
+            "protocolVersion": str,
+            "capabilities": dict,
+            "serverInfo": dict,
+        },
+        "tools/list": {"tools": list},
+        # `structuredContent` belongs HERE and not among the extras below: it is
+        # defined by 2025-06-18, which is inside the advertised range. It arrived
+        # ahead of the version that defined it once already — the skew the
+        # SUPPORTED_PROTOCOL_VERSIONS comment records — and negotiating that range
+        # is what ended that. Listing it as an extra would re-file a resolved
+        # problem as an open one.
+        "tools/call": {"content": list, "isError": bool, "structuredContent": dict},
+    }
+
+    @pytest.mark.parametrize("method", sorted(REQUIRED_MEMBERS))
+    def test_every_member_the_advertised_revisions_define_is_still_there(self, method):
+        """The extras did not displace anything.
+
+        A client on 2025-11-25 reads exactly these members; an extra field beside
+        them costs it nothing, and an extra field INSTEAD of one breaks it.
+        """
+        params, token = TestResultDiscriminator.CASES[method]
+        status, body = _call(_event(method, params=params, token=token))
+
+        assert status == 200, body
+        for member, expected_type in self.REQUIRED_MEMBERS[method].items():
+            assert member in body["result"], (
+                f"{method} no longer sends {member!r}, which the advertised "
+                f"revisions define"
+            )
+            assert isinstance(body["result"][member], expected_type), (
+                f"{method}.{member} is {type(body['result'][member]).__name__}, "
+                f"not {expected_type.__name__}: a retype, not an addition"
+            )
+
+    def test_the_extras_are_the_only_new_members(self):
+        """Stated as a closed set, so an undocumented extra fails too.
+
+        The provenance note is only worth having if it is complete: a field added to
+        a result without a line in that note is exactly the "deliberate bet or
+        mistake?" question the note exists to answer.
+        """
+        # `_meta` is the spec's own extension point and is defined by every
+        # advertised revision, so it is not an extra — what is INSIDE it is
+        # vendor-prefixed and covered by `test_the_vendor_prefix_is_not_one_the_
+        # spec_reserves`.
+        documented_extras = {"resultType", "ttlMs", "cacheScope", "_meta"}
+
+        for method, required in sorted(self.REQUIRED_MEMBERS.items()):
+            params, token = TestResultDiscriminator.CASES[method]
+            _status, body = _call(_event(method, params=params, token=token))
+            extras = set(body["result"]) - set(required)
+            assert extras <= documented_extras, (
+                f"{method} sends undocumented extra members {sorted(extras - documented_extras)}; "
+                f"add them to the PROVENANCE note in mcp_handler.py or remove them"
+            )
+
+    def test_the_extras_are_actually_present(self):
+        """Positive control for the subset assertion above.
+
+        With no extras at all, `extras <= documented_extras` holds vacuously and
+        this class would pass while the envelope sent nothing it claims to.
+        """
+        _status, body = _call(_event("initialize"))
+        assert "resultType" in body["result"]
+
+        _status, listing = _call(_event("tools/list", token=_TOKEN))
+        assert {"ttlMs", "cacheScope"} <= set(listing["result"])
+
+    def test_a_tool_result_keeps_the_text_block_a_pre_structured_client_reads(self):
+        """The oldest advertised revision has no `structuredContent`.
+
+        `content[0].text` carries the same payload serialized, so a 2024-11-05
+        client is unaffected by everything this envelope added — which is the
+        additive claim at its furthest reach.
+        """
+        _status, body = _call(_event(
+            "tools/call",
+            params={"name": "get_metrics_summary", "arguments": {}},
+            token=_TOKEN,
+        ))
+
+        content = body["result"]["content"]
+        assert content[0]["type"] == "text"
+        assert json.loads(content[0]["text"]) == body["result"]["structuredContent"]
+
+    def test_the_error_codes_outside_the_advertised_range_are_only_the_two_named(self):
+        """The reserved-range judgement call, pinned to its stated scope.
+
+        -32020 and -32022 are 2026-07-28's and are kept deliberately; the argument
+        is in the provenance note. What must NOT happen is a third code appearing in
+        that reserved sub-range, because "we use exactly the two the spec defines" is
+        the whole basis for keeping them.
+        """
+        reserved = range(-32099, -32019)
+        emitted = {
+            mcp_handler.JSONRPC_HEADER_MISMATCH,
+            mcp_handler.JSONRPC_UNSUPPORTED_PROTOCOL_VERSION,
+        }
+        module_codes = {
+            value for name, value in vars(mcp_handler).items()
+            if name.startswith('JSONRPC_') and isinstance(value, int)
+        }
+
+        assert module_codes & set(reserved) == emitted, (
+            f"a code in the spec-reserved -32020..-32099 range that is not one of "
+            f"the two 2026-07-28 defines: "
+            f"{sorted((module_codes & set(reserved)) - emitted)}"
+        )
+        # Positive control: the two ARE in the reserved range, or the assertion
+        # above is comparing two empty sets.
+        assert emitted <= set(reserved)
+
+
+# ===========================================================================
 # HTTP methods the transport defines and this server does not implement
 # ===========================================================================
 
@@ -1272,8 +1630,182 @@ class TestMethodNotAllowed:
         assert response["statusCode"] == 200
 
 
+class TestNotificationsAreAccepted:
+    """A notification is 202 with NO body, and never a JSON-RPC response.
+
+    Every advertised revision says it in identical words: "If the input is a
+    JSON-RPC response or notification: If the server accepts the input, the server
+    MUST return HTTP status code 202 Accepted with no body."
+
+    Two defects lived here, and both were client-visible:
+
+      • `notifications/initialized` was answered 200 with a full result carrying
+        `id: null` — a reply to a message that gets no reply, and an ill-formed one,
+        because a result's id must not be null and a client correlating by id holds
+        a response matching no request it sent.
+      • every OTHER notification fell through to the unknown-method branch and got
+        404. On this endpoint, in the revisions this server advertises, a 404 means
+        the SESSION was terminated and the client "MUST start a new session by
+        sending a new InitializeRequest" — so `notifications/cancelled`, the
+        transport's own cancellation mechanism, told a client to tear down a live
+        session over routine traffic.
+
+    Reverting the `_is_notification` branch in `lambda_handler` fails every test in
+    this class.
+    """
+
+    # The notification this server dispatches, plus three a conforming client may
+    # send that it does not. All four get the same answer, which is the point: a
+    # notification carries no obligation to act, so accepting and ignoring one is
+    # what a server with no cancellation semantics honestly does.
+    NOTIFICATIONS: ClassVar[tuple[str, ...]] = (
+        "notifications/initialized",
+        "notifications/cancelled",
+        "notifications/progress",
+        "notifications/roots/list_changed",
+    )
+
+    @pytest.mark.parametrize("method", NOTIFICATIONS)
+    def test_a_notification_is_202_with_an_empty_body(self, method):
+        response = _raw_call(_notification_event(method))
+
+        assert response["statusCode"] == 202, response["body"]
+        assert response["body"] == "", (
+            f"{method} was answered with a body: {response['body']}"
+        )
+
+    def test_the_undispatched_notifications_really_are_undispatched(self):
+        """Anti-vacuity for the parametrisation above.
+
+        Three of those four are not in the dispatch tables, and that is what makes
+        them the interesting cases: they used to reach the unknown-method branch.
+        If they were all dispatched, this class would only be testing the one that
+        always had a handler.
+        """
+        dispatched = {*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS}
+        undispatched = [m for m in self.NOTIFICATIONS if m not in dispatched]
+
+        assert len(undispatched) >= 3, (
+            f"only {undispatched} are undispatched; this class needs the "
+            f"not-implemented notifications to be the subject"
+        )
+
+    @pytest.mark.parametrize("method", NOTIFICATIONS)
+    def test_a_notification_is_never_answered_404(self, method):
+        """The finding, stated as the thing that must not happen.
+
+        A 404 on this endpoint instructs a client to re-initialize, so this is not
+        a matter of tidiness: normal cancellation traffic was corrupting session
+        state.
+        """
+        response = _raw_call(_notification_event(method))
+
+        assert response["statusCode"] != 404, (
+            f"{method} was answered 404, which tells the client its session died"
+        )
+
+    def test_a_notification_keeps_its_cors_headers(self):
+        """A browser-based client must be able to read the 202.
+
+        Without `Access-Control-Allow-Origin` the answer is opaque to it, which is
+        the same property every other response on this endpoint has.
+        """
+        response = _raw_call(_notification_event("notifications/initialized"))
+
+        assert response["headers"]["Access-Control-Allow-Origin"] == "*"
+
+    def test_an_accepted_notification_announces_no_content_type(self):
+        """There is no content to describe.
+
+        `Content-Type: application/json` on an empty body is a small lie a strict
+        client is entitled to complain about — and it is what a shared
+        `_cors_response` would have sent.
+        """
+        response = _raw_call(_notification_event("notifications/initialized"))
+
+        assert "Content-Type" not in response["headers"]
+
+    def test_a_notification_with_an_id_is_a_request_and_is_answered(self):
+        """JSON-RPC's definition is the id MEMBER, not the method name.
+
+        A `notifications/`-named message carrying an id is a request by that
+        definition, so it gets the request answer rather than being silently
+        accepted — a client that sent an id is waiting for something.
+        """
+        status, body = _call(_event("notifications/initialized"))
+
+        assert status == 404, body
+        assert body["error"]["code"] == -32601
+        assert body["id"] == 1
+
+    def test_a_null_id_is_not_a_notification(self):
+        """`"id": null` is a PRESENT member, so this is a malformed request rather
+        than a notification. Accepting it as one would let a client that meant to
+        correlate a response be answered with silence."""
+        response = _raw_call(_event(
+            body=json.dumps({"jsonrpc": "2.0", "id": None,
+                             "method": "notifications/cancelled", "params": {}}),
+        ))
+
+        assert response["statusCode"] != 202
+        assert json.loads(response["body"])["error"]["code"] == -32601
+
+    def test_a_non_notification_method_without_an_id_is_not_accepted(self):
+        """Both halves of `_is_notification` are required.
+
+        A `tools/call` with no id is not a notification — MCP defines none by that
+        name — and accepting it 202 would silently drop a request a client is
+        waiting on.
+        """
+        response = _raw_call(_notification_event("tools/call", token=_TOKEN))
+
+        assert response["statusCode"] != 202, response["body"]
+
+    def test_a_notification_never_reaches_the_token_store(self):
+        """It is accepted before dispatch and before authentication, so a
+        credential presented on one buys no probe of the store."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(
+                _notification_event("notifications/cancelled", token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 202
+        table.query.assert_not_called()
+
+    def test_a_notification_still_passes_the_transport_guards(self):
+        """202 is for a notification this server ACCEPTS.
+
+        A malformed transport is not accepted: the message has not said what it is,
+        and the Origin and header guards run before the message kind is considered.
+        """
+        response = _raw_call(_notification_event(
+            "notifications/initialized",
+            headers={"MCP-Protocol-Version": "1999-01-01"},
+        ))
+
+        assert response["statusCode"] == 400, response["body"]
+        assert json.loads(response["body"])["error"]["code"] == -32022
+
+    def test_a_disallowed_origin_is_refused_before_a_notification_is_accepted(self):
+        """The DNS-rebinding guard covers this path too — a 202 is still an answer
+        to a request a rebound page made."""
+        with patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com"):
+            response = mcp_handler.lambda_handler(
+                _notification_event("notifications/initialized",
+                                    headers={"Origin": "https://evil.example.net"}),
+                MagicMock(),
+            )
+
+        assert response["statusCode"] == 403, response["body"]
+
+
 class TestUnknownMethod:
-    """An unknown JSON-RPC method is -32601 and nothing else."""
+    """An unknown JSON-RPC REQUEST is -32601 with a 404, and nothing else.
+
+    A request, not a notification: the two used to share this branch, and 404 means
+    something different to a notification's sender. `TestNotificationsAreAccepted`
+    owns that half.
+    """
 
     def test_an_unknown_method_is_method_not_found(self):
         """-32601 with HTTP 404, which the Streamable HTTP transport REQUIRES.
@@ -1289,6 +1821,20 @@ class TestUnknownMethod:
         assert body["error"]["code"] == -32601
         assert "tools/teleport" in body["error"]["message"]
         assert status == 404, body
+
+    def test_the_two_message_kinds_get_different_answers(self):
+        """The split, asserted as a difference.
+
+        A single hard-coded answer satisfied both branches before, and that was the
+        defect: one status for "this method does not exist" and for "your session
+        died". Comparing the two answers is what stops one answer serving both.
+        """
+        request = _raw_call(_event("notifications/cancelled"))
+        notification = _raw_call(_notification_event("notifications/cancelled"))
+
+        assert request["statusCode"] == 404
+        assert notification["statusCode"] == 202
+        assert request["statusCode"] != notification["statusCode"]
 
     def test_an_unknown_method_never_reaches_the_token_store(self):
         """A method that does not exist cannot need a credential, so asking for
@@ -1749,24 +2295,35 @@ class TestADeadCredentialFailsTheHandshake:
         )
         assert not checked & set(mcp_handler.MCP_AUTH_METHODS)
 
-    @pytest.mark.parametrize("method", ["ping", "notifications/initialized"])
-    def test_a_keepalive_is_not_a_liveness_probe(self, method):
-        """`ping` and the notifications are deliberately NOT checked, and the
-        second reason is the stronger one.
+    def test_a_keepalive_is_not_a_liveness_probe(self):
+        """`ping` is deliberately NOT checked.
 
         Cost: `ping` is a keepalive, so checking it put a token-store read on every
         heartbeat of every session — on a route throttled at 20 rps whose authorizer
         caches for 300 s, which is how one valid-shaped token drives that stream
         past the cache. Before this, `ping` touched nothing.
-
-        Protocol: a NOTIFICATION CARRIES NO ID, so a 401 to one is a response to a
-        message JSON-RPC says must not receive one. And nobody concludes "connected"
-        from an un-refused notification, so the honesty defect was never here.
         """
-        status, body = _call(_event(method, token=_TOKEN), row=self._expired_row())
+        status, body = _call(_event("ping", token=_TOKEN), row=self._expired_row())
 
         assert status == 200, body
         assert "error" not in body
+
+    def test_a_notification_with_a_dead_credential_is_still_accepted(self):
+        """The other half of the same rule, now enforced structurally.
+
+        A NOTIFICATION CARRIES NO ID, so a 401 to one is a response to a message
+        JSON-RPC says must not receive one — and nobody concludes "connected" from
+        an un-refused notification, so the honesty defect was never here. The 202
+        answer reaches this before the dispatch does, which is why this is no longer
+        a matter of `_LIVENESS_CHECKED_METHODS`'s contents.
+        """
+        response = _raw_call(
+            _notification_event("notifications/initialized", token=_TOKEN),
+            row=self._expired_row(),
+        )
+
+        assert response["statusCode"] == 202, response["body"]
+        assert response["body"] == ""
 
     def test_the_liveness_check_never_stamps_last_used_at(self):
         """"Last used" means "last used to read something".

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -75,6 +75,19 @@ revert makes each assertion fail.
       test_no_advertised_revision_requires_a_body_grammar_this_server_refuses;
       deleting the `_is_batch` branch fails the rest.
 
+  TestADuplicatedHeaderIsRefused
+    — the header reader saw one value: it read `headers` and not `multiValueHeaders`,
+      and returned on the first case-insensitive match, so a request carrying two
+      `Mcp-Method` values was answered according to dict order. Deleting the duplicate
+      check in `_request_header` fails this class.
+
+  TestAnIdlessRequestIsRefused
+    — an id-less `ping` was answered 200 with a result carrying `id: null`: a reply to
+      a message JSON-RPC says gets no reply, in an envelope whose id must not be null.
+      Reverting the branch to fall through to the dispatch fails
+      test_an_idless_call_of_an_ordinary_method_is_refused; making it a 202 fails
+      test_an_idless_request_is_never_accepted.
+
   TestPostedResponsesAreAccepted
     — the 202 clause has two subjects ("a JSON-RPC response OR notification") and only
       the notification half was recognised: a posted response has no `method`, so it
@@ -1199,6 +1212,139 @@ class TestRoutingHeaders:
 
 
 # ===========================================================================
+# A header sent more than once — the same ambiguity, through a duplicate
+# ===========================================================================
+
+class TestADuplicatedHeaderIsRefused:
+    """Two different values for one header is the two-hops-disagree case again.
+
+    `_validate_routing_headers` refuses a routing echo that contradicts the BODY,
+    on the argument that an intermediary routes on the header while this server acts
+    on the body. A header sent TWICE is the same fault one layer down — a proxy
+    routing on the first `Mcp-Method` while this server compared the last — and that
+    guard's own words cover it: "there is no way to know which of the two statements
+    was the caller's intent".
+
+    The reader saw only one of them, in two ways, both verified:
+
+      • it read `event['headers']` alone, and a REST proxy event also carries
+        `multiValueHeaders` with every value — so the second was never compared;
+      • it returned on the FIRST case-insensitive match, so a direct invoke carrying
+        `Mcp-Method` and `mcp-method` was answered according to dict order. The same
+        wire request got two different answers depending on how the event was built.
+
+    Deleting the duplicate check in `_request_header` fails this class; reading only
+    `headers` again fails test_a_second_value_in_multi_value_headers_is_compared.
+    """
+
+    def _multi(self, name: str, values: list[str], *, method: str = "ping",
+               token: str | None = None) -> dict:
+        """An API-Gateway-shaped event: `headers` collapsed, `multiValueHeaders` full.
+
+        Both are populated because that is what the gateway delivers — `headers`
+        keeps the last value and `multiValueHeaders` keeps all of them — so a reader
+        that consults only the first sees a well-formed request.
+        """
+        event = _event(method, token=token, headers={name: values[-1]})
+        event["multiValueHeaders"] = {name.lower(): list(values)}
+        return event
+
+    def test_a_second_value_in_multi_value_headers_is_compared(self):
+        """The gateway-shaped case, and the one the old reader could not see."""
+        status, body = _call(self._multi("mcp-method", ["tools/list", "ping"]))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32020
+        assert "more than once" in body["error"]["message"]
+
+    def test_two_identical_values_are_one_value(self):
+        """Restating the same thing twice is not a contradiction.
+
+        A client or an intermediary that sends the same value again has said nothing
+        new, and refusing that would refuse requests for no gain — the duplicate
+        check is about ambiguity, not about repetition.
+        """
+        status, body = _call(self._multi("mcp-method", ["ping", "ping"]))
+
+        assert status == 200, body
+        assert "result" in body
+
+    @pytest.mark.parametrize("order", [
+        ("Mcp-Method", "mcp-method"),
+        ("mcp-method", "Mcp-Method"),
+    ])
+    def test_two_casings_of_one_header_do_not_depend_on_dict_order(self, order):
+        """The answer must not depend on which key came first.
+
+        Parametrised over BOTH orders, because that is the defect: the reader
+        returned on the first match, so one order was served and the other refused.
+        A fix that merely picked the last value would pass one of these and fail the
+        other.
+        """
+        first, second = order
+        status, body = _call(_event(
+            "ping", headers={first: "ping", second: "tools/list"},
+        ))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32020
+
+    def test_a_duplicated_version_header_is_refused_too(self):
+        """Every header read through the shared reader gets this, not just the
+        routing echoes: two claimed protocol revisions name no revision."""
+        status, body = _call(self._multi(
+            "mcp-protocol-version", ["2024-11-05", "2025-11-25"],
+        ))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32020
+
+    def test_a_duplicate_is_refused_before_the_token_store_is_probed(self):
+        """Same property as every other malformed transport: an ambiguous request
+        buys no probe of the credential store."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(
+                self._multi("mcp-method", ["tools/list", "ping"], token=_TOKEN),
+                MagicMock(),
+            )
+
+        assert response["statusCode"] == 400
+        table.query.assert_not_called()
+
+    def test_a_duplicated_credential_authenticates_nothing(self):
+        """Two credentials are not one credential.
+
+        `Authorization` is read through the same helper, and the fail-closed reading
+        is a 401 rather than a choice between them: serving whichever was read first
+        would let a caller present a good token alongside a revoked one. It reaches
+        the ordinary "invalid or missing" refusal, because from the authenticator's
+        seat that is what an unusable credential is.
+        """
+        event = _event("tools/list", token=_TOKEN)
+        event["multiValueHeaders"] = {
+            "authorization": [f"Bearer {_TOKEN}", "Bearer something-else"],
+        }
+
+        status, body = _call(event)
+
+        assert status == 401, body
+        assert body["error"]["code"] == -32001
+
+    def test_a_single_header_is_unaffected(self):
+        """Anti-vacuity: a check that refused every present header would pass every
+        assertion above and break every client."""
+        status, body = _call(_event("ping", headers={"Mcp-Method": "ping"}))
+
+        assert status == 200, body
+        assert "result" in body
+
+    def test_an_absent_header_is_still_absent(self):
+        """And the empty case: no values is None, not a duplicate of nothing."""
+        assert mcp_handler._request_header(_event("ping"), "mcp-method") is None
+        assert mcp_handler._header_values(_event("ping"), "mcp-method") == []
+
+
+# ===========================================================================
 # The result discriminator: spec resultType, local shape in _meta
 # ===========================================================================
 
@@ -2061,6 +2207,119 @@ class TestNotificationsAreAccepted:
         assert "id" not in json.loads(response["body"])
 
 
+class TestAnIdlessRequestIsRefused:
+    """An id-less message on a non-notification method is -32600 with NO `id`.
+
+    This was the last place a RESULT carrying `id: null` was sent to a message that
+    carries no id: `{"jsonrpc": "2.0", "method": "ping"}` — and the same for
+    `initialize` and `server/discover` — was answered 200 with a full result and a
+    null id. Both faults the 202 fix removed from the notification path, one method
+    over: a reply to a message JSON-RPC says gets no reply, in an envelope whose id
+    must not be null.
+
+    The two definitions disagree about what this message IS, and the answer satisfies
+    both. By JSON-RPC's ("a Request object without an id member") it is a
+    notification, so no result may be sent. By MCP's it is nothing — there is no
+    id-less `ping` — so it cannot be dispatched. A refusal with the id omitted is
+    what is left: a client that meant a notification is not replied to in anything it
+    correlates, and a client that forgot an id learns the request was not served.
+
+    NOT 202, and that is the load-bearing half: an id-less `tools/call` is a request
+    a client is waiting on, and silence is the worse failure — which
+    test_a_non_notification_method_without_an_id_is_not_accepted has always pinned.
+    Answering the shape per method would mean inventing an id-less variant of each.
+
+    Reverting the branch to fall through to the dispatch fails
+    test_an_idless_call_of_an_ordinary_method_is_refused; changing it to
+    `_accepted_no_content` fails test_an_idless_request_is_never_accepted.
+    """
+
+    # Every dispatchable non-notification method, derived rather than listed: the
+    # answer must not depend on which half of the dispatch the method is in, and the
+    # unauthenticated ones are exactly where the `id: null` result was being sent.
+    METHODS: ClassVar[tuple[str, ...]] = tuple(sorted(
+        method for method in (*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS)
+        if not method.startswith("notifications/")
+    ))
+
+    def test_the_derived_method_list_is_not_empty(self):
+        """Anti-vacuity for every parametrisation below."""
+        assert len(self.METHODS) >= 4, self.METHODS
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_an_idless_call_of_an_ordinary_method_is_refused(self, method):
+        """400 and -32600 — the code for a message that is not a well-formed
+        request, rather than -32601: the method exists, the envelope does not."""
+        response = _raw_call(_notification_event(method, token=_TOKEN))
+        body = json.loads(response["body"])
+
+        assert response["statusCode"] == 400, response["body"]
+        assert body["error"]["code"] == -32600
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_the_refusal_carries_no_id_member(self, method):
+        """The defect itself. Asserted with `not in` rather than against a value,
+        because the whole distinction is presence — the same distinction
+        `_is_notification` turns on and `_NO_ID` exists for."""
+        response = _raw_call(_notification_event(method, token=_TOKEN))
+
+        assert "id" not in json.loads(response["body"]), response["body"]
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_no_result_is_sent_for_a_message_that_gets_no_reply(self, method):
+        """Stated as the thing that must not happen: a RESULT is wrong under both
+        readings of this message, which is what made the old 200 a defect rather
+        than a stylistic choice."""
+        response = _raw_call(_notification_event(method, token=_TOKEN))
+
+        assert "result" not in json.loads(response["body"]), response["body"]
+
+    @pytest.mark.parametrize("method", METHODS)
+    def test_an_idless_request_is_never_accepted(self, method):
+        """Not 202 either, and this is the boundary against the notification path.
+
+        An id-less `tools/call` is a request a client is waiting on; accepting and
+        dropping it answers silence to a caller expecting a result.
+        """
+        response = _raw_call(_notification_event(method, token=_TOKEN))
+
+        assert response["statusCode"] != 202, response["body"]
+
+    def test_a_real_notification_still_reaches_its_202(self):
+        """Anti-overreach, and the ordering this branch depends on: it sits AFTER the
+        notification check, so a `notifications/`-prefixed message is unaffected."""
+        response = _raw_call(_notification_event("notifications/initialized"))
+
+        assert response["statusCode"] == 202, response["body"]
+        assert response["body"] == ""
+
+    def test_the_same_method_with_an_id_is_still_served(self):
+        """Anti-vacuity: the refusal is about the missing id, not about the method."""
+        status, body = _call(_event("ping"))
+
+        assert status == 200, body
+        assert body["id"] == 1
+
+    def test_an_idless_request_never_reaches_the_token_store(self):
+        """Refused before the dispatch and before authentication, like every other
+        malformed envelope: it buys no probe of the credential store."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(
+                _notification_event("tools/call", token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 400
+        table.query.assert_not_called()
+
+    def test_the_refusal_names_the_missing_id_rather_than_the_method(self):
+        """A caller reading this needs to know what to change. `Method not found` —
+        which an earlier shape of this path produced for some of these bodies — sends
+        it after a method name it spelled correctly."""
+        _status, body = _call(_notification_event("ping"))
+
+        assert "id" in body["error"]["message"].lower()
+
+
 class TestUnknownMethod:
     """An unknown JSON-RPC REQUEST is -32601 with a 404, and nothing else.
 
@@ -2416,15 +2675,21 @@ class TestPostedResponsesAreAccepted:
         assert body["error"]["code"] == -32600
         assert "batch" in body["error"]["message"].lower()
 
-    def test_a_body_that_is_neither_keeps_its_existing_answer(self):
-        """Anti-overreach for the other half: a bare `{"jsonrpc": "2.0"}` and a
-        `{"id": 1}` carry neither `result` nor `error`, so they are malformed
-        REQUESTS and keep the -32601 that `TestUnknownMethod` owns. Accepting them
-        202 would silently drop a request a client is waiting on."""
+    def test_a_body_that_is_neither_is_not_accepted(self):
+        """Anti-overreach for the other half: a body carrying neither `result` nor
+        `error` is not a response, and must not be accepted 202 — that would silently
+        drop a request a client is waiting on.
+
+        Which REFUSAL each gets is decided one layer down and is not this class's
+        subject: `{"id": 1}` names no method and is the -32601 `TestUnknownMethod`
+        owns, while `{"jsonrpc": "2.0"}` carries no id either and reaches the id-less
+        refusal (`TestAnIdlessRequestIsRefused`). Asserted as "not 202, and an error"
+        so this test states its own claim rather than restating theirs.
+        """
         for body_text in ('{"jsonrpc": "2.0"}', '{"id": 1}'):
-            status, body = _call(_event(body=body_text))
-            assert status == 404, f"{body_text} was answered {status}: {body}"
-            assert body["error"]["code"] == -32601
+            response = _raw_call(_event(body=body_text))
+            assert response["statusCode"] != 202, body_text
+            assert "error" in json.loads(response["body"]), body_text
 
     def test_an_ordinary_request_is_still_served(self):
         """Anti-vacuity: a branch that caught the ordinary object body would accept

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -204,6 +204,61 @@ class TestVersionNegotiation:
             mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
         ), "a repeated revision would make the preference order meaningless"
 
+    def test_only_handshake_based_revisions_are_advertised(self):
+        """This server advertises only revisions it actually implements.
+
+        The 2026-07-28 revision REMOVES the `initialize` handshake: every request
+        carries its protocol version and client capabilities in `_meta` as required
+        fields, a request missing them must be refused with -32602, and the header
+        must match the `_meta` value. This handler does none of that — it reads the
+        version from the header alone, ignores request `_meta`, and dispatches
+        `initialize`. Advertising that revision would counter-offer it to any client
+        whose version this server does not know, and a client that took the offer at
+        face value would then send modern requests to a handler that ignores the
+        metadata the spec told it to trust.
+
+        Written as "the handshake is what we implement, so the handshake is what we
+        advertise" — a bare `!= '2026-07-28'` would pass again the moment somebody
+        added 2027-xx-xx to the tuple without implementing it either.
+        """
+        assert 'initialize' in mcp_handler.MCP_METHODS, (
+            "this server is handshake-based; if that changed, this test's premise did"
+        )
+        # The handshake-based revisions, which is every published revision up to and
+        # including 2025-11-25. Anything later removed the handshake.
+        handshake_era = {
+            "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05",
+        }
+        advertised = set(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+
+        assert advertised <= handshake_era, (
+            f"advertising a post-handshake revision this envelope does not "
+            f"implement: {sorted(advertised - handshake_era)}. Implementing the "
+            f"per-request `_meta` era is a phase, not a tuple entry."
+        )
+
+    def test_the_revisions_the_deployed_server_negotiated_are_still_accepted(self):
+        """A client that handshook against the DEPLOYED server must keep working.
+
+        The deployed handler pinned 2024-11-05, so every connected client sends
+        `MCP-Protocol-Version: 2024-11-05` on every subsequent request. Dropping it
+        from the accepted set — while the header validator refuses anything not in
+        that set — turns each of those clients into a 400 at the next call.
+        2025-03-26 is here for the same reason: it is widely deployed, and it is the
+        value the spec tells a server to assume when the header is absent.
+
+        Accepting a revision is not preferring it: neither is the counter-offer.
+        """
+        for version in ("2024-11-05", "2025-03-26"):
+            assert version in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS, (
+                f"{version} was negotiable against a deployed build; refusing it "
+                f"now breaks every client that handshook on it"
+            )
+            status, _body = _call(_event(
+                "initialize", headers={"MCP-Protocol-Version": version},
+            ))
+            assert status == 200, f"{version} header refused"
+
     def test_the_supported_versions_are_ordered_newest_first(self):
         """The order is load-bearing: the first entry is the counter-offer.
 
@@ -520,6 +575,24 @@ class TestProtocolVersionHeader:
         status, body = _call(_event("initialize"))
 
         assert status == 200, body
+
+    def test_an_absent_header_reads_as_the_revision_the_spec_names(self):
+        """2025-03-26, not the newest revision this server speaks.
+
+        The header arrived in 2025-06-18, so a request without it comes from a
+        client written against something earlier. Reading absence as the NEWEST
+        supported revision silently upgrades exactly the clients that cannot be
+        upgraded — to a value the client never claimed.
+        """
+        assert mcp_handler.ASSUMED_PROTOCOL_VERSION == "2025-03-26"
+        assert mcp_handler._validated_protocol_version(_event("initialize")) == (
+            mcp_handler.ASSUMED_PROTOCOL_VERSION
+        )
+        # And it must be one this server actually serves, or the default would
+        # refuse every header-less client on the next line of the guard.
+        assert mcp_handler.ASSUMED_PROTOCOL_VERSION in (
+            mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+        )
 
     def test_an_empty_version_header_is_refused(self):
         """A client that sent the header empty said something, and what it said is
@@ -1096,11 +1169,12 @@ class TestMethodNotAllowed:
         assert allowed == {"POST", "OPTIONS"}
         assert http_method not in allowed
 
-    def test_the_allow_header_agrees_with_the_cors_declaration(self):
-        """One statement of which methods this endpoint serves, to two audiences.
+    def test_the_json_rpc_endpoint_allows_what_it_serves(self):
+        """`Allow` names the methods of the TARGET RESOURCE (RFC 9110 §15.5.6).
 
-        A hand-written second copy is how a preflight and a 405 come to disagree
-        about the same endpoint.
+        For this endpoint that happens to coincide with the CORS declaration, and
+        the coincidence is why deriving one from the other looked safe. It is not
+        safe in general — see the autoseed test below.
         """
         response = mcp_handler.lambda_handler(
             _event(http_method="PUT"), MagicMock(),
@@ -1108,12 +1182,49 @@ class TestMethodNotAllowed:
         allowed = {
             m.strip() for m in response["headers"]["Allow"].split(",")
         }
-        declared = {
-            m.strip()
-            for m in mcp_handler.CORS_HEADERS["Access-Control-Allow-Methods"].split(",")
-        }
 
-        assert allowed == declared
+        assert allowed == {"POST", "OPTIONS"}
+
+    @pytest.mark.parametrize("http_method", ["DELETE", "PUT", "PATCH"])
+    def test_the_autoseed_path_allows_the_method_it_actually_serves(self, http_method):
+        """The defect that made `Allow` per-path instead of per-function.
+
+        `Access-Control-Allow-Methods` is one constant for the whole Lambda and
+        answers "what may a browser preflight here"; `Allow` answers "what does
+        THIS RESOURCE support". Deriving the second from the first refused
+        `DELETE /v1/mcp/autoseed/{id}` with `Allow: POST, OPTIONS` — advertising a
+        set that omits the one method that path serves, and sending a client to
+        retry with POST on a path that only handles GET.
+
+        POST is NOT among these: a POST to this path is still routed to JSON-RPC
+        dispatch by the catch-all proxy route, so it answers -32601/404 rather than
+        405. That is existing routing behaviour and not this header's subject.
+        """
+        response = mcp_handler.lambda_handler({
+            "httpMethod": http_method,
+            "path": f"/v1/mcp/autoseed/{_PROJECT}",
+            "headers": {},
+        }, MagicMock())
+
+        assert response["statusCode"] == 405, response["body"]
+        allowed = {m.strip() for m in response["headers"]["Allow"].split(",")}
+        assert allowed == {"GET", "OPTIONS"}
+        assert http_method not in allowed
+
+    def test_the_two_paths_advertise_different_allow_sets(self):
+        """Stated as a difference, because that IS the property.
+
+        A single hard-coded set would satisfy each test above on its own; only
+        comparing the two answers shows the header is resolved per resource.
+        """
+        jsonrpc = mcp_handler.lambda_handler(_event(http_method="PUT"), MagicMock())
+        autoseed = mcp_handler.lambda_handler({
+            "httpMethod": "PUT",
+            "path": f"/v1/mcp/autoseed/{_PROJECT}",
+            "headers": {},
+        }, MagicMock())
+
+        assert jsonrpc["headers"]["Allow"] != autoseed["headers"]["Allow"]
 
     def test_a_405_carries_a_json_rpc_envelope_and_cors_headers(self):
         """Every answer from this endpoint is parseable by the client that asked,

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -75,6 +75,15 @@ revert makes each assertion fail.
       test_no_advertised_revision_requires_a_body_grammar_this_server_refuses;
       deleting the `_is_batch` branch fails the rest.
 
+  TestPostedResponsesAreAccepted
+    — the 202 clause has two subjects ("a JSON-RPC response OR notification") and only
+      the notification half was recognised: a posted response has no `method`, so it
+      fell through to the unknown-method branch and was answered 404 — the same
+      session-teardown instruction, reached by a third route. Deleting the
+      `_is_response` branch fails this class; dropping the `'method' in body` half of
+      the predicate fails
+      test_a_body_carrying_both_a_method_and_a_result_is_still_a_request.
+
   TestCacheScopeMatchesWhatTheResponseDependsOn
     — `server/discover` declared `cacheScope: public` while being liveness-checked, so
       a shared cache was licensed to replay its unauthenticated 200 across
@@ -776,7 +785,7 @@ class TestProtocolVersionHeader:
 
 
 class TestTheHandshakeIsExemptFromTheVersionRefusal:
-    """A client's FIRST request may name a revision this server does not have.
+    """A client's PRE-HANDSHAKE request may name a revision this server does not have.
 
     The header refusal and the `initialize` counter-offer are both right and they
     met in a place that served neither: a client whose newest revision is
@@ -786,9 +795,15 @@ class TestTheHandshakeIsExemptFromTheVersionRefusal:
     request was refused 400 and `_handle_initialize` never ran. The counter-offer
     that exists for exactly this client was unreachable by it.
 
-    Reverting the `method == 'initialize'` exemption in
-    `_validated_protocol_version` fails
-    test_a_current_generation_first_contact_is_counter_offered.
+    `server/discover` is the same case and was left behind by the first fix, which
+    exempted the literal string `'initialize'`. That method is defined ONLY by
+    2026-07-28, so the only client that can know its name is one obliged to send
+    that revision in the header: discovery answered 200 for a header-less request
+    and 400 for the conforming one. Narrowing `_PRE_HANDSHAKE_METHODS` back to
+    `{'initialize'}` fails test_discovery_answers_the_revision_that_defines_it;
+    widening it past the pre-handshake position fails
+    test_every_other_method_still_refuses_the_same_header, which is derived from the
+    dispatch tables minus the exempt set.
     """
 
     # The revision this server deliberately does not advertise, which is precisely
@@ -830,14 +845,54 @@ class TestTheHandshakeIsExemptFromTheVersionRefusal:
         assert status == 200, body
         assert body["result"]["protocolVersion"] == mcp_handler.PREFERRED_PROTOCOL_VERSION
 
-    @pytest.mark.parametrize("method", ["ping", "server/discover", "tools/list"])
+    def test_discovery_answers_the_revision_that_defines_it(self):
+        """The second half of the finding, and the sharper half.
+
+        `server/discover` and its `DiscoverResult` are defined ONLY by 2026-07-28, so
+        a client that knows the method name is a client of that revision — which its
+        own rules oblige to send `MCP-Protocol-Version: 2026-07-28` on every POST.
+        With the exemption confined to `initialize`, discovery answered 200 for a
+        header-less request and 400 for the conforming one: served only to a client
+        VIOLATING its own revision, and refused to the only client class that would
+        ever call it. The answer whose purpose is "everything a client would
+        otherwise learn from a failed call" was itself learnable only from a failed
+        call.
+
+        `supportedVersions` is asserted rather than just the status, because a 200
+        that did not carry the list would leave the client no better off.
+        """
+        status, body = _call(_event(
+            "server/discover", headers={"MCP-Protocol-Version": self._UNIMPLEMENTED},
+        ))
+
+        assert status == 200, body
+        assert "error" not in body, body
+        assert body["result"]["supportedVersions"] == list(
+            mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+        )
+
+    # Every dispatchable method that is NOT pre-handshake, derived from the dispatch
+    # tables minus the exempt set rather than restated — so a method added to either
+    # table, or to the exempt set, cannot slip past this without a decision.
+    _POST_HANDSHAKE_METHODS: ClassVar[tuple[str, ...]] = tuple(sorted(
+        method for method in (*mcp_handler.MCP_METHODS, *mcp_handler.MCP_AUTH_METHODS)
+        if method not in mcp_handler._PRE_HANDSHAKE_METHODS
+        and not method.startswith("notifications/")
+    ))
+
+    def test_the_derived_post_handshake_set_is_not_empty(self):
+        """Anti-vacuity for the parametrised test below: an exempt set that had
+        grown to cover every method would make it collect nothing and pass."""
+        assert len(self._POST_HANDSHAKE_METHODS) >= 3, self._POST_HANDSHAKE_METHODS
+
+    @pytest.mark.parametrize("method", _POST_HANDSHAKE_METHODS)
     def test_every_other_method_still_refuses_the_same_header(self, method):
-        """The asymmetry is the point, and it is not "initialize is special".
+        """The asymmetry is the point, and it is not "these two methods are special".
 
         Past the handshake a client HAS a negotiated value to send, so one this
-        server never offered is the client contradicting itself. Parametrized across
-        both halves of the dispatch so an exemption that leaked into the
-        unauthenticated methods generally, or into the authenticated path, fails.
+        server never offered is the client contradicting itself. Derived from both
+        halves of the dispatch so an exemption that leaked into the unauthenticated
+        methods generally, or into the authenticated path, fails.
         """
         status, body = _call(_event(
             method, headers={"MCP-Protocol-Version": self._UNIMPLEMENTED},
@@ -847,6 +902,39 @@ class TestTheHandshakeIsExemptFromTheVersionRefusal:
         assert status == 400, body
         assert body["error"]["code"] == -32022
         assert body["error"]["data"]["requested"] == self._UNIMPLEMENTED
+
+    def test_a_keepalive_is_not_a_pre_handshake_method(self):
+        """`ping` is the method the exemption must NOT reach, named explicitly.
+
+        It is the one that looks pre-handshake and is not: a client pings a session
+        it already has, so it has a negotiated value to send. The derived
+        parametrisation above covers it, and this states it directly so widening the
+        set to "everything unauthenticated" fails a test that says why.
+        """
+        assert "ping" not in mcp_handler._PRE_HANDSHAKE_METHODS
+
+    def test_the_two_sets_are_not_the_same_fact(self):
+        """`_PRE_HANDSHAKE_METHODS` and `_LIVENESS_CHECKED_METHODS` hold the same two
+        entries today and are not the same claim.
+
+        One means "the client has nothing negotiated to send"; the other means "the
+        response depends on the credential". Deriving either from the other would
+        make a future post-handshake credential-gated method — or a pre-handshake
+        method that is not liveness-checked — impossible to express. This test does
+        not assert they differ (they do not, yet); it asserts they are declared
+        separately, which is what keeps the coincidence from hardening into a
+        derivation.
+        """
+        pre_handshake = inspect.getsource(mcp_handler).split(
+            "_PRE_HANDSHAKE_METHODS: frozenset[str] = "
+        )[1].split("\n)")[0]
+        liveness = inspect.getsource(mcp_handler).split(
+            "_LIVENESS_CHECKED_METHODS: frozenset[str] = "
+        )[1].split("\n)")[0]
+
+        # Each is its own literal, not a reference to the other.
+        assert "_LIVENESS_CHECKED_METHODS" not in pre_handshake
+        assert "_PRE_HANDSHAKE_METHODS" not in liveness
 
     def test_the_exempted_handshake_still_negotiates_a_declared_version(self):
         """Exempt from the REFUSAL, not from the rule.
@@ -862,28 +950,40 @@ class TestTheHandshakeIsExemptFromTheVersionRefusal:
 
         assert negotiated in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
 
-    def test_a_malformed_sentinel_is_still_refused_on_the_handshake(self):
+    @pytest.mark.parametrize("method", sorted(mcp_handler._PRE_HANDSHAKE_METHODS))
+    def test_a_malformed_sentinel_is_still_refused_on_both(self, method):
         """The exemption is for an unsupported VERSION, not for a broken encoding.
 
         There is nothing to counter-offer about a value that does not decode: the
-        fault is the encoding and no negotiation fixes it.
+        fault is the encoding and no negotiation fixes it. Parametrised across the
+        exempt set so widening the exemption to "no version check at all on these
+        methods" fails.
         """
-        status, body = _call(_event("initialize", headers={
+        status, body = _call(_event(method, headers={
             "MCP-Protocol-Version": "=?base64?not-base64!!?=",
         }))
 
-        assert status == 400
+        assert status == 400, body
         assert body["error"]["code"] == -32600
         assert "base64" in body["error"]["message"]
 
-    def test_a_contradicting_routing_header_is_still_refused_on_the_handshake(self):
+    @pytest.mark.parametrize("method", sorted(mcp_handler._PRE_HANDSHAKE_METHODS))
+    def test_an_empty_version_header_is_still_refused_on_both(self, method):
+        """An empty header names no revision, so there is no claim to negotiate
+        against — and answering one would be answering a version question nobody
+        asked. The `and version` half of the exemption is what holds this."""
+        status, body = _call(_event(method, headers={"MCP-Protocol-Version": ""}))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32022
+
+    @pytest.mark.parametrize("method", sorted(mcp_handler._PRE_HANDSHAKE_METHODS))
+    def test_a_contradicting_routing_header_is_still_refused_on_both(self, method):
         """And the exemption is confined to the VERSION check, not to header
         validation as a whole."""
-        status, body = _call(_event(
-            "initialize", headers={"MCP-Method": "tools/call"},
-        ))
+        status, body = _call(_event(method, headers={"MCP-Method": "tools/call"}))
 
-        assert status == 400
+        assert status == 400, body
         assert body["error"]["code"] == -32020
 
 
@@ -1639,6 +1739,33 @@ class TestMethodNotAllowed:
 
         assert jsonrpc["headers"]["Allow"] != autoseed["headers"]["Allow"]
 
+    @pytest.mark.parametrize("http_method", ["GET", "DELETE"])
+    def test_a_405_lets_a_browser_read_what_is_allowed(self, http_method):
+        """`Allow` is not CORS-safelisted, so a browser received the 405 and hid the
+        one header that made it actionable.
+
+        That is the same failure `WWW-Authenticate` and `Vary` already document on
+        this endpoint, on the header that says WHAT TO RETRY WITH — which is the whole
+        point of resolving it per resource. Split and lowercased rather than compared
+        as a whole string, because the expose list's completeness is
+        api-stack.test.ts's subject and this test's claim is only that `Allow` is in
+        it.
+        """
+        response = mcp_handler.lambda_handler(
+            _event(http_method=http_method), MagicMock(),
+        )
+
+        assert response["statusCode"] == 405
+        exposed = {
+            h.strip().lower()
+            for h in response["headers"]["Access-Control-Expose-Headers"].split(",")
+        }
+        assert "allow" in exposed, (
+            f"the 405 sends Allow but does not expose it: {sorted(exposed)}"
+        )
+        # Positive control: the header it is meant to make readable is actually sent.
+        assert "Allow" in response["headers"]
+
     def test_a_405_carries_a_json_rpc_envelope_and_cors_headers(self):
         """Every answer from this endpoint is parseable by the client that asked,
         including the refusals — the property the BotoCoreError clause records."""
@@ -2156,6 +2283,156 @@ class TestBatchBodiesAreRefused:
         for body_text in ('"a string"', "42", "null"):
             status, body = _call(_event(body=body_text))
             assert status == 404, f"{body_text} was answered {status}: {body}"
+
+
+# ===========================================================================
+# A posted JSON-RPC response — the other subject of the 202 clause
+# ===========================================================================
+
+class TestPostedResponsesAreAccepted:
+    """A JSON-RPC RESPONSE gets 202 with no body, not the session-teardown 404.
+
+    The transport clause the notification branch is built on names two subjects —
+    "If the input is a JSON-RPC response or notification: … the server MUST return
+    HTTP status code 202 Accepted with no body" — and only the second was
+    recognised. A single response is a dict with no `method`, so `method` became
+    `''`, `_is_notification` was False (an `id` is present) and `_is_batch` was
+    False: it landed on the unknown-method branch and was answered
+    `404 -32601 "Method not found: "`. On every advertised revision that 404 means
+    the session was terminated and the client MUST re-initialize, so a stray
+    response — a client with a shared outbound queue, a misconfigured proxy — was
+    told to tear down a working session.
+
+    Accepted rather than refused, unlike a batch, and the difference is what the
+    server can do about it: a batch is a body grammar it does not implement, so a
+    refusal names a constraint the caller can act on, while a response is a message
+    it has no outstanding request to correlate against at all.
+
+    Deleting the `_is_response` branch in `lambda_handler` fails every test here;
+    dropping the `'method' in body` half of the predicate fails
+    test_a_body_carrying_both_a_method_and_a_result_is_still_a_request.
+    """
+
+    A_RESULT: ClassVar[str] = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}})
+    AN_ERROR: ClassVar[str] = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "error": {"code": -1, "message": "x"},
+    })
+
+    @pytest.mark.parametrize("label", ["A_RESULT", "AN_ERROR"])
+    def test_a_posted_response_is_202_with_an_empty_body(self, label):
+        """Both halves of JSON-RPC's response definition, because a client that
+        forwards one to the wrong endpoint forwards whichever it received."""
+        response = _raw_call(_event(body=getattr(self, label)))
+
+        assert response["statusCode"] == 202, response["body"]
+        assert response["body"] == ""
+
+    @pytest.mark.parametrize("label", ["A_RESULT", "AN_ERROR"])
+    def test_a_posted_response_is_never_answered_404(self, label):
+        """The finding, stated as the thing that must not happen — the same shape as
+        the batch and notification assertions, because it is the same defect reached
+        by a third route."""
+        response = _raw_call(_event(body=getattr(self, label)))
+
+        assert response["statusCode"] != 404, (
+            "a posted response answered 404 tells the client its session died"
+        )
+
+    @pytest.mark.parametrize("label", ["A_RESULT", "AN_ERROR"])
+    def test_a_posted_response_never_reaches_the_token_store(self, label):
+        """Accepted before the transport guards and before authentication, so a
+        credential presented on one buys no probe of the store."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(
+                _event(body=getattr(self, label), token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 202
+        table.query.assert_not_called()
+
+    def test_a_posted_response_is_accepted_before_a_routing_header_is_compared(self):
+        """A response carries no `method`, so there is nothing for `Mcp-Method` to
+        contradict.
+
+        Validating the routing echoes first reported a header/body mismatch against
+        `''` — an answer about a header, for a message that is not a request at all.
+        Same ordering argument as the batch branch, and the same reason it is
+        asserted through the answer a client receives.
+        """
+        response = _raw_call(_event(
+            body=self.A_RESULT, headers={"Mcp-Method": "ping"},
+        ))
+
+        assert response["statusCode"] == 202, response["body"]
+
+    def test_a_posted_response_keeps_its_cors_headers(self):
+        """A browser-based client must be able to read the 202, and the endpoint's
+        statement about what its answers depend on travels on every response."""
+        response = _raw_call(_event(body=self.A_RESULT))
+
+        headers = response["headers"]
+        assert headers["Access-Control-Allow-Origin"] == "*"
+        assert "Content-Type" not in headers
+        assert headers["Vary"] == "Authorization"
+
+    def test_a_body_carrying_both_a_method_and_a_result_is_still_a_request(self):
+        """The anti-overreach control: the predicate must not swallow a request.
+
+        A body with a `method` is a request whatever else it carries, so this one is
+        dispatched — `ping` answers it — rather than being accepted 202 and dropped
+        on the floor. A predicate written on `result`/`error` alone would have eaten
+        it silently.
+        """
+        status, body = _call(_event(body=json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "ping", "result": {},
+        })))
+
+        assert status == 200, body
+        assert "result" in body
+
+    def test_a_disallowed_origin_is_refused_before_a_response_is_accepted(self):
+        """The DNS-rebinding guard covers this path too: a 202 is still an answer to
+        a request a rebound page made."""
+        with patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com"):
+            response = mcp_handler.lambda_handler(
+                _event(body=self.A_RESULT, headers={"Origin": "https://evil.example.net"}),
+                MagicMock(),
+            )
+
+        assert response["statusCode"] == 403, response["body"]
+
+    def test_an_array_of_responses_is_still_the_batch_refusal(self):
+        """The two shapes get two answers, decided by the shape.
+
+        An array of responses is a legal 2025-03-26 batch body, so it belongs to the
+        branch that names batching — `_is_batch` runs first. Accepting it 202 would
+        tell a client its batch was processed.
+        """
+        status, body = _call(_event(body=json.dumps([
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+        ])))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32600
+        assert "batch" in body["error"]["message"].lower()
+
+    def test_a_body_that_is_neither_keeps_its_existing_answer(self):
+        """Anti-overreach for the other half: a bare `{"jsonrpc": "2.0"}` and a
+        `{"id": 1}` carry neither `result` nor `error`, so they are malformed
+        REQUESTS and keep the -32601 that `TestUnknownMethod` owns. Accepting them
+        202 would silently drop a request a client is waiting on."""
+        for body_text in ('{"jsonrpc": "2.0"}', '{"id": 1}'):
+            status, body = _call(_event(body=body_text))
+            assert status == 404, f"{body_text} was answered {status}: {body}"
+            assert body["error"]["code"] == -32601
+
+    def test_an_ordinary_request_is_still_served(self):
+        """Anti-vacuity: a branch that caught the ordinary object body would accept
+        every request this server has ever served with a 202 and no answer."""
+        status, body = _call(_event("initialize"))
+
+        assert status == 200, body
+        assert "result" in body
 
 
 # ===========================================================================

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -60,7 +60,32 @@ revert makes each assertion fail.
       `notifications/cancelled` traffic tore down live sessions. Deleting the
       `_is_notification` branch in `lambda_handler` fails every test in that class;
       answering a notification anywhere but 202-with-no-body fails
-      test_a_notification_is_202_with_an_empty_body.
+      test_a_notification_is_202_with_an_empty_body. And a REFUSED notification kept
+      the `id: null` the accepted one had lost: passing `req_id` instead of `_NO_ID`
+      in the `InvalidTransportHeader` catch fails
+      test_a_refused_notification_carries_no_id_member, while omitting the id
+      unconditionally fails test_a_refused_request_still_carries_its_id.
+
+  TestBatchBodiesAreRefused
+    — 2025-03-26 was advertised and is the one revision that mandates JSON-RPC
+      batching, which this handler does not implement: a legal array body fell through
+      to the unknown-method branch and was answered `404 -32601 "Method not found: "`,
+      and that 404 tells an advertised-revision client its session died. Re-adding
+      the revision to `SUPPORTED_PROTOCOL_VERSIONS` raises at import and fails
+      test_no_advertised_revision_requires_a_body_grammar_this_server_refuses;
+      deleting the `_is_batch` branch fails the rest.
+
+  TestCacheScopeMatchesWhatTheResponseDependsOn
+    — `server/discover` declared `cacheScope: public` while being liveness-checked, so
+      a shared cache was licensed to replay its unauthenticated 200 across
+      authorization contexts — to the request carrying a revoked token that was owed a
+      401. Restoring `CACHE_SCOPE_PUBLIC` there fails
+      test_no_public_answer_is_credential_gated.
+
+  TestTheHttpLayerStatesWhatTheBodyStates
+    — `cacheScope` travels in the JSON-RPC body and the caches in front of this
+      endpoint read headers, so the mitigation reached only body-parsing clients.
+      Removing `Vary` or `Cache-Control` from `CORS_HEADERS` fails this class.
 
   TestMethodNotAllowed / TestUnknownMethod
     — GET and DELETE are transport methods this server does not implement, so
@@ -288,27 +313,29 @@ class TestVersionNegotiation:
             f"per-request `_meta` era is a phase, not a tuple entry."
         )
 
-    def test_the_revisions_the_deployed_server_negotiated_are_still_accepted(self):
+    def test_the_revision_the_deployed_server_negotiated_is_still_accepted(self):
         """A client that handshook against the DEPLOYED server must keep working.
 
         The deployed handler pinned 2024-11-05, so every connected client sends
         `MCP-Protocol-Version: 2024-11-05` on every subsequent request. Dropping it
         from the accepted set — while the header validator refuses anything not in
         that set — turns each of those clients into a 400 at the next call.
-        2025-03-26 is here for the same reason: it is widely deployed, and it is the
-        value the spec tells a server to assume when the header is absent.
 
         Accepting a revision is not preferring it: neither is the counter-offer.
+
+        2025-03-26 was here too and is deliberately gone; see
+        `TestBatchBodiesAreRefused` for why (it mandates batching, which this handler
+        does not implement) and for why dropping it breaks no deployed client.
         """
-        for version in ("2024-11-05", "2025-03-26"):
-            assert version in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS, (
-                f"{version} was negotiable against a deployed build; refusing it "
-                f"now breaks every client that handshook on it"
-            )
-            status, _body = _call(_event(
-                "initialize", headers={"MCP-Protocol-Version": version},
-            ))
-            assert status == 200, f"{version} header refused"
+        version = "2024-11-05"
+        assert version in mcp_handler.SUPPORTED_PROTOCOL_VERSIONS, (
+            f"{version} was negotiable against a deployed build; refusing it "
+            f"now breaks every client that handshook on it"
+        )
+        status, _body = _call(_event(
+            "initialize", headers={"MCP-Protocol-Version": version},
+        ))
+        assert status == 200, f"{version} header refused"
 
     def test_the_supported_versions_are_ordered_newest_first(self):
         """The order is load-bearing: the first entry is the counter-offer.
@@ -508,9 +535,15 @@ class TestServerDiscover:
         assert result["ttlMs"] >= 60_000, (
             f"ttlMs={result['ttlMs']} looks like seconds, not milliseconds"
         )
-        # `public` is honest for this answer specifically: it names no project, no
-        # tool and no data, so a shared cache reveals nothing credential-shaped.
-        assert result["cacheScope"] == "public"
+        # `private`, and the earlier `public` was the defect: it was argued from the
+        # PAYLOAD (which names no project, no tool and no data — true) where the
+        # field is about the RESPONSE. This method is liveness-checked, so whether
+        # there is a 200 at all depends on the credential, and `public` licenses a
+        # shared cache to replay the unauthenticated 200 across authorization
+        # contexts — including to the request carrying a revoked token that was owed
+        # a 401. `TestCacheScopeMatchesWhatTheResponseDependsOn` pins the invariant
+        # generally; this pins the value a client actually reads.
+        assert result["cacheScope"] == "private"
 
     def test_the_discovery_answer_carries_no_undefined_top_level_fields(self):
         """The whole correction, stated once as a closed set.
@@ -645,11 +678,33 @@ class TestProtocolVersionHeader:
         assert mcp_handler._validated_protocol_version(_event("initialize")) == (
             mcp_handler.ASSUMED_PROTOCOL_VERSION
         )
-        # And it must be one this server actually serves, or the default would
-        # refuse every header-less client on the next line of the guard.
-        assert mcp_handler.ASSUMED_PROTOCOL_VERSION in (
+
+    def test_the_assumed_revision_is_a_reading_and_not_an_advertisement(self):
+        """It is deliberately NOT in the advertised range, and that is the point.
+
+        This test used to assert the opposite — that the assumed value is one the
+        server serves — on the reasoning that otherwise the guard would refuse every
+        header-less client on its next line. That reasoning was about the CODE PATH,
+        and the path returns before it compares anything, so the assertion was
+        pinning a coincidence rather than a requirement.
+
+        The requirement is the distinction: 2025-03-26 mandates batching, which this
+        handler does not implement, so it must not be OFFERED — and it is the value
+        the spec names as the reading for a header-less request, so it must not be
+        dropped. A fallback reading is not an advertisement, and conflating the two
+        is what re-added the revision in the first place.
+
+        A header-less request is still served, which is the property that reasoning
+        was reaching for; asserted directly rather than via the tuple.
+        """
+        assert mcp_handler.ASSUMED_PROTOCOL_VERSION not in (
             mcp_handler.SUPPORTED_PROTOCOL_VERSIONS
+        ), (
+            "the assumed revision is being advertised; if it is now implementable "
+            "in full, say so here rather than letting the two facts merge"
         )
+        status, _body = _call(_event("initialize"))
+        assert status == 200, "a header-less client must still be served"
 
     def test_an_empty_version_header_is_refused(self):
         """A client that sent the header empty said something, and what it said is
@@ -1798,6 +1853,86 @@ class TestNotificationsAreAccepted:
 
         assert response["statusCode"] == 403, response["body"]
 
+    # A refused notification, one per transport fault that can refuse one, with the
+    # status and code each is owed. The 202 fix covered the ACCEPTED case; these are
+    # the four requests that still came back carrying `id: null`.
+    REFUSALS: ClassVar[tuple[tuple[str, dict, int], ...]] = (
+        ("notifications/cancelled", {"MCP-Protocol-Version": "1999-01-01"}, -32022),
+        ("notifications/cancelled", {"Mcp-Method": "ping"}, -32020),
+        ("notifications/cancelled", {"Mcp-Name": "search_feedback"}, -32020),
+        ("notifications/progress", {"Mcp-Method": "=?base64?!!!?="}, -32600),
+    )
+
+    @pytest.mark.parametrize("method,headers,code", REFUSALS)
+    def test_a_refused_notification_carries_no_id_member(self, method, headers, code):
+        """The `id: null` defect, one branch over from where it was fixed.
+
+        Every advertised revision says a notification the server cannot accept gets an
+        HTTP error status whose body "MAY comprise a JSON-RPC error response that has
+        NO `id`". `"id": null` is a PRESENT member with a null value, which this module
+        already holds is a different thing — it is what `_is_notification` turns on,
+        what `test_a_null_id_is_not_a_notification` pins, and what the 3.4.0 entry
+        records about a result's id. A client correlating by id held an error entry
+        matching no request it ever sent.
+
+        Asserted with `not in` rather than against a value, because the whole
+        distinction is presence.
+        """
+        response = _raw_call(_notification_event(method, headers=headers))
+        body = json.loads(response["body"])
+
+        assert "id" not in body, (
+            f"{method} refused with an id member: {body}"
+        )
+
+    @pytest.mark.parametrize("method,headers,code", REFUSALS)
+    def test_a_refused_notification_keeps_its_status_and_its_code(self, method, headers, code):
+        """Only the envelope changed.
+
+        The 400 is what the advertised revisions require for a notification the server
+        cannot accept, and the code is the spec's own per-fault code — the machine
+        readable half a dual-era client's era probe reads. A fix that quietly
+        collapsed these to one generic answer would be the earlier `-32600` regression
+        wearing a different hat.
+        """
+        response = _raw_call(_notification_event(method, headers=headers))
+
+        assert response["statusCode"] == 400, response["body"]
+        assert json.loads(response["body"])["error"]["code"] == code
+
+    def test_a_refused_request_still_carries_its_id(self):
+        """Anti-vacuity, and the property that makes the change narrow.
+
+        Omitting the id unconditionally would break every client that correlates a
+        REQUEST's refusal — which is most of them, and it is why `_NO_ID` is a
+        sentinel rather than `None`: a request whose id could not be detected is still
+        reported as null.
+        """
+        response = _raw_call(_event(
+            "ping", headers={"MCP-Protocol-Version": "1999-01-01"},
+        ))
+        body = json.loads(response["body"])
+
+        assert body["id"] == 1, body
+
+    def test_a_rebound_origin_refusal_carries_no_id_either(self):
+        """The 403 runs before the body is even parsed, so it cannot know it is
+        answering a request — and the transport's wording for this refusal is the same
+        "no `id`".
+
+        Sending `id: null` there guessed at an id for a message that may have carried
+        none.
+        """
+        with patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com"):
+            response = mcp_handler.lambda_handler(
+                _notification_event("notifications/initialized",
+                                    headers={"Origin": "https://evil.example.net"}),
+                MagicMock(),
+            )
+
+        assert response["statusCode"] == 403
+        assert "id" not in json.loads(response["body"])
+
 
 class TestUnknownMethod:
     """An unknown JSON-RPC REQUEST is -32601 with a 404, and nothing else.
@@ -1852,17 +1987,175 @@ class TestUnknownMethod:
         assert status == 404
         assert body["error"]["code"] == -32601
 
-    @pytest.mark.parametrize("body_text", ["[]", '"a string"', "42", "null"])
+    @pytest.mark.parametrize("body_text", ['"a string"', "42", "null"])
     def test_a_non_object_body_is_not_a_crash(self, body_text):
         """The body is caller-controlled JSON and need not be an object. `[]`
         used to reach `.get` on a list — an AttributeError, i.e. a 502 with no
         envelope and no CORS headers, which is the failure mode the auth path's
-        catch-all exists to prevent."""
+        catch-all exists to prevent.
+
+        `[]` is no longer parametrised here: an ARRAY is a batch, which has its own
+        answer and its own reason (`TestBatchBodiesAreRefused`). It reached this
+        branch — and its 404 — precisely because "not a dict" was the only thing this
+        handler noticed about it.
+        """
         status, body = _call(_event(body=body_text))
 
         assert status == 404, body
         assert body["error"]["code"] == -32601
+        # `null`, not omitted: JSON-RPC reports an id it could not detect as null, and
+        # a malformed body is exactly that case. `_NO_ID` is for a message that
+        # carries no id BY DESIGN — a notification — which this is not.
         assert body["id"] is None
+
+
+# ===========================================================================
+# Batch bodies — the grammar of a revision this server no longer advertises
+# ===========================================================================
+
+class TestBatchBodiesAreRefused:
+    """An array body is refused NAMING batching, and 2025-03-26 is not advertised.
+
+    Batching is defined by exactly one revision: 2025-03-26 added it to the transport
+    ("an array batching one or more requests and/or notifications") and 2025-06-18
+    removed it again. This handler implements none of it, and it USED TO ADVERTISE
+    that revision — so a conforming client was told it could send a shape that was
+    then answered `404 -32601 "Method not found: "`, because a list has no `method`
+    to find. On the advertised revisions a 404 on this endpoint means the SESSION was
+    terminated and the client MUST re-initialize, so a client batching its
+    `initialized` notification was told to tear down a live session, and
+    re-initializing brought it straight back.
+
+    Two halves, and both are needed: the revision is no longer offered (so no client
+    is told this server accepts batches) AND an array is refused legibly (so a client
+    that sends one anyway learns the actual constraint).
+
+    Re-adding "2025-03-26" to `SUPPORTED_PROTOCOL_VERSIONS` fails
+    test_no_advertised_revision_requires_a_body_grammar_this_server_refuses — and
+    raises at IMPORT, from the guard beside the tuple. Deleting the `_is_batch`
+    branch in `lambda_handler` fails the rest.
+    """
+
+    ONLY_NOTIFICATIONS: ClassVar[str] = json.dumps([
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {"requestId": 1}},
+    ])
+    CONTAINS_A_REQUEST: ClassVar[str] = json.dumps([
+        {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    ])
+
+    def test_no_advertised_revision_requires_a_body_grammar_this_server_refuses(self):
+        """The rule, so a future entry is checked rather than reasoned about.
+
+        2025-03-26 was re-added in this PR for a good reason — a header validator was
+        refusing clients that had handshook against the deployed build — by reasoning
+        about the HEADER and not about the body grammar. That is the mistake this
+        assertion exists to catch, and the module raises on it at import too.
+        """
+        overlap = set(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS) & (
+            mcp_handler.BODY_GRAMMAR_UNIMPLEMENTED_VERSIONS
+        )
+        assert overlap == set(), (
+            f"advertising {sorted(overlap)}, whose body grammar this handler refuses. "
+            f"Either implement the grammar or stop offering the revision."
+        )
+        # Positive control: the constraint names something, or the line above is
+        # comparing an empty intersection of an empty set.
+        assert "2025-03-26" in mcp_handler.BODY_GRAMMAR_UNIMPLEMENTED_VERSIONS
+
+    @pytest.mark.parametrize("label", ["ONLY_NOTIFICATIONS", "CONTAINS_A_REQUEST"])
+    def test_a_batch_is_refused_as_a_malformed_request_not_a_missing_method(self, label):
+        """-32600, not -32601: there is no method here to be found.
+
+        `-32601 "Method not found: "` — with the empty method name the fall-through
+        produced — told a caller nothing about what it had actually done, and sent it
+        looking for a method name it never sent.
+        """
+        status, body = _call(_event(body=getattr(self, label)))
+
+        assert status == 400, body
+        assert body["error"]["code"] == -32600
+        assert "batch" in body["error"]["message"].lower(), (
+            f"the refusal does not name batching: {body['error']['message']!r}"
+        )
+
+    @pytest.mark.parametrize("label", ["ONLY_NOTIFICATIONS", "CONTAINS_A_REQUEST"])
+    def test_a_batch_is_never_answered_404(self, label):
+        """The finding, stated as the thing that must not happen.
+
+        A 404 here instructed the client to tear down its session and re-initialize,
+        so this was not untidiness: normal batched traffic was destroying sessions,
+        and the retry landed on the same answer.
+        """
+        status, _body = _call(_event(body=getattr(self, label)))
+
+        assert status != 404, (
+            "a batch answered 404 tells the client its session died"
+        )
+
+    def test_the_refusal_carries_a_machine_readable_recovery_path(self):
+        """A client should not have to parse English to find out what to do.
+
+        Same standard the -32022 refusal already meets: `supported` is what to retry
+        on, and `batchingSupported: false` is the constraint stated as data.
+        """
+        _status, body = _call(_event(body=self.CONTAINS_A_REQUEST))
+
+        data = body["error"]["data"]
+        assert data["supported"] == list(mcp_handler.SUPPORTED_PROTOCOL_VERSIONS)
+        assert data["batchingSupported"] is False
+
+    def test_a_batch_never_reaches_the_token_store(self):
+        """Refused before authentication, like every other malformed transport: a
+        body shape this server does not accept buys no probe of the credential
+        store."""
+        with patch("mcp_handler.projects_table") as table:
+            response = mcp_handler.lambda_handler(
+                _event(body=self.CONTAINS_A_REQUEST, token=_TOKEN), MagicMock(),
+            )
+
+        assert response["statusCode"] == 400
+        table.query.assert_not_called()
+
+    def test_a_batch_is_refused_before_a_routing_header_is_compared(self):
+        """A batch has no single `method`, so there is nothing for `Mcp-Method` to
+        contradict.
+
+        Validating the routing echoes first reported a header/body mismatch against
+        `''` — an answer about a header, for a request whose whole shape this server
+        does not accept. The ordering is asserted through the CODE a client receives,
+        because that is the part a client acts on.
+        """
+        _status, body = _call(_event(
+            body=self.CONTAINS_A_REQUEST, headers={"Mcp-Method": "ping"},
+        ))
+
+        assert body["error"]["code"] == -32600, (
+            f"a batch was diagnosed as a header mismatch: {body['error']}"
+        )
+
+    def test_a_single_message_is_still_served(self):
+        """Anti-vacuity, and the only thing this refusal must not do.
+
+        A guard on "is the body a list" that caught the ordinary object body would
+        refuse every request this server has ever served.
+        """
+        status, body = _call(_event("initialize"))
+
+        assert status == 200, body
+        assert "result" in body
+
+    def test_an_array_body_is_the_only_thing_this_refuses(self):
+        """The other non-object bodies keep their existing answer.
+
+        `"a string"`, `42` and `null` are malformed rather than batched, and reporting
+        batching for them would send a caller after a feature it never used.
+        `TestUnknownMethod` owns that half; this pins that the batch branch did not
+        swallow it.
+        """
+        for body_text in ('"a string"', "42", "null"):
+            status, body = _call(_event(body=body_text))
+            assert status == 404, f"{body_text} was answered {status}: {body}"
 
 
 # ===========================================================================
@@ -2053,18 +2346,33 @@ class TestToolCatalogueIsFilteredByAuthorization:
 
         assert body["result"]["cacheScope"] == "private"
 
-    def test_the_two_cacheable_answers_scope_differently(self):
-        """Anti-vacuity, and the distinction is the whole point of the field.
+    def test_both_cacheable_answers_declare_the_scope_their_table_states(self):
+        """Read from `METHOD_CACHE_SCOPES` rather than restated, because the value is
+        now the same for both and a restated literal would be a second copy of it.
 
-        Discovery is `public` (it names no project, tool or data) and the catalogue
-        is `private` (it is a function of the credential). A change that hard-coded
-        one value for both would pass each test above on its own.
+        This test used to assert the two DIFFER — discovery `public`, the catalogue
+        `private` — as an anti-vacuity guard against one hard-coded value. That guard
+        was pinning the very bug the `public` finding named: the difference it
+        protected was wrong, and asserting a difference made the wrong value look
+        deliberate. The vacuity it was worried about is covered instead by
+        `TestCacheScopeMatchesWhatTheResponseDependsOn`, which derives the rule from
+        what the response actually depends on — a stronger claim than "these two
+        strings are not equal".
         """
         _s, discovery = _call(_event("server/discover"))
         _s, listing = _call(_event("tools/list", token=_TOKEN))
 
-        assert discovery["result"]["cacheScope"] == "public"
-        assert listing["result"]["cacheScope"] == "private"
+        assert discovery["result"]["cacheScope"] == (
+            mcp_handler.METHOD_CACHE_SCOPES["server/discover"]
+        )
+        assert listing["result"]["cacheScope"] == (
+            mcp_handler.METHOD_CACHE_SCOPES["tools/list"]
+        )
+        # And the table says something: a scope not in the spec's vocabulary is a
+        # value no client can act on.
+        assert set(mcp_handler.METHOD_CACHE_SCOPES.values()) <= {
+            mcp_handler.CACHE_SCOPE_PUBLIC, mcp_handler.CACHE_SCOPE_PRIVATE,
+        }
 
     def test_the_cache_hint_agrees_with_the_declared_capability(self):
         """Two statements about notifications, from one fact."""
@@ -2109,6 +2417,203 @@ class TestToolCatalogueIsFilteredByAuthorization:
         response = mcp_handler.lambda_handler(_event("tools/list"), MagicMock())
 
         assert response["statusCode"] == 401, response["body"]
+
+
+# ===========================================================================
+# cacheScope describes the RESPONSE, and the HTTP layer says so too
+# ===========================================================================
+
+class TestCacheScopeMatchesWhatTheResponseDependsOn:
+    """`public` licenses a shared cache to serve a response ACROSS authorization
+    contexts, so it must not be declared by an answer that depends on one.
+
+    `server/discover` declared `public`, argued from its payload — which names no
+    project, no tool and no data, and is beside the point. The method is in
+    `_LIVENESS_CHECKED_METHODS`, so whether it answers 200 at all depends on the
+    credential presented: none is a 200, a revoked one is a 401. An intermediary was
+    therefore permitted to cache the unauthenticated 200 for an hour and replay it to
+    the request carrying the dead token — defeating the liveness check on precisely
+    the method that is in that set for the client which starts at discovery.
+
+    Two changes each correct on their own terms (the liveness check made discovery
+    credential-sensitive; the cache hints declared it credential-insensitive), which
+    is why the invariant is asserted across BOTH constants rather than either being
+    re-read on its own.
+
+    Restoring `CACHE_SCOPE_PUBLIC` on discovery fails
+    test_no_public_answer_is_credential_gated.
+    """
+
+    def test_no_public_answer_is_credential_gated(self):
+        """The invariant, derived from both constants rather than restating either."""
+        public_methods = {
+            method for method, scope in mcp_handler.METHOD_CACHE_SCOPES.items()
+            if scope == mcp_handler.CACHE_SCOPE_PUBLIC
+        }
+        gated = public_methods & mcp_handler._LIVENESS_CHECKED_METHODS
+
+        assert gated == set(), (
+            f"{sorted(gated)} declare cacheScope 'public' while their RESPONSE "
+            f"depends on the credential (liveness-checked), so a shared cache may "
+            f"serve a 200 where a 401 was owed. Either scope them 'private' or take "
+            f"them out of the liveness set."
+        )
+
+    def test_the_invariant_has_a_subject(self):
+        """Positive control: an empty intersection proves nothing about empty inputs.
+
+        Both sides have to be non-empty, and they have to OVERLAP in methods — this
+        rule is only about a method that is both cacheable and credential-gated, and
+        `server/discover` is the one that is. If it stopped being either, the test
+        above would pass while enforcing nothing.
+        """
+        assert mcp_handler.METHOD_CACHE_SCOPES, "no cacheable answers to check"
+        assert mcp_handler._LIVENESS_CHECKED_METHODS, "no credential-gated methods"
+        assert "server/discover" in mcp_handler.METHOD_CACHE_SCOPES
+        assert "server/discover" in mcp_handler._LIVENESS_CHECKED_METHODS
+
+    def test_the_credential_gate_on_discovery_is_real(self):
+        """The premise, driven rather than read off a constant.
+
+        The whole argument is that discovery's RESPONSE varies by credential. If it
+        did not — if a dead token got the same 200 as no token — `public` would have
+        been fine and this class would be enforcing a rule about nothing.
+        """
+        expired = _token_row(
+            expires_at=(datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        )
+        anonymous, _body = _call(_event("server/discover"))
+        with_a_dead_token, _body = _call(
+            _event("server/discover", token=_TOKEN), row=expired,
+        )
+
+        assert anonymous == 200
+        assert with_a_dead_token == 401, (
+            "discovery no longer depends on the credential, so the cache-scope rule "
+            "this class enforces has lost its subject"
+        )
+
+
+class TestTheHttpLayerStatesWhatTheBodyStates:
+    """`cacheScope` lives in the JSON-RPC body; the caches in front of this endpoint
+    read HEADERS.
+
+    API Gateway, a CDN and a corporate proxy do not parse a JSON-RPC result, so
+    `cacheScope: private` reached only the clients that were never the risk. The
+    catalogue genuinely varies — a full credential lists six tools, a `metrics:read`
+    one lists two, with different etags — and it was served with no HTTP-level signal
+    that it varies at all.
+
+    Removing `Vary` or `Cache-Control` from `CORS_HEADERS` fails this class.
+    """
+
+    def _headers(self, event: dict, **kwargs) -> dict:
+        return _raw_call(event, **kwargs)["headers"]
+
+    @pytest.mark.parametrize("event_kwargs", [
+        {"method": "tools/list", "token": _TOKEN},
+        {"method": "initialize"},
+        {"method": "server/discover"},
+        {"method": "tools/teleport"},
+    ])
+    def test_every_answer_names_authorization_as_the_axis_it_varies_on(self, event_kwargs):
+        """Unconditional, from the one choke point, rather than on the answers that
+        vary today.
+
+        The header costs nothing on an answer that does not vary — it forbids a cache
+        hit that would have been correct — while a missing one costs a
+        cross-credential hit. That asymmetry is the argument for having no condition
+        to get wrong, and it matches how the module treats fail-closed elsewhere.
+        """
+        headers = self._headers(_event(**event_kwargs))
+
+        varies_on = {name.strip().lower() for name in headers["Vary"].split(",")}
+        assert "authorization" in varies_on, (
+            f"{event_kwargs} answered without naming Authorization in Vary: "
+            f"{headers.get('Vary')!r}"
+        )
+
+    def test_the_401_says_it_varies_too(self):
+        """The most credential-dependent answer of all.
+
+        A cached 401 replayed to a request carrying a good credential is the same
+        defect facing the other way, and a refusal is exactly the kind of response an
+        intermediary is happy to reuse.
+        """
+        headers = self._headers(_event("tools/list"))
+
+        assert "authorization" in headers["Vary"].lower()
+
+    def test_origin_is_not_named_because_the_answer_does_not_vary_by_it(self):
+        """`Access-Control-Allow-Origin` is the static `*`, so naming `Origin` would
+        forbid cache hits for no reason.
+
+        Written as an absence with its reason, because "list every request header" is
+        the tempting wrong answer and it silently disables caching altogether.
+        """
+        headers = self._headers(_event("initialize"))
+
+        assert "origin" not in headers["Vary"].lower()
+        assert mcp_handler.CORS_HEADERS["Access-Control-Allow-Origin"] == "*", (
+            "the Allow-Origin header is no longer static, so Origin IS now an axis "
+            "this endpoint varies on and Vary must name it"
+        )
+
+    def test_a_shared_cache_is_told_not_to_store_the_answer(self):
+        """`Vary` says which header partitions the cache; `Cache-Control: private`
+        says a shared cache must not store the response at all.
+
+        Both, because a cache may honour one and not the other — a proxy that ignores
+        `Vary` and respects `private` still cannot serve one credential's catalogue to
+        another.
+        """
+        headers = self._headers(_event("tools/list", token=_TOKEN))
+
+        directives = {d.strip().lower() for d in headers["Cache-Control"].split(",")}
+        assert "private" in directives
+
+    def test_the_client_is_not_forbidden_the_reuse_the_body_invites(self):
+        """`no-store`/`no-cache` would contradict `ttlMs` at the HTTP layer.
+
+        The two statements have to agree, and the one they agree on is "yours to
+        reuse, not to share" — a client caching its OWN catalogue for `ttlMs` is
+        exactly what the hint asks for.
+        """
+        response = _raw_call(_event("tools/list", token=_TOKEN))
+        directives = {
+            d.strip().lower() for d in response["headers"]["Cache-Control"].split(",")
+        }
+
+        assert "no-store" not in directives
+        assert "no-cache" not in directives
+        # Positive control: the body really does invite reuse, or there is nothing to
+        # contradict.
+        assert json.loads(response["body"])["result"]["ttlMs"] > 0
+
+    def test_a_browser_can_read_the_header_that_says_the_answer_varies(self):
+        """`Vary` is not CORS-safelisted, so a browser receives it and hides it.
+
+        A statement the client cannot read is a statement to nobody — the same
+        failure `WWW-Authenticate` already documents on this endpoint.
+        """
+        headers = self._headers(_event("tools/list", token=_TOKEN))
+
+        exposed = {
+            name.strip().lower()
+            for name in headers["Access-Control-Expose-Headers"].split(",")
+        }
+        assert "vary" in exposed
+
+    def test_an_accepted_notification_carries_the_same_statement(self):
+        """The 202 builds its headers separately from `_cors_response`, which is how
+        one of them comes to be missing a header the other has.
+
+        Nothing caches a 202 in practice; the point is that the two builders do not
+        disagree about what this endpoint's answers depend on.
+        """
+        response = _raw_call(_notification_event("notifications/initialized"))
+
+        assert "authorization" in response["headers"]["Vary"].lower()
 
 
 # ===========================================================================

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -1352,6 +1352,26 @@ class TestADuplicatedHeaderIsRefused:
         # `''` — the diagnostic the coerce-first ordering used to produce.
         assert "does not match body value" not in body["error"]["message"]
 
+    def test_the_duplicate_message_shows_what_was_sent_not_the_coercion(self):
+        """A message asserting two values differ has to show two things that
+        differ.
+
+        Built from the coerced side, `{'mcp-method': [None, 42]}` produced
+        `different values ('', '')` — a sentence contradicting itself, telling
+        the reader nothing about what was actually sent. The display halves are
+        the dedup key, so what is shown as different is exactly what was judged
+        different.
+        """
+        event = _event("ping")
+        event["multiValueHeaders"] = {"mcp-method": [None, 42]}
+
+        _status, body = _call(event)
+        message = body["error"]["message"]
+
+        assert "None" in message, message
+        assert "42" in message, message
+        assert "'', ''" not in message, message
+
     def test_a_single_unusable_value_still_reads_as_the_empty_value(self):
         """Anti-overreach: the fix is about TWO values, not about non-strings.
 

--- a/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
+++ b/voc-datalake/lambda/api/test/test_mcp_protocol_envelope.py
@@ -307,10 +307,27 @@ class TestServerDiscover:
         assert not set(mcp_handler.MCP_AUTH_METHODS) & set(mcp_handler.MCP_METHODS)
 
     def test_it_reports_the_transport_headers_it_validates(self):
-        """A client cannot conform to a rule it cannot discover."""
+        """A client cannot conform to a rule it cannot discover.
+
+        Compared case-insensitively against what the handler READS, because the
+        two spellings are deliberately different: discovery reports the form a
+        client sends, the guard reads the form API Gateway delivers. Both must name
+        the same set of headers.
+        """
         result = self._discover()
 
-        assert set(result["transportHeaders"]) == set(mcp_handler.TRANSPORT_HEADERS)
+        assert {name.lower() for name in result["transportHeaders"]} == set(
+            mcp_handler.TRANSPORT_HEADERS
+        )
+
+    def test_it_reports_them_in_the_spelling_a_client_sends(self):
+        """The internal lowercase form is an artefact of API Gateway's
+        normalisation, and publishing it would document an implementation detail
+        as a contract."""
+        result = self._discover()
+
+        assert "MCP-Protocol-Version" in result["transportHeaders"]
+        assert result["transportHeaders"] == sorted(result["transportHeaders"])
 
     def test_it_reports_the_result_type_vocabulary(self):
         result = self._discover()
@@ -1016,6 +1033,36 @@ class TestToolCatalogueIsFilteredByAuthorization:
     def test_a_project_set_credential_with_no_projects_sees_no_project_tools(self):
         """Sealed to a set that names nothing reaches nothing."""
         listed = self._names(_token_row(read_reach=REACH_PROJECT_SET, projects=[]))
+
+        assert listed == []
+
+    def test_a_workspace_credential_with_no_projects_still_sees_the_project_tools(self):
+        """The asymmetry with the test above, and it is the honest one.
+
+        Workspace reach admits every project without consulting the id — a
+        workspace token reads a project it was not minted from, which
+        `test_workspace_token_reads_a_project_outside_its_own_set` pins on the
+        dispatch side. So an empty project set does not bound it, and a listing
+        that refused these tools would hide tools the dispatch allows.
+
+        This is the case the representative-project stand-in exists for: a listing
+        has to ask a project-shaped question with no project in hand.
+        """
+        listed = set(self._names(_token_row(projects=[])))
+        expected = set(mcp_handler.TOOL_HANDLERS)
+
+        assert listed == expected
+
+    def test_an_unusable_project_entry_does_not_pass_for_a_project(self):
+        """A row whose `projects` holds junk names no project.
+
+        `projects` is stored data and these values are what a `project-set` token
+        is bounded BY, so an entry that is not a usable id must not be counted as
+        one — the fail-closed reading, matching how a damaged `scopes` grants
+        nothing.
+        """
+        listed = self._names(_token_row(read_reach=REACH_PROJECT_SET,
+                                        projects=[None, "", 7, {}]))
 
         assert listed == []
 

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -1537,6 +1537,45 @@ class TestOriginValidation:
         assert response["statusCode"] == 403, response["body"]
 
     @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_two_unusable_origins_are_refused_not_read_as_absent(self, lambda_context):
+        """Two DIFFERENT unusable Origin values must not collapse into no Origin.
+
+        `_header_values` coerces a non-string candidate to `''` — and coercing
+        BEFORE deduplicating turned `[None, 42]` into a single `''`, which is how
+        this module spells ABSENT, and absent Origin passes the rebinding guard. So
+        the one guard whose whole subject is "do not pick between two claimed
+        origins" resolved two claimed origins to no origin at all and SERVED the
+        request — a fail-open, on the same direct-invoke event shape the non-dict
+        `headers` guard below already defends. Deduplicating on the raw candidate
+        keeps the two values two, and two values for `Origin` is the 403 the test
+        above pins. Moving the coercion back inside the dedup fails this test.
+        """
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["multiValueHeaders"] = {"origin": [None, 42]}
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] == 403, response["body"]
+
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_a_single_unusable_origin_still_reads_as_absent(self, lambda_context):
+        """Anti-overreach: the fix is about TWO values, not about non-strings.
+
+        A single unusable value keeps its existing reading — the empty string,
+        which the guard treats as no Origin presented. Refusing it would refuse
+        every direct invoke whose builder put something odd in one header, which
+        is a different (and unclaimed) policy.
+        """
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["multiValueHeaders"] = {"origin": [None]}
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] == 200, response["body"]
+
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
     def test_the_same_origin_twice_is_still_served(self, lambda_context):
         """Anti-vacuity: restating one allowed origin is not two origins, and
         refusing it would refuse a request nothing is wrong with."""

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -1511,6 +1511,46 @@ class TestOriginValidation:
             f"Origin spelled {spelling!r} bypassed the DNS-rebinding guard"
         )
 
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_two_claimed_origins_are_refused_rather_than_chosen_between(
+        self, lambda_context,
+    ):
+        """Picking one of two claimed origins is the one thing this guard must not do.
+
+        `Origin` is what this function exists to compare, so an intermediary that
+        forwarded the victim's origin alongside the attacker's would have it compare
+        whichever it happened to read first — and the allowed value is present here,
+        so a reader that stopped at the first match would SERVE this request. The
+        fail-closed reading is the refusal, which is the same reading the transport
+        headers apply to a duplicate (`-32020` there; a 403 here, because that is the
+        answer this guard's caller gives).
+        """
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["headers"]["origin"] = "https://voc.example.com"
+        event["multiValueHeaders"] = {
+            "origin": ["https://voc.example.com", "https://evil.example.net"],
+        }
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] == 403, response["body"]
+
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_the_same_origin_twice_is_still_served(self, lambda_context):
+        """Anti-vacuity: restating one allowed origin is not two origins, and
+        refusing it would refuse a request nothing is wrong with."""
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["headers"]["origin"] = "https://voc.example.com"
+        event["multiValueHeaders"] = {
+            "origin": ["https://voc.example.com", "https://voc.example.com"],
+        }
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] == 200, response["body"]
+
     @pytest.mark.parametrize("headers", [["x"], "origin", 7, [("origin", "x")]])
     @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
     def test_a_non_dict_headers_value_is_not_a_crash(self, headers, lambda_context):

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -1559,6 +1559,28 @@ class TestOriginValidation:
         assert response["statusCode"] == 403, response["body"]
 
     @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_equatable_but_distinct_unusable_origins_are_still_two_values(
+        self, lambda_context,
+    ):
+        """`==` folds the pairs Python equates across types, and the dedup must
+        not.
+
+        Deduplicating the raw candidates with `in` (i.e. `==`) collapsed
+        `[True, 1]` into one value — `True == 1` — which then coerced to `''`
+        and read as an absent Origin: the same fail-open the raw-candidate fix
+        closed, one equality quirk deeper. The dedup key is now the `repr`, and
+        `repr(True) != repr(1)`. Reverting the key to `==` on the raw candidate
+        fails this test and only this test.
+        """
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["multiValueHeaders"] = {"origin": [True, 1]}
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] == 403, response["body"]
+
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
     def test_a_single_unusable_origin_still_reads_as_absent(self, lambda_context):
         """Anti-overreach: the fix is about TWO values, not about non-strings.
 

--- a/voc-datalake/lambda/api/test/test_mcp_security.py
+++ b/voc-datalake/lambda/api/test/test_mcp_security.py
@@ -1487,6 +1487,54 @@ class TestOriginValidation:
         response = mcp_handler.lambda_handler(event, lambda_context)
         assert response["statusCode"] == 403
 
+    @pytest.mark.parametrize("spelling", ["Origin", "origin", "ORIGIN", "oRigin"])
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_every_casing_of_the_header_is_checked(self, spelling, lambda_context):
+        """A guard that reads two spellings by hand is bypassed by the third.
+
+        This function matched only `'origin'` and `'Origin'`, so `ORIGIN:` and
+        `oRigin:` walked past the DNS-rebinding guard entirely on a direct invoke or
+        any non-API-Gateway trigger — a check that fails OPEN. It now reads through
+        `_request_header`, the module's one case-insensitive header reader, which is
+        the same helper `_authenticate` and the transport headers use.
+
+        HTTP header names are case-insensitive, so all four of these are the same
+        header and a browser or a proxy may send any of them.
+        """
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["headers"][spelling] = "https://evil.example.net"
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] == 403, (
+            f"Origin spelled {spelling!r} bypassed the DNS-rebinding guard"
+        )
+
+    @pytest.mark.parametrize("headers", [["x"], "origin", 7, [("origin", "x")]])
+    @patch("mcp_handler.ALLOWED_ORIGIN", "https://voc.example.com")
+    def test_a_non_dict_headers_value_is_not_a_crash(self, headers, lambda_context):
+        """`event['headers']` is a dict or null from API Gateway — and this is not
+        the only way in.
+
+        `headers.get('origin')` on a list raised `AttributeError`, and this guard
+        runs FIRST in `lambda_handler`, outside its try/except: the result was a 502
+        with no JSON-RPC envelope and no CORS headers, which is precisely the failure
+        shape the `BotoCoreError` clause documents as the thing to avoid. A truthy
+        non-dict was needed to reach it, so `or {}` hid the falsy cases.
+
+        Reads as absence, which passes the guard — the same answer as no Origin at
+        all, and the only honest one: a malformed headers structure states no origin.
+        """
+        import mcp_handler
+        event = self._initialize_event(None)
+        event["headers"] = headers
+
+        response = mcp_handler.lambda_handler(event, lambda_context)
+
+        assert response["statusCode"] != 502, response.get("body")
+        assert response["statusCode"] == 200, response["body"]
+
     @patch("mcp_handler.ALLOWED_ORIGIN", "*")
     def test_wildcard_config_disables_the_guard(self, lambda_context):
         """Dev deployments set ALLOWED_ORIGIN='*'; any Origin then passes."""

--- a/voc-datalake/lambda/shared/mcp_tokens.py
+++ b/voc-datalake/lambda/shared/mcp_tokens.py
@@ -174,6 +174,19 @@ def reach_allows(
     no project dimension in the feedback corpus to narrow, so "allow it" would
     silently hand a supposedly sealed token the entire verbatim history. A
     caller that needs both gets ``workspace`` and accepts what that means.
+
+    ``token_projects`` that is not a list or tuple reaches NO project, which is
+    the fail-closed reading and closes a real hole rather than tidying a type
+    hint. ``project_id in token_projects`` is a membership test against a sequence
+    but a SUBSTRING test against a string, so a damaged row storing ``projects``
+    as ``"proj1"`` instead of ``["proj1"]`` admitted ``project_id="p"``,
+    ``"proj"``, and every other substring of its own value. That value is stored
+    data and it is the thing a ``project-set`` token is bounded BY, so a shape
+    that changes what the bound MEANS must not be accepted.
+
+    Note ``workspace`` reach returns above without consulting the set at all —
+    which is what makes it safe for a caller to ask about a representative
+    project id under that reach (see ``_tool_is_authorized`` in the MCP handler).
     """
     if read_reach == REACH_NONE:
         return False
@@ -186,6 +199,8 @@ def reach_allows(
     if read_reach == REACH_WORKSPACE:
         return True
     if read_reach == REACH_PROJECT_SET:
+        if not isinstance(token_projects, (list, tuple)):
+            return False
         return project_id in token_projects
     return False
 

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1372,6 +1372,88 @@ describe('mcp transport headers reach a browser', () => {
       }
     }
   });
+
+  // `mcp_handler.py` now sends `Vary: Authorization` on every response, because its
+  // answers depend on the credential and the caches in front of this endpoint read
+  // headers rather than the JSON-RPC body's `cacheScope`. `Vary` is not
+  // CORS-safelisted, so a browser receives it and hides it from the page unless the
+  // endpoint says otherwise — the same failure `WWW-Authenticate` already documents.
+  //
+  // Read out of the Python source for the same reason as the allow-list above: the
+  // handler's own responses carry ITS expose list and gateway-GENERATED ones (the
+  // authorizer's 401) carry the template's, so a header exposed by one and not the
+  // other is readable on some of this endpoint's answers and not others.
+  const pythonExposeHeaders = (): string[] => {
+    const source = readRepoFile('lambda', 'api', 'mcp_handler.py');
+    const value = source.match(
+      /^\s*'Access-Control-Expose-Headers':\s*'([^']+)',/m,
+    )?.[1];
+    expect(value, "could not read Access-Control-Expose-Headers from mcp_handler.py")
+      .toBeDefined();
+    return (value ?? '').split(',').map((h) => h.trim());
+  };
+
+  it('exposes every response header the handler expects a browser to read', () => {
+    const declared = pythonExposeHeaders();
+    // Positive control: a regex that matched nothing would make the loop vacuous.
+    expect(declared.map((h) => h.toLowerCase())).toContain('vary');
+
+    const responses = Object.values(
+      apiTemplate().findResources('AWS::ApiGateway::GatewayResponse'),
+    );
+    const ResponseSchema = z.object({
+      Properties: z.object({
+        ResponseType: z.string(),
+        ResponseParameters: z.record(z.string(), z.string()).optional(),
+      }),
+    });
+    const parsed = responses.map((r) => ResponseSchema.parse(r).Properties);
+    const withExpose = parsed.filter((props) => props.ResponseParameters?.[
+      'gatewayresponse.header.Access-Control-Expose-Headers'
+    ]);
+    expect(withExpose.length, 'no gateway response publishes an expose list')
+      .toBeGreaterThan(0);
+
+    for (const props of withExpose) {
+      const raw = props.ResponseParameters?.[
+        'gatewayresponse.header.Access-Control-Expose-Headers'
+      ] as string;
+      const exposed = new Set(
+        raw.replace(/^'|'$/g, '').split(',').map((h) => h.trim().toLowerCase()),
+      );
+      for (const header of declared) {
+        expect(
+          exposed,
+          `${header} is exposed by the handler but not by the ${props.ResponseType} response`,
+        ).toContain(header.toLowerCase());
+      }
+    }
+  });
+
+  it('tells a cache the authorizer 401 varies by credential', () => {
+    // The 401 is the most credential-dependent answer this API gives, and the
+    // authorizer produces it — so the `Vary` the handler sends never reaches it.
+    // Without this, an intermediary could cache that refusal against the endpoint
+    // alone and serve it to a request carrying a perfectly good credential.
+    const responses = Object.values(
+      apiTemplate().findResources('AWS::ApiGateway::GatewayResponse'),
+    );
+    const ResponseSchema = z.object({
+      Properties: z.object({
+        ResponseType: z.string(),
+        ResponseParameters: z.record(z.string(), z.string()).optional(),
+      }),
+    });
+    const unauthorized = responses
+      .map((r) => ResponseSchema.parse(r).Properties)
+      .filter((props) => props.ResponseType === 'UNAUTHORIZED');
+
+    expect(unauthorized.length, 'no UNAUTHORIZED gateway response in the template')
+      .toBe(1);
+    const vary = unauthorized[0].ResponseParameters?.['gatewayresponse.header.Vary'];
+    expect(vary, 'the UNAUTHORIZED response sends no Vary').toBeDefined();
+    expect((vary ?? '').toLowerCase()).toContain('authorization');
+  });
 });
 
 describe('unauthorized gateway response', () => {
@@ -1396,6 +1478,13 @@ describe('unauthorized gateway response', () => {
     expect(unauthorized, 'no UNAUTHORIZED gateway response in the template').toBeDefined();
     const params = unauthorized?.ResponseParameters ?? {};
     expect(params['gatewayresponse.header.WWW-Authenticate']).toBe('\'Bearer error="invalid_token"\'');
-    expect(params['gatewayresponse.header.Access-Control-Expose-Headers']).toBe("'WWW-Authenticate'");
+    // The challenge must be READABLE, which is the property this line is about —
+    // asserted as membership rather than as the whole list, because the list also
+    // carries `Content-Type` and `Vary` and pinning it exactly made this test fail
+    // when an unrelated header was exposed. 'mcp transport headers reach a browser'
+    // owns the completeness of the list; this owns the challenge being in it.
+    const exposed = (params['gatewayresponse.header.Access-Control-Expose-Headers'] ?? '')
+      .replace(/^'|'$/g, '').split(',').map((h) => h.trim().toLowerCase());
+    expect(exposed).toContain('www-authenticate');
   });
 });

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1272,6 +1272,108 @@ describe('mcp endpoint throttling', () => {
 });
 
 
+describe('mcp transport headers reach a browser', () => {
+  // `mcp_handler.py` reads and VALIDATES three transport headers, and a browser's
+  // preflight on this API is answered by API Gateway's generated OPTIONS mock —
+  // not by the handler. So the handler allowing them in its own CORS response is
+  // not enough: omitted from the gateway's list, a browser-based client that sends
+  // `MCP-Protocol-Version` is blocked by its own preflight before the Lambda ever
+  // sees the request, and the server ends up enforcing a rule against a header no
+  // browser can deliver.
+  //
+  // Read out of the PYTHON source rather than re-listed here, which is this repo's
+  // convention for a contract two languages have to agree on (see the
+  // MCP_TOKEN_PK test above): a header added to the handler and not to the gateway
+  // fails here instead of at a browser.
+  const pythonTransportHeaders = (): string[] => {
+    const source = readRepoFile('lambda', 'api', 'mcp_handler.py');
+    const block = source.match(/TRANSPORT_HEADERS:\s*tuple\[str, \.\.\.\]\s*=\s*\(([^)]*)\)/)?.[1];
+    expect(block, 'could not read TRANSPORT_HEADERS from mcp_handler.py').toBeDefined();
+    // The tuple holds the NAMED constants, so resolve each to its literal.
+    const names = [...(block ?? '').matchAll(/([A-Z_]+),/g)].map((m) => m[1]);
+    expect(names.length, 'TRANSPORT_HEADERS looks empty').toBeGreaterThan(0);
+    return names.map((name) => {
+      const value = source.match(new RegExp(`^${name} = '([^']+)'`, 'm'))?.[1];
+      expect(value, `could not resolve ${name} in mcp_handler.py`).toBeDefined();
+      return value as string;
+    });
+  };
+
+  /** The allow-list the generated OPTIONS mock actually publishes. */
+  const preflightAllowHeaders = (): string[] => {
+    const methods = Object.values(apiTemplate().findResources('AWS::ApiGateway::Method'));
+    const MethodSchema = z.object({
+      Properties: z.object({
+        HttpMethod: z.string(),
+        Integration: z.object({
+          IntegrationResponses: z.array(z.object({
+            ResponseParameters: z.record(z.string(), z.string()).optional(),
+          })).optional(),
+        }).optional(),
+      }),
+    });
+    for (const method of methods) {
+      const props = MethodSchema.parse(method).Properties;
+      if (props.HttpMethod !== 'OPTIONS') continue;
+      for (const response of props.Integration?.IntegrationResponses ?? []) {
+        const raw = response.ResponseParameters?.[
+          'method.response.header.Access-Control-Allow-Headers'
+        ];
+        if (raw) return raw.replace(/^'|'$/g, '').split(',');
+      }
+    }
+    throw new Error('no generated OPTIONS method published an Allow-Headers list');
+  };
+
+  it('allows every header the handler validates through the preflight', () => {
+    const allowed = new Set(preflightAllowHeaders().map((h) => h.trim().toLowerCase()));
+    const declared = pythonTransportHeaders();
+
+    // Positive control: a regex that silently matched nothing would make the
+    // subset assertion below vacuously true.
+    expect(declared.length).toBeGreaterThanOrEqual(3);
+    for (const header of declared) {
+      // Case-insensitively, because CORS header matching is — the handler reads
+      // the lowercase form API Gateway delivers, the gateway publishes the wire
+      // spelling, and both must name the same header.
+      expect(allowed, `${header} is validated by the handler but blocked by the preflight`)
+        .toContain(header.toLowerCase());
+    }
+  });
+
+  it('allows them on the gateway error responses too', () => {
+    // A 4XX/5XX from the gateway itself carries its own CORS headers, and a
+    // browser that cannot read the error sees a network failure instead of the
+    // 401 or 400 the server actually sent.
+    const responses = Object.values(
+      apiTemplate().findResources('AWS::ApiGateway::GatewayResponse'),
+    );
+    const ResponseSchema = z.object({
+      Properties: z.object({
+        ResponseType: z.string(),
+        ResponseParameters: z.record(z.string(), z.string()).optional(),
+      }),
+    });
+    const declared = pythonTransportHeaders().map((h) => h.toLowerCase());
+    const parsed = responses.map((r) => ResponseSchema.parse(r).Properties);
+    expect(parsed.length, 'no gateway responses in the template').toBeGreaterThan(0);
+
+    for (const props of parsed) {
+      const raw = props.ResponseParameters?.[
+        'gatewayresponse.header.Access-Control-Allow-Headers'
+      ];
+      if (!raw) continue;
+      const allowed = new Set(
+        raw.replace(/^'|'$/g, '').split(',').map((h) => h.trim().toLowerCase()),
+      );
+      for (const header of declared) {
+        expect(allowed, `${header} missing from the ${props.ResponseType} response`)
+          .toContain(header);
+      }
+    }
+  });
+});
+
 describe('unauthorized gateway response', () => {
   // The ONLY place a REST API can emit a true WWW-Authenticate on a 401:
   // Lambda-proxy responses have the header unconditionally remapped to

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -1290,8 +1290,24 @@ describe('mcp transport headers reach a browser', () => {
     const block = source.match(/TRANSPORT_HEADERS:\s*tuple\[str, \.\.\.\]\s*=\s*\(([^)]*)\)/)?.[1];
     expect(block, 'could not read TRANSPORT_HEADERS from mcp_handler.py').toBeDefined();
     // The tuple holds the NAMED constants, so resolve each to its literal.
-    const names = [...(block ?? '').matchAll(/([A-Z_]+),/g)].map((m) => m[1]);
+    //
+    // The trailing comma is NOT required by the match, and that matters: requiring it
+    // meant a tuple written without one silently lost its LAST entry, and a partial
+    // parse fails in the permissive direction — fewer headers checked, with nothing
+    // saying so, guarded only by the `>= 3` control below. The recovered count is
+    // cross-checked against the declaration lines so a drifted parse fails outright.
+    const entryLines = (block ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('#'));
+    const names = [...(block ?? '').matchAll(/([A-Z_]+)\s*,?/g)].map((m) => m[1]);
     expect(names.length, 'TRANSPORT_HEADERS looks empty').toBeGreaterThan(0);
+    expect(
+      names.length,
+      `recovered ${names.length} names from ${entryLines.length} declaration lines in `
+      + 'TRANSPORT_HEADERS: the regex and the Python literal have drifted. Keep one '
+      + 'named constant per line, or update this parse.',
+    ).toBe(entryLines.length);
     return names.map((name) => {
       const value = source.match(new RegExp(`^${name} = '([^']+)'`, 'm'))?.[1];
       expect(value, `could not resolve ${name} in mcp_handler.py`).toBeDefined();
@@ -1383,6 +1399,12 @@ describe('mcp transport headers reach a browser', () => {
   // handler's own responses carry ITS expose list and gateway-GENERATED ones (the
   // authorizer's 401) carry the template's, so a header exposed by one and not the
   // other is readable on some of this endpoint's answers and not others.
+  //
+  // ⚠️ This parse reads a single-quoted STRING LITERAL, so it breaks if that value is
+  // ever rewritten as a `','.join((...))` expression the way `Access-Control-Allow-
+  // Headers` above it already is — which is the likelier of the two ways to break it,
+  // because making the two neighbouring keys consistent is an obvious tidy-up. The
+  // Python declaration carries a note saying so.
   const pythonExposeHeaders = (): string[] => {
     const source = readRepoFile('lambda', 'api', 'mcp_handler.py');
     const value = source.match(
@@ -1396,7 +1418,10 @@ describe('mcp transport headers reach a browser', () => {
   it('exposes every response header the handler expects a browser to read', () => {
     const declared = pythonExposeHeaders();
     // Positive control: a regex that matched nothing would make the loop vacuous.
+    // Both of the non-safelisted headers the handler adds are named, so a parse that
+    // recovered only part of the list fails here rather than checking less.
     expect(declared.map((h) => h.toLowerCase())).toContain('vary');
+    expect(declared.map((h) => h.toLowerCase())).toContain('allow');
 
     const responses = Object.values(
       apiTemplate().findResources('AWS::ApiGateway::GatewayResponse'),

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -68,6 +68,27 @@ const CORS_ALLOW_HEADERS = [
  */
 const CORS_ALLOW_HEADERS_VALUE = `'${CORS_ALLOW_HEADERS.join(',')}'`;
 
+/**
+ * Response headers a browser-based client is allowed to READ.
+ *
+ * Neither of these is CORS-safelisted, so without this list a browser receives them
+ * and hides them from the page — the failure `WWW-Authenticate` already documents.
+ * `Vary` joins it because `mcp_handler.py` now sends `Vary: Authorization` on every
+ * response (its answers depend on the credential), and a header stating that fact
+ * which the client cannot read states it to nobody.
+ *
+ * `Content-Type` stays because the frontend reads it.
+ *
+ * Kept in lockstep with `mcp_handler.CORS_HEADERS['Access-Control-Expose-Headers']`
+ * by 'mcp transport headers reach a browser' in api-stack.test.ts: the handler's own
+ * responses carry its list and gateway-GENERATED ones carry this, so a header
+ * exposed by one and not the other is readable on some answers and not others.
+ */
+const CORS_EXPOSE_HEADERS = ['Content-Type', 'WWW-Authenticate', 'Vary'];
+
+/** The same list in the single-quoted form an API Gateway response header takes. */
+const CORS_EXPOSE_HEADERS_VALUE = `'${CORS_EXPOSE_HEADERS.join(',')}'`;
+
 export interface VocApiStackProps extends VocStackProps {
   // Core stack resources
   feedbackTable: dynamodb.Table;
@@ -1074,7 +1095,7 @@ export class VocApiStack extends VocStack {
         allowOrigins: apigateway.Cors.ALL_ORIGINS,
         allowMethods: apigateway.Cors.ALL_METHODS,
         allowHeaders: CORS_ALLOW_HEADERS,
-        exposeHeaders: ['Content-Type'],
+        exposeHeaders: CORS_EXPOSE_HEADERS,
       },
       cloudWatchRoleRemovalPolicy: cdk.RemovalPolicy.DESTROY
     });
@@ -1109,7 +1130,13 @@ export class VocApiStack extends VocStack {
         'Access-Control-Allow-Headers': CORS_ALLOW_HEADERS_VALUE,
         'Access-Control-Allow-Methods': "'GET,POST,PUT,DELETE,OPTIONS'",
         'WWW-Authenticate': '\'Bearer error="invalid_token"\'',
-        'Access-Control-Expose-Headers': "'WWW-Authenticate'",
+        'Access-Control-Expose-Headers': CORS_EXPOSE_HEADERS_VALUE,
+        // A 401 is the most credential-dependent answer this API gives, and it is
+        // produced by the authorizer rather than by the Lambda — so the `Vary`
+        // mcp_handler sends on its own responses does not reach it. Without this, an
+        // intermediary could cache the authorizer's 401 against the endpoint alone
+        // and serve it to a request carrying a perfectly good credential.
+        'Vary': "'Authorization'",
       },
     });
 

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -71,11 +71,16 @@ const CORS_ALLOW_HEADERS_VALUE = `'${CORS_ALLOW_HEADERS.join(',')}'`;
 /**
  * Response headers a browser-based client is allowed to READ.
  *
- * Neither of these is CORS-safelisted, so without this list a browser receives them
+ * None of these is CORS-safelisted, so without this list a browser receives them
  * and hides them from the page — the failure `WWW-Authenticate` already documents.
  * `Vary` joins it because `mcp_handler.py` now sends `Vary: Authorization` on every
  * response (its answers depend on the credential), and a header stating that fact
  * which the client cannot read states it to nobody.
+ *
+ * `Allow` is the same failure on the header that says what to RETRY WITH: the handler
+ * attaches it to every 405 and resolves it per resource, so a `DELETE` on the
+ * autoseed path is told `GET` rather than `POST` — and a browser-based client
+ * received the refusal with that instruction stripped out.
  *
  * `Content-Type` stays because the frontend reads it.
  *
@@ -84,7 +89,7 @@ const CORS_ALLOW_HEADERS_VALUE = `'${CORS_ALLOW_HEADERS.join(',')}'`;
  * responses carry its list and gateway-GENERATED ones carry this, so a header
  * exposed by one and not the other is readable on some answers and not others.
  */
-const CORS_EXPOSE_HEADERS = ['Content-Type', 'WWW-Authenticate', 'Vary'];
+const CORS_EXPOSE_HEADERS = ['Content-Type', 'WWW-Authenticate', 'Vary', 'Allow'];
 
 /** The same list in the single-quoted form an API Gateway response header takes. */
 const CORS_EXPOSE_HEADERS_VALUE = `'${CORS_EXPOSE_HEADERS.join(',')}'`;

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -24,6 +24,50 @@ import { PY_LAMBDA_ASSET_EXCLUDES } from '../utils/lambda-asset-excludes';
 import { VocStack, VocStackProps } from '../utils/voc-stack';
 import { SOURCE_PLACEHOLDER } from '../utils/naming';
 
+/**
+ * The MCP transport headers a browser-based client may send.
+ *
+ * These are read and VALIDATED by `mcp_handler.py` (`TRANSPORT_HEADERS` there),
+ * and a browser's preflight on this API is answered by API Gateway's generated
+ * OPTIONS mock rather than by the Lambda — so the handler allowing them in its own
+ * CORS response was not enough. Omitted here, a browser-based client that sends
+ * `MCP-Protocol-Version` was blocked by its own preflight before the handler ever
+ * saw the request: a rule the server enforces against a header no browser could
+ * deliver.
+ *
+ * Spelled the way the spec spells them (`Mcp-Method`, not `MCP-Method`). CORS
+ * header matching is case-insensitive, so this is about agreeing with the spec
+ * rather than about function.
+ *
+ * Kept in lockstep with the Python constant by 'mcp transport headers' in
+ * api-stack.test.ts, which reads `TRANSPORT_HEADERS` out of the handler source —
+ * the same cross-language pattern the `MCP_TOKEN_PK` test already uses.
+ */
+const MCP_TRANSPORT_HEADERS = ['MCP-Protocol-Version', 'Mcp-Method', 'Mcp-Name'];
+
+/**
+ * Every header this API accepts on a cross-origin request, declared ONCE.
+ *
+ * The list was previously written out four times — the preflight options plus
+ * three gateway responses — which is how a header comes to be allowed on the
+ * preflight and refused on the error path, or vice versa. The string form below is
+ * derived from this array rather than typed again.
+ */
+const CORS_ALLOW_HEADERS = [
+  'Content-Type',
+  'Authorization',
+  'X-Requested-With',
+  'X-Amz-Date',
+  'X-Amz-Security-Token',
+  ...MCP_TRANSPORT_HEADERS,
+];
+
+/**
+ * The same list in the single-quoted form an API Gateway response header takes.
+ * Derived, so the four places that state it cannot disagree.
+ */
+const CORS_ALLOW_HEADERS_VALUE = `'${CORS_ALLOW_HEADERS.join(',')}'`;
+
 export interface VocApiStackProps extends VocStackProps {
   // Core stack resources
   feedbackTable: dynamodb.Table;
@@ -1029,7 +1073,7 @@ export class VocApiStack extends VocStack {
       defaultCorsPreflightOptions: {
         allowOrigins: apigateway.Cors.ALL_ORIGINS,
         allowMethods: apigateway.Cors.ALL_METHODS,
-        allowHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Amz-Date', 'X-Amz-Security-Token'],
+        allowHeaders: CORS_ALLOW_HEADERS,
         exposeHeaders: ['Content-Type'],
       },
       cloudWatchRoleRemovalPolicy: cdk.RemovalPolicy.DESTROY
@@ -1040,11 +1084,11 @@ export class VocApiStack extends VocStack {
     // Gateway responses for CORS on errors
     this.api.addGatewayResponse('Default4XX', {
       type: apigateway.ResponseType.DEFAULT_4XX,
-      responseHeaders: { 'Access-Control-Allow-Origin': "'*'", 'Access-Control-Allow-Headers': "'Content-Type,Authorization,X-Requested-With,X-Amz-Date,X-Amz-Security-Token'", 'Access-Control-Allow-Methods': "'GET,POST,PUT,DELETE,OPTIONS'" },
+      responseHeaders: { 'Access-Control-Allow-Origin': "'*'", 'Access-Control-Allow-Headers': CORS_ALLOW_HEADERS_VALUE, 'Access-Control-Allow-Methods': "'GET,POST,PUT,DELETE,OPTIONS'" },
     });
     this.api.addGatewayResponse('Default5XX', {
       type: apigateway.ResponseType.DEFAULT_5XX,
-      responseHeaders: { 'Access-Control-Allow-Origin': "'*'", 'Access-Control-Allow-Headers': "'Content-Type,Authorization,X-Requested-With,X-Amz-Date,X-Amz-Security-Token'", 'Access-Control-Allow-Methods': "'GET,POST,PUT,DELETE,OPTIONS'" },
+      responseHeaders: { 'Access-Control-Allow-Origin': "'*'", 'Access-Control-Allow-Headers': CORS_ALLOW_HEADERS_VALUE, 'Access-Control-Allow-Methods': "'GET,POST,PUT,DELETE,OPTIONS'" },
     });
     // API-WIDE, deliberately: this fires on every gateway-GENERATED 401 —
     // the MCP token authorizer refusing a malformed Bearer shape, AND the
@@ -1062,7 +1106,7 @@ export class VocApiStack extends VocStack {
       type: apigateway.ResponseType.UNAUTHORIZED,
       responseHeaders: {
         'Access-Control-Allow-Origin': "'*'",
-        'Access-Control-Allow-Headers': "'Content-Type,Authorization,X-Requested-With,X-Amz-Date,X-Amz-Security-Token'",
+        'Access-Control-Allow-Headers': CORS_ALLOW_HEADERS_VALUE,
         'Access-Control-Allow-Methods': "'GET,POST,PUT,DELETE,OPTIONS'",
         'WWW-Authenticate': '\'Bearer error="invalid_token"\'',
         'Access-Control-Expose-Headers': "'WWW-Authenticate'",

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -2,7 +2,7 @@
   "description": "Fingerprint of the no-prefix synth. Regenerate with npx ts-node scripts/generate-baseline.ts ONLY for a change intended to alter the default templates — see the script header.",
   "stacks": {
     "VocApiStack": {
-      "templateSha256": "117cef1eb39cc38f0d9e3c879467d5ebc8d944fbbcd0677182bab3e755352669",
+      "templateSha256": "a00125b93493d1621846aed712c98be65739d4b7a68ad79f0bb941b9bd2fc007",
       "names": {
         "physicalNames": [
           "AWS::ApiGateway::Authorizer Name = voc-cognito-authorizer",

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -2,7 +2,7 @@
   "description": "Fingerprint of the no-prefix synth. Regenerate with npx ts-node scripts/generate-baseline.ts ONLY for a change intended to alter the default templates — see the script header.",
   "stacks": {
     "VocApiStack": {
-      "templateSha256": "f53984a9d025c77ca9889b3b288a6303ae1ba823ea8496db90d3d4b485e204e1",
+      "templateSha256": "22d45c8b7d4116f5acf9ff0d6820862ed7c519f5a43a4ef56102f2aa23ed8e7e",
       "names": {
         "physicalNames": [
           "AWS::ApiGateway::Authorizer Name = voc-cognito-authorizer",

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -2,7 +2,7 @@
   "description": "Fingerprint of the no-prefix synth. Regenerate with npx ts-node scripts/generate-baseline.ts ONLY for a change intended to alter the default templates — see the script header.",
   "stacks": {
     "VocApiStack": {
-      "templateSha256": "22d45c8b7d4116f5acf9ff0d6820862ed7c519f5a43a4ef56102f2aa23ed8e7e",
+      "templateSha256": "117cef1eb39cc38f0d9e3c879467d5ebc8d944fbbcd0677182bab3e755352669",
       "names": {
         "physicalNames": [
           "AWS::ApiGateway::Authorizer Name = voc-cognito-authorizer",


### PR DESCRIPTION
Phase 2b of the MCP plan. Phase 2a (#355) moved what the tools READ — every tool
delegates to the route that owns its data. This is the envelope around those
tools, deliberately a separate change because the two review on different terms:
one is about data correctness, this one is about protocol conformance.

The comment above `MCP_PROTOCOL_VERSION` already named every piece of this as the
owed next step, and said why bumping the version alone would have been dishonest.

## What changed

**Version negotiation, and `server/discover`.** `SUPPORTED_PROTOCOL_VERSIONS`
replaces the pinned string with the three revisions the spec covers, ordered
newest first. `initialize` answers with the client's version when this server
implements it and the newest one otherwise — a counter-offer rather than a refusal,
because `initialize` is where a client learns what it is talking to and an error
there leaves it nothing to fall back to. The `MCP-Protocol-Version` HEADER is
stricter and refuses an unsupported value: by then the handshake has happened, so
a version this server never offered can only be a client contradicting itself.

`server/discover` reports the revisions, the methods, the transport headers, the
`resultType` vocabulary and the cost classes — every list derived from the registry
that implements the thing, so a method that exists is listed and one that is only
listed cannot exist. It is unauthenticated (it names no project, no tool, no data)
and deliberately does not list tools, because that answer is credential-shaped.

**`resultType` on every result.** Built into `_jsonrpc_result` as a REQUIRED
positional argument, which is the design: a new result shape cannot ship without
naming itself. `{}` was both a `ping` answer and a notification ack; a tool error
differed from a tool result by one boolean and by whether `structuredContent`
happened to be present. An AST test fails the moment a seventh JSON-RPC envelope
is hand-rolled outside the two builders, so the property belongs to the module
rather than to the six call sites somebody remembered.

**Transport-header validation**, including the `=?base64?...?=` encoded-word
sentinel form. A malformed sentinel is refused with the ENCODING named — comparing
it literally would report `unsupported version =?base64?...?=` and send the caller
after a version number for a fault in the encoding. `MCP-Method` and `MCP-Name`
are routing echoes, so they can DISAGREE with the body; a disagreement is refused
rather than resolved in either direction, because one hop routes on the header
while the next acts on the body and there is no way to know which was meant.
Validation runs before authentication, so a malformed request buys no probe of the
token store — the same property the Origin guard has. (The Origin guard itself was
already correct and is unchanged; it now also covers the new method, asserted.)

**The shapes that were wrong or missing.** An unknown method is `-32601` and a
non-object body no longer reaches `.get` on a list. `GET` and `DELETE` — the two
Streamable HTTP transport methods this server does not implement — answer 405 with
an `Allow` header derived from the CORS declaration, so a preflight and a refusal
cannot disagree about the same endpoint. The autoseed `GET` route is unaffected
and pinned as such.

**Tool annotations and a cost class.** Every published tool gains
`annotations` (title plus the four behaviour hints — all read-only here, which is
what stops a client prompting for a read as though it were a write) and
a cost class under `_meta`'s vendor-namespaced key
(`com.amazonaws.voc-datalake/costClass`). The class is about the SHAPE of the read:
one keyed read, one Query, or a soft-capped candidate scan. `search_feedback` is the
expensive one, and a test pins that the expensive class is exactly the tool whose
output schema REQUIRES `is_partial` — truncation is the same fact surfacing at
answer time. The `required` list is the load-bearing half of that: another tool
publishes `is_partial` as a property, and REQUIRING it is what says "this read can
stop early". The cost table REFUSES to publish a tool with no class rather than
defaulting it to `cheap`.

**`tools/list` filtered by the authorization presented**, sorted by name, with its
own cache hints. Every caller used to see every tool regardless of scopes: a
`metrics:read` credential was shown `search_feedback`, called it, and got `-32003`.
A test drives every tool through the dispatch and asserts listed-ness and
callability agree in BOTH directions. Telling caches the list varies per credential
is the load-bearing part — a shared cache keyed on the endpoint alone would serve
one token's catalogue to another, which only became possible the moment the list
started varying. It is stated in two places: `cacheScope: private` in the payload
(the spec's own vocabulary, which replaced an earlier local `scope: credential`
spelling), and `Vary: Authorization` plus `Cache-Control: private` on the response,
which is the half an intermediary actually reads — a payload no cache parses cannot
protect a catalogue.

**The honesty defect.** A revoked or expired credential completed the whole
handshake and failed only at the first `tools/call`, so a dead token presented as a
connected server and sent whoever was debugging at the tools, the scopes and the
routes. A PRESENTED credential is now checked on the unauthenticated methods too,
and the refusal says the credential is the problem. An ABSENT credential still
initializes — that is how a client learns what to present — and a token-store fault
is still a 500 rather than "your token is invalid".

⚠️ That last sentence is true of this HANDLER and not of the deployed endpoint, and
the distinction is worth stating rather than discovering: `McpTokenAuthorizer` reads
`method.request.header.Authorization`, so API Gateway answers 401 before this Lambda
runs when the header is absent. Live, a credential-less `initialize` — and
`server/discover`, and the 405, and the parse error — never reach the code that
implements them. It fails CLOSED, so it is not a hole, and it is not introduced
here; but a client cannot currently use either method to learn what to present.
Whether to open a route for them is a security decision for the endpoint's owner,
so it is left out of this change and recorded in the deferred list below.

## ⚠️ Connected clients must reconnect

`MCP_SERVER_VERSION` 3.1.0 → **3.6.0** (this description first said 3.2.0; the
review rounds bumped it four more times, and the number a client checks has to be
the one that ships), with the published-shape fingerprint moved in
the same commit as the convention in `test_mcp_delegation.py` requires. The
fingerprint now covers the WHOLE published declaration rather than only
`outputSchema`: a client caches the entire entry at connect, so `inputSchema`,
`annotations` and `_meta` are as much of that cached contract as the output shape,
and fingerprinting only the output half let this very change move what clients
cache without moving the number that tells them to re-fetch it.

No declared output shape moved, so a client validating `structuredContent` is
unaffected. But the schemas carry `additionalProperties: false`, a client validates
against the `tools/list` it cached when it connected, and `tools.listChanged` is
`false` — there is no notification path. A session that predates this deploy holds
a catalogue with no annotations and no cost classes and will not be told. Reconnect
after deploying.

## Deliberately not in this change

Retiring the catch-all `/mcp/{proxy+}` route, which is part of the same phase in
the plan. Autoseed rides that route, so removing it in the same change that adds
the explicit autoseed route would refuse autoseed between the two deploys. That
sequencing needs two deploys, and leaving the proxy in place keeps this change
deployable in one step.

Opening a gateway route for the pre-handshake methods, per the caveat above. The
authorizer is attached to both the explicit `POST` and the catch-all proxy, so this
belongs with the proxy retirement rather than ahead of it — and letting a method
through an authorizer is a security-surface change that wants its own review, not a
line in a change about the envelope.

No IAM change: nothing here needs a new permission, so the inline-policy character
budget the size test measures is untouched.

## Build and test results

| Command | Result |
|---|---|
| `pytest lambda` (backend) | **2 924 passed**, 14 pre-existing failures in `lambda/shared/test/test_http.py` (`module 'shared' has no attribute 'http_utils'` — fails identically on `development`, unrelated) |
| `pytest lambda/api` | **1 883 passed**, 0 failed |
| `pytest lambda/api/test/test_mcp_*.py` | **369 passed** (124 of them new) |
| `npx vitest run` (CDK, 17 files) | **275 passed** |
| `npx tsc --noEmit` (CDK typecheck) | clean |
| `ruff check lambda plugins` | 507 findings, **identical count to `development`** — my files add none (verified by stashing). With the rule set `ruff.toml` documents (`F,E4,E7,E9`): 4 findings, identical to `development`, none in changed files. |
| `npm run build` (frontend) | **FAILS on `development` too** — `Rollup failed to resolve import "js-cookie" from @aws-amplify/core`, a dependency-resolution problem in this container. No frontend file is touched by this change. |

Mutation-checked rather than assumed. Reverting each behaviour fails specific
tests: pinning the negotiated version (2 fail), removing the header validation,
unfiltering `tools/list`, and deleting the dead-credential check (35 fail
together); dropping the `_published_tool` wrapper or the `resultType` injection
(17 fail).

## Decisions worth flagging

- **The counter-offer on `initialize` vs. the refusal on the header** is the one
  asymmetry a reviewer might read as an inconsistency. Reasoning is in the
  docstrings: before the handshake a client has nothing to fall back to; after it,
  a version this server never offered is the client contradicting itself.
- **A `workspace`-reach token with an empty project set still sees the project
  tools.** Workspace reach is not bounded by the set (pinned on the dispatch side
  by `test_workspace_token_reads_a_project_outside_its_own_set`), so hiding them
  would hide tools the dispatch allows. The listing asks a project-shaped question
  with no project in hand, and `_ANY_PROJECT` is the stand-in — only ever reached
  under workspace reach, which does not consult the id.
- **`_meta` rather than a top-level field for the cost class**, because it is the
  spec's own extension point: a client that does not know `costClass` ignores
  `_meta` wholesale rather than failing to validate a tool declaration carrying a
  field its schema does not define.
- **The `Allow` header is derived from the CORS declaration**, not written out
  again. Two hand-written lists is how a preflight and a 405 come to disagree.
- **Tests parse structure rather than grep source** where they can: the
  no-hand-rolled-envelope check walks the AST (a substring search cannot tell code
  from a comment about code), the `Allow` header is split into methods rather than
  substring-searched, and the version-order test asserts a property of the values
  rather than restating the list.

Link to issue: none — this is the second half of the phase begun in #355, which
named it in the handler comment rather than in an issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

## Agent notes

**What went well.** The handler had already written down what this change should
be — the comment above `MCP_PROTOCOL_VERSION` named the three versions,
`server/discover`, `resultType` and header validation, and explained why shipping
the version bump without them would be a lie. That made the scope unambiguous and
meant the hardest question (what does "conformance" mean here) was already
answered by the person who deferred it.

**What was difficult.** Two things. First, deciding where the strictness belongs:
negotiation and header validation look like the same check but need opposite
answers, and getting that wrong in either direction breaks real clients. Second,
the `tools/list` filter needs to answer a per-call question (reach) without the
per-call argument (which project), and the honest bound is weaker than the dispatch's
— stating that in the docstring rather than pretending the two are the same took
longer than the code.

**Conventions discovered.**
- Comments here carry ARGUMENT, not description. A block explains what the previous
  implementation was, why it was wrong, and which test fails if it comes back. Diffs
  that only describe behaviour would look out of place.
- Every declaration is checked against the thing it declares, by a test that fails
  when they drift: the persona schema is read from `schemas/persona.schema.json`, the
  reserved path segments are derived from the owning handlers' decorators, the IAM
  grant is read from the Python constant by a vitest. "Lockstep" is the local word.
- Tests state a REVERT STORY in the module docstring — which mutation makes each
  assertion fail — and every subset assertion carries a positive control against
  going vacuous. I followed both.
- Fingerprint-plus-version tests are the pattern for anything that leaves the
  account, and the failing assertion prints the new value so the fix is mechanical.
- `_meta` is the extension point of choice for non-standard fields.
- Fail-closed is the default everywhere, and the comments say so explicitly when a
  `.get(x, default)` would have been the permissive reading.

**Suggestions for future tasks here.**
- The container's Python venv and frontend `node_modules` are absent on arrival.
  `uv venv && uv pip install -r requirements-dev.txt` plus `aws-xray-sdk` and
  `pydantic` gets the backend suite green in about a minute; `npm install` at the
  repo root and in `voc-datalake/` gets vitest running. The CDK suite additionally
  needs `voc-datalake/frontend/dist/` to exist (any file) or 43 of its 51 cases fail
  on `CannotFindAsset` — worth creating before concluding anything is broken.
- `mise run build` is not defined in this repo; `npm run build` is the frontend
  build and it fails on `development` in this container for dependency reasons. Check
  the base branch before attributing a build failure to a change.
- The proxy-route retirement is the remaining piece of this phase and is genuinely
  two deploys: add the explicit autoseed route, deploy, then remove the catch-all.
  The repo has a precedent for staging such a removal behind a flag
  (`skipFeedbackFormItemRoutes` in `api-stack.ts`), which is the shape to copy.
- `test_mcp_security.py` is 2 400 lines and `test_mcp_delegation.py` 1 665. The
  third file added here follows the same split by SUBJECT (credential / data /
  envelope) rather than by size; keep adding subjects rather than growing one file.
