### PR TITLE
feat(prioritization): show the row count beside the heading

### DIFF
--- a/voc-datalake/frontend/public/locales/de/prioritization.json
+++ b/voc-datalake/frontend/public/locales/de/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "{{documents}} Dokumente, ein Stimmzettel"
   },
+  "rowCount_one": "{{count}} Vorschlag",
+  "rowCount_other": "{{count}} Vorschläge",
   "scores": {
     "confidence": "Konfidenz",
     "confidenceDescription": "Sicherheit bei Auswirkungs- und MeZ-Schätzungen",

--- a/voc-datalake/frontend/public/locales/en/prioritization.json
+++ b/voc-datalake/frontend/public/locales/en/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "{{documents}} documents, one ballot"
   },
+  "rowCount_one": "{{count}} proposal",
+  "rowCount_other": "{{count}} proposals",
   "scores": {
     "confidence": "Confidence",
     "confidenceDescription": "Certainty in impact and TTM estimates",

--- a/voc-datalake/frontend/public/locales/es/prioritization.json
+++ b/voc-datalake/frontend/public/locales/es/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "{{documents}} documentos, una papeleta"
   },
+  "rowCount_one": "{{count}} propuesta",
+  "rowCount_other": "{{count}} propuestas",
   "scores": {
     "confidence": "Confianza",
     "confidenceDescription": "Certeza en las estimaciones de impacto y TdC",

--- a/voc-datalake/frontend/public/locales/fr/prioritization.json
+++ b/voc-datalake/frontend/public/locales/fr/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "{{documents}} documents, un seul bulletin"
   },
+  "rowCount_one": "{{count}} proposition",
+  "rowCount_other": "{{count}} propositions",
   "scores": {
     "confidence": "Confiance",
     "confidenceDescription": "Certitude dans les estimations d'impact et de DmM",

--- a/voc-datalake/frontend/public/locales/ja/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ja/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "ドキュメント{{documents}}件、投票は1票"
   },
+  "rowCount_one": "提案{{count}}件",
+  "rowCount_other": "提案{{count}}件",
   "scores": {
     "confidence": "確信度",
     "confidenceDescription": "インパクトとTTM見積もりの確実性",

--- a/voc-datalake/frontend/public/locales/ko/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ko/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "문서 {{documents}}건, 표 1장"
   },
+  "rowCount_one": "제안 {{count}}건",
+  "rowCount_other": "제안 {{count}}건",
   "scores": {
     "confidence": "신뢰도",
     "confidenceDescription": "영향도 및 출시 시간 추정의 확실성",

--- a/voc-datalake/frontend/public/locales/pt/prioritization.json
+++ b/voc-datalake/frontend/public/locales/pt/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "{{documents}} documentos, uma cédula"
   },
+  "rowCount_one": "{{count}} proposta",
+  "rowCount_other": "{{count}} propostas",
   "scores": {
     "confidence": "Confiança",
     "confidenceDescription": "Certeza nas estimativas de impacto e TTM",

--- a/voc-datalake/frontend/public/locales/zh/prioritization.json
+++ b/voc-datalake/frontend/public/locales/zh/prioritization.json
@@ -121,6 +121,8 @@
   "row": {
     "multiDocument": "{{documents}} 个文档，一张选票"
   },
+  "rowCount_one": "{{count}} 个提案",
+  "rowCount_other": "{{count}} 个提案",
   "scores": {
     "confidence": "置信度",
     "confidenceDescription": "对影响力和上市时间估计的确定性",

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1114,15 +1114,15 @@ describe('Prioritization', () => {
     // beneath it from disagreeing.
 
     /**
-     * Everything the heading area says, as one string.
+     * The count badge, or null when the heading is showing none.
      *
-     * The h1's own wrapper, which holds the heading and the count and nothing else. Read
-     * as a whole so a test can assert what the area does NOT say: a count withheld is
-     * this reading back exactly the title, which stays true however a future plural form
-     * spells zero — whereas querying for the literal "0 proposals" only rules out one
-     * spelling of the claim.
+     * By testid, which is the only handle that holds for the ABSENCE cases in both of
+     * the directions they can rot. Querying for the text "0 proposals" rules out one
+     * spelling of the claim, so a later `rowCount_zero` form would pass unnoticed;
+     * reading the heading wrapper's whole text is spelling-proof but goes vacuous the
+     * moment anything is nested around the h1, which is a test that fails open.
      */
-    const headingArea = () => screen.getByRole('heading', { level: 1 }).parentElement
+    const rowCountBadge = () => screen.queryByTestId('prioritization-row-count')
 
     it('counts the rows beside the heading', async () => {
       // Two projects in the shared fixture, so TWO rows — p1's PRD and PR/FAQ are one
@@ -1144,9 +1144,11 @@ describe('Prioritization', () => {
       renderPrioritization()
 
       expect(await screen.findByText('2 proposals')).toBeInTheDocument()
-      const grid = screen.getByText('Total Proposals').closest<HTMLElement>('div.grid')
-      expect(within(grid ?? document.body).getByText('Total Proposals').previousElementSibling)
-        .toHaveTextContent('2')
+      // `toBe` on the text, not `toHaveTextContent`: that matcher is a SUBSTRING test
+      // for a string argument, so a card reading "12" or "20" would satisfy the very
+      // assertion this case exists to make.
+      expect(screen.getByText('Total Proposals').previousElementSibling?.textContent)
+        .toBe('2')
     })
 
     it('uses the singular form for a list of one', async () => {
@@ -1173,27 +1175,29 @@ describe('Prioritization', () => {
       renderPrioritization()
 
       expect(await screen.findByText('Loading documents...')).toBeInTheDocument()
-      expect(headingArea()).toHaveTextContent(/^Prioritization$/)
+      expect(rowCountBadge()).toBeNull()
     })
 
-    // Both empty branches, because the count is withheld for a reason that names them:
-    // the list says WHICH emptiness this is, and a bare zero cannot. The badge takes the
-    // same path through either, so this is one case run twice rather than two cases.
+    // EVERY empty branch, because the count is withheld for a reason that names them:
+    // the list says which emptiness this is, and a bare zero cannot. The badge takes one
+    // path through all three, so this is one case run three times — and `projects` is
+    // its own column rather than inferred from `documents`, so "a project that has no
+    // documents yet" is expressible instead of silently collapsing into "no projects".
     it.each([
-      ['no projects at all', 'No Documents Found', []],
-      ['only non-scorable documents', 'No Scorable Documents', [
-        { document_id: 'r1', document_type: 'research', title: 'Research Only', content: '', created_at: '2025-01-01' },
-      ]],
-    ])('does not claim "0 proposals" over the empty state for %s', async (_case, emptyTitle, documents) => {
-      mockGetProjects.mockResolvedValue({
-        projects: documents.length === 0 ? [] : [mockProjects[0]],
-      })
+      { emptiness: 'no projects at all', title: 'No Documents Found', projects: [], documents: [] },
+      { emptiness: 'a project with no documents yet', title: 'No Documents Found', projects: [mockProjects[0]], documents: [] },
+      {
+        emptiness: 'only non-scorable documents', title: 'No Scorable Documents', projects: [mockProjects[0]],
+        documents: [{ document_id: 'r1', document_type: 'research', title: 'Research Only', content: '', created_at: '2025-01-01' }],
+      },
+    ])('shows no count over the empty state for $emptiness', async ({ title, projects, documents }) => {
+      mockGetProjects.mockResolvedValue({ projects })
       mockGetProject.mockResolvedValue({ project_id: 'p1', documents })
 
       renderPrioritization()
 
-      expect(await screen.findByText(emptyTitle)).toBeInTheDocument()
-      expect(headingArea()).toHaveTextContent(/^Prioritization$/)
+      expect(await screen.findByText(title)).toBeInTheDocument()
+      expect(rowCountBadge()).toBeNull()
     })
 
     it('counts the rows still on screen when the score read fails', async () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1129,7 +1129,13 @@ describe('Prioritization', () => {
       // row, which is why this is not "three documents".
       renderPrioritization()
 
-      expect(await screen.findByText('2 proposals')).toBeInTheDocument()
+      // Read off the BADGE, not merely found somewhere on the page. The two cases below
+      // assert this node is absent, and if nothing ever asserts it is present, deleting
+      // the testid leaves those two passing for the wrong reason and the zero-gate
+      // unguarded. Keeping the string in the assertion still proves the plural resolved
+      // through the real locale JSON rather than falling back to the key.
+      expect((await screen.findByTestId('prioritization-row-count')).textContent)
+        .toBe('2 proposals')
       // Beside the h1, not inside it: the page's only level-1 heading has to keep
       // reading as the page's name to a screen reader and the document outline, and it
       // is what the breadcrumb names.
@@ -1185,7 +1191,10 @@ describe('Prioritization', () => {
     // documents yet" is expressible instead of silently collapsing into "no projects".
     it.each([
       { emptiness: 'no projects at all', title: 'No Documents Found', projects: [], documents: [] },
-      { emptiness: 'a project with no documents yet', title: 'No Documents Found', projects: [mockProjects[0]], documents: [] },
+      // Named for the state it actually reaches: the shared fixture's rows still name
+      // `d1`/`d2`, which this project no longer has, so `collectRows` drops every row.
+      // The one case where a detail IS loaded and holds no documents at all.
+      { emptiness: 'a project whose documents are gone', title: 'No Documents Found', projects: [mockProjects[0]], documents: [] },
       {
         emptiness: 'only non-scorable documents', title: 'No Scorable Documents', projects: [mockProjects[0]],
         documents: [{ document_id: 'r1', document_type: 'research', title: 'Research Only', content: '', created_at: '2025-01-01' }],

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1107,6 +1107,116 @@ describe('Prioritization', () => {
     })
   })
 
+  describe('the heading says how long the list is', () => {
+    // A reader cannot tell from the heading alone whether everything loaded, so the
+    // count goes beside it. The number is the LIST's own length rather than a second
+    // count computed from the documents, which is what keeps the badge and the rows
+    // beneath it from disagreeing.
+
+    /**
+     * Everything the heading area says, as one string.
+     *
+     * The h1's own wrapper, which holds the heading and the count and nothing else. Read
+     * as a whole so a test can assert what the area does NOT say: a count withheld is
+     * this reading back exactly the title, which stays true however a future plural form
+     * spells zero — whereas querying for the literal "0 proposals" only rules out one
+     * spelling of the claim.
+     */
+    const headingArea = () => screen.getByRole('heading', { level: 1 }).parentElement
+
+    it('counts the rows beside the heading', async () => {
+      // Two projects in the shared fixture, so TWO rows — p1's PRD and PR/FAQ are one
+      // row, which is why this is not "three documents".
+      renderPrioritization()
+
+      expect(await screen.findByText('2 proposals')).toBeInTheDocument()
+      // Beside the h1, not inside it: the page's only level-1 heading has to keep
+      // reading as the page's name to a screen reader and the document outline, and it
+      // is what the breadcrumb names.
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/^Prioritization$/)
+    })
+
+    it('agrees with the Total Proposals card', async () => {
+      // The badge counts `sortedRows` and the card counts `allRows`, so they agree only
+      // while the sort preserves length — which nothing else on the page asserts. They
+      // are two statements of the same quantity in the same viewport, and a reader who
+      // finds them disagreeing has reason to trust neither.
+      renderPrioritization()
+
+      expect(await screen.findByText('2 proposals')).toBeInTheDocument()
+      const grid = screen.getByText('Total Proposals').closest<HTMLElement>('div.grid')
+      expect(within(grid ?? document.body).getByText('Total Proposals').previousElementSibling)
+        .toHaveTextContent('2')
+    })
+
+    it('uses the singular form for a list of one', async () => {
+      // Not cosmetic. A count-only key needs both `rowCount_one` and `rowCount_other`
+      // under i18next's JSON v4 plurals, and a missing form renders the raw key path —
+      // the failure this page's own comments warn about elsewhere. Tests run the real
+      // locale JSON through the real i18next, so this case is what proves the forms
+      // resolve rather than that they merely exist in the file.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '2025-01-01' },
+      ]))
+
+      renderPrioritization()
+
+      expect(await screen.findByText('1 proposal')).toBeInTheDocument()
+      expect(screen.queryByText('rowCount')).toBeNull()
+    })
+
+    it('says nothing while the list is still loading', async () => {
+      // The badge must not appear over the spinner: a count is a claim about a list,
+      // and there is no list yet.
+      mockGetProjects.mockReturnValue(new Promise(() => {})) // Never resolves
+
+      renderPrioritization()
+
+      expect(await screen.findByText('Loading documents...')).toBeInTheDocument()
+      expect(headingArea()).toHaveTextContent(/^Prioritization$/)
+    })
+
+    // Both empty branches, because the count is withheld for a reason that names them:
+    // the list says WHICH emptiness this is, and a bare zero cannot. The badge takes the
+    // same path through either, so this is one case run twice rather than two cases.
+    it.each([
+      ['no projects at all', 'No Documents Found', []],
+      ['only non-scorable documents', 'No Scorable Documents', [
+        { document_id: 'r1', document_type: 'research', title: 'Research Only', content: '', created_at: '2025-01-01' },
+      ]],
+    ])('does not claim "0 proposals" over the empty state for %s', async (_case, emptyTitle, documents) => {
+      mockGetProjects.mockResolvedValue({
+        projects: documents.length === 0 ? [] : [mockProjects[0]],
+      })
+      mockGetProject.mockResolvedValue({ project_id: 'p1', documents })
+
+      renderPrioritization()
+
+      expect(await screen.findByText(emptyTitle)).toBeInTheDocument()
+      expect(headingArea()).toHaveTextContent(/^Prioritization$/)
+    })
+
+    it('counts the rows still on screen when the score read fails', async () => {
+      // The count follows the LIST, and the list deliberately survives a failed scores
+      // read on the rows the ensure confirmed (see the sibling suite). Withholding the
+      // badge on that failure would leave the heading silent above rows the reader can
+      // see and count by hand — and the count is not one of the numbers that read
+      // failed, so it has nothing to retract.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Feature A PR/FAQ', content: '', created_at: '2025-01-01' },
+        { document_id: 'd3', document_type: 'prfaq', title: 'Feature B PR/FAQ', content: '', created_at: '2025-01-02' },
+      ]))
+      mockGetPrioritizationScores.mockRejectedValue(new Error('API Error: 500'))
+
+      renderPrioritization()
+
+      expect(await screen.findByText('2 proposals')).toBeInTheDocument()
+      // And the failure is still reported. Counting the rows is not claiming the read
+      // worked.
+      expect(screen.getByRole('alert', { name: 'Scores could not be loaded' })).toBeInTheDocument()
+    })
+  })
+
   describe('PR/FAQ list', () => {
     it('displays PR/FAQ items after loading', async () => {
       renderPrioritization()

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1187,8 +1187,8 @@ describe('Prioritization', () => {
     // EVERY empty branch, because the count is withheld for a reason that names them:
     // the list says which emptiness this is, and a bare zero cannot. The badge takes one
     // path through all three, so this is one case run three times — and `projects` is
-    // its own column rather than inferred from `documents`, so "a project that has no
-    // documents yet" is expressible instead of silently collapsing into "no projects".
+    // its own column rather than inferred from `documents`, which is what lets the middle
+    // case have a project at all instead of collapsing into "no projects".
     it.each([
       { emptiness: 'no projects at all', title: 'No Documents Found', projects: [], documents: [] },
       // Named for the state it actually reaches: the shared fixture's rows still name

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1136,9 +1136,15 @@ describe('Prioritization', () => {
       // through the real locale JSON rather than falling back to the key.
       expect((await screen.findByTestId('prioritization-row-count')).textContent)
         .toBe('2 proposals')
-      // Beside the h1, not inside it: the page's only level-1 heading has to keep
-      // reading as the page's name to a screen reader and the document outline, and it
-      // is what the breadcrumb names.
+      // Beside the h1, not inside it: this heading has to keep reading as the page's
+      // name to a screen reader and the document outline, and it is what the breadcrumb
+      // names.
+      //
+      // `level: 1` is unambiguous HERE ONLY because this suite renders the page without
+      // the app shell. The DEPLOYED page has two level-1 headings — Layout renders the
+      // brand as one — so this query would be ambiguous in a test that mounted Layout,
+      // and no assertion in this file can speak for the page's overall heading
+      // structure. Verified in a browser, not here.
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/^Prioritization$/)
     })
 
@@ -1169,8 +1175,10 @@ describe('Prioritization', () => {
 
       renderPrioritization()
 
+      // No companion "the raw key is absent" assertion: finding `1 proposal` already
+      // proves the `_one` form resolved, and a missing form renders the key path
+      // INSTEAD of the text, so the two can never disagree.
       expect(await screen.findByText('1 proposal')).toBeInTheDocument()
-      expect(screen.queryByText('rowCount')).toBeNull()
     })
 
     it('says nothing while the list is still loading', async () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -474,7 +474,15 @@ function PrioritizationHeader({
         <div className="flex items-center gap-2 flex-wrap">
           <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
           {rowCount === 0 ? null : (
-            <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs sm:text-sm font-medium text-gray-600">
+            // The testid is what lets a test assert this is ABSENT without depending on
+            // how a zero would have been spelled or on where the badge sits. Querying
+            // for the text "0 proposals" only rules out one wording — a later
+            // `rowCount_zero` form would walk straight past it — and reading the
+            // wrapper's text depends on nothing being nested around the heading.
+            <span
+              data-testid="prioritization-row-count"
+              className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs sm:text-sm font-medium text-gray-600"
+            >
               {t('rowCount', { count: rowCount })}
             </span>
           )}

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -468,9 +468,12 @@ function PrioritizationHeader({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
-        {/* BESIDE the heading, not inside it: a screen reader announcing the page's
-            only h1 should read "Prioritization", which is also what the breadcrumb and
-            the document outline name. The count's own text is self-describing. */}
+        {/* BESIDE the heading, not inside it: a screen reader announcing this page's
+            heading should read "Prioritization", which is also what the breadcrumb and
+            the document outline name. The count's own text is self-describing.
+            (Not "the only h1" — the app shell's brand is an h1 too, so the deployed
+            page has two. That is pre-existing and separate; the point here is only
+            that THIS heading's accessible name stays the page's name.) */}
         <div className="flex items-center gap-2 flex-wrap">
           <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
           {rowCount === 0 ? null : (

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -438,6 +438,19 @@ function PrioritizationHeader({
    * that a reader cannot infer from the sliders has words above the list.
    */
   readonly saveBlocked: boolean
+  /**
+   * How many rows the list below is showing, or `null` while that is not yet known.
+   *
+   * `null` for the loading pass rather than `0`: the list renders a spinner until the
+   * projects and their documents are in hand, and a badge reading "0 proposals" over
+   * that spinner would assert an empty backlog the page has not established. It appears
+   * once there is a list to count, which is the moment the number means anything.
+   *
+   * Counts ROWS, the same unit as the "Total Proposals" card and the list itself, so the
+   * two numbers on the page cannot disagree. Deliberately not the number of documents:
+   * one row can hold a PRD and a PR/FAQ describing one idea.
+   */
+  readonly rowCount: number | null
   readonly onReset: () => void
   readonly onSave: () => void
 }) {
@@ -446,7 +459,21 @@ function PrioritizationHeader({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
-        <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
+        {/* The count sits BESIDE the heading, not inside it: a screen reader
+            announcing the page's only h1 should read "Prioritization", and the
+            heading is what the breadcrumb and the document outline name. Its own
+            text is self-describing ("12 proposals"), so it needs no extra label. */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
+          {rowCount === null ? null : (
+            <span
+              data-testid="prioritization-row-count"
+              className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs sm:text-sm font-medium text-gray-600"
+            >
+              {t('rowCount', { count: rowCount })}
+            </span>
+          )}
+        </div>
         <p className="text-sm sm:text-base text-gray-500 mt-1">{t('subtitle')}</p>
       </div>
       <div className="flex items-center gap-2 sm:gap-3">
@@ -872,6 +899,9 @@ export default function Prioritization() {
         hasChanges={hasChanges}
         isPending={saveMutation.isPending}
         saveBlocked={!ownBallots.inHand || overLongNotes.length > 0}
+        // The list's OWN length, so the badge and the rows below it are one number.
+        // Withheld while the list is still loading — see `rowCount` there.
+        rowCount={isLoading ? null : sortedRows.length}
         onReset={handleReset}
         onSave={() => saveMutation.mutate()}
       />

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -396,7 +396,7 @@ function PRFAQList({
 }
 
 function PrioritizationHeader({
-  hasChanges, isPending, saveBlocked, onReset, onSave,
+  hasChanges, isPending, saveBlocked, rowCount, onReset, onSave,
 }: {
   readonly hasChanges: boolean
   readonly isPending: boolean
@@ -439,18 +439,27 @@ function PrioritizationHeader({
    */
   readonly saveBlocked: boolean
   /**
-   * How many rows the list below is showing, or `null` while that is not yet known.
+   * How many rows the list below is showing.
    *
-   * `null` for the loading pass rather than `0`: the list renders a spinner until the
-   * projects and their documents are in hand, and a badge reading "0 proposals" over
-   * that spinner would assert an empty backlog the page has not established. It appears
-   * once there is a list to count, which is the moment the number means anything.
+   * NOT RENDERED AT ZERO, and that one rule is the whole of the state handling here,
+   * because "0 proposals" beside the heading asserts an empty backlog. Both states that
+   * reach this with nothing to count would be asserting one they have not established:
+   * the loading pass, where no documents have arrived to compose rows from and the list
+   * is still a spinner; and a genuinely empty list, where the list's own empty state
+   * already says so in words and says WHICH emptiness — no documents at all, or none of
+   * a scorable type — which a bare `0` cannot. A `number | null` prop was the same rule
+   * spelled twice, since a page with no rows yet has no other value to pass.
    *
-   * Counts ROWS, the same unit as the "Total Proposals" card and the list itself, so the
-   * two numbers on the page cannot disagree. Deliberately not the number of documents:
-   * one row can hold a PRD and a PR/FAQ describing one idea.
+   * Counts ROWS — the same UNIT as the "Total Proposals" card and as the list itself, so
+   * a reader comparing the two is comparing like with like. Deliberately not the number
+   * of documents: one row can hold a PRD and a PR/FAQ describing one idea.
+   *
+   * The same unit, not a promise of the same number. This is the LIST's length and the
+   * card's is the backlog's, which are equal only while nothing narrows the list — the
+   * first row filter or search box put on this page should make them differ, and each
+   * would then be right about what it is labelled.
    */
-  readonly rowCount: number | null
+  readonly rowCount: number
   readonly onReset: () => void
   readonly onSave: () => void
 }) {
@@ -459,17 +468,13 @@ function PrioritizationHeader({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
-        {/* The count sits BESIDE the heading, not inside it: a screen reader
-            announcing the page's only h1 should read "Prioritization", and the
-            heading is what the breadcrumb and the document outline name. Its own
-            text is self-describing ("12 proposals"), so it needs no extra label. */}
+        {/* BESIDE the heading, not inside it: a screen reader announcing the page's
+            only h1 should read "Prioritization", which is also what the breadcrumb and
+            the document outline name. The count's own text is self-describing. */}
         <div className="flex items-center gap-2 flex-wrap">
           <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
-          {rowCount === null ? null : (
-            <span
-              data-testid="prioritization-row-count"
-              className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs sm:text-sm font-medium text-gray-600"
-            >
+          {rowCount === 0 ? null : (
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs sm:text-sm font-medium text-gray-600">
               {t('rowCount', { count: rowCount })}
             </span>
           )}
@@ -891,6 +896,13 @@ export default function Prioritization() {
     return <div className="text-center py-12"><p className="text-gray-500">{t('configureApiEndpoint')}</p></div>
   }
 
+  // Whether the list is still a spinner. The heading's count relies on this being a
+  // SUBSET of "no rows yet": `collectRows` returns nothing until both these reads land,
+  // and neither query carries `placeholderData`, so a page that is loading always has
+  // zero rows and the header's own zero-gate covers the loading pass for free. Widening
+  // this to `isFetching` — the obvious way to spin on refetch — breaks that, because
+  // cached rows survive a refetch and the count would then sit over a spinner. Gate the
+  // badge explicitly if that happens.
   const isLoading = loadingProjects || loadingDetails
 
   return (
@@ -900,8 +912,10 @@ export default function Prioritization() {
         isPending={saveMutation.isPending}
         saveBlocked={!ownBallots.inHand || overLongNotes.length > 0}
         // The list's OWN length, so the badge and the rows below it are one number.
-        // Withheld while the list is still loading — see `rowCount` there.
-        rowCount={isLoading ? null : sortedRows.length}
+        // Nothing is gated here — the header withholds a zero, which covers the loading
+        // pass as well, since `collectRows` has no documents to compose rows from until
+        // the reads `isLoading` tracks have landed. See `rowCount` there.
+        rowCount={sortedRows.length}
         onReset={handleReset}
         onSave={() => saveMutation.mutate()}
       />

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -647,19 +647,24 @@ describe('the sort orders by the TEAM aggregate, not the caller own ballot', () 
     // `rowC` is local to the sibling cases, so this one mints its own third row.
     const rowC = rowView('c', 'Gamma', '2025-01-03')
     const rows = [rowA, rowB, rowC]
+    // Scored on ONE axis only (`a`, `b`) and absent entirely (`c`), which is what makes
+    // the four fields below land in three DIFFERENT grouping regimes rather than
+    // repeating one: `impact` splits them (a and b have a number, c does not);
+    // `time_to_market` and `priority_score` put all three in number-less blocks for two
+    // different reasons (a scored row with no value on the axis, versus no aggregate at
+    // all); and `created_at` is not team-ordered, so no grouping runs. The property has
+    // to hold in all three, and a number-less block is where a row can quietly vanish.
     const aggregates: Record<string, PrioritizationAggregate> = {
       a: aggregate({ impact: 5, reviewer_count: 2 }),
-      // `b` scored on one axis only and `c` absent entirely, so every arm of the
-      // grouping is exercised — the number-less block is where a row could be dropped.
       b: aggregate({ impact: 0, reviewer_count: 1 }),
     }
 
-    for (const field of ['priority_score', 'impact', 'time_to_market', 'created_at'] as const) {
-      for (const direction of ['asc', 'desc'] as const) {
+    for (const field of ['priority_score', 'impact', 'time_to_market', 'created_at'] as const) {      for (const direction of ['asc', 'desc'] as const) {
         const sorted = sortRows(rows, aggregates, field, direction)
         expect(sorted, `${field}/${direction}`).toHaveLength(rows.length)
         // Length alone would accept a duplicated row masking a dropped one.
-        expect(idsOf(sorted).slice().sort(), `${field}/${direction}`).toEqual(['a', 'b', 'c'])
+        // `idsOf` maps, so it already returns a fresh array — no copy needed before sort.
+        expect(idsOf(sorted).sort(), `${field}/${direction}`).toEqual(['a', 'b', 'c'])
       }
     }
   })

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -659,7 +659,8 @@ describe('the sort orders by the TEAM aggregate, not the caller own ballot', () 
       b: aggregate({ impact: 0, reviewer_count: 1 }),
     }
 
-    for (const field of ['priority_score', 'impact', 'time_to_market', 'created_at'] as const) {      for (const direction of ['asc', 'desc'] as const) {
+    for (const field of ['priority_score', 'impact', 'time_to_market', 'created_at'] as const) {
+      for (const direction of ['asc', 'desc'] as const) {
         const sorted = sortRows(rows, aggregates, field, direction)
         expect(sorted, `${field}/${direction}`).toHaveLength(rows.length)
         // Length alone would accept a duplicated row masking a dropped one.

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -638,6 +638,32 @@ describe('the sort orders by the TEAM aggregate, not the caller own ballot', () 
     }
   })
 
+  it('returns every row it was given, whatever the field and direction', () => {
+    // REORDERS, NEVER NARROWS — and something outside this file now depends on it: the
+    // heading's count badge reads `sortedRows.length` while the "Total Proposals" card
+    // reads the pre-sort `allRows.length`, so the two numbers on the page agree only
+    // while this holds. A filter added to the comparator would make them disagree
+    // silently, which is the failure this pins rather than describes.
+    // `rowC` is local to the sibling cases, so this one mints its own third row.
+    const rowC = rowView('c', 'Gamma', '2025-01-03')
+    const rows = [rowA, rowB, rowC]
+    const aggregates: Record<string, PrioritizationAggregate> = {
+      a: aggregate({ impact: 5, reviewer_count: 2 }),
+      // `b` scored on one axis only and `c` absent entirely, so every arm of the
+      // grouping is exercised — the number-less block is where a row could be dropped.
+      b: aggregate({ impact: 0, reviewer_count: 1 }),
+    }
+
+    for (const field of ['priority_score', 'impact', 'time_to_market', 'created_at'] as const) {
+      for (const direction of ['asc', 'desc'] as const) {
+        const sorted = sortRows(rows, aggregates, field, direction)
+        expect(sorted, `${field}/${direction}`).toHaveLength(rows.length)
+        // Length alone would accept a duplicated row masking a dropped one.
+        expect(idsOf(sorted).slice().sort(), `${field}/${direction}`).toEqual(['a', 'b', 'c'])
+      }
+    }
+  })
+
   it('groups unscored documents rather than ordering them against each other', () => {
     // Two rows nobody has scored tie, in both directions, so they stay in the order
     // they arrived rather than being ranked by a number neither has.

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -1612,6 +1612,11 @@ export function sortRows(
     }
     return SORT_BLOCK[view.kind]
   }
+  // REORDERS, never narrows — and something now depends on that beyond the list. The
+  // heading's count is taken from this function's output while the "Total Proposals"
+  // card counts its input, so the two agree only while every row given comes back. A
+  // filter belongs in a separate step the count can be pointed at deliberately, not in
+  // this comparator.
   return [...rows].sort((a, b) => {
     const blockA = blockOf(a)
     const blockB = blockOf(b)


### PR DESCRIPTION
## Summary

The Prioritization page's heading gave no sense of how long the list is, so a reader could not tell at a glance whether everything had loaded. A small count now sits beside the `h1`.

Kept to the heading area — the table is untouched.

```
Prioritization  ( 2 proposals )
Score and prioritize PRDs and PR/FAQs across all projects
```

## What it does

- `PrioritizationHeader` takes a `rowCount: number` and renders it as a pill beside the heading, never inside it, so the heading's accessible name stays the page's name.
- The number is the **list's own length** (`sortedRows.length`), not a second count derived from the documents, so the badge and the rows beneath it cannot disagree.
- **Nothing renders at zero.** "0 proposals" beside the heading asserts an empty backlog, and both states that arrive with nothing to count have not established one: the loading pass, and a genuinely empty list whose own empty state already says so in words *and* says which emptiness it is. A scores read that failed or is still paging also lands here with `isLoading` already cleared.
- Counts **rows**, the same unit as the "Total Proposals" card. One row can hold a PRD and a PR/FAQ describing one idea — real data already contains such a row.
- `rowCount_one` / `rowCount_other` in all eight locales.

## Verification

> ⚠️ **The verification block originally generated for this PR was wrong on both counts and is corrected here.** It reported `mise run build`: PASS and `mise run lint`: FAIL, which together read as "one gate failing". In fact:
>
> - **The reported `lint` FAIL is pre-existing and unrelated.** It is 507 ruff violations in `lambda/` and `plugins/`. Identical count on the base commit, and this PR touches no Python:
>   ```
>   ruff check lambda plugins @ this branch  → Found 507 errors.
>   ruff check lambda plugins @ f31a5f84     → Found 507 errors.   # base
>   ```
> - **The gate that mattered was never run.** `tsc` is a separate script (`npm run typecheck`), in `npm run check` but not in `lint`. The first commit on this branch declared `rowCount` in the props type and never destructured it, so it was an undefined identifier — `tsc` failed with two `TS2304`s and the page threw a `ReferenceError` on every render, taking 113 of its own vitest cases with it. ESLint passed clean throughout, because `no-undef` is off for TypeScript by design.

Gates re-run at this head:

| gate | result |
| --- | --- |
| `npm run typecheck:all` | **PASS** |
| `npm run lint:frontend` (`eslint . --max-warnings 0`) | **PASS** |
| `npx vitest run` (frontend) | **PASS** — 185 files, 3068 tests |
| `ruff check lambda plugins` | 507, **unchanged from base** (no Python in this diff) |
| `node scripts/i18n-check.mjs` | 0 missing / 0 extra / 0 unused for `rowCount` |
| `npx tsc -p tsconfig.test.json` | 102, **unchanged from base** (pre-existing; in no aggregate) |

### Tests

Nine cases. Each was checked by mutation rather than assumed:

| mutation | fails |
| --- | --- |
| drop the zero-gate **and** add a legal `rowCount_zero` form | 4 |
| delete `rowCount_one` | 1 (renders the raw key) |
| move the badge inside the `h1` | 1 |
| inflate the "Total Proposals" card by 10 | 1 |
| delete the badge's `data-testid` | 1 |
| make `sortRows` narrow (drop unscored rows) | 1 |
| make `sortRows` duplicate a row instead of dropping one | 1 |

The last two pin the invariant the badge/card agreement rests on: `sortRows` reorders without narrowing. The duplication case is there because a length-only assertion would accept a duplicated row masking a dropped one.

### Verified live

Deployed frontend-only and driven in a signed-in browser. Full evidence in a comment below; in short: badge, list and card agree at three different counts; `1 proposal` / `2 proposals` and `1 Vorschlag` / `2 Vorschläge` resolve against the real HTTP-loaded catalogues; the badge is genuinely absent over the empty state; zero console errors; sorting does not change the count; contrast 6.87:1.

Live testing also found that the deployed page has **two** `h1` elements — the app shell renders one too — which corrected a comment that had claimed "the page's only h1". That claim was unfalsifiable in the page suite, which renders without the app shell.

## Known, deliberately not addressed

- `StatsCards` is ungated, so "Total Proposals" prints a literal `0` in the same empty state where the badge stays silent. Pre-existing; confirmed live. If the badge's reasoning is right the follow-up is gating the card, not changing the badge.
- `es`/`fr`/`pt` have no CLDR `many` form, so they would render the raw key at a count of exactly 1,000,000. Also structurally invisible to `i18n-check`, which compares each locale to English key-for-key and English legitimately has no `_many`.
- No `aria-live` on the badge. Sorting is length-preserving and the page has no filter, so nothing a user does moves the count without also changing the list; a live region would announce a bare number while the rows changed silently, and would fire on the 0→N transition at mount. Measured live rather than argued.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
