### PR TITLE
feat(prioritization): show the listed row count beside the heading

### DIFF
--- a/voc-datalake/frontend/public/locales/de/prioritization.json
+++ b/voc-datalake/frontend/public/locales/de/prioritization.json
@@ -77,6 +77,8 @@
     "description": "Bewerten Sie jedes Dokument nach: <strong>Auswirkung</strong>, <strong>Markteinführungszeit</strong>, <strong>Strategische Passung</strong> und <strong>Konfidenz</strong>.",
     "title": "Priorisierungsrahmen"
   },
+  "headingCount_one": "{{count}} Vorschlag",
+  "headingCount_other": "{{count}} Vorschläge",
   "loading": "Dokumente werden geladen...",
   "noteTooLong": {
     "description": "Notizen sind auf {{max}} Zeichen begrenzt, und eine längere Notiz wird nicht gekürzt, sondern abgelehnt. Kürzen Sie die Notiz in der bearbeiteten Zeile und speichern Sie dann erneut. Es wurde noch nichts gespeichert.",

--- a/voc-datalake/frontend/public/locales/en/prioritization.json
+++ b/voc-datalake/frontend/public/locales/en/prioritization.json
@@ -77,6 +77,8 @@
     "description": "Score each document on: <strong>Impact</strong>, <strong>Time to Market</strong>, <strong>Strategic Fit</strong>, and <strong>Confidence</strong>.",
     "title": "Prioritization Framework"
   },
+  "headingCount_one": "{{count}} proposal",
+  "headingCount_other": "{{count}} proposals",
   "loading": "Loading documents...",
   "noteTooLong": {
     "description": "Notes are limited to {{max}} characters, and a longer note is refused rather than shortened. Trim the note on the row you edited, then save again. Nothing has been saved yet.",

--- a/voc-datalake/frontend/public/locales/es/prioritization.json
+++ b/voc-datalake/frontend/public/locales/es/prioritization.json
@@ -77,6 +77,8 @@
     "description": "Puntúe cada documento en: <strong>Impacto</strong>, <strong>Tiempo de comercialización</strong>, <strong>Ajuste estratégico</strong> y <strong>Confianza</strong>.",
     "title": "Marco de priorización"
   },
+  "headingCount_one": "{{count}} propuesta",
+  "headingCount_other": "{{count}} propuestas",
   "loading": "Cargando documentos...",
   "noteTooLong": {
     "description": "Las notas están limitadas a {{max}} caracteres, y una nota más larga se rechaza en lugar de recortarse. Acorte la nota de la fila que editó y vuelva a guardar. Todavía no se ha guardado nada.",

--- a/voc-datalake/frontend/public/locales/fr/prioritization.json
+++ b/voc-datalake/frontend/public/locales/fr/prioritization.json
@@ -77,6 +77,8 @@
     "description": "Évaluez chaque document sur : <strong>Impact</strong>, <strong>Délai de mise sur le marché</strong>, <strong>Adéquation stratégique</strong> et <strong>Confiance</strong>.",
     "title": "Cadre de priorisation"
   },
+  "headingCount_one": "{{count}} proposition",
+  "headingCount_other": "{{count}} propositions",
   "loading": "Chargement des documents...",
   "noteTooLong": {
     "description": "Les notes sont limitées à {{max}} caractères, et une note plus longue est refusée plutôt que tronquée. Raccourcissez la note de la ligne modifiée, puis enregistrez de nouveau. Rien n'a encore été enregistré.",

--- a/voc-datalake/frontend/public/locales/ja/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ja/prioritization.json
@@ -77,6 +77,8 @@
     "description": "各ドキュメントを次の基準で評価: <strong>インパクト</strong>、<strong>市場投入時間</strong>、<strong>戦略的適合性</strong>、<strong>確信度</strong>。",
     "title": "優先順位付けフレームワーク"
   },
+  "headingCount_one": "提案 {{count}} 件",
+  "headingCount_other": "提案 {{count}} 件",
   "loading": "ドキュメントを読み込み中...",
   "noteTooLong": {
     "description": "メモは{{max}}文字までで、これを超えるメモは切り詰められずに拒否されます。編集した行のメモを短くしてから、もう一度保存してください。まだ何も保存されていません。",

--- a/voc-datalake/frontend/public/locales/ko/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ko/prioritization.json
@@ -77,6 +77,8 @@
     "description": "각 문서를 다음 항목으로 평가하세요: <strong>영향도</strong>, <strong>출시 시간</strong>, <strong>전략적 부합도</strong>, <strong>신뢰도</strong>.",
     "title": "우선순위 지정 프레임워크"
   },
+  "headingCount_one": "제안 {{count}}건",
+  "headingCount_other": "제안 {{count}}건",
   "loading": "문서 로드 중...",
   "noteTooLong": {
     "description": "메모는 {{max}}자까지 입력할 수 있으며, 이를 넘는 메모는 잘리지 않고 거부됩니다. 수정한 행의 메모를 줄인 후 다시 저장하세요. 아직 저장된 내용은 없습니다.",

--- a/voc-datalake/frontend/public/locales/pt/prioritization.json
+++ b/voc-datalake/frontend/public/locales/pt/prioritization.json
@@ -77,6 +77,8 @@
     "description": "Pontue cada documento em: <strong>Impacto</strong>, <strong>Tempo para o Mercado</strong>, <strong>Alinhamento Estratégico</strong> e <strong>Confiança</strong>.",
     "title": "Framework de Priorização"
   },
+  "headingCount_one": "{{count}} proposta",
+  "headingCount_other": "{{count}} propostas",
   "loading": "Carregando documentos...",
   "noteTooLong": {
     "description": "As notas são limitadas a {{max}} caracteres, e uma nota mais longa é recusada em vez de encurtada. Reduza a nota da linha que você editou e salve novamente. Nada foi salvo ainda.",

--- a/voc-datalake/frontend/public/locales/zh/prioritization.json
+++ b/voc-datalake/frontend/public/locales/zh/prioritization.json
@@ -77,6 +77,8 @@
     "description": "对每个文档进行评分：<strong>影响力</strong>、<strong>上市时间</strong>、<strong>战略契合度</strong>和<strong>置信度</strong>。",
     "title": "优先级排序框架"
   },
+  "headingCount_one": "{{count}} 个提案",
+  "headingCount_other": "{{count}} 个提案",
   "loading": "加载文档中...",
   "noteTooLong": {
     "description": "备注最多 {{max}} 个字符，超出长度的备注会被拒绝，而不会被截断。请缩短所编辑行的备注，然后重新保存。目前尚未保存任何内容。",

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1067,6 +1067,88 @@ describe('Prioritization', () => {
     })
   })
 
+  describe('the heading says how long the list is', () => {
+    /** The badge beside the `<h1>`, or null while it is withheld. */
+    const countBadge = () => document.getElementById('prioritization-row-count')
+
+    it('counts the rows the list below renders, with their noun', async () => {
+      // Two projects in the default harness, so two rows — p1's PRD and PR/FAQ are
+      // ONE row. Counting documents would say three, which is the miscount the stats
+      // cards already fixed once; this badge reads the same array the list maps over.
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(countBadge()).toHaveTextContent('2 proposals')
+      })
+      // Adjacent to the heading, not floated somewhere else on the page: the point is
+      // that a reader looking at the title can see the size without scrolling.
+      const heading = screen.getByRole('heading', { name: 'Prioritization' })
+      expect(heading.parentElement).toContainElement(countBadge())
+    })
+
+    it('agrees with the Total Proposals card', async () => {
+      // Two numbers for one quantity is how a page loses a reader's trust, which is
+      // the whole reason this badge exists. Both read `allRows`, and this is what
+      // holds them to it.
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(countBadge()).toBeInTheDocument()
+      })
+      const grid = screen.getByText('Total Proposals').closest<HTMLElement>('div.grid')
+      const total = within(grid as HTMLElement).getByText('Total Proposals')
+        .previousElementSibling?.textContent
+      expect(countBadge()?.textContent).toContain(total ?? '')
+    })
+
+    it('says nothing while the list is still being read', async () => {
+      // A `0` here would be a claim about a backlog nobody has read yet — and it is
+      // the one number a reader would take as "the list finished and it is empty".
+      // The list's own spinner already covers this state.
+      mockGetProjects.mockReturnValue(new Promise(() => {}))
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('Loading documents...')).toBeInTheDocument()
+      })
+      expect(countBadge()).toBeNull()
+      // The heading itself is never withheld — only the count.
+      expect(screen.getByText('Prioritization')).toBeInTheDocument()
+    })
+
+    it('reads zero once the read lands empty', async () => {
+      // The opposite state, and the one the badge is most use in: the read finished
+      // and there is genuinely nothing, which a reader can now tell apart from a read
+      // that never landed.
+      mockGetProjects.mockResolvedValue({ projects: [] })
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
+      })
+      expect(countBadge()).toHaveTextContent('0 proposals')
+    })
+
+    it('counts a single row in the singular', async () => {
+      // `count` interpolation, so an English reader gets "1 proposal" rather than
+      // "1 proposals" — and every locale carries an `_other` form, so no reader gets
+      // a raw key path.
+      useLayout(oneRowPerDocument([
+        { document_id: 'd1', document_type: 'prfaq', title: 'Only One', created_at: '2025-01-01' },
+      ]))
+      mockGetPrioritizationScores.mockResolvedValue({ rows: DEFAULT_ROWS, scores: {}, aggregates: {} })
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(countBadge()).toHaveTextContent('1 proposal')
+      })
+      expect(countBadge()).not.toHaveTextContent('1 proposals')
+    })
+  })
+
   describe('loading state', () => {
     it('shows loading spinner while fetching', async () => {
       mockGetProjects.mockReturnValue(new Promise(() => {})) // Never resolves

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1071,72 +1071,45 @@ describe('Prioritization', () => {
     /** The badge beside the `<h1>`, or null while it is withheld. */
     const countBadge = () => document.getElementById('prioritization-row-count')
 
+    // Every withholding state below leaves `collectRows` at the same `0` an empty backlog
+    // gives, so the shared question is only ever whether that `0` was earned — and why an
+    // unearned one is the worst thing this badge could say is `rowCountPublishable`'s
+    // docstring. Each test names its own state and nothing more.
+
     it('counts the rows the list below renders, with their noun', async () => {
-      // Two projects in the default harness, so two rows — p1's PRD and PR/FAQ are
-      // ONE row. Counting documents would say three, which is the miscount the stats
-      // cards already fixed once; this badge reads the same array the list maps over.
+      // Two projects in the default harness, so two rows — p1's PRD and PR/FAQ are ONE row.
+      // Counting documents would say three, the miscount the stats cards already fixed once.
       renderPrioritization()
 
       await waitFor(() => {
         expect(countBadge()).toHaveTextContent('2 proposals')
       })
-      // Adjacent to the heading, not floated somewhere else on the page: the point is
-      // that a reader looking at the title can see the size without scrolling.
+      // Adjacent to the heading, so the size is readable without scrolling to find it.
       const heading = screen.getByRole('heading', { name: 'Prioritization' })
       expect(heading.parentElement).toContainElement(countBadge())
     })
 
     it('agrees with the Total Proposals card', async () => {
-      // Two numbers for one quantity is how a page loses a reader's trust, which is
-      // the whole reason this badge exists. Both read `allRows`, and this is what
-      // holds them to it.
+      // Two numbers for one quantity is how a page loses a reader's trust, which is the whole
+      // reason this badge exists. Both read `allRows`; this is what holds them to it.
       renderPrioritization()
 
       await waitFor(() => {
         expect(countBadge()).toBeInTheDocument()
       })
-      // The card carries no id and no test id, so its value is reachable only by
-      // adjacency — which has to be ASSERTED rather than shrugged at, or this test passes
-      // on a page that no longer has the card. Both steps used to be silent on failure:
-      // `total ?? ''` turned a moved value node into `toContain('')`, and a substring
-      // check on a bare numeral let a card reading `1` agree with `11 proposals`.
+      // The card has no id, so its value is reachable only by adjacency — which has to be
+      // asserted, or this passes on a page that no longer has the card. Both steps were once
+      // silent on failure: `total ?? ''` turned a moved value node into `toContain('')`, and a
+      // substring check let a card reading `1` agree with `11 proposals`. Hence the exact
+      // value, not `toBeTruthy()`, and the full badge string, noun included.
       const label = screen.getByText('Total Proposals')
       const total = label.previousElementSibling?.textContent
-      // The harness has two rows, so the card's own value is known: `toBeTruthy()` would
-      // pass for the string `'0'` and say nothing about which number agreed with which.
       expect(total).toBe('2')
-      // The FULL string, exactly: the badge's own noun is what makes this a comparison
-      // of two claims rather than of two digits.
       expect(countBadge()?.textContent).toBe(`${total} proposals`)
     })
 
-    it('does not contradict the Total Proposals card when a read fails', async () => {
-      // The case above only ever visits the state where both reads succeed, so it can
-      // never catch a DISAGREEMENT. Here the fan-out fails and the badge, which a reader
-      // takes as a statement about the whole backlog, says nothing at all — silence is the
-      // only non-contradicting thing available, since no number here is known to be the
-      // backlog's size.
-      //
-      // The card is NOT asserted. `StatsCards` renders `{rows.length}` unconditionally, so
-      // it still publishes a `0` labelled "Total Proposals" about this same unread backlog.
-      // That is pre-existing and out of scope for this change — but pinning it here would
-      // make a future fix to the card (dashing it on an unread rows source, which is what
-      // the reasoning behind this badge implies) arrive as a red test in the very file that
-      // argued for it.
-      mockGetProject.mockRejectedValue(new Error('500'))
-
-      renderPrioritization()
-
-      await waitFor(() => {
-        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
-      })
-      expect(countBadge()).toBeNull()
-    })
-
     it('says nothing while the list is still being read', async () => {
-      // A `0` here would be a claim about a backlog nobody has read yet (why that is the
-      // worst number this badge can print: `rowCountPublishable`). Nothing is lost by
-      // staying quiet — the list's own spinner already covers this state.
+      // Nothing is lost by staying quiet: the list's own spinner already covers this state.
       mockGetProjects.mockReturnValue(new Promise(() => {}))
 
       renderPrioritization()
@@ -1150,9 +1123,8 @@ describe('Prioritization', () => {
     })
 
     it('reads zero once the read lands empty', async () => {
-      // The opposite state, and the one the badge is most use in: the read finished
-      // and there is genuinely nothing, which a reader can now tell apart from a read
-      // that never landed.
+      // The state the badge is most use in: the read finished and there is genuinely nothing,
+      // which a reader can now tell apart from a read that never landed.
       mockGetProjects.mockResolvedValue({ projects: [] })
 
       renderPrioritization()
@@ -1164,9 +1136,7 @@ describe('Prioritization', () => {
     })
 
     it('counts a single row in the singular', async () => {
-      // `count` interpolation, so an English reader gets "1 proposal" rather than
-      // "1 proposals" — and every locale carries an `_other` form, so no reader gets
-      // a raw key path.
+      // `count` interpolation, so an English reader gets "1 proposal" (see the JSX for why).
       useLayout(oneRowPerDocument([
         { document_id: 'd1', document_type: 'prfaq', title: 'Only One', created_at: '2025-01-01' },
       ]))
@@ -1181,10 +1151,10 @@ describe('Prioritization', () => {
     })
 
     it('says nothing when the projects read fails', async () => {
-      // The regression the gate was changed for: a failed projects read settles with
-      // `isLoading === false` and `collectRows` at `[]`, so the old "is the list in flight"
-      // gate printed "0 proposals" about a backlog it never read. This read has NO error
-      // panel, so the badge was the only thing on screen that could have said otherwise.
+      // The regression the gate was changed for: a failed read settles with
+      // `isLoading === false`, so the old "is the list in flight" gate published here — and
+      // this read has no error panel, leaving the badge the only thing that could say
+      // otherwise.
       mockGetProjects.mockRejectedValue(new Error('500'))
 
       renderPrioritization()
@@ -1193,15 +1163,18 @@ describe('Prioritization', () => {
         expect(screen.getByText('No Documents Found')).toBeInTheDocument()
       })
       expect(countBadge()).toBeNull()
-      // The heading is never withheld — only the claim about the list's length.
       expect(screen.getByRole('heading', { name: 'Prioritization' })).toBeInTheDocument()
     })
 
     it('says nothing when the project fan-out fails', async () => {
-      // The other half, and the more confidently wrong one: the projects list LANDED, so
-      // the page holds proof there is a backlog, and it is the per-project read that
-      // failed. `collectRows` short-circuits on either being absent, so this state read
-      // "0 proposals" too.
+      // The more confidently wrong half: the projects list LANDED, so the page holds proof
+      // there is a backlog and it is the per-project read that failed. Silence is the only
+      // non-contradicting thing available, no number here being known to be the backlog's size.
+      //
+      // The Total Proposals card is NOT asserted: `StatsCards` renders `{rows.length}`
+      // unconditionally, so it still publishes a `0` about this same unread backlog. That is
+      // pre-existing and out of scope — and pinning it here would make a future fix to the card
+      // arrive as a red test in the very file that argued for it.
       mockGetProject.mockRejectedValue(new Error('500'))
 
       renderPrioritization()
@@ -1213,38 +1186,32 @@ describe('Prioritization', () => {
     })
 
     it('says nothing when the rows themselves could not be read', async () => {
-      // The third input, and the last hole in this gate. Both project reads land here, so
-      // `collectRows` gets past its short-circuits — but the MAP it counts comes from the
-      // scores read and the create asks, and neither answers. `allRows` is `[]` for a
-      // backlog nobody read, which is the same lie as the two above.
-      //
-      // The create asks have to fail too, and that is not padding: when they answer they
-      // hand back the rows they confirmed, the list renders them, and the badge counting
-      // them is CORRECT even with the scores read still pending. Only "no row source has
-      // answered" is a withholding state.
+      // The third input: both project reads land, so `collectRows` gets past its
+      // short-circuits, but the map it counts comes from the scores read and the create asks.
+      // Both have to fail, and that is not padding — when the create asks answer they hand
+      // back the rows they confirmed, and counting those is CORRECT with the scores read still
+      // pending.
       mockGetPrioritizationScores.mockRejectedValue(new Error('500'))
       mockCreatePrioritizationRow.mockRejectedValue(new Error('500'))
 
       renderPrioritization()
 
-      // Waited on the empty state, not on the panel: the panel appears the moment the
-      // scores read fails, which can be before the project reads settle — and while they
-      // are unsettled the badge is withheld for a reason this test is not about.
+      // Waited on the empty state, not the panel: the panel appears the moment the scores read
+      // fails, which can be before the project reads settle — and the badge is withheld there
+      // for a reason this test is not about.
       await waitFor(() => {
         expect(screen.getByText('No Documents Found')).toBeInTheDocument()
       })
       expect(countBadge()).toBeNull()
-      // Unlike the two project reads, this state DOES have words on screen. Both are
-      // asserted together on purpose: the panel is the reason this gap was deferred once,
-      // and the badge is withheld anyway, because "we could not read the scores" is not a
-      // licence to publish a number about the rows.
+      // Both asserted together: unlike the project reads this state has words on screen, and
+      // "we could not read the scores" is still no licence to publish a number about the rows.
       expect(screen.getByRole('alert', { name: 'Scores could not be loaded' })).toBeInTheDocument()
     })
 
     it('counts rows, not projects', async () => {
       // Two projects, ONE row: p2 holds only a research document, which the create route
-      // refuses and `rowsFor` composes no row for. So `rowCount={projects.length}` would
-      // read "2 proposals" here and every other case in this block would still pass it.
+      // refuses and `rowsFor` composes no row for. `rowCount={projects.length}` would read
+      // "2 proposals" here, and every other case in this block would still pass it.
       const details = [
         {
           project_id: 'p1',
@@ -1268,16 +1235,14 @@ describe('Prioritization', () => {
       await waitFor(() => {
         expect(countBadge()).toHaveTextContent('1 proposal')
       })
-      // And the row that does exist is on screen, so "1" is the list's length rather than
-      // a count of something that failed to render.
+      // And the row that does exist is on screen, so "1" is the list's length rather than a
+      // count of something that failed to render.
       expect(screen.getByText('Scorable')).toBeInTheDocument()
     })
 
     it('associates the heading with the count for a screen reader', async () => {
-      // The badge sits OUTSIDE the `<h1>` deliberately — folding it in would make a
-      // landmark heading's accessible name move with the data — so a screen reader
-      // reaching the heading meets "Prioritization" and nothing else unless the
-      // association is explicit.
+      // The badge sits OUTSIDE the `<h1>` (see the JSX), so a screen reader reaching the
+      // heading meets "Prioritization" and nothing else unless the association is explicit.
       renderPrioritization()
 
       await waitFor(() => {
@@ -1285,16 +1250,14 @@ describe('Prioritization', () => {
       })
       const heading = screen.getByRole('heading', { name: 'Prioritization' })
       expect(heading).toHaveAttribute('aria-describedby', 'prioritization-row-count')
-      // Described, not named: the accessible name is still the title alone, which is what
-      // the rest of this suite queries the heading by.
+      // Described, not named: the accessible name is still the title alone, which is what the
+      // rest of this suite queries the heading by.
       expect(heading).toHaveAccessibleName('Prioritization')
       expect(heading).toHaveAccessibleDescription('2 proposals')
     })
 
     it('describes the heading with nothing while the count is withheld', async () => {
-      // A dangling IDREF is worse than no description: it resolves to nothing, and the
-      // attribute has to be dropped with the badge rather than left pointing at an id
-      // that is no longer in the document.
+      // The attribute has to be dropped with the badge, never left dangling (see the JSX).
       mockGetProjects.mockRejectedValue(new Error('500'))
 
       renderPrioritization()

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.test.tsx
@@ -1095,16 +1095,48 @@ describe('Prioritization', () => {
       await waitFor(() => {
         expect(countBadge()).toBeInTheDocument()
       })
-      const grid = screen.getByText('Total Proposals').closest<HTMLElement>('div.grid')
-      const total = within(grid as HTMLElement).getByText('Total Proposals')
-        .previousElementSibling?.textContent
-      expect(countBadge()?.textContent).toContain(total ?? '')
+      // The card carries no id and no test id, so its value is reachable only by
+      // adjacency — which has to be ASSERTED rather than shrugged at, or this test passes
+      // on a page that no longer has the card. Both steps used to be silent on failure:
+      // `total ?? ''` turned a moved value node into `toContain('')`, and a substring
+      // check on a bare numeral let a card reading `1` agree with `11 proposals`.
+      const label = screen.getByText('Total Proposals')
+      const total = label.previousElementSibling?.textContent
+      // The harness has two rows, so the card's own value is known: `toBeTruthy()` would
+      // pass for the string `'0'` and say nothing about which number agreed with which.
+      expect(total).toBe('2')
+      // The FULL string, exactly: the badge's own noun is what makes this a comparison
+      // of two claims rather than of two digits.
+      expect(countBadge()?.textContent).toBe(`${total} proposals`)
+    })
+
+    it('does not contradict the Total Proposals card when a read fails', async () => {
+      // The case above only ever visits the state where both reads succeed, so it can
+      // never catch a DISAGREEMENT. Here the fan-out fails and the badge, which a reader
+      // takes as a statement about the whole backlog, says nothing at all — silence is the
+      // only non-contradicting thing available, since no number here is known to be the
+      // backlog's size.
+      //
+      // The card is NOT asserted. `StatsCards` renders `{rows.length}` unconditionally, so
+      // it still publishes a `0` labelled "Total Proposals" about this same unread backlog.
+      // That is pre-existing and out of scope for this change — but pinning it here would
+      // make a future fix to the card (dashing it on an unread rows source, which is what
+      // the reasoning behind this badge implies) arrive as a red test in the very file that
+      // argued for it.
+      mockGetProject.mockRejectedValue(new Error('500'))
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
+      })
+      expect(countBadge()).toBeNull()
     })
 
     it('says nothing while the list is still being read', async () => {
-      // A `0` here would be a claim about a backlog nobody has read yet — and it is
-      // the one number a reader would take as "the list finished and it is empty".
-      // The list's own spinner already covers this state.
+      // A `0` here would be a claim about a backlog nobody has read yet (why that is the
+      // worst number this badge can print: `rowCountPublishable`). Nothing is lost by
+      // staying quiet — the list's own spinner already covers this state.
       mockGetProjects.mockReturnValue(new Promise(() => {}))
 
       renderPrioritization()
@@ -1146,6 +1178,133 @@ describe('Prioritization', () => {
         expect(countBadge()).toHaveTextContent('1 proposal')
       })
       expect(countBadge()).not.toHaveTextContent('1 proposals')
+    })
+
+    it('says nothing when the projects read fails', async () => {
+      // The regression the gate was changed for: a failed projects read settles with
+      // `isLoading === false` and `collectRows` at `[]`, so the old "is the list in flight"
+      // gate printed "0 proposals" about a backlog it never read. This read has NO error
+      // panel, so the badge was the only thing on screen that could have said otherwise.
+      mockGetProjects.mockRejectedValue(new Error('500'))
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
+      })
+      expect(countBadge()).toBeNull()
+      // The heading is never withheld — only the claim about the list's length.
+      expect(screen.getByRole('heading', { name: 'Prioritization' })).toBeInTheDocument()
+    })
+
+    it('says nothing when the project fan-out fails', async () => {
+      // The other half, and the more confidently wrong one: the projects list LANDED, so
+      // the page holds proof there is a backlog, and it is the per-project read that
+      // failed. `collectRows` short-circuits on either being absent, so this state read
+      // "0 proposals" too.
+      mockGetProject.mockRejectedValue(new Error('500'))
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
+      })
+      expect(countBadge()).toBeNull()
+    })
+
+    it('says nothing when the rows themselves could not be read', async () => {
+      // The third input, and the last hole in this gate. Both project reads land here, so
+      // `collectRows` gets past its short-circuits — but the MAP it counts comes from the
+      // scores read and the create asks, and neither answers. `allRows` is `[]` for a
+      // backlog nobody read, which is the same lie as the two above.
+      //
+      // The create asks have to fail too, and that is not padding: when they answer they
+      // hand back the rows they confirmed, the list renders them, and the badge counting
+      // them is CORRECT even with the scores read still pending. Only "no row source has
+      // answered" is a withholding state.
+      mockGetPrioritizationScores.mockRejectedValue(new Error('500'))
+      mockCreatePrioritizationRow.mockRejectedValue(new Error('500'))
+
+      renderPrioritization()
+
+      // Waited on the empty state, not on the panel: the panel appears the moment the
+      // scores read fails, which can be before the project reads settle — and while they
+      // are unsettled the badge is withheld for a reason this test is not about.
+      await waitFor(() => {
+        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
+      })
+      expect(countBadge()).toBeNull()
+      // Unlike the two project reads, this state DOES have words on screen. Both are
+      // asserted together on purpose: the panel is the reason this gap was deferred once,
+      // and the badge is withheld anyway, because "we could not read the scores" is not a
+      // licence to publish a number about the rows.
+      expect(screen.getByRole('alert', { name: 'Scores could not be loaded' })).toBeInTheDocument()
+    })
+
+    it('counts rows, not projects', async () => {
+      // Two projects, ONE row: p2 holds only a research document, which the create route
+      // refuses and `rowsFor` composes no row for. So `rowCount={projects.length}` would
+      // read "2 proposals" here and every other case in this block would still pass it.
+      const details = [
+        {
+          project_id: 'p1',
+          documents: [{ document_id: 'd1', document_type: 'prfaq', title: 'Scorable', content: '', created_at: '2025-01-01' }],
+        },
+        {
+          project_id: 'p2',
+          documents: [{ document_id: 'r1', document_type: 'research', title: 'Research Only', content: '', created_at: '2025-01-01' }],
+        },
+      ]
+      mockGetProject.mockImplementation((id: string) => Promise.resolve(
+        details.find((detail) => detail.project_id === id) ?? { documents: [] },
+      ))
+      mockGetPrioritizationScores.mockResolvedValue({ rows: rowsFor(details), scores: {}, aggregates: {} })
+      mockCreatePrioritizationRow.mockImplementation((projectId: string) => Promise.resolve({
+        success: true, created: false, row: rowsFor(details)[rowId(projectId)],
+      }))
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(countBadge()).toHaveTextContent('1 proposal')
+      })
+      // And the row that does exist is on screen, so "1" is the list's length rather than
+      // a count of something that failed to render.
+      expect(screen.getByText('Scorable')).toBeInTheDocument()
+    })
+
+    it('associates the heading with the count for a screen reader', async () => {
+      // The badge sits OUTSIDE the `<h1>` deliberately — folding it in would make a
+      // landmark heading's accessible name move with the data — so a screen reader
+      // reaching the heading meets "Prioritization" and nothing else unless the
+      // association is explicit.
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(countBadge()).toBeInTheDocument()
+      })
+      const heading = screen.getByRole('heading', { name: 'Prioritization' })
+      expect(heading).toHaveAttribute('aria-describedby', 'prioritization-row-count')
+      // Described, not named: the accessible name is still the title alone, which is what
+      // the rest of this suite queries the heading by.
+      expect(heading).toHaveAccessibleName('Prioritization')
+      expect(heading).toHaveAccessibleDescription('2 proposals')
+    })
+
+    it('describes the heading with nothing while the count is withheld', async () => {
+      // A dangling IDREF is worse than no description: it resolves to nothing, and the
+      // attribute has to be dropped with the badge rather than left pointing at an id
+      // that is no longer in the document.
+      mockGetProjects.mockRejectedValue(new Error('500'))
+
+      renderPrioritization()
+
+      await waitFor(() => {
+        expect(screen.getByText('No Documents Found')).toBeInTheDocument()
+      })
+      expect(countBadge()).toBeNull()
+      expect(screen.getByRole('heading', { name: 'Prioritization' }))
+        .not.toHaveAttribute('aria-describedby')
     })
   })
 

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -396,16 +396,14 @@ function PRFAQList({
 }
 
 /**
- * The row-count badge's id — spelled once because TWO attributes depend on it agreeing.
- *
- * The badge carries it and the `<h1>`'s `aria-describedby` points at it, and a typo in
- * either is silent: the page looks right, the description resolves to nothing, and only a
- * screen reader notices.
+ * The row-count badge's id — spelled once because TWO attributes must agree on it. The badge
+ * carries it, the `<h1>`'s `aria-describedby` points at it, and a typo in either is silent:
+ * the page looks right, the description resolves to nothing, only a screen reader notices.
  *
  * A LITERAL, unlike `SortControls`' `useId()` one above, because two things outside the
- * render need to name it: the test helper that reaches the badge by id, and the
- * `abca-verify` block that checks `#prioritization-row-count` on the deployed page. A
- * generated id is unknowable from outside the render tree, so neither could select it.
+ * render tree select it — the test helper reaching the badge by id, and the `abca-verify`
+ * block checking `#prioritization-row-count` on the deployed page — and neither can know a
+ * generated one.
  */
 const ROW_COUNT_ID = 'prioritization-row-count'
 
@@ -415,21 +413,14 @@ function PrioritizationHeader({
   readonly hasChanges: boolean
   readonly isPending: boolean
   /**
-   * Has anything earned the right to state `rowCount`? The difference between "nothing is
-   * here" and "nothing arrived", which is the whole point of putting a number next to the
-   * heading.
-   *
-   * `rowCountPublishable`, over the three inputs the count is derived from. Which states
-   * answer false, why an empty projects list is not one of them, and why the question is
-   * not "is the list still loading" are all its docstring's — not restated here.
+   * Has anything earned the right to state `rowCount` — "nothing is here" as against "nothing
+   * arrived". Which states answer false, and why, is `rowCountPublishable`'s docstring.
    */
   readonly countPublishable: boolean
   /**
-   * How many rows the list below renders — `allRows.length`, the SAME array
-   * `PRFAQList` maps over and the same one "Total Proposals" counts, so the badge
-   * cannot disagree with either. Not the project count: a project holding a PRD and
-   * a PR/FAQ about one idea is one row, and this number is offered to a reader
-   * checking whether the list they can see finished loading.
+   * How many rows the list below renders — `allRows.length`, the SAME array `PRFAQList` maps
+   * over and "Total Proposals" counts, so the badge cannot disagree with either. Not the
+   * project count: one project's PRD and PR/FAQ about one idea are one row.
    */
   readonly rowCount: number
   /**
@@ -482,22 +473,17 @@ function PrioritizationHeader({
           {/* DESCRIBED BY the count, not named by it. The badge is a sibling of the `<h1>`
               rather than a child on purpose: folding it in would make a landmark heading's
               accessible name change with the data ("Prioritization 3"), and every
-              `getByRole('heading', { name: 'Prioritization' })` on this page — and in its
-              suite — would be querying a name that moves.
+              `getByRole('heading', { name: 'Prioritization' })` here and in the suite
+              would be querying a name that moves.
 
-              `aria-describedby` is a MODEST improvement rather than the thing that closes
-              the gap, and worth stating as one. The badge is a text sibling immediately
-              after the heading, so linear reading meets the count either way; what the
-              attribute adds is heading-jump navigation, where the name alone is all that
-              is announced. The cost is that a heading jump now announces the count twice.
-              Also a departure from precedent worth knowing about: every other
-              `aria-describedby` in this codebase describes something FOCUSABLE, and a
-              static heading is the first non-interactive target — the case where
-              screen-reader support is least consistent.
-
-              Conditional on the same boolean as the badge, so the IDREF is never dangling.
-              A description pointing at nothing is worse than none: it resolves to empty
-              and some readers announce the raw id instead. */}
+              A MODEST improvement, not the thing that closes the gap: the badge is a text
+              sibling right after the heading, so linear reading meets the count either way,
+              and what this adds is heading-jump navigation, where the name alone is
+              announced — at the cost of announcing the count twice there. A first here too,
+              every other `aria-describedby` in this codebase describing something FOCUSABLE,
+              and static targets being where screen-reader support is least consistent.
+              Conditional on the badge's own boolean, so the IDREF never dangles: pointing at
+              nothing resolves to empty and some readers announce the raw id. */}
           <h1
             aria-describedby={countPublishable ? ROW_COUNT_ID : undefined}
             className="text-xl sm:text-2xl font-bold text-gray-900"
@@ -505,24 +491,21 @@ function PrioritizationHeader({
             {t('title')}
           </h1>
           {/* How long the list below is, next to the heading, so a reader can tell at a
-              glance whether everything loaded rather than scrolling to find out.
+              glance whether everything loaded. WITHHELD rather than `0` in every state that
+              has not earned a number — which states those are is `rowCountPublishable`'s.
 
-              WITHHELD rather than `0` in every state that has not earned a number — which
-              states those are, and why a `0` there is the worst thing this badge could
-              say, is `rowCountPublishable`'s docstring.
+              The COUNT WITH ITS NOUN ("3 proposals"), not a bare numeral: beside a heading a
+              lone number has no subject, and the description above announces "3" into a
+              sentence of its own. `count` interpolation picks the plural, and every locale
+              carries both `_one` and `_other` (see `stats.unreadable`) so no reader gets a
+              raw key path. The key is a LITERAL with the condition outside `t(...)`:
+              `i18n-check` only sees a key it reads verbatim, so a ternary inside the call
+              reports both forms unused.
 
-              Renders the COUNT WITH ITS NOUN ("3 proposals") rather than a bare numeral:
-              beside a heading, a lone number has no subject, and the description above
-              announces "3" into a sentence of its own. `count` interpolation picks the
-              plural form, and every locale carries both `_one` and `_other` (see
-              `stats.unreadable`) so no reader gets a raw key path. The key is a LITERAL
-              with the condition outside `t(...)`: `i18n-check` only sees a key it reads
-              verbatim, so a ternary inside the call reports both forms unused.
-
-              `text-gray-600` per the measured contrast table in `BAND_STYLE`, which is
-              measured on exactly the background this badge sets for itself — `bg-gray-100`
-              #f3f4f6 — where gray-600 is 6.87:1 and gray-500 fails AA at 4.39:1. The
-              page's own background never comes into it; the pill covers it. */}
+              `text-gray-600` per the measured contrast table in `BAND_STYLE`, measured on
+              exactly the background this badge sets for itself — `bg-gray-100` #f3f4f6, where
+              gray-600 is 6.87:1 and gray-500 fails AA at 4.39:1. The pill covers the page's
+              own background, so that never comes into it. */}
           {countPublishable ? (
             <span id={ROW_COUNT_ID} className="rounded-full bg-gray-100 px-2 py-0.5 text-xs sm:text-sm font-medium text-gray-600">
               {t('headingCount', { count: rowCount })}
@@ -953,17 +936,14 @@ export default function Prioritization() {
       <PrioritizationHeader
         hasChanges={hasChanges}
         isPending={saveMutation.isPending}
-        // The same three inputs `allRows` is built from, not `isLoading`: a read that
-        // failed reaches `isLoading === false` with the same `0` an empty backlog has.
-        // Which states that publishes and which it withholds is `rowCountPublishable`'s
-        // docstring, and its unit tests.
+        // The same three inputs `allRows` is built from, not `isLoading`: a read that failed
+        // reaches `isLoading === false` with the same `0` an empty backlog has.
         countPublishable={rowCountPublishable({
           projects,
           details: allProjectDetails,
           savedScores,
           ensuredRows,
         })}
-        // The list's own array, so the badge counts exactly the rows rendered below.
         rowCount={allRows.length}
         saveBlocked={!ownBallots.inHand || overLongNotes.length > 0}
         onReset={handleReset}

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -33,8 +33,8 @@ import PRFAQRow from './PRFAQRow'
 import {
   applyBallotEdits, getScore, getTeamView, collectRows, isScorable,
   MAX_NOTE_LENGTH, normalizeAggregates, normalizeRow, normalizeRows, normalizeScores, ownBallotRead,
-  overLongNoteRows, priorityBand, projectsNeedingARow, READ_STATE_I18N_KEY, sortRows,
-  teamAggregatesOf, teamOrderingAvailable, uncountableTeamRead, withEditedField,
+  overLongNoteRows, priorityBand, projectsNeedingARow, READ_STATE_I18N_KEY, rowCountPublishable,
+  sortRows, teamAggregatesOf, teamOrderingAvailable, uncountableTeamRead, withEditedField,
 } from './prioritizationUtils'
 import type {
   PrioritizationRowView, SortField, SortDirection, TeamAggregates,
@@ -395,18 +395,35 @@ function PRFAQList({
   )
 }
 
+/**
+ * The row-count badge's id — spelled once because TWO attributes depend on it agreeing.
+ *
+ * The badge carries it and the `<h1>`'s `aria-describedby` points at it, and a typo in
+ * either is silent: the page looks right, the description resolves to nothing, and only a
+ * screen reader notices.
+ *
+ * A LITERAL, unlike `SortControls`' `useId()` one above, because two things outside the
+ * render need to name it: the test helper that reaches the badge by id, and the
+ * `abca-verify` block that checks `#prioritization-row-count` on the deployed page. A
+ * generated id is unknowable from outside the render tree, so neither could select it.
+ */
+const ROW_COUNT_ID = 'prioritization-row-count'
+
 function PrioritizationHeader({
-  hasChanges, isPending, isLoading, rowCount, saveBlocked, onReset, onSave,
+  hasChanges, isPending, countPublishable, rowCount, saveBlocked, onReset, onSave,
 }: {
   readonly hasChanges: boolean
   readonly isPending: boolean
   /**
-   * Is the list below still being fetched? Counts the difference between "nothing
-   * is here" and "nothing has arrived yet", which is the whole point of putting a
-   * number next to the heading: a bare `0` beside a spinner would be the page
-   * claiming an empty backlog it has not read.
+   * Has anything earned the right to state `rowCount`? The difference between "nothing is
+   * here" and "nothing arrived", which is the whole point of putting a number next to the
+   * heading.
+   *
+   * `rowCountPublishable`, over the three inputs the count is derived from. Which states
+   * answer false, why an empty projects list is not one of them, and why the question is
+   * not "is the list still loading" are all its docstring's — not restated here.
    */
-  readonly isLoading: boolean
+  readonly countPublishable: boolean
   /**
    * How many rows the list below renders — `allRows.length`, the SAME array
    * `PRFAQList` maps over and the same one "Total Proposals" counts, so the badge
@@ -462,29 +479,55 @@ function PrioritizationHeader({
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
         <div className="flex items-center gap-2">
-          <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
+          {/* DESCRIBED BY the count, not named by it. The badge is a sibling of the `<h1>`
+              rather than a child on purpose: folding it in would make a landmark heading's
+              accessible name change with the data ("Prioritization 3"), and every
+              `getByRole('heading', { name: 'Prioritization' })` on this page — and in its
+              suite — would be querying a name that moves.
+
+              `aria-describedby` is a MODEST improvement rather than the thing that closes
+              the gap, and worth stating as one. The badge is a text sibling immediately
+              after the heading, so linear reading meets the count either way; what the
+              attribute adds is heading-jump navigation, where the name alone is all that
+              is announced. The cost is that a heading jump now announces the count twice.
+              Also a departure from precedent worth knowing about: every other
+              `aria-describedby` in this codebase describes something FOCUSABLE, and a
+              static heading is the first non-interactive target — the case where
+              screen-reader support is least consistent.
+
+              Conditional on the same boolean as the badge, so the IDREF is never dangling.
+              A description pointing at nothing is worse than none: it resolves to empty
+              and some readers announce the raw id instead. */}
+          <h1
+            aria-describedby={countPublishable ? ROW_COUNT_ID : undefined}
+            className="text-xl sm:text-2xl font-bold text-gray-900"
+          >
+            {t('title')}
+          </h1>
           {/* How long the list below is, next to the heading, so a reader can tell at a
               glance whether everything loaded rather than scrolling to find out.
 
-              Withheld while the read is in flight: a `0` here would be a claim about a
-              backlog nobody has read yet, and it is the one number on this page a reader
-              would take as "the list finished and it is empty". The list below already
-              shows a spinner for that state, so nothing is lost by staying quiet.
+              WITHHELD rather than `0` in every state that has not earned a number — which
+              states those are, and why a `0` there is the worst thing this badge could
+              say, is `rowCountPublishable`'s docstring.
 
               Renders the COUNT WITH ITS NOUN ("3 proposals") rather than a bare numeral:
-              beside a heading, a lone number has no subject, and a screen reader
-              announcing "Prioritization 3" says nothing. `count` interpolation picks the
+              beside a heading, a lone number has no subject, and the description above
+              announces "3" into a sentence of its own. `count` interpolation picks the
               plural form, and every locale carries both `_one` and `_other` (see
-              `stats.unreadable`) so no reader gets a raw key path.
+              `stats.unreadable`) so no reader gets a raw key path. The key is a LITERAL
+              with the condition outside `t(...)`: `i18n-check` only sees a key it reads
+              verbatim, so a ternary inside the call reports both forms unused.
 
-              `text-gray-600` per the measured contrast table in `BAND_STYLE`: gray-500
-              fails AA below 18.5px on a gray background, and this badge is text-sm on
-              the page's gray-50. */}
-          {isLoading ? null : (
-            <span id="prioritization-row-count" className="rounded-full bg-gray-100 px-2 py-0.5 text-xs sm:text-sm font-medium text-gray-600">
+              `text-gray-600` per the measured contrast table in `BAND_STYLE`, which is
+              measured on exactly the background this badge sets for itself — `bg-gray-100`
+              #f3f4f6 — where gray-600 is 6.87:1 and gray-500 fails AA at 4.39:1. The
+              page's own background never comes into it; the pill covers it. */}
+          {countPublishable ? (
+            <span id={ROW_COUNT_ID} className="rounded-full bg-gray-100 px-2 py-0.5 text-xs sm:text-sm font-medium text-gray-600">
               {t('headingCount', { count: rowCount })}
             </span>
-          )}
+          ) : null}
         </div>
         <p className="text-sm sm:text-base text-gray-500 mt-1">{t('subtitle')}</p>
       </div>
@@ -910,7 +953,16 @@ export default function Prioritization() {
       <PrioritizationHeader
         hasChanges={hasChanges}
         isPending={saveMutation.isPending}
-        isLoading={isLoading}
+        // The same three inputs `allRows` is built from, not `isLoading`: a read that
+        // failed reaches `isLoading === false` with the same `0` an empty backlog has.
+        // Which states that publishes and which it withholds is `rowCountPublishable`'s
+        // docstring, and its unit tests.
+        countPublishable={rowCountPublishable({
+          projects,
+          details: allProjectDetails,
+          savedScores,
+          ensuredRows,
+        })}
         // The list's own array, so the badge counts exactly the rows rendered below.
         rowCount={allRows.length}
         saveBlocked={!ownBallots.inHand || overLongNotes.length > 0}

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.tsx
@@ -396,10 +396,25 @@ function PRFAQList({
 }
 
 function PrioritizationHeader({
-  hasChanges, isPending, saveBlocked, onReset, onSave,
+  hasChanges, isPending, isLoading, rowCount, saveBlocked, onReset, onSave,
 }: {
   readonly hasChanges: boolean
   readonly isPending: boolean
+  /**
+   * Is the list below still being fetched? Counts the difference between "nothing
+   * is here" and "nothing has arrived yet", which is the whole point of putting a
+   * number next to the heading: a bare `0` beside a spinner would be the page
+   * claiming an empty backlog it has not read.
+   */
+  readonly isLoading: boolean
+  /**
+   * How many rows the list below renders — `allRows.length`, the SAME array
+   * `PRFAQList` maps over and the same one "Total Proposals" counts, so the badge
+   * cannot disagree with either. Not the project count: a project holding a PRD and
+   * a PR/FAQ about one idea is one row, and this number is offered to a reader
+   * checking whether the list they can see finished loading.
+   */
+  readonly rowCount: number
   /**
    * True while a save cannot honestly be made, for either of two reasons.
    *
@@ -446,7 +461,31 @@ function PrioritizationHeader({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
-        <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{t('title')}</h1>
+          {/* How long the list below is, next to the heading, so a reader can tell at a
+              glance whether everything loaded rather than scrolling to find out.
+
+              Withheld while the read is in flight: a `0` here would be a claim about a
+              backlog nobody has read yet, and it is the one number on this page a reader
+              would take as "the list finished and it is empty". The list below already
+              shows a spinner for that state, so nothing is lost by staying quiet.
+
+              Renders the COUNT WITH ITS NOUN ("3 proposals") rather than a bare numeral:
+              beside a heading, a lone number has no subject, and a screen reader
+              announcing "Prioritization 3" says nothing. `count` interpolation picks the
+              plural form, and every locale carries both `_one` and `_other` (see
+              `stats.unreadable`) so no reader gets a raw key path.
+
+              `text-gray-600` per the measured contrast table in `BAND_STYLE`: gray-500
+              fails AA below 18.5px on a gray background, and this badge is text-sm on
+              the page's gray-50. */}
+          {isLoading ? null : (
+            <span id="prioritization-row-count" className="rounded-full bg-gray-100 px-2 py-0.5 text-xs sm:text-sm font-medium text-gray-600">
+              {t('headingCount', { count: rowCount })}
+            </span>
+          )}
+        </div>
         <p className="text-sm sm:text-base text-gray-500 mt-1">{t('subtitle')}</p>
       </div>
       <div className="flex items-center gap-2 sm:gap-3">
@@ -871,6 +910,9 @@ export default function Prioritization() {
       <PrioritizationHeader
         hasChanges={hasChanges}
         isPending={saveMutation.isPending}
+        isLoading={isLoading}
+        // The list's own array, so the badge counts exactly the rows rendered below.
+        rowCount={allRows.length}
         saveBlocked={!ownBallots.inHand || overLongNotes.length > 0}
         onReset={handleReset}
         onSave={() => saveMutation.mutate()}

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -11,6 +11,7 @@ import {
   getPriorityLabel, priorityBand, reviewersDisagreed, sortRows, getTeamView, teamScoreOf,
   applyBallotEdits, withEditedField, teamAggregatesOf, teamReadDelivered, normalizeScores,
   ownBallotRead, UNREADABLE_ROW, teamOrderingAvailable, uncountableTeamRead,
+  rowCountPublishable,
 } from './prioritizationUtils'
 import type { TeamAggregates, TeamAggregateRow, PrioritizationRowView } from './prioritizationUtils'
 import type { PrioritizationScore, PrioritizationAggregate, ProjectDocument } from '../../api/types'
@@ -385,6 +386,118 @@ describe('collectRows resolves stored rows against the documents on screen', () 
     )
 
     expect(rows[0].prototype).toBeUndefined()
+  })
+})
+
+/**
+ * A wire value that is NOT a list, where the declared type promises one.
+ *
+ * Parsed from JSON rather than cast into place, because that is how such a value
+ * genuinely reaches the page: the response type is a promise about the wire, not a proof
+ * of it, and `JSON.parse` is the one seam where the promise stops being checked.
+ */
+const notAList = (json: string): readonly unknown[] => JSON.parse(json)
+
+describe('rowCountPublishable withholds a count no read has earned', () => {
+  // `collectRows` answers `[]` whenever ANY of its three inputs is absent — the two
+  // project reads it short-circuits on, and the rows map that sets the number — so an
+  // unlanded read produces exactly the `0` an empty backlog does. Why that `0` is the
+  // worst number this badge could print is the predicate's own docstring.
+  //
+  // Two cases discriminate this predicate from the shapes it could have had: an empty
+  // projects list, where the details result is legitimately `undefined` because the query
+  // never ran, and a scores read that LANDED carrying an empty rows map, which is a real
+  // deployment rather than an unread one.
+
+  /** Both project reads landed, so only the row-source clause is left to decide. */
+  const projectReadsLanded = {
+    projects: [{ project_id: 'p1' }],
+    details: [{ documents: [] }],
+  }
+
+  it('withholds while the reads are still in flight', () => {
+    expect(rowCountPublishable({})).toBe(false)
+    expect(rowCountPublishable({ projects: undefined, details: undefined })).toBe(false)
+  })
+  it('withholds when the projects read failed', () => {
+    // The bug this predicate replaced: nothing is loading here, so the page printed
+    // "0 proposals" about a backlog it never read, with no error panel to contradict it.
+    // Indistinguishable from in-flight in these facts alone, and deliberately so — both
+    // answer "no list has landed", and the failure is the state that does not fix itself.
+    expect(rowCountPublishable({ projects: undefined })).toBe(false)
+  })
+  it('withholds when the projects landed but the detail fan-out failed', () => {
+    // The projects list in hand PROVES there is a backlog, which makes a `0` here the
+    // more confidently wrong of the two.
+    expect(rowCountPublishable({ projects: [{ project_id: 'p1' }], details: undefined })).toBe(false)
+  })
+  it('publishes when the projects read landed empty — the honest zero', () => {
+    // `undefined` details is not a failure here: the fan-out is enabled on a non-empty id
+    // list, so it never ran. Withholding would silence the state the badge is most use in.
+    //
+    // No row source either, and that is the point: this short-circuits BEFORE the
+    // row-source clause, because a projects read that landed empty has already said the
+    // whole backlog is empty and no rows map can add to it.
+    expect(rowCountPublishable({ projects: [], details: undefined })).toBe(true)
+  })
+  it('publishes when both reads landed and the scores read brought rows', () => {
+    expect(rowCountPublishable({
+      ...projectReadsLanded,
+      savedScores: { rows: { row_p1_default: {} } },
+    })).toBe(true)
+  })
+  it('publishes an empty fan-out result — it landed, it just carried nothing', () => {
+    expect(rowCountPublishable({
+      projects: [{ project_id: 'p1' }],
+      details: [],
+      savedScores: { rows: {} },
+    })).toBe(true)
+  })
+  it('publishes when the scores read landed carrying an EMPTY rows map', () => {
+    // A deployment with projects but genuinely no rows. The row-source clause asks whether
+    // a response ARRIVED, not whether it carried anything — the read said so, and that is
+    // the same kind of honest zero the empty projects list gets.
+    expect(rowCountPublishable({ ...projectReadsLanded, savedScores: { rows: {} } })).toBe(true)
+    // An absent `rows` field is the same fact: a deployment predating rows still answered.
+    expect(rowCountPublishable({ ...projectReadsLanded, savedScores: {} })).toBe(true)
+  })
+  it('withholds while no row source has answered yet', () => {
+    // The gap the earlier two-fact predicate published for. Both project reads landed, so
+    // `collectRows` no longer short-circuits — but the map that sets the number is still
+    // empty, because the scores read is paging and no create ask has handed a row back.
+    // The page printed "0 proposals" here with the list below showing "No Documents Found"
+    // and nothing at all on screen contradicting it.
+    expect(rowCountPublishable(projectReadsLanded)).toBe(false)
+    expect(rowCountPublishable({
+      ...projectReadsLanded, savedScores: undefined, ensuredRows: {},
+    })).toBe(false)
+  })
+  it('withholds when the scores read failed with no row ensured', () => {
+    // The same facts as in flight, and deliberately so — both say "no row source has
+    // answered". The difference is not in the facts but in the outcome: here that `0`
+    // would be TERMINAL rather than a moment old. The error panel above the list does
+    // report this read, which is more than the project reads get, but a number about rows
+    // nobody read is not made true by an apology beside it.
+    expect(rowCountPublishable({ ...projectReadsLanded, ensuredRows: {} })).toBe(false)
+  })
+  it('publishes on an ensured row alone, with the scores read still pending', () => {
+    // The common path: one round trip after the details land, the create asks hand back
+    // the rows they confirmed and the list renders them. EITHER half of the merged map is
+    // enough, because the page counts whichever arrived.
+    expect(rowCountPublishable({
+      ...projectReadsLanded,
+      ensuredRows: { row_p1_default: {} },
+    })).toBe(true)
+  })
+  it('withholds when the projects field arrives as something other than a list', () => {
+    // The page reads `projects` through `Array.isArray` for the same reason: the declared
+    // response type is a promise about the wire, not a proof, and a lie there leaves
+    // `collectRows` at `[]` exactly as a failure does.
+    // An object with a `length` is the pointed one: `!== undefined` would publish it,
+    // and `.length === 0` would too for `{"length":0}`.
+    expect(rowCountPublishable({ projects: notAList('{"length":0}') })).toBe(false)
+    expect(rowCountPublishable({ projects: notAList('"two"') })).toBe(false)
+    expect(rowCountPublishable({ projects: notAList('null') })).toBe(false)
   })
 })
 

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.test.ts
@@ -389,25 +389,13 @@ describe('collectRows resolves stored rows against the documents on screen', () 
   })
 })
 
-/**
- * A wire value that is NOT a list, where the declared type promises one.
- *
- * Parsed from JSON rather than cast into place, because that is how such a value
- * genuinely reaches the page: the response type is a promise about the wire, not a proof
- * of it, and `JSON.parse` is the one seam where the promise stops being checked.
- */
+/** A wire value that is NOT a list where the declared type promises one. Parsed from JSON
+ * rather than cast, `JSON.parse` being the seam where that type stops being checked. */
 const notAList = (json: string): readonly unknown[] => JSON.parse(json)
 
 describe('rowCountPublishable withholds a count no read has earned', () => {
-  // `collectRows` answers `[]` whenever ANY of its three inputs is absent — the two
-  // project reads it short-circuits on, and the rows map that sets the number — so an
-  // unlanded read produces exactly the `0` an empty backlog does. Why that `0` is the
-  // worst number this badge could print is the predicate's own docstring.
-  //
-  // Two cases discriminate this predicate from the shapes it could have had: an empty
-  // projects list, where the details result is legitimately `undefined` because the query
-  // never ran, and a scores read that LANDED carrying an empty rows map, which is a real
-  // deployment rather than an unread one.
+  // Every withholding case below leaves `collectRows` at the same `0` an empty backlog gives;
+  // why an unearned `0` is the worst number this badge could print is the predicate's docstring.
 
   /** Both project reads landed, so only the row-source clause is left to decide. */
   const projectReadsLanded = {
@@ -420,24 +408,20 @@ describe('rowCountPublishable withholds a count no read has earned', () => {
     expect(rowCountPublishable({ projects: undefined, details: undefined })).toBe(false)
   })
   it('withholds when the projects read failed', () => {
-    // The bug this predicate replaced: nothing is loading here, so the page printed
-    // "0 proposals" about a backlog it never read, with no error panel to contradict it.
-    // Indistinguishable from in-flight in these facts alone, and deliberately so — both
-    // answer "no list has landed", and the failure is the state that does not fix itself.
+    // The bug this predicate replaced, and indistinguishable from in-flight in these facts
+    // alone: nothing is loading, so the page published about a backlog it never read.
     expect(rowCountPublishable({ projects: undefined })).toBe(false)
   })
   it('withholds when the projects landed but the detail fan-out failed', () => {
-    // The projects list in hand PROVES there is a backlog, which makes a `0` here the
-    // more confidently wrong of the two.
+    // The projects list in hand PROVES there is a backlog, making a `0` here the more
+    // confidently wrong of the two.
     expect(rowCountPublishable({ projects: [{ project_id: 'p1' }], details: undefined })).toBe(false)
   })
   it('publishes when the projects read landed empty — the honest zero', () => {
-    // `undefined` details is not a failure here: the fan-out is enabled on a non-empty id
-    // list, so it never ran. Withholding would silence the state the badge is most use in.
-    //
-    // No row source either, and that is the point: this short-circuits BEFORE the
-    // row-source clause, because a projects read that landed empty has already said the
-    // whole backlog is empty and no rows map can add to it.
+    // `undefined` details is not a failure here: the fan-out is enabled on a non-empty id list,
+    // so it never ran, and withholding would silence the state the badge is most use in. No row
+    // source either, which is the point — this short-circuits ahead of that clause, an empty
+    // projects read having already said the whole backlog is empty.
     expect(rowCountPublishable({ projects: [], details: undefined })).toBe(true)
   })
   it('publishes when both reads landed and the scores read brought rows', () => {
@@ -454,47 +438,39 @@ describe('rowCountPublishable withholds a count no read has earned', () => {
     })).toBe(true)
   })
   it('publishes when the scores read landed carrying an EMPTY rows map', () => {
-    // A deployment with projects but genuinely no rows. The row-source clause asks whether
-    // a response ARRIVED, not whether it carried anything — the read said so, and that is
-    // the same kind of honest zero the empty projects list gets.
+    // A deployment with projects but genuinely no rows. The row-source clause asks whether a
+    // response ARRIVED, not whether it carried anything, so this is the honest zero again.
     expect(rowCountPublishable({ ...projectReadsLanded, savedScores: { rows: {} } })).toBe(true)
     // An absent `rows` field is the same fact: a deployment predating rows still answered.
     expect(rowCountPublishable({ ...projectReadsLanded, savedScores: {} })).toBe(true)
   })
   it('withholds while no row source has answered yet', () => {
-    // The gap the earlier two-fact predicate published for. Both project reads landed, so
-    // `collectRows` no longer short-circuits — but the map that sets the number is still
-    // empty, because the scores read is paging and no create ask has handed a row back.
-    // The page printed "0 proposals" here with the list below showing "No Documents Found"
-    // and nothing at all on screen contradicting it.
+    // The gap the earlier two-fact predicate published for: both project reads landed, but the
+    // map that sets the number is still empty because the scores read is paging and no create
+    // ask has handed a row back. The page printed "0 proposals" under "No Documents Found".
     expect(rowCountPublishable(projectReadsLanded)).toBe(false)
     expect(rowCountPublishable({
       ...projectReadsLanded, savedScores: undefined, ensuredRows: {},
     })).toBe(false)
   })
   it('withholds when the scores read failed with no row ensured', () => {
-    // The same facts as in flight, and deliberately so — both say "no row source has
-    // answered". The difference is not in the facts but in the outcome: here that `0`
-    // would be TERMINAL rather than a moment old. The error panel above the list does
-    // report this read, which is more than the project reads get, but a number about rows
-    // nobody read is not made true by an apology beside it.
+    // The same facts as in flight, deliberately; the difference is in the outcome, that `0`
+    // being TERMINAL. This read does have an error panel, unlike the project reads, but a
+    // number about rows nobody read is not made true by an apology beside it.
     expect(rowCountPublishable({ ...projectReadsLanded, ensuredRows: {} })).toBe(false)
   })
   it('publishes on an ensured row alone, with the scores read still pending', () => {
-    // The common path: one round trip after the details land, the create asks hand back
-    // the rows they confirmed and the list renders them. EITHER half of the merged map is
-    // enough, because the page counts whichever arrived.
+    // The common path: a round trip after the details land, the create asks hand back the rows
+    // they confirmed. EITHER half of the merged map is enough, the page counting what arrived.
     expect(rowCountPublishable({
       ...projectReadsLanded,
       ensuredRows: { row_p1_default: {} },
     })).toBe(true)
   })
   it('withholds when the projects field arrives as something other than a list', () => {
-    // The page reads `projects` through `Array.isArray` for the same reason: the declared
-    // response type is a promise about the wire, not a proof, and a lie there leaves
-    // `collectRows` at `[]` exactly as a failure does.
-    // An object with a `length` is the pointed one: `!== undefined` would publish it,
-    // and `.length === 0` would too for `{"length":0}`.
+    // The page reads `projects` through `Array.isArray` for the same reason: a lie about the
+    // shape leaves `collectRows` at `[]` exactly as a failure does. An object with a `length`
+    // is the pointed case — `!== undefined` would publish it, and so would `.length === 0`.
     expect(rowCountPublishable({ projects: notAList('{"length":0}') })).toBe(false)
     expect(rowCountPublishable({ projects: notAList('"two"') })).toBe(false)
     expect(rowCountPublishable({ projects: notAList('null') })).toBe(false)

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -1333,6 +1333,73 @@ export function projectsNeedingARow(
 }
 
 /**
+ * May the page state how long the list is — or has nothing yet earned a number?
+ *
+ * Guards the badge beside the `<h1>`, off ALL THREE inputs `collectRows` derives the
+ * number from: the two project reads it short-circuits to `[]` on, and the rows map that
+ * actually sets the count. Any of the three being absent produces exactly the same `0` a
+ * genuinely empty backlog does. That `0` is the one number on this page a reader would
+ * take as "the list finished and it is empty": it is offered as a completeness check, so
+ * it is read as a statement about the whole backlog rather than about what happened to
+ * arrive. The same reasoning `StatsCards` records for dashing its three team-derived
+ * cards — a zero is a claim, and no failed read said anything about any document —
+ * applies here one query over, and with less to fall back on, since there is no error
+ * panel for the project reads at all.
+ *
+ * So NOT "is the list in flight": that withholds the badge for the one state that fixes
+ * itself and publishes it for the ones that do not. And not `details !== undefined`
+ * either, which is the trap this predicate exists to name: when the projects read lands
+ * as `[]` the details query never runs (`enabled: projectIds.length > 0`), so its
+ * `undefined` result is LEGITIMATE rather than a failure — and that is precisely the
+ * honest empty state the badge is most use in. Hence: the projects read landed AND (it
+ * named no projects OR (the details read landed AND a row source has landed)).
+ *
+ * A ROW SOURCE is either half of the map the page merges for `collectRows` — the
+ * prioritization read's own `rows`, or the rows the create asks handed back — and EITHER
+ * landing is enough, because the page renders whichever arrives first. A landed scores
+ * read carrying an EMPTY rows map publishes: the read answered, and a deployment with
+ * projects but no rows is a real state to report. Only "no row source has answered yet"
+ * withholds, which covers the window before the scores read delivers — it scans a
+ * partition over up to `MAX_PRIORITIZATION_PAGES` round trips — and its failure, where
+ * that `0` is terminal rather than transient.
+ *
+ * Takes the raw facts, and is exported and unit-tested without rendering, for the reason
+ * `ownBallotRead` and `uncountableTeamRead` are: the question is easy to spell wrong at a
+ * JSX gate where only one of its states is on screen, and it keeps the page's own branch
+ * count inside the lint budget.
+ *
+ * In-flight is subsumed rather than special-cased, for each of the three inputs: a read
+ * that has not delivered leaves its fact absent, and absence is what every clause here
+ * tests. The empty projects list is the one state that publishes on a fact being absent,
+ * and it short-circuits BEFORE the row-source clause is reached — for the reason given
+ * against `details !== undefined` above, which no rows map can add to.
+ *
+ * `Array.isArray` rather than `!== undefined` on the projects half, because the page
+ * treats a non-array `projects` as no list (see its `projectIds`) — the wire is a
+ * promise about the shape, not a proof of it, and a lie there must withhold too.
+ */
+export function rowCountPublishable(read: {
+  /** The projects list as the read yielded it — `undefined` in flight, or on failure. */
+  readonly projects?: readonly unknown[]
+  /** The per-project fan-out's result: `undefined` in flight, on failure, or when unrun. */
+  readonly details?: readonly unknown[]
+  /**
+   * The prioritization response, whatever it carried: `undefined` in flight or on
+   * failure. Its mere PRESENCE is the fact — a response with an empty or absent `rows`
+   * map is still the read answering, and answering is what earns the number.
+   */
+  readonly savedScores?: unknown
+  /** The rows the create asks handed back — empty until one of them answers. */
+  readonly ensuredRows?: Record<string, unknown>
+}): boolean {
+  if (!Array.isArray(read.projects)) return false
+  if (read.projects.length === 0) return true
+  const rowSourceLanded = read.savedScores !== undefined
+    || Object.keys(read.ensuredRows ?? {}).length > 0
+  return read.details !== undefined && rowSourceLanded
+}
+
+/**
  * The rows the page renders: the server's rows, resolved against the documents on
  * screen.
  *

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -1335,59 +1335,42 @@ export function projectsNeedingARow(
 /**
  * May the page state how long the list is — or has nothing yet earned a number?
  *
- * Guards the badge beside the `<h1>`, off ALL THREE inputs `collectRows` derives the
- * number from: the two project reads it short-circuits to `[]` on, and the rows map that
- * actually sets the count. Any of the three being absent produces exactly the same `0` a
- * genuinely empty backlog does. That `0` is the one number on this page a reader would
- * take as "the list finished and it is empty": it is offered as a completeness check, so
- * it is read as a statement about the whole backlog rather than about what happened to
- * arrive. The same reasoning `StatsCards` records for dashing its three team-derived
- * cards — a zero is a claim, and no failed read said anything about any document —
- * applies here one query over, and with less to fall back on, since there is no error
- * panel for the project reads at all.
+ * Guards the badge beside the `<h1>`, off ALL THREE inputs `collectRows` derives the number
+ * from: the two project reads it short-circuits to `[]` on, and the rows map that sets the
+ * count. Any absent one yields the `0` an empty backlog does, and the badge is offered as a
+ * completeness check — so that `0` reads as a claim about the whole backlog. `StatsCards`
+ * dashes its team-derived cards to avoid the same claim, with more to fall back on than
+ * this: the project reads have no error panel at all.
  *
- * So NOT "is the list in flight": that withholds the badge for the one state that fixes
- * itself and publishes it for the ones that do not. And not `details !== undefined`
- * either, which is the trap this predicate exists to name: when the projects read lands
- * as `[]` the details query never runs (`enabled: projectIds.length > 0`), so its
- * `undefined` result is LEGITIMATE rather than a failure — and that is precisely the
- * honest empty state the badge is most use in. Hence: the projects read landed AND (it
- * named no projects OR (the details read landed AND a row source has landed)).
+ * So NOT "is the list in flight", which withholds the one state that fixes itself and
+ * publishes the ones that do not; in-flight needs no case of its own, an undelivered read
+ * leaving its fact absent and absence being what every clause tests. Nor
+ * `details !== undefined`, the trap this exists to name: a projects read landing `[]` never
+ * runs the details query (`enabled: projectIds.length > 0`), so that `undefined` is
+ * LEGITIMATE, and it is the honest empty state the badge is most use in. Hence the empty list
+ * publishes, short-circuiting ahead of a row-source clause no rows map could add to.
  *
  * A ROW SOURCE is either half of the map the page merges for `collectRows` — the
  * prioritization read's own `rows`, or the rows the create asks handed back — and EITHER
- * landing is enough, because the page renders whichever arrives first. A landed scores
- * read carrying an EMPTY rows map publishes: the read answered, and a deployment with
- * projects but no rows is a real state to report. Only "no row source has answered yet"
- * withholds, which covers the window before the scores read delivers — it scans a
- * partition over up to `MAX_PRIORITIZATION_PAGES` round trips — and its failure, where
- * that `0` is terminal rather than transient.
+ * landing suffices, the page rendering whichever arrives first. A landed scores read carrying
+ * an EMPTY rows map publishes: it answered, and projects-but-no-rows is a real deployment.
+ * Only "no row source answered" withholds, covering the window before the scores read
+ * delivers (up to `MAX_PRIORITIZATION_PAGES` round trips) and its failure, where that `0` is
+ * terminal rather than transient.
  *
- * Takes the raw facts, and is exported and unit-tested without rendering, for the reason
- * `ownBallotRead` and `uncountableTeamRead` are: the question is easy to spell wrong at a
- * JSX gate where only one of its states is on screen, and it keeps the page's own branch
- * count inside the lint budget.
+ * `Array.isArray` rather than `!== undefined` on the projects half, because the page reads a
+ * non-array `projects` as no list (see its `projectIds`) — the wire promises the shape rather
+ * than proving it, and a lie there must withhold too.
  *
- * In-flight is subsumed rather than special-cased, for each of the three inputs: a read
- * that has not delivered leaves its fact absent, and absence is what every clause here
- * tests. The empty projects list is the one state that publishes on a fact being absent,
- * and it short-circuits BEFORE the row-source clause is reached — for the reason given
- * against `details !== undefined` above, which no rows map can add to.
- *
- * `Array.isArray` rather than `!== undefined` on the projects half, because the page
- * treats a non-array `projects` as no list (see its `projectIds`) — the wire is a
- * promise about the shape, not a proof of it, and a lie there must withhold too.
+ * Raw facts, so the question is unit-testable without rendering, as `ownBallotRead` and
+ * `uncountableTeamRead` are, and the page's own branch count stays inside the lint budget.
  */
 export function rowCountPublishable(read: {
   /** The projects list as the read yielded it — `undefined` in flight, or on failure. */
   readonly projects?: readonly unknown[]
   /** The per-project fan-out's result: `undefined` in flight, on failure, or when unrun. */
   readonly details?: readonly unknown[]
-  /**
-   * The prioritization response, whatever it carried: `undefined` in flight or on
-   * failure. Its mere PRESENCE is the fact — a response with an empty or absent `rows`
-   * map is still the read answering, and answering is what earns the number.
-   */
+  /** The prioritization response, whatever it carried: `undefined` in flight or on failure. */
   readonly savedScores?: unknown
   /** The rows the create asks handed back — empty until one of them answers. */
   readonly ensuredRows?: Record<string, unknown>
@@ -1427,6 +1410,11 @@ export function rowCountPublishable(read: {
  * deleted, would otherwise show nothing for. A prototype is context rather than
  * something the row is scored on, so a stale pointer there costs a reader a demo, not
  * the meaning of their ballot.
+ *
+ * MOVES WITH `rowCountPublishable`: the short-circuits below decide when the count is `[]`,
+ * that predicate decides when such a `[]` may be published as a number, and it RESTATES these
+ * guards rather than deriving from them. Change one without the other and the badge publishes
+ * a count for a state this function now answers `[]` for.
  */
 export function collectRows(
   rows: Record<string, PrioritizationRow>,


### PR DESCRIPTION
## Summary

The Prioritization heading said nothing about how long the list below it is, so a reader could not tell at a glance whether the backlog had finished loading. A small count badge now sits next to the `<h1>`:

- **Counts the rows the list actually renders** — `allRows.length`, the same array `PRFAQList` maps over and the same one the "Total Proposals" card counts. Two numbers for one quantity is how a page loses the trust this badge exists to earn, so it reads the one array rather than re-deriving a count (a test pins the badge and the card to each other).
- **Withheld while the read is in flight.** A `0` there would be a claim about a backlog nobody has read yet, and it is the one number a reader would take as "the list finished and it is empty" — precisely the wrong reading. The list below already shows a spinner for that state. Once the read lands, `0 proposals` is honest and is the state the badge is most use in.
- **Counted with its noun** (`3 proposals`, `1 proposal`) via `count` interpolation, not a bare numeral: beside a heading a lone number has no subject, and a screen reader announcing "Prioritization 3" says nothing. New key `headingCount_one` / `headingCount_other` added to all eight locales (de, en, es, fr, ja, ko, pt, zh), which keeps `localeParity.test.ts` and `i18n-check` happy — CJK locales get the `_other` form they need.
- `text-gray-600` on the badge, per the measured contrast table already recorded in `BAND_STYLE` (gray-500 fails AA below 18.5px on this page's gray-50 background).

**The table/list itself is untouched** — the diff is the header component, the wiring of one prop from the page, the eight locale files, and tests.

### Decisions made

- **Rows, not projects or documents.** A project whose PRD and PR/FAQ describe one idea is *one* row on this page, and the stats cards were already fixed once for counting documents instead. The badge counts what is on screen.
- **Hidden rather than dashed during loading.** The stats cards use an explained `—` because they are permanently-present cards with labels; a badge beside a heading has no label to hang an explanation on, and it can simply not be there for the second the read takes.
- **No `aria-live`.** It is not an update announcement, it is part of the heading area; it renders with the list it describes.

## Build and test results

| Command | Result |
|---|---|
| `npm run typecheck` (`tsc -b --noEmit`) | **pass** |
| `npm run lint` (`eslint . --max-warnings 0`) | **pass** |
| `vitest run src/pages/Prioritization/Prioritization.test.tsx` | **pass** — 81/81 (5 new) |
| `vitest run src/i18n src/pages/Prioritization` | **pass** — 363/363, 12 files |
| `node scripts/i18n-check.mjs` | **unchanged** — `Total missing: 0 / extra: 12 / empty: 0 / untranslated: 20`, byte-identical to the same run on a stashed tree |
| `mise run build` | **not runnable** — `mise ERROR no tasks defined`; there is no mise task file in this repo |
| `vite build` (the real build, run directly) | **fails in this container for an environment reason, not the change**: `EMFILE: too many open files` from `lucide-react`'s per-icon ESM files. `ulimit -n` is 1024 and hard-capped, so it cannot be raised here; each rerun dies a few hundred modules further along at a different import. `tsc -b` — the type-checking half of `npm run build` — passes cleanly, and the setup notes record the build already failing before any of my changes. |

New tests, all of which fail without the change:

- counts the rows the list below renders, with their noun (and asserts the badge is the heading's sibling, i.e. actually *next to* it)
- agrees with the Total Proposals card
- says nothing while the list is still being read
- reads zero once the read lands empty
- counts a single row in the singular (`1 proposal`, not `1 proposals`)

```abca-verify
selector h1
selector #prioritization-row-count
text #prioritization-row-count "proposal"
no-console-errors
```

The three assertions are chosen to hold on an empty preview database: with no projects the read lands empty and the badge renders `0 proposals`, so the `text` line matches on the noun rather than on any seeded count. The badge's `id` is one I added, so it is a stable selector.

## Agent notes

**What went well.** This page turned out to have already solved the hard version of the problem twice, so the work was mostly a matter of not re-solving it differently. `StatsCards` had a long comment explaining exactly why "Total Proposals" counts rows and not documents, and why the other three cards dash rather than print `0` when the team read is uncountable — that reasoning transferred directly to the loading state of the badge, and reusing `allRows.length` (rather than counting projects, or `sortedRows`) is what let me write a test asserting the badge and the card agree.

**What was difficult.** The build. `mise run build` does not exist in this repo, and the real `vite build` cannot complete in this container: `lucide-react` ships one file per icon, the fd limit is 1024 and hard-capped, and the build dies with `EMFILE` at a different module each run. I verified the type-checking half (`tsc -b`) separately, which is the half that could plausibly be broken by a source change, and leaned on the test suite for the rest. Also worth knowing: `npx <pkg>` fails in this container (`npm error Lock compromised`) — `npm install` in `voc-datalake/frontend` and then `./node_modules/.bin/vitest` works.

**Conventions discovered.**
- Locale JSON is `json.dumps(..., indent=2, sort_keys=True)` exactly — keys sorted, two-space, trailing newline. I confirmed this by round-tripping all eight files before editing, which is worth doing: an unsorted insert produces a large spurious diff.
- Three separate gates watch i18n and they check different things: `localeParity.test.ts` (same key set everywhere, plus every English-pluralized key must have `_other` or a bare form in every locale), `i18nKeys.test.ts` (no colons in key paths — `:` is i18next's `nsSeparator` and this app depends on it), and `scripts/i18n-check.mjs` (missing/extra/empty/untranslated *and* unused keys). A new key must satisfy all three; the useful trick is to run `i18n-check` on a stashed tree and diff the totals, since it reports pre-existing noise.
- Keys must be **literals** inside `t(...)`. A ternary choosing between two keys inside the call makes `i18n-check` report both as unused — the existing code puts the condition outside the call and there are comments saying so.
- Comments in this codebase explain *why not* as much as *why*. I matched that register; the alternatives I rejected (bare numeral, `0` while loading, dashing like the cards) are written down at the code rather than only here.
- No `data-testid` anywhere in `src` — tests select by role and text. I added an `id` instead, which the page already uses for `aria-labelledby` targets and which the verify block needs.

**Suggestions for future tasks.**
- Adding a `mise.toml` (or setting `pipeline.buildCommand` to `npm run build`) would turn on the build gate that is currently inert. Bundling `lucide-react` imports, or raising the container fd limit, would make that build actually completable.
- `Prioritization.tsx` is ~1030 lines with four components in it; `PrioritizationHeader`, `StatsCards` and `SortControls` are independent and would each be easier to touch as their own file.
- `Prioritization.test.tsx` is ~2260 lines. Its `oneRowPerDocument` / `useLayout` / `R` proxy harness is genuinely good and worth reading before writing any new test on this page — but the file is at the point where splitting by concern (scores, read failures, notes, chrome) would help.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).