### PR TITLE
fix(metrics): report a partial aggregate window instead of asserting completeness

### DIFF
--- a/voc-datalake/frontend/public/locales/de/common.json
+++ b/voc-datalake/frontend/public/locales/de/common.json
@@ -77,6 +77,7 @@
     },
     "settings": "Einstellungen"
   },
+  "partialCountsHint": "Näherungswert: Der gesamte Zeitraum konnte nicht gelesen werden, die Zahlen sind eine Untergrenze",
   "partialWindowHint": "Filter eingrenzen, um alle zu sehen",
   "problemAnalysisPage": {
     "emptyHint": "Erweitere den Zeitraum oder passe die Filter an",

--- a/voc-datalake/frontend/public/locales/en/common.json
+++ b/voc-datalake/frontend/public/locales/en/common.json
@@ -77,6 +77,7 @@
     },
     "settings": "Settings"
   },
+  "partialCountsHint": "Approximate: the full window could not be read, counts are a lower bound",
   "partialWindowHint": "narrow filters to see all",
   "problemAnalysisPage": {
     "emptyHint": "Try expanding the time range or adjusting filters",

--- a/voc-datalake/frontend/public/locales/es/common.json
+++ b/voc-datalake/frontend/public/locales/es/common.json
@@ -80,6 +80,7 @@
     },
     "settings": "Configuración"
   },
+  "partialCountsHint": "Aproximado: no se pudo leer el periodo completo, los recuentos son un límite inferior",
   "partialWindowHint": "acota los filtros para verlos todos",
   "problemAnalysisPage": {
     "emptyHint": "Prueba a ampliar el rango de tiempo o ajustar los filtros",

--- a/voc-datalake/frontend/public/locales/fr/common.json
+++ b/voc-datalake/frontend/public/locales/fr/common.json
@@ -80,6 +80,7 @@
     },
     "settings": "Paramètres"
   },
+  "partialCountsHint": "Approximatif : la période complète n'a pas pu être lue, les décomptes sont une borne inférieure",
   "partialWindowHint": "affinez les filtres pour tout voir",
   "problemAnalysisPage": {
     "emptyHint": "Essayez d'élargir la plage de temps ou d'ajuster les filtres",

--- a/voc-datalake/frontend/public/locales/ja/common.json
+++ b/voc-datalake/frontend/public/locales/ja/common.json
@@ -77,6 +77,7 @@
     },
     "settings": "設定"
   },
+  "partialCountsHint": "概算値: 期間全体を読み取れなかったため、件数は下限値です",
   "partialWindowHint": "すべて表示するにはフィルターを絞り込んでください",
   "problemAnalysisPage": {
     "emptyHint": "期間を広げるかフィルターを調整してください",

--- a/voc-datalake/frontend/public/locales/ko/common.json
+++ b/voc-datalake/frontend/public/locales/ko/common.json
@@ -77,6 +77,7 @@
     },
     "settings": "설정"
   },
+  "partialCountsHint": "근사치: 전체 기간을 읽을 수 없어 집계는 최소값입니다",
   "partialWindowHint": "모두 보려면 필터를 좁히세요",
   "problemAnalysisPage": {
     "emptyHint": "기간을 넓히거나 필터를 조정해 보세요",

--- a/voc-datalake/frontend/public/locales/pt/common.json
+++ b/voc-datalake/frontend/public/locales/pt/common.json
@@ -80,6 +80,7 @@
     },
     "settings": "Configurações"
   },
+  "partialCountsHint": "Aproximado: não foi possível ler o período completo, as contagens são um limite inferior",
   "partialWindowHint": "refine os filtros para ver tudo",
   "problemAnalysisPage": {
     "emptyHint": "Tente ampliar o intervalo de tempo ou ajustar os filtros",

--- a/voc-datalake/frontend/public/locales/zh/common.json
+++ b/voc-datalake/frontend/public/locales/zh/common.json
@@ -77,6 +77,7 @@
     },
     "settings": "设置"
   },
+  "partialCountsHint": "近似值：无法读取完整时间范围，计数为下限",
   "partialWindowHint": "缩小筛选范围以查看全部",
   "problemAnalysisPage": {
     "emptyHint": "请尝试扩大时间范围或调整筛选条件",

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   SentimentBreakdown,
   CategoryBreakdown,
   SourceBreakdown,
+  PersonaBreakdown,
   IntegrationStatus,
   ScraperConfig,
   ScraperTemplate,
@@ -42,6 +43,7 @@ export type {
   SentimentBreakdown,
   CategoryBreakdown,
   SourceBreakdown,
+  PersonaBreakdown,
   IntegrationStatus,
   ScraperConfig,
   ScraperTemplate,
@@ -250,7 +252,7 @@ export const api = {
   },
   getPersonas: (range: DateRangeParams, source?: string) => {
     const searchParams = buildSearchParams({ ...range, source })
-    return fetchApi<{ period_days: number; personas: Record<string, number> }>(`/metrics/personas?${searchParams}`)
+    return fetchApi<PersonaBreakdown>(`/metrics/personas?${searchParams}`)
   },
   
   // Chat

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -107,9 +107,20 @@ export interface MetricsSummary {
   avg_sentiment: number
   urgent_count: number
   /**
-   * True when the metrics were computed from a truncated raw-item scan
-   * (review-date basis or source filter on a very large window) and the
-   * counts are a lower bound rather than exact aggregates.
+   * True when the window could not be read in full, so the counts are a lower
+   * bound rather than a total. Three independent reasons, and the route reports
+   * all of them under this one name:
+   *
+   * - the raw-item scan was truncated (review-date basis, or a source filter on
+   *   a very large window);
+   * - a metric partition read stopped before the end of its window;
+   * - the requested window is wider than aggregates are retained for (~90 days),
+   *   in which case the older rows have already been deleted and no complete
+   *   answer exists to give.
+   *
+   * Optional only for backward compatibility with a deployed API that omitted it
+   * on the aggregates path; treat an absent value as `false` (which is what
+   * `?? false` at the call site does) rather than as unknown.
    */
   is_partial?: boolean
   daily_totals: {

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -108,15 +108,17 @@ export interface MetricsSummary {
   urgent_count: number
   /**
    * True when the window could not be read in full, so the counts are a lower
-   * bound rather than a total. Three independent reasons, and the route reports
-   * all of them under this one name:
+   * bound rather than a total. THE canonical statement of this flag on the
+   * frontend — the sibling breakdown types point here rather than repeat it.
+   *
+   * Three independent reasons, reported under one name because the caller's
+   * response to all three is the same:
    *
    * - the raw-item scan was truncated (review-date basis, or a source filter on
    *   a very large window);
    * - a metric partition read stopped before the end of its window;
    * - the requested window is wider than aggregates are retained for (~90 days),
-   *   in which case the older rows have already been deleted and no complete
-   *   answer exists to give.
+   *   so the older rows are already deleted and no complete answer exists.
    *
    * Optional only for backward compatibility with a deployed API that omitted it
    * on the aggregates path; treat an absent value as `false` (which is what
@@ -137,18 +139,38 @@ export interface MetricsSummary {
 export interface SentimentBreakdown {
   period_days: number
   total: number
+  /** See {@link MetricsSummary.is_partial} — same flag, same three reasons. */
+  is_partial?: boolean
   breakdown: Record<string, number>
   percentages: Record<string, number>
 }
 
 export interface CategoryBreakdown {
   period_days: number
+  /** See {@link MetricsSummary.is_partial} — same flag, same three reasons. */
+  is_partial?: boolean
   categories: Record<string, number>
 }
 
 export interface SourceBreakdown {
   period_days: number
+  /** See {@link MetricsSummary.is_partial} — same flag, same three reasons. */
+  is_partial?: boolean
   sources: Record<string, number>
+}
+
+/**
+ * Response envelope for `/metrics/personas`.
+ *
+ * Named rather than inlined at the call site so the route's `is_partial` has
+ * somewhere to be declared: an inline generic is where a field goes to be
+ * invisible, which is the same defect this flag exists to close one layer down.
+ */
+export interface PersonaBreakdown {
+  period_days: number
+  /** See {@link MetricsSummary.is_partial} — same flag, same three reasons. */
+  is_partial?: boolean
+  personas: Record<string, number>
 }
 
 export interface IntegrationStatus {
@@ -214,6 +236,16 @@ export interface ScraperTemplate {
 export interface EntitiesResponse {
   period_days: number
   feedback_count: number
+  /**
+   * See {@link MetricsSummary.is_partial} — same flag, same three reasons.
+   *
+   * Describes the COUNTS (`feedback_count` and the category/source/persona maps).
+   * `entities.issues` is a deliberate sample on both of the route's paths — the
+   * newest rows of at most seven days, capped at `limit` — so it is not what this
+   * flag is about, and folding it in would make the flag true on nearly every
+   * call and therefore worth nothing.
+   */
+  is_partial?: boolean
   entities: {
     keywords: Record<string, number>
     categories: Record<string, number>

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.test.tsx
@@ -35,12 +35,19 @@ vi.mock('../../store/configStore', () => ({
   })),
 }))
 
-// Mock child components to simplify testing
+// Mock child components to simplify testing.
+//
+// `hint` is forwarded, not dropped: it is the only user-visible statement that a
+// total is a lower bound rather than exact, and a mock that swallows it lets the
+// hint be deleted — or left as an untranslated literal — with this suite green.
+// MetricCard's own test covers what it DOES with the value (title + aria-label);
+// here it just has to be reachable.
 vi.mock('../../components/MetricCard', () => ({
-  default: ({ title, value }: { title: string; value: string | number }) => (
+  default: ({ title, value, hint }: { title: string; value: string | number; hint?: string }) => (
     <div data-testid={`metric-${title.toLowerCase().replace(/\s/g, '-')}`}>
       <span>{title}</span>
       <span>{value}</span>
+      {hint && <span data-testid="metric-hint">{hint}</span>}
     </div>
   ),
 }))
@@ -151,6 +158,29 @@ describe('Dashboard', () => {
         expect(screen.getByText('~1,234')).toBeInTheDocument()
       })
       expect(screen.getByText('~5')).toBeInTheDocument()
+      // The `~` alone does not say WHY, so the hint carries the meaning. Asserted
+      // as the resolved English copy rather than the key, because a missing or
+      // misspelled key renders as the key name and would otherwise pass: the test
+      // setup loads the real public/locales/en/common.json.
+      // getAllByTestId: both counted cards carry the hint, and a getByTestId
+      // would fail on the second rather than on the thing under test.
+      const hints = screen.getAllByTestId('metric-hint')
+      expect(hints).toHaveLength(2)
+      expect(hints[0]).toHaveTextContent(
+        'Approximate: the full window could not be read, counts are a lower bound'
+      )
+    })
+
+    it('does not hint at approximation when the window was read in full', async () => {
+      // The positive control for the case above. Without it the hint could be
+      // rendered unconditionally — a permanent "approximate" is as uninformative
+      // as never showing it, and both read as "ignore this".
+      render(<Dashboard />, { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('1,234')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('metric-hint')).not.toBeInTheDocument()
     })
 
     it('displays average sentiment metric', async () => {

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.test.tsx
@@ -6,6 +6,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TestRouter } from '../../test/test-utils'
+// The copy under test, read from the locale file the app itself renders from —
+// the same source src/test/setup.ts loads into i18next.
+import enCommon from '../../../public/locales/en/common.json'
 
 // Mock API before importing component
 const mockGetSummary = vi.fn()
@@ -158,17 +161,20 @@ describe('Dashboard', () => {
         expect(screen.getByText('~1,234')).toBeInTheDocument()
       })
       expect(screen.getByText('~5')).toBeInTheDocument()
-      // The `~` alone does not say WHY, so the hint carries the meaning. Asserted
-      // as the resolved English copy rather than the key, because a missing or
-      // misspelled key renders as the key name and would otherwise pass: the test
-      // setup loads the real public/locales/en/common.json.
-      // getAllByTestId: both counted cards carry the hint, and a getByTestId
-      // would fail on the second rather than on the thing under test.
+      // The `~` alone does not say WHY, so the hint carries the meaning. The
+      // expected copy is READ from the English locale file rather than pasted
+      // here — the repo's lockstep idiom — so editing the wording is one change
+      // instead of two. A missing or misspelled key still fails, because i18next
+      // renders the key name and that is not what the file says.
+      //
+      // getAllByTestId, and no assertion on how MANY: more than one card carries
+      // the hint, a getByTestId would fail on the second rather than on the thing
+      // under test, and a count would be a tripwire on unrelated card edits.
       const hints = screen.getAllByTestId('metric-hint')
-      expect(hints).toHaveLength(2)
-      expect(hints[0]).toHaveTextContent(
-        'Approximate: the full window could not be read, counts are a lower bound'
-      )
+      expect(hints.length).toBeGreaterThan(0)
+      for (const hint of hints) {
+        expect(hint).toHaveTextContent(enCommon.partialCountsHint)
+      }
     })
 
     it('does not hint at approximation when the window was read in full', async () => {

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -81,11 +81,15 @@ function MetricsGrid({ summary, sourcesCount }: Readonly<MetricsGridProps>) {
   const avgSentiment = summary ? Number(summary.avg_sentiment) : 0
   const sentimentTrend = avgSentiment > 0 ? 'up' : 'down'
   const sentimentColor = avgSentiment > 0 ? 'green' : 'red'
-  // Review-basis metrics come from a budget-bounded scan; when truncated the
-  // counts are lower bounds and the cards must say so instead of look exact.
+  // The route reports this on BOTH of its paths now, and the hint no longer names
+  // only one of them: a review-basis or source-filtered answer comes from a
+  // budget-bounded scan, and an aggregates answer is short when a metric read
+  // stopped early or when the window reaches past the ~90 days aggregates are
+  // retained for. Either way the counts are lower bounds and the cards must say so
+  // instead of looking exact.
   const isPartial = summary?.is_partial ?? false
   const partialHint = isPartial
-    ? 'Approximate: the window exceeded the scan budget, counts are a lower bound'
+    ? 'Approximate: the full window could not be read, counts are a lower bound'
     : undefined
   const approx = (n: number | string) => (isPartial ? `~${n}` : n)
 

--- a/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/voc-datalake/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -78,19 +78,20 @@ interface MetricsGridProps {
 }
 
 function MetricsGrid({ summary, sourcesCount }: Readonly<MetricsGridProps>) {
+  // 'common', matching the namespace this file already reads, and where the
+  // sibling partial-window copy lives (`partialWindowHint`, used by the
+  // Categories results line): the hint is about counts being a lower bound, not
+  // about the dashboard.
+  const { t } = useTranslation('common')
   const avgSentiment = summary ? Number(summary.avg_sentiment) : 0
   const sentimentTrend = avgSentiment > 0 ? 'up' : 'down'
   const sentimentColor = avgSentiment > 0 ? 'green' : 'red'
-  // The route reports this on BOTH of its paths now, and the hint no longer names
-  // only one of them: a review-basis or source-filtered answer comes from a
-  // budget-bounded scan, and an aggregates answer is short when a metric read
-  // stopped early or when the window reaches past the ~90 days aggregates are
-  // retained for. Either way the counts are lower bounds and the cards must say so
-  // instead of looking exact.
+  // The route reports this on BOTH of its paths now, so the hint names neither
+  // cause — see `MetricsSummary.is_partial` in api/types.ts for the three of
+  // them. Whichever fired, the counts are a lower bound and the cards must say
+  // so instead of looking exact.
   const isPartial = summary?.is_partial ?? false
-  const partialHint = isPartial
-    ? 'Approximate: the full window could not be read, counts are a lower bound'
-    : undefined
+  const partialHint = isPartial ? t('partialCountsHint') : undefined
   const approx = (n: number | string) => (isPartial ? `~${n}` : n)
 
   return (

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -444,7 +444,24 @@ ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 #
 # No published tool declaration moved, so the fingerprinted catalogue is untouched a
 # third time.
-MCP_SERVER_VERSION = "3.6.0"
+#
+# 3.7.0 ADDS `is_partial` to `get_metrics_summary`'s output, which is a minor bump by
+# the rule above — but the reason it has to be declared is not "a field appeared".
+# `/metrics/summary` and the four breakdown routes now MEASURE window completeness on
+# their aggregates path instead of reporting a hardcoded `False`, and these tools pass
+# the route body through unprojected, so the flag reaches a client whether or not it
+# is declared. Publishing it is what makes it readable: `additionalProperties` is
+# absent from these two output shapes (not `false`), so an undeclared field would have
+# validated and then been invisible to a model reading the catalogue to decide what
+# the answer contains — a truncated total presented as authoritative, which is exactly
+# the defect being closed.
+#
+# `get_metrics_breakdown` already declared the field; what changed there is its
+# DESCRIPTION, which said "an aggregate read failed" and now names both reasons the
+# window can be short (a truncated read, and a window wider than the ~90 days
+# aggregates are retained for). A description is what a model reasons about, so one
+# that omits half the cause is the same class of untruth in prose.
+MCP_SERVER_VERSION = "3.7.0"
 
 
 # ============================================
@@ -1779,6 +1796,24 @@ _SUMMARY_TEXT_LIMIT = 500
 # so declaring `false` there would make this file the thing that breaks when a
 # route grows a field, which is precisely the coupling delegation removes.
 
+# What `is_partial` means on the two metrics tools, stated once because they mean
+# the same thing by it and a model reads the DESCRIPTION to decide how much weight
+# a number carries. It names both reasons an aggregates answer can be short — they
+# are independent, and a description mentioning one taught a reader that the other
+# could not happen:
+#
+#   • a metric partition read stopped before the end of its window, or
+#   • the requested window reaches further back than the ~90 days of aggregate
+#     rows DynamoDB still holds, in which case no complete answer exists to give.
+#
+# Either way the counts are a LOWER BOUND, which is the operative fact and so is
+# said in those words rather than left to be inferred from "incomplete".
+_IS_PARTIAL_DESCRIPTION = (
+    "True when the window could not be answered in full — a metric read stopped "
+    "short, or the window is wider than aggregates are retained for. The counts "
+    "are then a lower bound, not a total."
+)
+
 _FEEDBACK_SUMMARY_PROPERTIES: dict[str, Any] = {
     "id": {"type": "string"},
     "source": {"type": "string", "description": "Source platform"},
@@ -2285,6 +2320,7 @@ _TOOL_DECLARATIONS = [
                 "total_feedback": {"type": "integer"},
                 "avg_sentiment": {"type": "number", "description": "Weighted mean, -1..1"},
                 "urgent_count": {"type": "integer"},
+                "is_partial": {"type": "boolean", "description": _IS_PARTIAL_DESCRIPTION},
                 "daily_totals": {"type": "array", "items": {"type": "object"}},
                 "daily_sentiment": {"type": "array", "items": {"type": "object"}},
             },
@@ -2313,10 +2349,7 @@ _TOOL_DECLARATIONS = [
             "type": "object",
             "properties": {
                 "period_days": {"type": "integer"},
-                "is_partial": {
-                    "type": "boolean",
-                    "description": "True when an aggregate read failed and counts are incomplete",
-                },
+                "is_partial": {"type": "boolean", "description": _IS_PARTIAL_DESCRIPTION},
                 "breakdown": {"type": "object", "description": "Counts, when dimension=sentiment"},
                 "percentages": {"type": "object", "description": "Shares, when dimension=sentiment"},
                 "categories": {"type": "object", "description": "When dimension=categories"},

--- a/voc-datalake/lambda/api/mcp_handler.py
+++ b/voc-datalake/lambda/api/mcp_handler.py
@@ -461,6 +461,10 @@ ASSUMED_PROTOCOL_VERSION = "2025-03-26"
 # window can be short (a truncated read, and a window wider than the ~90 days
 # aggregates are retained for). A description is what a model reasons about, so one
 # that omits half the cause is the same class of untruth in prose.
+#
+# Declared but deliberately NOT `required` on either tool; the argument is at
+# `_IS_PARTIAL_DESCRIPTION`, where the declaration is, and it turns on these two
+# tools forwarding the route body unprojected.
 MCP_SERVER_VERSION = "3.7.0"
 
 
@@ -1808,6 +1812,17 @@ _SUMMARY_TEXT_LIMIT = 500
 #
 # Either way the counts are a LOWER BOUND, which is the operative fact and so is
 # said in those words rather than left to be inferred from "incomplete".
+#
+# DECLARED BUT NOT `required`, unlike `search_feedback`'s copy of the same flag,
+# and the difference is the projection: `search_feedback` BUILDS its body (`items`
+# from `_FEEDBACK_SUMMARY_PROPERTIES`), so every key it promises is a key it
+# writes, and a missing `is_partial` there really would be a bug. These two
+# forward the route body unprojected and fall back to `{}` when the delegated
+# payload is not a dict — so a `required` list here would make that honest empty
+# answer a schema violation in a validating client, reporting a transport-level
+# degradation as a malformed tool. Optional-and-declared is what these shapes can
+# truthfully say: the field is readable when present, and absent means the route
+# did not send it, not that the window was complete.
 _IS_PARTIAL_DESCRIPTION = (
     "True when the window could not be answered in full — a metric read stopped "
     "short, or the window is wider than aggregates are retained for. The counts "

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -249,23 +249,30 @@ def _window_exceeds_aggregate_retention(days: int) -> bool:
     read that may or may not happen, while this is a property of the request
     itself and holds even when every read succeeds and returns every row it can.
 
-    The aggregator gives each aggregate row a TTL of AGGREGATE_RETENTION_DAYS
-    days, so DynamoDB has already deleted the rows older than that. `validate_days`
-    admits up to MAX_FEEDBACK_WINDOW_DAYS (365), so `?days=365` queries a
-    sort-key range whose early part cannot exist any more: the query succeeds,
-    the totals under-report by whatever expired, and nothing in the read notices.
-    A window wider than the retention horizon simply CANNOT be answered
-    completely from aggregates, which is exactly the claim `is_partial` exists to
-    make.
+    Why the horizon exists at all, and why it is narrower than the widest window
+    a caller may request, is argued once where the value is declared —
+    `AGGREGATE_RETENTION_DAYS` in `shared/api.py`. The consequence here: past that
+    horizon the rows are already deleted, so the query succeeds, the totals
+    under-report by whatever expired, and nothing in the read notices. Such a
+    window simply CANNOT be answered completely from aggregates, which is exactly
+    the claim `is_partial` exists to make.
 
     Strictly greater-than: a window equal to the retention is the widest one the
     rows still cover, so flagging it would cry partial over a complete answer and
     teach callers to ignore the flag.
+
+    The boundary is the GUARANTEE, not the observed state: DynamoDB deletes
+    expired items on its own schedule, typically within 48 hours of the TTL, so a
+    window just past the horizon will sometimes still be answerable in full and
+    get reported partial anyway. That is the safe direction to be wrong in — a
+    lower bound presented as a lower bound — and the alternative is asking the
+    table whether the rows are still there, which is a read per date and answers
+    a question the caller did not ask.
     """
     return days > AGGREGATE_RETENTION_DAYS
 
 
-def _read_was_truncated(response: dict) -> bool:
+def _index_read_was_truncated(response: dict) -> bool:
     """True when a single unpaged query left rows behind.
 
     `/metrics/sources`, `/metrics/personas` and `/feedback/entities` read the
@@ -537,7 +544,7 @@ def get_entities():
         IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('source')
     )
-    is_partial = is_partial or _read_was_truncated(source_response)
+    is_partial = is_partial or _index_read_was_truncated(source_response)
     source_totals = {}
     date_range = set((current_date - timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days))
     for item in source_response.get('Items', []):
@@ -550,7 +557,7 @@ def get_entities():
         IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('persona')
     )
-    is_partial = is_partial or _read_was_truncated(persona_response)
+    is_partial = is_partial or _index_read_was_truncated(persona_response)
     persona_counts = {}
     for item in persona_response.get('Items', []):
         if item.get('sk') in date_range:
@@ -986,7 +993,7 @@ def get_source_metrics():
     )
     is_partial = (
         _window_exceeds_aggregate_retention(days)
-        or _read_was_truncated(response)
+        or _index_read_was_truncated(response)
     )
 
     source_totals = {}
@@ -1033,7 +1040,7 @@ def get_persona_metrics():
     )
     is_partial = (
         _window_exceeds_aggregate_retention(days)
-        or _read_was_truncated(response)
+        or _index_read_was_truncated(response)
     )
 
     personas = {}

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -16,7 +16,8 @@ from shared.aws import get_dynamodb_resource
 from shared.api import (
     create_api_resolver, validate_days, validate_limit, validate_int,
     validate_date_basis, DATE_BASIS_REVIEW, SEARCH_QUERY_MIN_LENGTH,
-    get_configured_categories, api_handler, DEFAULT_CATEGORIES
+    get_configured_categories, api_handler, DEFAULT_CATEGORIES,
+    AGGREGATE_RETENTION_DAYS,
 )
 from shared.exceptions import ValidationError
 from shared.feedback import basis_date, window_cutoff
@@ -184,8 +185,15 @@ def _scan_window_items(
     return items, is_partial
 
 
-def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dict]:
+def _query_metric_window(
+    pk: str, days: int, current_date: datetime
+) -> tuple[list[dict], bool]:
     """Read one metric partition's trailing `days` window, newest date first.
+
+    Returns ``(items, truncated)`` — the same shape, and the same meaning of the
+    second element, as :func:`_scan_recent_items` and :func:`_scan_window_items`,
+    so a caller that may take either the aggregates path or the scan path ORs one
+    kind of flag rather than reconciling two conventions.
 
     `sk` is 'YYYY-MM-DD' and ISO dates sort lexicographically, so a window is a
     contiguous sort-key range that `between()` bounds server-side: a fixed
@@ -207,28 +215,70 @@ def _query_metric_window(pk: str, days: int, current_date: datetime) -> list[dic
     items: list[dict] = []
     kwargs: dict = {'KeyConditionExpression': condition, 'ScanIndexForward': False}
     # A 365-day window of counter items sits far inside one 1 MB page today, but
-    # that rests on item width the aggregator controls, and these endpoints have
-    # no is_partial signal with which to report a truncated window. So follow the
-    # cursor -- but bounded, never `while True`: one date yields at most one item
-    # and an unfiltered page yields at least one, so a window of `days` dates
-    # cannot span more than `days` pages. A bound also means a surprising
-    # response shape degrades to a short read instead of spinning.
+    # that rests on item width the aggregator controls. So follow the cursor --
+    # but bounded, never `while True`: one date yields at most one item and an
+    # unfiltered page yields at least one, so a window of `days` dates cannot
+    # span more than `days` pages. A bound also means a surprising response
+    # shape degrades to a short read instead of spinning.
     for _ in range(days):
         response = aggregates_table.query(**kwargs)
         items.extend(response.get('Items', []))
         last_key = response.get('LastEvaluatedKey')
         if not last_key:
-            return items
+            return items, False
         kwargs['ExclusiveStartKey'] = last_key
     # Exhausting the bound with a cursor still open means the invariant above no
-    # longer holds, so the window really is partial. Nothing in the response
-    # shape can express that -- these endpoints have no is_partial flag -- so log
-    # it rather than return a quietly short answer that reads as authoritative.
+    # longer holds, so the window really is partial. This used to be logged and
+    # nothing more, on the argument that "nothing in the response shape can
+    # express that" -- which was false even then: six response sites in this file
+    # publish `is_partial`, and they were publishing a hardcoded False on this
+    # path. The flag is now RETURNED as well as logged, so an endpoint reporting a
+    # short read says so to its caller instead of only to CloudWatch.
     logger.warning(
         'Metric window paging hit its bound; returning a partial window',
         extra={'pk': pk, 'days': days, 'items': len(items)},
     )
-    return items
+    return items, True
+
+
+def _window_exceeds_aggregate_retention(days: int) -> bool:
+    """True when `days` reaches further back than stored aggregates survive.
+
+    A SECOND, independent reason an aggregates answer can be incomplete, and not
+    a variant of the paging one above: paging truncation is a property of one
+    read that may or may not happen, while this is a property of the request
+    itself and holds even when every read succeeds and returns every row it can.
+
+    The aggregator gives each aggregate row a TTL of AGGREGATE_RETENTION_DAYS
+    days, so DynamoDB has already deleted the rows older than that. `validate_days`
+    admits up to MAX_FEEDBACK_WINDOW_DAYS (365), so `?days=365` queries a
+    sort-key range whose early part cannot exist any more: the query succeeds,
+    the totals under-report by whatever expired, and nothing in the read notices.
+    A window wider than the retention horizon simply CANNOT be answered
+    completely from aggregates, which is exactly the claim `is_partial` exists to
+    make.
+
+    Strictly greater-than: a window equal to the retention is the widest one the
+    rows still cover, so flagging it would cry partial over a complete answer and
+    teach callers to ignore the flag.
+    """
+    return days > AGGREGATE_RETENTION_DAYS
+
+
+def _read_was_truncated(response: dict) -> bool:
+    """True when a single unpaged query left rows behind.
+
+    `/metrics/sources`, `/metrics/personas` and `/feedback/entities` read the
+    `gsi1-by-metric-type` index with ONE query and no cursor, so DynamoDB's 1 MB
+    page limit is the real bound on how many aggregate rows they see. That is the
+    same class of fact as the paging bound in `_query_metric_window` — rows exist
+    that were not counted — and it was being discarded in the same way.
+
+    REPORTED, not followed: paging these reads would change which data the answer
+    is computed from, and this change is about saying whether the window is
+    complete, not about widening it.
+    """
+    return bool(response.get('LastEvaluatedKey'))
 
 
 # ============================================
@@ -466,23 +516,28 @@ def get_entities():
             }
         }
     
+    # The aggregates path. `is_partial` is computed here, exactly as the scan
+    # path above computes it, rather than left to the `False` this response used
+    # to omit its way into: a reader cannot tell an absent flag from a false one.
+    is_partial = _window_exceeds_aggregate_retention(days)
+
     # Get categories from aggregates
     categories_list = get_configured_categories(aggregates_table)
     category_counts = {}
     for category in categories_list:
-        total = sum(
-            int(item.get('count', 0))
-            for item in _query_metric_window(
-                f'METRIC#daily_category#{category}', days, current_date)
-        )
+        window, truncated = _query_metric_window(
+            f'METRIC#daily_category#{category}', days, current_date)
+        is_partial = is_partial or truncated
+        total = sum(int(item.get('count', 0)) for item in window)
         if total > 0:
             category_counts[category] = total
-    
+
     # Get sources from aggregates
     source_response = aggregates_table.query(
         IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('source')
     )
+    is_partial = is_partial or _read_was_truncated(source_response)
     source_totals = {}
     date_range = set((current_date - timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days))
     for item in source_response.get('Items', []):
@@ -495,18 +550,19 @@ def get_entities():
         IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('persona')
     )
+    is_partial = is_partial or _read_was_truncated(persona_response)
     persona_counts = {}
     for item in persona_response.get('Items', []):
         if item.get('sk') in date_range:
             persona_name = item['pk'].replace('METRIC#persona#', '')
             persona_counts[persona_name] = persona_counts.get(persona_name, 0) + int(item.get('count', 0))
-    
+
     # Get feedback count
-    feedback_count = sum(
-        int(item.get('count', 0))
-        for item in _query_metric_window('METRIC#daily_total', days, current_date)
-    )
-    
+    total_window, total_truncated = _query_metric_window(
+        'METRIC#daily_total', days, current_date)
+    is_partial = is_partial or total_truncated
+    feedback_count = sum(int(item.get('count', 0)) for item in total_window)
+
     # Extract issues from recent feedback
     issues = {}
     feedback_items = []
@@ -528,9 +584,15 @@ def get_entities():
             problem_key = problem[:100].lower().strip()
             issues[problem_key] = issues.get(problem_key, 0) + 1
     
+    # `is_partial` describes the COUNTS (categories, sources, personas,
+    # feedback_count), which is what the scan branch's flag describes too. The
+    # `issues` map is a deliberate sample on both branches — the newest rows of
+    # at most seven days, capped at `limit` — and is not what this flag is about;
+    # folding that in would make it true on nearly every call and so mean nothing.
     return {
         'period_days': days,
         'feedback_count': feedback_count,
+        'is_partial': is_partial,
         'entities': {
             'keywords': {},
             'categories': dict(sorted(category_counts.items(), key=lambda x: x[1], reverse=True)),
@@ -768,31 +830,44 @@ def get_summary():
         return _summary_from_items(days)
     
     current_date = datetime.now(timezone.utc)
-    
+
+    # Three partitions, one flag: a short read of ANY of them makes the summary
+    # incomplete, so they OR rather than each reporting for themselves. The
+    # review-basis branch above already returns `is_partial` from its scan; this
+    # branch used to omit the key entirely, which a caller reads as "complete".
+    is_partial = _window_exceeds_aggregate_retention(days)
+
+    total_items, total_truncated = _query_metric_window(
+        'METRIC#daily_total', days, current_date)
+    is_partial = is_partial or total_truncated
     totals = [
         {'date': item['sk'], 'count': item.get('count', 0)}
-        for item in _query_metric_window('METRIC#daily_total', days, current_date)
+        for item in total_items
     ]
-    
+
+    sentiment_items, sentiment_truncated = _query_metric_window(
+        'METRIC#daily_sentiment_avg', days, current_date)
+    is_partial = is_partial or sentiment_truncated
     sentiment_data = []
-    for item in _query_metric_window('METRIC#daily_sentiment_avg', days, current_date):
+    for item in sentiment_items:
         if item.get('count', 0) > 0:
             avg = float(item.get('sum', 0)) / float(item.get('count', 1))
             sentiment_data.append({'date': item['sk'], 'avg_sentiment': round(avg, 3), 'count': item.get('count')})
-    
-    urgent_count = sum(
-        item.get('count', 0)
-        for item in _query_metric_window('METRIC#urgent', days, current_date)
-    )
-    
+
+    urgent_items, urgent_truncated = _query_metric_window(
+        'METRIC#urgent', days, current_date)
+    is_partial = is_partial or urgent_truncated
+    urgent_count = sum(item.get('count', 0) for item in urgent_items)
+
     total_feedback = sum(int(t.get('count', 0)) for t in totals)
     avg_sentiment = sum(float(s.get('avg_sentiment', 0)) * int(s.get('count', 0)) for s in sentiment_data) / max(total_feedback, 1)
-    
+
     return {
         'period_days': days,
         'total_feedback': total_feedback,
         'avg_sentiment': round(avg_sentiment, 3),
         'urgent_count': urgent_count,
+        'is_partial': is_partial,
         'daily_totals': totals,
         'daily_sentiment': sentiment_data
     }
@@ -820,13 +895,16 @@ def get_sentiment_metrics():
             if sentiment in result:
                 result[sentiment] += 1
     else:
+        # One partition per label, and a short read of any one of them leaves the
+        # breakdown (and therefore `total` and every percentage) understated, so
+        # truncation ORs across labels rather than being attributed to one.
+        is_partial = _window_exceeds_aggregate_retention(days)
         for sentiment in sentiments:
-            result[sentiment] = sum(
-                int(item.get('count', 0))
-                for item in _query_metric_window(
-                    f'METRIC#daily_sentiment#{sentiment}', days, current_date)
-            )
-    
+            window, truncated = _query_metric_window(
+                f'METRIC#daily_sentiment#{sentiment}', days, current_date)
+            is_partial = is_partial or truncated
+            result[sentiment] = sum(int(item.get('count', 0)) for item in window)
+
     total = sum(result.values())
     return {
         'period_days': days,
@@ -861,15 +939,19 @@ def get_category_metrics():
             category = item.get('category', 'other')
             result[category] = result.get(category, 0) + 1
     else:
+        # The reviewer-flagged instance (finding M4): this branch reported the
+        # `is_partial = False` initialised above without ever computing it, so 99
+        # of 6,239 items came back as a complete answer. One partition per
+        # category, so truncation in ANY of them makes the breakdown partial.
+        is_partial = _window_exceeds_aggregate_retention(days)
         for category in categories:
-            total = sum(
-                int(item.get('count', 0))
-                for item in _query_metric_window(
-                    f'METRIC#daily_category#{category}', days, current_date)
-            )
+            window, truncated = _query_metric_window(
+                f'METRIC#daily_category#{category}', days, current_date)
+            is_partial = is_partial or truncated
+            total = sum(int(item.get('count', 0)) for item in window)
             if total > 0:
                 result[category] = total
-    
+
     return {
         'period_days': days,
         'is_partial': is_partial,
@@ -902,18 +984,23 @@ def get_source_metrics():
         IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('source')
     )
-    
+    is_partial = (
+        _window_exceeds_aggregate_retention(days)
+        or _read_was_truncated(response)
+    )
+
     source_totals = {}
     current_date = datetime.now(timezone.utc)
     date_range = set((current_date - timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days))
-    
+
     for item in response.get('Items', []):
         if item.get('sk') in date_range:
             source = item['pk'].replace('METRIC#daily_source#', '')
             source_totals[source] = source_totals.get(source, 0) + int(item.get('count', 0))
-    
+
     return {
         'period_days': days,
+        'is_partial': is_partial,
         'sources': dict(sorted(source_totals.items(), key=lambda x: x[1], reverse=True))
     }
 
@@ -944,18 +1031,23 @@ def get_persona_metrics():
         IndexName=AGGREGATES_BY_METRIC_TYPE_INDEX,
         KeyConditionExpression=Key('metric_type').eq('persona')
     )
-    
+    is_partial = (
+        _window_exceeds_aggregate_retention(days)
+        or _read_was_truncated(response)
+    )
+
     personas = {}
     current_date = datetime.now(timezone.utc)
     date_range = set((current_date - timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days))
-    
+
     for item in response.get('Items', []):
         if item.get('sk') in date_range:
             persona_name = item['pk'].replace('METRIC#persona#', '')
             personas[persona_name] = personas.get(persona_name, 0) + int(item.get('count', 0))
-    
+
     return {
         'period_days': days,
+        'is_partial': is_partial,
         'personas': dict(sorted(personas.items(), key=lambda x: x[1], reverse=True))
     }
 

--- a/voc-datalake/lambda/api/test/metrics_publishing_routes.py
+++ b/voc-datalake/lambda/api/test/metrics_publishing_routes.py
@@ -7,10 +7,12 @@ file would be a copy, and the failure a stale copy produces is silence — a new
 endpoint publishing the flag simply never gets tested, which is how the flag came
 to be a hardcoded `False` on six of them.
 
-A plain helper module rather than an import between test modules: it is importable
-because `conftest.py` puts this directory on `sys.path` (the same reason
-`plugin_manifests.py` works), which does not depend on pytest's import mode or on
-which module pytest happened to load first.
+A plain helper module rather than an import between test modules. What makes it
+importable is one explicit line in `conftest.py` —
+`sys.path.append(os.path.dirname(os.path.abspath(__file__)))`, added so
+`plugin_manifests.py` resolves — not pytest's own path handling, so it does not
+turn on the import mode or on which test module pytest happened to load first.
+Importing a sibling TEST module would depend on both.
 
 Nothing here asserts. `test_metrics_partial_window` owns the positive control that
 the derivation is not empty, because a derivation that silently returns nothing
@@ -60,12 +62,21 @@ def _publishes_is_partial(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
 
 
 def routes_publishing_is_partial() -> dict[str, str]:
-    """`{route path: handler name}` for every route that publishes the flag."""
+    """`{route path: handler name}` for every route that publishes the flag.
+
+    EVERY path of a multi-decorator handler is recorded, not just the first. One
+    function answering two paths is legal in Powertools, and keeping only
+    `decorator_list[0]` would leave the other path publishing the flag with no
+    suite parametrized over it — silence again, in the same shape.
+    """
     found: dict[str, str] = {}
     for node in ast.walk(handler_tree()):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        paths = [p for p in (_route_path(d) for d in node.decorator_list) if p]
-        if paths and _publishes_is_partial(node):
-            found[paths[0]] = node.name
+        if not _publishes_is_partial(node):
+            continue
+        for decorator in node.decorator_list:
+            path = _route_path(decorator)
+            if path:
+                found[path] = node.name
     return found

--- a/voc-datalake/lambda/api/test/metrics_publishing_routes.py
+++ b/voc-datalake/lambda/api/test/metrics_publishing_routes.py
@@ -1,0 +1,71 @@
+"""Which `metrics_handler` routes publish `is_partial`, derived from its source.
+
+Two suites need this set and they need the SAME set:
+`test_metrics_partial_window` parametrizes its cases over it, and
+`test_mcp_delegation` asks which of those routes MCP can reach. A list in either
+file would be a copy, and the failure a stale copy produces is silence — a new
+endpoint publishing the flag simply never gets tested, which is how the flag came
+to be a hardcoded `False` on six of them.
+
+A plain helper module rather than an import between test modules: it is importable
+because `conftest.py` puts this directory on `sys.path` (the same reason
+`plugin_manifests.py` works), which does not depend on pytest's import mode or on
+which module pytest happened to load first.
+
+Nothing here asserts. `test_metrics_partial_window` owns the positive control that
+the derivation is not empty, because a derivation that silently returns nothing
+makes every suite standing on it vacuous.
+"""
+import ast
+from pathlib import Path
+
+HANDLER_SOURCE = Path(__file__).resolve().parents[1] / 'metrics_handler.py'
+
+# `@app.route(...)` included: it takes the path first as well, so a route
+# declared that way is still a route this derivation must see.
+_ROUTE_VERBS = frozenset({'get', 'post', 'put', 'patch', 'delete', 'route'})
+
+
+def handler_tree() -> ast.Module:
+    return ast.parse(HANDLER_SOURCE.read_text(encoding='utf-8'))
+
+
+def _route_path(decorator: ast.expr) -> str | None:
+    """`'/metrics/categories'` from `@app.get("/metrics/categories")`, else None."""
+    if not isinstance(decorator, ast.Call) or not isinstance(decorator.func, ast.Attribute):
+        return None
+    target = decorator.func.value
+    if not isinstance(target, ast.Name) or target.id != 'app':
+        return None
+    if decorator.func.attr not in _ROUTE_VERBS or not decorator.args:
+        return None
+    first = decorator.args[0]
+    return first.value if isinstance(first, ast.Constant) else None
+
+
+def _publishes_is_partial(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True when this function's own body builds a dict carrying `is_partial`.
+
+    Walked over the function body ONLY, so a sibling route's response cannot
+    answer for this one — the mistake that would make a parametrization look
+    complete while covering nothing.
+    """
+    for node in ast.walk(func):
+        if isinstance(node, ast.Dict) and any(
+            isinstance(key, ast.Constant) and key.value == 'is_partial'
+            for key in node.keys
+        ):
+            return True
+    return False
+
+
+def routes_publishing_is_partial() -> dict[str, str]:
+    """`{route path: handler name}` for every route that publishes the flag."""
+    found: dict[str, str] = {}
+    for node in ast.walk(handler_tree()):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        paths = [p for p in (_route_path(d) for d in node.decorator_list) if p]
+        if paths and _publishes_is_partial(node):
+            found[paths[0]] = node.name
+    return found

--- a/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
@@ -13,10 +13,19 @@ already been deleted. Lengthen it and the routes cry partial over answers they
 could give in full. Neither shows up as an error, in a log, or in any other test
 — which is precisely the shape of the defect `is_partial` exists to close.
 
-The value is read out of the aggregator with `inspect.signature` rather than
-re-stated here, so this test cannot itself become the stale copy. Same lockstep
-pattern as `test_feedback_page_limit_lockstep.py` (frontend page size ↔ endpoint
-maximum) and `shared/test/test_search_minimum_lockstep.py`.
+The value is read out of the aggregator rather than re-stated here, so this test
+cannot itself become the stale copy. Same lockstep pattern as
+`test_feedback_page_limit_lockstep.py` (frontend page size ↔ endpoint maximum) and
+`shared/test/test_search_minimum_lockstep.py`.
+
+Read by PARSING the aggregator, not by importing it. `inspect.signature` was the
+first implementation and it reaches the same value, but importing
+`aggregator.handler` from an api test executes another Lambda package's module
+scope — which creates a DynamoDB resource and reads `AGGREGATES_TABLE` — so the
+test would fail for an environmental reason (no region, no env var) in exactly the
+same red as real drift, and the two are not the same problem. `ast` reads the
+source without running it, and it is also what lets the call sites be checked at
+all.
 
 Which mutation makes each assertion fail: change `ttl_days`' default in
 `aggregator/handler.py`, or `AGGREGATE_RETENTION_DAYS` in `shared/api.py`,
@@ -25,28 +34,73 @@ without changing the other, and
 numbers. `test_both_writers_stamp_the_same_horizon` fails if only one of the two
 aggregator functions is changed — half the rows would then outlive the other
 half and no single constant could describe the window.
+`test_no_call_site_overrides_the_ttl` fails if a writer is called with an explicit
+`ttl_days`, which would make the default true and the rows' real horizon something
+else; `test_each_writer_applies_the_parameter_it_takes` fails if a writer accepts
+`ttl_days` and stamps something else, the same lie one level down.
 """
-import inspect
+import ast
+from pathlib import Path
 
 from shared.api import AGGREGATE_RETENTION_DAYS, MAX_FEEDBACK_WINDOW_DAYS
 
+# test/ → api/ → lambda/, then the sibling package that owns the value.
+_AGGREGATOR_SOURCE = (
+    Path(__file__).resolve().parents[2] / 'aggregator' / 'handler.py'
+)
+_TTL_PARAMETER = 'ttl_days'
+# The two functions that write aggregate rows. Both, because one TTL per writer
+# would mean two horizons over partitions a single window read spans.
+_WRITERS = ('update_counter', 'update_average')
+
+
+def _aggregator_tree() -> ast.Module:
+    return ast.parse(_AGGREGATOR_SOURCE.read_text(encoding='utf-8'))
+
+
+def _writer(function_name: str) -> ast.FunctionDef:
+    for node in ast.walk(_aggregator_tree()):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return node
+    raise AssertionError(
+        f'{function_name} is gone from {_AGGREGATOR_SOURCE.name}; the retention '
+        'horizon the metrics routes report is no longer stamped by it'
+    )
+
+
+def _ttl_parameter_position(function: ast.FunctionDef) -> int:
+    """Index of `ttl_days` among the positional parameters.
+
+    Needed twice over: to line the parameter up with its default (defaults are
+    right-aligned in the AST), and to spot a call that overrides it POSITIONALLY,
+    which a keyword-only search would miss.
+    """
+    names = [argument.arg for argument in function.args.args]
+    assert _TTL_PARAMETER in names, (
+        f'{function.name} no longer takes {_TTL_PARAMETER}; the horizon is then '
+        'decided somewhere this test cannot see'
+    )
+    return names.index(_TTL_PARAMETER)
+
 
 def _aggregator_ttl_default(function_name: str) -> int:
-    """The `ttl_days` default of one aggregator writer, read from its signature.
-
-    Imported inside the helper rather than at module scope so an aggregator that
-    cannot be imported fails these tests rather than collection of the file.
-    """
-    from aggregator import handler as aggregator_handler
-
-    parameter = inspect.signature(
-        getattr(aggregator_handler, function_name)
-    ).parameters['ttl_days']
-    assert parameter.default is not inspect.Parameter.empty, (
-        f'{function_name} no longer defaults ttl_days; the retention horizon the '
-        'metrics routes report is then decided per call site and cannot be a constant'
+    """The `ttl_days` default of one aggregator writer, read from its source."""
+    function = _writer(function_name)
+    position = _ttl_parameter_position(function)
+    defaults = function.args.defaults
+    # Defaults cover the LAST len(defaults) positional parameters.
+    offset = len(function.args.args) - len(defaults)
+    assert position >= offset, (
+        f'{function_name} no longer defaults {_TTL_PARAMETER}; the retention '
+        'horizon the metrics routes report is then decided per call site and '
+        'cannot be a constant'
     )
-    return parameter.default
+    default = defaults[position - offset]
+    assert isinstance(default, ast.Constant) and isinstance(default.value, int), (
+        f"{function_name}'s {_TTL_PARAMETER} default is no longer a literal int, "
+        'so a constant cannot describe it'
+    )
+    return default.value
 
 
 class TestAggregateRetentionLockstep:
@@ -59,6 +113,53 @@ class TestAggregateRetentionLockstep:
             'that survive, so a mismatch makes them either assert completeness over '
             'deleted data or report partial over data they have. Change both.'
         )
+
+    def test_no_call_site_overrides_the_ttl(self):
+        """A default is only the real horizon if nothing overrides it.
+
+        `update_counter(..., ttl_days=30)` at one call site would leave this
+        lockstep green — the default still matches the constant — while the rows
+        that site writes expire two months earlier than the metrics routes claim.
+        Positional overrides count too, which is why the parameter's INDEX is
+        derived rather than the keyword alone being searched for.
+        """
+        tree = _aggregator_tree()
+        positions = {name: _ttl_parameter_position(_writer(name)) for name in _WRITERS}
+
+        overrides = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            position = positions.get(node.func.id)
+            if position is None:
+                continue
+            if len(node.args) > position or any(
+                keyword.arg == _TTL_PARAMETER for keyword in node.keywords
+            ):
+                overrides.append(f'{node.func.id} at line {node.lineno}')
+
+        assert overrides == [], (
+            f'{overrides} pass an explicit {_TTL_PARAMETER}, so the rows they write '
+            f'do not live for AGGREGATE_RETENTION_DAYS and the metrics routes '
+            'report a horizon those partitions do not have'
+        )
+
+    def test_each_writer_applies_the_parameter_it_takes(self):
+        """The same lie one level down: a writer could accept `ttl_days` and stamp
+        a hardcoded number, in which case every assertion above is about a value
+        no row ever sees. `aggregator/test/test_handler.py` covers the arithmetic;
+        this only insists the parameter reaches it.
+        """
+        for name in _WRITERS:
+            function = _writer(name)
+            uses = [
+                node for node in ast.walk(function)
+                if isinstance(node, ast.Name) and node.id == _TTL_PARAMETER
+            ]
+            assert uses, (
+                f'{name} takes {_TTL_PARAMETER} and never reads it, so the TTL it '
+                'stamps is not the horizon this lockstep is about'
+            )
 
     def test_both_writers_stamp_the_same_horizon(self):
         """`update_counter` and `update_average` write into the SAME partitions

--- a/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
@@ -1,0 +1,87 @@
+"""The aggregate TTL and the retention the metrics routes report must be one value.
+
+`aggregator/handler.py` OWNS how long an aggregate row lives: `update_counter`
+and `update_average` each take `ttl_days: int = 90` and stamp a DynamoDB TTL from
+it. `shared/api.py` declares `AGGREGATE_RETENTION_DAYS`, which `metrics_handler`
+uses to decide whether a requested window reaches further back than the rows
+survive — the reason `?days=365` on the aggregates path reports `is_partial: true`.
+
+Nothing links them, and the drift is silent in the direction that matters:
+shorten the TTL to 30 without shortening the constant and every window between 31
+and 90 days goes back to being reported COMPLETE while a third or more of it has
+already been deleted. Lengthen it and the routes cry partial over answers they
+could give in full. Neither shows up as an error, in a log, or in any other test
+— which is precisely the shape of the defect `is_partial` exists to close.
+
+The value is read out of the aggregator with `inspect.signature` rather than
+re-stated here, so this test cannot itself become the stale copy. Same lockstep
+pattern as `test_feedback_page_limit_lockstep.py` (frontend page size ↔ endpoint
+maximum) and `shared/test/test_search_minimum_lockstep.py`.
+
+Which mutation makes each assertion fail: change `ttl_days`' default in
+`aggregator/handler.py`, or `AGGREGATE_RETENTION_DAYS` in `shared/api.py`,
+without changing the other, and
+`test_the_shared_constant_equals_the_aggregators_ttl_default` fails naming both
+numbers. `test_both_writers_stamp_the_same_horizon` fails if only one of the two
+aggregator functions is changed — half the rows would then outlive the other
+half and no single constant could describe the window.
+"""
+import inspect
+
+from shared.api import AGGREGATE_RETENTION_DAYS, MAX_FEEDBACK_WINDOW_DAYS
+
+
+def _aggregator_ttl_default(function_name: str) -> int:
+    """The `ttl_days` default of one aggregator writer, read from its signature.
+
+    Imported inside the helper rather than at module scope so an aggregator that
+    cannot be imported fails these tests rather than collection of the file.
+    """
+    from aggregator import handler as aggregator_handler
+
+    parameter = inspect.signature(
+        getattr(aggregator_handler, function_name)
+    ).parameters['ttl_days']
+    assert parameter.default is not inspect.Parameter.empty, (
+        f'{function_name} no longer defaults ttl_days; the retention horizon the '
+        'metrics routes report is then decided per call site and cannot be a constant'
+    )
+    return parameter.default
+
+
+class TestAggregateRetentionLockstep:
+    def test_the_shared_constant_equals_the_aggregators_ttl_default(self):
+        ttl_days = _aggregator_ttl_default('update_counter')
+        assert AGGREGATE_RETENTION_DAYS == ttl_days, (
+            f'aggregator writes rows with a {ttl_days}-day TTL but '
+            f'AGGREGATE_RETENTION_DAYS says {AGGREGATE_RETENTION_DAYS}. The metrics '
+            'routes use the constant to decide when a window is wider than the rows '
+            'that survive, so a mismatch makes them either assert completeness over '
+            'deleted data or report partial over data they have. Change both.'
+        )
+
+    def test_both_writers_stamp_the_same_horizon(self):
+        """`update_counter` and `update_average` write into the SAME partitions
+        that one window read spans (`METRIC#daily_total` counts beside
+        `METRIC#daily_sentiment_avg` sums), so two TTLs would mean two horizons
+        and no single constant could describe the window."""
+        assert (
+            _aggregator_ttl_default('update_counter')
+            == _aggregator_ttl_default('update_average')
+            == AGGREGATE_RETENTION_DAYS
+        )
+
+    def test_the_retention_is_narrower_than_the_widest_requestable_window(self):
+        """The premise of the whole check, asserted rather than assumed.
+
+        If retention ever reaches as far as `validate_days` allows, no aggregates
+        answer can be incomplete for this reason and the horizon check becomes
+        dead code that reports nothing — a green suite meaning "never triggered".
+        Making that a failure forces the check to be removed deliberately rather
+        than left as decoration.
+        """
+        assert AGGREGATE_RETENTION_DAYS < MAX_FEEDBACK_WINDOW_DAYS, (
+            'aggregates now retain as long as the widest window a caller may ask '
+            'for, so _window_exceeds_aggregate_retention can never be true. Remove '
+            'it and its tests rather than leaving a check that cannot fire.'
+        )

--- a/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
@@ -74,12 +74,25 @@ def _ttl_parameter_position(function: ast.FunctionDef) -> int:
     Needed twice over: to line the parameter up with its default (defaults are
     right-aligned in the AST), and to spot a call that overrides it POSITIONALLY,
     which a keyword-only search would miss.
+
+    Positional parameters only, so the two failures are told apart: the parameter
+    being gone is one thing, and it becoming keyword-only is another — the latter
+    moves its default into `kw_defaults` and makes a positional override
+    impossible, so both readers here would need rewriting rather than a message
+    about a parameter that is in fact still present.
     """
     names = [argument.arg for argument in function.args.args]
-    assert _TTL_PARAMETER in names, (
-        f'{function.name} no longer takes {_TTL_PARAMETER}; the horizon is then '
-        'decided somewhere this test cannot see'
-    )
+    if _TTL_PARAMETER not in names:
+        keyword_only = [argument.arg for argument in function.args.kwonlyargs]
+        assert _TTL_PARAMETER not in keyword_only, (
+            f'{function.name} takes {_TTL_PARAMETER} keyword-only now: its default '
+            'lives in kw_defaults and no call can override it positionally, so this '
+            'helper and test_no_call_site_overrides_the_ttl both need updating'
+        )
+        raise AssertionError(
+            f'{function.name} no longer takes {_TTL_PARAMETER}; the horizon is then '
+            'decided somewhere this test cannot see'
+        )
     return names.index(_TTL_PARAMETER)
 
 
@@ -122,6 +135,13 @@ class TestAggregateRetentionLockstep:
         that site writes expire two months earlier than the metrics routes claim.
         Positional overrides count too, which is why the parameter's INDEX is
         derived rather than the keyword alone being searched for.
+
+        SCOPE: calls written as a bare name inside `aggregator/handler.py`. A
+        `handler.update_counter(..., ttl_days=30)` from another module is not seen,
+        and neither is one reached through an alias. That is the safe direction —
+        every production writer of aggregate rows is in this file, and a new caller
+        elsewhere would be the change that has to justify itself — but the check is
+        not a proof about the whole repo.
         """
         tree = _aggregator_tree()
         positions = {name: _ttl_parameter_position(_writer(name)) for name in _WRITERS}

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -71,6 +71,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import mcp_handler
+# The set of metrics routes that publish `is_partial`, derived from the handler
+# source. Shared with `test_metrics_partial_window` so there is one derivation and
+# not two copies to drift apart.
+from metrics_publishing_routes import routes_publishing_is_partial
 from shared.mcp_delegate import DelegationUnavailable
 from shared.mcp_tokens import ALL_READ_SCOPES, REACH_WORKSPACE, mint_token
 
@@ -1750,9 +1754,12 @@ class TestMetricsToolsDeclareTheFlagTheyPassThrough:
         """
         schema = _tool_output_schema(tool)
 
-        assert "required" not in schema, (
+        # Scoped to THIS field, not to `required` being absent: `period_days` is
+        # sent by every one of these routes on every path, so requiring it later
+        # would be a correct change and must not fail here.
+        assert "is_partial" not in schema.get("required", []), (
             f"{tool} forwards the route body unprojected, so it cannot promise "
-            "keys it does not build; see _IS_PARTIAL_DESCRIPTION for the argument"
+            "is_partial is present; see _IS_PARTIAL_DESCRIPTION for the argument"
         )
         assert schema["properties"]["is_partial"]["type"] == "boolean"
 
@@ -1762,18 +1769,17 @@ class TestMetricsToolsDeclareTheFlagTheyPassThrough:
         They check the tools this change touched. This one asks the other
         direction: of the six routes that publish `is_partial`, which are reachable
         through MCP at all, and does something declare the flag for each? The
-        route set is DERIVED from `metrics_handler`'s source (shared with
-        `test_metrics_partial_window`, so there is one derivation, not two) and the
-        reachable set from the live `DOMAIN_ROUTES` table, so neither is a copy.
+        route set is DERIVED from `metrics_handler`'s source (via
+        `metrics_publishing_routes`, the helper `test_metrics_partial_window` reads
+        too, so there is one derivation and not two) and the reachable set from the
+        live `DOMAIN_ROUTES` table, so neither is a copy.
 
         `/feedback/entities` publishes the flag and is deliberately NOT exposed —
         it is in `_RESERVED_PATH_SEGMENTS` precisely so it cannot be reached. If it
         or another publishing route is ever added to `DOMAIN_ROUTES`, this fails,
         and the fix is to declare `is_partial` on whichever tool serves it.
         """
-        from test_metrics_partial_window import PUBLISHING_ROUTES
-
-        publishing = set(PUBLISHING_ROUTES)
+        publishing = set(routes_publishing_is_partial())
         assert len(publishing) == 6, f"derivation looks wrong: {sorted(publishing)}"
 
         reachable = {path for _domain, _method, path in mcp_handler.DOMAIN_ROUTES.values()}
@@ -1787,6 +1793,11 @@ class TestMetricsToolsDeclareTheFlagTheyPassThrough:
             f"{unaccounted} publish is_partial and are reachable through MCP, but no "
             "tool known to declare the flag serves them"
         )
-        # Anti-vacuous: the intersection must not be empty, or the check above
-        # passes by there being nothing to account for.
-        assert publishing & reachable == served_by_the_metrics_tools
+        # Anti-vacuous, and no more than that: the intersection must be non-empty
+        # or the check above passes by having nothing to account for. Deliberately
+        # NOT asserting equality with the served set — a future breakdown axis over
+        # a route that legitimately does not publish the flag is a correct change.
+        assert publishing & reachable, (
+            "no publishing route is reachable through MCP, so the check above "
+            "proved nothing"
+        )

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1734,3 +1734,59 @@ class TestMetricsToolsDeclareTheFlagTheyPassThrough:
         payload = _call(tool, args, fake)["result"]["structuredContent"]
 
         assert payload["is_partial"] is False
+
+    @pytest.mark.parametrize("tool", ["get_metrics_summary", "get_metrics_breakdown"])
+    def test_the_flag_is_declared_optional_because_the_body_is_not_projected(self, tool):
+        """The opposite choice from `search_feedback`, and deliberately so.
+
+        `search_feedback` BUILDS its body, so it can promise every key it declares
+        and `is_partial` is in its `required`. These two forward the route body
+        unprojected and fall back to `{}` when the delegated payload is not a dict.
+        A `required` list here would turn that honest empty answer into a schema
+        violation at a validating client — an error where the truthful reading is
+        "no data" — so the field is declared and optional. Changing that means
+        projecting the body first; this test is here so the choice is made rather
+        than copied from the tool next door.
+        """
+        schema = _tool_output_schema(tool)
+
+        assert "required" not in schema, (
+            f"{tool} forwards the route body unprojected, so it cannot promise "
+            "keys it does not build; see _IS_PARTIAL_DESCRIPTION for the argument"
+        )
+        assert schema["properties"]["is_partial"]["type"] == "boolean"
+
+    def test_every_mcp_reachable_route_that_publishes_the_flag_has_a_tool_declaring_it(self):
+        """The completeness question the two tests above cannot answer.
+
+        They check the tools this change touched. This one asks the other
+        direction: of the six routes that publish `is_partial`, which are reachable
+        through MCP at all, and does something declare the flag for each? The
+        route set is DERIVED from `metrics_handler`'s source (shared with
+        `test_metrics_partial_window`, so there is one derivation, not two) and the
+        reachable set from the live `DOMAIN_ROUTES` table, so neither is a copy.
+
+        `/feedback/entities` publishes the flag and is deliberately NOT exposed —
+        it is in `_RESERVED_PATH_SEGMENTS` precisely so it cannot be reached. If it
+        or another publishing route is ever added to `DOMAIN_ROUTES`, this fails,
+        and the fix is to declare `is_partial` on whichever tool serves it.
+        """
+        from test_metrics_partial_window import PUBLISHING_ROUTES
+
+        publishing = set(PUBLISHING_ROUTES)
+        assert len(publishing) == 6, f"derivation looks wrong: {sorted(publishing)}"
+
+        reachable = {path for _domain, _method, path in mcp_handler.DOMAIN_ROUTES.values()}
+        served_by_the_metrics_tools = {
+            "/metrics/summary",
+            *mcp_handler._BREAKDOWN_DIMENSIONS.values(),
+        }
+
+        unaccounted = sorted((publishing & reachable) - served_by_the_metrics_tools)
+        assert unaccounted == [], (
+            f"{unaccounted} publish is_partial and are reachable through MCP, but no "
+            "tool known to declare the flag serves them"
+        )
+        # Anti-vacuous: the intersection must not be empty, or the check above
+        # passes by there being nothing to account for.
+        assert publishing & reachable == served_by_the_metrics_tools

--- a/voc-datalake/lambda/api/test/test_mcp_delegation.py
+++ b/voc-datalake/lambda/api/test/test_mcp_delegation.py
@@ -1093,7 +1093,7 @@ class TestStructuredOutput:
         serialized = json.dumps(shapes, sort_keys=True)
         fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
-        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.6.0", "7131e9e21c26a1ed"), (
+        assert (mcp_handler.MCP_SERVER_VERSION, fingerprint) == ("3.7.0", "941e33f48bcca829"), (
             "a tool's published declaration changed. Move MCP_SERVER_VERSION — minor "
             "for an added field, MAJOR for a removal or a retype, because a client "
             "validates structuredContent against these schemas and caches the whole "
@@ -1671,3 +1671,66 @@ class TestSearchReportsItsTruncation:
 
         assert "is_partial" in schema["required"]
         assert schema["properties"]["is_partial"]["type"] == "boolean"
+
+
+class TestMetricsToolsDeclareTheFlagTheyPassThrough:
+    """M4: the metrics routes now MEASURE window completeness on their aggregates
+    path instead of reporting a hardcoded `False`, and these tools forward the
+    route body unprojected — so the flag arrives whether or not it is declared.
+
+    Declaring it is what makes it READABLE. `additionalProperties` is absent
+    (not `false`) from these two output shapes, so an undeclared `is_partial`
+    validates and is then invisible to a model reading the catalogue to decide
+    what the answer contains: a truncated total presented as authoritative, which
+    is the defect itself.
+
+    Deleting either declaration below fails these tests; nothing else in the
+    suite notices, because a pass-through tool cannot fail on a field it does not
+    reshape.
+    """
+
+    @pytest.mark.parametrize("tool", ["get_metrics_summary", "get_metrics_breakdown"])
+    def test_the_flag_is_declared_on_both_metrics_tools(self, tool):
+        declared = _tool_output_schema(tool)["properties"]
+
+        assert "is_partial" in declared, f"{tool} forwards is_partial without declaring it"
+        assert declared["is_partial"]["type"] == "boolean"
+
+    @pytest.mark.parametrize("tool", ["get_metrics_summary", "get_metrics_breakdown"])
+    def test_the_description_names_both_reasons_a_window_can_be_short(self, tool):
+        """The two causes are independent, so a description naming one teaches a
+        reader that the other cannot happen. This is prose a model reasons about,
+        not a comment."""
+        description = _tool_output_schema(tool)["properties"]["is_partial"]["description"]
+
+        assert "stopped short" in description, description
+        assert "retained" in description, description
+        assert "lower bound" in description, description
+
+    @pytest.mark.parametrize("tool,route", [
+        ("get_metrics_summary", "/metrics/summary"),
+        ("get_metrics_breakdown", "/metrics/categories"),
+    ])
+    def test_a_partial_route_answer_reaches_the_client_intact(self, tool, route):
+        args = {"dimension": "categories"} if tool == "get_metrics_breakdown" else {}
+        fake = _FakeLambda({route: {"period_days": 365, "is_partial": True,
+                                    "total_feedback": 99, "categories": {"delivery": 99}}})
+
+        payload = _call(tool, args, fake)["result"]["structuredContent"]
+
+        assert payload["is_partial"] is True
+        assert _schema_errors(payload, _tool_output_schema(tool)) == []
+
+    @pytest.mark.parametrize("tool,route", [
+        ("get_metrics_summary", "/metrics/summary"),
+        ("get_metrics_breakdown", "/metrics/categories"),
+    ])
+    def test_a_complete_route_answer_is_not_reported_partial(self, tool, route):
+        """The positive control: a flag that is always true says nothing."""
+        args = {"dimension": "categories"} if tool == "get_metrics_breakdown" else {}
+        fake = _FakeLambda({route: {"period_days": 7, "is_partial": False,
+                                    "total_feedback": 6239, "categories": {"delivery": 12}}})
+
+        payload = _call(tool, args, fake)["result"]["structuredContent"]
+
+        assert payload["is_partial"] is False

--- a/voc-datalake/lambda/api/test/test_metrics_handler.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler.py
@@ -173,8 +173,11 @@ class TestGetSentimentEndpoint:
         counts = {'positive': 60, 'negative': 20, 'neutral': 15, 'mixed': 5}
         
         def window_side_effect(pk, days, current_date):
+            # `(items, truncated)` — the helper reports truncation to its caller
+            # now, so a stub returning a bare list would report the tuple itself
+            # as the window.
             label = pk.rsplit('#', 1)[-1]
-            return [{'sk': '2026-01-07', 'count': counts[label]}]
+            return [{'sk': '2026-01-07', 'count': counts[label]}], False
         
         import sys
         import os
@@ -504,8 +507,9 @@ class TestGetCategoryMetrics:
         counts = {'product': 50, 'delivery': 30}
         
         def window_side_effect(pk, days, current_date):
+            # `(items, truncated)`; see the sentiment stub above.
             category = pk.rsplit('#', 1)[-1]
-            return [{'sk': '2026-01-07', 'count': counts[category]}]
+            return [{'sk': '2026-01-07', 'count': counts[category]}], False
         
         import sys
         import os
@@ -626,7 +630,7 @@ class TestQueryMetricWindow:
         current = datetime(2026, 3, 10, 12, 0, tzinfo=timezone.utc)
         with patch('metrics_handler.aggregates_table') as mock_table:
             mock_table.query.return_value = {'Items': [{'sk': '2026-03-10', 'count': 2}]}
-            items = _query_metric_window('METRIC#urgent', 7, current)
+            items, truncated = _query_metric_window('METRIC#urgent', 7, current)
 
         assert mock_table.query.call_count == 1
         assert mock_table.get_item.call_count == 0
@@ -638,6 +642,7 @@ class TestQueryMetricWindow:
             Key('pk').eq('METRIC#urgent') & Key('sk').between('2026-03-04', '2026-03-10')
         )
         assert items == [{'sk': '2026-03-10', 'count': 2}]
+        assert truncated is False
 
     def test_requests_newest_first_because_the_charts_read_that_order(self):
         """ScanIndexForward=False: a default query would silently reverse charts.
@@ -659,9 +664,9 @@ class TestQueryMetricWindow:
         """Paged windows are concatenated, in order, and the cursor is passed on.
 
         A 365-day window of counter items fits one 1 MB page today, but that
-        rests on item width the aggregator controls. If a page boundary ever
-        appears these endpoints have no is_partial signal, so a dropped page
-        would be a silently wrong total.
+        rests on item width the aggregator controls, so a dropped page would be
+        a silently wrong total. A window that PAGED to completion is not partial:
+        every row was read, just not in one request.
         """
         from metrics_handler import _query_metric_window
 
@@ -671,14 +676,15 @@ class TestQueryMetricWindow:
         ]
         with patch('metrics_handler.aggregates_table') as mock_table:
             mock_table.query.side_effect = pages
-            items = _query_metric_window('METRIC#urgent', 7,
-                                         datetime(2026, 3, 10, tzinfo=timezone.utc))
+            items, truncated = _query_metric_window(
+                'METRIC#urgent', 7, datetime(2026, 3, 10, tzinfo=timezone.utc))
 
         assert mock_table.query.call_count == 2
         assert items == [
             {'sk': '2026-03-10', 'count': 1},
             {'sk': '2026-03-09', 'count': 2},
         ]
+        assert truncated is False
         # Second call resumes from the first page's cursor.
         assert mock_table.query.call_args_list[1].kwargs['ExclusiveStartKey'] == {
             'pk': 'p', 'sk': '2026-03-10'
@@ -691,8 +697,10 @@ class TestQueryMetricWindow:
 
         By the bound's own invariant this is unreachable (a window of `days`
         dates cannot span more than `days` pages), so if it ever happens an
-        assumption has broken and that needs to be visible — these endpoints
-        have no is_partial field to carry the fact.
+        assumption has broken and that needs to be visible. The warning is now
+        the OPERATOR's copy of the fact; `truncated` is the caller's, and
+        `TestAggregatePathReportsPagingTruncation` covers what the endpoints do
+        with it.
         """
         from metrics_handler import _query_metric_window
 
@@ -703,11 +711,12 @@ class TestQueryMetricWindow:
                 'Items': [{'sk': '2026-03-10', 'count': 1}],
                 'LastEvaluatedKey': {'pk': 'p', 'sk': '2026-03-10'},
             }
-            items = _query_metric_window('METRIC#urgent', 3,
-                                         datetime(2026, 3, 10, tzinfo=timezone.utc))
+            items, truncated = _query_metric_window(
+                'METRIC#urgent', 3, datetime(2026, 3, 10, tzinfo=timezone.utc))
 
         assert mock_table.query.call_count == 3, 'bound should cap pages at `days`'
         assert len(items) == 3
+        assert truncated is True, 'the caller must be told, not just CloudWatch'
         assert mock_logger.warning.called, 'a partial window must not be silent'
 
     def test_does_not_warn_when_the_window_completes(self):
@@ -717,10 +726,11 @@ class TestQueryMetricWindow:
         with patch('metrics_handler.aggregates_table') as mock_table, \
              patch('metrics_handler.logger') as mock_logger:
             mock_table.query.return_value = {'Items': [{'sk': '2026-03-10', 'count': 1}]}
-            _query_metric_window('METRIC#urgent', 3,
-                                 datetime(2026, 3, 10, tzinfo=timezone.utc))
+            _, truncated = _query_metric_window(
+                'METRIC#urgent', 3, datetime(2026, 3, 10, tzinfo=timezone.utc))
 
         assert mock_table.query.call_count == 1
+        assert truncated is False
         assert not mock_logger.warning.called
 
     def test_a_single_day_window_is_the_current_date_alone(self):

--- a/voc-datalake/lambda/api/test/test_metrics_partial_window.py
+++ b/voc-datalake/lambda/api/test/test_metrics_partial_window.py
@@ -108,6 +108,44 @@ def _routes_publishing_is_partial() -> dict[str, str]:
 
 PUBLISHING_ROUTES = _routes_publishing_is_partial()
 
+_HELPER = '_query_metric_window'
+# test/ → api/ → lambda/. Every Lambda package lives under here, so this is the
+# scope in which "nobody else calls the helper" can be checked at all.
+_LAMBDA_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _calls_to_helper(tree: ast.Module) -> list[ast.Call]:
+    return [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == _HELPER
+    ]
+
+
+def _calls_unpacking_two_values(tree: ast.Module) -> list[ast.Call]:
+    """Helper calls assigned straight into a two-name tuple target.
+
+    `a, b = _query_metric_window(...)` qualifies. A call inside a `sum(...)`, a
+    comprehension, or a single-name assignment does not — which is the point: the
+    helper's return type changed from `list[dict]` to `tuple[list[dict], bool]`,
+    and every one of those forms still parses, runs, and produces a wrong answer
+    (iterating the 2-tuple, or counting the boolean as a row).
+    """
+    found: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        if not (isinstance(call.func, ast.Name) and call.func.id == _HELPER):
+            continue
+        if all(
+            isinstance(target, ast.Tuple) and len(target.elts) == 2
+            for target in node.targets
+        ):
+            found.append(call)
+    return found
+
 # Every one of them reaches its aggregates path on a plain `?days=N`: no
 # `source`, and the default 'imported' date basis. That is the path that used to
 # assert completeness, and the only extra parameter any of them needs.
@@ -187,6 +225,65 @@ class TestEveryPublishingRouteIsWired:
 
         assert 'is_partial' in body, f'{path} publishes no is_partial'
         assert isinstance(body['is_partial'], bool)
+
+
+class TestEveryCallerUnpacksTheTruncationFlag:
+    """A caller that ignores the second return value is a NEW silent defect.
+
+    The parametrized suites above can only see routes that publish `is_partial`,
+    so a caller that does not publish it — a future route, or a helper reading the
+    same partitions — is exactly the case they cannot catch. And the failure is
+    not a crash at the call: `sum(int(i.get('count', 0)) for i in helper(...))`
+    over a 2-tuple raises inside the generator, while `items = helper(...)`
+    followed by `len(items)` silently answers 2.
+    """
+
+    def test_the_derivation_sees_the_calls(self):
+        """The positive control: an empty derivation would make the check below
+        pass by never running."""
+        tree = ast.parse(_HANDLER_SOURCE.read_text(encoding='utf-8'))
+
+        callers = sorted(
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and _calls_to_helper(ast.Module(body=node.body, type_ignores=[]))
+        )
+        assert callers == [
+            'get_category_metrics', 'get_entities', 'get_sentiment_metrics', 'get_summary',
+        ], callers
+
+    def test_no_call_site_drops_the_flag(self):
+        tree = ast.parse(_HANDLER_SOURCE.read_text(encoding='utf-8'))
+        all_calls = _calls_to_helper(tree)
+        unpacked = {id(call) for call in _calls_unpacking_two_values(tree)}
+
+        dropped = sorted(call.lineno for call in all_calls if id(call) not in unpacked)
+        assert dropped == [], (
+            f'{_HELPER} returns (items, truncated); the call(s) at '
+            f'{_HANDLER_SOURCE.name} line(s) {dropped} do not unpack both, so a '
+            'truncated read is either reported as rows or dropped on the floor'
+        )
+
+    def test_nothing_outside_this_handler_calls_the_helper(self):
+        """The helper is private to `metrics_handler`, and its return type changed.
+
+        An importer in another Lambda package would iterate the 2-tuple and blow
+        up on `item.get(...)` at runtime, not in this suite — nothing else here
+        looks outside this file.
+        """
+        importers = sorted(
+            str(path.relative_to(_LAMBDA_ROOT))
+            for path in _LAMBDA_ROOT.rglob('*.py')
+            if path != _HANDLER_SOURCE
+            and 'test' not in path.parts
+            and not path.name.startswith('test_')
+            and _HELPER in path.read_text(encoding='utf-8')
+        )
+        assert importers == [], (
+            f'{_HELPER} is called outside metrics_handler.py ({importers}); those '
+            'call sites are not covered by the AST check above'
+        )
 
 
 class TestAggregatePathReportsPagingTruncation:

--- a/voc-datalake/lambda/api/test/test_metrics_partial_window.py
+++ b/voc-datalake/lambda/api/test/test_metrics_partial_window.py
@@ -50,63 +50,18 @@ from unittest.mock import patch
 
 import pytest
 
+from metrics_publishing_routes import (
+    HANDLER_SOURCE as _HANDLER_SOURCE,
+    handler_tree,
+    routes_publishing_is_partial,
+)
 from shared.api import AGGREGATE_RETENTION_DAYS, MAX_FEEDBACK_WINDOW_DAYS, clear_categories_cache
 
-_HANDLER_SOURCE = Path(__file__).resolve().parents[1] / 'metrics_handler.py'
-
-_ROUTE_VERBS = frozenset({'get', 'post', 'put', 'patch', 'delete', 'route'})
-
-
-def _route_path(decorator: ast.expr) -> str | None:
-    """`'/metrics/categories'` from `@app.get("/metrics/categories")`, else None."""
-    if not isinstance(decorator, ast.Call) or not isinstance(decorator.func, ast.Attribute):
-        return None
-    target = decorator.func.value
-    if not isinstance(target, ast.Name) or target.id != 'app':
-        return None
-    if decorator.func.attr not in _ROUTE_VERBS or not decorator.args:
-        return None
-    first = decorator.args[0]
-    return first.value if isinstance(first, ast.Constant) else None
-
-
-def _publishes_is_partial(func: ast.FunctionDef) -> bool:
-    """True when this function's own body builds a dict carrying `is_partial`.
-
-    Walked over the function body ONLY, so a sibling route's response cannot
-    answer for this one — the mistake that would make the parametrization below
-    look complete while covering nothing.
-    """
-    for node in ast.walk(func):
-        if isinstance(node, ast.Dict) and any(
-            isinstance(key, ast.Constant) and key.value == 'is_partial'
-            for key in node.keys
-        ):
-            return True
-    return False
-
-
-def _routes_publishing_is_partial() -> dict[str, str]:
-    """`{route path: handler name}` for every route that publishes the flag.
-
-    DERIVED from the handler source rather than listed here: a list would be a
-    copy that goes stale the moment a seventh endpoint starts publishing
-    `is_partial`, and the failure that copy produces is silence — the new
-    endpoint simply never gets tested, which is how the flag came to be a
-    hardcoded `False` on six of them.
-    """
-    tree = ast.parse(_HANDLER_SOURCE.read_text(encoding='utf-8'))
-    found: dict[str, str] = {}
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        paths = [p for p in (_route_path(d) for d in node.decorator_list) if p]
-        if paths and _publishes_is_partial(node):
-            found[paths[0]] = node.name
-    return found
-
-
-PUBLISHING_ROUTES = _routes_publishing_is_partial()
+# DERIVED from the handler source rather than listed here — see
+# `metrics_publishing_routes`, which `test_mcp_delegation` reads too so there is
+# one derivation and not two. `test_the_derivation_finds_the_routes_that_publish
+# _the_flag` below is its positive control.
+PUBLISHING_ROUTES = routes_publishing_is_partial()
 
 _HELPER = '_query_metric_window'
 # test/ → api/ → lambda/. Every Lambda package lives under here, so this is the
@@ -241,7 +196,7 @@ class TestEveryCallerUnpacksTheTruncationFlag:
     def test_the_derivation_sees_the_calls(self):
         """The positive control: an empty derivation would make the check below
         pass by never running."""
-        tree = ast.parse(_HANDLER_SOURCE.read_text(encoding='utf-8'))
+        tree = handler_tree()
 
         callers = sorted(
             node.name
@@ -254,7 +209,7 @@ class TestEveryCallerUnpacksTheTruncationFlag:
         ], callers
 
     def test_no_call_site_drops_the_flag(self):
-        tree = ast.parse(_HANDLER_SOURCE.read_text(encoding='utf-8'))
+        tree = handler_tree()
         all_calls = _calls_to_helper(tree)
         unpacked = {id(call) for call in _calls_unpacking_two_values(tree)}
 

--- a/voc-datalake/lambda/api/test/test_metrics_partial_window.py
+++ b/voc-datalake/lambda/api/test/test_metrics_partial_window.py
@@ -1,0 +1,534 @@
+"""The metrics endpoints must MEASURE completeness, not assert it.
+
+Every route in `metrics_handler.py` that publishes `is_partial` used to publish a
+hardcoded `False` on its aggregates path — the default path, a plain `?days=N` —
+because the flag was initialised to `False` beside the scan branch that sets it
+and the aggregates branch never touched it. Measured symptom of finding "M4":
+99 items of a 6,239-item corpus reported as a complete answer. Through MCP that
+is worse than on the dashboard, where a human has the corpus total next to the
+chart to notice with.
+
+Two INDEPENDENT faults make an aggregates answer incomplete, and each has its
+own tests here because neither implies the other:
+
+1. Paging truncation, which `_query_metric_window` already detected and threw
+   away (it logged and returned a short list). It now returns
+   `(items, truncated)`, the convention `_scan_recent_items` /
+   `_scan_window_items` already use.
+2. The aggregate retention horizon, which nothing detected at all. Aggregate
+   rows carry a 90-day TTL while `days` validates up to 365, so a window wider
+   than `AGGREGATE_RETENTION_DAYS` reads a partition whose older rows DynamoDB
+   has already deleted. Every read succeeds; the totals just under-report.
+
+Which mutation makes each assertion here fail:
+
+* `TestAggregatePathReportsPagingTruncation` — revert
+  `_query_metric_window`'s `return items, True` to `return items` (and the
+  callers' `or truncated` with it): the truncated cases report `False`.
+  `test_an_untruncated_window_is_reported_complete` is the positive control that
+  keeps this suite from passing by reporting `True` unconditionally.
+* `TestWindowWiderThanAggregateRetention` — delete the
+  `_window_exceeds_aggregate_retention(days)` seed from the aggregates branches
+  (or weaken `>` to `>=`... which breaks the boundary test instead): a 365-day
+  window reports `False`. The `days=90` case fails if the check is widened to
+  flag windows the rows still cover.
+* `TestEveryPublishingRouteIsWired` — add a route that returns `is_partial`
+  without wiring it and the derived parametrization picks it up and fails; the
+  derivation itself is guarded by
+  `test_the_derivation_finds_the_routes_that_publish_the_flag`, without which an
+  empty list would make every parametrized test vacuous.
+* `TestScanPathIsUnchanged` — anti-overreach. Fails if the retention horizon or
+  the paging flag is applied to the raw-item scan path, whose feedback rows keep
+  a 365-day TTL and are therefore complete over the widest window callers may
+  ask for, or if a partial aggregate read is "fixed" by falling back to scanning.
+"""
+import ast
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from shared.api import AGGREGATE_RETENTION_DAYS, MAX_FEEDBACK_WINDOW_DAYS, clear_categories_cache
+
+_HANDLER_SOURCE = Path(__file__).resolve().parents[1] / 'metrics_handler.py'
+
+_ROUTE_VERBS = frozenset({'get', 'post', 'put', 'patch', 'delete', 'route'})
+
+
+def _route_path(decorator: ast.expr) -> str | None:
+    """`'/metrics/categories'` from `@app.get("/metrics/categories")`, else None."""
+    if not isinstance(decorator, ast.Call) or not isinstance(decorator.func, ast.Attribute):
+        return None
+    target = decorator.func.value
+    if not isinstance(target, ast.Name) or target.id != 'app':
+        return None
+    if decorator.func.attr not in _ROUTE_VERBS or not decorator.args:
+        return None
+    first = decorator.args[0]
+    return first.value if isinstance(first, ast.Constant) else None
+
+
+def _publishes_is_partial(func: ast.FunctionDef) -> bool:
+    """True when this function's own body builds a dict carrying `is_partial`.
+
+    Walked over the function body ONLY, so a sibling route's response cannot
+    answer for this one — the mistake that would make the parametrization below
+    look complete while covering nothing.
+    """
+    for node in ast.walk(func):
+        if isinstance(node, ast.Dict) and any(
+            isinstance(key, ast.Constant) and key.value == 'is_partial'
+            for key in node.keys
+        ):
+            return True
+    return False
+
+
+def _routes_publishing_is_partial() -> dict[str, str]:
+    """`{route path: handler name}` for every route that publishes the flag.
+
+    DERIVED from the handler source rather than listed here: a list would be a
+    copy that goes stale the moment a seventh endpoint starts publishing
+    `is_partial`, and the failure that copy produces is silence — the new
+    endpoint simply never gets tested, which is how the flag came to be a
+    hardcoded `False` on six of them.
+    """
+    tree = ast.parse(_HANDLER_SOURCE.read_text(encoding='utf-8'))
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        paths = [p for p in (_route_path(d) for d in node.decorator_list) if p]
+        if paths and _publishes_is_partial(node):
+            found[paths[0]] = node.name
+    return found
+
+
+PUBLISHING_ROUTES = _routes_publishing_is_partial()
+
+# Every one of them reaches its aggregates path on a plain `?days=N`: no
+# `source`, and the default 'imported' date basis. That is the path that used to
+# assert completeness, and the only extra parameter any of them needs.
+INSIDE_RETENTION_DAYS = AGGREGATE_RETENTION_DAYS - 1
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime('%Y-%m-%d')
+
+
+def _aggregate_page(truncated: bool) -> dict:
+    """One page of aggregate rows, optionally with a cursor still open.
+
+    A single row shaped to satisfy every reader: `_query_metric_window` wants
+    `sk`/`count`, and the `gsi1-by-metric-type` readers want `pk`. `sk` is today
+    so the in-memory date-range filters keep it.
+    """
+    row = {'pk': 'METRIC#daily_source#webscraper', 'sk': _today(), 'count': 1}
+    page: dict = {'Items': [row]}
+    if truncated:
+        page['LastEvaluatedKey'] = {'pk': row['pk'], 'sk': row['sk']}
+    return page
+
+
+def _call_route(path: str, days: int, agg, fb, event_factory, context) -> dict:
+    """Drive one route down its aggregates path and return the parsed body."""
+    # `get_configured_categories` memoises module-side, so a value another test
+    # module left behind would decide which category partitions are read. Cleared
+    # both ways, as the other metrics tests do.
+    clear_categories_cache()
+    agg.get_item.return_value = {}
+    fb.query.return_value = {'Items': [], 'ScannedCount': 0}
+    from metrics_handler import lambda_handler
+
+    try:
+        response = lambda_handler(
+            event_factory(method='GET', path=path, query_params={'days': str(days)}),
+            context,
+        )
+    finally:
+        clear_categories_cache()
+    assert response['statusCode'] == 200, response['body']
+    return json.loads(response['body'])
+
+
+class TestEveryPublishingRouteIsWired:
+    """The derivation these parametrized suites stand on."""
+
+    def test_the_derivation_finds_the_routes_that_publish_the_flag(self):
+        """The positive control.
+
+        An empty or short derivation would make every parametrized case below
+        pass by never running, which is the failure mode this whole file exists
+        to close. The six named here are the response sites `is_partial` was
+        already published from; a seventh is welcome and belongs in this list
+        once it is wired.
+        """
+        assert set(PUBLISHING_ROUTES) == {
+            '/feedback/entities',
+            '/metrics/summary',
+            '/metrics/sentiment',
+            '/metrics/categories',
+            '/metrics/sources',
+            '/metrics/personas',
+        }, PUBLISHING_ROUTES
+
+    @pytest.mark.parametrize('path', sorted(PUBLISHING_ROUTES))
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_flag_is_present_and_boolean(
+        self, agg, fb, path, api_gateway_event, lambda_context
+    ):
+        """An absent flag reads as "complete" exactly like a false one."""
+        agg.query.return_value = _aggregate_page(truncated=False)
+        body = _call_route(path, INSIDE_RETENTION_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert 'is_partial' in body, f'{path} publishes no is_partial'
+        assert isinstance(body['is_partial'], bool)
+
+
+class TestAggregatePathReportsPagingTruncation:
+    """Fault 1: the paging bound, which the helper detected and discarded."""
+
+    @pytest.mark.parametrize('path', sorted(PUBLISHING_ROUTES))
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_truncated_aggregate_read_is_reported_partial(
+        self, agg, fb, path, api_gateway_event, lambda_context
+    ):
+        """Every page hands back another cursor, so every read stops short."""
+        agg.query.return_value = _aggregate_page(truncated=True)
+        body = _call_route(path, INSIDE_RETENTION_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert body['is_partial'] is True, (
+            f'{path} read a truncated window and called it complete'
+        )
+
+    @pytest.mark.parametrize('path', sorted(PUBLISHING_ROUTES))
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_an_untruncated_window_is_reported_complete(
+        self, agg, fb, path, api_gateway_event, lambda_context
+    ):
+        """The positive control for the case above.
+
+        Without it the wiring could satisfy every other test in this file by
+        reporting `True` unconditionally, which is the same defect pointing the
+        other way: a flag that is always set carries no information and gets
+        ignored.
+        """
+        agg.query.return_value = _aggregate_page(truncated=False)
+        body = _call_route(path, INSIDE_RETENTION_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert body['is_partial'] is False, (
+            f'{path} reported a complete window as partial'
+        )
+
+    @patch('metrics_handler.aggregates_table')
+    def test_the_helper_returns_the_flag_beside_the_items(self, agg):
+        """`(items, truncated)` — the shape the scan helpers already return, so a
+        route taking either path ORs one kind of flag rather than reconciling
+        two."""
+        from metrics_handler import _query_metric_window
+
+        agg.query.return_value = _aggregate_page(truncated=True)
+        items, truncated = _query_metric_window(
+            'METRIC#urgent', 3, datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert truncated is True
+        assert len(items) == 3, 'the bound still caps pages at `days`'
+
+    @patch('metrics_handler.aggregates_table')
+    def test_one_truncated_partition_out_of_many_makes_the_answer_partial(
+        self, agg, api_gateway_event, lambda_context
+    ):
+        """`/metrics/sentiment` reads four partitions; a short read of any one
+        understates `total` and every percentage, so the flag ORs across them
+        instead of being attributed to the last one read."""
+        # Keyed off the partition rather than call order, so exactly ONE of the
+        # four labels reads short and the other three are complete. A flat list
+        # of pages would instead be consumed by whichever partition paged first.
+        def one_short_partition(**kwargs):
+            # The pk is the FIRST value of the `pk = ... AND sk BETWEEN ...`
+            # condition the helper builds; reached through the public
+            # `get_expression` rather than a repr, which is an object address.
+            equals, _between = kwargs['KeyConditionExpression'].get_expression()['values']
+            pk = equals.get_expression()['values'][1]
+            return _aggregate_page(truncated=pk.endswith('daily_sentiment#negative'))
+
+        agg.query.side_effect = one_short_partition
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/metrics/sentiment',
+            query_params={'days': str(INSIDE_RETENTION_DAYS)},
+        )
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial'] is True
+
+
+class TestWindowWiderThanAggregateRetention:
+    """Fault 2: the retention horizon, which nothing detected at all.
+
+    Not a variant of fault 1. Paging truncation is a property of one read that
+    may or may not happen; this holds for the request itself even when every
+    read succeeds and returns every row that still exists.
+    """
+
+    @pytest.mark.parametrize('path', sorted(PUBLISHING_ROUTES))
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_window_beyond_the_retention_is_partial_by_construction(
+        self, agg, fb, path, api_gateway_event, lambda_context
+    ):
+        agg.query.return_value = _aggregate_page(truncated=False)
+        body = _call_route(path, MAX_FEEDBACK_WINDOW_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert body['is_partial'] is True, (
+            f'{path} answered a {MAX_FEEDBACK_WINDOW_DAYS}-day window from '
+            f'{AGGREGATE_RETENTION_DAYS} days of surviving rows and called it complete'
+        )
+
+    @pytest.mark.parametrize('path', sorted(PUBLISHING_ROUTES))
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_window_the_rows_still_cover_is_complete(
+        self, agg, fb, path, api_gateway_event, lambda_context
+    ):
+        """At exactly the retention the rows still cover the window, so flagging
+        it would cry partial over a complete answer and teach callers to ignore
+        the flag."""
+        agg.query.return_value = _aggregate_page(truncated=False)
+        body = _call_route(path, AGGREGATE_RETENTION_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert body['is_partial'] is False, (
+            f'{path} called a {AGGREGATE_RETENTION_DAYS}-day window partial'
+        )
+
+    def test_the_predicate_is_about_the_request_not_about_a_read(self):
+        """Exercised directly, because the boundary is the whole claim."""
+        from metrics_handler import _window_exceeds_aggregate_retention
+
+        assert _window_exceeds_aggregate_retention(AGGREGATE_RETENTION_DAYS + 1) is True
+        assert _window_exceeds_aggregate_retention(AGGREGATE_RETENTION_DAYS) is False
+        assert _window_exceeds_aggregate_retention(1) is False
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_wide_window_is_still_answered_from_aggregates(
+        self, agg, fb, api_gateway_event, lambda_context
+    ):
+        """Reporting the horizon must not widen or narrow what is read.
+
+        The honest answer to "this window exceeds what aggregates retain" is to
+        say so, not to silently fall back to a raw-item scan — which is a
+        different, budget-bounded set of numbers arriving under the same name.
+        """
+        agg.query.return_value = _aggregate_page(truncated=False)
+        body = _call_route('/metrics/categories', MAX_FEEDBACK_WINDOW_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert body['is_partial'] is True
+        assert body['period_days'] == MAX_FEEDBACK_WINDOW_DAYS
+        fb.query.assert_not_called()
+
+
+class TestScanPathIsUnchanged:
+    """Anti-overreach: neither new signal may leak onto the raw-item path.
+
+    Feedback rows are written with a 365-day TTL, so a scan reaches back as far
+    as `validate_days` allows. Only the 90-day AGGREGATE rows are the shorter
+    horizon, so applying it to a scan would report complete answers as partial.
+    """
+
+    @patch('metrics_handler.aggregates_table')
+    @patch('metrics_handler.feedback_table')
+    def test_a_complete_scan_of_the_widest_window_is_complete(
+        self, fb, agg, api_gateway_event, lambda_context
+    ):
+        fb.query.return_value = {'Items': [], 'ScannedCount': 0}
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/metrics/categories',
+            query_params={'days': str(MAX_FEEDBACK_WINDOW_DAYS), 'source': 'webscraper'},
+        )
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial'] is False
+
+    @patch('metrics_handler.aggregates_table')
+    @patch('metrics_handler.feedback_table')
+    def test_a_truncated_scan_still_reports_itself(
+        self, fb, agg, api_gateway_event, lambda_context
+    ):
+        """The behaviour that already worked, pinned so the rewiring cannot have
+        replaced the scan's flag with the aggregates one."""
+        today = datetime.now(timezone.utc)
+        fb.query.side_effect = [
+            {
+                'Items': [{
+                    'feedback_id': 'a-1', 'category': 'delivery',
+                    'source_platform': 'webscraper',
+                    'date': today.strftime('%Y-%m-%d'),
+                    'source_created_at': today.isoformat(),
+                }],
+                'ScannedCount': 10000,
+                'LastEvaluatedKey': {'pk': 'more'},
+            }
+        ] + [{'Items': [], 'ScannedCount': 0}] * 400
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/metrics/categories',
+            query_params={'days': '30', 'source': 'webscraper'},
+        )
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial'] is True
+        assert body['categories'] == {'delivery': 1}
+        # The scan path reads raw items only; a per-partition truncation must not
+        # be answered by also reading aggregates.
+        agg.query.assert_not_called()
+
+    @patch('metrics_handler.aggregates_table')
+    @patch('metrics_handler.feedback_table')
+    def test_the_review_basis_summary_still_reports_its_own_scan(
+        self, fb, agg, api_gateway_event, lambda_context
+    ):
+        today = datetime.now(timezone.utc)
+        fb.query.side_effect = [{
+            'Items': [{
+                'feedback_id': 'a-1', 'date': today.strftime('%Y-%m-%d'),
+                'source_created_at': today.isoformat(),
+            }],
+            'ScannedCount': 1,
+        }] + [{'Items': [], 'ScannedCount': 0}] * 400
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/metrics/summary',
+            query_params={'days': str(MAX_FEEDBACK_WINDOW_DAYS), 'date_basis': 'review'},
+        )
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial'] is False
+        assert body['total_feedback'] == 1
+        agg.query.assert_not_called()
+
+
+class TestUnpagedIndexReadsReportTruncation:
+    """The `gsi1-by-metric-type` readers page not at all, so 1 MB is their bound.
+
+    Same class of fact as the paging bound — rows exist that were not counted —
+    and it was discarded the same way. Reported rather than followed: paging
+    these reads would change which data the answer is computed from, which this
+    change deliberately does not do.
+    """
+
+    @pytest.mark.parametrize('path', ['/metrics/sources', '/metrics/personas'])
+    @patch('metrics_handler.aggregates_table')
+    def test_a_cursor_left_open_by_the_single_query_is_reported(
+        self, agg, path, api_gateway_event, lambda_context
+    ):
+        agg.query.return_value = _aggregate_page(truncated=True)
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(method='GET', path=path, query_params={'days': '7'})
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial'] is True
+        assert agg.query.call_count == 1, 'the read must not have been widened'
+
+    @pytest.mark.parametrize('path', ['/metrics/sources', '/metrics/personas'])
+    @patch('metrics_handler.aggregates_table')
+    def test_a_single_complete_page_is_not_partial(
+        self, agg, path, api_gateway_event, lambda_context
+    ):
+        agg.query.return_value = _aggregate_page(truncated=False)
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(method='GET', path=path, query_params={'days': '7'})
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert body['is_partial'] is False
+
+
+class TestWindowBoundsAreUnchanged:
+    """No window silently widened or narrowed: same dates, same request count."""
+
+    @patch('metrics_handler.aggregates_table')
+    def test_the_queried_date_range_is_the_requested_window(self, agg):
+        from boto3.dynamodb.conditions import Key
+        from metrics_handler import _query_metric_window
+
+        agg.query.return_value = {'Items': []}
+        _query_metric_window('METRIC#urgent', 7,
+                             datetime(2026, 3, 10, tzinfo=timezone.utc))
+
+        assert agg.query.call_args.kwargs['KeyConditionExpression'] == (
+            Key('pk').eq('METRIC#urgent') & Key('sk').between('2026-03-04', '2026-03-10')
+        )
+
+    @patch('metrics_handler.aggregates_table')
+    def test_summary_still_costs_three_queries_at_any_window(
+        self, agg, api_gateway_event, lambda_context
+    ):
+        """Including a window past the retention horizon: the flag is computed
+        from `days`, not bought with extra reads."""
+        from metrics_handler import lambda_handler
+
+        for days in ('1', '7', '90', '365'):
+            agg.reset_mock()
+            agg.query.return_value = _aggregate_page(truncated=False)
+            event = api_gateway_event(
+                method='GET', path='/metrics/summary', query_params={'days': days})
+            assert lambda_handler(event, lambda_context)['statusCode'] == 200
+            assert agg.query.call_count == 3, f'at days={days}'
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_partial_window_still_carries_the_counts_it_did_read(
+        self, agg, fb, api_gateway_event, lambda_context
+    ):
+        """Partial means "a lower bound", not "no answer" — the numbers that were
+        read are still returned."""
+        agg.query.return_value = _aggregate_page(truncated=True)
+        body = _call_route('/metrics/sentiment', INSIDE_RETENTION_DAYS, agg, fb,
+                           api_gateway_event, lambda_context)
+
+        assert body['is_partial'] is True
+        assert body['total'] > 0
+
+
+class TestDailySeriesOrderSurvivesTheNewReturnShape:
+    """`ScanIndexForward=False` is load-bearing for the charts, and unpacking a
+    tuple is exactly the sort of edit that quietly reorders a series."""
+
+    @patch('metrics_handler.aggregates_table')
+    def test_summary_keeps_daily_totals_newest_first(
+        self, agg, api_gateway_event, lambda_context
+    ):
+        newest = datetime.now(timezone.utc)
+        older = newest - timedelta(days=1)
+        agg.query.return_value = {'Items': [
+            {'sk': newest.strftime('%Y-%m-%d'), 'count': 2, 'sum': 1.0},
+            {'sk': older.strftime('%Y-%m-%d'), 'count': 1, 'sum': 0.5},
+        ]}
+
+        from metrics_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET', path='/metrics/summary', query_params={'days': '7'})
+        body = json.loads(lambda_handler(event, lambda_context)['body'])
+
+        assert [t['date'] for t in body['daily_totals']] == [
+            newest.strftime('%Y-%m-%d'), older.strftime('%Y-%m-%d'),
+        ]
+        assert agg.query.call_args.kwargs['ScanIndexForward'] is False

--- a/voc-datalake/lambda/shared/api.py
+++ b/voc-datalake/lambda/shared/api.py
@@ -77,6 +77,28 @@ SEARCH_QUERY_MIN_LENGTH = 2
 # timeout" READS this value and fails if raising it outgrows the budget.
 MAX_FEEDBACK_WINDOW_DAYS = 365
 
+# How long a pre-computed aggregate row survives, in days.
+#
+# The aggregator stamps a TTL on every counter and average row it writes
+# (`aggregator/handler.py`'s `update_counter`/`update_average`, `ttl_days`), and
+# DynamoDB deletes the row once it passes. So this is not a tuning knob: it is
+# the widest window the aggregate partitions can answer COMPLETELY.
+#
+# 🔑 It is declared here, beside MAX_FEEDBACK_WINDOW_DAYS, because the two are
+# in tension and nothing used to say so. `validate_days` admits up to 365 while
+# aggregates only reach back ~90, so `/metrics/*?days=365` reads a partition
+# whose older rows no longer exist and answers with a total that under-reports
+# by however much has expired — silently, because the read itself succeeds and
+# returns rows. `metrics_handler` now compares the requested window against this
+# value and reports `is_partial` when it is wider.
+#
+# The aggregator OWNS the value; this is the consumer's copy of it, and
+# `lambda/api/test/test_aggregate_retention_lockstep.py` reads the aggregator's
+# `ttl_days` default via `inspect.signature` and fails if the two drift. Shorten
+# the TTL there without shortening this and the endpoints go back to asserting
+# completeness over a window the data no longer covers.
+AGGREGATE_RETENTION_DAYS = 90
+
 
 def validate_days(
     value: str | int | None,
@@ -385,6 +407,7 @@ __all__ = [
     'validate_bool',
     'validate_date_basis',
     'MAX_PERSONAS_PER_GENERATION',
+    'AGGREGATE_RETENTION_DAYS',
     'DATE_BASIS_IMPORTED',
     'DATE_BASIS_REVIEW',
     'create_cors_config',


### PR DESCRIPTION
## Summary

Every route in `metrics_handler.py` that publishes `is_partial` published a **hardcoded `False` on its aggregates path** — the default path, a plain `?days=N` with no `source` and the import date basis. The flag was initialised beside the scan branch that sets it, and the aggregates branch never touched it, so the value was an *assertion* of completeness rather than a measurement. Audit finding **M4**: 99 items of a 6,239-item corpus returned as a complete answer. The reviewer flagged `get_category_metrics`; the same lie was in five other response sites, so all six are wired here.

### The two independent causes, which is the part worth checking

They are not the same fault and neither implies the other, so each gets its own signal and its own tests:

**1. Paging truncation — already detected, then thrown away.** `_query_metric_window` follows the cursor under a bound of `days` pages and, on exhausting the bound with a cursor still open, logged a warning and returned a short list. Its docstring justified that with *"these endpoints have no `is_partial` signal … Nothing in the response shape can express that"* — false even when written, since six response sites in the same file publish the field. It now returns `(items, truncated)`, following the existing `_scan_recent_items` / `_scan_window_items` convention rather than inventing a second one, and the docstring says what the function does. The warning stays as the *operator's* copy of the fact; `truncated` is the caller's.

A third site of the same class came out of tracing it: `/metrics/sources`, `/metrics/personas` and `/feedback/entities` read `gsi1-by-metric-type` with **one unpaged query**, so DynamoDB's 1 MB page limit bounds how many aggregate rows they see. `_read_was_truncated` reports the open cursor. **Reported, not followed** — paging it would change which data the answer is computed from.

**2. The aggregate retention horizon — detected by nothing at all.** This is a property of the *request*, not of a read: it holds even when every query succeeds and returns every row that still exists. Aggregate rows carry a 90-day TTL while `validate_days` admits 365, so `?days=365` queries a sort-key range whose early part DynamoDB has already deleted — the read succeeds, the totals under-report, nothing notices. A window wider than the retention **cannot** be answered completely from aggregates. Declared as `AGGREGATE_RETENTION_DAYS` in `shared/api.py`, beside `MAX_FEEDBACK_WINDOW_DAYS`, which is the ceiling it is in tension with. Strictly `>`: a window *equal* to the retention is still fully covered, and crying partial over a complete answer teaches callers to ignore the flag.

Where an endpoint reads several partitions (one per category, one per sentiment label, three for the summary) truncation in **any** of them makes the answer partial, so the flag ORs across them. Where an endpoint can take either path, the aggregates truncation ORs into whatever the scan path already computed.

`aggregator/handler.py` is **untouched** as instructed. The link is a lockstep test that reads `ttl_days`' default via `inspect.signature` and fails if the aggregator's TTL and the shared constant drift — in either direction.

### Not done

No window is widened or narrowed, no read gained a fallback to scanning, and no stored aggregate is backfilled. `period_days` and the queried date ranges are byte-identical; `/metrics/summary` still costs exactly three queries at every window including 365. Finding M7 (persona dimension bucketing) is untouched.

### One deliberate step beyond the brief

The MCP layer forwards these route bodies **unprojected**, so the newly-honest flag reaches a client whether or not it is declared — and `additionalProperties` is *absent* (not `false`) from both metrics tools' output shapes, so an undeclared `is_partial` validates and is then invisible to a model reading the catalogue. Since the audit's whole argument is that this matters more through MCP than on the dashboard, leaving it undeclared would have shipped the fix and kept the symptom. So `get_metrics_summary` declares it, `get_metrics_breakdown`'s description is corrected (it said *"an aggregate read failed"*, naming one of the two causes and thereby teaching a reader the other could not happen), and `MCP_SERVER_VERSION` moves 3.6.0 → 3.7.0 with the catalogue fingerprint updated in the same commit, as that lockstep test demands. The frontend `MetricsSummary` doc comment and the Dashboard's "exceeded the scan budget" hint described only the scan cause too.

## Tests

New `voc-datalake/lambda/api/test/test_metrics_partial_window.py` (46 cases) and `test_aggregate_retention_lockstep.py` (3 cases). Each module docstring states which mutation makes its assertions fail, per repo convention.

The **route list is derived** from the handler source by AST walk (`@app.<verb>` decorator + a response dict carrying `is_partial`, scoped to each function's own body) rather than hand-copied, so a future endpoint that publishes the flag without wiring it fails instead of silently never being tested. `test_the_derivation_finds_the_routes_that_publish_the_flag` is its positive control — without it an empty derivation would make every parametrized case pass by never running.

Every truncation assertion has a **positive control** asserting `false` on the complementary input, so the suite cannot pass by the flag being unconditionally true — which is the same defect pointing the other way.

## Mutation checks — run, not predicted

Each revert was applied to the working tree, the full suite run, then reverted:

| Mutation | Result |
|---|---|
| `_query_metric_window`'s `return items, True` → `return items, False` | **7 failed**, incl. `TestAggregatePathReportsPagingTruncation::test_a_truncated_aggregate_read_is_reported_partial[/metrics/summary, /metrics/sentiment, /metrics/categories]`, `::test_the_helper_returns_the_flag_beside_the_items`, `::test_one_truncated_partition_out_of_many_makes_the_answer_partial` |
| `_window_exceeds_aggregate_retention` → `return False` | **8 failed**, incl. `TestWindowWiderThanAggregateRetention::test_a_window_beyond_the_retention_is_partial_by_construction` on all **six** routes, `::test_the_predicate_is_about_the_request_not_about_a_read` |
| aggregator `ttl_days: int = 90` → `30` | **2 failed**: `TestAggregateRetentionLockstep::test_the_shared_constant_equals_the_aggregators_ttl_default`, `::test_both_writers_stamp_the_same_horizon` |
| `AGGREGATE_RETENTION_DAYS = 90` → `180` (the other drift direction) | same 2 failed |
| added a `/metrics/unwired` route publishing `is_partial` without wiring it | **3 failed**: the derivation control plus both parametrized suites picking the new route up |
| deleted `is_partial` from `get_metrics_summary`'s `outputSchema` | **3 failed**: `TestMetricsToolsDeclareTheFlagTheyPassThrough` ×2 plus the fingerprint lockstep |

## Build and test results

| Command | Result |
|---|---|
| `mise run build` | **not available** — `mise ERROR no tasks defined in <repo>`. No mise tasks exist in this repo (a known gap; the setup report also flagged build gating as inert). Ran the project's real build instead. |
| `npm run build` (frontend, the repo's `build` script) | **pass**, built in 8.82s |
| `pytest voc-datalake/lambda` | **3169 passed, 0 failed** (base tip 3110; +59 = 49 new cases plus 10 pre-existing that only run once `pydantic`/`aws-xray-sdk` are installed — see below) |
| `ruff check --select F,E4,E7,E9` on all changed Python files | **All checks passed!** |
| `ruff check lambda plugins` (repo-wide gate) | **508** — one *below* the pre-existing 509, not above |
| `npm run typecheck` (frontend) | **pass** |
| `npm run typecheck:cdk`, `typecheck:stream` | **pass** |
| `npx vitest run` (frontend) | **185 files, 3059 passed** |
| `npm test` (CDK) | **279 passed** — see note |
| `npm test` (lambda/stream) | **23 files, 365 passed** |
| `npm run lint` (frontend eslint, `--max-warnings 0`) | **pass** |

**Two environment notes, neither caused by this change:**

- The base suite reported 3110 on a checkout whose venv was missing `pydantic`, `aws-xray-sdk` and the layer deps — with those installed the *unmodified* base collects and passes 3112. My 3169 is measured against that same complete environment, so the delta is +57 from my 49 new cases and the collection differences, not a hidden regression. `aws-xray-sdk` is absent from `requirements-dev.txt` while `aws-lambda-powertools`' tracer imports it; worth a follow-up.
- The CDK suite fails 47/256 on a fresh checkout with `CannotFindAsset: Cannot find asset at voc-datalake/frontend/dist`. That is the missing frontend build, not a code fault: after `npm run build` all 279 pass. Verified pre-existing by stashing my changes.

## Decisions made

- **`_read_was_truncated` for the unpaged index reads.** Not named in the brief, but it is the same fact ("rows exist that were not counted") on three of the six routes being fixed, discarded the same way. Wiring the paging flag while leaving these silent would have left `/metrics/sources` and `/metrics/personas` still able to report a 1 MB-truncated read as complete. Reported only — no paging added.
- **`>` not `>=`** for the retention boundary, with a test on the exact-90 case pinning it.
- **`/feedback/entities`' `issues` map excluded** from the flag. It is a deliberate sample on *both* branches (newest rows of at most 7 days, capped at `limit`); folding it in would make the flag true on nearly every call, which is how a flag stops meaning anything. `is_partial` there describes the counts, matching what the scan branch's flag describes.
- **`test_the_retention_is_narrower_than_the_widest_requestable_window`** asserts the premise, so if retention ever reaches 365 the horizon check becomes provably dead code and fails loudly rather than sitting there as decoration.
- The `TestQueryMetricWindow` docstrings that asserted "these endpoints have no `is_partial` signal" were updated, since that claim is now the opposite of true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

## Agent notes

**What went well.** The brief's insistence that the two causes are independent turned out to be load-bearing for the *code*, not just the review: they need different mechanisms (one per-read and ORed, one computed once from `days`), and a single flag variable seeded by the horizon check and then ORed with each read's truncation is what lets both share one field honestly. Deriving the route list by AST instead of listing it caught a real gap — I'd initially wired only the `/metrics/*` four and the derivation immediately failed on `/feedback/entities`, which publishes the flag from its scan branch and had the same silent aggregates branch.

**What was difficult.** Three things. (1) The MCP boundary is where the audit says this defect actually bites, but touching it means moving `MCP_SERVER_VERSION` and a catalogue fingerprint — I nearly stopped at the handler, which would have shipped a fix whose symptom survived at the surface that matters. (2) Stubbing per-partition truncation needed reading the `pk` back out of a boto3 `Condition`; a `repr()`-based match silently matched nothing (object addresses) and the test passed for the wrong reason until I checked. Reaching through `get_expression()` is the honest way. (3) Getting the test environment green at all: the venv was absent and `pytest` failed at import on `aws_xray_sdk` and `pydantic` before any test ran.

**Repo conventions discovered/confirmed.** Lockstep tests are the idiom for any value owned in one place and consumed in another, and they read the other side's source (`inspect.signature`, regex over TypeScript, JSON schema files) rather than restating it — the point being that a restated copy is the thing that goes stale. Comments carry the *argument*, not a description, and load-bearing ones say why an alternative is wrong. Tests are named as outcomes and module docstrings name the mutation each assertion catches. Positive controls are expected wherever a check could pass by never running. `MCP_TOOLS` is fingerprinted against `MCP_SERVER_VERSION`, so any published-shape edit must bump both in one commit, and the version comment block wants a paragraph arguing major-vs-minor.

**Suggestions for future tasks here.** (a) `mise run build` still does not exist — worth adding, since the harness gates on it and currently cannot. (b) `aws-xray-sdk` belongs in `requirements-dev.txt`; without it `pytest` fails at collection. (c) The CDK suite depends on `frontend/dist` existing, so `npm run build` must precede `npm run test:cdk` — a note in the README's test section would save the next agent the same detour. (d) `ruff check lambda plugins` sits at ~508 pre-existing findings; treating that as a ratchet (assert it never rises) would be a cheap improvement. (e) `/metrics/sources` and `/metrics/personas` still read their index without paging, so a large enough deployment silently answers from one page — now at least *reported*, but the underlying read is worth fixing on its own.

---

## Review convergence (commits 3–6)

The automated review's blocker and all six should-fix items are addressed, plus the nits worth taking. What changed since the first two commits:

**Blocker — the hint was hardcoded English.** `partialCountsHint` now exists in all eight locale files and `MetricsGrid` renders `t('partialCountsHint')`. It went in `common`, beside the `partialWindowHint` the Categories results line already uses, rather than in `dashboard`: the string is about counts being a lower bound, not about the dashboard, and it keeps this file to one namespace — `scripts/i18n-check.mjs` infers a single namespace per file from the first `useTranslation`, so a `dashboard` hook in `MetricsGrid` would have made it misreport this file's existing `exportPdf` keys as missing. `Dashboard.test.tsx` forwards `hint` through its `MetricCard` mock, which was swallowing it, and asserts the copy read from `en/common.json` with a positive control on the complete-window case.

**Every `_query_metric_window` call site is now checked structurally.** `TestEveryCallerUnpacksTheTruncationFlag` asserts by AST that every call unpacks two values, and scans `lambda/` to assert nothing outside `metrics_handler.py` calls the helper at all. This is the case the parametrized suites cannot reach: they only see routes that *publish* the flag, and the failure of a non-publishing caller is not a crash — `items = helper(...)` silently answers `len == 2`.

**`is_partial` is representable everywhere it is emitted.** `SentimentBreakdown`, `CategoryBreakdown`, `SourceBreakdown`, `EntitiesResponse` and a new named `PersonaBreakdown` (replacing an inline generic at the `getPersonas` call site — where a field goes to be invisible) all declare it, pointing at the one canonical statement on `MetricsSummary.is_partial` instead of repeating it. No runtime validator sits in front of these responses, so nothing strips the field: all six getters are plain `fetchApi<T>` with no Zod schema or normalizer, and `useSummaryQuery` adds none.

**MCP coverage, asked in the other direction.** `test_every_mcp_reachable_route_that_publishes_the_flag_has_a_tool_declaring_it` derives the publishing routes from the handler source and the reachable set from the live `DOMAIN_ROUTES`, so `/feedback/entities` being deliberately unexposed is a fact the suite knows rather than a fact a reader has to check. Adding any publishing route to `DOMAIN_ROUTES` now fails until whichever tool serves it declares the field. The declaration is deliberately **not** `required` on these two tools — they forward the body unprojected and fall back to `{}`, so promising a key they do not build would turn an honest empty answer into a schema violation — and that choice is argued at `_IS_PARTIAL_DESCRIPTION` and pinned by a test scoped to `is_partial` alone.

**The retention lockstep no longer imports the aggregator.** It parses `aggregator/handler.py` with `ast`: importing it from an api test executes another package's module scope (a DynamoDB resource, `AGGREGATES_TABLE`), so the test failed for an environmental reason in the same red as real drift. Parsing also made two new assertions possible — no call site overrides `ttl_days` (positional overrides included; a single `ttl_days=30` would leave the lockstep green while those rows expire two months early), and each writer actually reads the parameter rather than stamping a literal. Its scope (bare-name calls inside that one file) is stated so it is not overread.

**Nits taken:** `_read_was_truncated` → `_index_read_was_truncated`; the ~48h TTL deletion lag written into `_window_exceeds_aggregate_retention`'s docstring, with the note that the boundary is the guarantee and not the observed state; and the rationale collapsed from five copies to two canonical statements (`AGGREGATE_RETENTION_DAYS` for the backend, `MetricsSummary.is_partial` for the frontend) with pointers elsewhere. **Nit not taken:** the cost of the truncation cases. Measured rather than assumed — `test_metrics_partial_window.py` runs 49 tests in 1.3s, so shrinking `days` would trade a real invariant (the paging cases sit just inside the retention horizon, which is what makes them about paging and not about the horizon) for nothing measurable.

**Mutations, re-run after the narrowing commits.** Each applied to the working tree, full suite run, then reverted:

| Mutation | Result |
|---|---|
| a `_query_metric_window` call site stops unpacking the flag | caught |
| an aggregator call site passes `ttl_days=30` | caught |
| a writer takes `ttl_days` and stamps a literal instead | caught |
| a publishing route added to `DOMAIN_ROUTES` with no tool declaring the flag | caught |
| `required: ["is_partial"]` added to an unprojected pass-through tool | caught (plus the fingerprint lockstep) |
| the dashboard hint points at a key no locale defines | caught |
| the hint deleted from one locale | caught |

**Gate re-run on the final commit:** `pytest lambda` **3177 passed** · frontend `vitest run` **185 files, 3060 passed** · `npm run lint` (eslint `--max-warnings 0`) pass · `tsc --noEmit` frontend and CDK pass · `ruff check --select F,E4,E7,E9` on the changed Python clean · `ruff check lambda plugins` **508**, unchanged from base · locale parity 31 tests pass · `i18n:check` shows the same two pre-existing `projectDetail:prototypeLink.*` findings as the base and nothing new.
