### PR TITLE
docs(contributing): point contributors at the development branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *development* branch. This is the branch that
-   integrates all incoming work, so both your branch point and your pull request base should be
-   *development*, not *main*.
+1. You are working against the latest source on the *development* branch, which is also the base for your pull request.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *main* branch.
+1. You are working against the latest source on the *development* branch. This is the branch that
+   integrates all incoming work, so both your branch point and your pull request base should be
+   *development*, not *main*.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -33,7 +35,7 @@ To send us a pull request, please:
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
+5. Send us a pull request targeting the *development* branch, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and


### PR DESCRIPTION
## Summary

**Task:** The CONTRIBUTING.md file tells contributors to work against the main branch, but the repository's default branch is development. A contributor following the document literally would open a pull request against the wrong base. Correcting the branch name in that document, and checking whether the same stale reference appears elsewhere in the docs, would remove the confusion.

### Commits

```
docs(contributing): point contributors at the development branch
CONTRIBUTING.md told contributors to work against `main`, but all
integration happens on `development`: it is 132 commits ahead of `main`
with `main` strictly behind, and the CI guard workflow gates pushes to
`development`. A contributor following the document literally would
branch from stale source and open the pull request against the wrong
base.

Name `development` as both the branch point and the pull request base.

Co-Authored-By: Claude <noreply@anthropic.com>

Task-Id: 01M0HWNM0F15EPY7E3A1G5KMSC
Prompt-Version: 1c9c10e027a2
---
```

## Verification

> ⚠️ **Build-regression gating is OFF for this repo.** No runnable `mise run build` task was found and no build command is configured, so a change that breaks the build still reports success. To enable gating, set `pipeline.buildCommand` in this repo's ABCA blueprint (e.g. `npm run build`).

- `mise run build` (post-agent): **PASS**
- `mise run lint` (post-agent): **FAIL**
- Agent cost: **$0.4673**

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).