### PR TITLE
test(mcp): prove every declared outputSchema against a real payload shape

### DIFF
--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -41,7 +41,37 @@ REVERT STORY — which mutation makes which assertion fail:
       exists to end. Its own positive control is
       test_the_completeness_check_notices_a_tool_with_no_sample: the check is a
       function, called with a registry missing an entry, so "the check cannot
-      detect anything" is itself a failure.
+      detect anything" is itself a failure. It compares SET DIFFERENCES rather
+      than asserting `== [victim]`, so it does not also fail whenever an
+      unrelated tool is missing a sample — a control that fails alongside its
+      own subject cannot say which of the two broke.
+
+  test_every_declared_property_is_demonstrated_by_some_sample
+    — the SUBSTANCE half of the above, because the presence half counts dict
+      keys rather than evidence. Both metrics tools end at
+      `ToolResult(body if isinstance(body, dict) else {})` and declare no
+      `required`, so a route body of `{}` is a SUCCESSFUL call whose empty
+      payload validates against an open schema: replacing only those two tools'
+      bodies with `{}` once left every case green. Now it names the properties
+      the sample failed to produce. Its own positive control is
+      test_the_substance_check_notices_a_sample_that_demonstrates_nothing, which
+      hollows a sample and requires the check to object.
+
+  TestTheDerivationsSurviveAnUnusualDeclaration
+    — nothing read at IMPORT time may raise on a declaration a client accepts.
+      `_closed_schema_tools()` and `_closed_item_schemas()` run inside
+      `@pytest.mark.parametrize`, so a raise there is a collection error that
+      aborts all ~2200 `lambda/api` tests and is attributed to whatever ran
+      next. Two declarations did exactly that: a published tool with no
+      `outputSchema` (`KeyError`, in place of the precise message §5.4's test
+      already carries) and a boolean sub-schema, which Draft 2020-12 permits and
+      `check_schema` accepts (`AttributeError`) — this file crashing on a schema
+      it also certifies as valid. Both now degrade to "no schema, closes
+      nothing", leaving the §5.4 test the single named reporter. The tolerance
+      has its own positive control, test_the_derivations_still_find_the_real
+      _closures: making `_output_schema` return `{}` unconditionally would
+      satisfy that whole class while rendering the file vacuous, since an empty
+      schema validates every payload.
 
   test_a_real_payload_validates_against_its_declared_output_schema
     — the guard proper. Verified non-vacuous two ways rather than by inspection:
@@ -450,12 +480,46 @@ _REQUIRED_HINTS: tuple[str, ...] = (
     "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint",
 )
 
+# Declared top-level properties that no sample can demonstrate, `tool` → `{prop}`.
+#
+# 🔑 EMPTY, and it must stay hard to add to. Every property declared by the six
+# tools published today is carried by at least one sample payload, so
+# `test_every_declared_property_is_demonstrated_by_some_sample` passes on arrival
+# — which is the point, exactly as with the §5.4 class: it is here so a Phase 3
+# tool cannot satisfy the sample requirement with a route body of `{}`.
+#
+# An entry here is a claim that a declared property CANNOT appear in any real
+# answer, which is nearly always a sign the declaration is wrong rather than the
+# sample. Anything added needs a comment saying why the route can never produce
+# it; if the honest reason is "I did not want to build the body", the answer is to
+# build the body.
+_PROPERTIES_NO_SAMPLE_CAN_SHOW: dict[str, frozenset[str]] = {}
+
 
 def _output_schema(name: str) -> dict:
-    """One tool's declared `outputSchema`, read from the published registry."""
+    """One tool's declared `outputSchema`, read from the published registry.
+
+    🔑 CANNOT raise for a published tool. `tool["outputSchema"]` was here first
+    and a published tool declaring none raised a bare `KeyError` — from inside
+    `_closed_schema_tools()` and `_closed_item_schemas()`, which are evaluated in
+    `@pytest.mark.parametrize` decorators, so at MODULE IMPORT. That is a
+    collection error aborting every test in `lambda/api` (2184 of them), and the
+    message a Phase 3 author reads is `KeyError: 'outputSchema'` rather than
+    `test_every_tool_declares_what_section_5_4_requires`'s
+    `f"{name} declares no outputSchema"` — the assertion written for exactly this
+    case, which never gets to run. `"outputSchema": None` was the same abort with
+    an `AttributeError` instead.
+
+    So a missing or non-dict declaration degrades to `{}`: an empty schema is
+    open and validates anything, `_closed_schema_tools()` reports the tool as not
+    closed, `_closed_item_schemas()` finds no arrays in it, and the §5.4 test
+    stays the single named reporter of the gap. Pinned by
+    `TestTheDerivationsSurviveAnUnusualDeclaration`.
+    """
     for tool in mcp_handler.MCP_TOOLS:
         if tool["name"] == name:
-            return tool["outputSchema"]
+            declared = tool.get("outputSchema")
+            return declared if isinstance(declared, dict) else {}
     raise AssertionError(f"no published tool named {name}")
 
 
@@ -524,6 +588,29 @@ def _rejects_at(payload, schema: dict, path: tuple) -> bool:
     return any(p[: len(path)] == path for p in _error_paths(payload, schema))
 
 
+def _first_sample(tool: str) -> tuple[str, dict, dict]:
+    """This tool's first registered `(case, arguments, bodies)` triple.
+
+    🔑 `_TOOL_SAMPLES[tool][0]` was written directly at seven sites, and the
+    controls that use them are parametrised from the PUBLISHED registry rather
+    than from `_TOOL_SAMPLES` — deliberately, since the two disagreeing is the
+    state this file exists to report. So a published tool with no sample turned
+    four of those controls into bare `KeyError` tracebacks that say nothing about
+    samples, drowning the three tests that do name the tool.
+    `test_every_published_tool_has_a_registered_sample_payload` stays the single
+    authoritative reporter; this just makes the collateral failures legible.
+    """
+    samples = _TOOL_SAMPLES.get(tool) or ()
+    if not samples:
+        pytest.fail(
+            f"{tool} is published and has no registered sample; add one to "
+            "_TOOL_SAMPLES, taken from the shape the delegated route really "
+            "returns. test_every_published_tool_has_a_registered_sample_payload "
+            "is the authoritative report of this."
+        )
+    return samples[0]
+
+
 def _tools_missing_samples(registry: dict) -> list[str]:
     """Published tools with no sample in this registry.
 
@@ -551,6 +638,64 @@ def _closed_schema_tools() -> list[str]:
     ]
 
 
+def _subschemas(schema: dict) -> dict:
+    """A schema's `properties` map, with anything that is not a dict schema dropped.
+
+    🔑 A sub-schema in Draft 2020-12 may be a BOOLEAN, not only an object:
+    `{"properties": {"x": true}}` is well-formed — `check_schema` accepts it —
+    and means "any value here", while `false` means "nothing is valid here".
+    `declared.get("type")` on one of those raised
+    `AttributeError: 'bool' object has no attribute 'get'`, and because
+    `_closed_item_schemas()` is evaluated in a `@pytest.mark.parametrize`
+    decorator the raise landed at module import: a collection error aborting all
+    2184 `lambda/api` tests, on a declaration this very file also certifies as
+    valid via `test_the_declaration_is_itself_a_valid_json_schema`.
+
+    A boolean sub-schema constrains no keys and closes no door, so dropping it
+    here is not a loss of coverage — it is the derivation saying "nothing to
+    control", which is what `test_some_array_closes_its_item_schema` then
+    reports if that were ever true of every array. No published tool uses one
+    today; Phase 3's ~thirty declarations are where an unusual-but-legal
+    construct first shows up. Pinned by
+    `TestTheDerivationsSurviveAnUnusualDeclaration`.
+    """
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+    return {k: v for k, v in properties.items() if isinstance(v, dict)}
+
+
+def _undemonstrated_properties(tool: str, registry: dict) -> set[str]:
+    """Declared top-level properties that no sample payload for `tool` carries.
+
+    🔑 The substance half of the completeness check, and it exists because the
+    presence half counts ENTRIES rather than evidence. Both metrics tools end at
+    `ToolResult(body if isinstance(body, dict) else {})` and declare no
+    `required`, so a route body of `{}` is a fully SUCCESSFUL call producing
+    `structuredContent: {}` — which validates against an open schema, satisfies
+    `_payload`'s error checks, and turns `-NO-SAMPLE` green while demonstrating
+    nothing. Replacing only those two tools' bodies with `{}` left all 52 cases
+    passing before this function existed.
+
+    Union across a tool's cases rather than per-case, because the cases exist
+    precisely to cover different branches: `get_metrics_breakdown`'s `sentiment`
+    dimension cannot carry `categories`, and demanding every case show every
+    property would be demanding one route answer with another's fields.
+
+    A property whose absence is legitimate goes in
+    `_PROPERTIES_NO_SAMPLE_CAN_SHOW` with a reason, so the exemption is a line of
+    the diff rather than a silence.
+    """
+    declared = set(_subschemas(_output_schema(tool)))
+    if not declared:
+        return set()
+    demonstrated: set[str] = set()
+    for _case, arguments, bodies in registry.get(tool) or ():
+        payload = _payload(tool, arguments, bodies)
+        demonstrated |= set(payload)
+    return declared - demonstrated - _PROPERTIES_NO_SAMPLE_CAN_SHOW.get(tool, frozenset())
+
+
 def _closed_item_schemas() -> list[tuple[str, str]]:
     """`(tool, array property)` for every array whose ITEMS close the door.
 
@@ -562,10 +707,13 @@ def _closed_item_schemas() -> list[tuple[str, str]]:
     """
     found = []
     for name in _PUBLISHED_TOOL_NAMES:
-        for prop, declared in (_output_schema(name).get("properties") or {}).items():
+        for prop, declared in _subschemas(_output_schema(name)).items():
             if declared.get("type") != "array":
                 continue
-            if (declared.get("items") or {}).get("additionalProperties") is False:
+            items = declared.get("items")
+            # `items` may be a boolean for the same reason a sub-schema may be:
+            # `{"items": true}` is legal and closes nothing.
+            if isinstance(items, dict) and items.get("additionalProperties") is False:
                 found.append((name, prop))
     return found
 
@@ -606,13 +754,188 @@ class TestEveryToolBringsASample:
         nothing" cannot be because the check finds nothing ever. Deleting the
         `_tools_missing_samples` body to `return []` fails HERE, with the name of
         the tool it should have reported.
+
+        🔑 A set DIFFERENCE against the unthinned registry, not
+        `== [victim]`. Exact equality made this control fail whenever some OTHER
+        tool was also missing a sample — `assert ['get_feedback_detail',
+        'search_feedback'] == ['search_feedback']` — so the control failed
+        alongside the very thing it controls and could not say which of the two
+        broke. That is the same reasoning `_rejects_at` needed its own positive
+        control for: a control must be sensitive to its own subject and to
+        nothing else.
         """
         victim = _PUBLISHED_TOOL_NAMES[0]
+        already = set(_tools_missing_samples(_TOOL_SAMPLES))
         thinned = {k: v for k, v in _TOOL_SAMPLES.items() if k != victim}
 
-        assert _tools_missing_samples(thinned) == [victim]
+        assert set(_tools_missing_samples(thinned)) - already == {victim}
         # An empty entry is as useless as an absent one and must read the same.
-        assert _tools_missing_samples({**_TOOL_SAMPLES, victim: ()}) == [victim]
+        assert set(
+            _tools_missing_samples({**_TOOL_SAMPLES, victim: ()})
+        ) - already == {victim}
+
+    @pytest.mark.parametrize("tool", _PUBLISHED_TOOL_NAMES)
+    def test_every_declared_property_is_demonstrated_by_some_sample(self, tool):
+        """A registered sample must EXERCISE the declaration, not merely exist.
+
+        🔑 The presence check above is satisfied by a dict key. For a tool with an
+        open schema and no `required` — which is both metrics tools, and the
+        archetype for Phase 3's pass-through tools — a route body of `{}` yields a
+        successful call with `structuredContent: {}` that validates, so every
+        assertion in this file passes while nothing about the declaration was
+        tested. Emptying only those two tools' bodies left 52/52 green.
+
+        Requiring every declared property to appear in the union of a tool's
+        payloads is what makes the registry un-gameable: a `{}` body now names the
+        seven properties it failed to show.
+        """
+        undemonstrated = _undemonstrated_properties(tool, _TOOL_SAMPLES)
+
+        assert undemonstrated == set(), (
+            f"{tool} declares {sorted(undemonstrated)} and no registered sample "
+            "produces them, so nothing here validates those declarations. Give "
+            "the sample a route body that carries them — or, if a real answer "
+            "genuinely cannot, add them to _PROPERTIES_NO_SAMPLE_CAN_SHOW with "
+            "the reason."
+        )
+
+    def test_the_substance_check_notices_a_sample_that_demonstrates_nothing(self):
+        """The positive control for the check above — the same shape of mutation
+        that used to pass unnoticed.
+
+        A registry whose route bodies are all `{}` is the exact loophole: the call
+        succeeds, the payload is empty, and only a substance check objects. If
+        `_undemonstrated_properties` were reduced to `return set()`, this is the
+        one test that fails.
+        """
+        # An open schema with no `required`, so `{}` really is a valid payload —
+        # a closed-schema tool would fail for the unrelated reason that its
+        # projection cannot produce `{}`.
+        victim = next(
+            (
+                name for name in _PUBLISHED_TOOL_NAMES
+                if _output_schema(name).get("additionalProperties") is not False
+                and not _output_schema(name).get("required")
+                and _subschemas(_output_schema(name))
+                and _TOOL_SAMPLES.get(name)
+            ),
+            None,
+        )
+        assert victim, (
+            "no published tool has an open, unrequired schema, so the `{}`-body "
+            "loophole this control is about no longer exists; delete it and say so"
+        )
+
+        case, arguments, bodies = _first_sample(victim)
+        # A distinct dict per route: `dict.fromkeys(bodies, {})` would share one
+        # object across every route, which `_FakeLambda` could mutate through.
+        hollowed = {
+            **_TOOL_SAMPLES,
+            victim: ((case, arguments, {route: {} for route in bodies}),),
+        }
+
+        assert _undemonstrated_properties(victim, _TOOL_SAMPLES) == set()
+        assert _undemonstrated_properties(victim, hollowed), (
+            f"{victim}'s sample was reduced to an empty route body and the "
+            "substance check still found every declared property demonstrated"
+        )
+
+
+# ===========================================================================
+# The derivations — robust against a legal but unusual declaration
+# ===========================================================================
+
+class TestTheDerivationsSurviveAnUnusualDeclaration:
+    """Nothing read at import time may raise on a declaration a client accepts.
+
+    🔑 `_closed_schema_tools()` and `_closed_item_schemas()` are evaluated inside
+    `@pytest.mark.parametrize` decorators, so anything they raise is a COLLECTION
+    error: all 2184 tests in `lambda/api` abort, attributed to whatever ran next,
+    and no pull-request gate would report it (the one workflow runs a single
+    stdlib-only file). Two declarations did exactly that —
+
+      • no `outputSchema` at all → `KeyError: 'outputSchema'`, in place of
+        `test_every_tool_declares_what_section_5_4_requires`'s precise
+        `f"{name} declares no outputSchema"`, which never got to run;
+      • a BOOLEAN sub-schema, which Draft 2020-12 permits and
+        `check_schema` accepts → `AttributeError: 'bool' object has no
+        attribute 'get'`, i.e. this file crashing on a schema it also certifies.
+
+    — so the file's own primary anticipated failure mode degraded into the least
+    diagnostic signal available. These tests keep the degradation graceful, which
+    is what leaves the §5.4 test as the single named reporter.
+    """
+
+    def test_a_tool_declaring_no_output_schema_reads_as_an_empty_schema(self, monkeypatch):
+        """No raise, and no false claim that the tool closes anything."""
+        published = [dict(tool) for tool in mcp_handler.MCP_TOOLS]
+        published[0].pop("outputSchema", None)
+        monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
+
+        assert _output_schema(published[0]["name"]) == {}
+        assert published[0]["name"] not in _closed_schema_tools()
+        assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+
+    def test_a_tool_whose_output_schema_is_not_a_dict_reads_as_an_empty_schema(
+        self, monkeypatch
+    ):
+        """`"outputSchema": None` was the same abort with a different exception."""
+        published = [dict(tool) for tool in mcp_handler.MCP_TOOLS]
+        published[0]["outputSchema"] = None
+        monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
+
+        assert _output_schema(published[0]["name"]) == {}
+        assert published[0]["name"] not in _closed_schema_tools()
+
+    def test_a_boolean_sub_schema_is_skipped_rather_than_crashing_the_derivation(
+        self, monkeypatch
+    ):
+        """`{"properties": {"x": true}}` is legal, means "anything", closes nothing.
+
+        Asserted to be legal here rather than assumed, so the test says WHY the
+        derivation has to tolerate it: `check_schema` accepting the declaration is
+        the whole reason a crash on it is this file's bug and not the tool's.
+        """
+        published = [copy.deepcopy(tool) for tool in mcp_handler.MCP_TOOLS]
+        published[0]["outputSchema"] = {
+            "type": "object",
+            "properties": {"anything": True, "nothing": False},
+        }
+        Draft202012Validator.check_schema(published[0]["outputSchema"])
+        monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
+
+        assert _subschemas(published[0]["outputSchema"]) == {}
+        # The assertion that matters: no AttributeError at what would be import.
+        assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+
+    def test_a_boolean_items_schema_is_skipped_rather_than_crashing_the_derivation(
+        self, monkeypatch
+    ):
+        """`{"items": true}` is the same construct one level down, and it closes
+        no door either — so the array must simply not be reported as closed."""
+        published = [copy.deepcopy(tool) for tool in mcp_handler.MCP_TOOLS]
+        published[0]["outputSchema"] = {
+            "type": "object",
+            "properties": {"rows": {"type": "array", "items": True}},
+        }
+        Draft202012Validator.check_schema(published[0]["outputSchema"])
+        monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
+
+        assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+
+    def test_the_derivations_still_find_the_real_closures(self):
+        """The positive control for all four above.
+
+        `_output_schema` returning `{}` unconditionally, or `_subschemas`
+        returning `{}` unconditionally, would satisfy every test in this class
+        while making the whole file vacuous — an empty schema validates every
+        payload. So the tolerant path must be shown NOT to be the only path.
+        """
+        assert _closed_schema_tools(), "the closed-schema derivation found nothing"
+        assert _closed_item_schemas(), "the closed-items derivation found nothing"
+        assert all(
+            _subschemas(_output_schema(name)) for name in _closed_schema_tools()
+        ), "a closed schema declared no usable properties"
 
 
 # ===========================================================================
@@ -724,7 +1047,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         `additionalProperties` passes every payload here, and passes exactly the
         declarations that are wrong.
         """
-        case, arguments, bodies = _TOOL_SAMPLES[tool][0]
+        case, arguments, bodies = _first_sample(tool)
         payload = _payload(tool, arguments, bodies)
         schema = _output_schema(tool)
 
@@ -765,7 +1088,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         that started forwarding unknown keys would break every validating client;
         this control is what says the declaration forbids it.
         """
-        case, arguments, bodies = _TOOL_SAMPLES[tool][0]
+        case, arguments, bodies = _first_sample(tool)
         payload = _payload(tool, arguments, bodies)
         schema = _output_schema(tool)
 
@@ -864,7 +1187,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         can pass for a different field's reason is not a control for this one.
         """
         personas_schema = _output_schema("list_personas")
-        payload = _payload("list_personas", *_TOOL_SAMPLES["list_personas"][0][1:])
+        payload = _payload("list_personas", *_first_sample("list_personas")[1:])
         assert _errors(payload, personas_schema) == [], "the sample must validate first"
 
         # Asserted, not assumed: a valid payload need not CONTAIN this path — the
@@ -889,7 +1212,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         ), _errors(broken, personas_schema)
 
         detail_schema = _output_schema("get_feedback_detail")
-        detail = _payload("get_feedback_detail", *_TOOL_SAMPLES["get_feedback_detail"][0][1:])
+        detail = _payload("get_feedback_detail", *_first_sample("get_feedback_detail")[1:])
         assert _errors(detail, detail_schema) == [], "the detail sample must validate first"
 
         assert _rejects_at({**detail, "keywords": {"0": "late"}}, detail_schema, ("keywords",))
@@ -907,7 +1230,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         that reports nothing on the day it is needed.
         """
         schema = _output_schema("list_personas")
-        payload = _payload("list_personas", *_TOOL_SAMPLES["list_personas"][0][1:])
+        payload = _payload("list_personas", *_first_sample("list_personas")[1:])
         assert _errors(payload, schema) == [], "the sample must validate first"
 
         broken = copy.deepcopy(payload)
@@ -922,7 +1245,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         is sometimes missing reads as "not truncated", which is the same wrong
         answer as asserting it false."""
         schema = _output_schema("search_feedback")
-        payload = _payload("search_feedback", *_TOOL_SAMPLES["search_feedback"][0][1:])
+        payload = _payload("search_feedback", *_first_sample("search_feedback")[1:])
         assert "is_partial" in schema.get("required", []), (
             "search_feedback no longer requires is_partial; this control moved"
         )
@@ -944,7 +1267,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         """
         mutated = copy.deepcopy(_output_schema("get_feedback_detail"))
         mutated["properties"]["keywords"]["type"] = "integer"
-        payload = _payload("get_feedback_detail", *_TOOL_SAMPLES["get_feedback_detail"][0][1:])
+        payload = _payload("get_feedback_detail", *_first_sample("get_feedback_detail")[1:])
 
         assert _errors(payload, _output_schema("get_feedback_detail")) == []
         assert _errors(payload, mutated), (

--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -137,7 +137,7 @@ REVERT STORY — which mutation makes which assertion fail:
   TestTheDerivationsSurviveAnUnusualDeclaration
     — nothing read at IMPORT time may raise on a declaration a client accepts, or
       on a fixture this file imports. `_closed_schema_tools()`,
-      `_closed_item_schemas()` and `_TOOL_SAMPLES` are all read inside
+      `_closed_subschemas()` and `_TOOL_SAMPLES` are all read inside
       `@pytest.mark.parametrize`, so a raise there is a collection error that
       aborts collection of the ENTIRE `lambda/api` suite and is attributed to
       whatever ran next. Three did exactly that: a published tool with no
@@ -173,15 +173,15 @@ REVERT STORY — which mutation makes which assertion fail:
       — the reason this file takes a `jsonschema` dependency instead of
       recursing over `properties` itself.
 
-  test_an_undeclared_key_inside_an_array_item_is_rejected
+  test_an_undeclared_key_inside_a_closed_subschema_is_rejected
     — the same closure one level DOWN, where M1 lived. The top-level control
       cannot reach it, because merging a key into the payload root never touches
       an element of `items`. Its anti-vacuity control is
-      test_some_array_closes_its_item_schema, and its positive counterpart is
+      test_some_declaration_closes_a_schema_below_the_root, and its positive counterpart is
       test_an_unrecognised_key_on_a_route_row_is_not_forwarded, which pins the
       projection behaviour that keeps the shape unreachable from a route.
 
-      Parametrised from `_closed_item_schemas`, which now derives from the SAME
+      Parametrised from `_closed_subschemas`, which now derives from the SAME
       walk the substance check uses. It used to walk root-level `properties` only,
       so a closed `items` nested inside another array's item schema — or inside a
       nested object — was parametrised by nothing while `_declared_sites` saw it
@@ -191,9 +191,43 @@ REVERT STORY — which mutation makes which assertion fail:
       nested array added to `_PERSONA_PROPERTIES` gave one substance-check failure
       and ZERO from this control. Its depth has its own anti-vacuity control,
       test_the_closed_item_derivation_can_find_a_closure_below_the_payload_root,
-      because test_some_array_closes_its_item_schema is satisfied by one closure at
+      because test_some_declaration_closes_a_schema_below_the_root is satisfied by one closure at
       the root and so passed throughout the round the derivation was shallow —
       "finds nothing deep" read as "there is nothing deep".
+
+      🔑 AND IT NO LONGER FILTERS ON THE ARRAY MARKER. One round it derived depth
+      correctly and still admitted only `path[-1] == '[]'`, so a closed nested
+      OBJECT was parametrised by nothing while a client enforced it — the same
+      defect one step narrower, and the array case was privileged only because
+      M1's happened to live there. Measured through production code before the
+      widening: closing the `scenario` persona section left the whole file at 75
+      passed, unchanged; after it, the same mutation produces a new control,
+      `list_personas-personas/[]/scenario`. The filter is now "below the root, and
+      closed", the root being excluded because `_closed_schema_tools` already
+      controls it by merging a key into the payload root.
+
+  test_no_published_declaration_uses_a_ref_the_walk_cannot_resolve
+    — the sibling of the unfollowed-keyword test, and it exists because that one
+      cannot cover this: it asks which keyword is PRESENT, and `$ref` IS followed,
+      so a `$ref` that is followed and FAILS was silence with a clean bill of
+      health. `_resolve_ref` returning None rather than {} for "could not resolve"
+      is what makes the difference reportable. Publish `{"$ref": "#Row"}` against
+      an `$anchor` — legal 2020-12, resolved perfectly by Draft202012Validator —
+      and before this the file was 75 passed; now it is one failure naming the
+      tool, the path and the ref. Its positive control is
+      test_the_ref_check_notices_each_pointer_it_cannot_follow, over an $anchor, a
+      remote pointer, a typo and a resolvable one.
+
+  test_no_published_declaration_nests_through_a_keyword_the_walk_collapses
+    — the THIRD category, after "followed" and "unfollowed": followed onto a
+      marker that MERGES cases a validator keeps apart. Over-crediting rather
+      than silence, which is the worse direction — a green case meaning less than
+      it says prompts nobody to look. `patternProperties`, `prefixItems` and a
+      schema-valued `additionalProperties` each credit a property a client would
+      reject at that position; `_COLLAPSED_KEYWORDS` records exactly what each
+      merges and what teaching it would cost. Declare any of the three on a
+      published tool and this fails by name (measured: three separate mutations,
+      three failures naming this test).
 
   test_a_nested_object_where_an_array_is_declared_is_rejected
     — M1's exact shape, in the two places a live writer can still produce it.
@@ -399,10 +433,72 @@ _METRICS_SOURCES_BODY = {
     "is_partial": True,
     "sources": {"webscraper": 4000, "feedback-form": 21},
 }
+# `/metrics/personas` — ⚠️ RE-TRANSCRIBED, and the reason is the risk this registry
+# names two comments below. Until #369 the route bucketed this dimension on a
+# free-text `persona_name`, so the body here read
+# `{"Priya Shah": 42, "Tobias Krenzler": 3}`. That change moved the axis to the
+# `persona_type` archetype enum and added `has_legacy_persona_buckets` — and this
+# transcription went stale the moment it merged, silently, because the tool's schema
+# is open and the substance check only walks declared → demonstrated. Nothing in this
+# file reported it; a human noticed. That is provenance level 2 behaving exactly as
+# the comment predicts, which is worth leaving on the record rather than tidying away.
+#
+# ⚠️ AND IT IS STILL UNDETECTABLE HERE. Putting the pre-#369 body back leaves the file
+# at 81 passed — measured. Nothing compares a transcription to the route it names, so
+# the correction below is a correction, not a guard. Closing it needs the route's own
+# return derived rather than copied, which is a route-side mechanism
+# (`test_persona_dimension_lockstep.py` is where that lives) and the natural next
+# slice; a check confined to this file could only compare the copy with itself.
 _METRICS_PERSONAS_BODY = {
     "period_days": 7,
     "is_partial": False,
-    "personas": {"Priya Shah": 42, "Tobias Krenzler": 3},
+    # An UNDECLARED key the route really returns, kept for the same reason
+    # `_METRICS_SENTIMENT_BODY` keeps `total`: it is the evidence that leaving these
+    # schemas open is load-bearing rather than an oversight.
+    "has_legacy_persona_buckets": False,
+    "personas": {"advocate": 530, "churn_risk": 322, "existing_customer": 312,
+                 "unknown": 34, "prospect": 30},
+}
+
+# The same route mid-transition, which is a real answer for ~90 days after the axis
+# moved: aggregate rows written by the old derivation still carry free-text names and
+# a capitalised `Unknown`, so the counts object mixes both value spaces and the route
+# says so. A model reading these keys is the caller this flag exists for.
+#
+# ⚠️ THIS CASE IS DOCUMENTATION, NOT ENFORCEMENT, and saying so is the point.
+# Deleting it leaves the file at 80 passed — measured, not assumed. It declares no
+# new property, and the substance check unions across a tool's cases, so nothing can
+# fail when it goes. It earns its place by recording a shape a reader would otherwise
+# have to reconstruct from two other files; it does not earn a claim of coverage.
+# The same is true of the empty-window cases below.
+_METRICS_PERSONAS_TRANSITION_BODY = {
+    "period_days": 30,
+    "is_partial": False,
+    "has_legacy_persona_buckets": True,
+    "personas": {"Unknown": 6237, "advocate": 12, "G.Adlung": 1},
+}
+
+# The empty answer from a metrics route: a window with nothing in it. A real answer
+# with a shape, and the same case `search_feedback`, `get_project` and `list_personas`
+# each register — the metrics tools were the three that did not, which review raised
+# in round one. It matters more for them than for the others, because these tools pass
+# their route's body through unprojected and their schemas carry no `required`, so an
+# EMPTY `structuredContent` is fully valid and fully vacuous; a registered empty case
+# is what makes the difference between the two observable.
+_METRICS_EMPTY_WINDOW_BODY = {
+    "period_days": 7,
+    "is_partial": False,
+    "total_feedback": 0,
+    "avg_sentiment": 0.0,
+    "urgent_count": 0,
+    "daily_totals": [],
+    "daily_sentiment": [],
+}
+_METRICS_EMPTY_BREAKDOWN_BODY = {
+    "period_days": 7,
+    "is_partial": False,
+    "has_legacy_persona_buckets": False,
+    "personas": {},
 }
 
 
@@ -485,6 +581,7 @@ _TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
         ("a complete window", {}, {"/metrics/summary": _METRICS_SUMMARY_BODY}),
         ("a partial window", {"days": 365},
          {"/metrics/summary": _METRICS_SUMMARY_PARTIAL_BODY}),
+        ("an empty window", {}, {"/metrics/summary": _METRICS_EMPTY_WINDOW_BODY}),
     ),
     "get_metrics_breakdown": (
         # All four dimensions, because each reaches a DIFFERENT route with a
@@ -497,6 +594,12 @@ _TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
          {"/metrics/sources": _METRICS_SOURCES_BODY}),
         ("personas", {"dimension": "personas"},
          {"/metrics/personas": _METRICS_PERSONAS_BODY}),
+        # The persona axis mid-transition, mixing both value spaces — see
+        # `_METRICS_PERSONAS_TRANSITION_BODY`.
+        ("personas, mid-transition", {"dimension": "personas"},
+         {"/metrics/personas": _METRICS_PERSONAS_TRANSITION_BODY}),
+        ("an empty window", {"dimension": "personas"},
+         {"/metrics/personas": _METRICS_EMPTY_BREAKDOWN_BODY}),
     ),
     "get_project": (
         ("metadata, three live persona shapes and all six document kinds",
@@ -698,7 +801,7 @@ def _output_schema(name: str) -> dict:
 
     🔑 CANNOT raise for a published tool. `tool["outputSchema"]` was here first
     and a published tool declaring none raised a bare `KeyError` — from inside
-    `_closed_schema_tools()` and `_closed_item_schemas()`, which are evaluated in
+    `_closed_schema_tools()` and `_closed_subschemas()`, which are evaluated in
     `@pytest.mark.parametrize` decorators, so at MODULE IMPORT. That is a
     collection error aborting the ENTIRE `lambda/api` suite, and the
     message a Phase 3 author reads is `KeyError: 'outputSchema'` rather than
@@ -709,7 +812,7 @@ def _output_schema(name: str) -> dict:
 
     So a missing or non-dict declaration degrades to `{}`: an empty schema is
     open and validates anything, `_closed_schema_tools()` reports the tool as not
-    closed, `_closed_item_schemas()` finds no arrays in it, and the §5.4 test
+    closed, `_closed_subschemas()` finds no arrays in it, and the §5.4 test
     stays the single named reporter of the gap. Pinned by
     `TestTheDerivationsSurviveAnUnusualDeclaration`.
     """
@@ -825,7 +928,7 @@ def _payload_reaching(tool: str, path: tuple) -> tuple[dict, tuple, dict]:
     `payload["personas"][0]` rather than a sentence.
 
     🔑 Takes a PATH, not a root property, so it reaches a site at any depth for
-    the same reason `_closed_item_schemas` now derives them: a closed `items`
+    the same reason `_closed_subschemas` now derives them: a closed `items`
     nested below the root has an element to mutate too, and a helper that could
     only look up a root key would have kept this control shallower than the
     derivation feeding it.
@@ -888,14 +991,14 @@ def _subschemas(schema: dict) -> dict:
     and means "any value here", while `false` means "nothing is valid here".
     `declared.get("type")` on one of those raised
     `AttributeError: 'bool' object has no attribute 'get'`, and because
-    `_closed_item_schemas()` is evaluated in a `@pytest.mark.parametrize`
+    `_closed_subschemas()` is evaluated in a `@pytest.mark.parametrize`
     decorator the raise landed at module import: a collection error aborting the
     entire `lambda/api` suite, on a declaration this very file also certifies as
     valid via `test_the_declaration_is_itself_a_valid_json_schema`.
 
     A boolean sub-schema constrains no keys and closes no door, so dropping it
     here is not a loss of coverage — it is the derivation saying "nothing to
-    control", which is what `test_some_array_closes_its_item_schema` then
+    control", which is what `test_some_declaration_closes_a_schema_below_the_root` then
     reports if that were ever true of every array. No published tool uses one
     today; Phase 3's ~thirty declarations are where an unusual-but-legal
     construct first shows up. Pinned by
@@ -917,6 +1020,13 @@ _MAP = "{}"
 # The keywords `_reachable_schemas` follows to another object schema. Named so
 # `test_no_published_declaration_nests_through_a_keyword_the_walk_cannot_follow`
 # can report what is NOT here rather than leaving it silent.
+#
+# Two of these are ALSO in `_COLLAPSED_KEYWORDS`, which is not a contradiction:
+# `patternProperties` and `prefixItems` are followed, so nothing beneath them is
+# invisible, and separately refused, because the marker they land on merges cases a
+# validator keeps apart. Followed and refused is the belt-and-braces position — the
+# walk reaches the subtree, and the author is still told the addressing is too coarse
+# to credit anything there.
 _FOLLOWED_KEYWORDS: tuple[str, ...] = (
     "$ref", "properties", "items", "prefixItems", "additionalProperties",
     "patternProperties", "anyOf", "allOf", "oneOf",
@@ -934,18 +1044,68 @@ _UNFOLLOWED_KEYWORDS: tuple[str, ...] = (
     "unevaluatedProperties", "unevaluatedItems", "$dynamicRef",
 )
 
+# Keywords the walk DOES follow, onto a path marker that collapses a distinction the
+# validator keeps. Followed, so nothing beneath them is invisible — but addressed
+# imprecisely, so the substance check can credit a property a client would never
+# accept there. That is over-crediting rather than silence, which is the more
+# dangerous direction: a green case that means less than it says.
+#
+# Exactly what each would over-credit, because "imprecise" is not actionable:
+#
+#   • `patternProperties` — every key at the `{}` marker is mapped, including one
+#     the PATTERN does not match. A payload key `total` credits the properties
+#     declared under `^persona_`, which a client applies only to matching keys.
+#     Teaching it means the marker carrying the pattern (`{^persona_}`), i.e. a
+#     wider label namespace.
+#   • a schema-valued `additionalProperties` — same marker, and by definition the
+#     keyword applies only to keys `properties` does NOT claim. The walk maps all of
+#     them, so a declared property name credits the additional schema.
+#   • `prefixItems` — positional schemas all collapse onto `[]`, so element 0
+#     credits the properties declared for element 1 and swapping two elements
+#     changes nothing. Teaching it means positional markers (`[0]`, `[1]`).
+#
+# Refused by name rather than measured wrongly, the same trade
+# `_UNFOLLOWED_KEYWORDS` makes — and free today, because no published declaration
+# uses any of the three. A Phase 3 author reaching for one is told to teach the
+# derivation, which is the point at which the addressing cost is worth paying.
+_COLLAPSED_KEYWORDS: tuple[str, ...] = ("patternProperties", "prefixItems")
 
-def _resolve_ref(ref: str, root) -> dict:
-    """A local `$ref` pointer resolved against the declaration it lives in.
+
+def _resolve_ref(ref: str, root) -> dict | None:
+    """A local JSON-POINTER `$ref` resolved against the declaration it lives in.
 
     Local only: a declaration is published inside `tools/list` and a client
     resolves it without fetching anything, so a remote pointer would be a defect
-    of a different kind. An unresolvable pointer yields `{}` — no site — for the
-    same reason every other derivation here degrades rather than raises: this runs
-    at import, under a `@pytest.mark.parametrize` decorator.
+    of a different kind. Degrades rather than raises for the same reason every
+    other derivation here does: this runs at import, under a
+    `@pytest.mark.parametrize` decorator.
+
+    🔑 `None` MEANS "COULD NOT RESOLVE", AND IT IS NOT THE SAME ANSWER AS `{}`.
+    An earlier round returned `{}` for both, which made an unresolvable pointer
+    indistinguishable from a pointer onto a legitimately empty schema — and that
+    is the file's recurring defect in its purest form, because all three
+    consumers of the walk go quiet at once: no site for the substance check, no
+    closure for the undeclared-key control, and `_stale_exemptions` reporting a
+    CORRECT exemption beneath the ref as a typo, whose only green fix is to delete
+    it. Returning `None` lets
+    `test_no_published_declaration_uses_a_ref_the_walk_cannot_resolve` say so by
+    name; the traversal still degrades, because `_reachable_schemas` ignores a
+    non-dict.
+
+    ⚠️ WHAT THIS DELIBERATELY DOES NOT RESOLVE, and why that is now safe: a
+    PLAIN-NAME pointer (`#Row` against an `$anchor`) and a remote one. Both are
+    legal 2020-12 and `Draft202012Validator` follows the first perfectly, so a
+    client enforces a declaration this walk cannot see. Teaching the resolver
+    `$anchor` is a real option; refusing it by name is the same trade
+    `_UNFOLLOWED_KEYWORDS` already makes for `contains` — the walk says what it
+    cannot measure instead of measuring it wrongly — and it costs a Phase 3 author
+    one restatement as `#/$defs/Row`, which every consumer here then follows.
     """
-    if not ref.startswith("#"):
-        return {}
+    if not ref.startswith("#/"):
+        # `#` alone is the whole document; `#Name` is an `$anchor`, which this
+        # resolver does not implement. Neither is a pointer, so neither is a
+        # failure to *follow* a pointer — both are reported, not guessed at.
+        return root if ref == "#" and isinstance(root, dict) else None
     target = root
     for raw in ref[1:].split("/"):
         if not raw:
@@ -953,13 +1113,34 @@ def _resolve_ref(ref: str, root) -> dict:
         token = raw.replace("~1", "/").replace("~0", "~")
         if isinstance(target, list):
             if not token.isdigit() or int(token) >= len(target):
-                return {}
+                return None
             target = target[int(token)]
         elif isinstance(target, dict) and token in target:
             target = target[token]
         else:
-            return {}
-    return target if isinstance(target, dict) else {}
+            return None
+    return target if isinstance(target, dict) else None
+
+
+def _unresolvable_refs(schema: dict) -> list[tuple[tuple, str]]:
+    """`(payload path, ref)` for every `$ref` the walk reaches and cannot follow.
+
+    Consumes `_reachable_schemas` rather than walking again — the one-walk rule
+    this file already learned twice: a second traversal is a second thing to keep
+    in step, and the closed-door control's shallow copy of the walk is what made
+    a nested closure invisible for a round.
+
+    A ref inside a subtree that is ITSELF unreachable cannot be reported, which is
+    the same ceiling `_UNFOLLOWED_KEYWORDS` has: detection happens where the walk
+    arrives. The first unresolvable ref on a path is what gets named, and fixing
+    it exposes anything beneath it.
+    """
+    found = []
+    for path, sub in _reachable_schemas(schema):
+        ref = sub.get("$ref")
+        if isinstance(ref, str) and _resolve_ref(ref, schema) is None:
+            found.append((path, ref))
+    return found
 
 
 def _reachable_schemas(
@@ -968,9 +1149,9 @@ def _reachable_schemas(
     """Every object schema a declaration reaches, with the payload path to it.
 
     🔑 ONE walk, shared by the substance check (`_declared_sites`) and by the
-    closed-door controls (`_closed_item_schemas`). They used to be two walks of
+    closed-door controls (`_closed_subschemas`). They used to be two walks of
     different depths, and the shallower one fed
-    `test_an_undeclared_key_inside_an_array_item_is_rejected` — the control this
+    `test_an_undeclared_key_inside_a_closed_subschema_is_rejected` — the control this
     file singles out as the architecturally important one, because M1 was inside
     `items`. A closed `items` nested below the root was parametrised by nothing
     while the substance check happily saw it, so the two halves of the file
@@ -1311,7 +1492,7 @@ def _stale_exemptions(exemptions: dict, registry: dict) -> list[str]:
     return findings
 
 
-def _closed_item_schemas() -> list[tuple[str, tuple]]:
+def _closed_subschemas() -> list[tuple[str, tuple]]:
     """`(tool, path)` for every ELEMENT schema that closes the door, at any depth.
 
     Needed one level down from `_closed_schema_tools` for the reason this file
@@ -1332,17 +1513,28 @@ def _closed_item_schemas() -> list[tuple[str, tuple]]:
     this control, which did not know the array existed; populated, both were
     silent.
 
-    Keyed by the same `_ARRAY`-marked path the substance check uses, so the two
-    halves of the file cannot drift back into disagreeing about depth. `type:
-    array` is deliberately NOT required: `{"items": {...}}` with no `type` still
-    constrains elements, and a validator enforces it.
+    🔑 ANY CLOSED SCHEMA BELOW THE ROOT, NOT ONLY AN ARRAY'S ELEMENTS. The
+    previous round kept `path[-1] == _ARRAY`, which is the same defect one step
+    narrower: a client enforces `additionalProperties: false` wherever it is
+    declared, and this control only covered the array case because that is where
+    M1's defect happened to live. A closed nested OBJECT was parametrised by
+    nothing. Confirmed through production code before the widening: closing the
+    `scenario` persona section left the whole file at 75 passed, unchanged.
+    Now the filter is "not the root, and closed" — the root is excluded only
+    because `_closed_schema_tools` already controls it, through a test that
+    merges the key into the payload root.
+
+    Keyed by the same marked path the substance check uses, so the two halves of
+    the file cannot drift back into disagreeing about depth. `type: array` is
+    deliberately NOT required: `{"items": {...}}` with no `type` still constrains
+    elements, and a validator enforces it.
     """
     found = []
     for name in _PUBLISHED_TOOL_NAMES:
         for path, sub in _reachable_schemas(_output_schema(name)):
             # `_reachable_schemas` already dropped a boolean `items`, which is
             # legal (`{"items": true}`) and closes nothing.
-            if path and path[-1] == _ARRAY and sub.get("additionalProperties") is False:
+            if path and sub.get("additionalProperties") is False:
                 found.append((name, path))
     return found
 
@@ -1609,6 +1801,127 @@ class TestEveryToolBringsASample:
             f"{list(_FOLLOWED_KEYWORDS)}."
         )
 
+    def test_no_published_declaration_nests_through_a_keyword_the_walk_collapses(self):
+        """What the walk addresses IMPRECISELY is refused, not credited wrongly.
+
+        🔑 THE THIRD CATEGORY, and the dangerous one. `_UNFOLLOWED_KEYWORDS` is
+        about silence — a declaration measured by nothing. These three are about
+        OVER-CREDITING: the walk follows them and lands on a marker (`[]`, `{}`)
+        that merges cases a validator keeps apart, so a sample can satisfy the
+        substance check for a property a client would reject at that position. A
+        green case that means less than it says is worse than an absent one,
+        because nothing prompts anyone to look.
+
+        `_COLLAPSED_KEYWORDS` carries the per-keyword detail. The schema-valued
+        `additionalProperties` case is checked separately because the keyword's mere
+        PRESENCE is not the problem — `True`/`False` are everywhere and both are
+        precise; only a sub-SCHEMA there is collapsed.
+
+        Free today: no published declaration uses any of them, which is why this is
+        a refusal rather than an addressing rework. Phase 3 pays that cost at the
+        moment it needs the construct.
+        """
+        findings = []
+        for name in _PUBLISHED_TOOL_NAMES:
+            for path, sub in _reachable_schemas(_output_schema(name)):
+                where = "/".join(path) or "<root>"
+                used = sorted(k for k in _COLLAPSED_KEYWORDS if k in sub)
+                if used:
+                    findings.append(f"{name} at {where}: {used}")
+                if isinstance(sub.get("additionalProperties"), dict):
+                    findings.append(f"{name} at {where}: schema-valued additionalProperties")
+
+        assert findings == [], (
+            "these declarations nest a schema through a keyword the walk follows but "
+            "addresses imprecisely, so the substance check can credit a property a "
+            "client would not accept at that position:\n"
+            + "\n".join(f"  • {f}" for f in findings)
+            + "\nGive the construct its own path marker in `_reachable_schemas` and "
+            "`_located_objects` (the way `[]` and `{}` work), or restate the "
+            "declaration with named `properties`. See `_COLLAPSED_KEYWORDS` for what "
+            "each one currently merges."
+        )
+
+    def test_no_published_declaration_uses_a_ref_the_walk_cannot_resolve(self):
+        """A `$ref` the resolver cannot follow is REFUSED, on the same grounds.
+
+        🔑 THE SIBLING OF THE TEST ABOVE, and it exists because that one cannot
+        cover this: it asks which keyword is PRESENT, and `$ref` is in
+        `_FOLLOWED_KEYWORDS` — so a `$ref` that is followed and fails resolves to
+        nothing while passing every check in the file. `_resolve_ref` returning
+        `None` rather than `{}` is what makes the difference reportable.
+
+        The three shapes this catches, all legal to publish and all enforced by a
+        client: a PLAIN-NAME pointer (`#Row` against an `$anchor`, which
+        `Draft202012Validator` resolves perfectly), a REMOTE one, and a TYPO'd
+        local one. The typo has a second, louder symptom — the validator raises and
+        five tests fail — so this test's unique contribution is the first two,
+        which are silent everywhere else.
+
+        Derived from the live registry, so a Phase 3 declaration that reaches for
+        `$anchor` is told to restate it as `#/$defs/Name` rather than shipping a
+        subtree nothing here measures.
+        """
+        findings = []
+        for name in _PUBLISHED_TOOL_NAMES:
+            for path, ref in _unresolvable_refs(_output_schema(name)):
+                findings.append(f"{name} at {'/'.join(path) or '<root>'}: {ref!r}")
+
+        assert findings == [], (
+            "these declarations point at a schema `_resolve_ref` cannot follow, so "
+            "everything beneath the pointer is measured by nothing here — no site "
+            "for the substance check, no closure for the undeclared-key control, "
+            "and a correct exemption below it reported as a typo:\n"
+            + "\n".join(f"  • {f}" for f in findings)
+            + "\nRestate it as a local JSON pointer (`#/$defs/Name`), or teach "
+            "`_resolve_ref` the form you need."
+        )
+
+    def test_the_ref_check_notices_each_pointer_it_cannot_follow(self):
+        """The positive control: each unfollowable shape, and silence for a good one.
+
+        Owned schemas rather than the registry, because nothing published uses these
+        forms — which is exactly why the check above passes today and why it would
+        be worth nothing unproven. `check_schema` on the `$anchor` case is the point
+        of the whole finding: a client accepts and enforces it.
+        """
+        anchored = {
+            "type": "object",
+            "$defs": {"Row": {"$anchor": "Row", "type": "object",
+                              "properties": {"id": {"type": "string"}}}},
+            "properties": {"rows": {"type": "array", "items": {"$ref": "#Row"}}},
+        }
+        Draft202012Validator.check_schema(anchored)
+        assert _unresolvable_refs(anchored) == [(("rows", _ARRAY), "#Row")], (
+            "a plain-name pointer against an $anchor must be reported: a client "
+            "resolves it and this walk does not."
+        )
+        # And it really is invisible to the walk — no site beneath it.
+        assert ("rows", _ARRAY) not in _declared_sites(anchored)
+
+        remote = {"type": "object",
+                  "properties": {"row": {"$ref": "https://example.test/s.json#/$defs/Row"}}}
+        assert [ref for _p, ref in _unresolvable_refs(remote)] == [
+            "https://example.test/s.json#/$defs/Row"
+        ]
+
+        typo = {"type": "object", "$defs": {"Row": {"type": "object"}},
+                "properties": {"row": {"$ref": "#/$defs/Rwo"}}}
+        assert _unresolvable_refs(typo) == [(("row",), "#/$defs/Rwo")]
+
+        good = {
+            "type": "object",
+            "$defs": {"Row": {"type": "object", "properties": {"id": {"type": "string"}}}},
+            "properties": {"rows": {"type": "array", "items": {"$ref": "#/$defs/Row"}}},
+        }
+        Draft202012Validator.check_schema(good)
+        assert _unresolvable_refs(good) == [], "a resolvable pointer must be silent"
+        assert _declared_sites(good)[("rows", _ARRAY)] == frozenset({"id"})
+
+        # `#` is the whole document, and resolving it is not a failure to follow a
+        # pointer — it is how a self-referential declaration is written.
+        assert _unresolvable_refs({"type": "object", "properties": {"self": {"$ref": "#"}}}) == []
+
     def test_no_published_declaration_uses_a_property_name_that_collides_with_a_label(self):
         """`_label`'s flat namespace assumes no property name contains `/`.
 
@@ -1840,7 +2153,7 @@ class TestEveryToolBringsASample:
 class TestTheDerivationsSurviveAnUnusualDeclaration:
     """Nothing read at import time may raise on a declaration a client accepts.
 
-    🔑 `_closed_schema_tools()`, `_closed_item_schemas()` and `_TOOL_SAMPLES` are
+    🔑 `_closed_schema_tools()`, `_closed_subschemas()` and `_TOOL_SAMPLES` are
     all read inside `@pytest.mark.parametrize` decorators, so anything they raise
     is a COLLECTION error: every test in `lambda/api` aborts, attributed to
     whatever ran next, and no pull-request gate would report it (the one workflow
@@ -1874,7 +2187,7 @@ class TestTheDerivationsSurviveAnUnusualDeclaration:
 
         assert _output_schema(published[0]["name"]) == {}
         assert published[0]["name"] not in _closed_schema_tools()
-        assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+        assert all(name != published[0]["name"] for name, _ in _closed_subschemas())
 
     def test_a_tool_whose_output_schema_is_not_a_dict_reads_as_an_empty_schema(
         self, monkeypatch
@@ -1906,7 +2219,7 @@ class TestTheDerivationsSurviveAnUnusualDeclaration:
 
         assert _subschemas(published[0]["outputSchema"]) == {}
         # The assertion that matters: no AttributeError at what would be import.
-        assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+        assert all(name != published[0]["name"] for name, _ in _closed_subschemas())
 
     def test_a_boolean_items_schema_is_skipped_rather_than_crashing_the_derivation(
         self, monkeypatch
@@ -1921,7 +2234,7 @@ class TestTheDerivationsSurviveAnUnusualDeclaration:
         Draft202012Validator.check_schema(published[0]["outputSchema"])
         monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
 
-        assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+        assert all(name != published[0]["name"] for name, _ in _closed_subschemas())
 
     def test_the_imported_persona_fixture_still_carries_the_sections_this_sample_extends(
         self,
@@ -1985,7 +2298,7 @@ class TestTheDerivationsSurviveAnUnusualDeclaration:
         payload. So the tolerant path must be shown NOT to be the only path.
         """
         assert _closed_schema_tools(), "the closed-schema derivation found nothing"
-        assert _closed_item_schemas(), "the closed-items derivation found nothing"
+        assert _closed_subschemas(), "the closed-items derivation found nothing"
         assert all(
             _subschemas(_output_schema(name)) for name in _closed_schema_tools()
         ), "a closed schema declared no usable properties"
@@ -2115,11 +2428,11 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         )
         assert any("a_field_no_one_declared" in e for e in errors), errors
 
-    def test_some_array_closes_its_item_schema(self):
+    def test_some_declaration_closes_a_schema_below_the_root(self):
         """Anti-vacuity for the nested control below, the same way
         `test_some_tool_closes_its_output_schema` is for the top-level one: an
         empty derivation would make an empty parametrization read as green."""
-        assert _closed_item_schemas(), (
+        assert _closed_subschemas(), (
             "no published array closes its item schema; the nested extra-key "
             "control below would cover nothing — and M1 lived inside `items`"
         )
@@ -2129,14 +2442,14 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
     ):
         """Anti-vacuity for the DEPTH of the derivation above, not just its size.
 
-        🔑 `test_some_array_closes_its_item_schema` is satisfied by one closure at
+        🔑 `test_some_declaration_closes_a_schema_below_the_root` is satisfied by one closure at
         the payload root, so it passed throughout the round in which this
         derivation walked root-level `properties` only — "finds nothing deep" read
         as "there is nothing deep". Every published closure happens to be at the
         root today, so the capability is asserted directly instead: a closed
         `items` nested inside another array's item schema must be FOUND.
 
-        🔑 Through `_closed_item_schemas()` ITSELF, over a substituted registry —
+        🔑 Through `_closed_subschemas()` ITSELF, over a substituted registry —
         not by re-implementing its filter over `_reachable_schemas`. Written the
         second way first, and reverting the derivation to its old root-only walk
         then left all 75 tests passing: the control was exercising the shared walk,
@@ -2165,7 +2478,7 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
 
         found = [
-            path for name, path in _closed_item_schemas()
+            path for name, path in _closed_subschemas()
             if name == published[0]["name"]
         ]
 
@@ -2177,9 +2490,9 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         )
 
     @pytest.mark.parametrize(
-        "tool,path", _closed_item_schemas(), ids=lambda p: p if isinstance(p, str) else "/".join(p)
+        "tool,path", _closed_subschemas(), ids=lambda p: p if isinstance(p, str) else "/".join(p)
     )
-    def test_an_undeclared_key_inside_an_array_item_is_rejected(self, tool, path):
+    def test_an_undeclared_key_inside_a_closed_subschema_is_rejected(self, tool, path):
         """The nested half of the closed-door control, one level DOWN.
 
         🔑 Architecturally the more important of the two, because M1 was inside

--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -57,6 +57,37 @@ REVERT STORY — which mutation makes which assertion fail:
       test_the_substance_check_notices_a_sample_that_demonstrates_nothing, which
       hollows a sample and requires the check to object.
 
+  test_no_exemption_from_the_substance_check_has_gone_stale
+    — the check above can be opted out of via
+      `_PROPERTIES_NO_SAMPLE_CAN_SHOW`, and an allowlist is the one structure
+      here whose FUNCTION is to remove a declaration from the checked set, so a
+      stale entry is the most costly silence available. All three stale forms
+      were silent: an entry for a property some sample does demonstrate (dead
+      weight that suppresses a real requirement the day the sample changes), an
+      entry for a property no schema declares (a typo, protecting nothing while
+      reading as though it does), and an entry for an unpublished tool — the same
+      condition test_the_registry_holds_no_sample_for_a_tool_that_is_not_published
+      catches for `_TOOL_SAMPLES`. This is the module's own `xfail(strict=True)`
+      argument applied to its other exemption mechanism. The dict is empty, so it
+      passes trivially and the FIRST entry anyone adds is checked. Its positive
+      control, test_the_staleness_check_notices_each_way_an_exemption_can_go
+      _stale, asserts each form separately — one combined dict would pass while
+      two of three detections were broken — and requires SILENCE for an exemption
+      that is still doing work, since a check reporting everything would satisfy
+      all three while making the allowlist unusable.
+
+  _payload_populating, at the three controls that mutate an array element
+    — `_TOOL_SAMPLES[tool][0]` made those controls depend on the FIRST registered
+      case populating a particular array, so reordering the registry — an
+      apparently cosmetic edit — broke them: only one of `get_project`'s three
+      cases populates `documents`, and moving the empty-project case first was
+      enough. Two of them failed with a bare `IndexError` from
+      `payload["personas"][0]` rather than a sentence. Selecting whichever case
+      populates the property removes the coupling instead of only diagnosing it;
+      reordering now changes nothing, and the genuine "no case populates it"
+      condition fails naming the tool, the property and how many samples were
+      searched.
+
   TestTheDerivationsSurviveAnUnusualDeclaration
     — nothing read at IMPORT time may raise on a declaration a client accepts.
       `_closed_schema_tools()` and `_closed_item_schemas()` run inside
@@ -493,6 +524,21 @@ _REQUIRED_HINTS: tuple[str, ...] = (
 # sample. Anything added needs a comment saying why the route can never produce
 # it; if the honest reason is "I did not want to build the body", the answer is to
 # build the body.
+#
+# 🔑 Checked in BOTH directions, by `_stale_exemptions` and
+# `test_no_exemption_from_the_substance_check_has_gone_stale`. An allowlist is the
+# one structure in this file whose function is to REMOVE a declaration from the
+# checked set, so an entry that has stopped being true is the most costly kind of
+# silence here — and all three ways it can stop being true were silent before that
+# test existed: an entry for a property some sample does demonstrate (dead weight
+# that would suppress a real requirement the day the sample changed), an entry for
+# a property no schema declares (a typo, or a renamed declaration, protecting
+# nothing while reading as though it does), and an entry for a tool that is no
+# longer published (exactly what
+# `test_the_registry_holds_no_sample_for_a_tool_that_is_not_published` exists to
+# catch for `_TOOL_SAMPLES`). This is the same reasoning the module docstring
+# gives for choosing `xfail(strict=True)` over a plain skip, applied to the other
+# exemption mechanism the file has: an exemption may not outlive its reason.
 _PROPERTIES_NO_SAMPLE_CAN_SHOW: dict[str, frozenset[str]] = {}
 
 
@@ -611,6 +657,43 @@ def _first_sample(tool: str) -> tuple[str, dict, dict]:
     return samples[0]
 
 
+def _payload_populating(tool: str, prop: str) -> dict:
+    """A payload from whichever registered case populates `prop`, not case zero.
+
+    🔑 Removes an ordering coupling rather than only diagnosing it. Several
+    controls need a NON-EMPTY array to mutate, and taking `_first_sample`'s
+    payload made them depend on the first registered case being one that
+    populates it — a dependency reordering `_TOOL_SAMPLES`, an apparently
+    cosmetic edit, silently breaks. Only one of `get_project`'s three cases
+    populates `documents`, so moving the empty-project case first was enough.
+
+    Searching the cases instead means those controls hold for any ordering, and
+    they still fail — with a sentence rather than an `IndexError` from
+    `payload["personas"][0]` — when NO case populates the property, which is the
+    genuine "this control has lost its subject" condition. The controls that must
+    use the first case specifically (the closed-item parametrisation names the
+    case in its own message) keep using `_first_sample`.
+    """
+    samples = _TOOL_SAMPLES.get(tool) or ()
+    if not samples:
+        pytest.fail(
+            f"{tool} is published and has no registered sample; add one to "
+            "_TOOL_SAMPLES. "
+            "test_every_published_tool_has_a_registered_sample_payload is the "
+            "authoritative report of this."
+        )
+    for _case, arguments, bodies in samples:
+        payload = _payload(tool, arguments, bodies)
+        if payload.get(prop):
+            return payload
+    pytest.fail(
+        f"none of {tool}'s {len(samples)} registered samples populates {prop!r}, "
+        "so there is nothing for this control to mutate. Give one of its cases a "
+        f"route body that produces a non-empty {prop!r}, or point the control at "
+        "another array declared by this tool."
+    )
+
+
 def _tools_missing_samples(registry: dict) -> list[str]:
     """Published tools with no sample in this registry.
 
@@ -689,11 +772,76 @@ def _undemonstrated_properties(tool: str, registry: dict) -> set[str]:
     declared = set(_subschemas(_output_schema(tool)))
     if not declared:
         return set()
+    return (
+        declared
+        - _demonstrated_properties(tool, registry)
+        - _PROPERTIES_NO_SAMPLE_CAN_SHOW.get(tool, frozenset())
+    )
+
+
+def _demonstrated_properties(tool: str, registry: dict) -> set[str]:
+    """Every top-level key the union of this tool's sample payloads carries.
+
+    Split out of `_undemonstrated_properties` so the staleness check for
+    `_PROPERTIES_NO_SAMPLE_CAN_SHOW` measures demonstration the SAME way the
+    requirement does. Two independent notions of "demonstrated" would let an
+    exemption be simultaneously necessary and stale, which is a contradiction no
+    reader could act on.
+    """
     demonstrated: set[str] = set()
     for _case, arguments, bodies in registry.get(tool) or ():
-        payload = _payload(tool, arguments, bodies)
-        demonstrated |= set(payload)
-    return declared - demonstrated - _PROPERTIES_NO_SAMPLE_CAN_SHOW.get(tool, frozenset())
+        demonstrated |= set(_payload(tool, arguments, bodies))
+    return demonstrated
+
+
+def _stale_exemptions(exemptions: dict, registry: dict) -> list[str]:
+    """Every way an entry in an exemption allowlist has stopped being true.
+
+    🔑 A FUNCTION, taking the allowlist as an argument, for the same reason
+    `_tools_missing_samples` is one: a check on an empty dict passes trivially
+    whether or not it can detect anything, so its own positive control has to be
+    able to hand it entries that ARE stale
+    (`test_the_staleness_check_notices_each_way_an_exemption_can_go_stale`).
+
+    Returns prose rather than raising, so one run reports every stale entry
+    instead of the first.
+    """
+    findings: list[str] = []
+    for tool in sorted(exemptions):
+        properties = exemptions[tool]
+        if tool not in _PUBLISHED_TOOL_NAMES:
+            findings.append(
+                f"{tool} is exempted from the substance check and is not a "
+                f"published tool; the exemption protects nothing. Remove it, or "
+                f"correct the name to one of {sorted(_PUBLISHED_TOOL_NAMES)}."
+            )
+            # No schema and no samples to compare against, so the two checks
+            # below would only add noise about a name that does not exist.
+            continue
+
+        declared = set(_subschemas(_output_schema(tool)))
+        undeclared = sorted(set(properties) - declared)
+        if undeclared:
+            findings.append(
+                f"{tool} exempts {undeclared}, which its outputSchema does not "
+                "declare — a typo, or a declaration that was renamed. The "
+                "exemption reads as though it protects something and does not."
+            )
+
+        # The `xfail(strict=True)` equivalent: an exemption that has become
+        # unnecessary must say so rather than persist. Left in place, it silently
+        # suppresses a real requirement the day the sample stops producing the
+        # property.
+        unnecessary = sorted(
+            set(properties) & _demonstrated_properties(tool, registry)
+        )
+        if unnecessary:
+            findings.append(
+                f"{tool} exempts {unnecessary} from the substance check and a "
+                "registered sample demonstrates them anyway; the exemption is no "
+                "longer needed and should be deleted."
+            )
+    return findings
 
 
 def _closed_item_schemas() -> list[tuple[str, str]]:
@@ -840,10 +988,90 @@ class TestEveryToolBringsASample:
             "substance check still found every declared property demonstrated"
         )
 
+    def test_no_exemption_from_the_substance_check_has_gone_stale(self):
+        """An exemption may not outlive its reason.
 
-# ===========================================================================
-# The derivations — robust against a legal but unusual declaration
-# ===========================================================================
+        🔑 The one direction this file otherwise always checks, applied to the
+        allowlist — the structure where a stale entry costs the most, because its
+        whole function is to remove a declaration from the checked set. All three
+        stale forms were silent: an entry for a property a sample DOES demonstrate,
+        an entry for a property no schema declares, and an entry for a tool that is
+        no longer published. The third is the exact condition
+        `test_the_registry_holds_no_sample_for_a_tool_that_is_not_published`
+        exists to catch for `_TOOL_SAMPLES`; the first is the
+        `pytest.mark.xfail(strict=True)` reasoning the module docstring gives —
+        the day an exemption becomes unnecessary, it says so.
+
+        Passes trivially while the dict is empty, which is why it is cheap to add
+        now: the first entry anyone writes is checked from the moment it lands,
+        rather than after someone remembers to come back for it.
+        """
+        stale = _stale_exemptions(_PROPERTIES_NO_SAMPLE_CAN_SHOW, _TOOL_SAMPLES)
+
+        assert stale == [], "stale entries in _PROPERTIES_NO_SAMPLE_CAN_SHOW:\n" + "\n".join(
+            f"  • {finding}" for finding in stale
+        )
+
+    def test_the_staleness_check_notices_each_way_an_exemption_can_go_stale(self):
+        """The positive control for the check above, one assertion per stale form.
+
+        🔑 The check runs against an EMPTY dict in real life, so it passes whether
+        or not it can detect anything — the precise shape of vacuity
+        `_tools_missing_samples` needed a control for. Each form is asserted
+        separately rather than by handing over one dict with all three: a single
+        combined assertion passes while two of the three detections are broken.
+        """
+        published = _PUBLISHED_TOOL_NAMES[0]
+        # Declared AND demonstrated, so an exemption naming it is stale for the
+        # "no longer necessary" reason ONLY — an undeclared payload key would also
+        # trip the "not declared" finding and the two would be indistinguishable.
+        demonstrated = sorted(
+            set(_subschemas(_output_schema(published)))
+            & _demonstrated_properties(published, _TOOL_SAMPLES)
+        )
+        assert demonstrated, (
+            f"{published} demonstrates no declared property at all, so this control "
+            "cannot construct an unnecessary exemption; the substance check is the "
+            "authoritative report of that"
+        )
+
+        # 1. An exemption for a tool that is not published.
+        renamed = _stale_exemptions(
+            {"a_tool_that_was_renamed_away": frozenset({"whatever"})}, _TOOL_SAMPLES
+        )
+        assert any("a_tool_that_was_renamed_away" in f for f in renamed), renamed
+
+        # 2. An exemption for a property no schema declares.
+        undeclared = _stale_exemptions(
+            {published: frozenset({"a_property_that_does_not_exist"})}, _TOOL_SAMPLES
+        )
+        assert any("a_property_that_does_not_exist" in f for f in undeclared), undeclared
+
+        # 3. An exemption that has become unnecessary, which is the form a
+        #    reviewer is least likely to notice by reading: the entry names a real
+        #    property of a real tool, and only comparing it against what the
+        #    samples actually produce shows it is dead weight.
+        unnecessary = _stale_exemptions(
+            {published: frozenset({demonstrated[0]})}, _TOOL_SAMPLES
+        )
+        assert any(demonstrated[0] in f for f in unnecessary), unnecessary
+
+        # And it must stay SILENT about an exemption that is still doing work. A
+        # check rewritten to report every entry would satisfy all three assertions
+        # above while making the allowlist unusable — the mirror of the `return
+        # True` failure mode `_rejects_at` needed its own control for.
+        #
+        # Every declared property is demonstrated today, so an exemption that is
+        # still necessary has to be constructed: with no samples registered for the
+        # tool, nothing is demonstrated, and an exemption for a property its schema
+        # really declares is exactly the entry the allowlist is for.
+        still_needed = _stale_exemptions(
+            {published: frozenset({demonstrated[0]})}, {**_TOOL_SAMPLES, published: ()}
+        )
+        assert still_needed == [], (
+            "the staleness check objected to an exemption that is still doing "
+            f"work, so no entry could ever survive it: {still_needed}"
+        )
 
 class TestTheDerivationsSurviveAnUnusualDeclaration:
     """Nothing read at import time may raise on a declaration a client accepts.
@@ -1087,17 +1315,18 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         `test_an_unrecognised_key_on_a_route_row_is_not_forwarded`). A projection
         that started forwarding unknown keys would break every validating client;
         this control is what says the declaration forbids it.
+
+        🔑 Whichever case populates `prop`, not case zero. Only one of
+        `get_project`'s three cases populates `documents`, so making the
+        empty-project case first — a reordering that reads as cosmetic — used to
+        break this. `_payload_populating` searches instead, and reports "none of
+        the N samples populates it" when that is genuinely true, which is the
+        condition worth failing on.
         """
-        case, arguments, bodies = _first_sample(tool)
-        payload = _payload(tool, arguments, bodies)
+        payload = _payload_populating(tool, prop)
         schema = _output_schema(tool)
 
-        assert _errors(payload, schema) == [], f"{tool} ({case}) does not validate to begin with"
-        assert payload.get(prop), (
-            f"{tool} ({case}): the sample no longer carries any {prop} item, so "
-            "there is nothing to inject an undeclared key into; pick a sample "
-            "whose first case populates it"
-        )
+        assert _errors(payload, schema) == [], f"{tool} does not validate to begin with"
 
         broken = copy.deepcopy(payload)
         broken[prop][0]["a_field_no_one_declared"] = 1
@@ -1187,7 +1416,11 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         can pass for a different field's reason is not a control for this one.
         """
         personas_schema = _output_schema("list_personas")
-        payload = _payload("list_personas", *_first_sample("list_personas")[1:])
+        # Whichever case populates `personas`, not case zero: `payload["personas"][0]`
+        # raised a bare `IndexError` when the first registered case was one of the
+        # empty-project ones, so an apparently cosmetic reordering of the registry
+        # produced a traceback rather than a sentence.
+        payload = _payload_populating("list_personas", "personas")
         assert _errors(payload, personas_schema) == [], "the sample must validate first"
 
         # Asserted, not assumed: a valid payload need not CONTAIN this path — the
@@ -1230,7 +1463,9 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         that reports nothing on the day it is needed.
         """
         schema = _output_schema("list_personas")
-        payload = _payload("list_personas", *_first_sample("list_personas")[1:])
+        # As above: any case that populates `personas`, so registry order cannot
+        # turn this control into an `IndexError`.
+        payload = _payload_populating("list_personas", "personas")
         assert _errors(payload, schema) == [], "the sample must validate first"
 
         broken = copy.deepcopy(payload)

--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -1,0 +1,720 @@
+"""Every published tool's `outputSchema` checked against a real payload shape.
+
+Plan §10 Phase 3 adds roughly thirty delegated tools, each declaring an
+`outputSchema` with `additionalProperties: false`. Until this file, NOTHING
+compared a declaration against the shape the delegated route actually returns,
+and the cost of that gap is on record as finding M1 of
+`analysis/BUG-mcp-tool-truthfulness-GITHUB-ISSUE.md`: `list_personas` declared
+`pain_points` and `behaviors` as `array` while live rows held nested objects, so
+a validating client — the official MCP SDK, by default — rejected the whole
+response with `-32602`. The tool was UNCALLABLE in production while every test
+passed. #356 fixed that tool; this file closes the class.
+
+What makes it a guard rather than a test of six tools:
+
+  • the tool list is READ from `mcp_handler.MCP_TOOLS`, so a Phase 3 tool is
+    covered the moment it is published, without anyone remembering this file;
+  • a tool with NO registered sample FAILS. It does not skip. The tool most
+    likely to be wrong is the one nobody wrote a sample for, so an opt-out would
+    make the whole file decorative;
+  • the payload is not a dict written to match the schema — it is what the tool
+    ITSELF produces from a route body taken from the delegation suite's stubs.
+    Writing the schema out twice would prove only that it can be copied.
+
+⚠️ This file REPORTS mismatches, it does not fix them. A declaration that
+disagrees with a real payload is a finding for a follow-up, marked `xfail` here
+with the mismatch named. A schema change in the same commit would make the
+guard's own correctness unfalsifiable: a reviewer could not tell whether it
+passes because it works or because the declaration was bent to fit it.
+
+REVERT STORY — which mutation makes which assertion fail:
+
+  test_every_published_tool_has_a_registered_sample_payload
+    — the load-bearing one. Delete a tool's entry from `_TOOL_SAMPLES` and this
+      fails, naming it. Turn it into a `pytest.skip` and it passes for a tool
+      whose declaration nobody has ever validated, which is the state this file
+      exists to end. Its own positive control is
+      test_the_completeness_check_notices_a_tool_with_no_sample: the check is a
+      function, called with a registry missing an entry, so "the check cannot
+      detect anything" is itself a failure.
+
+  test_a_real_payload_validates_against_its_declared_output_schema
+    — the guard proper. Verified non-vacuous two ways rather than by inspection:
+      test_breaking_a_declared_type_in_a_copy_of_a_schema_rejects_a_real_payload
+      mutates a COPY of a schema and asserts the same sample stops validating,
+      and the negative controls below reject payloads a partial validator would
+      wave through.
+
+  test_an_undeclared_key_is_rejected_where_the_schema_closes_the_door
+    — proves the validator RUNS and that `additionalProperties: false` means
+      what it says. Drop it and a hand-rolled validator ignoring
+      `additionalProperties` would pass exactly the declarations that are wrong
+      — the reason this file takes a `jsonschema` dependency instead of
+      recursing over `properties` itself.
+
+  test_a_nested_object_where_an_array_is_declared_is_rejected
+    — M1's exact shape, in the two places a live writer can still produce it.
+      Drop it and a validator that never descends into `items` reads as green.
+
+  test_every_tool_declares_what_section_5_4_requires
+    — `outputSchema`, `annotations` (the four hints plus a title) and a cost
+      class under `_meta`. #360 already ships all three, so this passes on
+      arrival by design: it is here so a Phase 3 tool cannot land without them.
+
+WHERE THE SAMPLES CAME FROM. Each entry below names its provenance. None was
+invented to fit a schema; where a field's real shape is uncertain the MESSIER
+variant is preferred, because the nested-object case is what broke M1 and the
+tidy one is what hid it.
+"""
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mcp_handler
+
+# The delegation suite's stubs and row fixtures, imported rather than copied.
+#
+# Copying them is the one thing this file must not do: a fixture that drifts from
+# the shapes the routes really produce is how M1 survived a full green suite, and
+# two copies drift by construction. The sibling import resolves because
+# `conftest.py` appends this directory to `sys.path` — the same one line that
+# makes `plugin_manifests.py` and `metrics_publishing_routes.py` importable — so
+# it does not depend on pytest's import mode or on which module loads first.
+#
+# `_FakeLambda` is the ground truth that matters most here: it replays a canned
+# ROUTE BODY, so the payload this file validates is the tool's own output for a
+# realistic route answer, not a dict transcribed from the declaration.
+from test_mcp_delegation import (
+    _GENERATED_PERSONA,
+    _IMPORTED_PERSONA,
+    _PROJECT,
+    _SPARSE_PERSONA,
+    _call,
+    _FakeLambda,
+    _feedback_row,
+)
+
+# `search_feedback`'s text-search branch; the filter-only branch answers from
+# `/feedback`. Both are exercised below because they are different route bodies.
+_SEARCH_ROUTE = "/feedback/search"
+_LIST_ROUTE = "/feedback"
+_FEEDBACK_ID = "1ae1eb6abcd7d3a2e364f46139f98466"
+_DETAIL_ROUTE = f"/feedback/{_FEEDBACK_ID}"
+_PROJECT_ROUTE = f"/projects/{_PROJECT}"
+
+
+@pytest.fixture(autouse=True)
+def _functions_configured(monkeypatch):
+    """Both delegation targets named, as the stack supplies them.
+
+    Declared here rather than imported: an autouse fixture applies to the module
+    that DEFINES it, so importing the delegation suite's copy would give this
+    file the stub bodies and none of the environment they need.
+    """
+    monkeypatch.setenv("METRICS_FUNCTION", "voc-metrics-api")
+    monkeypatch.setenv("PROJECTS_FUNCTION", "voc-projects-api")
+
+
+# ---------------------------------------------------------------------------
+# Route bodies, per delegated route
+# ---------------------------------------------------------------------------
+#
+# Each of these is the shape the route that owns the data actually returns. The
+# provenance is on every one, because "a representative payload" is only worth
+# something if someone can check where it came from.
+
+# A raw feedback row as the processor writes it, from the delegation suite's
+# `_feedback_row()` — real-shaped id, `source_platform` / `original_text` /
+# `sentiment_label` under their storage names, `rating` as a number, a 900-char
+# verbatim so the summary truncation is exercised.
+_FEEDBACK_ROW = _feedback_row()
+
+# The SAME row with every field replaced by the wrong type. Copied from
+# `test_mcp_delegation.py::TestFeedbackDeclaredTypes` — a row of DynamoDB
+# attribute-value dicts, lists in string slots, a `None`, a float — and kept
+# because M1 was a wrong TYPE reaching a client, not a missing key. If the
+# projection ever stops coercing, THIS is the sample that catches it.
+_HOSTILE_FEEDBACK_ROW = _feedback_row(
+    source_platform=["webscraper"],
+    source_created_at={"S": "2026-08-01T10:11:12Z"},
+    sentiment_label=None,
+    sentiment_score={"N": "-0.8"},
+    category=7,
+    urgency=["high"],
+    persona_type={"a": "b"},
+    original_text=12345,
+    problem_summary=[1, 2],
+    journey_stage=9,
+    problem_root_cause_hypothesis={"k": "v"},
+    direct_customer_quote=3.5,
+    keywords="late",
+)
+
+# The legacy row: a plain `id`, no `feedback_id`, and nothing else. Rows this
+# thin predate most of the enrichment and are still in the corpus, so the
+# typed-default half of the projection is what this sample proves.
+_LEGACY_FEEDBACK_ROW = {"id": "legacy-1", "original_text": "arrived late"}
+
+# One document per storage prefix, keyed by sort key exactly as
+# `projects.get_project` returns them (asserted against the real route by
+# `test_mcp_delegation.py::test_the_document_sort_key_is_still_there`). All six
+# kinds, because the in-process tool recognised two of them.
+_DOCUMENTS = [
+    {"sk": f"{prefix}{i}", "document_id": f"doc_2026081914300{i}", "title": f"doc {i}"}
+    for i, prefix in enumerate(mcp_handler._DOCUMENT_KINDS)
+]
+
+# `/metrics/summary`'s own return dict, field for field, from
+# `metrics_handler.get_summary` — `avg_sentiment` a rounded float, the two daily
+# series as lists of `{date, count}` / `{date, avg_sentiment, count}`. The
+# values are the ones `test_metrics_handler.py::TestGetSummaryEndpoint` asserts
+# the route computes from one aggregate row.
+_METRICS_SUMMARY_BODY = {
+    "period_days": 7,
+    "total_feedback": 50,
+    "avg_sentiment": 0.5,
+    "urgent_count": 50,
+    "is_partial": False,
+    "daily_totals": [{"date": "2026-01-07", "count": 50}],
+    "daily_sentiment": [{"date": "2026-01-07", "avg_sentiment": 0.5, "count": 50}],
+}
+
+# The degraded answer from the same route: a window wider than aggregates are
+# retained for. `is_partial` true with real counts beside it, which is the shape
+# `test_metrics_partial_window` pins.
+_METRICS_SUMMARY_PARTIAL_BODY = {
+    **_METRICS_SUMMARY_BODY,
+    "period_days": 365,
+    "is_partial": True,
+}
+
+# `/metrics/sentiment` — note `total`, which the route publishes and the tool's
+# schema does not declare. Legal, and deliberately so: the metrics tools pass
+# their route's body through unprojected, so their schemas leave
+# `additionalProperties` open. Kept in the sample precisely BECAUSE it is
+# undeclared: it is the evidence that the open declaration is load-bearing.
+_METRICS_SENTIMENT_BODY = {
+    "period_days": 7,
+    "total": 6239,
+    "is_partial": False,
+    "breakdown": {"positive": 1200, "neutral": 2000, "negative": 3000, "mixed": 39},
+    "percentages": {"positive": 19.2, "neutral": 32.1, "negative": 48.1, "mixed": 0.6},
+}
+# `/metrics/categories`, `/metrics/sources`, `/metrics/personas` — the three
+# routes that answer with one counts object, sorted descending by count.
+_METRICS_CATEGORIES_BODY = {
+    "period_days": 7,
+    "is_partial": False,
+    "categories": {"delivery": 300, "pricing": 120, "product_quality": 8},
+}
+_METRICS_SOURCES_BODY = {
+    "period_days": 7,
+    "is_partial": True,
+    "sources": {"webscraper": 4000, "feedback-form": 21},
+}
+_METRICS_PERSONAS_BODY = {
+    "period_days": 7,
+    "is_partial": False,
+    "personas": {"Priya Shah": 42, "Tobias Krenzler": 3},
+}
+
+
+# ---------------------------------------------------------------------------
+# The sample registry
+# ---------------------------------------------------------------------------
+#
+# One tool → one or more cases, each `(case name, tool arguments, route bodies)`.
+# The registry holds ROUTE BODIES rather than finished payloads on purpose: the
+# payload is then produced by the tool under test, so this file cannot
+# accidentally validate a shape the tool never emits.
+#
+# 🔑 Adding a tool to `MCP_TOOLS` and not to this dict is a FAILING test, not a
+# silent gap. That is the whole point — see the module docstring's revert story.
+_TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
+    "search_feedback": (
+        # The text-search branch, with the route's own truncation flag set. The
+        # tool renames it to `is_partial`, which it declares REQUIRED.
+        ("search branch, truncated scan", {"query": "late"}, {
+            _SEARCH_ROUTE: {
+                "count": 1,
+                "query": "late",
+                "items": [_FEEDBACK_ROW],
+                "is_partial_window": True,
+            },
+        }),
+        # The filter-only branch: a different route, a different body.
+        ("filter-only branch", {"category": "delivery"}, {
+            _LIST_ROUTE: {
+                "count": 1, "total": 1, "offset": 0, "limit": 20,
+                "is_partial_window": False,
+                "items": [_FEEDBACK_ROW, _LEGACY_FEEDBACK_ROW],
+            },
+        }),
+        # The messy variant. A row of entirely wrong types must still yield a
+        # payload that satisfies the declaration — otherwise the answer is M1.
+        ("a row of wrong types", {"query": "late"}, {
+            _SEARCH_ROUTE: {"items": [_HOSTILE_FEEDBACK_ROW]},
+        }),
+        # The empty answer, which is a real answer and still has a shape.
+        ("nothing matched", {"query": "late"}, {
+            _SEARCH_ROUTE: {"count": 0, "items": [], "is_partial_window": False},
+        }),
+    ),
+    "get_feedback_detail": (
+        ("an enriched row", {"feedback_id": _FEEDBACK_ID}, {
+            _DETAIL_ROUTE: _FEEDBACK_ROW,
+        }),
+        ("a row of wrong types", {"feedback_id": _FEEDBACK_ID}, {
+            _DETAIL_ROUTE: _HOSTILE_FEEDBACK_ROW,
+        }),
+        ("a legacy row carrying only a plain id", {"feedback_id": _FEEDBACK_ID}, {
+            _DETAIL_ROUTE: _LEGACY_FEEDBACK_ROW,
+        }),
+    ),
+    "get_metrics_summary": (
+        ("a complete window", {}, {"/metrics/summary": _METRICS_SUMMARY_BODY}),
+        ("a partial window", {"days": 365},
+         {"/metrics/summary": _METRICS_SUMMARY_PARTIAL_BODY}),
+    ),
+    "get_metrics_breakdown": (
+        # All four dimensions, because each reaches a DIFFERENT route with a
+        # different body, and one tool schema has to describe all four.
+        ("sentiment", {"dimension": "sentiment"},
+         {"/metrics/sentiment": _METRICS_SENTIMENT_BODY}),
+        ("categories", {"dimension": "categories"},
+         {"/metrics/categories": _METRICS_CATEGORIES_BODY}),
+        ("sources", {"dimension": "sources"},
+         {"/metrics/sources": _METRICS_SOURCES_BODY}),
+        ("personas", {"dimension": "personas"},
+         {"/metrics/personas": _METRICS_PERSONAS_BODY}),
+    ),
+    "get_project": (
+        ("metadata, three live persona shapes and all six document kinds",
+         {"project_id": _PROJECT}, {
+             _PROJECT_ROUTE: {
+                 "project": {
+                     "name": "Morning Briefing",
+                     "description": "The daily catch-up app",
+                     "created_at": "2026-08-19T14:30:00+00:00",
+                     # Present on every real row and dropped by the tool: the
+                     # route injects it at read time.
+                     "kiro_default_export_prompt": "…",
+                 },
+                 "personas": [_GENERATED_PERSONA, _IMPORTED_PERSONA, _SPARSE_PERSONA],
+                 "documents": _DOCUMENTS,
+             },
+         }),
+        # A `tagline` that is a list, from the writer that constrains nothing.
+        # `get_project` is the tool that WAS callable, so this is the live half
+        # of M1: `p.get('tagline', '')` cannot correct a list.
+        ("a persona whose tagline is a list", {"project_id": _PROJECT}, {
+            _PROJECT_ROUTE: {
+                "project": {"name": "Morning Briefing"},
+                "personas": [{**_SPARSE_PERSONA, "tagline": ["Night-shift", "supervisor"]}],
+                "documents": [],
+            },
+        }),
+        ("an empty project", {"project_id": _PROJECT}, {
+            _PROJECT_ROUTE: {"project": {"name": "Empty"}, "personas": [], "documents": []},
+        }),
+    ),
+    "list_personas": (
+        # The three live persona shapes together: the schema-following writer,
+        # the importer that constrains nothing (`workarounds` a STRING where the
+        # generated row has a list, section keys this file never chose), and the
+        # thinnest row in the corpus. All three from the delegation suite, which
+        # took them from live rows.
+        ("the three live persona shapes", {"project_id": _PROJECT}, {
+            _PROJECT_ROUTE: {
+                "project": {"name": "Morning Briefing"},
+                "personas": [_GENERATED_PERSONA, _IMPORTED_PERSONA, _SPARSE_PERSONA],
+                "documents": _DOCUMENTS,
+            },
+        }),
+        # M1's exact shape at the source: nested objects inside the sections that
+        # were once declared `array`, and a scalar where the generated row has a
+        # list. This is the row that made the tool uncallable.
+        ("a persona carrying nested objects where lists are declared",
+         {"project_id": _PROJECT}, {
+             _PROJECT_ROUTE: {
+                 "project": {"name": "Morning Briefing"},
+                 "personas": [{
+                     **_SPARSE_PERSONA,
+                     "confidence": ["high"],
+                     "feedback_count": "42",
+                     "pain_points": {
+                         "current_challenges": {"a": "alerts", "b": "noise"},
+                         "emotional_impact": ["tired", "resigned"],
+                     },
+                     "behaviors": {"tools_used": {"ios": True}},
+                     "quotes": {"text": "not even a list"},
+                 }],
+                 "documents": [],
+             },
+         }),
+        ("a project with no personas", {"project_id": _PROJECT}, {
+            _PROJECT_ROUTE: {"project": {"name": "Empty"}, "personas": [], "documents": []},
+        }),
+    ),
+}
+
+# The declared tool names, read from the published registry. Parametrising over
+# THIS rather than over `_TOOL_SAMPLES` is what makes a new tool with no sample a
+# red test instead of an absence nobody sees.
+_PUBLISHED_TOOL_NAMES: tuple[str, ...] = tuple(
+    tool["name"] for tool in mcp_handler.MCP_TOOLS
+)
+
+# §5.4's behaviour hints. Named here so the assertion says which one is missing.
+_REQUIRED_HINTS: tuple[str, ...] = (
+    "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint",
+)
+
+
+def _output_schema(name: str) -> dict:
+    """One tool's declared `outputSchema`, read from the published registry."""
+    for tool in mcp_handler.MCP_TOOLS:
+        if tool["name"] == name:
+            return tool["outputSchema"]
+    raise AssertionError(f"no published tool named {name}")
+
+
+def _payload(tool: str, arguments: dict, bodies: dict) -> dict:
+    """What the tool puts in `structuredContent` for these route bodies.
+
+    Fails rather than returns on an errored call: a tool that refused the sample
+    produces no payload, and validating `{}` against an open schema is how a
+    conformance suite goes green while proving nothing.
+    """
+    result = _call(tool, arguments, _FakeLambda(bodies))
+    assert "error" not in result, f"{tool}: the sample call failed: {result['error']}"
+    inner = result["result"]
+    assert inner["isError"] is False, f"{tool}: the sample call was a tool error: {inner}"
+    assert "structuredContent" in inner, f"{tool}: the call returned no structuredContent"
+    return inner["structuredContent"]
+
+
+def _errors(payload, schema: dict) -> list[str]:
+    """Every way this payload violates this schema, deepest-first, as prose.
+
+    A REAL validator, not a subset of one. A hand-rolled check that skipped
+    `additionalProperties` or never descended into `items` would pass exactly the
+    declarations that are wrong — both constructs carry a live finding between
+    them (M1 was inside `items`).
+    """
+    validator = Draft202012Validator(schema)
+    return [
+        f"{'/'.join(str(p) for p in error.absolute_path) or '<root>'}: {error.message}"
+        for error in validator.iter_errors(payload)
+    ]
+
+
+def _tools_missing_samples(registry: dict) -> list[str]:
+    """Published tools with no sample in this registry.
+
+    A FUNCTION rather than a comprehension inside the test, so the completeness
+    check can itself be called with a registry that is missing an entry —
+    `test_the_completeness_check_notices_a_tool_with_no_sample`. A check nobody
+    checks is the one that quietly returns nothing.
+    """
+    return sorted(
+        name for name in _PUBLISHED_TOOL_NAMES if not registry.get(name)
+    )
+
+
+def _closed_schema_tools() -> list[str]:
+    """The tools whose `outputSchema` forbids undeclared top-level keys.
+
+    Derived from the declarations rather than listed: the split between closed
+    (projected answers) and open (pass-through route bodies) is a real design
+    decision in `mcp_handler`, and a list here would be a second opinion about
+    it.
+    """
+    return [
+        name for name in _PUBLISHED_TOOL_NAMES
+        if _output_schema(name).get("additionalProperties") is False
+    ]
+
+
+# ===========================================================================
+# Coverage — a tool with no sample fails
+# ===========================================================================
+
+class TestEveryToolBringsASample:
+    def test_every_published_tool_has_a_registered_sample_payload(self):
+        """The load-bearing requirement: this cannot be opted out of.
+
+        A Phase 3 tool either brings a payload taken from the route it delegates
+        to, or the suite is red. Skipping the unregistered ones would leave the
+        tool most likely to be wrong — the one nobody wrote a sample for — as the
+        only tool nothing validates.
+        """
+        missing = _tools_missing_samples(_TOOL_SAMPLES)
+
+        assert missing == [], (
+            f"published with no sample payload: {missing}. Add one to "
+            "_TOOL_SAMPLES, taken from the shape the delegated route really "
+            "returns — not written to match the schema."
+        )
+
+    def test_the_registry_holds_no_sample_for_a_tool_that_is_not_published(self):
+        """The other direction. A renamed tool leaves a sample validating
+        nothing, and an entry that no longer matches a published name is exactly
+        as invisible as a missing one."""
+        stale = sorted(set(_TOOL_SAMPLES) - set(_PUBLISHED_TOOL_NAMES))
+
+        assert stale == [], f"samples for tools that are not published: {stale}"
+
+    def test_the_completeness_check_notices_a_tool_with_no_sample(self):
+        """The positive control for the check above.
+
+        Called with the real registry minus one entry, so "the check found
+        nothing" cannot be because the check finds nothing ever. Deleting the
+        `_tools_missing_samples` body to `return []` fails HERE, with the name of
+        the tool it should have reported.
+        """
+        victim = _PUBLISHED_TOOL_NAMES[0]
+        thinned = {k: v for k, v in _TOOL_SAMPLES.items() if k != victim}
+
+        assert _tools_missing_samples(thinned) == [victim]
+        # An empty entry is as useless as an absent one and must read the same.
+        assert _tools_missing_samples({**_TOOL_SAMPLES, victim: ()}) == [victim]
+
+
+# ===========================================================================
+# The guard — a real payload against its own declaration
+# ===========================================================================
+
+def _cases() -> list:
+    """Every (tool, case) pair, as pytest parameters named for the case.
+
+    Built from the PUBLISHED tool list, so a tool with no samples contributes one
+    parameter that fails with its own name rather than silently contributing
+    none.
+    """
+    params = []
+    for name in _PUBLISHED_TOOL_NAMES:
+        samples = _TOOL_SAMPLES.get(name) or ()
+        if not samples:
+            params.append(pytest.param(name, None, id=f"{name}-NO-SAMPLE"))
+            continue
+        for case, arguments, bodies in samples:
+            params.append(pytest.param(
+                name, (arguments, bodies), id=f"{name}-{case.replace(' ', '_')}",
+            ))
+    return params
+
+
+class TestDeclaredSchemasHoldAgainstRealPayloads:
+    @pytest.mark.parametrize("tool,sample", _cases())
+    def test_a_real_payload_validates_against_its_declared_output_schema(self, tool, sample):
+        """The guard. What the tool emits must satisfy what it advertises.
+
+        `sample is None` is the unregistered case, and it FAILS here as well as
+        in the coverage test above — once with the tool's name in the test id,
+        which is what a Phase 3 author reads first.
+        """
+        assert sample is not None, (
+            f"{tool} publishes an outputSchema and has no sample payload; "
+            "nothing validates its declaration"
+        )
+        arguments, bodies = sample
+        payload = _payload(tool, arguments, bodies)
+
+        errors = _errors(payload, _output_schema(tool))
+        assert errors == [], f"{tool} payload violates its own outputSchema: {errors}"
+
+    @pytest.mark.parametrize("tool", _PUBLISHED_TOOL_NAMES)
+    def test_the_declaration_is_itself_a_valid_json_schema(self, tool):
+        """A malformed declaration is not a validating client's problem to find.
+
+        `check_schema` is what catches `{"type": "arary"}` or an `items` beside a
+        `type: object`: constructs a client's validator either rejects outright
+        or silently ignores, in which case the field is unvalidated and nothing
+        says so.
+        """
+        Draft202012Validator.check_schema(_output_schema(tool))
+
+
+# ===========================================================================
+# Negative controls — what proves the validator is running
+# ===========================================================================
+
+class TestTheValidatorRejectsWhatTheDeclarationsForbid:
+    def test_some_tool_closes_its_output_schema(self):
+        """Anti-vacuity for the parametrization below: if no schema declared
+        `additionalProperties: false`, the extra-key control would be an empty
+        parametrization reading as green."""
+        assert _closed_schema_tools(), (
+            "no published tool closes its outputSchema; the extra-key control "
+            "below would cover nothing"
+        )
+
+    @pytest.mark.parametrize("tool", _closed_schema_tools())
+    def test_an_undeclared_key_is_rejected_where_the_schema_closes_the_door(self, tool):
+        """`additionalProperties: false` must mean it.
+
+        This is the control that proves a validator is RUNNING at all: a
+        partial implementation that walks `properties` and ignores
+        `additionalProperties` passes every payload here, and passes exactly the
+        declarations that are wrong.
+        """
+        case, arguments, bodies = _TOOL_SAMPLES[tool][0]
+        payload = _payload(tool, arguments, bodies)
+        schema = _output_schema(tool)
+
+        # Valid first, so the rejection below is attributable to the added key
+        # and not to a sample that never conformed.
+        assert _errors(payload, schema) == [], f"{tool} ({case}) does not validate to begin with"
+
+        errors = _errors({**payload, "a_field_no_one_declared": 1}, schema)
+        assert errors, (
+            f"{tool} declares additionalProperties: false and accepted an "
+            "undeclared key; the validator is not enforcing it"
+        )
+        assert any("a_field_no_one_declared" in e for e in errors), errors
+
+    def test_an_undeclared_key_is_accepted_where_the_schema_leaves_it_open(self):
+        """The other half of that split, and it is deliberate.
+
+        The metrics tools forward a route body unprojected, so they do not
+        control the keys and declare `additionalProperties` open. Asserting the
+        rejection everywhere would be asserting a design this server
+        deliberately does not have — and would turn a route growing a field into
+        a failure in this file.
+        """
+        schema = _output_schema("get_metrics_breakdown")
+
+        assert schema.get("additionalProperties") is not False
+        assert _errors({**_METRICS_CATEGORIES_BODY, "added_next_quarter": 1}, schema) == []
+
+    def test_a_nested_object_where_an_array_is_declared_is_rejected(self):
+        """M1's exact shape: an object in a slot declared `array`.
+
+        Both places a live writer can still produce it — a persona section's
+        string list, and the one declared array on the feedback detail. A
+        validator that never descends into `items` reads green on both, which is
+        what let M1 reach production.
+        """
+        personas_schema = _output_schema("list_personas")
+        payload = _payload("list_personas", *_TOOL_SAMPLES["list_personas"][0][1:])
+        assert _errors(payload, personas_schema) == [], "the sample must validate first"
+
+        broken = copy.deepcopy(payload)
+        broken["personas"][0]["pain_points"]["current_challenges"] = {"a": "alerts"}
+        errors = _errors(broken, personas_schema)
+        assert any("current_challenges" in e or "array" in e for e in errors), errors
+
+        detail_schema = _output_schema("get_feedback_detail")
+        detail = _payload("get_feedback_detail", *_TOOL_SAMPLES["get_feedback_detail"][0][1:])
+        assert _errors(detail, detail_schema) == []
+
+        assert _errors({**detail, "keywords": {"0": "late"}}, detail_schema)
+        # And a string where the array is declared: the flat-value case, which is
+        # what the importer really writes.
+        assert _errors({**detail, "keywords": "late"}, detail_schema)
+
+    def test_a_string_where_an_integer_is_declared_is_rejected(self):
+        """`feedback_count` arrives as a DynamoDB `Decimal` and on old rows not
+        at all, so a writer putting `"42"` there is not hypothetical."""
+        schema = _output_schema("list_personas")
+        payload = _payload("list_personas", *_TOOL_SAMPLES["list_personas"][0][1:])
+
+        broken = copy.deepcopy(payload)
+        broken["personas"][0]["feedback_count"] = "42"
+
+        assert _errors(broken, schema)
+
+    def test_a_required_field_that_is_absent_is_rejected(self):
+        """`search_feedback` promises `is_partial` on every answer. A flag that
+        is sometimes missing reads as "not truncated", which is the same wrong
+        answer as asserting it false."""
+        schema = _output_schema("search_feedback")
+        payload = _payload("search_feedback", *_TOOL_SAMPLES["search_feedback"][0][1:])
+        assert "is_partial" in schema.get("required", []), (
+            "search_feedback no longer requires is_partial; this control moved"
+        )
+
+        assert _errors({k: v for k, v in payload.items() if k != "is_partial"}, schema)
+
+    def test_breaking_a_declared_type_in_a_copy_of_a_schema_rejects_a_real_payload(self):
+        """The guard mutation-checked against itself, in the suite.
+
+        A COPY of the declaration, never `mcp_handler`'s own: this file reports
+        mismatches and changes nothing. If a declared type can be broken and the
+        same real payload still validates, then the payload was never being
+        checked against that field and every green run above meant nothing.
+        """
+        mutated = copy.deepcopy(_output_schema("get_feedback_detail"))
+        mutated["properties"]["keywords"]["type"] = "integer"
+        payload = _payload("get_feedback_detail", *_TOOL_SAMPLES["get_feedback_detail"][0][1:])
+
+        assert _errors(payload, _output_schema("get_feedback_detail")) == []
+        assert _errors(payload, mutated), (
+            "a declared type was broken and the payload still validated; the "
+            "guard is not reading the declaration it claims to"
+        )
+
+    def test_closing_an_open_schema_in_a_copy_rejects_a_real_route_body(self):
+        """The same mutation for the other half of the split.
+
+        The metrics schemas are open BECAUSE the route sends fields they do not
+        declare — `/metrics/sentiment` sends `total`. Closing a copy must reject
+        the real body, which is what makes "open on purpose" a fact about the
+        payload rather than an assertion in a comment.
+        """
+        schema = _output_schema("get_metrics_breakdown")
+        assert _errors(_METRICS_SENTIMENT_BODY, schema) == []
+
+        closed = {**copy.deepcopy(schema), "additionalProperties": False}
+        errors = _errors(_METRICS_SENTIMENT_BODY, closed)
+
+        assert any("total" in e for e in errors), errors
+
+
+# ===========================================================================
+# §5.4 — what every declaration must carry
+# ===========================================================================
+
+class TestEveryToolDeclaresWhatTheSpecSectionRequires:
+    """#360 already ships all of this, so this class passes on arrival.
+
+    That is the point: it is not here to find a defect today, it is here so a
+    Phase 3 tool cannot land without an output schema, without the behaviour
+    hints a client uses to decide whether a call needs a human's permission, or
+    without the cost class a model uses to choose between two tools.
+    """
+
+    @pytest.mark.parametrize("tool", mcp_handler.MCP_TOOLS, ids=lambda t: t["name"])
+    def test_every_tool_declares_what_section_5_4_requires(self, tool):
+        name = tool["name"]
+
+        assert isinstance(tool.get("outputSchema"), dict), f"{name} declares no outputSchema"
+        assert tool["outputSchema"].get("type") == "object", (
+            f"{name}: structuredContent is an object, so its schema must say so"
+        )
+
+        annotations = tool.get("annotations")
+        assert isinstance(annotations, dict), f"{name} publishes no annotations"
+        assert annotations.get("title"), (
+            f"{name} has no human-readable title; a client shows the raw name in "
+            "its permission prompt"
+        )
+        missing_hints = [hint for hint in _REQUIRED_HINTS if hint not in annotations]
+        assert missing_hints == [], f"{name} omits behaviour hints: {missing_hints}"
+        for hint in _REQUIRED_HINTS:
+            assert isinstance(annotations[hint], bool), (
+                f"{name}.{hint} is a hint a client branches on; it must be a boolean"
+            )
+
+        cost_class = (tool.get("_meta") or {}).get(mcp_handler.COST_CLASS_KEY)
+        assert cost_class in mcp_handler.COST_CLASSES, (
+            f"{name} declares cost class {cost_class!r}, not one of "
+            f"{mcp_handler.COST_CLASSES}"
+        )

--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -22,10 +22,15 @@ What makes it a guard rather than a test of six tools:
     Writing the schema out twice would prove only that it can be copied.
 
 ⚠️ This file REPORTS mismatches, it does not fix them. A declaration that
-disagrees with a real payload is a finding for a follow-up, marked `xfail` here
-with the mismatch named. A schema change in the same commit would make the
-guard's own correctness unfalsifiable: a reviewer could not tell whether it
-passes because it works or because the declaration was bent to fit it.
+disagrees with a real payload surfaces as a FAILING parametrised case and is
+fixed in a separate follow-up; changing a schema in the same commit would make
+the guard's own correctness unfalsifiable, because a reviewer could not tell
+whether it passes because it works or because the declaration was bent to fit
+it. If a fix genuinely has to be deferred, the marker is
+`pytest.mark.xfail(strict=True, reason=...)` naming the field and the tracking
+issue — strict, so the day the declaration is corrected this file says so
+instead of silently keeping a stale exemption. There is no such marker today: no
+published tool mismatches its declaration.
 
 REVERT STORY — which mutation makes which assertion fail:
 
@@ -52,9 +57,26 @@ REVERT STORY — which mutation makes which assertion fail:
       — the reason this file takes a `jsonschema` dependency instead of
       recursing over `properties` itself.
 
+  test_an_undeclared_key_inside_an_array_item_is_rejected
+    — the same closure one level DOWN, where M1 lived. The top-level control
+      cannot reach it, because merging a key into the payload root never touches
+      an element of `items`. Its anti-vacuity control is
+      test_some_array_closes_its_item_schema, and its positive counterpart is
+      test_an_unrecognised_key_on_a_route_row_is_not_forwarded, which pins the
+      projection behaviour that keeps the shape unreachable from a route.
+
   test_a_nested_object_where_an_array_is_declared_is_rejected
     — M1's exact shape, in the two places a live writer can still produce it.
       Drop it and a validator that never descends into `items` reads as green.
+      Every negative control here asserts the unmutated payload validates FIRST
+      and then matches the error's PATH (`_rejects_at`), not the message prose:
+      a substring matcher on prose is satisfied by an unrelated field failing,
+      and a control with no "valid first" assertion goes green the day its sample
+      stops conforming for a reason it was never about. `_rejects_at` therefore
+      has its own positive control,
+      test_the_path_matcher_distinguishes_one_field_from_another — rewrite it to
+      `return True` and every other control here still passes, because none of
+      them ever asks it to say no.
 
   test_every_tool_declares_what_section_5_4_requires
     — `outputSchema`, `annotations` (the four hints plus a title) and a cost
@@ -64,7 +86,8 @@ REVERT STORY — which mutation makes which assertion fail:
 WHERE THE SAMPLES CAME FROM. Each entry below names its provenance. None was
 invented to fit a schema; where a field's real shape is uncertain the MESSIER
 variant is preferred, because the nested-object case is what broke M1 and the
-tidy one is what hid it.
+tidy one is what hid it. `_TOOL_SAMPLES` states the ranked convention a Phase 3
+author should follow when a route has no fixture yet.
 """
 
 import copy
@@ -72,7 +95,28 @@ import sys
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
+
+# 🔑 A hard failure, NOT `pytest.importorskip`. `jsonschema` is pinned in
+# `requirements-dev.txt` and installed by the venv recipe in
+# `docs/deployment.md`, which is where `npm run test:backend` gets its
+# interpreter. An `importorskip` would skip this whole file whenever the pin is
+# missing and report a successful run that validated nothing — precisely the
+# "green suite, uncallable tool" state M1 lived in. So the import stays fatal.
+#
+# Re-raised only to NAME the fix: a bare ModuleNotFoundError in a venv created
+# before this pin reads as a broken checkout, and the failure a developer sees
+# should say which file to install. It stays a collection error either way.
+try:
+    from jsonschema import Draft202012Validator
+except ModuleNotFoundError as exc:  # pragma: no cover - environment, not logic
+    raise ModuleNotFoundError(
+        "jsonschema is required by this MCP outputSchema conformance suite and is "
+        "pinned in voc-datalake/requirements-dev.txt. A virtualenv created before "
+        "that pin will not have it: re-run "
+        "`.venv/bin/pip install -r requirements-dev.txt`. This suite is NOT "
+        "skippable — skipping it would report a passing run that validated no "
+        "tool declaration at all."
+    ) from exc
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -82,15 +126,22 @@ import mcp_handler
 #
 # Copying them is the one thing this file must not do: a fixture that drifts from
 # the shapes the routes really produce is how M1 survived a full green suite, and
-# two copies drift by construction. The sibling import resolves because
-# `conftest.py` appends this directory to `sys.path` — the same one line that
-# makes `plugin_manifests.py` and `metrics_publishing_routes.py` importable — so
-# it does not depend on pytest's import mode or on which module loads first.
+# two copies drift by construction.
+#
+# 🔑 Imported by PACKAGE PATH, not as a bare `test_mcp_delegation`. Both resolve —
+# `conftest.py` puts `lambda/` and this directory on `sys.path` — but they do not
+# resolve to the same object. `lambda/api/test/__init__.py` exists, so pytest
+# imports the delegation suite as `api.test.test_mcp_delegation`; a bare import
+# executes its module body a SECOND time under a second name, leaving two sets of
+# fixture objects for the same source file. That is the "two copies drift by
+# construction" failure this import exists to avoid, arriving through the import
+# system instead of through a copy-paste. `sys.modules` proves it: with the bare
+# form, `[n for n in sys.modules if "mcp_delegation" in n]` has two entries.
 #
 # `_FakeLambda` is the ground truth that matters most here: it replays a canned
 # ROUTE BODY, so the payload this file validates is the tool's own output for a
 # realistic route answer, not a dict transcribed from the declaration.
-from test_mcp_delegation import (
+from api.test.test_mcp_delegation import (
     _GENERATED_PERSONA,
     _IMPORTED_PERSONA,
     _PROJECT,
@@ -236,6 +287,29 @@ _METRICS_PERSONAS_BODY = {
 #
 # 🔑 Adding a tool to `MCP_TOOLS` and not to this dict is a FAILING test, not a
 # silent gap. That is the whole point — see the module docstring's revert story.
+#
+# WHERE A PHASE 3 AUTHOR SHOULD GET A ROUTE BODY, in order of preference. This is
+# the one decision each of the ~30 new tools has to make, so it is stated once
+# here rather than left to be inferred from the provenance comments above:
+#
+#   1. An existing fixture from the suite that owns the route. Best, because it
+#      is already maintained against the route and cannot drift independently —
+#      `_feedback_row()` and the three persona shapes come from
+#      `test_mcp_delegation.py`, which took them from live rows.
+#   2. The route handler's own `return` dict, transcribed field for field, with a
+#      comment naming the function and the test that pins those values. This is
+#      what the metrics bodies below are, and it is second-best because a human
+#      transcription is exactly the link that can drift.
+#   3. Driving the route handler with a stubbed table. Strongest chain of custody
+#      and NOT used here: it would make this file depend on a second handler's
+#      stubbing (`metrics_handler`'s `aggregates_table`, which
+#      `test_metrics_handler.py` already sets up), so a change to that stubbing
+#      would break a schema-conformance suite for a reason that has nothing to do
+#      with schemas. Worth reaching for if a route's shape is hard to state by
+#      hand — a many-branch aggregation — but not by default.
+#
+# What is NOT acceptable at any level: a dict written by reading the outputSchema.
+# That proves a declaration can be copied, which is not in question.
 _TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
     "search_feedback": (
         # The text-search branch, with the route's own truncation flag set. The
@@ -401,18 +475,53 @@ def _payload(tool: str, arguments: dict, bodies: dict) -> dict:
 
 
 def _errors(payload, schema: dict) -> list[str]:
-    """Every way this payload violates this schema, deepest-first, as prose.
+    """Every way this payload violates this schema, as prose, for a failure message.
 
     A REAL validator, not a subset of one. A hand-rolled check that skipped
     `additionalProperties` or never descended into `items` would pass exactly the
     declarations that are wrong — both constructs carry a live finding between
     them (M1 was inside `items`).
+
+    Unordered — `iter_errors` yields in the validator's own keyword and property
+    iteration order, so a shallow violation can precede a deep one. Nothing here
+    reads `errors[0]`, and a control that wants to name WHICH field failed must
+    use `_error_paths` rather than searching this prose: a message can mention
+    `'array'` because some other declared array broke.
     """
     validator = Draft202012Validator(schema)
     return [
         f"{'/'.join(str(p) for p in error.absolute_path) or '<root>'}: {error.message}"
         for error in validator.iter_errors(payload)
     ]
+
+
+def _error_paths(payload, schema: dict) -> list[tuple]:
+    """The payload path of every violation, as a tuple of keys and indices.
+
+    🔑 The attributable half of `_errors`. A control that asserts "this field is
+    rejected" by searching the message prose for a substring accepts an error
+    raised somewhere else entirely: `any("array" in e for e in errors)` passes
+    when an UNRELATED declared array is broken, and `list_personas` payloads
+    carry several. Matching on `absolute_path` names the field the control claims
+    to be about, so the control fails if that field stops being checked even
+    while the payload keeps failing for another reason.
+    """
+    return [
+        tuple(error.absolute_path)
+        for error in Draft202012Validator(schema).iter_errors(payload)
+    ]
+
+
+def _rejects_at(payload, schema: dict, path: tuple) -> bool:
+    """Whether some violation is at `path` or inside it.
+
+    Prefix rather than equality: `additionalProperties: false` reports at the
+    OBJECT that carried the undeclared key, while a wrong type reports at the
+    value, so a control that wants "the failure is attributable to this subtree"
+    cannot pin the exact depth without restating the validator's own reporting
+    rules.
+    """
+    return any(p[: len(path)] == path for p in _error_paths(payload, schema))
 
 
 def _tools_missing_samples(registry: dict) -> list[str]:
@@ -440,6 +549,25 @@ def _closed_schema_tools() -> list[str]:
         name for name in _PUBLISHED_TOOL_NAMES
         if _output_schema(name).get("additionalProperties") is False
     ]
+
+
+def _closed_item_schemas() -> list[tuple[str, str]]:
+    """`(tool, array property)` for every array whose ITEMS close the door.
+
+    Derived the same way as `_closed_schema_tools`, and needed for the same
+    reason one level down: M1 lived inside `items`, so the nested closure is the
+    architecturally important one to control, and the top-level control cannot
+    reach it — merging a key into the payload root never touches an element of
+    `items`.
+    """
+    found = []
+    for name in _PUBLISHED_TOOL_NAMES:
+        for prop, declared in (_output_schema(name).get("properties") or {}).items():
+            if declared.get("type") != "array":
+                continue
+            if (declared.get("items") or {}).get("additionalProperties") is False:
+                found.append((name, prop))
+    return found
 
 
 # ===========================================================================
@@ -547,6 +675,37 @@ class TestDeclaredSchemasHoldAgainstRealPayloads:
 # ===========================================================================
 
 class TestTheValidatorRejectsWhatTheDeclarationsForbid:
+    def test_the_path_matcher_distinguishes_one_field_from_another(self):
+        """The positive control for `_rejects_at`, which every control below uses.
+
+        🔑 A matcher is the one kind of helper whose failure mode is silent
+        approval: rewrite `_rejects_at` to `return True` and every negative
+        control below still passes, because each one only ever asks it to confirm
+        a rejection. So it is exercised here against a schema and payload owned by
+        this test — required to say NO for a path that did not fail, and no for a
+        payload with no errors at all, which is what the mutated version cannot
+        do.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "wanted": {"type": "array", "items": {"type": "string"}},
+                "other": {"type": "array", "items": {"type": "string"}},
+            },
+        }
+        valid = {"wanted": ["a"], "other": ["b"]}
+        broken_elsewhere = {"wanted": ["a"], "other": {"not": "a list"}}
+
+        assert _rejects_at(broken_elsewhere, schema, ("other",))
+        assert not _rejects_at(broken_elsewhere, schema, ("wanted",)), (
+            "the path matcher attributed a failure to a field that did not fail; "
+            "every control below would then pass for the wrong reason"
+        )
+        assert not _rejects_at(valid, schema, ("wanted",))
+        assert not _rejects_at(valid, schema, ()), (
+            "the path matcher reported a rejection for a payload with no errors"
+        )
+
     def test_some_tool_closes_its_output_schema(self):
         """Anti-vacuity for the parametrization below: if no schema declared
         `additionalProperties: false`, the extra-key control would be an empty
@@ -580,6 +739,86 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         )
         assert any("a_field_no_one_declared" in e for e in errors), errors
 
+    def test_some_array_closes_its_item_schema(self):
+        """Anti-vacuity for the nested control below, the same way
+        `test_some_tool_closes_its_output_schema` is for the top-level one: an
+        empty derivation would make an empty parametrization read as green."""
+        assert _closed_item_schemas(), (
+            "no published array closes its item schema; the nested extra-key "
+            "control below would cover nothing — and M1 lived inside `items`"
+        )
+
+    @pytest.mark.parametrize("tool,prop", _closed_item_schemas())
+    def test_an_undeclared_key_inside_an_array_item_is_rejected(self, tool, prop):
+        """The nested half of the closed-door control, one level DOWN.
+
+        🔑 Architecturally the more important of the two, because M1 was inside
+        `items`: a client's validator descends there, and a validator of ours that
+        did not would pass exactly the declarations that are wrong. The top-level
+        control cannot reach this — merging a key into the payload root never
+        touches an element of an array.
+
+        Not reachable from a route body today, and that is itself the thing worth
+        pinning: the projections whitelist item keys, so an unrecognised field on
+        a route's row is dropped before it reaches the payload (asserted by
+        `test_an_unrecognised_key_on_a_route_row_is_not_forwarded`). A projection
+        that started forwarding unknown keys would break every validating client;
+        this control is what says the declaration forbids it.
+        """
+        case, arguments, bodies = _TOOL_SAMPLES[tool][0]
+        payload = _payload(tool, arguments, bodies)
+        schema = _output_schema(tool)
+
+        assert _errors(payload, schema) == [], f"{tool} ({case}) does not validate to begin with"
+        assert payload.get(prop), (
+            f"{tool} ({case}): the sample no longer carries any {prop} item, so "
+            "there is nothing to inject an undeclared key into; pick a sample "
+            "whose first case populates it"
+        )
+
+        broken = copy.deepcopy(payload)
+        broken[prop][0]["a_field_no_one_declared"] = 1
+
+        assert _rejects_at(broken, schema, (prop, 0)), (
+            f"{tool}.{prop} items declare additionalProperties: false and the "
+            f"validator accepted an undeclared key inside {prop}[0]: "
+            f"{_errors(broken, schema)}"
+        )
+
+    def test_an_unrecognised_key_on_a_route_row_is_not_forwarded(self):
+        """The positive half: the projection is what keeps the nested case unreachable.
+
+        The control above proves the DECLARATION forbids an undeclared key inside
+        an array item. This proves the tool never produces one, which is the
+        reason the control above cannot be driven from a route body — and the
+        property that would silently disappear if a projection were rewritten to
+        pass rows through.
+        """
+        search = _payload("search_feedback", {"query": "late"}, {
+            _SEARCH_ROUTE: {
+                "count": 1,
+                "query": "late",
+                "is_partial_window": False,
+                "items": [{**_FEEDBACK_ROW, "brand_new_route_field": "surprise"}],
+            },
+        })
+        assert search["items"], "the sample produced no items to inspect"
+        assert "brand_new_route_field" not in search["items"][0], (
+            "an unrecognised key on a feedback row reached the payload; the "
+            "declaration closes the item schema, so a validating client would "
+            "reject the whole response"
+        )
+
+        project = _payload("get_project", {"project_id": _PROJECT}, {
+            _PROJECT_ROUTE: {
+                "project": {"name": "Morning Briefing"},
+                "personas": [],
+                "documents": [{**_DOCUMENTS[0], "unexpected": "surprise"}],
+            },
+        })
+        assert project["documents"], "the sample produced no documents to inspect"
+        assert "unexpected" not in project["documents"][0]
+
     def test_an_undeclared_key_is_accepted_where_the_schema_leaves_it_open(self):
         """The other half of that split, and it is deliberate.
 
@@ -588,11 +827,26 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         rejection everywhere would be asserting a design this server
         deliberately does not have — and would turn a route growing a field into
         a failure in this file.
+
+        🔑 The undeclared key is added to the ROUTE BODY and driven through the
+        tool, not merged into the schema's input directly. Validating the body
+        would assume the tool is a pure pass-through — exactly the assumption the
+        rest of this file refuses to make, and the one that would silently stop
+        being true the day a projection is added here.
         """
         schema = _output_schema("get_metrics_breakdown")
-
         assert schema.get("additionalProperties") is not False
-        assert _errors({**_METRICS_CATEGORIES_BODY, "added_next_quarter": 1}, schema) == []
+
+        payload = _payload("get_metrics_breakdown", {"dimension": "categories"}, {
+            "/metrics/categories": {**_METRICS_CATEGORIES_BODY, "added_next_quarter": 1},
+        })
+
+        assert "added_next_quarter" in payload, (
+            "the tool dropped the undeclared key before the validator saw it, so "
+            "this control no longer says anything about the open declaration; it "
+            "now projects its answer and the declaration should say so"
+        )
+        assert _errors(payload, schema) == []
 
     def test_a_nested_object_where_an_array_is_declared_is_rejected(self):
         """M1's exact shape: an object in a slot declared `array`.
@@ -601,35 +855,67 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         string list, and the one declared array on the feedback detail. A
         validator that never descends into `items` reads green on both, which is
         what let M1 reach production.
+
+        🔑 Matched on the error PATH, not on the message prose. A disjunction like
+        `any("current_challenges" in e or "array" in e ...)` was here first and is
+        satisfiable by an unrelated failure: breaking `personas[0].quotes` instead
+        yields `personas/0/quotes: ... is not of type 'array'`, which the prose
+        matcher accepts while `current_challenges` is untouched. A control that
+        can pass for a different field's reason is not a control for this one.
         """
         personas_schema = _output_schema("list_personas")
         payload = _payload("list_personas", *_TOOL_SAMPLES["list_personas"][0][1:])
         assert _errors(payload, personas_schema) == [], "the sample must validate first"
 
+        # Asserted, not assumed: a valid payload need not CONTAIN this path — the
+        # persona item schema declares no `required`, so `_GENERATED_PERSONA` or
+        # the projection could stop emitting the section and the mutation below
+        # would raise KeyError instead of failing with a diagnosis.
+        section = payload["personas"][0].get("pain_points")
+        assert isinstance(section, dict) and isinstance(
+            section.get("current_challenges"), list
+        ), (
+            "the sample no longer contains a nested string-list section at "
+            "personas[0].pain_points.current_challenges, which is the exact shape "
+            f"M1 was; found {section!r}. Point this control at another nested "
+            "list declared `array`, or restore a sample that carries one."
+        )
+
         broken = copy.deepcopy(payload)
         broken["personas"][0]["pain_points"]["current_challenges"] = {"a": "alerts"}
-        errors = _errors(broken, personas_schema)
-        assert any("current_challenges" in e or "array" in e for e in errors), errors
+
+        assert _rejects_at(
+            broken, personas_schema, ("personas", 0, "pain_points", "current_challenges")
+        ), _errors(broken, personas_schema)
 
         detail_schema = _output_schema("get_feedback_detail")
         detail = _payload("get_feedback_detail", *_TOOL_SAMPLES["get_feedback_detail"][0][1:])
-        assert _errors(detail, detail_schema) == []
+        assert _errors(detail, detail_schema) == [], "the detail sample must validate first"
 
-        assert _errors({**detail, "keywords": {"0": "late"}}, detail_schema)
+        assert _rejects_at({**detail, "keywords": {"0": "late"}}, detail_schema, ("keywords",))
         # And a string where the array is declared: the flat-value case, which is
         # what the importer really writes.
-        assert _errors({**detail, "keywords": "late"}, detail_schema)
+        assert _rejects_at({**detail, "keywords": "late"}, detail_schema, ("keywords",))
 
     def test_a_string_where_an_integer_is_declared_is_rejected(self):
         """`feedback_count` arrives as a DynamoDB `Decimal` and on old rows not
-        at all, so a writer putting `"42"` there is not hypothetical."""
+        at all, so a writer putting `"42"` there is not hypothetical.
+
+        Valid first and matched on the path, for the same reason as the control
+        above: asserting only that the mutated payload has SOME error goes green
+        if the sample stops conforming for an unrelated reason, which is a control
+        that reports nothing on the day it is needed.
+        """
         schema = _output_schema("list_personas")
         payload = _payload("list_personas", *_TOOL_SAMPLES["list_personas"][0][1:])
+        assert _errors(payload, schema) == [], "the sample must validate first"
 
         broken = copy.deepcopy(payload)
         broken["personas"][0]["feedback_count"] = "42"
 
-        assert _errors(broken, schema)
+        assert _rejects_at(broken, schema, ("personas", 0, "feedback_count")), _errors(
+            broken, schema
+        )
 
     def test_a_required_field_that_is_absent_is_rejected(self):
         """`search_feedback` promises `is_partial` on every answer. A flag that
@@ -640,8 +926,13 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         assert "is_partial" in schema.get("required", []), (
             "search_feedback no longer requires is_partial; this control moved"
         )
+        assert _errors(payload, schema) == [], "the sample must validate first"
 
-        assert _errors({k: v for k, v in payload.items() if k != "is_partial"}, schema)
+        errors = _errors({k: v for k, v in payload.items() if k != "is_partial"}, schema)
+        # `required` reports at the OBJECT that lacks the key, so the path is the
+        # root for every missing field and cannot distinguish them: this is the one
+        # control where the message is the only place the field name appears.
+        assert any("is_partial" in e for e in errors), errors
 
     def test_breaking_a_declared_type_in_a_copy_of_a_schema_rejects_a_real_payload(self):
         """The guard mutation-checked against itself, in the suite.
@@ -661,20 +952,35 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
             "guard is not reading the declaration it claims to"
         )
 
-    def test_closing_an_open_schema_in_a_copy_rejects_a_real_route_body(self):
+    def test_closing_an_open_schema_in_a_copy_rejects_a_real_payload(self):
         """The same mutation for the other half of the split.
 
         The metrics schemas are open BECAUSE the route sends fields they do not
         declare — `/metrics/sentiment` sends `total`. Closing a copy must reject
-        the real body, which is what makes "open on purpose" a fact about the
+        the real payload, which is what makes "open on purpose" a fact about the
         payload rather than an assertion in a comment.
+
+        Driven through the tool for the same reason as the control above: the
+        equivalence between a metrics route body and the tool's payload holds only
+        while the tool projects nothing, and this file's whole method is to not
+        assume that.
         """
         schema = _output_schema("get_metrics_breakdown")
-        assert _errors(_METRICS_SENTIMENT_BODY, schema) == []
+        payload = _payload("get_metrics_breakdown", {"dimension": "sentiment"}, {
+            "/metrics/sentiment": _METRICS_SENTIMENT_BODY,
+        })
+        assert _errors(payload, schema) == []
+        assert "total" in payload, (
+            "the payload no longer carries `total`, the undeclared field that makes "
+            "the open declaration load-bearing; this control needs another one"
+        )
 
         closed = {**copy.deepcopy(schema), "additionalProperties": False}
-        errors = _errors(_METRICS_SENTIMENT_BODY, closed)
+        errors = _errors(payload, closed)
 
+        # `additionalProperties` reports at the containing object, so the path is
+        # the root here and the field name lives only in the message — the same
+        # exception `test_a_required_field_that_is_absent_is_rejected` documents.
         assert any("total" in e for e in errors), errors
 
 

--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -77,6 +77,30 @@ REVERT STORY — which mutation makes which assertion fail:
       an element missing one, and a control that cannot construct its own negative
       case only reports what the production code already does.
 
+      And through every KEYWORD that nests a schema, not only `properties` and
+      `items`. `Draft202012Validator` follows `$ref`, `anyOf`/`allOf`/`oneOf`,
+      `prefixItems` and a schema-valued `additionalProperties`/`patternProperties`,
+      so a declaration nesting that way was live for a client and invisible here —
+      an asymmetry, not merely a gap. Worse than invisible: `_stale_exemptions`
+      measures "declared" over the same walk, so a legitimate exemption for a
+      `$ref`'d property was reported as a TYPO and the only way to satisfy the file
+      was to delete a correct entry. The reviewer's five-construct probe found one
+      site, the root, with all five nested properties unmeasured; it now finds
+      six. test_the_substance_check_measures_through_every_keyword_that_nests_a
+      _schema is the control, asserting both directions over a schema it owns, and
+      what the walk CANNOT follow is refused by name rather than lost — see
+      test_no_published_declaration_nests_through_a_keyword_the_walk_cannot_follow.
+
+  test_no_published_declaration_uses_a_property_name_that_collides_with_a_label
+    — `_label` joins a path with `/`, so a property literally named `a/b` at the
+      root produces the same label as `b` inside object `a`, and one exemption
+      would silence both indistinguishably. The flat namespace is deliberate — an
+      allowlist's whole job is to be writable by hand, and escaping would put a
+      second addressing scheme in the one structure that must not need one — so
+      the assumption is CHECKED rather than only documented, which is the
+      treatment this file gives its other deliberate limitations. `[]` and `{}`
+      are reserved for the same reason.
+
   test_no_exemption_from_the_substance_check_has_gone_stale
     — the check above can be opted out of via
       `_PROPERTIES_NO_SAMPLE_CAN_SHOW`, and an allowlist is the one structure
@@ -96,33 +120,44 @@ REVERT STORY — which mutation makes which assertion fail:
       that is still doing work, since a check reporting everything would satisfy
       all three while making the allowlist unusable.
 
-  _payload_populating, at the three controls that mutate an array element
+  _payload_reaching, at the three controls that mutate an array element
     — `_TOOL_SAMPLES[tool][0]` made those controls depend on the FIRST registered
       case populating a particular array, so reordering the registry — an
       apparently cosmetic edit — broke them: only one of `get_project`'s three
       cases populates `documents`, and moving the empty-project case first was
       enough. Two of them failed with a bare `IndexError` from
       `payload["personas"][0]` rather than a sentence. Selecting whichever case
-      populates the property removes the coupling instead of only diagnosing it;
-      reordering now changes nothing, and the genuine "no case populates it"
-      condition fails naming the tool, the property and how many samples were
-      searched.
+      reaches the site removes the coupling instead of only diagnosing it;
+      reordering now changes nothing, and the genuine "no case reaches it"
+      condition fails naming the tool, the site and how many samples were
+      searched. It takes a PATH rather than a root property, so it reaches a site
+      at any depth — a helper that could only look up a root key would have kept
+      the control shallower than the derivation feeding it.
 
   TestTheDerivationsSurviveAnUnusualDeclaration
-    — nothing read at IMPORT time may raise on a declaration a client accepts.
-      `_closed_schema_tools()` and `_closed_item_schemas()` run inside
+    — nothing read at IMPORT time may raise on a declaration a client accepts, or
+      on a fixture this file imports. `_closed_schema_tools()`,
+      `_closed_item_schemas()` and `_TOOL_SAMPLES` are all read inside
       `@pytest.mark.parametrize`, so a raise there is a collection error that
-      aborts all ~2200 `lambda/api` tests and is attributed to whatever ran
-      next. Two declarations did exactly that: a published tool with no
+      aborts collection of the ENTIRE `lambda/api` suite and is attributed to
+      whatever ran next. Three did exactly that: a published tool with no
       `outputSchema` (`KeyError`, in place of the precise message §5.4's test
-      already carries) and a boolean sub-schema, which Draft 2020-12 permits and
+      already carries); a boolean sub-schema, which Draft 2020-12 permits and
       `check_schema` accepts (`AttributeError`) — this file crashing on a schema
-      it also certifies as valid. Both now degrade to "no schema, closes
-      nothing", leaving the §5.4 test the single named reporter. The tolerance
-      has its own positive control, test_the_derivations_still_find_the_real
-      _closures: making `_output_schema` return `{}` unconditionally would
-      satisfy that whole class while rendering the file vacuous, since an empty
-      schema validates every payload.
+      it also certifies as valid; and `_GENERATED_PERSONA["identity"]` in a
+      sample, where renaming that key in `test_mcp_delegation.py` gave
+      `KeyError: 'identity'` and took the suite to ZERO collected tests. The third
+      is the only one where the raising code was this file's own, and the coupling
+      is one-directional and to a PRIVATE name in another module, so nothing over
+      there will stop the rename. All three now degrade — "no schema, closes
+      nothing" and `.get(section, {})` — leaving the §5.4 test and the substance
+      check as the named reporters: the rename now reads as *"list_personas
+      declares ['personas/[]/identity/age_range', …] and no registered sample
+      produces them"* beside a test naming the fixture's owner, with 2199 other
+      tests still running. The tolerance has its own positive control,
+      test_the_derivations_still_find_the_real_closures: making `_output_schema`
+      return `{}` unconditionally would satisfy that whole class while rendering
+      the file vacuous, since an empty schema validates every payload.
 
   test_a_real_payload_validates_against_its_declared_output_schema
     — the guard proper. Verified non-vacuous two ways rather than by inspection:
@@ -145,6 +180,20 @@ REVERT STORY — which mutation makes which assertion fail:
       test_some_array_closes_its_item_schema, and its positive counterpart is
       test_an_unrecognised_key_on_a_route_row_is_not_forwarded, which pins the
       projection behaviour that keeps the shape unreachable from a route.
+
+      Parametrised from `_closed_item_schemas`, which now derives from the SAME
+      walk the substance check uses. It used to walk root-level `properties` only,
+      so a closed `items` nested inside another array's item schema — or inside a
+      nested object — was parametrised by nothing while `_declared_sites` saw it
+      perfectly well: the two halves of the file disagreed about how deep a
+      declaration goes, and the shallower half was the one guarding M1's level.
+      Confirmed reachable through production code, not only synthetically: a closed
+      nested array added to `_PERSONA_PROPERTIES` gave one substance-check failure
+      and ZERO from this control. Its depth has its own anti-vacuity control,
+      test_the_closed_item_derivation_can_find_a_closure_below_the_payload_root,
+      because test_some_array_closes_its_item_schema is satisfied by one closure at
+      the root and so passed throughout the round the derivation was shallow —
+      "finds nothing deep" read as "there is nothing deep".
 
   test_a_nested_object_where_an_array_is_declared_is_rejected
     — M1's exact shape, in the two places a live writer can still produce it.
@@ -529,6 +578,24 @@ _TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
         # exotic one. This is provenance level 2 of the convention above: a
         # transcription from the schema that owns the shape, not a dict written by
         # reading the tool's `outputSchema`.
+        #
+        # 🔑 `.get(section, {})`, never `_GENERATED_PERSONA["section"]`. This dict
+        # is module-level and `_cases()` reads it inside a
+        # `@pytest.mark.parametrize` decorator, so a subscript here evaluates at
+        # IMPORT: renaming one section key in `test_mcp_delegation.py` — a
+        # plausible edit, since that suite re-derives its section names from
+        # `schemas/persona.schema.json` — raised `KeyError: 'identity'` and took
+        # the whole `lambda/api` suite to zero collected tests. That is exactly the
+        # blast radius `TestTheDerivationsSurviveAnUnusualDeclaration` exists to
+        # prevent, arriving from a fixture instead of from a declaration, and the
+        # coupling is one-directional and to a PRIVATE name in another module, so
+        # nothing over there will stop the rename.
+        #
+        # Degrading instead hands the report to this round's own addition: the
+        # substance check names the properties the samples stopped demonstrating
+        # (`personas/[]/identity/age_range` …), which is a diagnosis rather than a
+        # traceback. `test_the_imported_persona_fixture_still_carries_the_sections
+        # _this_sample_extends` is the assertion that says so by name.
         ("a generated row carrying every canonical persona field",
          {"project_id": _PROJECT}, {
              _PROJECT_ROUTE: {
@@ -536,23 +603,23 @@ _TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
                  "personas": [{
                      **_GENERATED_PERSONA,
                      "identity": {
-                         **_GENERATED_PERSONA["identity"],
+                         **_GENERATED_PERSONA.get("identity", {}),
                          "bio": "Reads on the commute, decides at the weekend.",
                          "education": "LLB, University of Leeds",
                          "family_status": "Two children at primary school",
                          "income_bracket": "£60k-£80k",
                      },
                      "goals_motivations": {
-                         **_GENERATED_PERSONA["goals_motivations"],
+                         **_GENERATED_PERSONA.get("goals_motivations", {}),
                          "success_definition": "Nothing important was missed",
                          "underlying_motivations": ["Be the informed one at work"],
                      },
                      "behaviors": {
-                         **_GENERATED_PERSONA["behaviors"],
+                         **_GENERATED_PERSONA.get("behaviors", {}),
                          "activity_frequency": "Every weekday morning",
                      },
                      "context_environment": {
-                         **_GENERATED_PERSONA["context_environment"],
+                         **_GENERATED_PERSONA.get("context_environment", {}),
                          "social_context": "Alone, before the household wakes",
                          "influencers": ["Her local WhatsApp group"],
                      },
@@ -579,8 +646,9 @@ _REQUIRED_HINTS: tuple[str, ...] = (
 )
 
 # Declared properties that no sample can demonstrate, `tool` → `{label}`, where a
-# label is `_label`'s path: a root property is its own name, and `"[]"` marks a
-# descent through an array — `personas/[]/identity/bio`.
+# label is `_label`'s path: a root property is its own name, `"[]"` marks a descent
+# through an array and `"{}"` a descent through a schema-valued map
+# (`additionalProperties`) — `personas/[]/identity/bio`.
 #
 # 🔑 EMPTY, and it must stay hard to add to. Every property declared by the six
 # tools published today is carried by at least one sample payload, at every depth,
@@ -632,7 +700,7 @@ def _output_schema(name: str) -> dict:
     and a published tool declaring none raised a bare `KeyError` — from inside
     `_closed_schema_tools()` and `_closed_item_schemas()`, which are evaluated in
     `@pytest.mark.parametrize` decorators, so at MODULE IMPORT. That is a
-    collection error aborting every test in `lambda/api` (2184 of them), and the
+    collection error aborting the ENTIRE `lambda/api` suite, and the
     message a Phase 3 author reads is `KeyError: 'outputSchema'` rather than
     `test_every_tool_declares_what_section_5_4_requires`'s
     `f"{name} declares no outputSchema"` — the assertion written for exactly this
@@ -740,22 +808,27 @@ def _first_sample(tool: str) -> tuple[str, dict, dict]:
     return samples[0]
 
 
-def _payload_populating(tool: str, prop: str) -> dict:
-    """A payload from whichever registered case populates `prop`, not case zero.
+def _payload_reaching(tool: str, path: tuple) -> tuple[dict, tuple, dict]:
+    """A payload from whichever case reaches `path`, plus the object found there.
 
-    🔑 Removes an ordering coupling rather than only diagnosing it. Several
-    controls need a NON-EMPTY array to mutate, and taking `_first_sample`'s
-    payload made them depend on the first registered case being one that
-    populates it — a dependency reordering `_TOOL_SAMPLES`, an apparently
-    cosmetic edit, silently breaks. Only one of `get_project`'s three cases
-    populates `documents`, so moving the empty-project case first was enough.
+    Returns `(payload, concrete path, object)` where the object is a REFERENCE
+    into the payload, so a caller holding it can mutate through it and then ask
+    `_rejects_at` about the concrete path it mutated.
 
-    Searching the cases instead means those controls hold for any ordering, and
-    they still fail — with a sentence rather than an `IndexError` from
-    `payload["personas"][0]` — when NO case populates the property, which is the
-    genuine "this control has lost its subject" condition. The controls that must
-    use the first case specifically (the closed-item parametrisation names the
-    case in its own message) keep using `_first_sample`.
+    🔑 Searches the cases rather than taking `_TOOL_SAMPLES[tool][0]`, which
+    removes an ordering coupling instead of only diagnosing it. Several controls
+    need a populated array to mutate, and taking the first case made them depend
+    on that case being one that populates it — a dependency an apparently cosmetic
+    reordering of the registry silently breaks. Only one of `get_project`'s three
+    cases populates `documents`, so moving the empty-project case first was
+    enough, and two of the controls then failed with a bare `IndexError` from
+    `payload["personas"][0]` rather than a sentence.
+
+    🔑 Takes a PATH, not a root property, so it reaches a site at any depth for
+    the same reason `_closed_item_schemas` now derives them: a closed `items`
+    nested below the root has an element to mutate too, and a helper that could
+    only look up a root key would have kept this control shallower than the
+    derivation feeding it.
     """
     samples = _TOOL_SAMPLES.get(tool) or ()
     if not samples:
@@ -765,15 +838,18 @@ def _payload_populating(tool: str, prop: str) -> dict:
             "test_every_published_tool_has_a_registered_sample_payload is the "
             "authoritative report of this."
         )
+    label = "/".join(path) or "<root>"
     for _case, arguments, bodies in samples:
         payload = _payload(tool, arguments, bodies)
-        if payload.get(prop):
-            return payload
+        found = _located_objects(payload, path)
+        if found:
+            at, obj = found[0]
+            return payload, at, obj
     pytest.fail(
-        f"none of {tool}'s {len(samples)} registered samples populates {prop!r}, "
-        "so there is nothing for this control to mutate. Give one of its cases a "
-        f"route body that produces a non-empty {prop!r}, or point the control at "
-        "another array declared by this tool."
+        f"none of {tool}'s {len(samples)} registered samples reaches {label}, so "
+        "there is nothing for this control to mutate. Give one of its cases a "
+        f"route body that populates {label}, or point the control at another site "
+        "declared by this tool."
     )
 
 
@@ -813,8 +889,8 @@ def _subschemas(schema: dict) -> dict:
     `declared.get("type")` on one of those raised
     `AttributeError: 'bool' object has no attribute 'get'`, and because
     `_closed_item_schemas()` is evaluated in a `@pytest.mark.parametrize`
-    decorator the raise landed at module import: a collection error aborting all
-    2184 `lambda/api` tests, on a declaration this very file also certifies as
+    decorator the raise landed at module import: a collection error aborting the
+    entire `lambda/api` suite, on a declaration this very file also certifies as
     valid via `test_the_declaration_is_itself_a_valid_json_schema`.
 
     A boolean sub-schema constrains no keys and closes no door, so dropping it
@@ -831,71 +907,237 @@ def _subschemas(schema: dict) -> dict:
     return {k: v for k, v in properties.items() if isinstance(v, dict)}
 
 
-def _declared_sites(schema, path: tuple = ()) -> dict[tuple, frozenset[str]]:
-    """Every object schema in a declaration, keyed by the payload path reaching it.
+# The two path markers that stand for "descend through a container" rather than
+# naming a key: an array element, and an arbitrary key of a schema-valued map
+# (`additionalProperties` / `patternProperties`). Both are reserved words in the
+# label namespace `_label` builds — see its docstring.
+_ARRAY = "[]"
+_MAP = "{}"
 
-    🔑 Recursive, because the substance check stopping at the payload ROOT was the
-    one gap left at the level this file's own architecture argument singles out.
-    `_closed_item_schemas` descends into `items` for the negative controls — M1
-    lived there — but the requirement that a declaration be DEMONSTRATED by some
-    sample was measured only against top-level `properties`. So a Phase 3 author
-    could declare `"pain_points": {"type": "array"}` inside an item schema, have
-    no sample element ever carry that key, and every test here pass: item schemas
-    declare no `required`, and `additionalProperties: false` constrains only keys
-    that are PRESENT. Verified by injecting an item-level property no route emits
-    into a published declaration — 66 passed, in both `list_personas.personas`
-    and `search_feedback.items`. The first client to call the tool would be the
-    first thing to check it, which is exactly M1.
+# The keywords `_reachable_schemas` follows to another object schema. Named so
+# `test_no_published_declaration_nests_through_a_keyword_the_walk_cannot_follow`
+# can report what is NOT here rather than leaving it silent.
+_FOLLOWED_KEYWORDS: tuple[str, ...] = (
+    "$ref", "properties", "items", "prefixItems", "additionalProperties",
+    "patternProperties", "anyOf", "allOf", "oneOf",
+)
 
-    `"[]"` marks a descent through `items`, so one flat path names a site at any
-    depth: `("personas", "[]", "identity")`. Arrays are collapsed rather than
-    indexed on purpose — element 0 carrying a key and element 1 not is a
-    difference between rows, not between declarations, and the union across
-    elements is what "some sample demonstrates this" means.
+# Draft 2020-12's other ways to nest an object schema. `Draft202012Validator`
+# enforces every one of them, so a declaration nesting this way is LIVE for a
+# client while being invisible to the walk — the same asymmetry the `$ref` finding
+# was about. Not implemented, because none has a single payload path a label could
+# name: `if`/`then` and `not` describe conditional or negated shapes, and
+# `contains` matches an unknown subset of elements, so "which property is
+# demonstrated where" has no well-defined answer. Rejected loudly instead.
+_UNFOLLOWED_KEYWORDS: tuple[str, ...] = (
+    "contains", "if", "then", "else", "not", "dependentSchemas", "propertyNames",
+    "unevaluatedProperties", "unevaluatedItems", "$dynamicRef",
+)
 
-    Tolerant in the same way `_subschemas` is, and for the same reason: this runs
-    under `@pytest.mark.parametrize`, so anything it raises is a collection error
-    aborting the whole `lambda/api` suite. A boolean sub-schema, a non-dict
-    `items`, a `properties` that is not a map — all legal or all harmless, and all
-    simply contribute no site.
+
+def _resolve_ref(ref: str, root) -> dict:
+    """A local `$ref` pointer resolved against the declaration it lives in.
+
+    Local only: a declaration is published inside `tools/list` and a client
+    resolves it without fetching anything, so a remote pointer would be a defect
+    of a different kind. An unresolvable pointer yields `{}` — no site — for the
+    same reason every other derivation here degrades rather than raises: this runs
+    at import, under a `@pytest.mark.parametrize` decorator.
     """
-    sites: dict[tuple, frozenset[str]] = {}
+    if not ref.startswith("#"):
+        return {}
+    target = root
+    for raw in ref[1:].split("/"):
+        if not raw:
+            continue
+        token = raw.replace("~1", "/").replace("~0", "~")
+        if isinstance(target, list):
+            if not token.isdigit() or int(token) >= len(target):
+                return {}
+            target = target[int(token)]
+        elif isinstance(target, dict) and token in target:
+            target = target[token]
+        else:
+            return {}
+    return target if isinstance(target, dict) else {}
+
+
+def _reachable_schemas(
+    schema, root=None, path: tuple = (), seen: frozenset = frozenset()
+) -> list[tuple[tuple, dict]]:
+    """Every object schema a declaration reaches, with the payload path to it.
+
+    🔑 ONE walk, shared by the substance check (`_declared_sites`) and by the
+    closed-door controls (`_closed_item_schemas`). They used to be two walks of
+    different depths, and the shallower one fed
+    `test_an_undeclared_key_inside_an_array_item_is_rejected` — the control this
+    file singles out as the architecturally important one, because M1 was inside
+    `items`. A closed `items` nested below the root was parametrised by nothing
+    while the substance check happily saw it, so the two halves of the file
+    disagreed about how deep a declaration goes and the shallower half was the one
+    guarding M1's level.
+
+    🔑 Follows every keyword in `_FOLLOWED_KEYWORDS`, not just `properties` and
+    `items`. `Draft202012Validator` follows all of them, which is what made the
+    old gap asymmetric: a `$ref`'d `additionalProperties: false` is enforced
+    against a real client while being invisible here. Worse than invisible, in
+    fact — `_stale_exemptions` measures "declared" over this walk, so a legitimate
+    exemption for a `$ref`'d property was reported as a typo and the only way to
+    satisfy the file was to delete a CORRECT entry. Phase 3's ~thirty declarations
+    are built "from shared pieces" per `mcp_handler.py`'s own comment, so `$defs`
+    plus `$ref` is the natural next step for deduplicating the persona sections.
+    What it cannot follow is refused by name in
+    `test_no_published_declaration_nests_through_a_keyword_the_walk_cannot_follow`
+    rather than lost.
+
+    Paths mark a descent through a container with `_ARRAY` or `_MAP` and name a
+    key otherwise, so one flat tuple locates a site at any depth:
+    `("personas", "[]", "identity")`. Containers are collapsed rather than indexed
+    — element 0 carrying a key and element 1 not is a difference between rows, not
+    between declarations, and the union across elements is what "some sample
+    demonstrates this" means. `anyOf`/`allOf`/`oneOf` branches and a `$ref` target
+    contribute at the SAME path as their parent, because they describe the same
+    place in the payload.
+
+    Tolerant throughout, and for the reason above: a boolean sub-schema, a
+    non-dict `items`, a `properties` that is not a map, an unresolvable pointer —
+    all legal or all harmless, and all simply contribute no site. `seen` carries
+    the pointers already followed on this branch, so a self-referential `$defs`
+    entry terminates instead of recursing forever.
+    """
     if not isinstance(schema, dict):
-        return sites
+        return []
+    if root is None:
+        root = schema
 
-    declared = _subschemas(schema)
-    if declared:
-        sites[path] = frozenset(declared)
-        for prop, sub in declared.items():
-            sites.update(_declared_sites(sub, path + (prop,)))
+    found: list[tuple[tuple, dict]] = [(path, schema)]
 
+    # Same place in the payload: a `$ref` target and each composition branch
+    # describe the object at `path`, not one below it.
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and ref not in seen:
+        found += _reachable_schemas(
+            _resolve_ref(ref, root), root, path, seen | {ref}
+        )
+    for keyword in ("anyOf", "allOf", "oneOf"):
+        for branch in schema.get(keyword) or ():
+            if isinstance(branch, dict):
+                found += _reachable_schemas(branch, root, path, seen)
+
+    for prop, sub in _subschemas(schema).items():
+        found += _reachable_schemas(sub, root, path + (prop,), seen)
+
+    # `items` and `prefixItems` both describe elements, and both collapse to the
+    # same `_ARRAY` marker: a tuple-typed array's element 0 and element 1 are still
+    # rows of one list as far as "some sample carries this key" is concerned.
     items = schema.get("items")
     if isinstance(items, dict):
-        sites.update(_declared_sites(items, path + ("[]",)))
+        found += _reachable_schemas(items, root, path + (_ARRAY,), seen)
+    for entry in schema.get("prefixItems") or ():
+        if isinstance(entry, dict):
+            found += _reachable_schemas(entry, root, path + (_ARRAY,), seen)
+
+    # A schema-valued `additionalProperties` / `patternProperties` is a map whose
+    # KEYS are data — `{"mapped": {"additionalProperties": {...}}}`. `False` and
+    # `True` are the closure flags the other derivations read and nest nothing.
+    for keyword in ("additionalProperties", "patternProperties"):
+        declared = schema.get(keyword)
+        if isinstance(declared, dict) and keyword == "additionalProperties":
+            found += _reachable_schemas(declared, root, path + (_MAP,), seen)
+        elif isinstance(declared, dict):
+            for sub in declared.values():
+                if isinstance(sub, dict):
+                    found += _reachable_schemas(sub, root, path + (_MAP,), seen)
+    return found
+
+
+def _declared_sites(schema) -> dict[tuple, frozenset[str]]:
+    """The properties declared at each payload path, unioned across branches.
+
+    🔑 Built from `_reachable_schemas`, so the substance check stopping at the
+    payload ROOT is closed at every depth and through every keyword the walk
+    follows. Stopping at the root left the level this file's own architecture
+    argument singles out unmeasured: a property declared inside a closed `items`
+    could be demonstrated by no sample and still pass everything here, because
+    item schemas declare no `required` and `additionalProperties: false`
+    constrains only keys that are PRESENT. Verified by injecting an item-level
+    property no route emits into a published declaration — 66 passed, in both
+    `list_personas.personas` and `search_feedback.items`.
+
+    Unioned rather than overwritten, because several branches can describe one
+    path: an `allOf` of two object schemas declares the properties of both, and a
+    `$ref` beside sibling keywords is legal in 2020-12.
+    """
+    sites: dict[tuple, frozenset[str]] = {}
+    for path, sub in _reachable_schemas(schema):
+        declared = frozenset(_subschemas(sub))
+        if declared:
+            sites[path] = sites.get(path, frozenset()) | declared
     return sites
+
+
+def _located_objects(value, path: tuple, at: tuple = ()) -> list[tuple[tuple, dict]]:
+    """Every object `path` reaches in `value`, with its CONCRETE payload path.
+
+    The payload-side counterpart of `_reachable_schemas`, and the reason it
+    returns concrete paths rather than only the objects: a control that mutates an
+    element has to name where it mutated, so `_rejects_at` can be asked about that
+    exact element instead of about the whole subtree. `("personas", "[]")` locates
+    `("personas", 0)`.
+
+    References into `value`, so a caller holding a deep copy can mutate through
+    them. A path this payload does not reach contributes nothing rather than
+    raising: a sample that does not reach a site is precisely the "no sample
+    demonstrates it" finding, and it has to be reportable as a sentence rather
+    than a `KeyError`.
+    """
+    if not path:
+        return [(at, value)] if isinstance(value, dict) else []
+    head, rest = path[0], path[1:]
+    if head == _ARRAY:
+        if not isinstance(value, list):
+            return []
+        return [
+            found
+            for index, element in enumerate(value)
+            for found in _located_objects(element, rest, at + (index,))
+        ]
+    if head == _MAP:
+        if not isinstance(value, dict):
+            return []
+        return [
+            found
+            for key, sub in value.items()
+            for found in _located_objects(sub, rest, at + (key,))
+        ]
+    if not isinstance(value, dict) or head not in value:
+        return []
+    return _located_objects(value[head], rest, at + (head,))
 
 
 def _keys_at(value, path: tuple) -> set[str]:
     """Every key some part of `value` carries at `path`, unioned across elements.
 
-    The payload-side counterpart of `_declared_sites`. A path that does not exist
-    in this payload contributes nothing rather than raising: a sample that does
-    not reach a site is precisely the "no sample demonstrates it" finding, and it
-    has to be reportable as a sentence rather than a `KeyError`.
+    A thin reading of `_located_objects`, so there is exactly ONE payload-side
+    walk to keep in step with the schema-side one. Two would be the same
+    "derivations disagree about depth" defect the schema side just had.
     """
-    if not path:
-        return set(value) if isinstance(value, dict) else set()
-    head, rest = path[0], path[1:]
-    if head == "[]":
-        if not isinstance(value, list):
-            return set()
-        seen: set[str] = set()
-        for element in value:
-            seen |= _keys_at(element, rest)
-        return seen
-    if not isinstance(value, dict):
-        return set()
-    return _keys_at(value.get(head), rest) if head in value else set()
+    return {key for _at, obj in _located_objects(value, path) for key in obj}
+
+
+def _dig(value, at: tuple):
+    """The object at a CONCRETE payload path — real keys and indices, no markers.
+
+    The counterpart of `_located_objects` for a caller that already knows where it
+    is going: a control locates an element in the payload it validated, deep-copies
+    that payload, and then has to reach the same element in the copy. Mutating the
+    reference from the original instead would leave the payload the control
+    asserted valid and the payload it asserted rejected as two different objects,
+    which is the one thing every negative control here depends on not being true.
+    """
+    for key in at:
+        value = value[key]
+    return value
 
 
 def _label(path: tuple, prop: str) -> str:
@@ -906,6 +1148,19 @@ def _label(path: tuple, prop: str) -> str:
     and so `_stale_exemptions` can check an entry against the declarations and the
     samples without a second addressing scheme. A root property is its own name,
     unprefixed, which keeps every existing message reading the way it did.
+
+    🔑 The namespace ASSUMES no declared property name contains `/`, and that
+    `_ARRAY` / `_MAP` are not property names either. JSON Schema permits all
+    three, and a property literally named `a/b` at the root produces the same
+    label as property `b` inside object `a` — so one exemption would silence both
+    declarations and `_stale_exemptions` could not tell a reader which. Escaping,
+    or keeping the tuple and rendering it only for messages, would remove the
+    ambiguity at the cost of a second addressing scheme in the one structure whose
+    entire job is to be writable by hand. The trade is taken deliberately, and
+    CHECKED rather than merely documented, by
+    `test_no_published_declaration_uses_a_property_name_that_collides_with_a_label`
+    — so the day a Phase 3 declaration uses a slash, this file says so instead of
+    quietly conflating two properties.
     """
     return "/".join((*path, prop))
 
@@ -1056,25 +1311,39 @@ def _stale_exemptions(exemptions: dict, registry: dict) -> list[str]:
     return findings
 
 
-def _closed_item_schemas() -> list[tuple[str, str]]:
-    """`(tool, array property)` for every array whose ITEMS close the door.
+def _closed_item_schemas() -> list[tuple[str, tuple]]:
+    """`(tool, path)` for every ELEMENT schema that closes the door, at any depth.
 
-    Derived the same way as `_closed_schema_tools`, and needed for the same
-    reason one level down: M1 lived inside `items`, so the nested closure is the
+    Needed one level down from `_closed_schema_tools` for the reason this file
+    singles out: M1 lived inside `items`, so the nested closure is the
     architecturally important one to control, and the top-level control cannot
-    reach it — merging a key into the payload root never touches an element of
-    `items`.
+    reach it — merging a key into the payload root never touches an element of an
+    array.
+
+    🔑 Derived from `_reachable_schemas`, at ANY depth, not from a second walk of
+    root-level `properties`. The shallow version reported only arrays declared at
+    the payload root, so a closed `items` inside another array's item schema — or
+    inside a nested object — was parametrised by nothing, while
+    `_declared_sites` saw it perfectly well. That is the same "a derivation that
+    stops short produces silence" defect the substance check had one round
+    earlier, in the sibling derivation feeding the control that argument is
+    about. Confirmed reachable through production code: a closed nested array
+    added to `_PERSONA_PROPERTIES` gave one substance-check failure and ZERO from
+    this control, which did not know the array existed; populated, both were
+    silent.
+
+    Keyed by the same `_ARRAY`-marked path the substance check uses, so the two
+    halves of the file cannot drift back into disagreeing about depth. `type:
+    array` is deliberately NOT required: `{"items": {...}}` with no `type` still
+    constrains elements, and a validator enforces it.
     """
     found = []
     for name in _PUBLISHED_TOOL_NAMES:
-        for prop, declared in _subschemas(_output_schema(name)).items():
-            if declared.get("type") != "array":
-                continue
-            items = declared.get("items")
-            # `items` may be a boolean for the same reason a sub-schema may be:
-            # `{"items": true}` is legal and closes nothing.
-            if isinstance(items, dict) and items.get("additionalProperties") is False:
-                found.append((name, prop))
+        for path, sub in _reachable_schemas(_output_schema(name)):
+            # `_reachable_schemas` already dropped a boolean `items`, which is
+            # legal (`{"items": true}`) and closes nothing.
+            if path and path[-1] == _ARRAY and sub.get("additionalProperties") is False:
+                found.append((name, path))
     return found
 
 
@@ -1203,6 +1472,176 @@ class TestEveryToolBringsASample:
         ), (
             "no published declaration nests properties inside an array item — the "
             f"level M1 lived at. Sites found: {with_depth}"
+        )
+
+    def test_the_substance_check_measures_through_every_keyword_that_nests_a_schema(self):
+        """The descent must follow `$ref` and the composition keywords, not only
+        `properties` and `items`.
+
+        🔑 `Draft202012Validator` follows all of them, which is what made the old
+        gap asymmetric rather than merely incomplete: a `$ref`'d
+        `additionalProperties: false` is enforced against a real client while being
+        invisible here, so the declaration's first check would be a client's —
+        exactly M1. Worse, `_stale_exemptions` measures "declared" over this walk,
+        so a legitimate exemption for a `$ref`'d property was reported as a typo and
+        the only way to satisfy the file was to delete a CORRECT entry.
+
+        Over a schema this control owns, and `check_schema`'d first so it cannot
+        pass because the constructs are nonsense. No published declaration uses any
+        of them today — Phase 3's ~thirty, built "from shared pieces" per
+        `mcp_handler.py`'s own comment, are where `$defs` plus `$ref` is the natural
+        way to deduplicate the persona sections.
+        """
+        schema = {
+            "type": "object",
+            "$defs": {"Row": {"type": "object", "properties": {"via_ref": {"type": "string"}}}},
+            "properties": {
+                "rows": {"type": "array", "items": {"$ref": "#/$defs/Row"}},
+                "either": {"anyOf": [{"type": "object", "properties": {"via_anyof": {}}}]},
+                "merged": {"allOf": [{"type": "object", "properties": {"via_allof": {}}}]},
+                "one": {"oneOf": [{"type": "object", "properties": {"via_oneof": {}}}]},
+                "tuples": {
+                    "type": "array",
+                    "prefixItems": [{"type": "object", "properties": {"via_prefix": {}}}],
+                },
+                "mapped": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object", "properties": {"via_ap": {}},
+                    },
+                },
+                "patterned": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x": {"type": "object", "properties": {"via_pp": {}}},
+                    },
+                },
+            },
+        }
+        Draft202012Validator.check_schema(schema)
+
+        # Every one of the seven is measured: an empty payload demonstrates none of
+        # them, and each must be REPORTED rather than silently unmeasured.
+        reported = _undemonstrated_labels(schema, [{}])
+        for label in (
+            "rows/[]/via_ref", "either/via_anyof", "merged/via_allof", "one/via_oneof",
+            "tuples/[]/via_prefix", "mapped/{}/via_ap", "patterned/{}/via_pp",
+        ):
+            assert label in reported, (
+                f"{label} is declared and no payload demonstrates it, and the walk "
+                f"did not report it — a client's validator enforces it. Got: "
+                f"{sorted(reported)}"
+            )
+
+        # And the other direction, or a walk that reported every conceivable label
+        # would satisfy the loop above: a payload that really does carry them must
+        # be credited, at each marker.
+        populated = {
+            "rows": [{"via_ref": "a"}],
+            "either": {"via_anyof": 1},
+            "merged": {"via_allof": 1},
+            "one": {"via_oneof": 1},
+            "tuples": [{"via_prefix": 1}],
+            "mapped": {"any_key": {"via_ap": 1}},
+            "patterned": {"xkey": {"via_pp": 1}},
+        }
+        assert _undemonstrated_labels(schema, [populated]) == set(), (
+            "a payload carrying every declared property was still reported as "
+            f"demonstrating some of them: {sorted(_undemonstrated_labels(schema, [populated]))}"
+        )
+
+    def test_a_self_referential_declaration_does_not_hang_the_walk(self):
+        """A `$defs` entry that refers to itself is legal and describes a tree.
+
+        The walk follows `$ref`, so without a visited set a recursive declaration
+        recurses until the interpreter stops it — and because the walk runs inside a
+        `@pytest.mark.parametrize` decorator, that is a `RecursionError` at import
+        aborting collection of the whole `lambda/api` suite, which is the failure
+        class this file has a test class for.
+        """
+        schema = {
+            "type": "object",
+            "$defs": {"Node": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string"},
+                    "children": {"type": "array", "items": {"$ref": "#/$defs/Node"}},
+                },
+            }},
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+        Draft202012Validator.check_schema(schema)
+
+        sites = _declared_sites(schema)
+
+        assert sites[("root",)] == frozenset({"value", "children"}), sites
+        assert "root/value" in _undemonstrated_labels(schema, [{}])
+
+    def test_no_published_declaration_nests_through_a_keyword_the_walk_cannot_follow(self):
+        """What the walk cannot follow is REFUSED, not silently unmeasured.
+
+        🔑 `contains`, `if`/`then`, `not`, `propertyNames`, `dependentSchemas` and
+        the `unevaluated*` keywords nest a schema at no single payload path a label
+        could name — a conditional or negated shape has no "the property lives
+        here", and `contains` matches an unknown subset of elements. So the walk
+        does not follow them, and rather than leave that as the silence this whole
+        round was about, a declaration using one fails HERE with the tool and the
+        keyword. A Phase 3 author is then told to teach the derivation, which is the
+        actionable version of "your declaration is measured by nothing".
+
+        Derived from `_UNFOLLOWED_KEYWORDS` and the live registry, so adding support
+        for one is a single edit to that tuple rather than to a test.
+        """
+        findings = []
+        for name in _PUBLISHED_TOOL_NAMES:
+            for path, sub in _reachable_schemas(_output_schema(name)):
+                used = sorted(k for k in _UNFOLLOWED_KEYWORDS if k in sub)
+                if used:
+                    findings.append(f"{name} at {'/'.join(path) or '<root>'}: {used}")
+
+        assert findings == [], (
+            "these declarations nest a schema through a keyword _reachable_schemas "
+            "does not follow, so the properties beneath it are measured by nothing "
+            "here while a client's validator enforces them:\n"
+            + "\n".join(f"  • {f}" for f in findings)
+            + "\nTeach _reachable_schemas to follow it (and give it a path marker "
+            "the way `[]` and `{}` are), or restate the declaration in terms of "
+            f"{list(_FOLLOWED_KEYWORDS)}."
+        )
+
+    def test_no_published_declaration_uses_a_property_name_that_collides_with_a_label(self):
+        """`_label`'s flat namespace assumes no property name contains `/`.
+
+        🔑 The assumption CHECKED rather than only documented, which is the
+        treatment this file gives its other deliberate limitations. A property
+        literally named `a/b` at the root produces the same label as property `b`
+        inside object `a`, so one `_PROPERTIES_NO_SAMPLE_CAN_SHOW` entry would
+        silence two declarations and `_stale_exemptions` could not tell a reader
+        which. JSON Schema permits the name; nothing declares one today, and the
+        trade — a flat namespace an exemption can be written by hand, over escaping
+        or a second addressing scheme — is taken deliberately.
+
+        The two path markers are reserved for the same reason: a property named
+        `[]` would be indistinguishable from a descent through an array.
+        """
+        collisions = []
+        for name in _PUBLISHED_TOOL_NAMES:
+            for path, sub in _reachable_schemas(_output_schema(name)):
+                for prop in _subschemas(sub):
+                    if "/" in prop or prop in (_ARRAY, _MAP):
+                        collisions.append(
+                            f"{name} declares {prop!r} at {'/'.join(path) or '<root>'}"
+                        )
+
+        assert collisions == [], (
+            "these property names collide with the label namespace "
+            "_PROPERTIES_NO_SAMPLE_CAN_SHOW is written in, so an exemption could "
+            "not name one unambiguously:\n"
+            + "\n".join(f"  • {c}" for c in collisions)
+            + f"\nA name containing '/' is ambiguous with a nested path, and "
+            f"{_ARRAY!r}/{_MAP!r} are the markers for a descent through a "
+            "container. Either rename the property, or give _label an escaping "
+            "scheme and say why it became worth the second addressing scheme."
         )
 
     def test_the_substance_check_notices_a_sample_that_demonstrates_nothing(self):
@@ -1401,22 +1840,30 @@ class TestEveryToolBringsASample:
 class TestTheDerivationsSurviveAnUnusualDeclaration:
     """Nothing read at import time may raise on a declaration a client accepts.
 
-    🔑 `_closed_schema_tools()` and `_closed_item_schemas()` are evaluated inside
-    `@pytest.mark.parametrize` decorators, so anything they raise is a COLLECTION
-    error: all 2184 tests in `lambda/api` abort, attributed to whatever ran next,
-    and no pull-request gate would report it (the one workflow runs a single
-    stdlib-only file). Two declarations did exactly that —
+    🔑 `_closed_schema_tools()`, `_closed_item_schemas()` and `_TOOL_SAMPLES` are
+    all read inside `@pytest.mark.parametrize` decorators, so anything they raise
+    is a COLLECTION error: every test in `lambda/api` aborts, attributed to
+    whatever ran next, and no pull-request gate would report it (the one workflow
+    runs a single stdlib-only file). The scope is named rather than counted on
+    purpose — the count drifts on nearly every PR, and a number a reader can see is
+    wrong invites them to discount the argument it is making, which is that a
+    collection error is a different KIND of event from a test failure. Three
+    declarations did exactly that —
 
       • no `outputSchema` at all → `KeyError: 'outputSchema'`, in place of
         `test_every_tool_declares_what_section_5_4_requires`'s precise
         `f"{name} declares no outputSchema"`, which never got to run;
       • a BOOLEAN sub-schema, which Draft 2020-12 permits and
         `check_schema` accepts → `AttributeError: 'bool' object has no
-        attribute 'get'`, i.e. this file crashing on a schema it also certifies.
+        attribute 'get'`, i.e. this file crashing on a schema it also certifies;
+      • a renamed key in the delegation suite's persona fixture, which the
+        samples used to SUBSCRIPT → `KeyError: 'identity'`. Same class and same
+        radius, reached from a fixture rather than a declaration, and the one
+        instance where the raising code was this file's own samples.
 
     — so the file's own primary anticipated failure mode degraded into the least
     diagnostic signal available. These tests keep the degradation graceful, which
-    is what leaves the §5.4 test as the single named reporter.
+    is what leaves the §5.4 test and the substance check as the named reporters.
     """
 
     def test_a_tool_declaring_no_output_schema_reads_as_an_empty_schema(self, monkeypatch):
@@ -1475,6 +1922,59 @@ class TestTheDerivationsSurviveAnUnusualDeclaration:
         monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
 
         assert all(name != published[0]["name"] for name, _ in _closed_item_schemas())
+
+    def test_the_imported_persona_fixture_still_carries_the_sections_this_sample_extends(
+        self,
+    ):
+        """The fixture coupling reported as an assertion, not a `KeyError`.
+
+        🔑 `_TOOL_SAMPLES` spreads `_GENERATED_PERSONA`'s section dicts, and it is
+        a MODULE-LEVEL dict read inside a `@pytest.mark.parametrize` decorator, so
+        a subscript there evaluates at import: `_GENERATED_PERSONA["identity"]`
+        raised `KeyError: 'identity'` when that key was renamed in
+        `test_mcp_delegation.py` and took the whole `lambda/api` suite to zero
+        collected tests, with the bare `KeyError` as the entire diagnostic. Same
+        class and same blast radius as the round-two `KeyError: 'outputSchema'`,
+        reached from a fixture rather than a declaration.
+
+        The samples now use `.get(section, {})`, so the rename degrades into
+        `test_every_declared_property_is_demonstrated_by_some_sample` naming the
+        properties no sample produces any more — which is the better signal, and
+        the outcome the round-two fix was designed for. This test is the one that
+        says WHY those fields went missing, so a reader is pointed at the fixture's
+        owner instead of at this file's samples.
+
+        Derived from the registry, not from a list of four names: it asks which
+        canonical persona sections the sample writes as objects and requires the
+        fixture to still carry each. A hardcoded list would go stale in the silent
+        direction the moment a fifth section were spread in.
+        """
+        extended = {
+            key
+            for _case, _arguments, bodies in _TOOL_SAMPLES.get("list_personas") or ()
+            for body in bodies.values()
+            for persona in body.get("personas") or ()
+            for key, value in persona.items()
+            if key in mcp_handler._PERSONA_SECTIONS and isinstance(value, dict)
+        }
+        assert extended, (
+            "no registered list_personas sample writes a canonical persona section "
+            "as an object, so this control has no coupling to check; if the samples "
+            "no longer spread the delegation suite's fixture, delete it and say so"
+        )
+
+        missing = sorted(section for section in extended if section not in _GENERATED_PERSONA)
+        assert missing == [], (
+            f"_GENERATED_PERSONA no longer carries {missing}, which this file's "
+            "samples extend to demonstrate the canonical persona fields. The "
+            "fixture is owned by api/test/test_mcp_delegation.py, which cannot "
+            "know these keys are load-bearing for a second suite — so if a section "
+            "was renamed there, rename it in _TOOL_SAMPLES too. The samples use "
+            "`.get(section, {})` precisely so this reads as a failure here and in "
+            "test_every_declared_property_is_demonstrated_by_some_sample, rather "
+            "than as a KeyError that aborts collection of the whole lambda/api "
+            "suite."
+        )
 
     def test_the_derivations_still_find_the_real_closures(self):
         """The positive control for all four above.
@@ -1624,8 +2124,62 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
             "control below would cover nothing — and M1 lived inside `items`"
         )
 
-    @pytest.mark.parametrize("tool,prop", _closed_item_schemas())
-    def test_an_undeclared_key_inside_an_array_item_is_rejected(self, tool, prop):
+    def test_the_closed_item_derivation_can_find_a_closure_below_the_payload_root(
+        self, monkeypatch
+    ):
+        """Anti-vacuity for the DEPTH of the derivation above, not just its size.
+
+        🔑 `test_some_array_closes_its_item_schema` is satisfied by one closure at
+        the payload root, so it passed throughout the round in which this
+        derivation walked root-level `properties` only — "finds nothing deep" read
+        as "there is nothing deep". Every published closure happens to be at the
+        root today, so the capability is asserted directly instead: a closed
+        `items` nested inside another array's item schema must be FOUND.
+
+        🔑 Through `_closed_item_schemas()` ITSELF, over a substituted registry —
+        not by re-implementing its filter over `_reachable_schemas`. Written the
+        second way first, and reverting the derivation to its old root-only walk
+        then left all 75 tests passing: the control was exercising the shared walk,
+        which the substance check already proves is deep, while the derivation that
+        actually feeds the parametrisation went unmeasured. A control has to call
+        the function whose depth it claims to be about.
+
+        The registry is substituted rather than a published declaration used,
+        because no published declaration nests a closure today — the same reason
+        `test_the_substance_check_descends_into_array_items` owns its schema.
+        """
+        nested = {
+            "type": "object", "additionalProperties": False,
+            "properties": {"groups": {"type": "array", "items": {
+                "type": "object", "additionalProperties": False,
+                "properties": {"rows": {"type": "array", "items": {
+                    "type": "object", "additionalProperties": False,
+                    "properties": {"a": {"type": "string"}},
+                }}},
+            }}},
+        }
+        Draft202012Validator.check_schema(nested)
+
+        published = [copy.deepcopy(tool) for tool in mcp_handler.MCP_TOOLS]
+        published[0]["outputSchema"] = nested
+        monkeypatch.setattr(mcp_handler, "MCP_TOOLS", published)
+
+        found = [
+            path for name, path in _closed_item_schemas()
+            if name == published[0]["name"]
+        ]
+
+        assert ("groups", _ARRAY) in found, found
+        assert ("groups", _ARRAY, "rows", _ARRAY) in found, (
+            "a closed item schema nested below the payload root was not "
+            "parametrised, so no undeclared-key control covers it — the level M1 "
+            f"lived at. Found: {found}"
+        )
+
+    @pytest.mark.parametrize(
+        "tool,path", _closed_item_schemas(), ids=lambda p: p if isinstance(p, str) else "/".join(p)
+    )
+    def test_an_undeclared_key_inside_an_array_item_is_rejected(self, tool, path):
         """The nested half of the closed-door control, one level DOWN.
 
         🔑 Architecturally the more important of the two, because M1 was inside
@@ -1634,6 +2188,12 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         control cannot reach this — merging a key into the payload root never
         touches an element of an array.
 
+        🔑 Mutates the element at the DERIVED path, at any depth, rather than
+        `payload[prop][0]`. The derivation used to see only root-level arrays, so a
+        closure nested below the root was covered by nothing; keying on the path
+        `_reachable_schemas` produced is what keeps this control's reach equal to
+        the derivation's.
+
         Not reachable from a route body today, and that is itself the thing worth
         pinning: the projections whitelist item keys, so an unrecognised field on
         a route's row is dropped before it reaches the payload (asserted by
@@ -1641,24 +2201,28 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         that started forwarding unknown keys would break every validating client;
         this control is what says the declaration forbids it.
 
-        🔑 Whichever case populates `prop`, not case zero. Only one of
+        🔑 Whichever case reaches the path, not case zero. Only one of
         `get_project`'s three cases populates `documents`, so making the
         empty-project case first — a reordering that reads as cosmetic — used to
-        break this. `_payload_populating` searches instead, and reports "none of
-        the N samples populates it" when that is genuinely true, which is the
-        condition worth failing on.
+        break this. `_payload_reaching` searches instead, and reports "none of the
+        N samples reaches it" when that is genuinely true, which is the condition
+        worth failing on.
         """
-        payload = _payload_populating(tool, prop)
         schema = _output_schema(tool)
+        label = "/".join(path)
+        payload, at, _element = _payload_reaching(tool, path)
 
         assert _errors(payload, schema) == [], f"{tool} does not validate to begin with"
 
         broken = copy.deepcopy(payload)
-        broken[prop][0]["a_field_no_one_declared"] = 1
+        # Dug out of the COPY: the element `_payload_reaching` returned references
+        # the original, and mutating that would leave the payload this control
+        # asserted valid and the payload it asserts is rejected as one object.
+        _dig(broken, at)["a_field_no_one_declared"] = 1
 
-        assert _rejects_at(broken, schema, (prop, 0)), (
-            f"{tool}.{prop} items declare additionalProperties: false and the "
-            f"validator accepted an undeclared key inside {prop}[0]: "
+        assert _rejects_at(broken, schema, at), (
+            f"{tool}.{label} items declare additionalProperties: false and the "
+            f"validator accepted an undeclared key inside {at}: "
             f"{_errors(broken, schema)}"
         )
 
@@ -1741,32 +2305,34 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         can pass for a different field's reason is not a control for this one.
         """
         personas_schema = _output_schema("list_personas")
-        # Whichever case populates `personas`, not case zero: `payload["personas"][0]`
-        # raised a bare `IndexError` when the first registered case was one of the
-        # empty-project ones, so an apparently cosmetic reordering of the registry
-        # produced a traceback rather than a sentence.
-        payload = _payload_populating("list_personas", "personas")
+        # Whichever case reaches a persona element, not case zero:
+        # `payload["personas"][0]` raised a bare `IndexError` when the first
+        # registered case was one of the empty-project ones, so an apparently
+        # cosmetic reordering of the registry produced a traceback rather than a
+        # sentence.
+        payload, at, persona = _payload_reaching("list_personas", ("personas", _ARRAY))
         assert _errors(payload, personas_schema) == [], "the sample must validate first"
 
         # Asserted, not assumed: a valid payload need not CONTAIN this path — the
         # persona item schema declares no `required`, so `_GENERATED_PERSONA` or
         # the projection could stop emitting the section and the mutation below
         # would raise KeyError instead of failing with a diagnosis.
-        section = payload["personas"][0].get("pain_points")
+        section = persona.get("pain_points")
         assert isinstance(section, dict) and isinstance(
             section.get("current_challenges"), list
         ), (
             "the sample no longer contains a nested string-list section at "
-            "personas[0].pain_points.current_challenges, which is the exact shape "
-            f"M1 was; found {section!r}. Point this control at another nested "
-            "list declared `array`, or restore a sample that carries one."
+            f"{'/'.join(str(p) for p in at)}.pain_points.current_challenges, which "
+            f"is the exact shape M1 was; found {section!r}. Point this control at "
+            "another nested list declared `array`, or restore a sample that carries "
+            "one."
         )
 
         broken = copy.deepcopy(payload)
-        broken["personas"][0]["pain_points"]["current_challenges"] = {"a": "alerts"}
+        _dig(broken, at)["pain_points"]["current_challenges"] = {"a": "alerts"}
 
         assert _rejects_at(
-            broken, personas_schema, ("personas", 0, "pain_points", "current_challenges")
+            broken, personas_schema, (*at, "pain_points", "current_challenges")
         ), _errors(broken, personas_schema)
 
         detail_schema = _output_schema("get_feedback_detail")
@@ -1788,15 +2354,15 @@ class TestTheValidatorRejectsWhatTheDeclarationsForbid:
         that reports nothing on the day it is needed.
         """
         schema = _output_schema("list_personas")
-        # As above: any case that populates `personas`, so registry order cannot
-        # turn this control into an `IndexError`.
-        payload = _payload_populating("list_personas", "personas")
+        # As above: any case that reaches a persona element, so registry order
+        # cannot turn this control into an `IndexError`.
+        payload, at, _persona = _payload_reaching("list_personas", ("personas", _ARRAY))
         assert _errors(payload, schema) == [], "the sample must validate first"
 
         broken = copy.deepcopy(payload)
-        broken["personas"][0]["feedback_count"] = "42"
+        _dig(broken, at)["feedback_count"] = "42"
 
-        assert _rejects_at(broken, schema, ("personas", 0, "feedback_count")), _errors(
+        assert _rejects_at(broken, schema, (*at, "feedback_count")), _errors(
             broken, schema
         )
 

--- a/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
+++ b/voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py
@@ -57,6 +57,26 @@ REVERT STORY — which mutation makes which assertion fail:
       test_the_substance_check_notices_a_sample_that_demonstrates_nothing, which
       hollows a sample and requires the check to object.
 
+      It measures EVERY DEPTH, not the payload root. Stopping at the root left the
+      level this file's own architecture argument singles out unmeasured: a
+      property declared inside a closed `items` could be demonstrated by no sample
+      and still pass everything here, because item schemas declare no `required`
+      and `additionalProperties: false` constrains only keys that are PRESENT.
+      Injecting a property no route emits into
+      `list_personas.personas.items.properties` left 66 passing; it is now
+      reported as `personas/[]/nested_prop_no_route_emits`. Descending also found
+      nine canonical persona fields below the item level that no sample reached,
+      which is why a fifth `list_personas` case exists. Two controls, because the
+      requirement passing cannot distinguish "descends and finds everything
+      demonstrated" from "does not descend":
+      test_the_substance_check_measures_below_the_payload_root asserts the
+      derivation reaches inside an array item at all, and
+      test_the_substance_check_descends_into_array_items hollows an ELEMENT of a
+      schema it OWNS — owned rather than registry-driven because the projections
+      fill every declared item key unconditionally, so no route body can produce
+      an element missing one, and a control that cannot construct its own negative
+      case only reports what the production code already does.
+
   test_no_exemption_from_the_substance_check_has_gone_stale
     — the check above can be opted out of via
       `_PROPERTIES_NO_SAMPLE_CAN_SHOW`, and an allowlist is the one structure
@@ -493,6 +513,53 @@ _TOOL_SAMPLES: dict[str, tuple[tuple[str, dict, dict], ...]] = {
                  "documents": [],
              },
          }),
+        # The fully-populated generated row, carrying the canonical fields the
+        # three fixtures above happen not to. Required because the substance check
+        # descends to EVERY depth: nine properties declared inside
+        # `personas[].identity` / `.goals_motivations` / `.behaviors` /
+        # `.context_environment` were reached by no sample, so nothing validated
+        # their declared types — the item-level gap in miniature. See
+        # `_PROPERTIES_NO_SAMPLE_CAN_SHOW` for why they were sampled rather than
+        # exempted.
+        #
+        # Every key and value below is a field of `schemas/persona.schema.json`,
+        # the contract `projects.py` generation writes to, at the type that schema
+        # declares — an optional field a generated row carries when the model
+        # answered that part of the prompt, which is the ordinary case, not an
+        # exotic one. This is provenance level 2 of the convention above: a
+        # transcription from the schema that owns the shape, not a dict written by
+        # reading the tool's `outputSchema`.
+        ("a generated row carrying every canonical persona field",
+         {"project_id": _PROJECT}, {
+             _PROJECT_ROUTE: {
+                 "project": {"name": "Morning Briefing"},
+                 "personas": [{
+                     **_GENERATED_PERSONA,
+                     "identity": {
+                         **_GENERATED_PERSONA["identity"],
+                         "bio": "Reads on the commute, decides at the weekend.",
+                         "education": "LLB, University of Leeds",
+                         "family_status": "Two children at primary school",
+                         "income_bracket": "£60k-£80k",
+                     },
+                     "goals_motivations": {
+                         **_GENERATED_PERSONA["goals_motivations"],
+                         "success_definition": "Nothing important was missed",
+                         "underlying_motivations": ["Be the informed one at work"],
+                     },
+                     "behaviors": {
+                         **_GENERATED_PERSONA["behaviors"],
+                         "activity_frequency": "Every weekday morning",
+                     },
+                     "context_environment": {
+                         **_GENERATED_PERSONA["context_environment"],
+                         "social_context": "Alone, before the household wakes",
+                         "influencers": ["Her local WhatsApp group"],
+                     },
+                 }],
+                 "documents": [],
+             },
+         }),
         ("a project with no personas", {"project_id": _PROJECT}, {
             _PROJECT_ROUTE: {"project": {"name": "Empty"}, "personas": [], "documents": []},
         }),
@@ -511,13 +578,29 @@ _REQUIRED_HINTS: tuple[str, ...] = (
     "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint",
 )
 
-# Declared top-level properties that no sample can demonstrate, `tool` → `{prop}`.
+# Declared properties that no sample can demonstrate, `tool` → `{label}`, where a
+# label is `_label`'s path: a root property is its own name, and `"[]"` marks a
+# descent through an array — `personas/[]/identity/bio`.
 #
 # 🔑 EMPTY, and it must stay hard to add to. Every property declared by the six
-# tools published today is carried by at least one sample payload, so
-# `test_every_declared_property_is_demonstrated_by_some_sample` passes on arrival
-# — which is the point, exactly as with the §5.4 class: it is here so a Phase 3
-# tool cannot satisfy the sample requirement with a route body of `{}`.
+# tools published today is carried by at least one sample payload, at every depth,
+# so `test_every_declared_property_is_demonstrated_by_some_sample` passes on
+# arrival — which is the point, exactly as with the §5.4 class: it is here so a
+# Phase 3 tool cannot satisfy the sample requirement with a route body of `{}`.
+#
+# It was empty when the requirement stopped at the payload root, and it is STILL
+# empty now that the requirement descends to every depth — but that is a fact
+# about this diff, not a property of the samples it inherited. Descending found
+# nine declared properties below the item level that no sample reached
+# (`personas/[]/identity/bio`, `education`, `family_status`, `income_bracket`,
+# `goals_motivations/success_definition`, `underlying_motivations`,
+# `behaviors/activity_frequency`, `context_environment/social_context`,
+# `influencers`), every one of them a real field of
+# `schemas/persona.schema.json` that a generated row can carry. So the samples
+# were extended to carry them rather than the declarations exempted: nine
+# exemptions would have been nine claims that a canonical persona field cannot
+# appear in a real answer, which is false, and an allowlist that absorbs the first
+# finding it is asked about is one that will absorb the next.
 #
 # An entry here is a claim that a declared property CANNOT appear in any real
 # answer, which is nearly always a sign the declaration is wrong rather than the
@@ -748,8 +831,109 @@ def _subschemas(schema: dict) -> dict:
     return {k: v for k, v in properties.items() if isinstance(v, dict)}
 
 
+def _declared_sites(schema, path: tuple = ()) -> dict[tuple, frozenset[str]]:
+    """Every object schema in a declaration, keyed by the payload path reaching it.
+
+    🔑 Recursive, because the substance check stopping at the payload ROOT was the
+    one gap left at the level this file's own architecture argument singles out.
+    `_closed_item_schemas` descends into `items` for the negative controls — M1
+    lived there — but the requirement that a declaration be DEMONSTRATED by some
+    sample was measured only against top-level `properties`. So a Phase 3 author
+    could declare `"pain_points": {"type": "array"}` inside an item schema, have
+    no sample element ever carry that key, and every test here pass: item schemas
+    declare no `required`, and `additionalProperties: false` constrains only keys
+    that are PRESENT. Verified by injecting an item-level property no route emits
+    into a published declaration — 66 passed, in both `list_personas.personas`
+    and `search_feedback.items`. The first client to call the tool would be the
+    first thing to check it, which is exactly M1.
+
+    `"[]"` marks a descent through `items`, so one flat path names a site at any
+    depth: `("personas", "[]", "identity")`. Arrays are collapsed rather than
+    indexed on purpose — element 0 carrying a key and element 1 not is a
+    difference between rows, not between declarations, and the union across
+    elements is what "some sample demonstrates this" means.
+
+    Tolerant in the same way `_subschemas` is, and for the same reason: this runs
+    under `@pytest.mark.parametrize`, so anything it raises is a collection error
+    aborting the whole `lambda/api` suite. A boolean sub-schema, a non-dict
+    `items`, a `properties` that is not a map — all legal or all harmless, and all
+    simply contribute no site.
+    """
+    sites: dict[tuple, frozenset[str]] = {}
+    if not isinstance(schema, dict):
+        return sites
+
+    declared = _subschemas(schema)
+    if declared:
+        sites[path] = frozenset(declared)
+        for prop, sub in declared.items():
+            sites.update(_declared_sites(sub, path + (prop,)))
+
+    items = schema.get("items")
+    if isinstance(items, dict):
+        sites.update(_declared_sites(items, path + ("[]",)))
+    return sites
+
+
+def _keys_at(value, path: tuple) -> set[str]:
+    """Every key some part of `value` carries at `path`, unioned across elements.
+
+    The payload-side counterpart of `_declared_sites`. A path that does not exist
+    in this payload contributes nothing rather than raising: a sample that does
+    not reach a site is precisely the "no sample demonstrates it" finding, and it
+    has to be reportable as a sentence rather than a `KeyError`.
+    """
+    if not path:
+        return set(value) if isinstance(value, dict) else set()
+    head, rest = path[0], path[1:]
+    if head == "[]":
+        if not isinstance(value, list):
+            return set()
+        seen: set[str] = set()
+        for element in value:
+            seen |= _keys_at(element, rest)
+        return seen
+    if not isinstance(value, dict):
+        return set()
+    return _keys_at(value.get(head), rest) if head in value else set()
+
+
+def _label(path: tuple, prop: str) -> str:
+    """One declared property as a single string, `personas/[]/identity/bio`.
+
+    A flat label rather than a `(path, prop)` pair so that
+    `_PROPERTIES_NO_SAMPLE_CAN_SHOW` stays one namespace an exemption can name,
+    and so `_stale_exemptions` can check an entry against the declarations and the
+    samples without a second addressing scheme. A root property is its own name,
+    unprefixed, which keeps every existing message reading the way it did.
+    """
+    return "/".join((*path, prop))
+
+
+def _undemonstrated_labels(schema: dict, payloads: list, exempt=frozenset()) -> set[str]:
+    """Declared properties, at ANY depth, that none of these payloads carries.
+
+    🔑 Pure: a schema and a list of payloads in, labels out, with no reference to
+    the live registry. That is what lets the item-level descent have a positive
+    control over a schema and payloads the control OWNS
+    (`test_the_substance_check_descends_into_array_items`), instead of one that can
+    only be exercised by whatever the real projections happen to emit. The
+    registry-driven requirement is the thin wrapper below.
+    """
+    missing: set[str] = set()
+    for path, declared in _declared_sites(schema).items():
+        seen: set[str] = set()
+        for payload in payloads:
+            seen |= _keys_at(payload, path)
+        for prop in declared - seen:
+            label = _label(path, prop)
+            if label not in exempt:
+                missing.add(label)
+    return missing
+
+
 def _undemonstrated_properties(tool: str, registry: dict) -> set[str]:
-    """Declared top-level properties that no sample payload for `tool` carries.
+    """Declared properties that no sample payload for `tool` carries.
 
     🔑 The substance half of the completeness check, and it exists because the
     presence half counts ENTRIES rather than evidence. Both metrics tools end at
@@ -769,28 +953,52 @@ def _undemonstrated_properties(tool: str, registry: dict) -> set[str]:
     `_PROPERTIES_NO_SAMPLE_CAN_SHOW` with a reason, so the exemption is a line of
     the diff rather than a silence.
     """
-    declared = set(_subschemas(_output_schema(tool)))
-    if not declared:
-        return set()
-    return (
-        declared
-        - _demonstrated_properties(tool, registry)
-        - _PROPERTIES_NO_SAMPLE_CAN_SHOW.get(tool, frozenset())
+    return _undemonstrated_labels(
+        _output_schema(tool),
+        _sample_payloads(tool, registry),
+        _PROPERTIES_NO_SAMPLE_CAN_SHOW.get(tool, frozenset()),
     )
 
 
+def _sample_payloads(tool: str, registry: dict) -> list[dict]:
+    """Every payload this tool's registered cases produce, in registry order."""
+    return [
+        _payload(tool, arguments, bodies)
+        for _case, arguments, bodies in registry.get(tool) or ()
+    ]
+
+
+def _declared_properties(tool: str) -> set[str]:
+    """Every property this tool declares, at any depth, as a label."""
+    return {
+        _label(path, prop)
+        for path, declared in _declared_sites(_output_schema(tool)).items()
+        for prop in declared
+    }
+
+
 def _demonstrated_properties(tool: str, registry: dict) -> set[str]:
-    """Every top-level key the union of this tool's sample payloads carries.
+    """Every declared property the union of this tool's sample payloads carries.
 
     Split out of `_undemonstrated_properties` so the staleness check for
     `_PROPERTIES_NO_SAMPLE_CAN_SHOW` measures demonstration the SAME way the
     requirement does. Two independent notions of "demonstrated" would let an
     exemption be simultaneously necessary and stale, which is a contradiction no
     reader could act on.
+
+    Restricted to DECLARED labels, because that is the vocabulary an exemption is
+    written in: a payload key at a site the schema does not describe is not
+    something anyone could exempt, and reporting it would make the staleness
+    check's "a sample demonstrates this anyway" finding unactionable.
     """
+    payloads = _sample_payloads(tool, registry)
+    schema = _output_schema(tool)
     demonstrated: set[str] = set()
-    for _case, arguments, bodies in registry.get(tool) or ():
-        demonstrated |= set(_payload(tool, arguments, bodies))
+    for path, declared in _declared_sites(schema).items():
+        seen: set[str] = set()
+        for payload in payloads:
+            seen |= _keys_at(payload, path)
+        demonstrated |= {_label(path, prop) for prop in declared & seen}
     return demonstrated
 
 
@@ -819,7 +1027,11 @@ def _stale_exemptions(exemptions: dict, registry: dict) -> list[str]:
             # below would only add noise about a name that does not exist.
             continue
 
-        declared = set(_subschemas(_output_schema(tool)))
+        # Every declared label, at any depth, because an exemption may name an
+        # item-level or nested property — `personas/[]/identity/bio` — now that the
+        # requirement descends there. Measuring "declared" only at the root would
+        # report every legitimate nested exemption as a typo.
+        declared = _declared_properties(tool)
         undeclared = sorted(set(properties) - declared)
         if undeclared:
             findings.append(
@@ -936,15 +1148,61 @@ class TestEveryToolBringsASample:
         Requiring every declared property to appear in the union of a tool's
         payloads is what makes the registry un-gameable: a `{}` body now names the
         seven properties it failed to show.
+
+        🔑 At EVERY depth, not just the payload root. Measuring only top-level
+        `properties` left the level this file's own architecture argument singles
+        out unmeasured: an item-level declaration could be demonstrated by no
+        sample and still pass everything here, because item schemas declare no
+        `required` and `additionalProperties: false` constrains only keys that are
+        present. Injecting `nested_prop_no_route_emits` into
+        `list_personas.personas.items.properties` used to leave 66 passing; it is
+        now reported as `personas/[]/nested_prop_no_route_emits`.
         """
         undemonstrated = _undemonstrated_properties(tool, _TOOL_SAMPLES)
 
         assert undemonstrated == set(), (
             f"{tool} declares {sorted(undemonstrated)} and no registered sample "
-            "produces them, so nothing here validates those declarations. Give "
-            "the sample a route body that carries them — or, if a real answer "
-            "genuinely cannot, add them to _PROPERTIES_NO_SAMPLE_CAN_SHOW with "
-            "the reason."
+            "produces them, so nothing here validates those declarations. A label "
+            "like personas/[]/identity/bio is a property declared inside an array "
+            "item. Give the sample a route body that carries them — or, if a real "
+            "answer genuinely cannot, add them to _PROPERTIES_NO_SAMPLE_CAN_SHOW "
+            "with the reason."
+        )
+
+    def test_the_substance_check_measures_below_the_payload_root(self):
+        """Anti-vacuity for the descent: the requirement above must reach an
+        item schema, not merely be capable of it.
+
+        🔑 `_declared_sites` returning only the root — the behaviour this round
+        replaced — would satisfy every case of the requirement above while leaving
+        26 item-level and nested declarations unmeasured, which is the silence the
+        finding was about. The requirement passing cannot distinguish "descends and
+        finds everything demonstrated" from "does not descend", so the derivation
+        is asserted to reach depth directly.
+
+        Derived, not named: it asks whether SOME published tool declares properties
+        below the root, and says to delete the control if that ever stops being
+        true. Hardcoding `list_personas` would go stale in the silent direction the
+        moment the persona item schema were flattened.
+        """
+        deep = {
+            tool: sorted(
+                path for path in _declared_sites(_output_schema(tool)) if path
+            )
+            for tool in _PUBLISHED_TOOL_NAMES
+        }
+        with_depth = {tool: paths for tool, paths in deep.items() if paths}
+
+        assert with_depth, (
+            "no published tool declares any property below the payload root, so "
+            "the descent this control is about covers nothing; if the declarations "
+            "are genuinely all flat now, delete this control and say so"
+        )
+        assert any(
+            "[]" in path for paths in with_depth.values() for path in paths
+        ), (
+            "no published declaration nests properties inside an array item — the "
+            f"level M1 lived at. Sites found: {with_depth}"
         )
 
     def test_the_substance_check_notices_a_sample_that_demonstrates_nothing(self):
@@ -987,6 +1245,72 @@ class TestEveryToolBringsASample:
             f"{victim}'s sample was reduced to an empty route body and the "
             "substance check still found every declared property demonstrated"
         )
+
+    def test_the_substance_check_descends_into_array_items(self):
+        """The positive control for the descent: hollow an array ELEMENT and the
+        check must name the item properties it no longer demonstrates.
+
+        🔑 Over a schema and payloads this control OWNS, rather than through the
+        registry. The registry-driven version could only be exercised by whatever
+        the real projections happen to emit — and the projections fill every
+        declared item key unconditionally, so no route body can produce an element
+        missing one. A control that cannot construct its own negative case is a
+        control that reports whatever the production code already does, which is
+        the opposite of the point.
+
+        Two directions, because a check that descends but never returns is as
+        useless as one that never descends: a populated element must be measured
+        as demonstrating its keys, and a hollow one must be reported by name. The
+        second is what fails if `_declared_sites` is reverted to the root only.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "shown": {"type": "string"},
+                            "unshown": {"type": "string"},
+                            "nested": {
+                                "type": "object",
+                                "properties": {"deep": {"type": "string"}},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        # Legal, so the control cannot pass because the schema is nonsense.
+        Draft202012Validator.check_schema(schema)
+
+        populated = {"rows": [{"shown": "a", "nested": {"deep": "d"}}]}
+        assert _undemonstrated_labels(schema, [populated]) == {"rows/[]/unshown"}, (
+            "the descent misreported a populated element; it must credit the keys "
+            "an element carries and report only the ones it does not"
+        )
+
+        # A hollow element loses `nested/deep` too: a site no payload reaches
+        # demonstrates nothing beneath it either, which is the reporting a reader
+        # needs — "this whole subtree is unsampled", not just its topmost key.
+        hollow = {"rows": [{}]}
+        assert _undemonstrated_labels(schema, [hollow]) == {
+            "rows/[]/shown", "rows/[]/unshown", "rows/[]/nested", "rows/[]/nested/deep",
+        }, "an element hollowed to {} was still counted as demonstrating its keys"
+
+        # And the exemption vocabulary has to be able to name a nested label,
+        # otherwise a legitimate item-level exemption is unwritable.
+        assert _undemonstrated_labels(
+            schema, [populated], frozenset({"rows/[]/unshown"})
+        ) == set()
+
+        # An empty array demonstrates nothing inside it, which is why the
+        # empty-project cases cannot satisfy the requirement on their own.
+        assert _undemonstrated_labels(schema, [{"rows": []}]) == {
+            "rows/[]/shown", "rows/[]/unshown", "rows/[]/nested", "rows/[]/nested/deep",
+        }
 
     def test_no_exemption_from_the_substance_check_has_gone_stale(self):
         """An exemption may not outlive its reason.
@@ -1072,6 +1396,7 @@ class TestEveryToolBringsASample:
             "the staleness check objected to an exemption that is still doing "
             f"work, so no entry could ever survive it: {still_needed}"
         )
+
 
 class TestTheDerivationsSurviveAnUnusualDeclaration:
     """Nothing read at import time may raise on a declaration a client accepts.

--- a/voc-datalake/requirements-dev.txt
+++ b/voc-datalake/requirements-dev.txt
@@ -14,20 +14,17 @@ boto3-stubs[dynamodb,s3,sqs,secretsmanager,bedrock-runtime]>=1.35.0
 # Lambda Powertools (same as production)
 aws-lambda-powertools>=3.0.0
 
-# JSON Schema validation, TEST-ONLY — deliberately not in any Lambda layer.
+# JSON Schema validation for `lambda/api/test/test_mcp_output_schema_conformance.py`,
+# which validates each MCP tool's declared `outputSchema` against a payload the
+# tool really produces. That file's docstring carries the why.
 #
-# `test_mcp_output_schema_conformance.py` validates each MCP tool's declared
-# `outputSchema` against a payload the tool really produces, and it must use the
-# same kind of validator a CLIENT uses: a validating MCP client rejects a whole
-# response with -32602 when `structuredContent` disagrees with the declaration,
-# which is how `list_personas` came to be uncallable in production while every
-# test passed. A hand-rolled subset validator is what that suite used to have,
-# and a partial implementation ignoring `additionalProperties` or never
-# descending into `items` passes exactly the declarations that are wrong.
+# TEST-ONLY, deliberately absent from `lambda/layers/*`: nothing at runtime
+# validates against these schemas — the server PUBLISHES them and the client
+# checks them — so it stays out of the deployed bundle.
 #
-# Nothing at runtime validates against these schemas — the server PUBLISHES them
-# and the client checks them — so this stays out of `lambda/layers/*` and out of
-# the deployed bundle.
+# `<5`: a major release may change `Draft202012Validator`'s semantics, and this
+# suite's findings are only meaningful against a validator that behaves the way a
+# client's does today.
 jsonschema>=4.23.0,<5
 
 # Code quality — ruff is the only Python linter; the root gate runs

--- a/voc-datalake/requirements-dev.txt
+++ b/voc-datalake/requirements-dev.txt
@@ -14,6 +14,22 @@ boto3-stubs[dynamodb,s3,sqs,secretsmanager,bedrock-runtime]>=1.35.0
 # Lambda Powertools (same as production)
 aws-lambda-powertools>=3.0.0
 
+# JSON Schema validation, TEST-ONLY — deliberately not in any Lambda layer.
+#
+# `test_mcp_output_schema_conformance.py` validates each MCP tool's declared
+# `outputSchema` against a payload the tool really produces, and it must use the
+# same kind of validator a CLIENT uses: a validating MCP client rejects a whole
+# response with -32602 when `structuredContent` disagrees with the declaration,
+# which is how `list_personas` came to be uncallable in production while every
+# test passed. A hand-rolled subset validator is what that suite used to have,
+# and a partial implementation ignoring `additionalProperties` or never
+# descending into `items` passes exactly the declarations that are wrong.
+#
+# Nothing at runtime validates against these schemas — the server PUBLISHES them
+# and the client checks them — so this stays out of `lambda/layers/*` and out of
+# the deployed bundle.
+jsonschema>=4.23.0,<5
+
 # Code quality — ruff is the only Python linter; the root gate runs
 # `ruff check lambda plugins` (config in ruff.toml, issue #201)
 ruff>=0.15.0


### PR DESCRIPTION
## Summary

A parametrised guard that, for **every tool in the published registry**, validates a payload the tool really produces against that tool's own declared `outputSchema`.

Phase 3 (plan §10) adds roughly thirty declarations, each with `additionalProperties: false`, and nothing today compares a declaration against the shape its delegated route actually returns. That gap is already on record as finding **M1** of `analysis/BUG-mcp-tool-truthfulness-GITHUB-ISSUE.md`: `list_personas` declared `pain_points` / `behaviors` as `array` while live rows held nested objects, so a validating client rejected the whole response with `-32602` — the tool was uncallable in production while every test passed. #356 fixed that tool; this closes the class before thirty more chances at it land.

One logical change: a test plus a pinned test-only dependency.

- **`voc-datalake/lambda/api/test/test_mcp_output_schema_conformance.py`** (new, 720 lines)
- **`voc-datalake/requirements-dev.txt`** — `jsonschema>=4.23.0,<5`, test-only, with a comment saying why it is not in any Lambda layer (nothing at runtime validates against these schemas; the server publishes them and the client checks them).

### How it is a guard, not a test of six tools

1. **The tool list is derived, never restated.** Parametrisation walks `mcp_handler.MCP_TOOLS`, so a Phase 3 tool is covered the moment it is published.
2. **A tool with no registered sample FAILS.** Twice, deliberately: once in `test_every_published_tool_has_a_registered_sample_payload` (naming it), and once as a parametrised case with id `<tool>-NO-SAMPLE`, which is what a Phase 3 author reads first. There is no skip path. The completeness check is a *function* (`_tools_missing_samples`) so it has its own positive control — called with the real registry minus one entry, it must report exactly that entry, so "the check found nothing" cannot be because the check finds nothing ever. The reverse direction is checked too: a sample for a tool that is no longer published is as invisible as a missing one.
3. **A real JSON Schema validator**, `Draft202012Validator`. Not hand-rolled: a partial implementation that ignores `additionalProperties` or never descends into `items` passes exactly the declarations that are wrong (M1 lived inside `items`). Each declaration is also run through `check_schema`, so a malformed declaration is not a client's problem to discover.
4. **Samples are route BODIES, not payloads.** The registry holds `(case, tool arguments, route bodies)`; the payload is produced by invoking the tool through `test_mcp_delegation._FakeLambda`. So the file cannot accidentally validate a shape the tool never emits, and an errored/refused sample call fails rather than validating `{}` against an open schema.

### Where each sample came from

None was invented to match a schema. Where a field's real shape is uncertain the *messier* variant is used, because the nested-object case is what broke M1 and the tidy one is what hid it.

| Sample | Provenance |
|---|---|
| `_FEEDBACK_ROW` | `test_mcp_delegation._feedback_row()` — storage names (`source_platform`, `original_text`, `sentiment_label`), numeric `rating`, 900-char verbatim so summary truncation is exercised |
| `_HOSTILE_FEEDBACK_ROW` | the wrong-types row from `test_mcp_delegation.py::TestFeedbackDeclaredTypes` — DynamoDB attribute-value dicts, lists in string slots, a `None`, a float, a flat `keywords` string |
| `_LEGACY_FEEDBACK_ROW` | the plain-`id`-only row from `test_a_row_carrying_only_a_plain_id_still_reports_it` |
| personas (three shapes) | `_GENERATED_PERSONA`, `_IMPORTED_PERSONA`, `_SPARSE_PERSONA` — the delegation suite's live-row fixtures: the schema-following writer, the importer that constrains nothing (`workarounds` a *string* where the other has a list), and the thinnest row in the corpus |
| a persona with nested objects where lists are declared | M1's exact shape at the source: `current_challenges` an object, `emotional_impact` a list, `feedback_count` a string, `quotes` not even a list |
| a persona whose `tagline` is a list | from `test_the_project_summary_coerces_the_persona_fields_it_declares` — the live half of M1 in `get_project` |
| `_DOCUMENTS` | one document per `_DOCUMENT_KINDS` sort-key prefix, keyed as `projects.get_project` returns them (all six kinds — the in-process tool recognised two) |
| `_METRICS_SUMMARY_BODY` | `metrics_handler.get_summary`'s own return dict, field for field, with the values `test_metrics_handler.py::TestGetSummaryEndpoint` asserts the route computes from one aggregate row |
| `_METRICS_SENTIMENT_BODY` | `metrics_handler.get_sentiment_metrics` — includes `total`, which the route publishes and the tool schema does **not** declare; kept precisely because it is the evidence that the open declaration is load-bearing |
| `_METRICS_CATEGORIES/SOURCES/PERSONAS_BODY` | the three one-counts-object routes, sorted descending as those routes sort them |

### Negative controls

Every one asserts the unmutated payload validates **first**, then matches the violation's `absolute_path` (`_rejects_at`) rather than searching the message prose. Prose matching was the weakness the review found: `any("current_challenges" in e or "array" in e ...)` is satisfied by *any* declared array failing anywhere, so breaking `personas[0].quotes` instead satisfied the assertion standing in for M1's exact shape.

- an extra key is **rejected** for every schema declaring `additionalProperties: false` (derived from the declarations, not listed);
- an extra key is **rejected inside an array item**, for every `items` that closes the door — `search_feedback.items`, `get_project.personas` / `.documents`, `list_personas.personas`, derived by `_closed_item_schemas()` with its own anti-vacuity assertion. **This is the architecturally important half**: M1 lived inside `items`, and merging a key at the payload root never reaches an array element;
- an unrecognised key on a route row is **not forwarded** into the payload — the positive counterpart, pinning the projection behaviour that makes the nested case unreachable from a route today. A projection that started passing rows through would break every validating client and now fails here;
- an extra key is **accepted** where the schema is open — the metrics tools forward an unprojected route body, so asserting rejection everywhere would assert a design this server deliberately does not have. Now driven **through the tool**, not validated as a bare route body;
- a nested object where `array` is declared is rejected at the path `("personas", 0, "pain_points", "current_challenges")`, with that path asserted to exist and be a list first (the persona item schema declares no `required`, so a valid payload need not carry it — a missing path used to raise `KeyError` rather than fail diagnostically); plus `keywords` on the feedback detail, as both an object and the flat string the importer really writes;
- a string where `integer` is declared is rejected at `("personas", 0, "feedback_count")`;
- an absent `required` field is rejected, naming `is_partial`. `required` reports at the object that lacks the key, so the path is the root for every missing field and the message is the only place the name appears — the one documented exception to path matching, shared with the closed-metrics control;
- a *copy* of a declaration with a broken type rejects the same payload that otherwise validates;
- a *copy* of an open metrics schema, closed, rejects the real **payload** on `total`;
- **`_rejects_at` has its own positive control.** A matcher is the one helper whose failure mode is silent approval: rewritten to `return True`, every control above still passes, because none of them ever asks it to say *no*. So it is exercised against a schema and payload owned by that test and required to answer no for a field that did not fail.

### §5.4 declaration checks

`outputSchema` present and `type: object`; `annotations` present with a title plus all four boolean hints; a cost class under `_meta` drawn from `COST_CLASSES`. #360 already ships all of these, so this half passes on arrival — it is here so a Phase 3 tool cannot land without them.

## Scope: findings only, no fixes

Nothing outside the new test file and `requirements-dev.txt` is touched — no tool declaration, no `mcp_handler.py`, no `shared/mcp_delegate.py`, no route, no CDK. **The guard found no mismatch in the six tools published today**, and no `xfail` was needed. That is the expected outcome after #356 and #358, not evidence the guard is inert — the negative controls and the five mutation runs below are what prove it is live.

The module docstring now names the real deferral convention rather than describing an absent one: a mismatch surfaces as a failing parametrised case and is fixed in a follow-up; if a fix must be deferred the marker is `pytest.mark.xfail(strict=True, reason=...)` naming the field and the issue — strict, so a stale exemption cannot outlive the defect. There is no such marker in the file.

## Does any gate install `jsonschema` or run this guard?

Checked against the repo, because a top-level `from jsonschema import Draft202012Validator` would be a collection error for the whole `lambda/api` suite if the dependency were absent.

**CI cannot be affected.** There is exactly one workflow, [`.github/workflows/no-event-logging-guard.yml`](.github/workflows/no-event-logging-guard.yml). It installs `pytest` and nothing else, and runs one file — `lambda/api/test/test_no_event_logging.py` — with `--noconftest` and `-o addopts=""`. Its own header comment says so: *"Deliberately narrow: this executes ONE test file, not the backend suite."* No CI job collects `lambda/api`, so a missing `jsonschema` cannot turn any check red, and equally **no pull-request gate runs this guard at all**. Its protection is contributor discipline via `npm run check` until that changes — a pre-existing repo condition, not this PR's to fix.

**The local case is real and already covered.** `npm run test:backend` is `.venv/bin/python -m pytest`. The documented recipe for that venv, `docs/deployment.md` lines 693-698, is `pip install -r requirements-dev.txt -r lambda/layers/ingestion-deps/requirements.txt -r lambda/layers/processing-deps/requirements.txt` — so **the pin is installed by the documented path** and no doc change is owed. The gap is a venv created *before* this pin, where `pip install` was never re-run.

For that case the import is now re-raised with a message naming the fix:

```
ModuleNotFoundError: jsonschema is required by this MCP outputSchema conformance
suite and is pinned in voc-datalake/requirements-dev.txt. A virtualenv created
before that pin will not have it: re-run
`.venv/bin/pip install -r requirements-dev.txt`. This suite is NOT skippable —
skipping it would report a passing run that validated no tool declaration at all.
```

Verified by blocking `jsonschema` through a `sys.meta_path` finder: **1 error during collection**, that message.

**The import stays unconditional.** `pytest.importorskip` would skip the whole file whenever the pin is missing and report a successful run that validated nothing — precisely the "green suite, uncallable tool" state M1 lived in. A missing dependency should be loud.

## Round-two review: two import-time aborts and one loophole

`080041f` addresses the three findings that were still live, plus two smaller ones.

### Blocking — the derivations aborted collection of the whole `lambda/api` suite

`_output_schema` returned `tool["outputSchema"]`, and `_closed_item_schemas` called `.get("type")` on every value in `properties`. Both are read inside `@pytest.mark.parametrize` decorators, so both raised at **module import** — a collection error, not a test failure:

| Declaration | Was | Blast radius |
|---|---|---|
| published tool with no `outputSchema` | `KeyError: 'outputSchema'` | all `lambda/api` tests abort |
| `"outputSchema": None` | `AttributeError: 'NoneType' ... 'get'` | same |
| a **boolean sub-schema** — `{"properties": {"x": true}}`, legal Draft 2020-12 | `AttributeError: 'bool' object has no attribute 'get'` | same |

The third is the one the audit re-graded to blocking, correctly: it is the identical failure class and blast radius as the first, and `aa11dba` introduced it. The irony the review named is real — `test_the_declaration_is_itself_a_valid_json_schema` **passes** for a boolean sub-schema, so the file crashed on a declaration it also certifies as valid. I confirmed `check_schema` accepts both `true` and `false` there.

Both now degrade to "no schema, closes nothing": `_output_schema` returns `{}` for a non-dict declaration, and a new `_subschemas` helper drops non-dict values from `properties` (with the same treatment for a boolean `items`). That leaves `test_every_tool_declares_what_section_5_4_requires` as the single named reporter, which is what it was written to be.

Verified by mutating **production code** rather than the guard's fixtures:

| Mutation in `mcp_handler.py` | Before | After |
|---|---|---|
| rename the first tool's `outputSchema` key | `1 error during collection` | **2 failed, 60 passed** — including `test_every_tool_declares_what_section_5_4_requires[search_feedback]`: *"search_feedback declares no outputSchema"* |
| add `"legal_boolean_subschema": True` to a published `properties` | `AttributeError: 'bool' object has no attribute 'get'`, `1 error during collection` | **64 passed** |

And the tolerance is not allowed to be the only path. `test_the_derivations_still_find_the_real_closures` is its positive control: `_output_schema` returning `{}` unconditionally would satisfy every test in the new class while making the file vacuous (an empty schema validates any payload). That mutation **fails 8**.

### The completeness check counted entries, not evidence

The review's probe was right and reproduced exactly: replacing **only** the two metrics tools' route bodies with `{}` left every case passing. Both end at `ToolResult(body if isinstance(body, dict) else {})` and declare no `required`, so `{}` is a fully *successful* call whose empty payload validates against an open schema — `_payload`'s error checks never fire.

`test_every_declared_property_is_demonstrated_by_some_sample` now requires the union of a tool's sample payloads to cover every declared top-level property. Union across cases rather than per-case, because the cases exist to cover different branches — `get_metrics_breakdown`'s `sentiment` dimension cannot carry `categories`, and demanding otherwise would demand one route answer with another's fields. `_PROPERTIES_NO_SAMPLE_CAN_SHOW` is the documented allowlist and is **empty**: every property of all six tools is already demonstrated, matching the review's own 4/4, 7/7, 7/7, 8/8, 2/2, 15/15 measurement.

| Mutation | Result |
|---|---|
| empty **only** the metrics route bodies | **3 failed** — both metrics tools named with the properties they failed to show, plus the substance control. Was 52/52 passing |
| `_undemonstrated_properties` → `return set()` | **1 failed**, its own positive control, and only that |

### `_TOOL_SAMPLES[tool][0]` at seven sites, and the positive control's exact equality

Both fixed as proposed. `_first_sample(tool)` calls `pytest.fail` naming the tool and pointing at `_TOOL_SAMPLES`. Removing `get_feedback_detail`'s entry now gives 6 failures with **zero** bare `KeyError` tracebacks — the three that were tracebacks now read *"get_feedback_detail is published and has no registered sample; add one to _TOOL_SAMPLES ..."*.

The completeness positive control compares set differences, so it no longer fails alongside the thing it controls. Visible in that same run: `test_the_completeness_check_notices_a_tool_with_no_sample` **passed**, where it previously failed with `assert ['get_feedback_detail', 'search_feedback'] == ['search_feedback']`.

## Does any gate install `jsonschema` or run this guard?

Settled with evidence, since a top-level `from jsonschema import Draft202012Validator` would be a collection error for the whole `lambda/api` suite if the dependency were absent.

**CI cannot be affected.** There is exactly one workflow, [`.github/workflows/no-event-logging-guard.yml`](.github/workflows/no-event-logging-guard.yml). It installs `pytest` and nothing else (line 38) and runs one file — `lambda/api/test/test_no_event_logging.py` — with `--noconftest` and `-o addopts=""` (lines 57-58). Its own header says so: *"Deliberately narrow: this executes ONE test file, not the backend suite."* No CI job collects `lambda/api`, so a missing `jsonschema` cannot turn any check red — and equally **no pull-request gate runs this guard at all**.

**The documented local path already installs the pin, so no doc change is owed by this PR.** `docs/deployment.md` line 696 creates the venv with `pip install -r requirements-dev.txt -r lambda/layers/ingestion-deps/requirements.txt -r lambda/layers/processing-deps/requirements.txt`, and `npm run test:backend` is `.venv/bin/python -m pytest` against that venv — so the pin arrives through the documented command. One precision worth recording, since I checked rather than assumed: that command sits in the *CI/CD example workflow* block, not in the `#quality-checks` section the README's `test:backend` note links to, which shows `pytest` invocations but never the venv creation. That is a pre-existing documentation gap about a venv this PR did not introduce, so it is not this diff's to close; the real gap for this pin is a venv created *before* it, where `pip install` was never re-run.

For that case the import is re-raised naming the fix:

```
ModuleNotFoundError: jsonschema is required by this MCP outputSchema conformance
suite and is pinned in voc-datalake/requirements-dev.txt. A virtualenv created
before that pin will not have it: re-run
`.venv/bin/pip install -r requirements-dev.txt`. This suite is NOT skippable —
skipping it would report a passing run that validated no tool declaration at all.
```

Verified by blocking `jsonschema` through a `sys.meta_path` finder: **1 error during collection**, carrying that message. **The import stays unconditional** — `pytest.importorskip` would skip the whole file whenever the pin is missing and report a successful run that validated nothing, precisely the "green suite, uncallable tool" state M1 lived in.

## Round-three review: an exemption that could outlive its reason, and a registry-ordering coupling

`1492ad4` addresses both remaining findings. Still test-only.

### `_PROPERTIES_NO_SAMPLE_CAN_SHOW` had no staleness check

The review was right, and its probe reproduced exactly: with the allowlist monkeypatched to `{"search_feedback": frozenset({"count", "a_property_that_does_not_exist"}), "a_tool_that_was_renamed_away": frozenset({"whatever"})}`, `_undemonstrated_properties` returned `set()` and **no test objected to any of the three stale forms**.

That is the one direction this file otherwise always checks, missing from the structure where it costs most — an allowlist's whole function is to *remove* a declaration from the checked set, so a dead entry is the most expensive silence available. It is also the module docstring's own `xfail(strict=True)` argument ("strict, so a stale exemption cannot outlive the defect") applied to the other exemption mechanism the file has.

`_stale_exemptions(exemptions, registry)` now reports all three forms, as prose so one run names every stale entry rather than the first. It takes the allowlist as an argument for the same reason `_tools_missing_samples` does: a check that only ever runs against an empty dict passes whether or not it can detect anything, so its positive control has to be able to hand it entries that *are* stale.

`_demonstrated_properties` is split out of `_undemonstrated_properties` so the staleness check measures demonstration the **same way** the requirement does. Two independent notions of "demonstrated" would let an exemption be simultaneously necessary and stale — a contradiction no reader could act on.

| Mutation | Result |
|---|---|
| the review's exact three-form stale dict | **1 failed** — all three findings reported by name: the unpublished tool (listing the six real names), the undeclared property, and `count`, which a sample demonstrates anyway. Was **0 failed** |
| `_stale_exemptions` → `return findings` immediately | **1 failed**, its own positive control, and only that |
| `_stale_exemptions` → report every entry | **1 failed**, the same control — via its silence assertion |

The positive control asserts each form **separately** rather than handing over one dict with all three: a single combined assertion passes while two of the three detections are broken. It also requires *silence* for an exemption that is still doing work, which is the mirror failure mode — a check reporting everything would satisfy all three detection assertions while making the allowlist unusable. The dict is empty today, so the requirement passes trivially and the first entry anyone adds is checked from the moment it lands.

### The registry-ordering coupling, fixed rather than only diagnosed

The review measured it precisely: three controls read `_TOOL_SAMPLES[tool][0]` and needed the *first* case to populate a particular array, and only **one of `get_project`'s three cases** populates `documents` — so moving the empty-project case first, an apparently cosmetic edit, broke `test_an_undeclared_key_inside_an_array_item_is_rejected[get_project-documents]`. Two of the three failed with a bare `IndexError` from `payload["personas"][0]` rather than a sentence.

Took the review's stronger option: `_payload_populating(tool, prop)` searches for a case that populates the property instead of hardcoding index 0, so **reordering cannot break them at all**. The diagnostic is kept for the condition that genuinely matters — no case populating it — naming the tool, the property and how many samples were searched.

| Mutation | Result |
|---|---|
| move `list_personas`'s empty-project case first | **67 passed**. Was 3 failed |
| move `get_project`'s empty-project case first | **67 passed** |
| reduce `list_personas` to its empty-project case only | **3 failed**, all three reading *"none of list_personas's 1 registered samples populates 'personas' …"* — **0 bare `IndexError`**, where two were tracebacks |

## Round-four review: the substance check stopped at the payload root

`76ffa5f` addresses both remaining findings. Still test-only — the diff touches one file.

### The substance requirement did not descend into `items`, the level M1 lived at

The review's probe reproduced exactly: injecting a property no route emits into `list_personas.personas.items.properties` left **66 passed**, and the same into `search_feedback.items` likewise. `_undemonstrated_properties` derived its checked set from `properties` at the payload **root**, so a declaration inside a closed `items` schema could be demonstrated by no sample and validated by nothing. Item schemas declare no `required` and `additionalProperties: false` constrains only keys that are *present*, so nothing else in the file reaches it either — the declaration's first real check would be a client's.

That is the round-two finding one level down, landing on the level this file's own architecture argument singles out: `test_an_undeclared_key_inside_an_array_item_is_rejected` is documented as the more important of the two *because* M1 was inside `items`, while the requirement that a declaration be exercised stopped short of it.

**Went one level further than proposed.** Descending only into `_closed_item_schemas()`'s pairs would have closed the item level and left the same gap immediately beneath it — `list_personas.personas.items` nests six object schemas and a second array (`quotes[]`), none of which was measured. So `_declared_sites` walks a declaration to any depth, keyed by a payload path where `"[]"` marks a descent through an array (`("personas", "[]", "identity")`), with `_keys_at` as the payload-side counterpart unioning across elements. Fixing only the depth the probe used would have been the shallow-derivation defect this repo treats as a defect precisely because the failure it produces is silence.

**The review's item-level measurement was exact — 11/11, 3/3, 4/4, 12/12 — which is why the deeper walk was worth doing.** Below it, nine declared properties were reached by no sample:

| Site | declared | demonstrated | reached by no sample |
|---|---|---|---|
| `personas/[]/identity` | 7 | 3 | `bio`, `education`, `family_status`, `income_bracket` |
| `personas/[]/goals_motivations` | 4 | 2 | `success_definition`, `underlying_motivations` |
| `personas/[]/behaviors` | 5 | 4 | `activity_frequency` |
| `personas/[]/context_environment` | 5 | 3 | `social_context`, `influencers` |

**Sampled, not exempted.** Every one is a real field of `schemas/persona.schema.json`, the contract `projects.py` generation writes to, so nine exemptions would have been nine claims that a canonical persona field cannot appear in a real answer — false. A fifth `list_personas` case carries them at the types that schema declares: provenance level 2 of the stated convention, transcribed from the schema that owns the shape, never from the tool's `outputSchema`. `_PROPERTIES_NO_SAMPLE_CAN_SHOW` is **still empty**, and its comment now records that the emptiness is a fact about this diff rather than something inherited — an allowlist that absorbs the first finding it is asked about will absorb the next. `_stale_exemptions` measures "declared" over the deep labels, otherwise every legitimate nested exemption would read as a typo.

**Two positive controls, because the requirement passing cannot distinguish "descends and finds everything demonstrated" from "does not descend".**

- `test_the_substance_check_measures_below_the_payload_root` — anti-vacuity on the derivation: some published declaration must nest properties inside an array item. Derived rather than naming `list_personas`, with a message saying to delete the control if the declarations ever go flat, since hardcoding would go stale in the silent direction.
- `test_the_substance_check_descends_into_array_items` — hollows an **element**, over a schema and payloads the control **owns**. Owned rather than registry-driven because the projections fill every declared item key unconditionally (an empty persona row still yields all 12), so no route body can produce an element missing one; a control that cannot construct its own negative case only reports what production already does. It checks both directions — a populated element must be *credited*, a hollow one *reported* — since a check that descends but never returns is as useless as one that never descends.

`_undemonstrated_properties` and `_demonstrated_properties` both delegate to one pure `_undemonstrated_labels(schema, payloads, exempt)`, so the exemption-vs-requirement contradiction round three closed stays unreachable.

| Mutation | Result |
|---|---|
| the review's item-level injection | **1 failed**, naming `personas/[]/nested_prop_no_route_emits`. Was **66 passed** |
| the same one level deeper (`personas[].identity`) | **1 failed**, naming `personas/[]/identity/deep_prop_no_route_emits` |
| `_declared_sites` → root only (revert of this fix) | **2 failed** — exactly the two new controls, nothing else |
| `_undemonstrated_labels` → `set()` | **2 failed** |
| `_keys_at` ignores the path | **4 failed** |
| a stale nested exemption (one demonstrated anyway, one undeclared) | **1 failed**, both forms named by their nested labels |

### Four of five classes were already PEP 8 compliant

Checked with `ruff check --isolated --preview --select E301,E302,E303,E305,E306` rather than by eye, since `E3` is not in ruff's defaults and `ruff.toml` does not extend the selection. It reports exactly **one** finding, `TestTheDerivationsSurviveAnUnusualDeclaration`, now fixed.

The other three the review listed are preceded by a `# ====` section banner with two blank lines before *that*; pycodestyle counts blank lines before the leading comment block, not between comment and `class`, so they already satisfy E302 — and inserting a line would divorce each banner from the thing it labels. The review's underlying observation was the load-bearing one: that class was the only one with no banner, which is exactly why it read as though still inside `TestEveryToolBringsASample`.

## Scope: findings only, no fixes

Nothing outside the new test file and `requirements-dev.txt` is touched — no tool declaration, no `mcp_handler.py`, no `shared/mcp_delegate.py`, no route, no CDK. **The guard found no mismatch in the six tools published today**, and no `xfail` was needed. That is the expected outcome after #356 and #358, not evidence the guard is inert — the negative controls and the mutation runs are what prove it is live.

## Build and test results

Environment note: the container had no `voc-datalake/.venv`. Created it from the documented recipe (`requirements-dev.txt` plus both layer requirements files) plus `aws-xray-sdk`, which is absent from every requirements file and without which 12 modules fail collection. No repo file was changed for this.

| Command | Result |
|---|---|
| `pytest lambda` on **base tip** (`3d7f105`) | **3278 passed, 0 failed** |
| `pytest lambda` on **this branch** | **3347 passed, 0 failed** (+69, all from the new file) |
| `pytest lambda/api/test/test_mcp_output_schema_conformance.py` | **69 passed** |
| `npm run test:backend` (the repo's own gate, `lambda` + `plugins`) | **3640 passed, 0 failed** |
| the same file in a venv **without** the pin | **1 error during collection**, naming `requirements-dev.txt` and the `pip install` to run — not a skip |
| `ruff check --select F,E4,E7,E9` on the changed file | clean |
| `ruff check` on the changed file, **full default rule set** | clean (one real `RUF024` finding surfaced and fixed: `dict.fromkeys(bodies, {})` shared one dict across routes) |
| `ruff check --isolated --preview --select E301,E302,E303,E305,E306` on the changed file | clean (one `E302` surfaced and fixed; see round four) |
| `ruff check lambda plugins` (repo-wide) | **509 errors on base tip, 509 on this branch** — unchanged |
| `mise run build` / `mise run lint` | no such task in this repo — `mise ERROR no tasks defined in ...`, and `mise tasks` lists none. `npm run lint:python` is `ruff check lambda plugins`, reported above; this change contains no frontend code |

**Did the guard find a mismatch?** No. All six published tools' payloads satisfy their own declarations, and no `xfail` was needed.

### Mutation-check of the guard against itself

Every row was actually run and reverted. The first two are against **production code**, which is the stronger evidence:

| Mutation | Result |
|---|---|
| `mcp_handler._coerce_declared` returns `value` uncoerced — a faithful reintroduction of the M1 defect class in production code | **18 failed**, 46 passed |
| `_project_feedback` forwards the raw row (`{**item, **projected}`) | **13 failed**, 51 passed |
| rename a published tool's `outputSchema` key | **2 failed** with the §5.4 message, was a collection abort |
| a boolean sub-schema in a published `properties` | **64 passed**, was a collection abort |
| `_output_schema` → `{}` unconditionally (tolerance made vacuous) | **8 failed** |
| empty **only** the metrics route bodies | **3 failed**, was 52/52 green |
| `_undemonstrated_properties` → `set()` | **1 failed**, its own positive control only |
| remove `get_feedback_detail`'s sample entry | **6 failed**, all named; 0 bare `KeyError` |
| `_rejects_at` → `return True` | **1 failed** — its own positive control, and only that |
| `_closed_item_schemas()` → `[]` | **1 failed** on the anti-vacuity assertion |
| break `personas[0].quotes` instead of `current_challenges` | **1 failed** on the nested-array control |
| the review's three-form stale exemption dict | **1 failed**, all three named. Was **0 failed** |
| `_stale_exemptions` → return early / report everything | **1 failed** each, its own positive control only |
| reorder `_TOOL_SAMPLES` so an empty case is first (`list_personas`, then `get_project`) | **67 passed** each. Was 3 failed |
| reduce `list_personas` to its empty-project case | **3 failed**, all sentences; **0 bare `IndexError`** |
| an item-level property no route emits (`personas.items`) | **1 failed**, named. Was **66 passed** |
| the same one level deeper (`personas[].identity`) | **1 failed**, named |
| `_declared_sites` → root only | **2 failed** — exactly the two new controls |
| `_undemonstrated_labels` → `set()` | **2 failed** |
| `_keys_at` ignores the path | **4 failed** |
| a stale **nested** exemption, both forms | **1 failed**, both named by nested label |

## Decisions made

- **Imported by package path, not as a bare sibling.** `from test_mcp_delegation import ...` resolved, but not to the module pytest already had: `lambda/api/test/__init__.py` exists, so pytest imports the delegation suite as `api.test.test_mcp_delegation`, and the bare form executed its module body a second time under a second name. `sys.modules` showed both. That is the same "two copies drift by construction" failure the import exists to avoid, arriving through the import system instead of a copy-paste. Now `from api.test.test_mcp_delegation import ...`, verified to leave exactly one entry. Promoting the fixtures into a helper module beside the tests is the better end state and the right follow-up — it would also remove the private-name coupling — but it edits a 1,803-line suite in a diff that should read as "a guard was added".
- **Sample provenance is now a stated convention, not per-fixture folklore.** A ranked list sits beside `_TOOL_SAMPLES`: an existing fixture from the suite that owns the route, else the handler's `return` dict transcribed with a comment naming the function and the test that pins its values, else driving the handler with a stubbed table. The third is deliberately not used here — it would make a schema-conformance suite depend on `metrics_handler`'s `aggregates_table` stubbing, so a change there would break this file for a reason unrelated to schemas. It is worth reaching for when a route's shape is hard to state by hand. What is never acceptable at any level is a dict written by reading the `outputSchema`.
- **The autouse env fixture is redeclared, not imported** — an autouse fixture applies to the module that defines it, so importing the delegation suite's copy would give this file the stubs and none of the environment they need.
- **`test_mcp_delegation.py`'s existing `_schema_errors` subset checker was left in place.** Removing it would be a refactor of a 1,803-line suite in a diff that is supposed to read as "a guard was added". The new file's docstring records why it does not reuse it.
- **New file rather than an addition to `test_mcp_delegation.py`**, following the repo's stated convention of splitting test files by subject (credential / data / envelope) rather than by size. Schema conformance is a different subject with a different failure mode from route translation.
- **`requirements-dev.txt`'s comment block trimmed** from 16 lines to the facts not stated elsewhere: test-only, why it is absent from `lambda/layers/*`, and what the `<5` bound guards against (a major release changing `Draft202012Validator` semantics). The M1 narrative lives in the test module's docstring; the pin now points there. Checked `THIRD-PARTY-LICENSES.md` — npm packages only, no entry owed.

## Agent notes

**What went well.** The repo's existing fixtures made the "realistic samples" requirement tractable — `_GENERATED_PERSONA` / `_IMPORTED_PERSONA` / `_SPARSE_PERSONA` and the wrong-types feedback row already encode hard-won knowledge about what live writers produce, and reusing them was strictly better than anything I could have invented. Driving the payload through `_FakeLambda` rather than registering finished dicts turned out to be the single most valuable design choice: it makes the samples un-fakeable, because the tool's own projection sits between the sample and the assertion.

**What was difficult.** The container environment was the main obstacle: `mise run build`/`lint` do not exist in this repo, and the interpreter on `PATH` was not the one with the test dependencies. `pydantic` was missing, which silently turned 1150 pre-existing tests red and briefly looked like a repo problem — worth establishing a clean base-tip count *before* trusting any failure. Deciding what counts as a mismatch versus a deliberate design choice also took care: the open/closed `additionalProperties` split in `mcp_handler` is intentional and documented, so the guard had to derive the split from the declarations rather than assert one policy, and I added a mutation test for the *open* case too so "open on purpose" is a fact about the payload rather than a claim in a comment.

**Conventions discovered.** Comments are load-bearing and argue why a shape was chosen over the obvious alternative. Test names are outcomes. Module docstrings carry a revert map naming which mutation each assertion catches. Derivations read from source (`ast`, the live registry, the canonical schema file) rather than restating; a hardcoded list is treated as a defect because the failure a stale copy produces is *silence*. Every non-vacuity concern gets its own positive control, including controls on the controls. `ruff.toml` runs a wide default rule set, and the repo currently carries 509 pre-existing findings, so "clean on changed files, count must not rise" is the workable gate.

**Suggestions for future tasks.** (1) The follow-up this PR implies: `test_mcp_delegation.py`'s `_schema_errors` is now a second, weaker validator beside a real one — replacing it with `jsonschema` would remove the subset implementation and its maintenance risk. (2) The natural companion: promote `_FakeLambda`, `_call`, `_feedback_row` and the persona shapes into a helper module beside the tests, following the `plugin_manifests.py` / `metrics_publishing_routes.py` pattern, which removes the private-name coupling between two test modules that the package-path import only mitigates. (3) `requirements-dev.txt` does not pin the transitive set needed to run `pytest lambda` (`aws-xray-sdk` is in no requirements file at all, and 12 modules fail collection without it); one documented command would save the next agent the same detour. (4) No pull-request gate runs the backend suite, so this guard — and every other backend test — is enforced only by contributor discipline via `npm run check`. A workflow running `npm run lint:python && npm run test:backend` on pull requests would make backend regressions attributable; today a Phase 3 tool could abort collection for the whole `lambda/api` suite and no automated check would report it.

**Review rounds.** Round four: two findings in `76ffa5f` — the substance check stopping at the payload root (fixed one level further than proposed, since descending only to `items` would have left the same gap beneath it, and the nine properties it surfaced were sampled rather than exempted) and the blank-line note (one real `E302`, the other four already compliant via their section banners). Round two: eight threads, six addressed in `aa11dba`, one answered with evidence (the `jsonschema` gate question), one acknowledged with a documented follow-up (the helper-module refactor, mitigated by the package-path import). Round three: three blocking/robustness findings in `080041f`, then the two remaining in `1492ad4` — the stale-exemption direction and the registry-ordering coupling. Both round-three findings were reproduced with the reviewer's own probes before being fixed, and both fixes ship with the mutation that proves them live.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

```abca-verify
no-ui
```



