### PR TITLE
fix(aggregator): reverse deletions and edits, sparing aged-out days

### DIFF
--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -1,6 +1,32 @@
 """
 VoC Aggregation Processor Lambda
-Updates real-time aggregates in DynamoDB when new feedback arrives via Streams.
+Updates real-time aggregates in DynamoDB as feedback is inserted, edited and
+deleted via Streams.
+
+Why REMOVE is handled two different ways
+----------------------------------------
+Two TTLs meet in this file, and they have different lengths:
+
+* the feedback table's items are stamped `ttl = now + 365 days`
+  (`processor/handler.py`), and the table has `timeToLiveAttribute: 'ttl'`
+  (`lib/stacks/core-stack.ts`). One year after ingestion DynamoDB deletes them
+  en masse, and every deletion arrives here as a REMOVE record;
+* the aggregate rows this Lambda writes expire after 90 days
+  (`ttl_days=90` below), refreshed on each write. The row for date D is
+  therefore gone around D+90 — long before the raw items of date D age out.
+
+So a REMOVE arriving from TTL expiry is a record about a date whose aggregate row
+no longer exists, and `if_not_exists(#field, :zero) + :inc` with `:inc = -1`
+would RECREATE that row holding `count = -1` and stamp it with a fresh 90-day
+TTL. A window query reaching back that far would then serve a negative count that
+no feedback ever justified. That failure only starts about a year after deploy,
+which is exactly why it has to be designed against rather than tested into.
+
+Hence: TTL expiry is not a correction (the feedback of 2026-01-15 really did
+arrive on 2026-01-15; garbage-collecting the raw item a year later does not
+change that daily total) and is skipped. A user-initiated delete IS a correction
+and decrements — under a condition that cannot create a row and cannot go below
+zero.
 """
 import os
 from datetime import datetime, timezone
@@ -8,6 +34,7 @@ from decimal import Decimal
 from typing import Any
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, batch_processor
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBRecord
+from botocore.exceptions import ClientError
 
 # Shared module imports
 from shared.logging import logger, tracer, metrics
@@ -32,10 +59,41 @@ def get_metric_type(pk: str) -> str | None:
     return None
 
 
+def _is_conditional_check_failure(error: Exception) -> bool:
+    """True for DynamoDB's ConditionalCheckFailedException, however it arrives.
+
+    The error CODE in the response is the dependable signal — boto3's resource
+    layer raises a dynamically-built ClientError subclass, so its type name is a
+    botocore implementation detail. The type name is checked as well because a
+    test double raises the named exception with no response payload. Same helper
+    shape as `product_doc_extractor/handler.py`.
+    """
+    response = getattr(error, 'response', None)
+    code = (response.get('Error') or {}).get('Code') if isinstance(response, dict) else None
+    return (code == 'ConditionalCheckFailedException'
+            or type(error).__name__ == 'ConditionalCheckFailedException')
+
+
 def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: int = 90):
-    """Atomically update a counter in the aggregates table."""
+    """Atomically update a counter in the aggregates table.
+
+    An increment may create the row (that is how a date's first item registers).
+    A DEcrement may not: it is guarded so that it applies only to a row that is
+    still there and still above zero. Two distinct failures are prevented, and
+    both would be invisible without the guard:
+
+    * a row that has already expired under its 90-day TTL has nothing left to
+      correct, and `if_not_exists(#field, :zero) + :inc` would happily resurrect
+      it holding a negative count with a fresh 90-day TTL;
+    * DynamoDB Streams deliver at-least-once, so the same REMOVE can arrive
+      twice; the floor at zero makes the second delivery a no-op rather than a
+      count of -1.
+
+    ConditionalCheckFailedException is therefore the expected, benign outcome of
+    a decrement with nothing to decrement, and is swallowed.
+    """
     ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
-    
+
     # Build update expression - include metric_type for GSI if applicable
     metric_type = get_metric_type(pk)
     update_expr = 'SET #field = if_not_exists(#field, :zero) + :inc, #ttl = :ttl, updated_at = :now'
@@ -46,104 +104,231 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
         ':ttl': ttl,
         ':now': datetime.now(timezone.utc).isoformat()
     }
-    
+
     if metric_type:
         update_expr += ', metric_type = :metric_type'
         attr_values[':metric_type'] = metric_type
-    
-    aggregates_table.update_item(
-        Key={'pk': pk, 'sk': sk},
-        UpdateExpression=update_expr,
-        ExpressionAttributeNames=attr_names,
-        ExpressionAttributeValues=attr_values
-    )
+
+    kwargs: dict[str, Any] = {}
+    if increment < 0:
+        kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #field >= :floor'
+        attr_values[':floor'] = -increment
+
+    try:
+        aggregates_table.update_item(
+            Key={'pk': pk, 'sk': sk},
+            UpdateExpression=update_expr,
+            ExpressionAttributeNames=attr_names,
+            ExpressionAttributeValues=attr_values,
+            **kwargs
+        )
+    except ClientError as e:
+        if increment >= 0 or not _is_conditional_check_failure(e):
+            raise
+        logger.info(f"Skipped decrement of {field} on {pk}/{sk}: nothing to correct")
 
 
-def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90):
-    """Update running average in aggregates table."""
+def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: int = 1):
+    """Update running average in aggregates table.
+
+    `sign=-1` reverses a previously recorded value (subtract from `sum`,
+    decrement `count`). It carries the same condition as a counter decrement,
+    for the same reason: an expired row must not be recreated holding
+    `count = -1`, and a redelivered REMOVE must not push `count` below zero.
+    """
     ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
-    
-    aggregates_table.update_item(
-        Key={'pk': pk, 'sk': sk},
-        UpdateExpression='''
-            SET #sum = if_not_exists(#sum, :zero) + :val,
-                #count = if_not_exists(#count, :zero) + :one,
-                #ttl = :ttl,
-                updated_at = :now
-        ''',
-        ExpressionAttributeNames={'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'},
-        ExpressionAttributeValues={
-            ':val': value,
-            ':one': 1,
-            ':zero': Decimal('0'),
-            ':ttl': ttl,
-            ':now': datetime.now(timezone.utc).isoformat()
-        }
+
+    attr_values: dict[str, Any] = {
+        ':val': value if sign > 0 else -value,
+        ':one': sign,
+        ':zero': Decimal('0'),
+        ':ttl': ttl,
+        ':now': datetime.now(timezone.utc).isoformat()
+    }
+
+    kwargs: dict[str, Any] = {}
+    if sign < 0:
+        # A distinct :floor rather than reusing :one, which is -1 here.
+        kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #count >= :floor'
+        attr_values[':floor'] = 1
+
+    try:
+        aggregates_table.update_item(
+            Key={'pk': pk, 'sk': sk},
+            UpdateExpression='''
+                SET #sum = if_not_exists(#sum, :zero) + :val,
+                    #count = if_not_exists(#count, :zero) + :one,
+                    #ttl = :ttl,
+                    updated_at = :now
+            ''',
+            ExpressionAttributeNames={'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'},
+            ExpressionAttributeValues=attr_values,
+            **kwargs
+        )
+    except ClientError as e:
+        if sign >= 0 or not _is_conditional_check_failure(e):
+            raise
+        logger.info(f"Skipped reversal of average on {pk}/{sk}: nothing to correct")
+
+
+def _image_date(item: dict) -> str:
+    """The date bucket an image belongs to."""
+    return item.get('date') or datetime.now(timezone.utc).strftime('%Y-%m-%d')
+
+
+def _image_score(item: dict) -> Decimal:
+    """The sentiment score an image contributes to the running average."""
+    return item.get('sentiment_score', Decimal('0'))
+
+
+def counter_dimensions(item: dict) -> list[tuple[str, str]]:
+    """The (pk, field) counters one feedback item contributes to.
+
+    ONE description of the dimensions, shared by the increment and the decrement
+    path, because the two drifting apart is the failure mode this fix exists to
+    remove: a dimension added to the insert path only would go up forever and
+    never come back down — precisely the shape of the original bug, just narrower.
+    This replaces eight hardcoded `update_counter` calls; an inverted copy of
+    those eight would have re-created that hazard on day one.
+
+    NOTE `persona_name` is read here even though the processor writes
+    `persona_type` (so ~everything buckets as `Unknown`). That is a separate
+    finding, tracked separately; reading a different field here than the insert
+    path read would make decrements miss the row the insert created, which is
+    strictly worse than the wrong bucket name. Fix it in one place when it is
+    fixed.
+    """
+    source_platform = item.get('source_platform', 'unknown')
+    category = item.get('category', 'other')
+    sentiment_label = item.get('sentiment_label', 'neutral')
+    urgency = item.get('urgency', 'low')
+    persona = item.get('persona_name', 'Unknown')
+
+    dimensions = [
+        ('METRIC#daily_total', 'count'),
+        (f'METRIC#daily_source#{source_platform}', 'count'),
+        (f'METRIC#daily_category#{category}', 'count'),
+        (f'METRIC#daily_sentiment#{sentiment_label}', 'count'),
+    ]
+
+    # Urgency counts (for alerts) — only urgent items have a row at all, so a
+    # non-high item must not write one in either direction.
+    if urgency == 'high':
+        dimensions.append(('METRIC#urgent', 'count'))
+
+    if persona:
+        dimensions.append((f'METRIC#persona#{persona}', 'count'))
+
+    # Category + sentiment combo
+    dimensions.append((f'METRIC#category_sentiment#{category}#{sentiment_label}', 'count'))
+
+    return dimensions
+
+
+def counter_keys(item: dict) -> set[tuple[str, str, str]]:
+    """`counter_dimensions` with the item's date filled in: (pk, date, field).
+
+    Every counter in this module is written under a BARE `YYYY-MM-DD` sort key,
+    because the streaming reader sums a window with `sk BETWEEN :oldest AND
+    :newest` — see test_streaming_categories_lockstep.py. Producing the sort key
+    in exactly one place is what keeps that pinnable now that the call sites are
+    generic.
+    """
+    date = _image_date(item)
+    return {(pk, date, field) for pk, field in counter_dimensions(item)}
+
+
+def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int):
+    """Move every named counter by `sign`.
+
+    The ONE place a counter key is unpacked into an `update_counter` call, so
+    there is exactly one line in this module deciding what a counter's sort key
+    is. Sorted only to make the write order deterministic for tests and logs.
+    """
+    for pk, date, field in sorted(keys):
+        update_counter(pk, date, field, increment=sign)
+
+
+def apply_feedback(item: dict, sign: int):
+    """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution."""
+    apply_counter_keys(counter_keys(item), sign)
+
+    # Daily sentiment score average
+    sentiment_score = _image_score(item)
+    if sentiment_score:
+        date = _image_date(item)
+        update_average('METRIC#daily_sentiment_avg', date, sentiment_score, sign=sign)
+
+    verb = 'Updated' if sign > 0 else 'Reversed'
+    logger.info(
+        f"{verb} aggregates for source={item.get('source_platform', 'unknown')}, "
+        f"category={item.get('category', 'other')}"
     )
 
 
 @tracer.capture_method
 def process_new_feedback(item: dict):
     """Update aggregates for a new feedback item."""
-    date = item.get('date', datetime.now(timezone.utc).strftime('%Y-%m-%d'))
-    source_platform = item.get('source_platform', 'unknown')
-    category = item.get('category', 'other')
-    sentiment_label = item.get('sentiment_label', 'neutral')
-    sentiment_score = item.get('sentiment_score', Decimal('0'))
-    urgency = item.get('urgency', 'low')
-    persona = item.get('persona_name', 'Unknown')
-    
-    # Daily totals
-    update_counter('METRIC#daily_total', date, 'count')
-    
-    # Daily by source platform
-    update_counter(f'METRIC#daily_source#{source_platform}', date, 'count')
-    
-    # Daily by category
-    update_counter(f'METRIC#daily_category#{category}', date, 'count')
-    
-    # Daily by sentiment
-    update_counter(f'METRIC#daily_sentiment#{sentiment_label}', date, 'count')
-    
-    # Daily sentiment score average
-    if sentiment_score:
-        update_average('METRIC#daily_sentiment_avg', date, sentiment_score)
-    
-    # Urgency counts (for alerts)
-    if urgency == 'high':
-        update_counter('METRIC#urgent', date, 'count')
-    
-    # Persona counts
-    if persona:
-        update_counter(f'METRIC#persona#{persona}', date, 'count')
-    
-    # Category + sentiment combo
-    update_counter(f'METRIC#category_sentiment#{category}#{sentiment_label}', date, 'count')
-    
-    logger.info(f"Updated aggregates for date={date}, source={source_platform}, category={category}")
+    apply_feedback(item, 1)
 
 
-def record_handler(record: DynamoDBRecord) -> dict:
-    """Process a single DynamoDB Stream record."""
-    # event_name is an enum in Powertools, compare with .value or string representation
-    event_name = str(record.event_name).split('.')[-1] if record.event_name else None
-    logger.info(f"Processing record: event_name={event_name}")
-    
-    if event_name != 'INSERT':
-        logger.info(f"Skipping non-INSERT event: {event_name}")
-        return {"status": "skipped", "reason": "not an insert"}
-    
-    new_image = record.dynamodb.new_image if record.dynamodb else None
-    if not new_image:
-        logger.warning("No new_image in record")
-        return {"status": "skipped", "reason": "no new image"}
-    
-    logger.info(f"new_image keys: {list(new_image.keys()) if new_image else 'None'}")
-    
-    # Convert DynamoDB format to regular dict
-    # Powertools may already deserialize, check both formats
+@tracer.capture_method
+def process_deleted_feedback(item: dict):
+    """Reverse the aggregates a now-deleted feedback item contributed.
+
+    Only for a USER-initiated delete. TTL expiry is filtered out upstream in
+    `record_handler` — see the module docstring for why ageing out must not
+    change a past day's totals.
+    """
+    apply_feedback(item, -1)
+
+
+@tracer.capture_method
+def process_modified_feedback(old_item: dict, new_item: dict):
+    """Move an item between buckets after an in-place edit.
+
+    The ingestion path cannot emit MODIFY (`processor/handler.py` writes with a
+    single `put_item`), but the Data Explorer's `PUT /data-explorer/feedback`
+    edits records in place and its allowlist includes `category`,
+    `sentiment_label`, `sentiment_score` and `urgency` — four of the dimensions
+    `counter_dimensions` buckets on. So MODIFY is not hypothetical, and skipping
+    it would leave an edited item counted under the bucket it left.
+
+    Only dimensions whose value actually changed are touched, so an edit to, say,
+    `problem_summary` writes nothing at all: with `-1` then `+1` on an identical
+    (pk, sk) the net is zero, but each pair of writes would refresh the row's
+    90-day TTL and burn capacity, and the decrement half could be refused as a
+    conditional check failure against a row sitting at zero and so leave the
+    increment un-cancelled. Symmetric difference of the two dimension sets is
+    also the only formulation that stays correct when `date` itself is edited,
+    which moves EVERY counter to another sk.
+    """
+    old_keys, new_keys = counter_keys(old_item), counter_keys(new_item)
+
+    apply_counter_keys(old_keys - new_keys, -1)
+    apply_counter_keys(new_keys - old_keys, 1)
+
+    old_date, new_date = _image_date(old_item), _image_date(new_item)
+    old_score, new_score = _image_score(old_item), _image_score(new_item)
+    if (old_date, old_score) != (new_date, new_score):
+        if old_score:
+            update_average('METRIC#daily_sentiment_avg', old_date, old_score, sign=-1)
+        if new_score:
+            update_average('METRIC#daily_sentiment_avg', new_date, new_score, sign=1)
+
+    logger.info(
+        f"Rebucketed aggregates: {len(old_keys - new_keys)} decrement(s), "
+        f"{len(new_keys - old_keys)} increment(s)"
+    )
+
+
+def deserialize_image(image: dict) -> dict:
+    """Convert a stream image to a plain dict.
+
+    Powertools may already have deserialized it, so both formats are accepted.
+    """
     item = {}
-    for key, value in new_image.items():
+    for key, value in image.items():
         if isinstance(value, dict):
             # Raw DynamoDB format
             if 'S' in value:
@@ -159,11 +344,85 @@ def record_handler(record: DynamoDBRecord) -> dict:
         else:
             # Already deserialized
             item[key] = value
-    
+    return item
+
+
+def is_ttl_expiry(record: DynamoDBRecord) -> bool:
+    """True when this REMOVE is DynamoDB's own TTL reaper, not a person.
+
+    A TTL deletion is the only REMOVE that carries `userIdentity`, with
+    `principalId == 'dynamodb.amazonaws.com'` and `type == 'Service'`; a delete
+    made through the API carries none.
+
+    A MISSING or unreadable `userIdentity` is therefore treated as a USER
+    deletion. That is the deliberate direction to fail in: a real user delete is
+    the case this fix exists for, and misreading one as TTL expiry would leave
+    the aggregate permanently overstated — the bug we are here to remove. The
+    opposite misreading costs at most one decrement, and even that cannot corrupt
+    the row: the decrement is conditional, so against an aged-out row it is a
+    no-op rather than a resurrected negative count.
+    """
+    identity = record.user_identity if hasattr(record, 'user_identity') else None
+    if not isinstance(identity, dict):
+        return False
+    return (identity.get('principalId') == 'dynamodb.amazonaws.com'
+            and identity.get('type') == 'Service')
+
+
+def record_handler(record: DynamoDBRecord) -> dict:
+    """Process a single DynamoDB Stream record.
+
+    INSERT adds to the aggregates, REMOVE takes back out (unless TTL did the
+    deleting) and MODIFY moves an item between buckets. Counting only INSERTs is
+    what made `get_metrics_summary` (aggregates) and `search_feedback` (scan)
+    report different totals for the same window.
+    """
+    # event_name is an enum in Powertools, compare with .value or string representation
+    event_name = str(record.event_name).split('.')[-1] if record.event_name else None
+    logger.info(f"Processing record: event_name={event_name}")
+
+    if event_name not in ('INSERT', 'REMOVE', 'MODIFY'):
+        logger.info(f"Skipping unrecognized event: {event_name}")
+        return {"status": "skipped", "reason": "unrecognized event"}
+
+    stream = record.dynamodb
+    new_image = stream.new_image if stream else None
+    old_image = stream.old_image if stream else None
+
+    if event_name == 'REMOVE':
+        if is_ttl_expiry(record):
+            # Ageing out is not a correction — see the module docstring.
+            logger.info("Skipping TTL-driven REMOVE: aggregates keep the historical count")
+            return {"status": "skipped", "reason": "ttl expiry"}
+        if not old_image:
+            logger.warning("No old_image in REMOVE record")
+            return {"status": "skipped", "reason": "no old image"}
+        item = deserialize_image(old_image)
+        logger.info(f"Reversing feedback: date={item.get('date')}, source={item.get('source_platform')}")
+        process_deleted_feedback(item)
+        metrics.add_metric(name="AggregatesUpdated", unit="Count", value=1)
+        return {"status": "success"}
+
+    if event_name == 'MODIFY':
+        if not old_image or not new_image:
+            logger.warning("MODIFY record is missing an image; cannot rebucket")
+            return {"status": "skipped", "reason": "incomplete images"}
+        process_modified_feedback(deserialize_image(old_image), deserialize_image(new_image))
+        metrics.add_metric(name="AggregatesUpdated", unit="Count", value=1)
+        return {"status": "success"}
+
+    if not new_image:
+        logger.warning("No new_image in record")
+        return {"status": "skipped", "reason": "no new image"}
+
+    logger.info(f"new_image keys: {list(new_image.keys()) if new_image else 'None'}")
+
+    item = deserialize_image(new_image)
+
     logger.info(f"Processing feedback: date={item.get('date')}, source={item.get('source_platform')}")
     process_new_feedback(item)
     metrics.add_metric(name="AggregatesUpdated", unit="Count", value=1)
-    
+
     return {"status": "success"}
 
 

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -782,9 +782,9 @@ def _rebucket_average(
     Returns how many of the two writes landed.
     """
     landed = 0
-    # The ROW whose reversal was refused as already-empty, if any — not a bare flag.
-    # `None` covers every other outcome: landed, never attempted, or refused for the
-    # row being absent.
+    # The ROW whose reversal was refused, if any — not a bare flag, so a refusal on
+    # one day cannot suppress a write aimed at another. `None` means no reversal was
+    # refused: it landed, or none was attempted at all.
     blocked_row: str | None = None
     if old_score and old_live:
         if update_average(SENTIMENT_AVG_PK, old_date, old_score, sign=-1):

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -104,6 +104,16 @@ Known residuals
   note and the code cannot drift apart.
 * `update_average` FLOORS `count`, NOT `sum` — see its docstring for why adding a
   bound on `sum` would refuse legitimate reversals rather than fix anything.
+* AN EDIT THAT MOVES AN ITEM ONTO A LIVE DAY WHOSE AVERAGE ROW HAS EXPIRED still
+  creates that row holding the one arriving score. The pairing rule learns a row is
+  gone only from a reversal aimed at it, and a cross-day increment lands where no
+  reversal went. It is undecidable from the two images: a live day with no average
+  row looks identical whether the row expired or the day is taking its first scored
+  item, and the second must be created. Closing it needs a per-day marker for "has
+  ever held a scored item", i.e. new state, so it is left as a residual with
+  `test_a_cross_day_arrival_onto_an_expired_average_still_fragments_it` pinning
+  today's behaviour. The same-day case IS closed, because there the refused reversal
+  is the evidence.
 """
 import os
 from collections.abc import Mapping
@@ -733,6 +743,18 @@ def _rebucket_average(
         so there is no half to be inconsistent with, and refusing the increment
         would lose the item from the metrics surface entirely — which is the
         count-dropping failure `_day_has_aggregates` exists to avoid;
+    WHAT THIS RULE CANNOT SEE, since it is the failure direction of the rule itself:
+    it learns that a row is gone only from a reversal AIMED AT THAT ROW. A cross-day
+    edit's increment lands on a day no reversal touched, so an item arriving on a live
+    day whose average row has expired still creates it holding one score — the same
+    fragment, on the arrival side. Closing that needs evidence this module does not
+    have: a live day with no average row is indistinguishable from a day taking its
+    FIRST scored item, which must be created, and nothing in the two images tells them
+    apart. It would need a per-day marker for "has ever held a scored item", i.e. new
+    state. Recorded as a residual in the module docstring and pinned by
+    `test_a_cross_day_arrival_onto_an_expired_average_still_fragments_it` so the note
+    and the behaviour cannot drift apart.
+
     A REVERSAL THAT WAS REFUSED BLOCKS ITS OWN ROW EITHER WAY, and the reason the
     absent case is not the exception it looks like is the guard above: a reversal is
     attempted only when the OLD image carried a score, and `apply_feedback` writes

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -50,12 +50,24 @@ Which writes may create a row, and which may not
   SIDE, because an edit can move an item from a live day onto a dead one and every
   increment then lands on the dead day.
 
-A rebucket's two halves of the AVERAGE stand or fall together. The counters cannot
-split (a symmetric difference never sends `-1` and `+1` to one key), but the average
-is two conditional writes to one row: a reversal refused against a row at
-`count == 0` while the re-application applies would leave that row asserting an item
-no feedback justifies, and `get_summary` divides `sum/count` into the day's average
-and weights it into the headline number. See `_rebucket_average`.
+A rebucket's two halves of the AVERAGE stand or fall together WHEN THEY TARGET ONE
+ROW. The counters cannot split (a symmetric difference never sends `-1` and `+1` to
+one key), but the average is two conditional writes to (SENTIMENT_AVG_PK, date): a
+reversal refused against a row at `count == 0` while the re-application applies would
+leave that row asserting an item no feedback justifies, and `get_summary` divides
+`sum/count` into the day's average and weights it into the headline number.
+
+The pairing is keyed on the ROW rather than on the edit, because an edited `date`
+sends the two writes to two different days and a refusal on one says nothing about the
+other — pairing across that gap dropped the item from the new day's average while
+every one of its counters moved there, the same split relocated to the day that
+UNDERSTATES. And the two ways a reversal can be refused mean opposite things: a row
+present at zero must not be added to, while a row that is ABSENT was never reversed
+and so may be created on a live day, exactly as a counter's first bucket of the day
+is. `update_average` therefore reports WHICH of its condition's clauses failed rather
+than a bare success flag. A write declined by that rule is counted as
+DECLINED_METRIC — REFUSED_METRIC cannot cover it, since a write never issued gives
+DynamoDB nothing to refuse. See `_rebucket_average` and `AverageWrite`.
 
 A reversal also refuses to GUESS a date. `_image_date` falls back to today when an
 image carries no `date` field, which is defensible for an INSERT (today is at
@@ -94,6 +106,7 @@ import os
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
+from enum import Enum
 from typing import Any
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, batch_processor
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBRecord
@@ -124,10 +137,22 @@ processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
 # REFUSED_METRIC is the one that matters when something is wrong: a steady trickle
 # is ordinary (deletions of aged-out days), a spike means either a redelivery
 # storm or that rows are expiring while their feedback is still being edited.
+#
+# DECLINED_METRIC is its counterpart for a write this module chose NOT to attempt.
+# REFUSED_METRIC can only ever count DynamoDB's refusals — `_log_refusal` runs in an
+# `except ClientError`, so a write never issued is invisible to it by construction.
+# The average's pairing rule declines exactly such a write, and without its own
+# metric that skip would be unobservable while REBUCKETED_METRIC still fired for the
+# counter writes that landed: an operator would see a healthy rebucket and no
+# anomaly, with the day's average having quietly lost an item. Distinct from REFUSED
+# because the two need different responses — a refusal is DynamoDB reporting there
+# was nothing to correct, a decline is this code declining to make a row
+# inconsistent, and only the second is a decision an operator can argue with.
 UPDATED_METRIC = "AggregatesUpdated"
 REVERSED_METRIC = "AggregatesReversed"
 REBUCKETED_METRIC = "AggregatesRebucketed"
 REFUSED_METRIC = "AggregateWriteRefused"
+DECLINED_METRIC = "AggregateWriteDeclined"
 
 # The feedback field the persona counter buckets by, as a constant so that
 # test_persona_field_lockstep.py can pin it against the field the PROCESSOR
@@ -171,6 +196,40 @@ _TRANSIENT_READ_ERRORS = frozenset({
 })
 
 
+class AverageWrite(Enum):
+    """How an `update_average` call ended.
+
+    Three outcomes rather than a bool because a rebucket's re-application has to
+    branch on WHICH refusal it received, and a bool erases that: re-applying to a
+    row that is present and claiming zero items corrupts it, while re-applying to a
+    row that does not exist is the ordinary creation of a fresh bucket. Collapsing
+    the two is the defect this enum exists to make unavailable — see
+    `_rebucket_average`.
+
+    An Enum and not two bools, because `landed=False, absent=True` has a fourth
+    state (`landed=True, absent=True`) that means nothing, and a reader would have
+    to know it never occurs.
+    """
+    LANDED = 'landed'
+    # Refused: the row exists and its `count` is already at the floor. Nothing was
+    # reversed, and this row must not be re-applied to.
+    ROW_AT_FLOOR = 'row_at_floor'
+    # Refused: no row. Nothing was reversed, and nothing is left dangling — a
+    # re-application on a live day may create it.
+    ROW_ABSENT = 'row_absent'
+
+    def __bool__(self) -> bool:
+        """True only for LANDED, so `if update_average(...)` still reads correctly.
+
+        Every existing caller asks "did this write land?", and an Enum is otherwise
+        truthy in all three states — which would silently turn every such check into
+        a tautology, counting refused writes as landed. That is the reverse of the
+        landed-not-attempted distinction the metrics depend on, so the truthiness is
+        defined rather than left to Python's default.
+        """
+        return self is AverageWrite.LANDED
+
+
 def get_metric_type(pk: str) -> str | None:
     """Extract metric type from pk for GSI indexing."""
     if pk.startswith('METRIC#daily_source#'):
@@ -189,6 +248,18 @@ def _log_refusal(what: str, pk: str, sk: str):
     """
     logger.info(f"Refused {what} on {pk}/{sk}: nothing to correct")
     metrics.add_metric(name=REFUSED_METRIC, unit="Count", value=1)
+
+
+def _log_decline(what: str, pk: str, sk: str, because: str):
+    """A write this module chose not to ATTEMPT. Counted, for the same reason.
+
+    `_log_refusal` cannot cover this: it runs inside an `except ClientError`, so a
+    write never issued produces no refusal to count and the skip would be invisible
+    to REFUSED_METRIC while REBUCKETED_METRIC still claimed the edit moved
+    aggregates. A guard that silently declines work is one that gets debugged twice.
+    """
+    logger.info(f"Declined {what} on {pk}/{sk}: {because}")
+    metrics.add_metric(name=DECLINED_METRIC, unit="Count", value=1)
 
 
 def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: int = 90) -> bool:
@@ -260,11 +331,27 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
     return True
 
 
-def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: int = 1) -> bool:
+def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90,
+                   sign: int = 1) -> 'AverageWrite':
     """Update running average in aggregates table.
 
-    Returns whether the write LANDED, like `update_counter` and for the same
-    reasons — the rebucket's reversal and re-application must not be able to split.
+    Returns HOW the write ended, not merely whether it landed, because the rebucket
+    cannot act on a refusal it cannot explain. `update_counter` answers a bool
+    because its callers only ever ask "did this move?"; the two refusals of a
+    reversal mean opposite things here:
+
+    * ROW_AT_FLOOR — the row is present and claims zero items. Re-applying to THIS
+      row would make it claim one that no feedback justifies, so the paired
+      re-application is declined (see `_rebucket_average`);
+    * ROW_ABSENT — there is no row. Nothing was reversed, so nothing is left
+      dangling, and a re-application on a LIVE day may create it exactly as a
+      counter's increment creates a brand-new bucket.
+
+    Told apart by `ReturnValuesOnConditionCheckFailure`, which returns the old item
+    with the ConditionalCheckFailedException when one existed — so the distinction
+    costs no extra read and cannot race a second look at the row. It needs
+    botocore >= 1.31.60; the pinned floor is boto3 >= 1.35 (requirements-dev.txt)
+    and the Python 3.14 Lambda runtime ships far newer.
 
     `sign=-1` reverses a previously recorded value (subtract from `sum`, decrement
     `count`), under the same condition as an `update_counter` decrement and for the
@@ -300,6 +387,11 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: i
         # A distinct :floor rather than reusing :one, which is -1 here.
         kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #count >= :floor'
         attr_values[':floor'] = 1
+        # Ask for the old item ALONGSIDE the refusal, so a refused reversal can say
+        # which of its two clauses failed. Without this the caller has to either
+        # re-read the row (racing itself) or treat both refusals alike, and they
+        # call for opposite decisions — see this function's docstring.
+        kwargs['ReturnValuesOnConditionCheckFailure'] = 'ALL_OLD'
 
     try:
         aggregates_table.update_item(
@@ -318,8 +410,19 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: i
         if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
         _log_refusal('reversal of average', pk, sk)
-        return False
-    return True
+        # `Item` rides along with the refusal only when a row existed to fail the
+        # `#count >= :floor` half; its absence means `attribute_exists(pk)` failed,
+        # so the row is gone. That reading needs the request to have ASKED for it,
+        # which the branch above always does.
+        if not isinstance(e.response, Mapping):
+            # Nothing readable at all. ROW_AT_FLOOR is the answer that DECLINES the
+            # paired write, so an unreadable refusal cannot license re-applying to a
+            # row that may be present and empty. Erring the other way would make the
+            # pairing rule silently conditional on the shape of an error response.
+            return AverageWrite.ROW_AT_FLOOR
+        return (AverageWrite.ROW_AT_FLOOR if 'Item' in e.response
+                else AverageWrite.ROW_ABSENT)
+    return AverageWrite.LANDED
 
 
 def _day_has_aggregates(date: str) -> bool:
@@ -660,21 +763,42 @@ def _rebucket_average(
     """Move one item's contribution to the running average, as a PAIR.
 
     Split out because the pairing rule is the whole content: reverse first, and
-    re-apply only if that reversal landed. A refused reversal means the row is
-    already at `count == 0` — it is claiming no items — and adding the new score
-    anyway makes it claim one, at the edited score, that no feedback justifies.
-    `get_summary` serves `sum/count` per date and weights it by count into the
-    headline average, so that is served-data corruption rather than a skew nobody
-    reads.
+    re-apply only if that reversal left the TARGET ROW able to accept it. A reversal
+    refused against a row already at `count == 0` means that row is claiming no
+    items, and adding the new score makes it claim one, at the edited score, that no
+    feedback justifies. `get_summary` serves `sum/count` per date and weights it by
+    count into the headline average, so that is served-data corruption rather than a
+    skew nobody reads.
 
-    Two cases have NO reversal to pair with, and the increment is right in both:
+    THE PAIRING IS PER ROW, NOT PER EDIT. This is the correction to the first
+    version, which consulted one `reversal_refused` flag however far apart the two
+    writes were aimed. When `date` is edited the reversal and the re-application are
+    writes to TWO DIFFERENT rows, and a refusal on the old day says nothing whatever
+    about the new day's row — but the flag skipped it anyway, so the item vanished
+    from the new day's average while all of its counters, `daily_total` included,
+    moved onto that day. The two then describe different sets of items: exactly the
+    split this pairing exists to prevent, relocated to the day that UNDERSTATES,
+    since `get_summary` weights each date's average by its own count. So the
+    re-application is blocked only when it targets the very row whose reversal was
+    refused, which for a single row is the original rule unchanged.
+
+    Three cases have NO reversal to pair with, and the increment is right in all:
 
       * an old score of zero contributed nothing to the average, so nothing was
         reversed and nothing is left dangling;
       * an aged-out old day was never asked (`old_live` is False). Its row is gone,
         so there is no half to be inconsistent with, and refusing the increment
         would lose the item from the metrics surface entirely — which is the
-        count-dropping failure `_day_has_aggregates` exists to avoid.
+        count-dropping failure `_day_has_aggregates` exists to avoid;
+      * the reversal found NO ROW (`ROW_ABSENT`) on a live day. Nothing was
+        reversed, so again nothing dangles, and the re-application is the ordinary
+        creation of a bucket on a day that is live — the same latitude every counter
+        increment already has, and the reason `update_average` reports which of its
+        two condition clauses failed rather than a bare False. That case is reachable
+        without any race: `apply_feedback` writes the average only `if
+        sentiment_score`, so a day whose items are all unscored has a `daily_total`
+        (the day reads live) and no average row at all, and an ordinary score edit on
+        it would otherwise write nothing anywhere.
 
     WHY THE COUNTERS ARE NOT PAIRED THIS WAY, though they look symmetrical: a
     refused counter decrement and its increment go to DIFFERENT keys (that is what
@@ -688,21 +812,30 @@ def _rebucket_average(
     Returns how many of the two writes landed.
     """
     landed = 0
-    reversal_refused = False
+    # The ROW whose reversal was refused as already-empty, if any — not a bare flag.
+    # `None` covers every other outcome: landed, never attempted, or refused for the
+    # row being absent.
+    blocked_row: str | None = None
     if old_score and old_live:
-        if update_average(SENTIMENT_AVG_PK, old_date, old_score, sign=-1):
+        outcome = update_average(SENTIMENT_AVG_PK, old_date, old_score, sign=-1)
+        if outcome is AverageWrite.LANDED:
             landed += 1
-        else:
-            reversal_refused = True
-            logger.info(
-                f"Refused reversal of the average on {old_date}, so the paired "
-                f"re-application on {new_date} is skipped: applying it alone would "
-                f"leave the row claiming an item that is not there"
-            )
+        elif outcome is AverageWrite.ROW_AT_FLOOR:
+            blocked_row = old_date
 
-    if (new_score and new_live and not reversal_refused
-            and update_average(SENTIMENT_AVG_PK, new_date, new_score, sign=1)):
-        landed += 1
+    if new_score and new_live:
+        if new_date == blocked_row:
+            # Same row, refused as empty: applying alone would make it claim an item
+            # that is not there. Declined rather than attempted, so counted as such —
+            # DynamoDB never sees this write and cannot refuse it on our behalf.
+            _log_decline(
+                're-application of the average', SENTIMENT_AVG_PK, new_date,
+                f'its reversal on {old_date} was refused against a row already at '
+                f'zero, so applying the new score alone would leave that row '
+                f'claiming an item no feedback justifies',
+            )
+        elif update_average(SENTIMENT_AVG_PK, new_date, new_score, sign=1):
+            landed += 1
     return landed
 
 

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -61,13 +61,16 @@ The pairing is keyed on the ROW rather than on the edit, because an edited `date
 sends the two writes to two different days and a refusal on one says nothing about the
 other — pairing across that gap dropped the item from the new day's average while
 every one of its counters moved there, the same split relocated to the day that
-UNDERSTATES. And the two ways a reversal can be refused mean opposite things: a row
-present at zero must not be added to, while a row that is ABSENT was never reversed
-and so may be created on a live day, exactly as a counter's first bucket of the day
-is. `update_average` therefore reports WHICH of its condition's clauses failed rather
-than a bare success flag. A write declined by that rule is counted as
-DECLINED_METRIC — REFUSED_METRIC cannot cover it, since a write never issued gives
-DynamoDB nothing to refuse. See `_rebucket_average` and `AverageWrite`.
+UNDERSTATES. Within one row, though, EITHER refusal blocks: a reversal is attempted
+only when the old image carried a score, which means the insert did write that row, so
+finding it gone means it EXPIRED rather than that it never existed. Creating it again
+from the one edited item gives the date a `count == 1` average that `get_summary`
+serves as the whole day's figure, next to a `daily_total` collected from every item of
+that date — the one-score fragment described above, arriving below the granularity the
+day sentinel can see, because `daily_total`'s TTL is refreshed by every item while the
+average row's is refreshed only by scored ones. A write declined by that rule is
+counted as DECLINED_METRIC — REFUSED_METRIC cannot cover it, since a write never
+issued gives DynamoDB nothing to refuse. See `_rebucket_average`.
 
 A reversal also refuses to GUESS a date. `_image_date` falls back to today when an
 image carries no `date` field, which is defensible for an INSERT (today is at
@@ -106,7 +109,6 @@ import os
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
-from enum import Enum
 from typing import Any
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, batch_processor
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBRecord
@@ -194,40 +196,6 @@ _TRANSIENT_READ_ERRORS = frozenset({
     'RequestTimeoutException',
     'TransactionConflictException',
 })
-
-
-class AverageWrite(Enum):
-    """How an `update_average` call ended.
-
-    Three outcomes rather than a bool because a rebucket's re-application has to
-    branch on WHICH refusal it received, and a bool erases that: re-applying to a
-    row that is present and claiming zero items corrupts it, while re-applying to a
-    row that does not exist is the ordinary creation of a fresh bucket. Collapsing
-    the two is the defect this enum exists to make unavailable — see
-    `_rebucket_average`.
-
-    An Enum and not two bools, because `landed=False, absent=True` has a fourth
-    state (`landed=True, absent=True`) that means nothing, and a reader would have
-    to know it never occurs.
-    """
-    LANDED = 'landed'
-    # Refused: the row exists and its `count` is already at the floor. Nothing was
-    # reversed, and this row must not be re-applied to.
-    ROW_AT_FLOOR = 'row_at_floor'
-    # Refused: no row. Nothing was reversed, and nothing is left dangling — a
-    # re-application on a live day may create it.
-    ROW_ABSENT = 'row_absent'
-
-    def __bool__(self) -> bool:
-        """True only for LANDED, so `if update_average(...)` still reads correctly.
-
-        Every existing caller asks "did this write land?", and an Enum is otherwise
-        truthy in all three states — which would silently turn every such check into
-        a tautology, counting refused writes as landed. That is the reverse of the
-        landed-not-attempted distinction the metrics depend on, so the truthiness is
-        defined rather than left to Python's default.
-        """
-        return self is AverageWrite.LANDED
 
 
 def get_metric_type(pk: str) -> str | None:
@@ -332,26 +300,17 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
 
 
 def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90,
-                   sign: int = 1) -> 'AverageWrite':
+                   sign: int = 1) -> bool:
     """Update running average in aggregates table.
 
-    Returns HOW the write ended, not merely whether it landed, because the rebucket
-    cannot act on a refusal it cannot explain. `update_counter` answers a bool
-    because its callers only ever ask "did this move?"; the two refusals of a
-    reversal mean opposite things here:
-
-    * ROW_AT_FLOOR — the row is present and claims zero items. Re-applying to THIS
-      row would make it claim one that no feedback justifies, so the paired
-      re-application is declined (see `_rebucket_average`);
-    * ROW_ABSENT — there is no row. Nothing was reversed, so nothing is left
-      dangling, and a re-application on a LIVE day may create it exactly as a
-      counter's increment creates a brand-new bucket.
-
-    Told apart by `ReturnValuesOnConditionCheckFailure`, which returns the old item
-    with the ConditionalCheckFailedException when one existed — so the distinction
-    costs no extra read and cannot race a second look at the row. It needs
-    botocore >= 1.31.60; the pinned floor is boto3 >= 1.35 (requirements-dev.txt)
-    and the Python 3.14 Lambda runtime ships far newer.
+    Returns whether the write LANDED, exactly as `update_counter` does. A refusal
+    needs no further explanation, because the rebucket treats BOTH ways a reversal
+    can be refused the same: neither licenses re-applying to that row alone. A row
+    present at `count == 0` must not be made to claim an item, and a row that is
+    ABSENT is absent because it EXPIRED — a reversal is attempted only for an old
+    image that carried a score, so the insert did write that row. Re-creating it
+    from the single edited item is the one-score fragment `_rebucket_average`
+    describes.
 
     `sign=-1` reverses a previously recorded value (subtract from `sum`, decrement
     `count`), under the same condition as an `update_counter` decrement and for the
@@ -387,11 +346,6 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90,
         # A distinct :floor rather than reusing :one, which is -1 here.
         kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #count >= :floor'
         attr_values[':floor'] = 1
-        # Ask for the old item ALONGSIDE the refusal, so a refused reversal can say
-        # which of its two clauses failed. Without this the caller has to either
-        # re-read the row (racing itself) or treat both refusals alike, and they
-        # call for opposite decisions — see this function's docstring.
-        kwargs['ReturnValuesOnConditionCheckFailure'] = 'ALL_OLD'
 
     try:
         aggregates_table.update_item(
@@ -410,19 +364,8 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90,
         if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
         _log_refusal('reversal of average', pk, sk)
-        # `Item` rides along with the refusal only when a row existed to fail the
-        # `#count >= :floor` half; its absence means `attribute_exists(pk)` failed,
-        # so the row is gone. That reading needs the request to have ASKED for it,
-        # which the branch above always does.
-        if not isinstance(e.response, Mapping):
-            # Nothing readable at all. ROW_AT_FLOOR is the answer that DECLINES the
-            # paired write, so an unreadable refusal cannot license re-applying to a
-            # row that may be present and empty. Erring the other way would make the
-            # pairing rule silently conditional on the shape of an error response.
-            return AverageWrite.ROW_AT_FLOOR
-        return (AverageWrite.ROW_AT_FLOOR if 'Item' in e.response
-                else AverageWrite.ROW_ABSENT)
-    return AverageWrite.LANDED
+        return False
+    return True
 
 
 def _day_has_aggregates(date: str) -> bool:
@@ -790,15 +733,20 @@ def _rebucket_average(
         so there is no half to be inconsistent with, and refusing the increment
         would lose the item from the metrics surface entirely — which is the
         count-dropping failure `_day_has_aggregates` exists to avoid;
-      * the reversal found NO ROW (`ROW_ABSENT`) on a live day. Nothing was
-        reversed, so again nothing dangles, and the re-application is the ordinary
-        creation of a bucket on a day that is live — the same latitude every counter
-        increment already has, and the reason `update_average` reports which of its
-        two condition clauses failed rather than a bare False. That case is reachable
-        without any race: `apply_feedback` writes the average only `if
-        sentiment_score`, so a day whose items are all unscored has a `daily_total`
-        (the day reads live) and no average row at all, and an ordinary score edit on
-        it would otherwise write nothing anywhere.
+    A REVERSAL THAT WAS REFUSED BLOCKS ITS OWN ROW EITHER WAY, and the reason the
+    absent case is not the exception it looks like is the guard above: a reversal is
+    attempted only when the OLD image carried a score, and `apply_feedback` writes
+    the average whenever `sentiment_score` is set — so the insert did write this row,
+    and finding it gone means it EXPIRED. Recreating it from the one edited item hands
+    the date a `count == 1` average, which `get_summary` serves as that whole day's
+    figure and weights by 1 against a `total_feedback` drawn from `daily_total` — a
+    row collected from every item of the date. That is the one-score fragment
+    `process_modified_feedback` calls the worst of them, and the day sentinel cannot
+    see it: `daily_total`'s TTL is refreshed by every item while the average row's is
+    refreshed only by scored ones, and TTL deletion is best-effort besides, so the
+    two rows of one day expire independently and the day still reads live. Leaving no
+    row is the honest outcome — an expired average is absent, and `get_summary` skips
+    what is not there rather than reporting a wrong number for it.
 
     WHY THE COUNTERS ARE NOT PAIRED THIS WAY, though they look symmetrical: a
     refused counter decrement and its increment go to DIFFERENT keys (that is what
@@ -817,22 +765,24 @@ def _rebucket_average(
     # row being absent.
     blocked_row: str | None = None
     if old_score and old_live:
-        outcome = update_average(SENTIMENT_AVG_PK, old_date, old_score, sign=-1)
-        if outcome is AverageWrite.LANDED:
+        if update_average(SENTIMENT_AVG_PK, old_date, old_score, sign=-1):
             landed += 1
-        elif outcome is AverageWrite.ROW_AT_FLOOR:
+        else:
+            # Refused, whether by the floor or by the row being gone. Both mean this
+            # row cannot take the re-application on its own — see the docstring.
             blocked_row = old_date
 
     if new_score and new_live:
         if new_date == blocked_row:
-            # Same row, refused as empty: applying alone would make it claim an item
-            # that is not there. Declined rather than attempted, so counted as such —
+            # Same row, and its reversal was refused: applying alone would leave the
+            # row claiming one item, at the edited score, that the day's real history
+            # does not justify. Declined rather than attempted, so counted as such —
             # DynamoDB never sees this write and cannot refuse it on our behalf.
             _log_decline(
                 're-application of the average', SENTIMENT_AVG_PK, new_date,
-                f'its reversal on {old_date} was refused against a row already at '
-                f'zero, so applying the new score alone would leave that row '
-                f'claiming an item no feedback justifies',
+                f'its reversal on {old_date} was refused, so the row is either at '
+                f'zero or expired, and applying the new score alone would leave it '
+                f'claiming an item no present feedback justifies',
             )
         elif update_average(SENTIMENT_AVG_PK, new_date, new_score, sign=1):
             landed += 1

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -27,8 +27,62 @@ arrive on 2026-01-15; garbage-collecting the raw item a year later does not
 change that daily total) and is skipped. A user-initiated delete IS a correction
 and decrements — under a condition that cannot create a row and cannot go below
 zero.
+
+Which writes may create a row, and which may not
+------------------------------------------------
+* an INCREMENT may create the row. That is how a date's first item registers, and
+  it is equally true of a rebucket: the first item edited into a category today is
+  that category's first row today;
+* a DECREMENT may not. An aggregate that has already aged out has nothing left to
+  correct, and creating it would mean serving a negative count no feedback ever
+  justified. Guarded with `attribute_exists(pk) AND #field >= :floor`, whose
+  ConditionalCheckFailedException is the expected, benign outcome — swallowed, and
+  counted as REFUSED_METRIC so a run of them is visible rather than silent;
+* a REBUCKET OF AN AGED-OUT DAY writes nothing at all. Its decrements would be
+  refused anyway, but the increments would not, and `PUT /data-explorer/feedback`
+  can edit a record of any age while its aggregate rows are gone after 90 days —
+  leaving a fresh 90-day-TTL'd fragment (`count = 1`, and a one-score
+  `daily_sentiment_avg` row) for a date whose real totals were collected months
+  ago. `validate_days` admits windows up to 365 days, so `/metrics/summary` and
+  `/metrics/trends` would serve those fragments as the day's totals. The check is
+  on the DAY, not per row — see `_day_has_aggregates` for why the per-row form
+  drops legitimate counts instead of protecting anything.
+
+A reversal also refuses to GUESS a date. `_image_date` falls back to today when an
+image carries no `date` field, which is defensible for an INSERT (today is at
+least the day the row was created) and arbitrary for a REMOVE: an undated item
+ingested on D and deleted on D+40 would decrement the D+40 counters, corrupting a
+legitimate current-day aggregate while leaving D overstated — and no
+ConditionExpression can catch that, because the target row exists and is above the
+floor. So the reversal and rebucket paths read `_image_date_or_none` and skip when
+it answers None. A missed `-1` beats a `-1` aimed at the wrong day, the same
+direction the TTL argument takes.
+
+Known residuals
+---------------
+* NO BACKFILL. Aggregate rows written before this change carry the drift from
+  every past deletion; nothing here repairs stored values, it only stops new
+  drift. Repairing them needs a rebuild-from-scan path that does not exist.
+* NOT IDEMPOTENT UNDER REDELIVERY. DynamoDB Streams deliver at-least-once, and
+  the event source is configured with `retryAttempts: 3` and
+  `reportBatchItemFailures: true`, so a batch that partially fails re-presents
+  records whose writes already landed. A redelivered REMOVE decrements a second
+  time (the floor at zero only makes that a no-op when the counter is ALREADY at
+  zero — against a counter at 3 it lands on 1, not 2), and a redelivered MODIFY
+  moves the count twice in both directions. What the conditions do guarantee is
+  narrower and still worth having: no resurrected row, and no negative counter.
+  Fixing this properly means recording each record's `eventID`/`sequence_number`
+  through `shared/idempotency.py` — the shared `processingRole` is already granted
+  the idempotency table, but this function is not given its name in the
+  environment, so it is a CDK change as well as a code one, and it buys a write
+  per stream record on the hot path. Deliberately left for its own change, with
+  the tests in TestRedeliveryMovesACounterTwice pinning today's behaviour so this
+  note and the code cannot drift apart.
+* `update_average` FLOORS `count`, NOT `sum` — see its docstring for why adding a
+  bound on `sum` would refuse legitimate reversals rather than fix anything.
 """
 import os
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
@@ -38,7 +92,7 @@ from botocore.exceptions import ClientError
 
 # Shared module imports
 from shared.logging import logger, tracer, metrics
-from shared.aws import get_dynamodb_resource
+from shared.aws import get_dynamodb_resource, is_conditional_check_failure
 
 # AWS Clients (using shared module for connection reuse)
 dynamodb = get_dynamodb_resource()
@@ -48,6 +102,35 @@ AGGREGATES_TABLE = os.environ['AGGREGATES_TABLE']
 aggregates_table = dynamodb.Table(AGGREGATES_TABLE)
 
 processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
+
+# One metric name per BEHAVIOUR, not one for all three.
+#
+# Before this change the Lambda did one thing and emitted one metric. It now does
+# three materially different things, and emitting `AggregatesUpdated` for all of
+# them would leave the new behaviour unobservable in production — which is a small
+# echo of why the original bug lasted as long as it did: nothing outside the
+# database could show whether aggregates ever came back DOWN. An operator
+# confirming this fix is live wants to see AggregatesReversed climb.
+#
+# REFUSED_METRIC is the one that matters when something is wrong: a steady trickle
+# is ordinary (deletions of aged-out days), a spike means either a redelivery
+# storm or that rows are expiring while their feedback is still being edited.
+UPDATED_METRIC = "AggregatesUpdated"
+REVERSED_METRIC = "AggregatesReversed"
+REBUCKETED_METRIC = "AggregatesRebucketed"
+REFUSED_METRIC = "AggregateWriteRefused"
+
+# The feedback field the persona counter buckets by, as a constant so that
+# test_persona_field_lockstep.py can pin it against the field the PROCESSOR
+# writes. It is a constant rather than an inline `item.get('persona_name')` for
+# one reason: this name has to change on both sides of the stream at once. A
+# decrement reads it out of the OLD image of an item whose insert read it out of
+# the new one, so "fix" it here alone and every reversal misses the row its own
+# insert created — the counter goes up and never comes down, which is the shape of
+# the bug this module was just repaired for. The processor writes `persona_name`
+# AND `persona_type` (`processor/handler.py`), so either is a real field; the
+# lockstep is about the two sides agreeing, not about which of the two wins.
+PERSONA_FIELD = 'persona_name'
 
 
 def get_metric_type(pk: str) -> str | None:
@@ -59,38 +142,40 @@ def get_metric_type(pk: str) -> str | None:
     return None
 
 
-def _is_conditional_check_failure(error: Exception) -> bool:
-    """True for DynamoDB's ConditionalCheckFailedException, however it arrives.
+def _log_refusal(what: str, pk: str, sk: str):
+    """A write the condition refused. Ordinary, but not to be silent about.
 
-    The error CODE in the response is the dependable signal — boto3's resource
-    layer raises a dynamically-built ClientError subclass, so its type name is a
-    botocore implementation detail. The type name is checked as well because a
-    test double raises the named exception with no response payload. Same helper
-    shape as `product_doc_extractor/handler.py`.
+    Counted as well as logged, because "did the reversal path ever refuse
+    anything?" is a question about production, not about one invocation, and
+    CloudWatch is where it gets answered.
     """
-    response = getattr(error, 'response', None)
-    code = (response.get('Error') or {}).get('Code') if isinstance(response, dict) else None
-    return (code == 'ConditionalCheckFailedException'
-            or type(error).__name__ == 'ConditionalCheckFailedException')
+    logger.info(f"Refused {what} on {pk}/{sk}: nothing to correct")
+    metrics.add_metric(name=REFUSED_METRIC, unit="Count", value=1)
 
 
 def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: int = 90):
     """Atomically update a counter in the aggregates table.
 
-    An increment may create the row (that is how a date's first item registers).
-    A DEcrement may not: it is guarded so that it applies only to a row that is
-    still there and still above zero. Two distinct failures are prevented, and
-    both would be invisible without the guard:
+    An increment may create the row — that is how a date's first item registers,
+    and it stays true for a REBUCKET, because the first item edited into a category
+    today is that category's first row today just as much as a fresh arrival would
+    be. What keeps a rebucket from creating rows for an AGED-OUT day is a check on
+    the day, not on the row: see `_day_has_aggregates`.
+
+    A DEcrement may not create. Two failures are prevented, both invisible without
+    the guard:
 
     * a row that has already expired under its 90-day TTL has nothing left to
-      correct, and `if_not_exists(#field, :zero) + :inc` would happily resurrect
-      it holding a negative count with a fresh 90-day TTL;
-    * DynamoDB Streams deliver at-least-once, so the same REMOVE can arrive
-      twice; the floor at zero makes the second delivery a no-op rather than a
-      count of -1.
+      correct, and `if_not_exists(#field, :zero) + :inc` would resurrect it holding
+      a negative count with a fresh 90-day TTL, which a window query reaching that
+      far back would then serve;
+    * the floor at zero keeps a decrement from driving a counter NEGATIVE.
 
-    ConditionalCheckFailedException is therefore the expected, benign outcome of
-    a decrement with nothing to decrement, and is swallowed.
+    The floor is not idempotency: a redelivered REMOVE against a counter at 3 still
+    lands on 2 and then 1 — see the module docstring's known residuals.
+
+    ConditionalCheckFailedException is therefore an expected, benign outcome of a
+    decrement with nothing to decrement, and is swallowed (and counted).
     """
     ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
 
@@ -123,18 +208,32 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
             **kwargs
         )
     except ClientError as e:
-        if increment >= 0 or not _is_conditional_check_failure(e):
+        if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
-        logger.info(f"Skipped decrement of {field} on {pk}/{sk}: nothing to correct")
+        _log_refusal(f'decrement of {field}', pk, sk)
 
 
 def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: int = 1):
     """Update running average in aggregates table.
 
-    `sign=-1` reverses a previously recorded value (subtract from `sum`,
-    decrement `count`). It carries the same condition as a counter decrement,
-    for the same reason: an expired row must not be recreated holding
-    `count = -1`, and a redelivered REMOVE must not push `count` below zero.
+    `sign=-1` reverses a previously recorded value (subtract from `sum`, decrement
+    `count`), under the same condition as an `update_counter` decrement and for the
+    same reasons — see that docstring and the module one.
+
+    WHAT THE CONDITION DOES NOT COVER: it floors `count`, not `sum`. `:val` is the
+    score the CURRENT image carries, while the row holds the sum of the scores
+    actually applied, so a reversal quoting a different score than its insert did
+    (an edit whose two halves were split across batches, a replayed record) leaves
+    `sum` inconsistent with `count` in a way `count` cannot reveal, and
+    `get_summary` serves `sum/count` as the day's average.
+
+    A bound on `sum` was considered and rejected: scores run -1..1, so removing a
+    NEGATIVE score raises `sum` and the bound would have to mirror, and any such
+    bound refuses the legitimate reversal it cannot distinguish from the stale one
+    — trading a skewed average for a permanently overstated `count`, which is the
+    bug this module exists to remove. The coherent fix is to store per-item
+    contributions so a reversal subtracts what was actually added; that is a schema
+    change, and out of scope here. Recorded in the module docstring as a residual.
     """
     ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
 
@@ -166,14 +265,63 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: i
             **kwargs
         )
     except ClientError as e:
-        if sign >= 0 or not _is_conditional_check_failure(e):
+        if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
-        logger.info(f"Skipped reversal of average on {pk}/{sk}: nothing to correct")
+        _log_refusal('reversal of average', pk, sk)
+
+
+def _day_has_aggregates(date: str) -> bool:
+    """Does the daily total for `date` still exist?
+
+    The question a REBUCKET has to answer before it may write, and it is a question
+    about the DAY rather than about any one counter row. `attribute_exists(pk)` on
+    each increment looks like the same guard and is not: an edit that moves an item
+    into a category no item has used TODAY has no row for that category yet, and
+    refusing it would DROP the count — the decrement lands on the bucket the item
+    left and the increment vanishes, so the day's per-category counts stop summing
+    to its total. That is a new inconsistency of exactly the kind this module was
+    repaired for, so the per-row form is not the conservative choice it appears to
+    be. (A moto test caught it: `test_rebucketing_a_day_that_does_have_rows_...`.)
+
+    `METRIC#daily_total` is the right sentinel because EVERY item writes it — it is
+    the one counter with no condition attached to its presence, so it exists if and
+    only if some item of that date was ingested and the row has not yet aged out.
+    If it is gone, the whole day is gone, and an edit to an item of that day must
+    leave no trace rather than plant a one-count fragment under a fresh 90-day TTL
+    that a 365-day metrics window would serve as the day's totals.
+
+    A read per rebucket, on a day whose edits are rare, against a table this
+    function already holds read access to. A failed read answers True: a rebucket
+    that cannot check is treated as a live day, which risks one fragment rather than
+    silently dropping every edit if the table is briefly unreadable.
+    """
+    try:
+        response = aggregates_table.get_item(Key={'pk': 'METRIC#daily_total', 'sk': date})
+    except ClientError as e:
+        logger.warning(f"Could not read the daily total for {date}: {e}; treating the day as live")
+        return True
+    return 'Item' in response
+
+
+def _image_date_or_none(item: dict) -> str | None:
+    """The date bucket an image belongs to, or None if it does not say.
+
+    The STRICT accessor, for the paths that must not guess: a reversal or a
+    rebucket aimed at a date the image never named would move a counter that has
+    nothing to do with the item, and no ConditionExpression can catch that because
+    the row it hits exists and is above the floor. See the module docstring.
+    """
+    return item.get('date') or None
 
 
 def _image_date(item: dict) -> str:
-    """The date bucket an image belongs to."""
-    return item.get('date') or datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    """The date bucket a NEWLY INSERTED image belongs to.
+
+    The today-fallback is only defensible here: for an arrival, today is at least
+    the day the row was created. Reversal paths read `_image_date_or_none` and skip
+    rather than substitute now() — a missed `-1` beats a `-1` on the wrong day.
+    """
+    return _image_date_or_none(item) or datetime.now(timezone.utc).strftime('%Y-%m-%d')
 
 
 def _image_score(item: dict) -> Decimal:
@@ -191,24 +339,31 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     This replaces eight hardcoded `update_counter` calls; an inverted copy of
     those eight would have re-created that hazard on day one.
 
-    NOTE `persona_name` is read here even though the processor writes
-    `persona_type` (so ~everything buckets as `Unknown`). That is a separate
-    finding, tracked separately; reading a different field here than the insert
-    path read would make decrements miss the row the insert created, which is
-    strictly worse than the wrong bucket name. Fix it in one place when it is
-    fixed.
+    URGENCY IS THE ONLY CONDITIONAL DIMENSION. Every other item below is appended
+    unconditionally, because each read has a non-empty default — a reader asking
+    "which of these might be absent?" gets one answer, not two.
+
+    The persona field is read through PERSONA_FIELD, and
+    test_persona_field_lockstep.py pins that name against the field
+    `processor/handler.py` actually writes. Prose could not hold that: reading a
+    different field here than the insert path read makes every DECREMENT miss the
+    row its insert created, so the two must move together, and "fix it in one
+    place" is only true while something fails when they diverge.
     """
     source_platform = item.get('source_platform', 'unknown')
     category = item.get('category', 'other')
     sentiment_label = item.get('sentiment_label', 'neutral')
     urgency = item.get('urgency', 'low')
-    persona = item.get('persona_name', 'Unknown')
+    # `or`, not a `.get` default: a stripped item can carry an explicit None, and
+    # `METRIC#persona#None` is a bucket nothing else would ever write to.
+    persona = item.get(PERSONA_FIELD) or 'Unknown'
 
     dimensions = [
         ('METRIC#daily_total', 'count'),
         (f'METRIC#daily_source#{source_platform}', 'count'),
         (f'METRIC#daily_category#{category}', 'count'),
         (f'METRIC#daily_sentiment#{sentiment_label}', 'count'),
+        (f'METRIC#persona#{persona}', 'count'),
     ]
 
     # Urgency counts (for alerts) — only urgent items have a row at all, so a
@@ -216,25 +371,27 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     if urgency == 'high':
         dimensions.append(('METRIC#urgent', 'count'))
 
-    if persona:
-        dimensions.append((f'METRIC#persona#{persona}', 'count'))
-
     # Category + sentiment combo
     dimensions.append((f'METRIC#category_sentiment#{category}#{sentiment_label}', 'count'))
 
     return dimensions
 
 
-def counter_keys(item: dict) -> set[tuple[str, str, str]]:
-    """`counter_dimensions` with the item's date filled in: (pk, date, field).
+def counter_keys(item: dict, date: str) -> set[tuple[str, str, str]]:
+    """`counter_dimensions` with a date filled in: (pk, date, field).
 
     Every counter in this module is written under a BARE `YYYY-MM-DD` sort key,
     because the streaming reader sums a window with `sk BETWEEN :oldest AND
     :newest` — see test_streaming_categories_lockstep.py. Producing the sort key
     in exactly one place is what keeps that pinnable now that the call sites are
     generic.
+
+    The date is PASSED IN rather than read from the item here, because the two
+    directions read it differently: an arrival may fall back to today, a reversal
+    may not guess at all. Deciding that inside this function would mean either the
+    reversal silently guessing or the insert path refusing an undated arrival it
+    used to accept.
     """
-    date = _image_date(item)
     return {(pk, date, field) for pk, field in counter_dimensions(item)}
 
 
@@ -249,14 +406,13 @@ def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int):
         update_counter(pk, date, field, increment=sign)
 
 
-def apply_feedback(item: dict, sign: int):
-    """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution."""
-    apply_counter_keys(counter_keys(item), sign)
+def apply_feedback(item: dict, sign: int, date: str):
+    """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`."""
+    apply_counter_keys(counter_keys(item, date), sign)
 
     # Daily sentiment score average
     sentiment_score = _image_score(item)
     if sentiment_score:
-        date = _image_date(item)
         update_average('METRIC#daily_sentiment_avg', date, sentiment_score, sign=sign)
 
     verb = 'Updated' if sign > 0 else 'Reversed'
@@ -269,22 +425,36 @@ def apply_feedback(item: dict, sign: int):
 @tracer.capture_method
 def process_new_feedback(item: dict):
     """Update aggregates for a new feedback item."""
-    apply_feedback(item, 1)
+    date = _image_date(item)
+    apply_feedback(item, 1, date)
 
 
 @tracer.capture_method
-def process_deleted_feedback(item: dict):
+def process_deleted_feedback(item: dict) -> bool:
     """Reverse the aggregates a now-deleted feedback item contributed.
 
     Only for a USER-initiated delete. TTL expiry is filtered out upstream in
     `record_handler` — see the module docstring for why ageing out must not
     change a past day's totals.
+
+    Returns False, having written NOTHING, when the deleted image named no date.
+    Substituting today would decrement whichever day this Lambda happens to run
+    on — a legitimate current-day aggregate — while leaving the item's real day
+    overstated, and the ConditionExpression cannot catch it because that row exists
+    and is above the floor. Only legacy or hand-written rows lack `date` (the
+    processor always sets it), which makes this latent rather than active; a missed
+    `-1` is still the right way to be wrong about it.
     """
-    apply_feedback(item, -1)
+    date = _image_date_or_none(item)
+    if date is None:
+        logger.warning("REMOVE image carries no `date`; refusing to guess which day to reverse")
+        return False
+    apply_feedback(item, -1, date)
+    return True
 
 
 @tracer.capture_method
-def process_modified_feedback(old_item: dict, new_item: dict):
+def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
     """Move an item between buckets after an in-place edit.
 
     The ingestion path cannot emit MODIFY (`processor/handler.py` writes with a
@@ -302,24 +472,74 @@ def process_modified_feedback(old_item: dict, new_item: dict):
     increment un-cancelled. Symmetric difference of the two dimension sets is
     also the only formulation that stays correct when `date` itself is edited,
     which moves EVERY counter to another sk.
+
+    AN EDIT TO AN AGED-OUT DAY WRITES NOTHING. The decrements are refused anyway
+    (their rows are gone), but the increments are not: an unconditional `+1` leaves
+    a one-count fragment — and a one-score `daily_sentiment_avg` row, the worst of
+    them, since `get_summary` divides `sum/count` per date and weights it by count —
+    for a date whose real totals were collected months ago, stamped with a fresh
+    90-day TTL. `validate_days` admits windows up to 365 days, so `/metrics/summary`
+    and `/metrics/trends` would then serve those fragments as the day's totals.
+    `PUT /data-explorer/feedback` can edit a record of any age, so this is reachable
+    by ordinary use, not by a race.
+
+    The check is on the DAY (`_day_has_aggregates`), not on each row. Guarding each
+    increment with `attribute_exists(pk)` instead looks equivalent and is not: an
+    edit that moves an item into a category no item has used today has no row for
+    that category yet, and refusing it DROPS the count — the decrement lands, the
+    increment vanishes, and the day's per-category counts no longer sum to its
+    total. Trading one inconsistency for another is not a fix, so the two cases have
+    to be told apart, and only the day can tell them apart.
+
+    Returns the number of writes attempted (0 when the day is gone or the edit
+    touched no dimension), or None when either image named no date — a rebucket
+    needs both days, and guessing one of them moves a counter that has nothing to do
+    with the item.
     """
-    old_keys, new_keys = counter_keys(old_item), counter_keys(new_item)
+    old_date, new_date = _image_date_or_none(old_item), _image_date_or_none(new_item)
+    if old_date is None or new_date is None:
+        logger.warning("MODIFY image carries no `date`; refusing to guess which days to rebucket")
+        return None
 
-    apply_counter_keys(old_keys - new_keys, -1)
-    apply_counter_keys(new_keys - old_keys, 1)
+    old_keys = counter_keys(old_item, old_date)
+    new_keys = counter_keys(new_item, new_date)
+    decrements, increments = old_keys - new_keys, new_keys - old_keys
 
-    old_date, new_date = _image_date(old_item), _image_date(new_item)
     old_score, new_score = _image_score(old_item), _image_score(new_item)
-    if (old_date, old_score) != (new_date, new_score):
+    moves_the_average = (old_date, old_score) != (new_date, new_score)
+    if not (decrements or increments or moves_the_average):
+        # Nothing to do, and no read to pay for: the common case, an edit to a field
+        # no counter buckets on.
+        return 0
+
+    # Checked once for the pair. An edited `date` makes these two different days,
+    # and a live day on either side is enough to make the edit a real correction
+    # rather than an attempt to rewrite history — the half that lands on the dead
+    # day is refused (decrement) or plants nothing anyone asked for.
+    if not (_day_has_aggregates(old_date) or _day_has_aggregates(new_date)):
+        logger.info(
+            f"Skipping rebucket of an aged-out day ({old_date} -> {new_date}): "
+            f"its aggregates have expired and must not be partially recreated"
+        )
+        return 0
+
+    apply_counter_keys(decrements, -1)
+    apply_counter_keys(increments, 1)
+
+    writes = len(decrements) + len(increments)
+    if moves_the_average:
         if old_score:
             update_average('METRIC#daily_sentiment_avg', old_date, old_score, sign=-1)
+            writes += 1
         if new_score:
             update_average('METRIC#daily_sentiment_avg', new_date, new_score, sign=1)
+            writes += 1
 
     logger.info(
-        f"Rebucketed aggregates: {len(old_keys - new_keys)} decrement(s), "
-        f"{len(new_keys - old_keys)} increment(s)"
+        f"Rebucketed aggregates: {len(decrements)} decrement(s), "
+        f"{len(increments)} increment(s)"
     )
+    return writes
 
 
 def deserialize_image(image: dict) -> dict:
@@ -361,12 +581,44 @@ def is_ttl_expiry(record: DynamoDBRecord) -> bool:
     opposite misreading costs at most one decrement, and even that cannot corrupt
     the row: the decrement is conditional, so against an aged-out row it is a
     no-op rather than a resurrected negative count.
+
+    Read from `raw_event` and accepted as any Mapping, so this branch is pinned to
+    the EVENT SHAPE rather than to a Powertools return type. `record.user_identity`
+    returns a bare dict today and `None`/`{}` when absent, but a release that
+    wrapped it in a `DictWrapper` would fail an `isinstance(..., dict)` test and
+    quietly reclassify EVERY TTL REMOVE as a user delete — the whole branch dead,
+    the suite still green, because the tests build records from raw event dicts and
+    so follow Powertools rather than pinning it.
     """
-    identity = record.user_identity if hasattr(record, 'user_identity') else None
-    if not isinstance(identity, dict):
+    identity = record.raw_event.get('userIdentity') if isinstance(record.raw_event, Mapping) else None
+    if not isinstance(identity, Mapping):
         return False
     return (identity.get('principalId') == 'dynamodb.amazonaws.com'
             and identity.get('type') == 'Service')
+
+
+def _event_name(record: DynamoDBRecord) -> str | None:
+    """The record's `eventName`, as the EVENT spells it.
+
+    Read from `raw_event`, not from `record.event_name`. Powertools resolves that
+    property through `DynamoDBRecordEventName[...]`, so it raises `KeyError` for
+    any name outside the three the enum knows — which would happen BEFORE the
+    membership check below could return a graceful skip, and with
+    `reportBatchItemFailures: true` the record would then be reported failed and
+    redelivered until it aged out of the stream. Streams preserve per-shard order,
+    so one permanently-failing record blocks its partition: a poison pill in place
+    of the skip. The stream API has exactly three event names today, so this is
+    about the failure MODE rather than a likely event.
+
+    Falls back to the property when `raw_event` is not a mapping, which is the case
+    for the MagicMock-based records in the older tests.
+    """
+    raw = getattr(record, 'raw_event', None)
+    if isinstance(raw, Mapping):
+        name = raw.get('eventName')
+        return name if isinstance(name, str) else None
+    # event_name is an enum in Powertools, compare with .value or string representation
+    return str(record.event_name).split('.')[-1] if record.event_name else None
 
 
 def record_handler(record: DynamoDBRecord) -> dict:
@@ -376,9 +628,13 @@ def record_handler(record: DynamoDBRecord) -> dict:
     deleting) and MODIFY moves an item between buckets. Counting only INSERTs is
     what made `get_metrics_summary` (aggregates) and `search_feedback` (scan)
     report different totals for the same window.
+
+    One metric per behaviour, because the three now do materially different things
+    and a single `AggregatesUpdated` would leave reversals invisible from outside
+    the table — see the metric constants at the top of this module. A rebucket that
+    wrote nothing emits nothing, so the count means "aggregates moved".
     """
-    # event_name is an enum in Powertools, compare with .value or string representation
-    event_name = str(record.event_name).split('.')[-1] if record.event_name else None
+    event_name = _event_name(record)
     logger.info(f"Processing record: event_name={event_name}")
 
     if event_name not in ('INSERT', 'REMOVE', 'MODIFY'):
@@ -399,16 +655,20 @@ def record_handler(record: DynamoDBRecord) -> dict:
             return {"status": "skipped", "reason": "no old image"}
         item = deserialize_image(old_image)
         logger.info(f"Reversing feedback: date={item.get('date')}, source={item.get('source_platform')}")
-        process_deleted_feedback(item)
-        metrics.add_metric(name="AggregatesUpdated", unit="Count", value=1)
+        if not process_deleted_feedback(item):
+            return {"status": "skipped", "reason": "no date"}
+        metrics.add_metric(name=REVERSED_METRIC, unit="Count", value=1)
         return {"status": "success"}
 
     if event_name == 'MODIFY':
         if not old_image or not new_image:
             logger.warning("MODIFY record is missing an image; cannot rebucket")
             return {"status": "skipped", "reason": "incomplete images"}
-        process_modified_feedback(deserialize_image(old_image), deserialize_image(new_image))
-        metrics.add_metric(name="AggregatesUpdated", unit="Count", value=1)
+        writes = process_modified_feedback(deserialize_image(old_image), deserialize_image(new_image))
+        if writes is None:
+            return {"status": "skipped", "reason": "no date"}
+        if writes:
+            metrics.add_metric(name=REBUCKETED_METRIC, unit="Count", value=1)
         return {"status": "success"}
 
     if not new_image:
@@ -421,7 +681,7 @@ def record_handler(record: DynamoDBRecord) -> dict:
 
     logger.info(f"Processing feedback: date={item.get('date')}, source={item.get('source_platform')}")
     process_new_feedback(item)
-    metrics.add_metric(name="AggregatesUpdated", unit="Count", value=1)
+    metrics.add_metric(name=UPDATED_METRIC, unit="Count", value=1)
 
     return {"status": "success"}
 

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -46,7 +46,16 @@ Which writes may create a row, and which may not
   ago. `validate_days` admits windows up to 365 days, so `/metrics/summary` and
   `/metrics/trends` would serve those fragments as the day's totals. The check is
   on the DAY, not per row — see `_day_has_aggregates` for why the per-row form
-  drops legitimate counts instead of protecting anything.
+  drops legitimate counts instead of protecting anything — and it is applied PER
+  SIDE, because an edit can move an item from a live day onto a dead one and every
+  increment then lands on the dead day.
+
+A rebucket's two halves of the AVERAGE stand or fall together. The counters cannot
+split (a symmetric difference never sends `-1` and `+1` to one key), but the average
+is two conditional writes to one row: a reversal refused against a row at
+`count == 0` while the re-application applies would leave that row asserting an item
+no feedback justifies, and `get_summary` divides `sum/count` into the day's average
+and weights it into the headline number. See `_rebucket_average`.
 
 A reversal also refuses to GUESS a date. `_image_date` falls back to today when an
 image carries no `date` field, which is defensible for an INSERT (today is at
@@ -132,6 +141,35 @@ REFUSED_METRIC = "AggregateWriteRefused"
 # lockstep is about the two sides agreeing, not about which of the two wins.
 PERSONA_FIELD = 'persona_name'
 
+# The two aggregate rows this module names outside `counter_dimensions`, hoisted
+# for the reason PERSONA_FIELD is: a second unmarked copy of one of these strings
+# is what makes an argument elsewhere in the file true or false.
+#
+# DAILY_TOTAL_PK is the sentinel `_day_has_aggregates` reads, and that read is only
+# a sound test of "is this day still here?" because this is the ONE counter every
+# item writes unconditionally — see that docstring. Spelling it twice would leave a
+# reader of the sentinel having to know that the copy in `counter_dimensions` is
+# what licenses the argument.
+DAILY_TOTAL_PK = 'METRIC#daily_total'
+SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
+
+# Client error codes worth failing OPEN for without shouting: a blip, a throttle, a
+# retryable server-side fault. Anything outside this set is a misconfiguration
+# (`AccessDeniedException`, `ValidationException`, `ResourceNotFoundException`), and
+# `_day_has_aggregates` still fails open on it — but says so at `error`, because a
+# permanently inert guard must not look like a bad afternoon. See that docstring.
+_TRANSIENT_READ_ERRORS = frozenset({
+    'ProvisionedThroughputExceededException',
+    'ThrottlingException',
+    'ThrottlingException.TooManyRequests',
+    'RequestLimitExceeded',
+    'InternalServerError',
+    'ServiceUnavailable',
+    'RequestTimeout',
+    'RequestTimeoutException',
+    'TransactionConflictException',
+})
+
 
 def get_metric_type(pk: str) -> str | None:
     """Extract metric type from pk for GSI indexing."""
@@ -153,8 +191,15 @@ def _log_refusal(what: str, pk: str, sk: str):
     metrics.add_metric(name=REFUSED_METRIC, unit="Count", value=1)
 
 
-def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: int = 90):
+def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: int = 90) -> bool:
     """Atomically update a counter in the aggregates table.
+
+    Returns whether the write LANDED. False means a condition refused it, which is
+    an ordinary outcome for a decrement and never happens to an increment (they
+    carry no condition). Callers that must know the difference: the rebucket, whose
+    two halves have to stand or fall together, and the metric that claims
+    "aggregates moved" — a count of writes ATTEMPTED would make that claim false
+    for an edit whose every write was refused.
 
     An increment may create the row — that is how a date's first item registers,
     and it stays true for a REBUCKET, because the first item edited into a category
@@ -211,10 +256,15 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
         if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
         _log_refusal(f'decrement of {field}', pk, sk)
+        return False
+    return True
 
 
-def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: int = 1):
+def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: int = 1) -> bool:
     """Update running average in aggregates table.
+
+    Returns whether the write LANDED, like `update_counter` and for the same
+    reasons — the rebucket's reversal and re-application must not be able to split.
 
     `sign=-1` reverses a previously recorded value (subtract from `sum`, decrement
     `count`), under the same condition as an `update_counter` decrement and for the
@@ -268,6 +318,8 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90, sign: i
         if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
         _log_refusal('reversal of average', pk, sk)
+        return False
+    return True
 
 
 def _day_has_aggregates(date: str) -> bool:
@@ -283,22 +335,47 @@ def _day_has_aggregates(date: str) -> bool:
     repaired for, so the per-row form is not the conservative choice it appears to
     be. (A moto test caught it: `test_rebucketing_a_day_that_does_have_rows_...`.)
 
-    `METRIC#daily_total` is the right sentinel because EVERY item writes it — it is
-    the one counter with no condition attached to its presence, so it exists if and
-    only if some item of that date was ingested and the row has not yet aged out.
-    If it is gone, the whole day is gone, and an edit to an item of that day must
-    leave no trace rather than plant a one-count fragment under a fresh 90-day TTL
-    that a 365-day metrics window would serve as the day's totals.
+    DAILY_TOTAL_PK is the right sentinel because EVERY item writes it — it is the
+    one counter with no condition attached to its presence, so it exists if and only
+    if some item of that date was ingested and the row has not yet aged out. If it is
+    gone, the whole day is gone, and an edit to an item of that day must leave no
+    trace rather than plant a one-count fragment under a fresh 90-day TTL that a
+    365-day metrics window would serve as the day's totals. That argument depends on
+    `counter_dimensions` writing this same pk unconditionally, which is why the two
+    read one constant rather than two matching literals.
 
-    A read per rebucket, on a day whose edits are rare, against a table this
-    function already holds read access to. A failed read answers True: a rebucket
-    that cannot check is treated as a live day, which risks one fragment rather than
-    silently dropping every edit if the table is briefly unreadable.
+    A read per rebucket, on a day whose edits are rare, against a table the shared
+    `processingRole` already holds read access to (`aggregatesTable.grantReadWriteData`
+    in processing-stack-consolidated.ts).
+
+    A FAILED READ ANSWERS TRUE: a rebucket that cannot check is treated as a live
+    day, which risks one recoverable fragment rather than silently dropping every
+    edit while the table is briefly unreadable. But the two reasons a read fails are
+    not equally survivable, so they are not logged alike. A throttle is a bad
+    afternoon; `AccessDeniedException` or `ValidationException` is a
+    misconfiguration, under which this guard is PERMANENTLY inert and every edit to
+    an aged-out day plants the fragments the guard exists to prevent — indefinitely,
+    and with `logger.warning` indistinguishable from the blip it was designed for.
+    Hence `logger.error` for anything outside `_TRANSIENT_READ_ERRORS`: the fail-open
+    direction is unchanged, its cause is not silent.
     """
     try:
-        response = aggregates_table.get_item(Key={'pk': 'METRIC#daily_total', 'sk': date})
+        response = aggregates_table.get_item(Key={'pk': DAILY_TOTAL_PK, 'sk': date})
     except ClientError as e:
-        logger.warning(f"Could not read the daily total for {date}: {e}; treating the day as live")
+        code = e.response.get('Error', {}).get('Code', '') if isinstance(e.response, Mapping) else ''
+        message = (
+            f"Could not read the daily total for {date}: {e}; treating the day as live"
+        )
+        if code in _TRANSIENT_READ_ERRORS:
+            logger.warning(message)
+        else:
+            # Not a blip. Until this is fixed the aged-out-day guard cannot refuse
+            # anything, so say so at a level an operator is alerted on.
+            logger.error(
+                f"{message}. `{code}` is not transient, so this guard is INERT until "
+                f"it is fixed and every edit to an aged-out day will plant aggregate "
+                f"fragments for it."
+            )
         return True
     return 'Item' in response
 
@@ -359,7 +436,10 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     persona = item.get(PERSONA_FIELD) or 'Unknown'
 
     dimensions = [
-        ('METRIC#daily_total', 'count'),
+        # DAILY_TOTAL_PK, not the literal: `_day_has_aggregates` reads this same
+        # constant as its sentinel, and its argument for doing so is that this line
+        # is unconditional. Two spellings would leave that dependency unmarked.
+        (DAILY_TOTAL_PK, 'count'),
         (f'METRIC#daily_source#{source_platform}', 'count'),
         (f'METRIC#daily_category#{category}', 'count'),
         (f'METRIC#daily_sentiment#{sentiment_label}', 'count'),
@@ -395,15 +475,20 @@ def counter_keys(item: dict, date: str) -> set[tuple[str, str, str]]:
     return {(pk, date, field) for pk, field in counter_dimensions(item)}
 
 
-def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int):
-    """Move every named counter by `sign`.
+def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int) -> int:
+    """Move every named counter by `sign`, returning how many writes LANDED.
 
     The ONE place a counter key is unpacked into an `update_counter` call, so
     there is exactly one line in this module deciding what a counter's sort key
     is. Sorted only to make the write order deterministic for tests and logs.
+
+    Landed, not attempted: a caller counting attempts would report that aggregates
+    moved for an edit whose every write was refused by its condition.
     """
-    for pk, date, field in sorted(keys):
-        update_counter(pk, date, field, increment=sign)
+    return sum(
+        1 for pk, date, field in sorted(keys)
+        if update_counter(pk, date, field, increment=sign)
+    )
 
 
 def apply_feedback(item: dict, sign: int, date: str):
@@ -413,7 +498,7 @@ def apply_feedback(item: dict, sign: int, date: str):
     # Daily sentiment score average
     sentiment_score = _image_score(item)
     if sentiment_score:
-        update_average('METRIC#daily_sentiment_avg', date, sentiment_score, sign=sign)
+        update_average(SENTIMENT_AVG_PK, date, sentiment_score, sign=sign)
 
     verb = 'Updated' if sign > 0 else 'Reversed'
     logger.info(
@@ -491,10 +576,33 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
     total. Trading one inconsistency for another is not a fix, so the two cases have
     to be told apart, and only the day can tell them apart.
 
-    Returns the number of writes attempted (0 when the day is gone or the edit
-    touched no dimension), or None when either image named no date — a rebucket
-    needs both days, and guessing one of them moves a counter that has nothing to do
-    with the item.
+    THE DAY IS CHECKED PER SIDE, not once for the pair. `old_live or new_live` reads
+    as a reasonable "is this edit a real correction?" and is not: an edit whose
+    `date` moves an item FROM a live day TO a dead one would pass it, and then every
+    unconditional increment lands on the dead day — recreating the whole seven-row
+    fragment, `daily_total` included, so the sentinel afterwards reports the dead day
+    as live for every subsequent edit. So decrements are applied only when the day
+    they leave is live, increments only when the day they arrive at is live. Each
+    distinct date is read once, which also stops the common same-day rebucket paying
+    for two identical reads of one key.
+
+    THE AVERAGE'S TWO HALVES STAND OR FALL TOGETHER. The counter dimensions are a
+    symmetric difference precisely so a `-1` and a `+1` never land on the same key,
+    but the average has no such protection: it is two conditional writes to
+    (SENTIMENT_AVG_PK, date), and `#count >= :floor` can refuse the reversal against
+    a row sitting at zero while the re-application applies unconditionally — leaving
+    the row asserting one item, at the new score, that no present feedback justifies,
+    which `get_summary` then divides into the day's average and weights into the
+    headline `avg_sentiment`. So the increment half is applied only if the reversal
+    half LANDED, or if there was no reversal to pair with (an old score of zero has
+    nothing to reverse, and a dead old day has nothing to correct).
+
+    Returns the number of writes that LANDED (0 when both days are gone, when the
+    edit touched no dimension, or when every write was refused), or None when either
+    image named no date — a rebucket needs both days, and guessing one of them moves
+    a counter that has nothing to do with the item. Landed rather than attempted
+    because `record_handler` spends this as REBUCKETED_METRIC, whose claim is that
+    aggregates MOVED.
     """
     old_date, new_date = _image_date_or_none(old_item), _image_date_or_none(new_item)
     if old_date is None or new_date is None:
@@ -512,34 +620,90 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
         # no counter buckets on.
         return 0
 
-    # Checked once for the pair. An edited `date` makes these two different days,
-    # and a live day on either side is enough to make the edit a real correction
-    # rather than an attempt to rewrite history — the half that lands on the dead
-    # day is refused (decrement) or plants nothing anyone asked for.
-    if not (_day_has_aggregates(old_date) or _day_has_aggregates(new_date)):
+    # One read per DISTINCT date: a same-day edit — the common case, since `date` is
+    # not in the Data Explorer's updatable_fields — asks the one question once.
+    liveness = {date: _day_has_aggregates(date) for date in {old_date, new_date}}
+    old_live, new_live = liveness[old_date], liveness[new_date]
+    if not (old_live or new_live):
         logger.info(
             f"Skipping rebucket of an aged-out day ({old_date} -> {new_date}): "
             f"its aggregates have expired and must not be partially recreated"
         )
         return 0
 
-    apply_counter_keys(decrements, -1)
-    apply_counter_keys(increments, 1)
+    writes = 0
+    if old_live:
+        writes += apply_counter_keys(decrements, -1)
+    elif decrements:
+        logger.info(f"Not decrementing {len(decrements)} counter(s) on the aged-out {old_date}")
+    if new_live:
+        writes += apply_counter_keys(increments, 1)
+    elif increments:
+        # The half the `or` used to let through. These are unconditional writes, so
+        # nothing but this branch stops them creating the day.
+        logger.info(f"Not incrementing {len(increments)} counter(s) on the aged-out {new_date}")
 
-    writes = len(decrements) + len(increments)
     if moves_the_average:
-        if old_score:
-            update_average('METRIC#daily_sentiment_avg', old_date, old_score, sign=-1)
-            writes += 1
-        if new_score:
-            update_average('METRIC#daily_sentiment_avg', new_date, new_score, sign=1)
-            writes += 1
+        writes += _rebucket_average(old_date, old_score, old_live, new_date, new_score, new_live)
 
     logger.info(
         f"Rebucketed aggregates: {len(decrements)} decrement(s), "
-        f"{len(increments)} increment(s)"
+        f"{len(increments)} increment(s), {writes} landed"
     )
     return writes
+
+
+def _rebucket_average(
+    old_date: str, old_score: Decimal, old_live: bool,
+    new_date: str, new_score: Decimal, new_live: bool,
+) -> int:
+    """Move one item's contribution to the running average, as a PAIR.
+
+    Split out because the pairing rule is the whole content: reverse first, and
+    re-apply only if that reversal landed. A refused reversal means the row is
+    already at `count == 0` — it is claiming no items — and adding the new score
+    anyway makes it claim one, at the edited score, that no feedback justifies.
+    `get_summary` serves `sum/count` per date and weights it by count into the
+    headline average, so that is served-data corruption rather than a skew nobody
+    reads.
+
+    Two cases have NO reversal to pair with, and the increment is right in both:
+
+      * an old score of zero contributed nothing to the average, so nothing was
+        reversed and nothing is left dangling;
+      * an aged-out old day was never asked (`old_live` is False). Its row is gone,
+        so there is no half to be inconsistent with, and refusing the increment
+        would lose the item from the metrics surface entirely — which is the
+        count-dropping failure `_day_has_aggregates` exists to avoid.
+
+    WHY THE COUNTERS ARE NOT PAIRED THIS WAY, though they look symmetrical: a
+    refused counter decrement and its increment go to DIFFERENT keys (that is what
+    makes them a symmetric difference), so each row is left internally consistent
+    and the only cost is a bucket that reads one high and another one low. This row
+    holds `sum` and `count` for the same day, and a split leaves the two describing
+    different sets of items — a state no per-row floor can express, and the one
+    `get_summary` divides. Pairing here and not there is that difference, not an
+    inconsistency.
+
+    Returns how many of the two writes landed.
+    """
+    landed = 0
+    reversal_refused = False
+    if old_score and old_live:
+        if update_average(SENTIMENT_AVG_PK, old_date, old_score, sign=-1):
+            landed += 1
+        else:
+            reversal_refused = True
+            logger.info(
+                f"Refused reversal of the average on {old_date}, so the paired "
+                f"re-application on {new_date} is skipped: applying it alone would "
+                f"leave the row claiming an item that is not there"
+            )
+
+    if (new_score and new_live and not reversal_refused
+            and update_average(SENTIMENT_AVG_PK, new_date, new_score, sign=1)):
+        landed += 1
+    return landed
 
 
 def deserialize_image(image: dict) -> dict:
@@ -631,8 +795,11 @@ def record_handler(record: DynamoDBRecord) -> dict:
 
     One metric per behaviour, because the three now do materially different things
     and a single `AggregatesUpdated` would leave reversals invisible from outside
-    the table — see the metric constants at the top of this module. A rebucket that
-    wrote nothing emits nothing, so the count means "aggregates moved".
+    the table — see the metric constants at the top of this module. A rebucket emits
+    nothing unless a write LANDED, so the count means "aggregates moved" rather than
+    "a rebucket was attempted": `process_modified_feedback` returns writes that
+    landed, and an edit whose every write was refused by its condition moved nothing
+    while still being separately visible as REFUSED_METRIC.
     """
     event_name = _event_name(record)
     logger.info(f"Processing record: event_name={event_name}")

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -5,9 +5,146 @@ Tests the core aggregation functions:
 - update_average()
 - process_new_feedback()
 - record_handler()
+
+The stream consumer used to count only INSERTs, so every aggregate held items
+EVER inserted and never came back down — `get_metrics_summary` (aggregates) and
+`search_feedback` (scan) then reported different totals for the same window.
+Handling REMOVE and MODIFY is the fix, and the classes below pin the three
+decisions inside it that a naive implementation gets wrong. The revert map:
+
+  TestTtlExpiryLeavesHistoryAlone
+    — the feedback table expires items at 365 days while aggregate rows expire at
+      90, so a TTL REMOVE always concerns a date whose row is already gone.
+      Deleting the `is_ttl_expiry` skip in `record_handler` fails
+      `test_a_ttl_expiry_writes_nothing_at_all`; its sibling
+      `test_a_user_delete_of_the_same_item_does_write` is the positive control,
+      so the pair cannot both pass by the mock being inert.
+      `test_a_remove_with_no_user_identity_is_treated_as_a_user_delete` pins the
+      chosen direction for an unreadable identity; inverting that default fails
+      it.
+
+  TestADeleteReversesExactlyWhatTheInsertAdded
+    — derives both write sets from the handler rather than restating them, so a
+      dimension added to the increment path without a matching reverse fails
+      `test_the_reversed_dimensions_are_exactly_the_incremented_ones`. Replacing
+      the shared `counter_dimensions` with an inverted hand-written twin is the
+      mutation this is aimed at.
+
+  TestADecrementCannotCreateOrGoNegative
+    — dropping the `ConditionExpression` from `update_counter`'s decrement branch
+      fails `test_a_decrement_against_a_missing_row_creates_nothing` (moto really
+      does refuse the write, and without the condition the row is created holding
+      `-1` with a fresh 90-day TTL) and
+      `test_a_repeated_remove_does_not_push_a_counter_below_zero` (Streams are
+      at-least-once). Re-raising ConditionalCheckFailedException instead of
+      swallowing it fails `test_a_refused_decrement_is_not_an_error`.
+
+  TestAnEditMovesAnItemBetweenBuckets
+    — restoring the old `if event_name != 'INSERT': return` for MODIFY fails
+      seven of these plus `test_skips_a_modify_missing_an_image`. Rebucketing
+      every dimension instead of only the changed ones fails
+      `test_dimensions_whose_value_did_not_change_are_not_written` and
+      `test_an_edit_touching_no_dimension_writes_nothing`; dropping the
+      `urgency == 'high'` guard fails five tests across three classes, including
+      `test_urgency_raised_to_high_adds_the_urgent_count`.
+
+Each of those reverts was RUN, not predicted. Two more were run for the same
+reason:
+
+  * having the reverse path skip one dimension — the shape an inverted
+    hand-written twin of the eight original `update_counter` calls would
+    eventually take — fails
+    `test_the_reversed_dimensions_are_exactly_the_incremented_ones`;
+  * treating an absent `userIdentity` as TTL expiry fails
+    `test_a_remove_with_no_user_identity_is_treated_as_a_user_delete` plus both
+    tests that delete without one.
 """
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
+from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBRecord
+
+TTL_IDENTITY = {'principalId': 'dynamodb.amazonaws.com', 'type': 'Service'}
+
+
+def _to_ddb(item: dict) -> dict:
+    """Serialize a plain dict the way a stream image arrives."""
+    out = {}
+    for key, value in item.items():
+        if isinstance(value, bool):
+            out[key] = {'BOOL': value}
+        elif isinstance(value, (int, float, Decimal)):
+            out[key] = {'N': str(value)}
+        else:
+            out[key] = {'S': str(value)}
+    return out
+
+
+def _record(event_name: str, *, new=None, old=None, user_identity=None) -> DynamoDBRecord:
+    """A real Powertools stream record, not a MagicMock.
+
+    A MagicMock answers any attribute, so `record.user_identity` on one would be
+    a truthy mock and the TTL branch could never be exercised honestly.
+    """
+    body: dict = {'eventName': event_name, 'eventSource': 'aws:dynamodb', 'dynamodb': {}}
+    if new is not None:
+        body['dynamodb']['NewImage'] = _to_ddb(new)
+    if old is not None:
+        body['dynamodb']['OldImage'] = _to_ddb(old)
+    if user_identity is not None:
+        body['userIdentity'] = user_identity
+    return DynamoDBRecord(body)
+
+
+def _writes(mock_table) -> list[tuple[str, str, str, int]]:
+    """Every write a mocked aggregates table received, as (pk, sk, field, delta).
+
+    Derived from the calls rather than restated, so the assertions below compare
+    what the handler DID in one direction against what it did in the other.
+    """
+    out = []
+    for call in mock_table.update_item.call_args_list:
+        kwargs = call.kwargs
+        key, names, values = kwargs['Key'], kwargs['ExpressionAttributeNames'], kwargs['ExpressionAttributeValues']
+        if '#field' in names:
+            out.append((key['pk'], key['sk'], names['#field'], values[':inc']))
+        else:
+            # update_average: `:one` carries the sign of the count movement.
+            out.append((key['pk'], key['sk'], 'sum', values[':one']))
+    return out
+
+
+def _dimensions(writes) -> set[tuple[str, str, str]]:
+    """The (pk, sk, field) triples written, dropping the direction."""
+    return {(pk, sk, field) for pk, sk, field, _ in writes}
+
+
+@pytest.fixture
+def real_aggregates_table():
+    """A moto-backed aggregates table, so condition expressions are really evaluated.
+
+    The floor-at-zero and no-resurrection properties are properties of DynamoDB's
+    evaluation of the ConditionExpression. A mock cannot refuse a write, so
+    against a mock those tests would pass with the condition deleted.
+    """
+    with mock_aws():
+        table = boto3.resource('dynamodb', region_name='us-east-1').create_table(
+            TableName='test-aggregates',
+            KeySchema=[
+                {'AttributeName': 'pk', 'KeyType': 'HASH'},
+                {'AttributeName': 'sk', 'KeyType': 'RANGE'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'pk', 'AttributeType': 'S'},
+                {'AttributeName': 'sk', 'AttributeType': 'S'},
+            ],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        with patch('aggregator.handler.aggregates_table', table):
+            yield table
 
 
 class TestGetMetricType:
@@ -315,31 +452,48 @@ class TestRecordHandler:
         assert result['status'] == 'success'
         mock_process.assert_called_once()
 
+    @patch('aggregator.handler.aggregates_table')
     @patch('aggregator.handler.process_new_feedback')
-    def test_skips_modify_event(self, mock_process):
-        """Skips MODIFY events from DynamoDB stream."""
+    def test_does_not_treat_a_modify_as_an_insert(self, mock_process, mock_table):
+        """A MODIFY is rebucketed, never counted as a fresh arrival."""
         from aggregator.handler import record_handler
-        
-        record = MagicMock()
-        record.event_name = 'MODIFY'
-        
-        result = record_handler(record)
-        
-        assert result['status'] == 'skipped'
-        assert result['reason'] == 'not an insert'
+
+        record = _record('MODIFY', old={'date': '2025-01-15'}, new={'date': '2025-01-15'})
+
+        record_handler(record)
+
         mock_process.assert_not_called()
 
     @patch('aggregator.handler.process_new_feedback')
-    def test_skips_remove_event(self, mock_process):
-        """Skips REMOVE events from DynamoDB stream."""
+    def test_skips_a_modify_missing_an_image(self, mock_process):
+        """Cannot rebucket without both images, so writes nothing."""
         from aggregator.handler import record_handler
-        
-        record = MagicMock()
-        record.event_name = 'REMOVE'
-        
-        result = record_handler(record)
-        
+
+        result = record_handler(_record('MODIFY', new={'date': '2025-01-15'}))
+
         assert result['status'] == 'skipped'
+        assert result['reason'] == 'incomplete images'
+        mock_process.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    @patch('aggregator.handler.process_new_feedback')
+    def test_does_not_treat_a_remove_as_an_insert(self, mock_process, mock_table):
+        """A REMOVE reverses, never counts up."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old={'date': '2025-01-15'}))
+
+        mock_process.assert_not_called()
+
+    @patch('aggregator.handler.process_deleted_feedback')
+    def test_skips_a_remove_with_no_old_image(self, mock_process):
+        """Without an old image there is nothing to reverse."""
+        from aggregator.handler import record_handler
+
+        result = record_handler(_record('REMOVE'))
+
+        assert result['status'] == 'skipped'
+        assert result['reason'] == 'no old image'
         mock_process.assert_not_called()
 
     @patch('aggregator.handler.process_new_feedback')
@@ -402,3 +556,333 @@ class TestRecordHandler:
         item = call_args.args[0]
         assert item['date'] == '2025-01-15'
         assert item['source_platform'] == 'webscraper'
+
+
+class TestTtlExpiryLeavesHistoryAlone:
+    """A REMOVE from the TTL reaper must not change any aggregate.
+
+    Feedback items live 365 days; the aggregate row for the date they arrived on
+    lives 90. So the TTL REMOVE for the feedback of date D arrives around D+365,
+    when the row for D is long gone — and an unconditional decrement would
+    RECREATE it holding a negative count with a fresh 90-day TTL. The item really
+    did arrive on D; garbage-collecting it later is not a correction.
+    """
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_ttl_expiry_writes_nothing_at_all(self, mock_table, sample_feedback_item):
+        from aggregator.handler import record_handler
+
+        result = record_handler(
+            _record('REMOVE', old=sample_feedback_item, user_identity=TTL_IDENTITY)
+        )
+
+        assert result == {"status": "skipped", "reason": "ttl expiry"}
+        mock_table.update_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_user_delete_of_the_same_item_does_write(self, mock_table, sample_feedback_item):
+        """Positive control for the test above: the mock is not inert."""
+        from aggregator.handler import record_handler
+
+        result = record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        assert result == {"status": "success"}
+        assert mock_table.update_item.call_count > 0
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_remove_with_no_user_identity_is_treated_as_a_user_delete(
+        self, mock_table, sample_feedback_item
+    ):
+        """An absent identity fails TOWARD correcting the count.
+
+        A real user delete is the case this fix exists for, and misreading one as
+        TTL expiry leaves the aggregate permanently overstated. The opposite
+        misreading costs one decrement, and the ConditionExpression keeps even
+        that from corrupting a row.
+        """
+        from aggregator.handler import record_handler
+
+        record = _record('REMOVE', old=sample_feedback_item)
+        assert 'userIdentity' not in record.raw_event
+
+        assert record_handler(record) == {"status": "success"}
+        assert mock_table.update_item.call_count > 0
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_non_service_identity_is_a_user_delete(self, mock_table, sample_feedback_item):
+        """Only `dynamodb.amazonaws.com` + `Service` means the reaper."""
+        from aggregator.handler import record_handler
+
+        record = _record(
+            'REMOVE', old=sample_feedback_item,
+            user_identity={'principalId': 'AIDAEXAMPLE', 'type': 'AssumedRole'},
+        )
+
+        assert record_handler(record) == {"status": "success"}
+        assert mock_table.update_item.call_count > 0
+
+
+class TestADeleteReversesExactlyWhatTheInsertAdded:
+    """Every dimension the insert incremented, the delete decrements.
+
+    Both sets are derived from the handler, never restated here, so a dimension
+    added to one path only fails this rather than passing a stale list.
+    """
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_the_reversed_dimensions_are_exactly_the_incremented_ones(
+        self, mock_table, sample_urgent_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_urgent_feedback_item))
+        inserted = _writes(mock_table)
+        mock_table.reset_mock()
+
+        record_handler(_record('REMOVE', old=sample_urgent_feedback_item))
+        removed = _writes(mock_table)
+
+        assert _dimensions(inserted) == _dimensions(removed)
+        assert all(delta == 1 for *_, delta in inserted)
+        assert all(delta == -1 for *_, delta in removed)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_the_sentiment_average_is_reversed_too(self, mock_table, sample_feedback_item):
+        """`sum` moves back by the same score, and `count` back by one."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        avg = [c.kwargs for c in mock_table.update_item.call_args_list
+               if c.kwargs['Key']['pk'] == 'METRIC#daily_sentiment_avg']
+        assert len(avg) == 1
+        assert avg[0]['ExpressionAttributeValues'][':val'] == Decimal('-0.85')
+        assert avg[0]['ExpressionAttributeValues'][':one'] == -1
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_non_urgent_delete_does_not_touch_the_urgent_row(
+        self, mock_table, sample_feedback_item
+    ):
+        """No urgent row was ever written for it, so none may be decremented."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        assert not [c for c in mock_table.update_item.call_args_list
+                    if c.kwargs['Key']['pk'] == 'METRIC#urgent']
+
+
+class TestADecrementCannotCreateOrGoNegative:
+    """The guard on the decrement, evaluated by a real DynamoDB implementation."""
+
+    def test_a_decrement_against_a_missing_row_creates_nothing(self, real_aggregates_table):
+        """An aggregate that has already expired has nothing to correct.
+
+        Without the ConditionExpression, `if_not_exists(#field, :zero) + :inc`
+        creates the row holding `-1` and stamps a fresh 90-day TTL on it — a
+        negative count served by any window query reaching that far back.
+        """
+        from aggregator.handler import update_counter
+
+        update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=-1)
+
+        assert real_aggregates_table.scan()['Items'] == []
+
+    def test_a_repeated_remove_does_not_push_a_counter_below_zero(self, real_aggregates_table):
+        """Streams deliver at-least-once, so the same REMOVE can arrive twice."""
+        from aggregator.handler import update_counter
+
+        update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=1)
+        update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=-1)
+        update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=-1)
+
+        items = real_aggregates_table.scan()['Items']
+        assert [i['count'] for i in items] == [Decimal(0)]
+
+    def test_an_average_reversal_against_a_missing_row_creates_nothing(self, real_aggregates_table):
+        from aggregator.handler import update_average
+
+        update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1)
+
+        assert real_aggregates_table.scan()['Items'] == []
+
+    def test_an_average_count_does_not_go_below_zero(self, real_aggregates_table):
+        from aggregator.handler import update_average
+
+        update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
+        update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1)
+        update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1)
+
+        item = real_aggregates_table.scan()['Items'][0]
+        assert item['count'] == Decimal(0)
+        assert item['sum'] == Decimal(0)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_refused_decrement_is_not_an_error(self, mock_table):
+        """ConditionalCheckFailedException is the expected benign outcome."""
+        from aggregator.handler import update_counter
+
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'gone'}},
+            'UpdateItem',
+        )
+
+        update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=-1)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_any_other_dynamodb_error_still_raises(self, mock_table):
+        """Only the condition failure is benign; a throttle must reach the batch processor."""
+        from aggregator.handler import update_counter
+
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ProvisionedThroughputExceededException', 'Message': 'slow down'}},
+            'UpdateItem',
+        )
+
+        with pytest.raises(ClientError):
+            update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=-1)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_increment_carries_no_condition(self, mock_table):
+        """A date's FIRST item has no row yet, so the increment must be free to create one."""
+        from aggregator.handler import update_counter
+
+        update_counter('METRIC#daily_total', '2025-01-15', 'count')
+
+        assert 'ConditionExpression' not in mock_table.update_item.call_args.kwargs
+
+
+class TestAnEditMovesAnItemBetweenBuckets:
+    """MODIFY comes from `PUT /data-explorer/feedback`, which edits in place."""
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_changed_category_moves_the_count(self, mock_table, sample_feedback_item):
+        from aggregator.handler import record_handler
+
+        edited = {**sample_feedback_item, 'category': 'billing'}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        writes = _writes(mock_table)
+        assert ('METRIC#daily_category#product_quality', '2025-01-15', 'count', -1) in writes
+        assert ('METRIC#daily_category#billing', '2025-01-15', 'count', 1) in writes
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_dimensions_whose_value_did_not_change_are_not_written(
+        self, mock_table, sample_feedback_item
+    ):
+        """An unrelated edit writes nothing; a category edit touches only category rows.
+
+        Rebucketing everything would net to zero but refresh each row's 90-day
+        TTL, and a decrement refused against a row at zero would leave its paired
+        increment un-cancelled.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+        touched = {pk for pk, _, _, _ in _writes(mock_table)}
+
+        assert touched == {
+            'METRIC#daily_category#product_quality',
+            'METRIC#daily_category#billing',
+            'METRIC#category_sentiment#product_quality#positive',
+            'METRIC#category_sentiment#billing#positive',
+        }
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_edit_touching_no_dimension_writes_nothing(self, mock_table, sample_feedback_item):
+        from aggregator.handler import record_handler
+
+        edited = {**sample_feedback_item, 'problem_summary': 'reworded by a human'}
+
+        result = record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        assert result == {"status": "success"}
+        mock_table.update_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_urgency_downgraded_from_high_removes_the_urgent_count(
+        self, mock_table, sample_urgent_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        edited = {**sample_urgent_feedback_item, 'urgency': 'low'}
+
+        record_handler(_record('MODIFY', old=sample_urgent_feedback_item, new=edited))
+
+        writes = _writes(mock_table)
+        assert ('METRIC#urgent', '2025-01-15', 'count', -1) in writes
+        assert not [w for w in writes if w[0] == 'METRIC#urgent' and w[3] == 1]
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_non_urgent_edit_never_writes_an_urgent_row(self, mock_table, sample_feedback_item):
+        """Neither side is high, so `METRIC#urgent` must not appear in either direction."""
+        from aggregator.handler import record_handler
+
+        edited = {**sample_feedback_item, 'urgency': 'medium'}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        assert not [w for w in _writes(mock_table) if w[0] == 'METRIC#urgent']
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_urgency_raised_to_high_adds_the_urgent_count(self, mock_table, sample_feedback_item):
+        from aggregator.handler import record_handler
+
+        edited = {**sample_feedback_item, 'urgency': 'high'}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        assert ('METRIC#urgent', '2025-01-15', 'count', 1) in _writes(mock_table)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_edited_date_moves_every_counter_to_the_new_day(
+        self, mock_table, sample_feedback_item
+    ):
+        """`date` is the one field whose edit rebuckets all dimensions at once."""
+        from aggregator.handler import record_handler
+
+        edited = {**sample_feedback_item, 'date': '2025-02-01'}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        writes = _writes(mock_table)
+        assert {sk for _, sk, _, delta in writes if delta == -1} == {'2025-01-15'}
+        assert {sk for _, sk, _, delta in writes if delta == 1} == {'2025-02-01'}
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_edited_sentiment_score_moves_the_average(self, mock_table, sample_feedback_item):
+        from aggregator.handler import record_handler
+
+        edited = {**sample_feedback_item, 'sentiment_score': Decimal('0.10')}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        avg = [c.kwargs['ExpressionAttributeValues'] for c in mock_table.update_item.call_args_list
+               if c.kwargs['Key']['pk'] == 'METRIC#daily_sentiment_avg']
+        assert [(v[':val'], v[':one']) for v in avg] == [
+            (Decimal('-0.85'), -1), (Decimal('0.10'), 1),
+        ]
+
+
+class TestCounterDimensions:
+    """The single description of the dimensions both directions are built from."""
+
+    def test_an_urgent_item_adds_the_urgent_dimension(
+        self, sample_feedback_item, sample_urgent_feedback_item
+    ):
+        from aggregator.handler import counter_dimensions
+
+        plain = set(counter_dimensions(sample_feedback_item))
+        urgent = set(counter_dimensions(sample_urgent_feedback_item))
+
+        assert ('METRIC#urgent', 'count') in urgent
+        assert ('METRIC#urgent', 'count') not in plain
+
+    def test_a_missing_dimension_falls_back_to_the_same_default_both_ways(self):
+        """Increment and decrement must derive identical pks for a sparse item."""
+        from aggregator.handler import counter_dimensions
+
+        assert counter_dimensions({}) == counter_dimensions({'date': '2025-01-15'})
+        assert ('METRIC#daily_source#unknown', 'count') in counter_dimensions({})

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -74,12 +74,35 @@ decisions inside it that a naive implementation gets wrong. The revert map:
 
   TestTheAveragesTwoHalvesCannotSplit
     — the average is two conditional writes to ONE row, so unlike the counters it
-      can split: dropping `not reversal_refused` fails
+      can split: dropping the pairing fails
       `test_a_refused_reversal_does_not_let_its_increment_land`, and skipping the
       re-application unconditionally (the over-correction) fails four tests
       including `test_an_item_gaining_a_score_it_never_had_is_applied`. Moto-backed
       of necessity — a mock cannot refuse the reversal, so the pairing rule would
       never be exercised against one.
+
+  TestThePairingIsPerRowAndNotPerEdit
+    — the pairing above is keyed on the ROW, not on one flag consulted however far
+      apart the two writes are aimed. Restoring the flag (`if blocked_row is not
+      None`) fails `test_a_cross_day_edit_still_reaches_the_new_days_average` and
+      nothing else, which is why that test exists: every test in the class above
+      passes with the defect present. Removing the block altogether fails three,
+      including `test_the_same_day_block_is_not_weakened_by_that`, so neither
+      direction can be got wrong silently. Treating a reversal refused for a
+      MISSING row as blocking — collapsing AverageWrite back to a bool — fails
+      `test_a_reversal_refused_for_a_missing_row_does_not_block_the_new_score`, and
+      making the decline silent fails
+      `test_a_declined_re_application_is_counted_rather_than_silent` (REFUSED_METRIC
+      counts DynamoDB's refusals, so a write never issued is invisible to it).
+
+  TestUpdateAverageReportsWhichConditionFailed
+    — the signal the class above spends, pinned on its own. Deleting
+      `ReturnValuesOnConditionCheckFailure` fails four tests across both classes,
+      because without it a refusal carries no `Item` and every refused reversal
+      reads as ROW_ABSENT. Removing `AverageWrite.__bool__` fails
+      `test_only_the_landed_outcome_is_truthy` — an Enum is otherwise truthy in all
+      three states, which would make `if update_average(...)` a tautology and count
+      refused writes as landed.
 
   TestTheDaySentinelIsTheCounterEveryItemWrites
     — `_day_has_aggregates`'s soundness is a fact about `counter_dimensions`, so it
@@ -1453,6 +1476,281 @@ class TestTheAveragesTwoHalvesCannotSplit:
                                         'sentiment_score': Decimal('0.10')}))
 
         assert REFUSED_METRIC in [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list]
+
+
+class TestThePairingIsPerRowAndNotPerEdit:
+    """A refusal on one day's average row says nothing about another day's.
+
+    The pairing rule above is right for a SAME-DAY edit, where both writes hit one
+    (SENTIMENT_AVG_PK, date). An edited `date` makes them two writes to two rows, and
+    consulting a single `reversal_refused` flag across that gap dropped the item from
+    the new day's average while every one of its counters — `daily_total` included —
+    moved onto that day. The row and the counters then describe different sets of
+    items, which is the split the pairing exists to prevent, moved to the day that
+    UNDERSTATES: `get_summary` weights each date's `sum/count` by that same count.
+
+    So the block is keyed on the ROW, and these tests are what tell the two
+    formulations apart — the flag version passes every test in the class above.
+
+    Moto-backed throughout: a mock cannot refuse the reversal, so against one the
+    reversal always "lands", `blocked_row` stays None and the distinction is never
+    exercised.
+    """
+
+    @staticmethod
+    def _avg(table, date):
+        item = table.get_item(Key={'pk': 'METRIC#daily_sentiment_avg', 'sk': date}).get('Item')
+        return None if item is None else (item['count'], item['sum'])
+
+    @staticmethod
+    def _count(table, pk, date):
+        item = table.get_item(Key={'pk': pk, 'sk': date}).get('Item')
+        return None if item is None else item['count']
+
+    def test_a_cross_day_edit_still_reaches_the_new_days_average(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """The reproduction. The old day's row is at zero; the new day's is not.
+
+        An insert then a delete leaves `(daily_sentiment_avg, 2025-01-15)` present and
+        empty — so the old day reads live and its reversal is refused by the floor —
+        while an unrelated scored item keeps 2025-02-01 live with a real average. The
+        edit moves the first item onto that day. With the pairing keyed on a flag the
+        new day's average stayed at one item while its `daily_total` reached two.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(0), Decimal(0))
+
+        other = {**sample_feedback_item, 'feedback_id': 'other', 'date': '2025-02-01',
+                 'sentiment_score': Decimal('0.90')}
+        record_handler(_record('INSERT', new=other))
+        assert self._avg(real_aggregates_table, '2025-02-01') == (Decimal(1), Decimal('0.90'))
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'date': '2025-02-01'}))
+
+        # Both halves of the day now describe the same two items.
+        assert self._avg(real_aggregates_table, '2025-02-01') == (Decimal(2), Decimal('1.75'))
+        assert self._count(real_aggregates_table, 'METRIC#daily_total', '2025-02-01') == Decimal(2)
+
+    def test_the_same_day_block_is_not_weakened_by_that(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """The other direction: keying on the row must still block the same row.
+
+        Without this, dropping the pairing altogether would pass the test above. It is
+        the same reproduction as
+        `TestTheAveragesTwoHalvesCannotSplit::test_a_refused_reversal_does_not_let_its_increment_land`,
+        restated here so the per-row formulation is pinned from both sides in one place.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
+
+        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(0), Decimal(0))
+
+    def test_a_score_edit_on_a_live_day_with_no_average_row_creates_it(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """A day can be live and have NO average row, without any race.
+
+        `apply_feedback` writes the average only `if sentiment_score`, so a day whose
+        items are all unscored has a `daily_total` (it reads live) and no
+        `daily_sentiment_avg` at all. The reversal of a zero old score is never
+        attempted, and the re-application must create the row — the same latitude a
+        counter increment has for a brand-new bucket on a live day.
+        """
+        from aggregator.handler import record_handler
+
+        unscored = {**sample_feedback_item, 'sentiment_score': Decimal(0)}
+        record_handler(_record('INSERT', new=unscored))
+        assert self._avg(real_aggregates_table, '2025-01-15') is None
+
+        record_handler(_record('MODIFY', old=unscored,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.30')}))
+
+        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(1), Decimal('0.30'))
+
+    def test_a_reversal_refused_for_a_missing_row_does_not_block_the_new_score(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """ROW_ABSENT is not ROW_AT_FLOOR, and only the second may block.
+
+        The day is live (a `daily_total` is planted directly) while the average row is
+        absent, and the OLD score is non-zero — so the reversal is really attempted and
+        really refused, by `attribute_exists(pk)` rather than by the floor. Nothing was
+        reversed, so nothing dangles and the re-application must land. Treating both
+        refusals alike leaves the edited score nowhere.
+        """
+        from aggregator.handler import record_handler
+
+        real_aggregates_table.put_item(
+            Item={'pk': 'METRIC#daily_total', 'sk': '2025-01-15', 'count': Decimal(1)}
+        )
+        assert self._avg(real_aggregates_table, '2025-01-15') is None
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
+
+        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(1), Decimal('0.10'))
+
+    def test_a_declined_re_application_is_counted_rather_than_silent(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """A write we decline to make cannot be counted by DynamoDB refusing it.
+
+        REFUSED_METRIC is emitted from an `except ClientError`, so it can only ever
+        count refusals of writes that were ISSUED. The pairing skip issues none, and
+        without its own metric an operator would see REBUCKETED_METRIC — the counters
+        did move — and no anomaly at all, while the day's average had lost an item.
+        """
+        from aggregator.handler import (
+            DECLINED_METRIC,
+            REBUCKETED_METRIC,
+            record_handler,
+        )
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        with patch('aggregator.handler.metrics') as mock_metrics:
+            record_handler(_record('MODIFY', old=sample_feedback_item,
+                                   new={**sample_feedback_item,
+                                        'sentiment_score': Decimal('0.10')}))
+
+        names = [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list]
+        assert DECLINED_METRIC in names
+        # And it is not confused with the rebucket having moved something.
+        assert REBUCKETED_METRIC not in names
+
+    def test_nothing_is_declined_when_the_pair_is_left_alone(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Positive control: an ordinary score edit declines nothing.
+
+        Without this, emitting DECLINED_METRIC unconditionally would pass the test
+        above while making the new signal meaningless.
+        """
+        from aggregator.handler import DECLINED_METRIC, record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+
+        with patch('aggregator.handler.metrics') as mock_metrics:
+            record_handler(_record('MODIFY', old=sample_feedback_item,
+                                   new={**sample_feedback_item,
+                                        'sentiment_score': Decimal('0.10')}))
+
+        names = [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list]
+        assert DECLINED_METRIC not in names
+        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(1), Decimal('0.10'))
+
+
+class TestUpdateAverageReportsWhichConditionFailed:
+    """`update_average`'s three outcomes, against a real DynamoDB implementation.
+
+    The enum exists so `_rebucket_average` can tell "this row is claiming zero items"
+    from "there is no row", because re-applying is wrong for the first and right for
+    the second. A bool erased that distinction and a bool is what the first version
+    returned, so these pin the signal itself rather than only its consequence.
+    """
+
+    def test_a_landed_write_reports_landed(self, real_aggregates_table):
+        from aggregator.handler import AverageWrite, update_average
+
+        outcome = update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
+
+        assert outcome is AverageWrite.LANDED
+
+    def test_a_reversal_against_an_empty_row_reports_the_floor(self, real_aggregates_table):
+        from aggregator.handler import AverageWrite, update_average
+
+        update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
+        update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1)
+
+        outcome = update_average(
+            'METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1
+        )
+
+        assert outcome is AverageWrite.ROW_AT_FLOOR
+
+    def test_a_reversal_against_a_missing_row_reports_absent(self, real_aggregates_table):
+        from aggregator.handler import AverageWrite, update_average
+
+        outcome = update_average(
+            'METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1
+        )
+
+        assert outcome is AverageWrite.ROW_ABSENT
+
+    def test_only_the_landed_outcome_is_truthy(self):
+        """Existing callers ask `if update_average(...)`, and an Enum is truthy.
+
+        Without `__bool__` every such check would pass in all three states, silently
+        counting refused writes as landed — the reverse of the landed-not-attempted
+        distinction REBUCKETED_METRIC depends on.
+        """
+        from aggregator.handler import AverageWrite
+
+        assert bool(AverageWrite.LANDED)
+        assert not bool(AverageWrite.ROW_AT_FLOOR)
+        assert not bool(AverageWrite.ROW_ABSENT)
+
+    def test_an_unreadable_refusal_is_read_as_the_blocking_outcome(self):
+        """A refusal whose response cannot be read at all must not permit the write.
+
+        ROW_ABSENT is the outcome that LICENSES a re-application, so it must never be
+        the answer arrived at by default. Here the response is not a mapping — the
+        shape no reading can interpret — and the outcome is the one that declines, so
+        the pairing rule cannot be made conditional on an error's shape.
+
+        A response that IS readable and simply carries no `Item` is a different case
+        and genuinely means the row was absent; that is
+        `test_a_reversal_against_a_missing_row_reports_absent`, against moto.
+
+        The exception is shaped the way `shared/aws.py::is_conditional_check_failure`
+        documents one arriving: a ClientError subclass NAMED
+        ConditionalCheckFailedException — which is how boto3's resource layer really
+        raises it — carrying no readable response, so the predicate recognises it by
+        type name and this branch is reached rather than the error re-raised.
+        """
+        from aggregator.handler import AverageWrite, update_average
+
+        class ConditionalCheckFailedException(ClientError):
+            """Named like boto3's own, with an unreadable `response`."""
+
+            def __init__(self):
+                super().__init__(
+                    {'Error': {'Code': 'ConditionalCheckFailedException'}}, 'UpdateItem'
+                )
+                self.response = None  # type: ignore[assignment]
+
+        with patch('aggregator.handler.aggregates_table') as mock_table:
+            mock_table.update_item.side_effect = ConditionalCheckFailedException()
+            outcome = update_average(
+                'METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1
+            )
+
+        assert outcome is AverageWrite.ROW_AT_FLOOR
+
+    def test_an_increment_asks_for_no_return_values(self, mock_aggregates_table):
+        """`ReturnValuesOnConditionCheckFailure` belongs only to the conditional half.
+
+        An increment carries no condition, so the parameter would be meaningless on
+        it — and DynamoDB rejects it without one.
+        """
+        from aggregator.handler import update_average
+
+        with patch('aggregator.handler.aggregates_table') as mock_table:
+            update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
+
+        assert 'ReturnValuesOnConditionCheckFailure' not in mock_table.update_item.call_args.kwargs
 
 
 class TestRedeliveryMovesACounterTwice:

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -64,6 +64,28 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       form was found to DROP counts rather than protect anything. Making the
       unreadable-day case fail closed fails
       `test_an_unreadable_day_is_treated_as_live`.
+      The check is PER SIDE: restoring `old_live or new_live` fails
+      `test_an_edit_moving_an_item_onto_a_dead_day_creates_no_row_there`, and
+      over-correcting it to `old_live and new_live` fails
+      `test_that_edit_still_decrements_the_live_day_it_left` plus two others — so
+      neither direction of that guard can be got wrong silently. Evaluating the
+      sentinel once per SIDE rather than per distinct DATE fails
+      `test_a_same_day_rebucket_reads_the_sentinel_once`.
+
+  TestTheAveragesTwoHalvesCannotSplit
+    — the average is two conditional writes to ONE row, so unlike the counters it
+      can split: dropping `not reversal_refused` fails
+      `test_a_refused_reversal_does_not_let_its_increment_land`, and skipping the
+      re-application unconditionally (the over-correction) fails four tests
+      including `test_an_item_gaining_a_score_it_never_had_is_applied`. Moto-backed
+      of necessity — a mock cannot refuse the reversal, so the pairing rule would
+      never be exercised against one.
+
+  TestTheDaySentinelIsTheCounterEveryItemWrites
+    — `_day_has_aggregates`'s soundness is a fact about `counter_dimensions`, so it
+      is asserted rather than commented. Spelling the sentinel as a second literal
+      fails 13 tests; logging a non-transient read failure at `warning` fails
+      `test_a_denied_day_read_fails_open_but_is_logged_as_an_error`.
 
   TestRedeliveryMovesACounterTwice
     — the KNOWN RESIDUAL, pinned at what the code really does rather than at what
@@ -87,7 +109,17 @@ decisions inside it that a naive implementation gets wrong. The revert map:
   TestEachBehaviourEmitsItsOwnMetric
     — collapsing the three metrics back into one fails all of these. Emitting the
       rebucket metric unconditionally fails
-      `test_an_edit_that_moved_nothing_counts_as_nothing`.
+      `test_an_edit_that_moved_nothing_counts_as_nothing`. Counting writes
+      ATTEMPTED rather than LANDED — in `apply_counter_keys`, or by having
+      `update_counter` always report success — fails
+      `test_an_edit_whose_every_write_was_refused_counts_as_nothing`, whose whole
+      subject is that "aggregates moved" is a claim about writes that landed.
+
+  TestAReversalRefusesToGuessTheDay::test_a_dateless_insert_still_buckets_under_today
+    — freezes the clock the HANDLER reads (`_frozen_clock`) rather than reading
+      `datetime.now()` a second time in the test. Restoring the second read fails
+      the test whenever the two clocks disagree, which across UTC midnight they do;
+      deleting the fallback it is a positive control for fails it always.
 
 Each of those reverts was RUN, not predicted. Two more were run for the same
 reason:
@@ -104,7 +136,8 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from contextlib import contextmanager
+from datetime import datetime
 from moto import mock_aws
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
@@ -163,6 +196,31 @@ def _writes(mock_table) -> list[tuple[str, str, str, int]]:
 def _dimensions(writes) -> set[tuple[str, str, str]]:
     """The (pk, sk, field) triples written, dropping the direction."""
     return {(pk, sk, field) for pk, sk, field, _ in writes}
+
+
+@contextmanager
+def _frozen_clock(instant: str):
+    """Freeze the clock the HANDLER reads, yielding the date it will bucket under.
+
+    Any test whose expected value is "today" has to read the same clock the code
+    does, or the two disagree across UTC midnight and the test fails for no defect.
+    Yielding the date rather than letting the caller compute one is what makes that
+    impossible to get wrong here.
+
+    A `datetime` SUBCLASS, not a MagicMock: the handler also calls `.timestamp()`
+    for the TTL and `.isoformat()` for `updated_at`, and a mock would answer those
+    with mocks that DynamoDB then refuses — so the frozen clock has to be a real
+    datetime in every respect but `now`.
+    """
+    fixed = datetime.fromisoformat(instant)
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    with patch('aggregator.handler.datetime', _Frozen):
+        yield fixed.strftime('%Y-%m-%d')
 
 
 @pytest.fixture
@@ -1005,15 +1063,25 @@ class TestAReversalRefusesToGuessTheDay:
 
     @patch('aggregator.handler.aggregates_table')
     def test_a_dateless_insert_still_buckets_under_today(self, mock_table):
-        """The today-fallback is KEPT for the insert path — behaviour preserved."""
+        """The today-fallback is KEPT for the insert path — behaviour preserved.
+
+        The clock is FROZEN rather than read twice. Reading
+        `datetime.now(timezone.utc)` here and letting the handler read its own
+        compares two independent clocks, so an invocation that straddles UTC
+        midnight fails for a non-defect reason — one run in ~86400, and CI at
+        midnight UTC is not exotic. This test is a deliberate positive control
+        against someone tidying up the insert path's fallback after the reversal
+        paths stopped using it, so it has to be unconditionally reliable rather
+        than nearly so. Deleting the fallback still fails it: without one an
+        undated insert writes nothing at all.
+        """
         from aggregator.handler import record_handler
 
-        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-
-        result = record_handler(_record('INSERT', new={'source_platform': 'webscraper'}))
+        with _frozen_clock('2025-06-01T12:00:00+00:00') as frozen:
+            result = record_handler(_record('INSERT', new={'source_platform': 'webscraper'}))
 
         assert result == {"status": "success"}
-        assert {sk for _, sk, _, _ in _writes(mock_table)} == {today}
+        assert {sk for _, sk, _, _ in _writes(mock_table)} == {frozen}
 
 
 class TestARebucketCannotResurrectAnAgedOutDay:
@@ -1035,6 +1103,17 @@ class TestARebucketCannotResurrectAnAgedOutDay:
     the test that failed when this was first written as `attribute_exists(pk)` per
     increment: the obvious form drops the count of every edit that moves an item
     into a category no item has used that day yet.
+
+    WHY IT IS ASKED PER SIDE. `old_live or new_live` reads as a reasonable "is this
+    edit a real correction?", and an edit whose `date` moves an item FROM a live day
+    TO a dead one satisfies it — after which every increment, which carries no
+    condition by design, lands on the dead day and recreates the whole fragment,
+    `daily_total` included, so the sentinel afterwards calls the dead day live for
+    every later edit. Both directions of that are pinned:
+    `test_an_edit_moving_an_item_onto_a_dead_day_creates_no_row_there` fails on the
+    permissive form, and `test_that_edit_still_decrements_the_live_day_it_left`
+    fails on the over-correction (`and`) that would refuse the whole edit and leave
+    the item counted on a day it has left.
 
     Deleting the `_day_has_aggregates` check fails the first three here. All run
     against moto, because a mock can neither refuse a write nor answer a get_item.
@@ -1135,6 +1214,84 @@ class TestARebucketCannotResurrectAnAgedOutDay:
         assert counts[('METRIC#daily_total', '2025-02-01')] == Decimal(2)
         assert ('METRIC#daily_total', '2024-01-01') not in counts
 
+    def test_an_edit_moving_an_item_onto_a_dead_day_creates_no_row_there(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """The direction `old_live or new_live` let through.
+
+        The item leaves a LIVE day for one whose aggregates are gone. A guard that
+        asks only whether EITHER side is live passes this, and then every increment
+        — which carries no condition, deliberately, so a new bucket on a live day can
+        be created — lands on the dead day: seven freshly 90-day-TTL'd rows for a
+        date whose real totals were collected months ago, `daily_sentiment_avg` among
+        them. Worse than the pre-guard behaviour in one respect, because
+        `METRIC#daily_total` is recreated too and the sentinel then reports the dead
+        day as LIVE for every subsequent edit.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'date': '2024-01-01'}))
+
+        dead_day = [i for i in real_aggregates_table.scan()['Items'] if i['sk'] == '2024-01-01']
+        assert dead_day == []
+
+    def test_that_edit_still_decrements_the_live_day_it_left(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Per SIDE, not all-or-nothing: the live half of that edit is real.
+
+        The item genuinely left 2025-01-15, and that day's aggregates are still
+        there to correct. Refusing the whole edit because its destination is gone
+        would leave the item counted on a day it is no longer on — the overstatement
+        this module exists to remove.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'date': '2024-01-01'}))
+
+        counts = {(i['pk'], i['sk']): i['count'] for i in real_aggregates_table.scan()['Items']}
+        assert counts[('METRIC#daily_total', '2025-01-15')] == Decimal(0)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_same_day_rebucket_reads_the_sentinel_once(self, mock_table, sample_feedback_item):
+        """One read per DISTINCT date, not one per side.
+
+        `date` is not in the Data Explorer's updatable_fields, so both dates being
+        equal is the common case — and the short-circuit `or` this replaced only
+        skipped the second read when the FIRST answered True, so the dead-day path
+        (the one that ends in a skip) read the identical key twice.
+        """
+        from aggregator.handler import record_handler
+
+        mock_table.get_item.return_value = {}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert mock_table.get_item.call_count == 1
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_cross_day_rebucket_reads_both_days(self, mock_table, sample_feedback_item):
+        """Positive control for the test above: two dates really are two reads.
+
+        Without this, collapsing the check to a single read of one side would pass
+        the same-day assertion while leaving the other side unchecked.
+        """
+        from aggregator.handler import record_handler
+
+        mock_table.get_item.return_value = {}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'date': '2025-02-01'}))
+
+        assert sorted(c.kwargs['Key']['sk'] for c in mock_table.get_item.call_args_list) == [
+            '2025-01-15', '2025-02-01',
+        ]
+
     @patch('aggregator.handler.aggregates_table')
     def test_an_edit_touching_no_dimension_costs_no_read(self, mock_table, sample_feedback_item):
         """The common case pays for nothing: no writes AND no day check.
@@ -1169,6 +1326,133 @@ class TestARebucketCannotResurrectAnAgedOutDay:
                                new={**sample_feedback_item, 'category': 'billing'}))
 
         assert mock_table.update_item.call_count > 0
+
+
+class TestTheAveragesTwoHalvesCannotSplit:
+    """A rebucket's average reversal and re-application stand or fall together.
+
+    The counter dimensions are moved as a symmetric difference so that `-1` and `+1`
+    never land on one key. The average gets no such protection from that argument: it
+    is TWO conditional writes to (SENTIMENT_AVG_PK, date), and `#count >= :floor` can
+    refuse the reversal against a row already at zero while the re-application
+    applies unconditionally. The row then claims one item, at the edited score, that
+    no present feedback justifies — and `get_summary` divides `sum/count` per date and
+    weights it by count into the headline `avg_sentiment`, so it is served-data
+    corruption rather than a skew nobody reads.
+
+    Distinct from the `sum`-vs-`count` residual in `update_average`'s docstring, which
+    is about a reversal quoting the WRONG score. Here both scores are right and it is
+    the pairing that breaks.
+
+    All moto-backed: a mock cannot refuse a write, so against one the reversal would
+    always "land" and the pairing rule would never be exercised.
+    """
+
+    @staticmethod
+    def _avg(table, date='2025-01-15'):
+        item = table.get_item(Key={'pk': 'METRIC#daily_sentiment_avg', 'sk': date}).get('Item')
+        return None if item is None else (item['count'], item['sum'])
+
+    def test_a_refused_reversal_does_not_let_its_increment_land(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """The reproduction: a LIVE day whose average row sits at count == 0.
+
+        An insert then a delete leaves the row present (so the day is live and the
+        rebucket proceeds) and empty. The score edit's reversal is refused by the
+        floor; its re-application must not apply alone.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+        assert self._avg(real_aggregates_table) == (Decimal(0), Decimal(0))
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
+
+        assert self._avg(real_aggregates_table) == (Decimal(0), Decimal(0))
+
+    def test_an_edit_on_a_day_with_items_still_moves_the_average(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Positive control: the pairing must not refuse an ordinary edit.
+
+        Without this, skipping the increment unconditionally would pass the test
+        above while silently dropping every legitimate score correction.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
+
+        assert self._avg(real_aggregates_table) == (Decimal(1), Decimal('0.10'))
+
+    def test_an_item_gaining_a_score_it_never_had_is_applied(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """No reversal to pair with, so nothing is left dangling by applying.
+
+        A zero old score contributed nothing to the average, so there is no half that
+        could have been refused — the increment is unconditional and correct.
+        """
+        from aggregator.handler import record_handler
+
+        scoreless = {**sample_feedback_item, 'sentiment_score': Decimal(0)}
+        record_handler(_record('INSERT', new=scoreless))
+        record_handler(_record('MODIFY', old=scoreless,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.40')}))
+
+        assert self._avg(real_aggregates_table) == (Decimal(1), Decimal('0.4'))
+
+    def test_an_item_losing_its_score_is_reversed_with_nothing_to_re_apply(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal(0)}))
+
+        assert self._avg(real_aggregates_table) == (Decimal(0), Decimal(0))
+
+    def test_a_score_edit_moving_off_a_dead_day_still_lands_on_the_live_one(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """A dead old day has no reversal to pair with either, and must not block.
+
+        The old row is gone, so there is no half to be inconsistent with; refusing
+        the increment would lose the item from the average altogether — the
+        count-dropping failure `_day_has_aggregates` exists to avoid.
+        """
+        from aggregator.handler import record_handler
+
+        arrived = {**sample_feedback_item, 'date': '2025-02-01'}
+        record_handler(_record('INSERT', new=arrived))
+        record_handler(_record('MODIFY',
+                               old={**sample_feedback_item, 'date': '2024-01-01',
+                                    'sentiment_score': Decimal('0.20')},
+                               new=arrived))
+
+        assert self._avg(real_aggregates_table, '2025-02-01') == (Decimal(2), Decimal('1.70'))
+        assert self._avg(real_aggregates_table, '2024-01-01') is None
+
+    def test_a_refused_reversal_is_still_counted_as_refused(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Skipping the pair must not also hide it: the refusal stays visible."""
+        from aggregator.handler import REFUSED_METRIC, record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        with patch('aggregator.handler.metrics') as mock_metrics:
+            record_handler(_record('MODIFY', old=sample_feedback_item,
+                                   new={**sample_feedback_item,
+                                        'sentiment_score': Decimal('0.10')}))
+
+        assert REFUSED_METRIC in [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list]
 
 
 class TestRedeliveryMovesACounterTwice:
@@ -1309,6 +1593,85 @@ class TestTtlExpiryIsReadFromTheEventNotFromPowertools:
         assert is_ttl_expiry(record) is False
 
 
+class TestTheDaySentinelIsTheCounterEveryItemWrites:
+    """`_day_has_aggregates`'s argument depends on a fact about another function.
+
+    Reading `METRIC#daily_total` is only a sound test of "is this day still here?"
+    because that is the ONE counter every item writes unconditionally. That premise
+    lives in `counter_dimensions`, so the two read one constant — and this class
+    asserts the premise rather than trusting the comment that states it.
+    """
+
+    def test_the_sentinel_is_a_dimension_every_item_writes(self):
+        from aggregator.handler import DAILY_TOTAL_PK, counter_dimensions
+
+        for item in ({}, {'date': '2025-01-15'}, {'urgency': 'high', 'category': 'billing'}):
+            assert (DAILY_TOTAL_PK, 'count') in counter_dimensions(item), (
+                f'{item} writes no {DAILY_TOTAL_PK} counter, so its presence no '
+                f'longer means "this day was ingested" and _day_has_aggregates is '
+                f'reading a sentinel that can be absent for a live day.'
+            )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_the_day_check_reads_that_same_pk(self, mock_table, sample_feedback_item):
+        """One constant, so the sentinel and the dimension cannot drift apart."""
+        from aggregator.handler import DAILY_TOTAL_PK, record_handler
+
+        mock_table.get_item.return_value = {}
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert [c.kwargs['Key']['pk'] for c in mock_table.get_item.call_args_list] == [
+            DAILY_TOTAL_PK,
+        ]
+
+    @patch('aggregator.handler.logger')
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_throttled_day_read_warns_and_fails_open(
+        self, mock_table, mock_logger, sample_feedback_item
+    ):
+        """A blip: survive it, and say so at the level a blip deserves."""
+        from aggregator.handler import record_handler
+
+        mock_table.get_item.side_effect = ClientError(
+            {'Error': {'Code': 'ProvisionedThroughputExceededException', 'Message': 'slow'}},
+            'GetItem',
+        )
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert mock_table.update_item.call_count > 0
+        assert mock_logger.warning.called
+        assert not mock_logger.error.called
+
+    @patch('aggregator.handler.logger')
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_denied_day_read_fails_open_but_is_logged_as_an_error(
+        self, mock_table, mock_logger, sample_feedback_item
+    ):
+        """A misconfiguration is not a bad afternoon.
+
+        `AccessDeniedException` means this guard is PERMANENTLY inert: every edit to
+        an aged-out day plants the fragments it exists to prevent, indefinitely. The
+        fail-open direction is still right — dropping every edit is worse — but at
+        `warning` it is indistinguishable from the throttle the fail-open was
+        designed for, so nothing would ever surface it.
+        """
+        from aggregator.handler import record_handler
+
+        mock_table.get_item.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'no'}}, 'GetItem',
+        )
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert mock_table.update_item.call_count > 0
+        assert mock_logger.error.called
+
+
 class TestEachBehaviourEmitsItsOwnMetric:
     """Three materially different behaviours, three metrics.
 
@@ -1393,6 +1756,49 @@ class TestEachBehaviourEmitsItsOwnMetric:
                                new={**sample_feedback_item, 'category': 'billing'}))
 
         assert self._names(mock_metrics) == []
+
+    @patch('aggregator.handler.metrics')
+    def test_an_edit_whose_every_write_was_refused_counts_as_nothing(
+        self, mock_metrics, real_aggregates_table, sample_feedback_item
+    ):
+        """"Aggregates moved" is a claim about writes that LANDED.
+
+        A live day, and an edit whose only changed dimension is a decrement of
+        `METRIC#urgent` — a row that never existed, because the item was never
+        urgent. One write attempted, refused by its condition, zero aggregates
+        moved. Counting attempts would put a datapoint on the one metric an operator
+        reads to confirm reversals are happening, for an edit that moved nothing.
+
+        Moto-backed of necessity: a mock cannot refuse the write, so against one this
+        would pass with the landed/attempted distinction deleted.
+        """
+        from aggregator.handler import REFUSED_METRIC, record_handler
+
+        # A live day (daily_total present) with no `METRIC#urgent` row on it.
+        real_aggregates_table.put_item(
+            Item={'pk': 'METRIC#daily_total', 'sk': '2025-01-15', 'count': Decimal(1)}
+        )
+
+        record_handler(_record('MODIFY', old={**sample_feedback_item, 'urgency': 'high'},
+                               new={**sample_feedback_item, 'urgency': 'low'}))
+
+        # The refusal is visible; the rebucket is not claimed.
+        assert self._names(mock_metrics) == [REFUSED_METRIC]
+
+    @patch('aggregator.handler.metrics')
+    def test_an_edit_that_did_move_a_counter_still_counts_as_rebucketed(
+        self, mock_metrics, real_aggregates_table, sample_feedback_item
+    ):
+        """Positive control: counting LANDED writes must not stop counting at all."""
+        from aggregator.handler import REBUCKETED_METRIC, record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        mock_metrics.reset_mock()
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert REBUCKETED_METRIC in self._names(mock_metrics)
 
     @patch('aggregator.handler.metrics')
     @patch('aggregator.handler.aggregates_table')

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -48,6 +48,47 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       `urgency == 'high'` guard fails five tests across three classes, including
       `test_urgency_raised_to_high_adds_the_urgent_count`.
 
+  TestAReversalRefusesToGuessTheDay
+    — `_image_date`'s today-fallback is safe for an arrival and arbitrary for a
+      reversal. Having `process_deleted_feedback` or `process_modified_feedback`
+      read `_image_date` instead of `_image_date_or_none` fails
+      `test_a_dateless_remove_writes_nothing` and both MODIFY tests here;
+      `test_a_dateless_insert_still_buckets_under_today` is the other direction —
+      the insert path's fallback is deliberately KEPT, so removing it fails too.
+
+  TestARebucketCannotResurrectAnAgedOutDay
+    — deleting the `_day_has_aggregates` check fails the first three. Writing it
+      as `attribute_exists(pk)` on each increment instead — the obvious form —
+      fails `test_an_edit_into_a_brand_new_bucket_on_a_live_day_still_lands` and
+      `test_an_edit_that_moves_an_item_onto_a_live_day_lands`, which is how that
+      form was found to DROP counts rather than protect anything. Making the
+      unreadable-day case fail closed fails
+      `test_an_unreadable_day_is_treated_as_live`.
+
+  TestRedeliveryMovesACounterTwice
+    — the KNOWN RESIDUAL, pinned at what the code really does rather than at what
+      would be nice. These fail if idempotency is ever added, which is the point:
+      the module docstring's residual note and the behaviour cannot drift apart.
+
+  TestAnUnrecognizedEventIsSkippedRatherThanFatal
+    — restoring `str(record.event_name)` in place of the `raw_event` read fails
+      `test_an_unrecognized_event_name_is_skipped` with the KeyError that would
+      have made the record a poison pill in production.
+      `test_powertools_really_does_raise_on_an_unknown_event_name` asserts the
+      premise, so a Powertools that stopped raising is reported rather than
+      silently making the workaround redundant.
+
+  TestTtlExpiryIsReadFromTheEventNotFromPowertools
+    — narrowing `isinstance(identity, Mapping)` back to `dict` fails
+      `test_an_identity_arriving_as_another_mapping_is_still_ttl_expiry`, which is
+      the case that would otherwise turn every TTL REMOVE into a decrement with
+      the branch dead and the suite green.
+
+  TestEachBehaviourEmitsItsOwnMetric
+    — collapsing the three metrics back into one fails all of these. Emitting the
+      rebucket metric unconditionally fails
+      `test_an_edit_that_moved_nothing_counts_as_nothing`.
+
 Each of those reverts was RUN, not predicted. Two more were run for the same
 reason:
 
@@ -62,6 +103,8 @@ reason:
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from collections.abc import Mapping
+from datetime import datetime, timezone
 from moto import mock_aws
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
@@ -120,6 +163,24 @@ def _writes(mock_table) -> list[tuple[str, str, str, int]]:
 def _dimensions(writes) -> set[tuple[str, str, str]]:
     """The (pk, sk, field) triples written, dropping the direction."""
     return {(pk, sk, field) for pk, sk, field, _ in writes}
+
+
+@pytest.fixture
+def live_day_table():
+    """A mocked aggregates table whose day check answers "this day is live".
+
+    A rebucket first asks `_day_has_aggregates` whether the day's aggregates still
+    exist, because an edit must not partially recreate a day that aged out. An
+    UNCONFIGURED MagicMock answers that question with a MagicMock, and
+    `'Item' in <MagicMock>` is False — so every MODIFY test written against a bare
+    mock would assert on the writes of a rebucket that had been skipped, i.e. on
+    nothing. Stating the day is live is therefore part of the arrangement of any
+    test whose subject is which counters an edit moves; the aged-out case has its
+    own class, against moto, where the answer comes from a real table.
+    """
+    with patch('aggregator.handler.aggregates_table') as table:
+        table.get_item.return_value = {'Item': {'pk': 'METRIC#daily_total', 'count': Decimal(1)}}
+        yield table
 
 
 @pytest.fixture
@@ -755,21 +816,19 @@ class TestADecrementCannotCreateOrGoNegative:
 class TestAnEditMovesAnItemBetweenBuckets:
     """MODIFY comes from `PUT /data-explorer/feedback`, which edits in place."""
 
-    @patch('aggregator.handler.aggregates_table')
-    def test_a_changed_category_moves_the_count(self, mock_table, sample_feedback_item):
+    def test_a_changed_category_moves_the_count(self, live_day_table, sample_feedback_item):
         from aggregator.handler import record_handler
 
         edited = {**sample_feedback_item, 'category': 'billing'}
 
         record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
 
-        writes = _writes(mock_table)
+        writes = _writes(live_day_table)
         assert ('METRIC#daily_category#product_quality', '2025-01-15', 'count', -1) in writes
         assert ('METRIC#daily_category#billing', '2025-01-15', 'count', 1) in writes
 
-    @patch('aggregator.handler.aggregates_table')
     def test_dimensions_whose_value_did_not_change_are_not_written(
-        self, mock_table, sample_feedback_item
+        self, live_day_table, sample_feedback_item
     ):
         """An unrelated edit writes nothing; a category edit touches only category rows.
 
@@ -781,7 +840,7 @@ class TestAnEditMovesAnItemBetweenBuckets:
 
         record_handler(_record('MODIFY', old=sample_feedback_item,
                                new={**sample_feedback_item, 'category': 'billing'}))
-        touched = {pk for pk, _, _, _ in _writes(mock_table)}
+        touched = {pk for pk, _, _, _ in _writes(live_day_table)}
 
         assert touched == {
             'METRIC#daily_category#product_quality',
@@ -790,8 +849,7 @@ class TestAnEditMovesAnItemBetweenBuckets:
             'METRIC#category_sentiment#billing#positive',
         }
 
-    @patch('aggregator.handler.aggregates_table')
-    def test_an_edit_touching_no_dimension_writes_nothing(self, mock_table, sample_feedback_item):
+    def test_an_edit_touching_no_dimension_writes_nothing(self, live_day_table, sample_feedback_item):
         from aggregator.handler import record_handler
 
         edited = {**sample_feedback_item, 'problem_summary': 'reworded by a human'}
@@ -799,11 +857,10 @@ class TestAnEditMovesAnItemBetweenBuckets:
         result = record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
 
         assert result == {"status": "success"}
-        mock_table.update_item.assert_not_called()
+        live_day_table.update_item.assert_not_called()
 
-    @patch('aggregator.handler.aggregates_table')
     def test_urgency_downgraded_from_high_removes_the_urgent_count(
-        self, mock_table, sample_urgent_feedback_item
+        self, live_day_table, sample_urgent_feedback_item
     ):
         from aggregator.handler import record_handler
 
@@ -811,12 +868,11 @@ class TestAnEditMovesAnItemBetweenBuckets:
 
         record_handler(_record('MODIFY', old=sample_urgent_feedback_item, new=edited))
 
-        writes = _writes(mock_table)
+        writes = _writes(live_day_table)
         assert ('METRIC#urgent', '2025-01-15', 'count', -1) in writes
         assert not [w for w in writes if w[0] == 'METRIC#urgent' and w[3] == 1]
 
-    @patch('aggregator.handler.aggregates_table')
-    def test_a_non_urgent_edit_never_writes_an_urgent_row(self, mock_table, sample_feedback_item):
+    def test_a_non_urgent_edit_never_writes_an_urgent_row(self, live_day_table, sample_feedback_item):
         """Neither side is high, so `METRIC#urgent` must not appear in either direction."""
         from aggregator.handler import record_handler
 
@@ -824,21 +880,19 @@ class TestAnEditMovesAnItemBetweenBuckets:
 
         record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
 
-        assert not [w for w in _writes(mock_table) if w[0] == 'METRIC#urgent']
+        assert not [w for w in _writes(live_day_table) if w[0] == 'METRIC#urgent']
 
-    @patch('aggregator.handler.aggregates_table')
-    def test_urgency_raised_to_high_adds_the_urgent_count(self, mock_table, sample_feedback_item):
+    def test_urgency_raised_to_high_adds_the_urgent_count(self, live_day_table, sample_feedback_item):
         from aggregator.handler import record_handler
 
         edited = {**sample_feedback_item, 'urgency': 'high'}
 
         record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
 
-        assert ('METRIC#urgent', '2025-01-15', 'count', 1) in _writes(mock_table)
+        assert ('METRIC#urgent', '2025-01-15', 'count', 1) in _writes(live_day_table)
 
-    @patch('aggregator.handler.aggregates_table')
     def test_an_edited_date_moves_every_counter_to_the_new_day(
-        self, mock_table, sample_feedback_item
+        self, live_day_table, sample_feedback_item
     ):
         """`date` is the one field whose edit rebuckets all dimensions at once."""
         from aggregator.handler import record_handler
@@ -847,19 +901,18 @@ class TestAnEditMovesAnItemBetweenBuckets:
 
         record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
 
-        writes = _writes(mock_table)
+        writes = _writes(live_day_table)
         assert {sk for _, sk, _, delta in writes if delta == -1} == {'2025-01-15'}
         assert {sk for _, sk, _, delta in writes if delta == 1} == {'2025-02-01'}
 
-    @patch('aggregator.handler.aggregates_table')
-    def test_an_edited_sentiment_score_moves_the_average(self, mock_table, sample_feedback_item):
+    def test_an_edited_sentiment_score_moves_the_average(self, live_day_table, sample_feedback_item):
         from aggregator.handler import record_handler
 
         edited = {**sample_feedback_item, 'sentiment_score': Decimal('0.10')}
 
         record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
 
-        avg = [c.kwargs['ExpressionAttributeValues'] for c in mock_table.update_item.call_args_list
+        avg = [c.kwargs['ExpressionAttributeValues'] for c in live_day_table.update_item.call_args_list
                if c.kwargs['Key']['pk'] == 'METRIC#daily_sentiment_avg']
         assert [(v[':val'], v[':one']) for v in avg] == [
             (Decimal('-0.85'), -1), (Decimal('0.10'), 1),
@@ -886,3 +939,483 @@ class TestCounterDimensions:
 
         assert counter_dimensions({}) == counter_dimensions({'date': '2025-01-15'})
         assert ('METRIC#daily_source#unknown', 'count') in counter_dimensions({})
+
+
+class TestAReversalRefusesToGuessTheDay:
+    """`_image_date`'s today-fallback is safe on an arrival and unsafe on a reversal.
+
+    For an INSERT, today is at least the day the row was created, so the counter it
+    creates is defensible. For a REMOVE it is arbitrary: an undated item ingested on
+    D and deleted on D+40 would decrement the D+40 counters — corrupting a
+    legitimate current-day aggregate while leaving D overstated — and the
+    ConditionExpression cannot catch it, because that row exists and is above the
+    floor. A missed `-1` is the right way to be wrong here.
+
+    Only legacy or hand-written rows lack `date` (`processor/handler.py` always sets
+    it), so this is latent rather than active; the failure it prevents is a silent
+    write to the wrong day, which is the class of bug this module exists to remove.
+    """
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_dateless_remove_writes_nothing(self, mock_table, sample_feedback_item):
+        from aggregator.handler import record_handler
+
+        dateless = {k: v for k, v in sample_feedback_item.items() if k != 'date'}
+
+        result = record_handler(_record('REMOVE', old=dateless))
+
+        assert result == {"status": "skipped", "reason": "no date"}
+        mock_table.update_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_dated_remove_of_the_same_item_does_write(self, mock_table, sample_feedback_item):
+        """Positive control: the skip above is the date, not an inert mock."""
+        from aggregator.handler import record_handler
+
+        assert record_handler(_record('REMOVE', old=sample_feedback_item)) == {"status": "success"}
+        assert mock_table.update_item.call_count > 0
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_modify_whose_old_image_has_no_date_writes_nothing(
+        self, mock_table, sample_feedback_item
+    ):
+        """A rebucket needs BOTH days: one of them guessed moves an unrelated counter."""
+        from aggregator.handler import record_handler
+
+        dateless = {k: v for k, v in sample_feedback_item.items() if k != 'date'}
+
+        result = record_handler(_record('MODIFY', old=dateless,
+                                       new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert result == {"status": "skipped", "reason": "no date"}
+        mock_table.update_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_modify_whose_new_image_has_no_date_writes_nothing(
+        self, mock_table, sample_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        edited = {k: v for k, v in sample_feedback_item.items() if k != 'date'}
+
+        result = record_handler(_record('MODIFY', old=sample_feedback_item, new=edited))
+
+        assert result == {"status": "skipped", "reason": "no date"}
+        mock_table.update_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_dateless_insert_still_buckets_under_today(self, mock_table):
+        """The today-fallback is KEPT for the insert path — behaviour preserved."""
+        from aggregator.handler import record_handler
+
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+
+        result = record_handler(_record('INSERT', new={'source_platform': 'webscraper'}))
+
+        assert result == {"status": "success"}
+        assert {sk for _, sk, _, _ in _writes(mock_table)} == {today}
+
+
+class TestARebucketCannotResurrectAnAgedOutDay:
+    """An edit to a day whose aggregates have expired writes nothing at all.
+
+    The module's central argument is that a write must not recreate an aggregate row
+    that has expired under its 90-day TTL. The decrement half of a rebucket is
+    refused by its own condition; the increments are not, and `PUT
+    /data-explorer/feedback` can edit a record of any age with no recency
+    constraint. So an unguarded rebucket leaves freshly TTL-stamped fragments
+    (`count = 1`, and a one-score `daily_sentiment_avg` row) for a date whose real
+    totals were collected months ago — and `validate_days` admits windows up to 365
+    days, so `/metrics/summary` and `/metrics/trends` serve them as that day's
+    totals. The average row is the worst of the three, because `get_summary` divides
+    `sum/count` per date and weights it by count into the headline number.
+
+    WHY THE GUARD IS ON THE DAY AND NOT ON EACH ROW is pinned by
+    `test_an_edit_into_a_brand_new_bucket_on_a_live_day_still_lands` below, which is
+    the test that failed when this was first written as `attribute_exists(pk)` per
+    increment: the obvious form drops the count of every edit that moves an item
+    into a category no item has used that day yet.
+
+    Deleting the `_day_has_aggregates` check fails the first three here. All run
+    against moto, because a mock can neither refuse a write nor answer a get_item.
+    """
+
+    def test_rebucketing_a_day_with_no_rows_writes_nothing(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert real_aggregates_table.scan()['Items'] == []
+
+    def test_an_edited_score_on_a_day_with_no_rows_creates_no_average_row(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """The resurrected average row is the most damaging of the three."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
+
+        assert real_aggregates_table.scan()['Items'] == []
+
+    def test_an_edited_date_does_not_conjure_a_day_that_is_gone(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Editing `date` moves every counter — onto a day whose rows may be gone."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'date': '2025-02-01'}))
+
+        assert real_aggregates_table.scan()['Items'] == []
+
+    def test_rebucketing_a_day_that_does_have_rows_still_moves_the_count(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Positive control: a live day's edit is applied, not refused."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'sentiment_label': 'negative'}))
+
+        counts = {i['pk']: i['count'] for i in real_aggregates_table.scan()['Items']}
+        assert counts['METRIC#daily_sentiment#positive'] == Decimal(0)
+        assert counts['METRIC#daily_sentiment#negative'] == Decimal(1)
+        # The unchanged dimensions were never touched, so they still hold the insert.
+        assert counts['METRIC#daily_total'] == Decimal(1)
+
+    def test_an_edit_into_a_brand_new_bucket_on_a_live_day_still_lands(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """The reason the guard is a day check rather than `attribute_exists(pk)`.
+
+        No item has used `billing` on this date, so that counter has no row — and
+        refusing to create it would DROP the count: the decrement lands on
+        `product_quality`, the increment vanishes, and the day's per-category counts
+        stop summing to `daily_total`. Guarding each increment on its own row's
+        existence trades the resurrection bug for a fresh undercount, which is not a
+        fix; only the day can tell "this bucket is new" from "this day is gone".
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        counts = {i['pk']: i['count'] for i in real_aggregates_table.scan()['Items']}
+        assert counts['METRIC#daily_category#product_quality'] == Decimal(0)
+        assert counts['METRIC#daily_category#billing'] == Decimal(1)
+        assert counts['METRIC#daily_category#billing'] + \
+            counts['METRIC#daily_category#product_quality'] == counts['METRIC#daily_total']
+
+    def test_an_edit_that_moves_an_item_onto_a_live_day_lands(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """One live day of the two is enough: the edit IS a real correction.
+
+        The item is moving off a day whose aggregates are gone and onto one that is
+        live. The dead day's decrements are refused by their own condition, and the
+        live day's increments must land — otherwise a date correction silently loses
+        the item from the metrics surface altogether.
+        """
+        from aggregator.handler import record_handler
+
+        arrived = {**sample_feedback_item, 'date': '2025-02-01'}
+        record_handler(_record('INSERT', new=arrived))
+        # Now pretend the item had been recorded under an aged-out day and is being
+        # corrected forward onto the live one.
+        record_handler(_record('MODIFY', old={**sample_feedback_item, 'date': '2024-01-01'},
+                               new=arrived))
+
+        counts = {(i['pk'], i['sk']): i['count'] for i in real_aggregates_table.scan()['Items']}
+        assert counts[('METRIC#daily_total', '2025-02-01')] == Decimal(2)
+        assert ('METRIC#daily_total', '2024-01-01') not in counts
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_edit_touching_no_dimension_costs_no_read(self, mock_table, sample_feedback_item):
+        """The common case pays for nothing: no writes AND no day check.
+
+        An edit to `problem_summary` moves no counter, so there is no rebucket to
+        guard and no reason to read the daily total for it.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'problem_summary': 'reworded'}))
+
+        mock_table.update_item.assert_not_called()
+        mock_table.get_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_unreadable_day_is_treated_as_live(self, mock_table, sample_feedback_item):
+        """A rebucket that cannot check must not silently drop every edit.
+
+        One fragment on an aged-out day is recoverable and visible; dropping every
+        edit while the table is briefly unreadable is the failure that looks like
+        nothing happened.
+        """
+        from aggregator.handler import record_handler
+
+        mock_table.get_item.side_effect = ClientError(
+            {'Error': {'Code': 'ProvisionedThroughputExceededException', 'Message': 'slow'}},
+            'GetItem',
+        )
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert mock_table.update_item.call_count > 0
+
+
+class TestRedeliveryMovesACounterTwice:
+    """The known residual, pinned at the value the code really produces.
+
+    Streams deliver at-least-once and the event source carries `retryAttempts: 3`
+    with `reportBatchItemFailures: true`, so a batch that partially fails
+    re-presents records whose writes already landed. The floor at zero is NOT
+    idempotency — it only no-ops a redelivered REMOVE when the counter is already at
+    zero. These tests exist so the module docstring's residual and the behaviour
+    cannot drift apart: if idempotency is ever added, they fail and say so.
+    """
+
+    def test_a_redelivered_remove_decrements_again_above_zero(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        for _ in range(3):
+            record_handler(_record('INSERT', new=sample_feedback_item))
+        remove = _record('REMOVE', old=sample_feedback_item)
+        record_handler(remove)
+        record_handler(remove)
+
+        counts = {i['pk']: i['count'] for i in real_aggregates_table.scan()['Items']}
+        # 2 is the true value: three inserts, one deletion. 1 is what redelivery
+        # produces, and what the module docstring records as a residual. If this
+        # starts failing with 2, idempotency was added — delete the residual note.
+        assert counts['METRIC#daily_total'] == Decimal(1)
+
+    def test_a_redelivered_modify_moves_the_count_twice(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """Worse than a replayed REMOVE: it re-applies BOTH halves."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+        edited = {**sample_feedback_item, 'category': 'billing'}
+        record_handler(_record('INSERT', new=edited))
+        modify = _record('MODIFY', old=sample_feedback_item, new=edited)
+        record_handler(modify)
+        record_handler(modify)
+
+        counts = {i['pk']: i['count'] for i in real_aggregates_table.scan()['Items']}
+        # True values after one edit: product_quality 0, billing 2.
+        assert counts['METRIC#daily_category#product_quality'] == Decimal(0)
+        assert counts['METRIC#daily_category#billing'] == Decimal(3)
+
+
+class TestAnUnrecognizedEventIsSkippedRatherThanFatal:
+    """The documented graceful skip has to be REACHABLE.
+
+    `record.event_name` resolves through `DynamoDBRecordEventName[...]`, so reading
+    it raises `KeyError` for any name outside the three the enum knows — before the
+    membership check could return `skipped`. With `reportBatchItemFailures: true` the
+    record would then be reported failed and redelivered until it aged out of the
+    stream, and because Streams preserve per-shard order one permanently-failing
+    record blocks its partition: a poison pill in place of the skip. Reading
+    `raw_event` is what makes the branch reachable and testable.
+    """
+
+    def test_powertools_really_does_raise_on_an_unknown_event_name(self):
+        """The premise, asserted rather than assumed.
+
+        If a future Powertools stops raising, the handler's `raw_event` read is
+        merely redundant instead of load-bearing, and this test says so.
+        """
+        record = _record('SOMETHING_NEW')
+        with pytest.raises(KeyError):
+            # Assigned rather than accessed bare, so this reads as the deliberate
+            # evaluation it is (and not as a stray statement to a linter).
+            resolved = record.event_name
+            assert resolved  # unreachable; the property raises
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_unrecognized_event_name_is_skipped(self, mock_table):
+        from aggregator.handler import record_handler
+
+        result = record_handler(_record('SOMETHING_NEW', new={'date': '2025-01-15'}))
+
+        assert result == {"status": "skipped", "reason": "unrecognized event"}
+        mock_table.update_item.assert_not_called()
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_record_with_no_event_name_at_all_is_skipped(self, mock_table):
+        from aggregator.handler import record_handler
+
+        record = DynamoDBRecord({'dynamodb': {'NewImage': _to_ddb({'date': '2025-01-15'})}})
+
+        assert record_handler(record) == {"status": "skipped", "reason": "unrecognized event"}
+        mock_table.update_item.assert_not_called()
+
+
+class TestTtlExpiryIsReadFromTheEventNotFromPowertools:
+    """The TTL branch must not be able to go dead silently.
+
+    `hasattr(record, 'user_identity')` is always true, and an
+    `isinstance(identity, dict)` test ties the branch to Powertools returning a bare
+    dict. That holds across the versions in play — but a release that wrapped it in
+    a `DictWrapper` would degrade the check to "user delete" for EVERY TTL REMOVE,
+    which is the failure the module docstring spends a paragraph arguing against,
+    with the whole branch dead and the suite still green (the tests build records
+    from raw event dicts, so they follow Powertools rather than pinning it).
+    """
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_identity_arriving_as_another_mapping_is_still_ttl_expiry(self, mock_table):
+        """Reading `raw_event` as a Mapping is what survives a wrapped value."""
+        from aggregator.handler import is_ttl_expiry
+
+        class Wrapped(Mapping):
+            """Not a dict: the shape a future Powertools DictWrapper would take."""
+
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def __len__(self):
+                return len(self._data)
+
+        record = _record('REMOVE', old={'date': '2025-01-15'})
+        record.raw_event['userIdentity'] = Wrapped(TTL_IDENTITY)
+
+        assert is_ttl_expiry(record) is True
+
+    def test_an_identity_that_is_not_a_mapping_is_a_user_delete(self):
+        """The documented fail-toward-user-delete direction, unchanged."""
+        from aggregator.handler import is_ttl_expiry
+
+        record = _record('REMOVE', old={'date': '2025-01-15'})
+        record.raw_event['userIdentity'] = 'dynamodb.amazonaws.com'
+
+        assert is_ttl_expiry(record) is False
+
+
+class TestEachBehaviourEmitsItsOwnMetric:
+    """Three materially different behaviours, three metrics.
+
+    One undifferentiated `AggregatesUpdated` would leave reversals unobservable in
+    CloudWatch — a small echo of why the original bug lasted as long as it did:
+    nothing outside the table could show whether aggregates ever came back DOWN. An
+    operator confirming this fix is live watches AggregatesReversed; one watching for
+    trouble watches AggregateWriteRefused.
+    """
+
+    @staticmethod
+    def _names(mock_metrics) -> list[str]:
+        return [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list]
+
+    def test_the_four_metric_names_are_distinct(self):
+        """The assertions below read the CONSTANTS, so this reads their values.
+
+        Without this, pointing REVERSED_METRIC and REBUCKETED_METRIC back at
+        `AggregatesUpdated` would leave every test in this class green while
+        restoring exactly the blindness they exist to remove — the tests would be
+        agreeing with the handler about a name instead of pinning that the three
+        behaviours are TOLD APART. Verified by running that revert: it passes
+        without this assertion and fails with it.
+        """
+        from aggregator import handler
+
+        names = [handler.UPDATED_METRIC, handler.REVERSED_METRIC,
+                 handler.REBUCKETED_METRIC, handler.REFUSED_METRIC]
+        assert len(set(names)) == len(names), (
+            f'The aggregator emits {names} for four different outcomes; two of them '
+            f'share a name, so CloudWatch cannot tell an insert from a reversal — '
+            f'which is the observability gap that let the original bug run.'
+        )
+
+    @patch('aggregator.handler.metrics')
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_insert_counts_as_updated(self, mock_table, mock_metrics, sample_feedback_item):
+        from aggregator.handler import UPDATED_METRIC, record_handler
+
+        record_handler(_record('INSERT', new=sample_feedback_item))
+
+        assert self._names(mock_metrics) == [UPDATED_METRIC]
+
+    @patch('aggregator.handler.metrics')
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_delete_counts_as_reversed(self, mock_table, mock_metrics, sample_feedback_item):
+        from aggregator.handler import REVERSED_METRIC, record_handler
+
+        record_handler(_record('REMOVE', old=sample_feedback_item))
+
+        assert self._names(mock_metrics) == [REVERSED_METRIC]
+
+    @patch('aggregator.handler.metrics')
+    def test_an_edit_counts_as_rebucketed(self, mock_metrics, live_day_table, sample_feedback_item):
+        from aggregator.handler import REBUCKETED_METRIC, record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert self._names(mock_metrics) == [REBUCKETED_METRIC]
+
+    @patch('aggregator.handler.metrics')
+    def test_an_edit_that_moved_nothing_counts_as_nothing(
+        self, mock_metrics, live_day_table, sample_feedback_item
+    ):
+        """The metric means "aggregates moved", so a no-op edit must not inflate it."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'problem_summary': 'reworded'}))
+
+        assert self._names(mock_metrics) == []
+
+    @patch('aggregator.handler.metrics')
+    def test_an_edit_to_an_aged_out_day_counts_as_nothing(
+        self, mock_metrics, sample_feedback_item, real_aggregates_table
+    ):
+        """Skipped for the day being gone is still "no aggregates moved"."""
+        from aggregator.handler import record_handler
+
+        record_handler(_record('MODIFY', old=sample_feedback_item,
+                               new={**sample_feedback_item, 'category': 'billing'}))
+
+        assert self._names(mock_metrics) == []
+
+    @patch('aggregator.handler.metrics')
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_refused_write_is_counted(self, mock_table, mock_metrics):
+        """A run of refusals means rows are expiring while their feedback is edited."""
+        from aggregator.handler import REFUSED_METRIC, update_counter
+
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'gone'}},
+            'UpdateItem',
+        )
+
+        update_counter('METRIC#daily_total', '2025-01-15', 'count', increment=-1)
+
+        assert self._names(mock_metrics) == [REFUSED_METRIC]
+
+    @patch('aggregator.handler.metrics')
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_skipped_ttl_expiry_counts_as_nothing(
+        self, mock_table, mock_metrics, sample_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old=sample_feedback_item, user_identity=TTL_IDENTITY))
+
+        assert self._names(mock_metrics) == []

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -88,21 +88,24 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       nothing else, which is why that test exists: every test in the class above
       passes with the defect present. Removing the block altogether fails three,
       including `test_the_same_day_block_is_not_weakened_by_that`, so neither
-      direction can be got wrong silently. Treating a reversal refused for a
-      MISSING row as blocking — collapsing AverageWrite back to a bool — fails
-      `test_a_reversal_refused_for_a_missing_row_does_not_block_the_new_score`, and
-      making the decline silent fails
+      direction can be got wrong silently. Making the decline silent fails
       `test_a_declined_re_application_is_counted_rather_than_silent` (REFUSED_METRIC
       counts DynamoDB's refusals, so a write never issued is invisible to it).
+      Within ONE row EITHER refusal blocks, because a reversal is attempted only for
+      an old image that carried a score, so an absent row is one that EXPIRED:
+      letting that case through fails
+      `test_a_reversal_refused_for_an_expired_row_does_not_recreate_it`, and
+      over-correcting to block on the row's absence rather than on a refused reversal
+      fails `test_an_absent_row_is_still_created_when_no_reversal_was_attempted`.
+      Those two differ only in whether a reversal was attempted, so neither
+      direction can be got wrong silently either.
 
-  TestUpdateAverageReportsWhichConditionFailed
-    — the signal the class above spends, pinned on its own. Deleting
-      `ReturnValuesOnConditionCheckFailure` fails four tests across both classes,
-      because without it a refusal carries no `Item` and every refused reversal
-      reads as ROW_ABSENT. Removing `AverageWrite.__bool__` fails
-      `test_only_the_landed_outcome_is_truthy` — an Enum is otherwise truthy in all
-      three states, which would make `if update_average(...)` a tautology and count
-      refused writes as landed.
+  TestUpdateAverageReportsWhetherItLanded
+    — the signal the class above spends, pinned on its own. Returning True from the
+      refusal branch fails `test_a_reversal_against_an_empty_row_reports_false` and
+      `test_a_reversal_against_a_missing_row_reports_false`; re-raising instead of
+      swallowing an unreadable refusal fails
+      `test_an_unreadable_refusal_is_still_a_refusal`.
 
   TestTheDaySentinelIsTheCounterEveryItemWrites
     — `_day_has_aggregates`'s soundness is a fact about `counter_dimensions`, so it
@@ -1492,6 +1495,12 @@ class TestThePairingIsPerRowAndNotPerEdit:
     So the block is keyed on the ROW, and these tests are what tell the two
     formulations apart — the flag version passes every test in the class above.
 
+    Keyed on the row is not the same as keyed on the row's EXISTENCE. Within one row
+    either refusal blocks, and the two tests at the end of this class are the pair
+    that pins it: an absent row whose reversal was refused expired and must not be
+    recreated, while an absent row nobody tried to reverse belongs to a day taking
+    its first scored item and must be.
+
     Moto-backed throughout: a mock cannot refuse the reversal, so against one the
     reversal always "lands", `blocked_row` stays None and the distinction is never
     exercised.
@@ -1556,16 +1565,17 @@ class TestThePairingIsPerRowAndNotPerEdit:
 
         assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(0), Decimal(0))
 
-    def test_a_score_edit_on_a_live_day_with_no_average_row_creates_it(
+    def test_an_absent_row_is_still_created_when_no_reversal_was_attempted(
         self, real_aggregates_table, sample_feedback_item
     ):
-        """A day can be live and have NO average row, without any race.
+        """The other side of the test above, and what keeps its guard from over-reaching.
 
-        `apply_feedback` writes the average only `if sentiment_score`, so a day whose
-        items are all unscored has a `daily_total` (it reads live) and no
-        `daily_sentiment_avg` at all. The reversal of a zero old score is never
-        attempted, and the re-application must create the row — the same latitude a
-        counter increment has for a brand-new bucket on a live day.
+        Both tests act on a live day with no average row; only the ATTEMPTED REVERSAL
+        tells them apart. Here the old score is zero, so `apply_feedback` never wrote
+        the row and there is nothing to have expired — the day genuinely has its first
+        scored item, and the write must land. Blocking on the row's absence rather than
+        on a refused reversal would fail this while still passing the test above, which
+        is the over-correction this pins.
         """
         from aggregator.handler import record_handler
 
@@ -1578,28 +1588,45 @@ class TestThePairingIsPerRowAndNotPerEdit:
 
         assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(1), Decimal('0.30'))
 
-    def test_a_reversal_refused_for_a_missing_row_does_not_block_the_new_score(
+    def test_a_reversal_refused_for_an_expired_row_does_not_recreate_it(
         self, real_aggregates_table, sample_feedback_item
     ):
-        """ROW_ABSENT is not ROW_AT_FLOOR, and only the second may block.
+        """A row that is ABSENT on a live day is absent because it EXPIRED.
 
-        The day is live (a `daily_total` is planted directly) while the average row is
-        absent, and the OLD score is non-zero — so the reversal is really attempted and
-        really refused, by `attribute_exists(pk)` rather than by the floor. Nothing was
-        reversed, so nothing dangles and the re-application must land. Treating both
-        refusals alike leaves the edited score nowhere.
+        The reversal is attempted only for an old image that carried a score, and
+        `apply_feedback` writes the average whenever a score is set — so the insert did
+        write this row, and its absence is the 90-day TTL, not a day that never had
+        one. The two rows of a day expire independently: `daily_total` is refreshed by
+        every item of the date, the average only by scored ones, and TTL deletion is
+        best-effort besides. So the day still reads live.
+
+        THE FIXTURE IS THE POINT. Three scored items make the day's real average cover
+        three, so re-creating the row from the one edited item is visibly a fragment:
+        `count == 1` beside a `daily_total` of 3, which `get_summary` would serve as
+        that whole day's figure. Planting a one-item day instead makes `count == 1`
+        look consistent and hides exactly this.
         """
         from aggregator.handler import record_handler
 
-        real_aggregates_table.put_item(
-            Item={'pk': 'METRIC#daily_total', 'sk': '2025-01-15', 'count': Decimal(1)}
+        items = [
+            {**sample_feedback_item, 'feedback_id': f'f{n}', 'sentiment_score': score}
+            for n, score in enumerate([Decimal('0.90'), Decimal('0.60'), Decimal('0.30')])
+        ]
+        for item in items:
+            record_handler(_record('INSERT', new=item))
+        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(3), Decimal('1.80'))
+
+        real_aggregates_table.delete_item(
+            Key={'pk': 'METRIC#daily_sentiment_avg', 'sk': '2025-01-15'}
         )
+        assert self._count(real_aggregates_table, 'METRIC#daily_total', '2025-01-15') == Decimal(3)
+
+        record_handler(_record('MODIFY', old=items[0],
+                               new={**items[0], 'sentiment_score': Decimal('0.10')}))
+
+        # No row at all is the honest outcome: `get_summary` skips what is absent
+        # rather than reporting one item's score as the day's average.
         assert self._avg(real_aggregates_table, '2025-01-15') is None
-
-        record_handler(_record('MODIFY', old=sample_feedback_item,
-                               new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
-
-        assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(1), Decimal('0.10'))
 
     def test_a_declined_re_application_is_counted_rather_than_silent(
         self, real_aggregates_table, sample_feedback_item
@@ -1652,75 +1679,51 @@ class TestThePairingIsPerRowAndNotPerEdit:
         assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(1), Decimal('0.10'))
 
 
-class TestUpdateAverageReportsWhichConditionFailed:
-    """`update_average`'s three outcomes, against a real DynamoDB implementation.
+class TestUpdateAverageReportsWhetherItLanded:
+    """`update_average`'s contract, against a real DynamoDB implementation.
 
-    The enum exists so `_rebucket_average` can tell "this row is claiming zero items"
-    from "there is no row", because re-applying is wrong for the first and right for
-    the second. A bool erased that distinction and a bool is what the first version
-    returned, so these pin the signal itself rather than only its consequence.
+    It answers a bool, like `update_counter`, because its one branching caller treats
+    both refusals alike: neither a row sitting at the floor nor a row that has expired
+    may take a re-application on its own. These pin the signal itself rather than only
+    its consequence in `_rebucket_average`.
     """
 
-    def test_a_landed_write_reports_landed(self, real_aggregates_table):
-        from aggregator.handler import AverageWrite, update_average
+    def test_a_landed_write_reports_true(self, real_aggregates_table):
+        from aggregator.handler import update_average
 
-        outcome = update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
+        assert update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
 
-        assert outcome is AverageWrite.LANDED
-
-    def test_a_reversal_against_an_empty_row_reports_the_floor(self, real_aggregates_table):
-        from aggregator.handler import AverageWrite, update_average
+    def test_a_reversal_against_an_empty_row_reports_false(self, real_aggregates_table):
+        from aggregator.handler import update_average
 
         update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
         update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1)
 
-        outcome = update_average(
+        assert not update_average(
             'METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1
         )
 
-        assert outcome is AverageWrite.ROW_AT_FLOOR
+    def test_a_reversal_against_a_missing_row_reports_false(self, real_aggregates_table):
+        """And writes nothing — the row must not be resurrected holding a negative."""
+        from aggregator.handler import update_average
 
-    def test_a_reversal_against_a_missing_row_reports_absent(self, real_aggregates_table):
-        from aggregator.handler import AverageWrite, update_average
-
-        outcome = update_average(
+        assert not update_average(
             'METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1
         )
+        assert real_aggregates_table.get_item(
+            Key={'pk': 'METRIC#daily_sentiment_avg', 'sk': '2025-01-15'}
+        ).get('Item') is None
 
-        assert outcome is AverageWrite.ROW_ABSENT
-
-    def test_only_the_landed_outcome_is_truthy(self):
-        """Existing callers ask `if update_average(...)`, and an Enum is truthy.
-
-        Without `__bool__` every such check would pass in all three states, silently
-        counting refused writes as landed — the reverse of the landed-not-attempted
-        distinction REBUCKETED_METRIC depends on.
-        """
-        from aggregator.handler import AverageWrite
-
-        assert bool(AverageWrite.LANDED)
-        assert not bool(AverageWrite.ROW_AT_FLOOR)
-        assert not bool(AverageWrite.ROW_ABSENT)
-
-    def test_an_unreadable_refusal_is_read_as_the_blocking_outcome(self):
-        """A refusal whose response cannot be read at all must not permit the write.
-
-        ROW_ABSENT is the outcome that LICENSES a re-application, so it must never be
-        the answer arrived at by default. Here the response is not a mapping — the
-        shape no reading can interpret — and the outcome is the one that declines, so
-        the pairing rule cannot be made conditional on an error's shape.
-
-        A response that IS readable and simply carries no `Item` is a different case
-        and genuinely means the row was absent; that is
-        `test_a_reversal_against_a_missing_row_reports_absent`, against moto.
+    def test_an_unreadable_refusal_is_still_a_refusal(self):
+        """A refusal whose response cannot be read is swallowed, not re-raised.
 
         The exception is shaped the way `shared/aws.py::is_conditional_check_failure`
         documents one arriving: a ClientError subclass NAMED
         ConditionalCheckFailedException — which is how boto3's resource layer really
         raises it — carrying no readable response, so the predicate recognises it by
-        type name and this branch is reached rather than the error re-raised.
+        type name and the refusal branch is reached rather than the error re-raised.
         """
-        from aggregator.handler import AverageWrite, update_average
+        from aggregator.handler import update_average
 
         class ConditionalCheckFailedException(ClientError):
             """Named like boto3's own, with an unreadable `response`."""
@@ -1733,24 +1736,11 @@ class TestUpdateAverageReportsWhichConditionFailed:
 
         with patch('aggregator.handler.aggregates_table') as mock_table:
             mock_table.update_item.side_effect = ConditionalCheckFailedException()
-            outcome = update_average(
+            landed = update_average(
                 'METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'), sign=-1
             )
 
-        assert outcome is AverageWrite.ROW_AT_FLOOR
-
-    def test_an_increment_asks_for_no_return_values(self, mock_aggregates_table):
-        """`ReturnValuesOnConditionCheckFailure` belongs only to the conditional half.
-
-        An increment carries no condition, so the parameter would be meaningless on
-        it — and DynamoDB rejects it without one.
-        """
-        from aggregator.handler import update_average
-
-        with patch('aggregator.handler.aggregates_table') as mock_table:
-            update_average('METRIC#daily_sentiment_avg', '2025-01-15', Decimal('0.85'))
-
-        assert 'ReturnValuesOnConditionCheckFailure' not in mock_table.update_item.call_args.kwargs
+        assert landed is False
 
 
 class TestRedeliveryMovesACounterTwice:

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -99,6 +99,10 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       fails `test_an_absent_row_is_still_created_when_no_reversal_was_attempted`.
       Those two differ only in whether a reversal was attempted, so neither
       direction can be got wrong silently either.
+      `test_a_cross_day_arrival_onto_an_expired_average_still_fragments_it` is the
+      RESIDUAL of that rule, pinned rather than fixed: the increment on the far side
+      of a cross-day edit lands where no reversal went, so an expired row there is
+      invisible. It fails if the residual is ever closed, which is deliberate.
 
   TestUpdateAverageReportsWhetherItLanded
     — the signal the class above spends, pinned on its own. Returning True from the
@@ -1564,6 +1568,47 @@ class TestThePairingIsPerRowAndNotPerEdit:
                                new={**sample_feedback_item, 'sentiment_score': Decimal('0.10')}))
 
         assert self._avg(real_aggregates_table, '2025-01-15') == (Decimal(0), Decimal(0))
+
+    def test_a_cross_day_arrival_onto_an_expired_average_still_fragments_it(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """THE RESIDUAL, pinned at what the code really does rather than what is nice.
+
+        The rule blocks a re-application only on a row whose OWN reversal was refused,
+        so it cannot see an expired row on the far side of a cross-day edit: the
+        increment lands where no reversal went. The arrival day therefore gets a
+        one-score average row exactly as the same-day case used to.
+
+        Left unfixed because it is undecidable from the two images. A live day with no
+        average row is the same observation whether the row expired or the day is
+        taking its first scored item — and the second must be created, which
+        `test_an_absent_row_is_still_created_when_no_reversal_was_attempted` pins. It
+        needs a per-day "has ever held a scored item" marker, i.e. new state.
+
+        This test FAILS if that residual is ever closed, which is the point: whoever
+        closes it should have to change this assertion deliberately.
+        """
+        from aggregator.handler import record_handler
+
+        for n, score in enumerate([Decimal('0.90'), Decimal('0.60'), Decimal('0.30')]):
+            record_handler(_record('INSERT', new={
+                **sample_feedback_item, 'feedback_id': f'e{n}',
+                'date': '2025-02-01', 'sentiment_score': score,
+            }))
+        mover = {**sample_feedback_item, 'feedback_id': 'mover', 'date': '2025-01-15',
+                 'sentiment_score': Decimal('0.50')}
+        record_handler(_record('INSERT', new=mover))
+
+        # The arrival day's average row ages out; its daily_total does not.
+        real_aggregates_table.delete_item(
+            Key={'pk': 'METRIC#daily_sentiment_avg', 'sk': '2025-02-01'}
+        )
+
+        record_handler(_record('MODIFY', old=mover, new={**mover, 'date': '2025-02-01'}))
+
+        # One score, beside a daily_total of four. Named, not defended.
+        assert self._avg(real_aggregates_table, '2025-02-01') == (Decimal(1), Decimal('0.50'))
+        assert self._count(real_aggregates_table, 'METRIC#daily_total', '2025-02-01') == Decimal(4)
 
     def test_an_absent_row_is_still_created_when_no_reversal_was_attempted(
         self, real_aggregates_table, sample_feedback_item

--- a/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
+++ b/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
@@ -1,0 +1,189 @@
+"""Lockstep test: the field the persona counter buckets by is a field the
+processor actually writes.
+
+WHY THIS IS A TEST AND NOT A COMMENT
+    `counter_dimensions` used to say, in prose, "`persona_name` is read here even
+    though the processor writes `persona_type`; do not just change it". Prose
+    cannot hold that, for a reason particular to this function: it is now the
+    SINGLE description of the dimensions, spent in both directions. The insert path
+    reads this field out of an item's NEW image and creates a counter row named
+    after the value; the reversal path reads the same field out of the OLD image of
+    the same item to find that row again. Change the name on its own and every
+    decrement misses the row its own insert created — the counter goes up and never
+    comes back down, which is the exact shape of the bug this module was repaired
+    for, reintroduced in one dimension.
+
+    So the hazard is not "the wrong field name". It is a field name changed HERE
+    while the writer is left alone, or a writer field renamed while this is left
+    alone. Both are drift between two copies of one fact, which is what a lockstep
+    is for, and neither is visible in any other test: a wrong name buckets
+    everything as `Unknown` and every existing assertion still passes, because the
+    fixtures and the handler agree with each other about a field the production
+    writer may not produce at all.
+
+WHAT IS PINNED, AND WHAT IS DELIBERATELY NOT
+    Pinned: the field `aggregator/handler.py::PERSONA_FIELD` names is one the
+    processor's item literal really writes. NOT pinned: WHICH of the processor's two
+    persona fields it should be. `persona_name` (the LLM's free-text name) and
+    `persona_type` (a small enum) are both real fields, and bucketing by either is
+    a defensible product decision — one gives many partitions, the other a handful.
+    Asserting a specific choice here would be this file inventing a requirement.
+
+    That leaves one thing worth naming out loud, because it is the reason the
+    deferral in the PR was contentious: `persona_name` is `null` whenever the model
+    returns no name, and the processor strips None values before writing, so those
+    items carry NO `persona_name` and bucket as `Unknown`. That is a data-quality
+    property of the enrichment output, not a lockstep violation — the counter is
+    genuinely counting "items whose persona we could not name". If the product
+    decision becomes "bucket by type instead", changing PERSONA_FIELD is the whole
+    change, and this test keeps passing because `persona_type` is written too.
+
+REVERT MAP
+    * Point PERSONA_FIELD at a field the processor does not write (`persona`,
+      `persona_label`) — fails
+      test_the_persona_field_is_one_the_processor_writes.
+    * Inline `item.get('persona_name')` back into `counter_dimensions` and drop the
+      constant — fails test_the_persona_field_is_read_through_the_constant, which
+      is what keeps the two directions reading ONE name rather than two literals
+      that happen to match today.
+    * Have the processor stop writing the field this reads — fails the first test,
+      from the other side.
+"""
+import ast
+import re
+from pathlib import Path
+
+from aggregator.handler import PERSONA_FIELD, counter_dimensions
+
+PROCESSOR_SOURCE = 'lambda/processor/handler.py'
+AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
+DIMENSIONS_FUNCTION = 'counter_dimensions'
+
+
+def _read(relative: str) -> str:
+    # lambda/aggregator/test/ -> voc-datalake/
+    path = Path(__file__).resolve().parents[3] / relative
+    assert path.is_file(), (
+        f'{relative} not found — did the file move? If so, update the path '
+        f'constant in this test file.'
+    )
+    return path.read_text(encoding='utf-8')
+
+
+def _processor_persona_fields() -> set[str]:
+    """The `persona_*` keys the processor's feedback item literal writes.
+
+    Read as source text rather than by calling the builder, because building an
+    item means an LLM response, a Bedrock client and a dozen environment
+    variables; the question here is only which KEYS the literal names.
+    """
+    source = _read(PROCESSOR_SOURCE)
+    fields = set(re.findall(r"^\s*'(persona_\w+)':", source, re.MULTILINE))
+    assert fields, (
+        f'No `persona_*` keys found in {PROCESSOR_SOURCE}. If the item literal was '
+        f'restructured, follow it here — an empty set would make the assertion '
+        f'below pass for the wrong reason.'
+    )
+    return fields
+
+
+def _aggregator_persona_reads() -> list[str]:
+    """Every `item.get(...)` argument inside `counter_dimensions`, unparsed.
+
+    Parsed with `ast`, scoped to the one function, so a mention in a docstring or
+    another function cannot answer for it — the convention the rest of this repo's
+    locksteps follow, and for the usual reason: a pattern that reads a comment as
+    code fails a correct module.
+    """
+    tree = ast.parse(_read(AGGREGATOR_SOURCE))
+    functions = [node for node in ast.walk(tree)
+                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                 and node.name == DIMENSIONS_FUNCTION]
+    assert len(functions) == 1, (
+        f'Expected exactly one {DIMENSIONS_FUNCTION} in {AGGREGATOR_SOURCE}; found '
+        f'{len(functions)}. A second copy is the drift this file exists to prevent.'
+    )
+    reads: list[str] = []
+    for statement in functions[0].body:
+        for node in ast.walk(statement):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'get' and node.args):
+                reads.append(ast.unparse(node.args[0]))
+    return reads
+
+
+class TestThePersonaCounterReadsAFieldThatExists:
+    def test_the_persona_field_is_one_the_processor_writes(self):
+        written = _processor_persona_fields()
+        assert PERSONA_FIELD in written, (
+            f'{AGGREGATOR_SOURCE} buckets the persona counter by '
+            f'`{PERSONA_FIELD}`, which {PROCESSOR_SOURCE} does not write — it '
+            f'writes {sorted(written)}. Every item would bucket as `Unknown`, and '
+            f'no other test would notice, because the aggregator fixtures agree '
+            f'with the aggregator rather than with the writer.'
+        )
+
+    def test_the_persona_field_is_read_through_the_constant(self):
+        """One name, not two literals that happen to agree.
+
+        The increment and the decrement path both come through this function, so a
+        literal here is only one copy — but a literal is also what makes it
+        possible to "fix" the field in a way that changes what the reversal looks
+        for without changing what the insert created. The constant is the seam this
+        lockstep and the handler share; reading the field any other way puts the
+        pin and the code back out of contact.
+        """
+        reads = _aggregator_persona_reads()
+        assert 'PERSONA_FIELD' in reads, (
+            f'{AGGREGATOR_SOURCE}::{DIMENSIONS_FUNCTION} reads {reads} — none of '
+            f'them the PERSONA_FIELD constant this test pins. Read the field '
+            f'through the constant so that changing it changes both directions at '
+            f'once and this lockstep still has something to hold.'
+        )
+        assert PERSONA_FIELD not in reads, (
+            f'{AGGREGATOR_SOURCE}::{DIMENSIONS_FUNCTION} also reads the literal '
+            f'"{PERSONA_FIELD}" alongside the constant. Two spellings of one field '
+            f'is the drift, whichever of them is currently right.'
+        )
+
+
+class TestTheDefaultBucketIsStable:
+    """An item with no persona must land in a NAMED bucket, the same one in both
+    directions — and never in one built out of `None`.
+
+    `METRIC#persona#None` is the failure a `.get(field, 'Unknown')` default does not
+    prevent: the processor strips None values, but a stream image edited by hand, or
+    any writer that stores an explicit null, delivers the key present and empty. The
+    default then does not apply, `Unknown` is not used, and the counter goes to a
+    partition nothing else writes to or reads from — invisible, and unreachable by
+    the reversal if the field is ever repopulated.
+    """
+
+    def test_a_missing_persona_buckets_under_unknown(self):
+        assert ('METRIC#persona#Unknown', 'count') in counter_dimensions({})
+
+    def test_an_explicitly_null_persona_buckets_under_unknown_too(self):
+        assert ('METRIC#persona#Unknown', 'count') in counter_dimensions(
+            {PERSONA_FIELD: None}
+        )
+
+    def test_an_empty_persona_name_buckets_under_unknown_too(self):
+        assert ('METRIC#persona#Unknown', 'count') in counter_dimensions(
+            {PERSONA_FIELD: ''}
+        )
+
+    def test_the_persona_dimension_is_never_absent(self):
+        """Urgency is the only conditional dimension.
+
+        Pinned because `counter_dimensions` is the single description both
+        directions read: a dimension that is sometimes present and sometimes not,
+        for a reason other than the item's own value, is how one direction writes a
+        row the other never comes back for.
+        """
+        for item in ({}, {PERSONA_FIELD: None}, {PERSONA_FIELD: 'Happy Customer'}):
+            personas = [pk for pk, _ in counter_dimensions(item)
+                        if pk.startswith('METRIC#persona#')]
+            assert len(personas) == 1, (
+                f'{item} produced {personas}; exactly one persona counter must be '
+                f'written for every item, in both directions.'
+            )

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -84,10 +84,22 @@ AGGREGATOR_COUNTER_WRITERS = ('update_counter', 'update_average')
 # (`update_counter(pk, date, field)` serves both the increment and the reversal).
 AGGREGATOR_KEY_PRODUCER = 'counter_keys'
 
-# The expressions allowed to produce the `date` a counter is keyed by: the
-# accessor that returns the item's own `date` field, and the unpacking of a triple
+# The expressions allowed to produce the `date` a counter is keyed by: the two
+# accessors that return the item's own `date` field, and the unpacking of a triple
 # this module already built. Nothing else may reach a sort key.
-AGGREGATOR_DATE_ACCESSOR = '_image_date'
+#
+# TWO accessors because the insert path and the reversal path may not answer the
+# same way for an image carrying no `date`: an arrival may fall back to today (it
+# arrived today), a reversal may not guess at all — a `-1` aimed at a day the item
+# never named corrupts a legitimate aggregate, and no condition expression can
+# catch it. Both return the `date` FIELD when there is one, which is all this file
+# is pinning; the difference between them is what they do when there is not.
+AGGREGATOR_DATE_ACCESSORS = ('_image_date', '_image_date_or_none')
+
+# The one iteration that hands a counter its sort key, matched EXACTLY. A prefix
+# test (`startswith('sorted(')`) would exempt any sorted() call at all —
+# `date = sorted(some_composite_list)[0]` would have passed it.
+AGGREGATOR_KEY_ITERATION = 'sorted(keys)'
 
 # The names the aggregator spends as a counter sort key. Three rather than one
 # because rebucketing an edited item writes to the date it LEFT and the date it
@@ -406,7 +418,32 @@ def _aggregator_counter_writes() -> list[tuple[str, str]]:
     return writes
 
 
-def _aggregator_sort_key_bindings() -> list[str]:
+def _explains_a_counter_date(value: ast.expr) -> bool:
+    """True when this expression is one of the shapes allowed to produce a sort key.
+
+    Matched on the PARSED expression, not on its text, because the two textual
+    tests this replaces admitted shapes the assertion did not mean to allow:
+
+      * `AGGREGATOR_KEY_PRODUCER not in binding` was a SUBSTRING test, so any
+        expression merely containing `counter_keys` was exempt —
+        `f'{counter_keys(item)}-{project}'` would have passed while binding a
+        composite sort key, which is exactly what this file exists to fail on;
+      * `startswith('sorted(')` exempted any `sorted(...)` call at all, so
+        `date = sorted(some_composite_list)[0]` would have passed too.
+
+    Here a call is a call: the accessors and the key producer must be the WHOLE
+    expression, and the one iteration that hands out sort keys is matched by exact
+    text. An f-string containing any of them is a JoinedStr, not a Call, and fails.
+    """
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+        if value.func.id in AGGREGATOR_DATE_ACCESSORS:
+            return True
+        if value.func.id == AGGREGATOR_KEY_PRODUCER:
+            return True
+    return ast.unparse(value) == AGGREGATOR_KEY_ITERATION
+
+
+def _aggregator_sort_key_bindings() -> list[ast.expr]:
     """Every expression the aggregator binds the name `date` to.
 
     Since the aggregator learned to REVERSE a deletion, its counter calls are
@@ -415,16 +452,17 @@ def _aggregator_sort_key_bindings() -> list[str]:
     the sibling assertion — every call site passes something spelled `date` —
     nearly free to satisfy, so it no longer carries the guarantee on its own. This
     helper follows the sort key to where it is now PRODUCED, and pins the small
-    set of expressions allowed to produce it: the accessor `_image_date`, which
-    returns the item's `date` field unmodified, or the unpacking of a triple built
-    by `counter_keys`. An f-string, a concatenation, a project id appended — any
-    of them appears here as an unrecognized binding and fails.
+    set of expressions allowed to produce it: one of the two accessors in
+    AGGREGATOR_DATE_ACCESSORS, which return the item's `date` field unmodified, or
+    the unpacking of a triple this module already built. An f-string, a
+    concatenation, a project id appended — any of them appears here as an
+    unrecognized binding and fails.
 
     `for` targets are read as well as assignments, because
     `for pk, date, field in sorted(keys)` is how the call sites now get theirs.
     """
     tree = ast.parse(_read(AGGREGATOR_SOURCE))
-    bindings: list[str] = []
+    bindings: list[ast.expr] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             targets, value = node.targets, node.value
@@ -448,7 +486,7 @@ def _aggregator_sort_key_bindings() -> list[str]:
                 pairs = [(target, value)]
             for name_node, value_node in pairs:
                 if isinstance(name_node, ast.Name) and name_node.id in AGGREGATOR_DATE_NAMES:
-                    bindings.append(ast.unparse(value_node))
+                    bindings.append(value_node)
     return bindings
 
 
@@ -697,21 +735,28 @@ class TestCounterSortKeyShapeLockstep:
         # form needs — unlike a pattern, it cannot read SOME of the call sites, so
         # there is no partial-blindness case left to count against.
         #
-        # The floor is FOUR, not the eight it was before the aggregator learned to
-        # reverse a deletion. The eight hardcoded `update_counter` calls became one
-        # generic call driven by a list of dimensions, deliberately: the increment
-        # and the decrement path must not be able to drift apart, which an inverted
-        # copy of eight call sites guarantees they eventually would. Lowering the
-        # floor is therefore not a weakening of this pin — the pin moved, and
-        # test_the_only_sort_key_the_aggregator_builds_is_the_item_date below is
-        # where the guarantee now lives, reading the one function that builds the
-        # keys those four call sites spend.
-        assert len(writes) >= 4, (
-            f'Found only {len(writes)} counter writes in {AGGREGATOR_SOURCE}; this '
-            f'module writes at least four (insert, delete, and both halves of a '
-            f'rebucketing edit). If the writers were renamed, update '
-            f'AGGREGATOR_COUNTER_WRITERS in this file — do not lower the floor, '
-            f'because the assertion below proves nothing without it.'
+        # The floor is ONE, and it used to be eight. It was eight while the
+        # aggregator had eight hardcoded `update_counter` calls and the count of
+        # them was the only thing standing between this assertion and vacuous
+        # truth. Those eight became one generic call driven by a list of dimensions
+        # when the aggregator learned to reverse a deletion — deliberately, because
+        # the increment and the decrement path must not be able to drift apart, and
+        # an inverted copy of eight call sites guarantees they eventually would.
+        #
+        # So the number of call sites is no longer a fact about anything: it is a
+        # refactoring artifact, and any further legitimate consolidation (folding
+        # the two `update_average` calls in `process_modified_feedback` into one
+        # helper, say) would fail a test whose subject had not changed. What this
+        # floor is FOR is only that the helper read something — the guarantee itself
+        # moved to test_the_only_sort_key_the_aggregator_builds_is_the_item_date
+        # below, which reads the one function that BUILDS the keys these call sites
+        # spend, and to its sibling pinning what may produce that key's date.
+        assert writes, (
+            f'Found no counter writes in {AGGREGATOR_SOURCE}, so the assertion '
+            f'below would pass on an empty list. If the writers were renamed or '
+            f'moved, update AGGREGATOR_COUNTER_WRITERS in this file — this floor '
+            f'exists so that a helper reading nothing fails loudly rather than '
+            f'silently satisfying its own assertion.'
         )
         composite = sorted({sk for _, sk in writes if sk not in AGGREGATOR_DATE_NAMES})
         assert not composite, (
@@ -743,25 +788,77 @@ class TestCounterSortKeyShapeLockstep:
     def test_that_date_can_only_have_come_from_the_item_field(self):
         """And the name itself is only ever bound to the item's date.
 
-        Two producers are legal: `_image_date(item)`, which returns the `date`
-        field or today's date and nothing else, and unpacking a triple this module
-        already built. Any third — an f-string, a concatenation, a project id
-        appended — is what this fails on, and it fails BEFORE the value reaches a
-        sort key that a range query would then silently over-count.
+        Three producers are legal: either accessor in AGGREGATOR_DATE_ACCESSORS,
+        which return the `date` field and nothing else, the key producer itself, and
+        the one iteration that hands out sort keys. Any fourth — an f-string, a
+        concatenation, a project id appended — is what this fails on, and it fails
+        BEFORE the value reaches a sort key that a range query would then silently
+        over-count.
+
+        Matched as parsed calls (`_explains_a_counter_date`) rather than by prefix
+        or substring, so an expression that merely CONTAINS a legal producer is not
+        exempt by containing it.
         """
+        bindings = _aggregator_sort_key_bindings()
+        assert bindings, (
+            f'No counter sort-key binding found in {AGGREGATOR_SOURCE}, so this '
+            f'assertion would pass on an empty list. If the names changed, update '
+            f'AGGREGATOR_DATE_NAMES rather than leaving the sort key unpinned.'
+        )
         unexplained = sorted({
-            binding for binding in _aggregator_sort_key_bindings()
-            if not binding.startswith(f'{AGGREGATOR_DATE_ACCESSOR}(')
-            and AGGREGATOR_KEY_PRODUCER not in binding
-            and not binding.startswith('sorted(')
+            ast.unparse(binding) for binding in bindings
+            if not _explains_a_counter_date(binding)
         })
         assert not unexplained, (
             f'{AGGREGATOR_SOURCE} binds a counter sort key from {unexplained}. '
-            f'Only {AGGREGATOR_DATE_ACCESSOR}() and the unpacking of a '
-            f'{AGGREGATOR_KEY_PRODUCER}() triple may produce one, because '
+            f'Only {list(AGGREGATOR_DATE_ACCESSORS)}, {AGGREGATOR_KEY_PRODUCER}() '
+            f'and `{AGGREGATOR_KEY_ITERATION}` may produce one, because '
             f'{STREAM_SOURCE} reads these sort keys as bare dates. If a new '
             f'source is genuinely right, add it here deliberately.'
         )
+
+
+class TestTheSortKeyAllowlistItself:
+    """The allowlist decides whether the pin above passes, so what it ADMITS is
+    the thing to check — a hatch wide enough to walk a composite sort key through
+    leaves the pin green while unpinned, which is the outcome the rest of this file
+    goes to some length to prevent.
+
+    Both cases below are the two the previous textual form really did admit: it
+    exempted any expression CONTAINING `counter_keys`, and any expression starting
+    `sorted(`. Neither is a hypothetical shape.
+    """
+
+    @staticmethod
+    def _explains(source: str) -> bool:
+        return _explains_a_counter_date(ast.parse(source, mode='eval').body)
+
+    def test_each_declared_accessor_explains_a_date(self):
+        for accessor in AGGREGATOR_DATE_ACCESSORS:
+            assert self._explains(f'{accessor}(item)'), (
+                f'{accessor} is declared legal in AGGREGATOR_DATE_ACCESSORS but the '
+                f'allowlist does not recognise it, so a correct aggregator fails.'
+            )
+
+    def test_the_key_iteration_and_producer_explain_a_date(self):
+        assert self._explains(AGGREGATOR_KEY_ITERATION)
+        assert self._explains(f'{AGGREGATOR_KEY_PRODUCER}(item, date)')
+
+    def test_an_fstring_merely_containing_the_producer_is_not_explained(self):
+        # The substring hatch. `counter_keys` appears in the text, and the value is
+        # a composite sort key.
+        assert not self._explains(f"f'{{{AGGREGATOR_KEY_PRODUCER}(item)}}-{{project}}'")
+
+    def test_an_fstring_merely_containing_an_accessor_is_not_explained(self):
+        assert not self._explains(f"f'{{{AGGREGATOR_DATE_ACCESSORS[0]}(item)}}#{{project_id}}'")
+
+    def test_some_other_sorted_call_is_not_explained(self):
+        # The prefix hatch: `startswith('sorted(')` exempted this, and it binds
+        # whatever the first element of an unrelated list happens to be.
+        assert not self._explains('sorted(some_composite_list)[0]')
+
+    def test_a_concatenation_is_not_explained(self):
+        assert not self._explains(f"{AGGREGATOR_DATE_ACCESSORS[0]}(item) + '#' + project")
 
 
 class TestNotConfiguredFallbackLockstep:

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -80,6 +80,22 @@ PYTHON_WRITER_SK_PATTERN = rf'^CATEGORIES_SK = {_Q}([^\'"]+){_Q}'
 # The counter writers whose sort key the streaming window predicate depends on.
 AGGREGATOR_COUNTER_WRITERS = ('update_counter', 'update_average')
 
+# The one function that BUILDS a counter key, now that the call sites are generic
+# (`update_counter(pk, date, field)` serves both the increment and the reversal).
+AGGREGATOR_KEY_PRODUCER = 'counter_keys'
+
+# The expressions allowed to produce the `date` a counter is keyed by: the
+# accessor that returns the item's own `date` field, and the unpacking of a triple
+# this module already built. Nothing else may reach a sort key.
+AGGREGATOR_DATE_ACCESSOR = '_image_date'
+
+# The names the aggregator spends as a counter sort key. Three rather than one
+# because rebucketing an edited item writes to the date it LEFT and the date it
+# arrived at, and calling both `date` in one function would be worse than naming
+# them. Every one of them is pinned to the accessor above, so the list being
+# longer costs nothing — an unpinned fourth name fails the sibling assertion.
+AGGREGATOR_DATE_NAMES = ('date', 'old_date', 'new_date')
+
 # The never-written key streaming chat used to ask for, assembled rather than
 # written out so that a repository-wide search for it keeps returning nothing
 # outside build artifacts — which is itself part of the fix.
@@ -390,6 +406,87 @@ def _aggregator_counter_writes() -> list[tuple[str, str]]:
     return writes
 
 
+def _aggregator_sort_key_bindings() -> list[str]:
+    """Every expression the aggregator binds the name `date` to.
+
+    Since the aggregator learned to REVERSE a deletion, its counter calls are
+    generic: one `update_counter(pk, date, field)` serves the increment and the
+    decrement, which is what stops the two paths from drifting apart. That makes
+    the sibling assertion — every call site passes something spelled `date` —
+    nearly free to satisfy, so it no longer carries the guarantee on its own. This
+    helper follows the sort key to where it is now PRODUCED, and pins the small
+    set of expressions allowed to produce it: the accessor `_image_date`, which
+    returns the item's `date` field unmodified, or the unpacking of a triple built
+    by `counter_keys`. An f-string, a concatenation, a project id appended — any
+    of them appears here as an unrecognized binding and fails.
+
+    `for` targets are read as well as assignments, because
+    `for pk, date, field in sorted(keys)` is how the call sites now get theirs.
+    """
+    tree = ast.parse(_read(AGGREGATOR_SOURCE))
+    bindings: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.For):
+            targets, value = [node.target], node.iter
+        else:
+            continue
+        for target in targets:
+            # A parallel assignment is read ELEMENT BY ELEMENT where both sides are
+            # tuples — `old_date, new_date = _image_date(a), _image_date(b)` binds
+            # each name to one accessor call, and reporting the whole right-hand
+            # side would make a correct aggregator look unexplained.
+            if (isinstance(target, ast.Tuple) and isinstance(value, ast.Tuple)
+                    and len(target.elts) == len(value.elts)):
+                pairs = list(zip(target.elts, value.elts))
+            elif isinstance(target, ast.Tuple):
+                # Unpacking something that is not a literal tuple (a triple built
+                # elsewhere): the whole iterable explains every name in it.
+                pairs = [(element, value) for element in target.elts]
+            else:
+                pairs = [(target, value)]
+            for name_node, value_node in pairs:
+                if isinstance(name_node, ast.Name) and name_node.id in AGGREGATOR_DATE_NAMES:
+                    bindings.append(ast.unparse(value_node))
+    return bindings
+
+
+def _aggregator_counter_key_sort_keys() -> list[str]:
+    """The sort-key element of every triple `counter_keys` builds.
+
+    `counter_keys` is the single producer of counter keys, so its comprehension
+    is the one expression that decides whether a counter's sort key is a bare
+    date. Read as the SECOND element of the built tuple, by the writer's own
+    name, so a restructuring that stops producing a 3-tuple fails loudly here
+    rather than leaving the sort key unpinned.
+    """
+    tree = ast.parse(_read(AGGREGATOR_SOURCE))
+    producers = [node for node in ast.walk(tree)
+                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                 and node.name == AGGREGATOR_KEY_PRODUCER]
+    assert len(producers) == 1, (
+        f'Expected exactly one {AGGREGATOR_KEY_PRODUCER} in {AGGREGATOR_SOURCE}; '
+        f'found {len(producers)}. This helper reads the ONE place counter sort '
+        f'keys are built — if that moved or was renamed, follow it here rather '
+        f'than deleting the assertion that depends on it.'
+    )
+    sort_keys: list[str] = []
+    # The BODY only. The return annotation `set[tuple[str, str, str]]` is a
+    # three-element tuple too, and reading it would report the type name `str` as
+    # a sort key — a correct aggregator failing on its own type hint.
+    for statement in producers[0].body:
+        for node in ast.walk(statement):
+            if isinstance(node, ast.Tuple) and len(node.elts) == 3:
+                sort_keys.append(ast.unparse(node.elts[1]))
+    assert sort_keys, (
+        f'{AGGREGATOR_SOURCE}::{AGGREGATOR_KEY_PRODUCER} no longer builds a '
+        f'(pk, sk, field) triple, so its sort key cannot be read here and the '
+        f'assertion below would pass on an empty list.'
+    )
+    return sort_keys
+
+
 def _processor_default_categories() -> list[str]:
     """The default taxonomy as the ENRICHMENT PROMPT spells it: one pipe-delimited
     string, not a list.
@@ -599,13 +696,24 @@ class TestCounterSortKeyShapeLockstep:
         # assertion below for the wrong reason. This is the only guard the parsed
         # form needs — unlike a pattern, it cannot read SOME of the call sites, so
         # there is no partial-blindness case left to count against.
-        assert len(writes) >= 8, (
+        #
+        # The floor is FOUR, not the eight it was before the aggregator learned to
+        # reverse a deletion. The eight hardcoded `update_counter` calls became one
+        # generic call driven by a list of dimensions, deliberately: the increment
+        # and the decrement path must not be able to drift apart, which an inverted
+        # copy of eight call sites guarantees they eventually would. Lowering the
+        # floor is therefore not a weakening of this pin — the pin moved, and
+        # test_the_only_sort_key_the_aggregator_builds_is_the_item_date below is
+        # where the guarantee now lives, reading the one function that builds the
+        # keys those four call sites spend.
+        assert len(writes) >= 4, (
             f'Found only {len(writes)} counter writes in {AGGREGATOR_SOURCE}; this '
-            f'module writes at least eight. If the writers were renamed, update '
+            f'module writes at least four (insert, delete, and both halves of a '
+            f'rebucketing edit). If the writers were renamed, update '
             f'AGGREGATOR_COUNTER_WRITERS in this file — do not lower the floor, '
             f'because the assertion below proves nothing without it.'
         )
-        composite = sorted({sk for _, sk in writes if sk != 'date'})
+        composite = sorted({sk for _, sk in writes if sk not in AGGREGATOR_DATE_NAMES})
         assert not composite, (
             f'{AGGREGATOR_SOURCE} keys a counter by {composite} rather than by '
             f'the bare `date`. {STREAM_SOURCE} sums these partitions with '
@@ -613,6 +721,46 @@ class TestCounterSortKeyShapeLockstep:
             f'inside a date window — so streaming chat would silently count rows '
             f'that are not days. If a composite sort key is really wanted here, '
             f'the streaming reader needs a different predicate, not a wider one.'
+        )
+
+    def test_the_only_sort_key_the_aggregator_builds_is_the_item_date(self):
+        """Where the guarantee lives now that the call sites are generic.
+
+        A generic `update_counter(pk, date, field)` says nothing about what `date`
+        holds, so the sibling assertion above would stay green while the value
+        bound to that name grew a suffix. `counter_keys` is the single producer,
+        and its sort key must be the accessor that returns the item's own `date`
+        field — nothing appended.
+        """
+        sort_keys = sorted(set(_aggregator_counter_key_sort_keys()))
+        assert sort_keys == ['date'], (
+            f'{AGGREGATOR_SOURCE}::{AGGREGATOR_KEY_PRODUCER} builds counter keys '
+            f'whose sort key is {sort_keys} rather than the bare `date`. '
+            f'{STREAM_SOURCE} sums these partitions with a range predicate over '
+            f'dates, so anything else sorts inside a window it is unrelated to.'
+        )
+
+    def test_that_date_can_only_have_come_from_the_item_field(self):
+        """And the name itself is only ever bound to the item's date.
+
+        Two producers are legal: `_image_date(item)`, which returns the `date`
+        field or today's date and nothing else, and unpacking a triple this module
+        already built. Any third — an f-string, a concatenation, a project id
+        appended — is what this fails on, and it fails BEFORE the value reaches a
+        sort key that a range query would then silently over-count.
+        """
+        unexplained = sorted({
+            binding for binding in _aggregator_sort_key_bindings()
+            if not binding.startswith(f'{AGGREGATOR_DATE_ACCESSOR}(')
+            and AGGREGATOR_KEY_PRODUCER not in binding
+            and not binding.startswith('sorted(')
+        })
+        assert not unexplained, (
+            f'{AGGREGATOR_SOURCE} binds a counter sort key from {unexplained}. '
+            f'Only {AGGREGATOR_DATE_ACCESSOR}() and the unpacking of a '
+            f'{AGGREGATOR_KEY_PRODUCER}() triple may produce one, because '
+            f'{STREAM_SOURCE} reads these sort keys as bare dates. If a new '
+            f'source is genuinely right, add it here deliberately.'
         )
 
 

--- a/voc-datalake/lambda/product_doc_extractor/handler.py
+++ b/voc-datalake/lambda/product_doc_extractor/handler.py
@@ -27,14 +27,16 @@ WHY NO aws_lambda_powertools, AND NO `lambda/shared/` IMPORTS
     needs Docker). Stdlib + boto3 only, like the two Python handlers CoreStack
     already ships (`lambda/custom_resources/admin_bootstrap.py`, `model_pin.py`).
 
-    The cost of that isolation is this file re-implements three small things that
+    The cost of that isolation is this file re-implements four small things that
     exist in `shared/`: model resolution (see _resolve_model_id, which mirrors
     `shared/model_config.py::get_active_model_id` exactly), the reserved-word
-    aliasing in the status writes (pattern from `shared/jobs.py`), and structured
+    aliasing in the status writes (pattern from `shared/jobs.py`), structured
     JSON logging with per-record context (see JsonFormatter — powertools' output
     shape and `append_keys` behaviour, in a stdlib Formatter subclass, on a named
     logger that does not propagate, which is the shape powertools' own Logger
-    takes). All three are pinned by tests.
+    takes), and the conditional-check-failure predicate (see
+    _is_conditional_check_failure, which mirrors
+    `shared/aws.py::is_conditional_check_failure`). All four are pinned by tests.
 
     WHAT THE ISOLATION DOES NOT COST is structured logs. Emitting plain text
     because powertools is unavailable would be a non-sequitur: the JSON shape is
@@ -552,6 +554,11 @@ def _is_conditional_check_failure(error: Exception) -> bool:
     layer raises a dynamically-built ClientError subclass, so its type name is a
     botocore implementation detail. The type name is checked as well because a
     test double raises the named exception with no response payload.
+
+    A copy of `shared/aws.py::is_conditional_check_failure`, which is where every
+    other handler gets this predicate. This file cannot import `shared/` — see
+    the module docstring — so the duplication is the price of that isolation and
+    not a preference. Change both, or neither.
     """
     response = getattr(error, 'response', None)
     code = (response.get('Error') or {}).get('Code') if isinstance(response, dict) else None

--- a/voc-datalake/lambda/shared/aws.py
+++ b/voc-datalake/lambda/shared/aws.py
@@ -26,9 +26,33 @@ def get_dynamodb_resource():
     return _dynamodb_resource
 
 
+def is_conditional_check_failure(error: Exception) -> bool:
+    """True for DynamoDB's ConditionalCheckFailedException, however it arrives.
+
+    The error CODE in the response is the dependable signal — boto3's resource
+    layer raises a dynamically-built ClientError subclass, so its type name is a
+    botocore implementation detail. The type name is checked as well because a
+    test double raises the named exception with no response payload.
+
+    ONE copy, here, because every conditional write in this app needs the same
+    predicate and each caller reaches it through a different failure path: a
+    refused write is the EXPECTED outcome of a guarded update (a decrement with
+    nothing to decrement, a status write against a record already terminal), so
+    misclassifying it swallows a real error or raises on a benign one. A second
+    copy is how the next arrival path for this exception gets fixed in one place
+    and missed in the other. `product_doc_extractor/handler.py` cannot import
+    this — it is stdlib+boto3 only by design, see its module docstring — and
+    keeps its own copy with a comment pointing here.
+    """
+    response = getattr(error, 'response', None)
+    code = (response.get('Error') or {}).get('Code') if isinstance(response, dict) else None
+    return (code == 'ConditionalCheckFailedException'
+            or type(error).__name__ == 'ConditionalCheckFailedException')
+
+
 def get_s3_client():
     """Get shared S3 client with connection reuse.
-    
+
     Configured with Signature Version 4 for KMS-encrypted bucket compatibility.
     """
     global _s3_client

--- a/voc-datalake/lambda/shared/test/test_aws.py
+++ b/voc-datalake/lambda/shared/test/test_aws.py
@@ -106,3 +106,110 @@ class TestInvokeLambdaAsync:
             Payload='{"key": "value"}'
         )
         assert result == {'StatusCode': 202}
+
+
+class TestIsConditionalCheckFailure:
+    """Both signals, because the exception arrives two different ways.
+
+    Every conditional write in this app depends on this predicate to tell an
+    EXPECTED refusal (a decrement with nothing to decrement, a status write against
+    a record already terminal) from a real failure, and it gets the two wrong in
+    opposite directions: too narrow and a benign refusal is re-raised into the batch
+    processor, too wide and a throttle is swallowed as if nothing happened. So both
+    branches are covered, and so is what must NOT match.
+    """
+
+    @staticmethod
+    def _client_error(code: str) -> Exception:
+        from botocore.exceptions import ClientError
+        return ClientError(
+            {'Error': {'Code': code, 'Message': 'the conditional request failed'}},
+            'UpdateItem',
+        )
+
+    def test_the_response_code_is_recognized(self):
+        """The dependable signal: boto3's resource layer raises a ClientError whose
+        dynamically-built subclass name is a botocore implementation detail."""
+        from shared.aws import is_conditional_check_failure
+
+        assert is_conditional_check_failure(
+            self._client_error('ConditionalCheckFailedException')
+        ) is True
+
+    def test_the_exception_type_name_is_recognized_too(self):
+        """A test double raises the named exception with no response payload."""
+        from shared.aws import is_conditional_check_failure
+
+        ConditionalCheckFailedException = type('ConditionalCheckFailedException',
+                                               (Exception,), {})
+
+        assert is_conditional_check_failure(ConditionalCheckFailedException()) is True
+
+    def test_another_dynamodb_error_is_not_a_refusal(self):
+        """A throttle must reach the caller; swallowing it loses the write silently."""
+        from shared.aws import is_conditional_check_failure
+
+        assert is_conditional_check_failure(
+            self._client_error('ProvisionedThroughputExceededException')
+        ) is False
+
+    def test_an_error_with_no_response_at_all_is_not_a_refusal(self):
+        """`getattr(error, 'response', None)` must not raise on a bare exception."""
+        from shared.aws import is_conditional_check_failure
+
+        assert is_conditional_check_failure(RuntimeError('boom')) is False
+
+    def test_a_malformed_response_is_not_a_refusal(self):
+        """`response['Error']` can be absent or None; neither may raise here."""
+        from shared.aws import is_conditional_check_failure
+
+        for response in ({}, {'Error': None}, {'Error': {}}, 'not a dict'):
+            error = RuntimeError('boom')
+            error.response = response
+            assert is_conditional_check_failure(error) is False, response
+
+
+class TestTheExtractorsCopyStaysInStep:
+    """`product_doc_extractor/handler.py` keeps its OWN copy of the predicate.
+
+    Not by preference: that Lambda is stdlib+boto3 only so CoreStack never needs
+    container bundling, so it cannot import `shared/`. The duplication is therefore
+    load-bearing and permanent, which makes it exactly the kind of thing that drifts
+    — whoever finds a third arrival path for this exception fixes one copy. This pins
+    the two bodies against each other rather than trusting the comment that says to
+    change both.
+    """
+
+    @staticmethod
+    def _function_body(source: str, name: str) -> str:
+        import ast
+        tree = ast.parse(source)
+        functions = [node for node in ast.walk(tree)
+                     if isinstance(node, ast.FunctionDef) and node.name == name]
+        assert len(functions) == 1, f'expected one {name}; found {len(functions)}'
+        # Docstrings differ deliberately (each points at the other), so only the
+        # executable statements are compared.
+        body = [node for node in functions[0].body
+                if not (isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant))]
+        return '\n'.join(ast.unparse(node) for node in body)
+
+    def test_the_two_copies_have_identical_logic(self):
+        from pathlib import Path
+
+        # lambda/shared/test/ -> voc-datalake/lambda/
+        lambda_root = Path(__file__).resolve().parents[2]
+        shared = self._function_body(
+            (lambda_root / 'shared' / 'aws.py').read_text(encoding='utf-8'),
+            'is_conditional_check_failure',
+        )
+        extractor = self._function_body(
+            (lambda_root / 'product_doc_extractor' / 'handler.py').read_text(encoding='utf-8'),
+            '_is_conditional_check_failure',
+        )
+
+        assert shared == extractor, (
+            'shared/aws.py::is_conditional_check_failure and '
+            'product_doc_extractor/handler.py::_is_conditional_check_failure have '
+            'drifted. The extractor cannot import shared/ (see its module '
+            'docstring), so the copy is permanent — change both, or neither.'
+        )


### PR DESCRIPTION
## Summary

**The dashboard's headline numbers disagreed with its own feedback list, and deleting a record never fixed it.** `lambda/aggregator/handler.py` — the DynamoDB Streams consumer that maintains every pre-computed metric — returned early on anything but `INSERT`. So a delete or an edit never moved a counter, and each aggregate counted items **ever inserted**. `get_metrics_summary` (which reads the aggregates) and `search_feedback` (which scans) reported different totals for the same window; at `days=7`, total 1 against count 0. That is finding **M6** of the MCP truthfulness audit. A person notices because the dashboard shows both numbers side by side; a model calling one MCP tool has nothing to cross-check.

This handles the other two stream events. The whole shape of it is decided by one interaction that is invisible from the aggregator alone: **feedback items expire after 365 days, aggregate rows after 90, and the counter update is `if_not_exists(#field, :zero) + :inc`** — so a `-1` aimed at a row that has already expired does not fail, it **creates** that row holding a negative count under a fresh 90-day TTL, which any window query reaching back that far then serves. Almost every decision below is a consequence of that.

### What the change does

**1. A TTL-driven REMOVE is skipped, not decremented.** Items are stamped `ttl = now + 365 days` (`processor/handler.py`) on a table with `timeToLiveAttribute: 'ttl'` (`core-stack.ts`), while aggregate rows default to `ttl_days=90`. So the TTL REMOVE for the feedback of date D arrives around D+365, nine months after that day's aggregate row disappeared. Ageing out is also not a *correction*: the feedback of 2026-01-15 really did arrive on 2026-01-15. TTL deletions are identified by `userIdentity` (`principalId == 'dynamodb.amazonaws.com'`, `type == 'Service'`).

**2. A user REMOVE decrements, and can neither create a row nor go negative.** `ConditionExpression='attribute_exists(pk) AND #field >= :floor'`, with `ConditionalCheckFailedException` swallowed for a decrement only. `update_average` takes a `sign` with the same treatment. Every dimension the insert incremented is reversed: daily total, source, category, sentiment, urgency (only when `high`), persona, and the category+sentiment combo.

**3. MODIFY rebuckets.** Ingestion cannot emit MODIFY (the processor writes with a single `put_item`), but `PUT /data-explorer/feedback` edits in place and its allowlist includes `category`, `sentiment_label`, `sentiment_score` and `urgency`. Handled as the **symmetric difference** of the two images' dimension sets, so an unrelated edit writes nothing at all — a `-1`/`+1` pair on one key nets to zero but refreshes that row's TTL and burns capacity, and the decrement half can be refused while its increment lands. Symmetric difference is also the only formulation that survives an edited `date`, which moves every counter to a different sort key.

**4. One description of the dimensions, spent twice.** The eight hardcoded `update_counter` calls became `counter_dimensions` / `counter_keys` / `apply_counter_keys`. A hand-written inverted twin would have recreated the original bug in miniature — a dimension added to one path only. `test_the_reversed_dimensions_are_exactly_the_incremented_ones` derives **both** sets from the handler rather than restating them, so that drift fails.

**5. Neither reversal path guesses a day.** `_image_date` falls back to today, which is defensible for an arrival and arbitrary for a reversal: an undated item ingested on D and deleted on D+40 would decrement D+40's counters — a legitimate current-day aggregate — while leaving D overstated, and no `ConditionExpression` can catch it, because that row exists and is above the floor. REMOVE and MODIFY read `_image_date_or_none` and write nothing rather than guess. The INSERT fallback is deliberately kept, and pinned by its own test.

**6. A rebucket cannot resurrect an aged-out day, and the check is per SIDE.** The decrements against a dead day are refused anyway; the increments are not, and an unconditional `+1` leaves a one-count fragment — including a one-score `daily_sentiment_avg` row, the worst of them — for a date whose real totals were collected months ago. The guard asks whether the **day** still has aggregates, not whether each row exists: refusing per row would drop the count of an item edited into a category no item has used today. And it is evaluated per side, because `old_live or new_live` would pass an edit moving an item from a live day onto a dead one, whose increments then recreate the dead day in full.

**7. The average's two halves stand or fall together, per ROW.** The counters cannot split — a symmetric difference never sends `-1` and `+1` to one key — but the average is two conditional writes to `(SENTIMENT_AVG_PK, date)`, and a reversal refused while the re-application lands leaves that row claiming an item no feedback justifies, which `get_summary` divides into the day's average and weights into the headline figure. So the re-application is skipped when it targets **the very row** whose reversal was refused. Keyed on the row and not on the edit, because an edited `date` sends the two writes to two different days, and blocking across that gap dropped the item from the new day's average while all of its counters moved there. Within one row **either** refusal blocks: a reversal is attempted only for an old image that carried a score, so an absent row is one that **expired**, and re-creating it from the single edited item is the same fragment as item 6, one granularity below what the day check can see.

**8. Two smaller correctness items.** An unrecognised `eventName` reaches its `skipped` branch instead of raising inside Powertools' enum lookup — which, under `reportBatchItemFailures`, made the record a poison pill rather than a graceful skip. And `is_conditional_check_failure` moved to `shared/aws.py` instead of being a second verbatim copy of `product_doc_extractor`'s; the one unavoidable remaining copy is pinned by an AST comparison rather than by a comment.

### Deliberately not done

- **`persona_name` is left wrong.** `counter_dimensions` reads `persona_name` while the processor writes `persona_type`, so nearly everything buckets as `Unknown`. That is finding **M7**, tracked separately. Reading a different field here than the insert path read would make decrements miss the rows the inserts created — strictly worse than a wrong bucket name.
- **No backfill.** This stops new drift; it does not repair stored values. **Known residual:** rows written before this deploy stay overstated by the number of items since deleted from their date. Repairing them needs a rebuild-from-scan path that does not exist.
- **Not idempotent under redelivery.** Streams are at-least-once. The floor at zero makes a redelivered REMOVE a no-op only when the counter is already there: a counter at 3 lands on 2, then 1. A redelivered MODIFY moves the count twice. Pinned by tests at what the code really does, so the note and the code cannot drift.
- **`update_average` floors `count`, not `sum`.** A reversal quoting a different score than its insert did leaves `sum` inconsistent with `count`. A bound on `sum` cannot distinguish a stale reversal from a legitimate one — scores run −1..1, so reversing a negative score *raises* `sum`. The coherent fix is per-item contributions, i.e. a schema change.
- **A cross-day arrival onto a live day whose average row expired still creates it holding one score.** The pairing rule in item 7 learns a row is gone only from a reversal aimed at that row, and a cross-day increment lands where no reversal went. Undecidable from the two images: a live day with no average row is the same observation whether the row expired or the day is taking its first scored item, and the second must be created. Needs a per-day "has ever held a scored item" marker, i.e. new state. The **same-day** case is closed, because there the refused reversal is itself the evidence.
- **No alarm or dashboard for the new metrics.** `AggregatesUpdated`, `AggregateWriteRefused`, `AggregateWriteDeclined` and `AggregatesRebucketed` are emitted and distinct, but nothing outside `lambda/aggregator/` references them.
- No change to the metrics API handlers, to any schema, or to the CDK. The event source already streams `NEW_AND_OLD_IMAGES` with no event-type filter, so REMOVE and MODIFY records were arriving all along and being dropped in Python.

### One collateral change, and why it is not a weakening

`lambda/api/test/test_streaming_categories_lockstep.py` pins that every aggregate counter is keyed by a bare `YYYY-MM-DD`, because streaming chat sums those partitions with `sk BETWEEN :oldest AND :newest`. Its denominator asserted `len(writes) >= 8`, counting the eight literal `update_counter` call sites that item 4 deliberately collapses. Rather than lower the floor — which would leave the sort key effectively unpinned, since a generic `update_counter(pk, date, field)` says nothing about what `date` holds — the guarantee moved to where the sort key is now *produced*:

- `test_the_only_sort_key_the_aggregator_builds_is_the_item_date` reads the one function that builds counter keys and asserts its sort-key element is the bare `date`;
- `test_that_date_can_only_have_come_from_the_item_field` asserts the only expressions allowed to bind a counter's date are `_image_date(...)` and the unpacking of a `counter_keys` triple, by matching parsed nodes rather than text.

Both were mutation-checked: appending a suffix inside `counter_keys` fails the first, and building the date by concatenation fails the second.

## Build and test results

`mise run build`: **no build task is defined** for this repo (`mise ERROR no tasks defined`), so build gating here is inert. Validation is the Python suite, ruff, and mutation reverts. Every baseline was re-measured in a clean worktree at the stated commit, not quoted from the task.

`development` was merged into this branch after the figures below were taken, bringing in **#365**, so both columns are re-stated against the merged head. The two are separated on purpose: #365 contributes **+65 tests and +2 ruff findings**, and neither is this PR's to claim.

| Command | Base | This branch |
|---|---|---|
| `pytest lambda` | 3177 passed (`development`, incl. #365) | **3278 passed, 0 failed** |
| `pytest lambda/aggregator` | 28 passed | **115 passed** |
| `ruff check lambda plugins` | 509 (`development`, incl. #365) | **509 — ±0** |

Ruff's `±0` is asserted per file, not by the total agreeing: the per-file finding counts on the merged head are **identical** to `development`'s, so this PR's seven files contribute none of the 509. The +2 against the earlier 507 arrived with #365.

Before the merge, measured at this PR's original base (`#361`): base `pytest lambda` 3112 → **3213**, ruff 507 → **507**.
| `ruff check --select F,E4,E7,E9` (changed files) | — | **All checks passed** |

Environment prerequisites, worth recording: `pytest lambda` needs `aws-xray-sdk` plus both `lambda/layers/*/requirements.txt` installed alongside `requirements-dev.txt`, or ~1100 tests fail at import and look like regressions. There is also an interpreter trap — `python3` on PATH may have no pytest at all while the venv does.

### Mutation checks — every revert was RUN, not predicted

| Revert | Fails |
|---|---|
| Delete the `is_ttl_expiry` skip | `test_a_ttl_expiry_writes_nothing_at_all` |
| Treat absent `userIdentity` as TTL expiry | 5 |
| Delete `update_counter`'s decrement `ConditionExpression` | `test_a_decrement_against_a_missing_row_creates_nothing`, `test_a_repeated_remove_does_not_push_a_counter_below_zero` |
| Delete `update_average`'s reversal `ConditionExpression` | 2 |
| Restore `MODIFY` → skip | 8 |
| Reverse path skips one dimension (the inverted-twin failure) | `test_the_reversed_dimensions_are_exactly_the_incremented_ones` + 1 |
| Drop the `urgency == 'high'` guard | 5 across three classes |
| Rebucket every dimension rather than only the changed ones | 3 |
| Read `_image_date` instead of `_image_date_or_none` on a reversal | `test_a_dateless_remove_writes_nothing` + both MODIFY tests |
| Delete the `_day_has_aggregates` check | 3 |
| Write that check as `attribute_exists(pk)` per increment instead | 2 — which is how that form was found to DROP counts |
| Restore `old_live or new_live` | `test_an_edit_moving_an_item_onto_a_dead_day_creates_no_row_there` |
| Over-correct it to `old_live and new_live` | 3 |
| Drop the average pairing | 4 |
| Block the average unconditionally (over-correct) | 3 |
| Key the pairing on the edit rather than the row | 1 — `test_a_cross_day_edit_still_reaches_the_new_days_average` |
| Block on the row's absence rather than on a refused reversal | 2 — the first-score tests |
| Never re-apply the average on the arrival side | 9 — incl. the cross-day residual test, so that test asserts a write and not only prose |
| Spell the day sentinel as a second literal | 13 |
| Append a suffix inside `counter_keys` | `test_the_only_sort_key_the_aggregator_builds_is_the_item_date` |
| Build the date by concatenation | `test_that_date_can_only_have_come_from_the_item_field` |

Every condition-guard test runs against **moto**, not a mock, deliberately: a mock cannot refuse a write, so against one they would pass with the `ConditionExpression` deleted. The TTL test has an explicit positive control (`test_a_user_delete_of_the_same_item_does_write`) with an identical image, so the pair cannot both pass by the mock being inert. Stream records are real `DynamoDBRecord` objects rather than `MagicMock`s, because a `MagicMock`'s `user_identity` is truthy and the TTL branch could never be exercised honestly. Where a test's fixture decides whether it can fail — the average-row cases especially, where planting a one-item day makes `count == 1` look consistent — the fixture's size is stated in the test.

## Decisions made

- **Absent or unreadable `userIdentity` counts as a user delete.** A real user delete is the case being fixed, and misreading one as TTL expiry leaves the aggregate permanently overstated — the original bug. The opposite misreading costs at most one decrement, and the `ConditionExpression` keeps even that from corrupting anything.
- **A MODIFY missing either image is skipped** rather than guessed at. Rebucketing needs both sides.
- **The day check fails OPEN** on an unreadable read, and splits by cause — a throttle is not an `AccessDenied`, and only the transient kind is survived quietly.
- **Sorted iteration** in `apply_counter_keys`, only to make write order deterministic for tests and logs.
- A side benefit worth naming: a `put_item` overwriting an existing feedback id emits MODIFY, and the symmetric-difference handling makes that a no-op instead of a double count.

## Not verified

Nothing here has been deployed. All evidence is the Python suite, ruff, and the mutation reverts above; the aggregator's real behaviour against a live table and a real TTL expiry is not something a test can reach. The `ReturnValuesOnConditionCheckFailure`-based reading of a refusal was **removed** rather than shipped, so no claim now rests on moto's fidelity for that parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

