### PR TITLE
docs(readme): add a Running the Tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ See [Deployment Guide](docs/deployment.md) for detailed instructions.
 
 ```bash
 npm run install:all   # once, installs root + CDK + frontend dependencies
-npm test              # frontend Vitest suite
+npm run test          # frontend Vitest suite
 ```
 
 Other suites live behind their own scripts: `npm run test:cdk` (CDK),
 `npm run test:stream` (streaming chat Lambda), and `npm run test:backend`
-(Python pytest). `npm run check` runs lint, typecheck, and all four suites —
-the gate to run before opening a pull request. See
+(Python pytest — needs the Python venv, which `install:all` does not create;
+see the [Deployment Guide](docs/deployment.md#quality-checks)).
+`npm run check` runs the full quality gate before you open a pull request. See
 [Quality Checks](docs/deployment.md#quality-checks) for what each script covers.
 
 ## 🔐 Initial Login

--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ npm run deploy:all
 
 See [Deployment Guide](docs/deployment.md) for detailed instructions.
 
+## 🧪 Running the Tests
+
+```bash
+npm run install:all   # once, installs root + CDK + frontend dependencies
+npm test              # frontend Vitest suite
+```
+
+Other suites live behind their own scripts: `npm run test:cdk` (CDK),
+`npm run test:stream` (streaming chat Lambda), and `npm run test:backend`
+(Python pytest). `npm run check` runs lint, typecheck, and all four suites —
+the gate to run before opening a pull request. See
+[Quality Checks](docs/deployment.md#quality-checks) for what each script covers.
+
 ## 🔐 Initial Login
 
 After deployment, an initial admin user is created automatically:


### PR DESCRIPTION
## Summary

Adds a short `## 🧪 Running the Tests` section to the README, placed directly after the Quick Start (the existing development instructions) and before Initial Login.

The section names the two things a newcomer needs and previously had to dig out of `package.json`:

- `npm run install:all` — the install step (root + CDK + frontend)
- `npm test` — the test command (frontend Vitest)

It then points at the other three suites (`test:cdk`, `test:stream`, `test:backend`), at `npm run check` as the full pre-PR gate, and links to the existing [Quality Checks](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/docs/deployment.md#quality-checks) table rather than duplicating it. 13 lines added, README-only, no code touched.

## Build and test results

- `mise run build` — **not available**: `mise ERROR no tasks defined in /workspace/...`. This repo has no mise tasks; the task harness also reported the initial `mise run build` failing before any of my changes, so this is pre-existing and not caused by this PR.
- `npm run lint` — **fails, pre-existing and unrelated**: `sh: 1: eslint: not found` at the very first leg (`lint:frontend`). The frontend `node_modules` are not installed in this container, so ESLint cannot start. The harness likewise recorded lint failing before my changes. No JS/TS/Python file is touched by this PR, so lint coverage of this diff is vacuous either way.
- Targeted validation of the change instead, all passing:
  - Every script named in the new section verified to exist in the root `package.json` via `node -e` against `require('./package.json').scripts` — `install:all`, `test`, `test:cdk`, `test:stream`, `test:backend`, `check` all report `OK`.
  - The link target `docs/deployment.md` exists and contains a literal `## Quality Checks` heading (line 45), so the `#quality-checks` anchor resolves.
  - Rendered Markdown re-read after editing to confirm heading level, fence, and wrapping are consistent with the surrounding sections.

## Decisions made

- **Placement**: after Quick Start, since that is where the install command already appears and the task asked for "near the existing development instructions."
- **`npm test` over `npm run test`**: shorter and equivalent; the deployment doc uses `npm run test`, but the README is the welcoming surface.
- **Kept it to a few lines** as requested: the per-command breakdown already exists in `docs/deployment.md`, so I linked it rather than restating the table.
- **Did not claim CI runs `npm run check`.** My first draft said "the same gate CI uses"; the only workflow in `.github/workflows` is `no-event-logging-guard.yml`, whose own comment describes `npm run check` as the repo's *local* gate. Reworded to "the gate to run before opening a pull request."
- No verification block: this change has no web UI surface.

## Agent notes

**What went well**
- The repo is unusually well documented already — `docs/deployment.md` had an accurate per-script table, so the work was mostly about discoverability (surfacing two commands + a link) rather than writing new content. Linking beat duplicating.
- Script names were cheap to verify programmatically against `package.json`, which caught nothing but made the claims in the README trustworthy.

**What was difficult**
- Neither of the harness's standard gates is usable here: there are no mise tasks at all, and `npm run lint` dies immediately because frontend deps aren't installed. Both were already failing before my change, so I could not use them as a signal and validated the diff directly instead.
- Easy to overstate CI behaviour. The single workflow is a narrow guard test, *not* a general test run, and it explicitly notes that the real gate is local. Worth reading that comment before describing CI anywhere in docs.

**Conventions discovered**
- The root `package.json` is a thin orchestration layer: nearly every script delegates via `--prefix voc-datalake` / `--prefix voc-datalake/frontend`. Contributors should stay at the root.
- Four separate test suites (frontend Vitest, CDK Vitest, stream Lambda Vitest, Python pytest) — "the tests" is genuinely plural in this repo, which is exactly why the README needed this pointer.
- Python tooling expects the checked-in venv: `.venv/bin/python -m pytest` / `-m ruff`, not bare `pytest`.
- `npm run check` chains with `&&`, so the first failure masks all later legs — `docs/deployment.md` calls this out and it is good triage advice.
- README sections use an emoji prefix on every `##` heading; I matched that with 🧪.
- Commit and PR titles follow conventional commits with a required scope, and recent history commonly appends a `(#NNN)` issue reference.

**Suggestions for future tasks**
- Add a mise task or set `pipeline.buildCommand` in the blueprint so build-regression gating stops being inert; `npm run build` (frontend `tsc -b && vite build`) would be the natural choice.
- Container setup should run `npm run install:all` — without frontend `node_modules`, lint, typecheck, and the frontend test suite are all unrunnable.
- CONTRIBUTING.md says to work against the *main* branch, but the default branch is `development`. Worth fixing in a follow-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).