### PR TITLE
fix(metrics): bucket the persona dimension on the archetype, not the name

### DIFF
--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -453,10 +453,26 @@ const handlers = {
         keywords: {},
         categories: countBy(i => i.category),
         issues: countBy(i => i.problem_summary),
-        // The ARCHETYPE, matching metrics_handler's `_persona_bucket`: both of the
+        // The ARCHETYPE, matching `shared/feedback.py::persona_bucket`: both of the
         // real route's branches bucket by `persona_type`, and an item with none
         // counts as `unknown` rather than being dropped, so the persona map sums to
         // `feedback_count`.
+        //
+        // 🔑 THIS COPY IS DELIBERATELY NOT PINNED, and may be edited freely. The
+        // Python side declares the field, the empty value and the archetype enum once
+        // in `shared/feedback.py` and forbids either Lambda from spelling them inline,
+        // because a drift there is a WRONG NUMBER served to a caller. A Node dev stub
+        // serves no production traffic, so a drift here costs a confusing afternoon —
+        // not a wrong answer — and it cannot import from `lambda/shared/`. The trade
+        // is that this file has to be followed by hand when the axis moves, which is
+        // what happened to it: it bucketed on `persona_name` for one round, so local
+        // dev was written against a value space production had stopped producing.
+        //
+        // The one thing it does NOT reproduce is the enum closure — an out-of-contract
+        // `persona_type` gets its own bucket here and would be counted as `unknown` by
+        // the real route. Every fixture above uses a declared archetype, so the two
+        // agree in practice; if a fixture ever needs an out-of-contract value, add the
+        // membership test rather than leaving the stub disagreeing.
         personas: countBy(i => i.persona_type || 'unknown'),
         sources: countBy(i => i.source_platform),
       },

--- a/voc-datalake/frontend/mock-server.js
+++ b/voc-datalake/frontend/mock-server.js
@@ -23,7 +23,12 @@ const mockFeedback = [
     impact_area: 'operations',
     problem_summary: 'Customer experiencing significant delivery delay',
     direct_customer_quote: 'Ordered 2 weeks ago and still waiting',
+    // Both persona fields, as the real processor writes them. The persona METRICS
+    // axis buckets by `persona_type` — a closed enum — because `persona_name` is
+    // legitimately null for the anonymous feedback that is most of a real corpus;
+    // see the note beside PERSONA_FIELD in lambda/shared/feedback.py.
     persona_name: 'Impatient Shopper',
+    persona_type: 'churn_risk',
     // Written today, imported today
     source_created_at: new Date().toISOString(),
     processed_at: new Date().toISOString(),
@@ -45,6 +50,7 @@ const mockFeedback = [
     // optional fields are omitted rather than null.
     direct_customer_quote: 'resolved my issue within minutes',
     persona_name: 'Satisfied Customer',
+    persona_type: 'advocate',
     // Written 3 days ago, imported today
     source_created_at: daysAgo(3),
     processed_at: new Date().toISOString(),
@@ -65,6 +71,7 @@ const mockFeedback = [
     problem_summary: 'Multiple defective products received',
     direct_customer_quote: 'last 3 orders had defects',
     persona_name: 'Repeat Customer',
+    persona_type: 'existing_customer',
     // Old backfilled review: written ~400 days ago, imported today.
     // Visible under the imported basis, filtered out under the review basis.
     source_created_at: daysAgo(400),
@@ -446,7 +453,11 @@ const handlers = {
         keywords: {},
         categories: countBy(i => i.category),
         issues: countBy(i => i.problem_summary),
-        personas: countBy(i => i.persona_name),
+        // The ARCHETYPE, matching metrics_handler's `_persona_bucket`: both of the
+        // real route's branches bucket by `persona_type`, and an item with none
+        // counts as `unknown` rather than being dropped, so the persona map sums to
+        // `feedback_count`.
+        personas: countBy(i => i.persona_type || 'unknown'),
         sources: countBy(i => i.source_platform),
       },
     };
@@ -495,12 +506,16 @@ const handlers = {
   }),
   'GET /metrics/personas': () => ({
     period_days: 7,
+    // The closed archetype enum the real route now returns
+    // (`existing_customer|prospect|churn_risk|advocate|unknown`), not free-text
+    // names — a stub returning names would have the dashboard developed against a
+    // value space production no longer produces.
     personas: {
-      'Impatient Shopper': 234,
-      'Price-Sensitive Buyer': 198,
-      'Quality Seeker': 167,
-      'First-Time Customer': 145,
-      'Loyal Customer': 123,
+      existing_customer: 234,
+      churn_risk: 198,
+      prospect: 167,
+      advocate: 145,
+      unknown: 123,
     },
   }),
   'POST /chat': () => ({

--- a/voc-datalake/frontend/src/api/client.test.ts
+++ b/voc-datalake/frontend/src/api/client.test.ts
@@ -864,7 +864,12 @@ describe('API Client', () => {
 
   describe('getPersonas', () => {
     it('fetches personas with days parameter', async () => {
-      const mockResponse = { period_days: 7, personas: { 'Power User': 50, 'Casual User': 30 } }
+      // Contract archetype codes, which is what this route now returns: the persona
+      // axis buckets on `persona_type` and is closed to the enrichment enum, so a
+      // free-text key here would document a shape the API cannot produce.
+      const mockResponse = {
+        period_days: 7, personas: { existing_customer: 50, churn_risk: 30 },
+      }
       ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResponse),

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -170,6 +170,20 @@ export interface PersonaBreakdown {
   period_days: number
   /** See {@link MetricsSummary.is_partial} — same flag, same three reasons. */
   is_partial?: boolean
+  /**
+   * Keys are enrichment-contract ARCHETYPE CODES, not display labels:
+   * `existing_customer | prospect | churn_risk | advocate | unknown`
+   * (`PERSONA_ARCHETYPES` in `lambda/shared/feedback.py`, which closes the axis so
+   * anything outside the set is counted as `unknown`).
+   *
+   * So whoever first renders this dimension must MAP them, through i18n like every
+   * other user-facing label — printing a key would put `churn_risk` on screen. They
+   * are codes on purpose: the axis used to bucket on a free-text `persona_name`, and
+   * a caller grouping by a dimension can enumerate a contract enum and cannot
+   * enumerate free text. During the ~90 days aggregate rows written before the move
+   * survive, this map can also carry their legacy free-text keys and a separate
+   * `Unknown` — see the transition note at `PERSONA_UNKNOWN`.
+   */
   personas: Record<string, number>
 }
 

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -171,6 +171,20 @@ export interface PersonaBreakdown {
   /** See {@link MetricsSummary.is_partial} — same flag, same three reasons. */
   is_partial?: boolean
   /**
+   * True when `personas` carries at least one bucket the current axis cannot write —
+   * i.e. a row written before the dimension moved to `persona_type`, which is free
+   * text or a capitalised `Unknown`. The counts are correct either way; the flag says
+   * the KEY SPACE is mid-transition, which resolves itself once no pre-move aggregate
+   * row survives its 90-day TTL.
+   *
+   * Published on every branch, false included, for the reason `is_partial` is: a
+   * reader cannot tell an absent flag from a false one. A consumer rendering this
+   * dimension during the transition should expect keys outside the archetype set and
+   * must not merge them into `unknown` — see `has_legacy_persona_buckets` in
+   * `lambda/shared/feedback.py` for why that would destroy information.
+   */
+  has_legacy_persona_buckets?: boolean
+  /**
    * Keys are enrichment-contract ARCHETYPE CODES, not display labels:
    * `existing_customer | prospect | churn_risk | advocate | unknown`
    * (`PERSONA_ARCHETYPES` in `lambda/shared/feedback.py`, which closes the axis so
@@ -260,6 +274,9 @@ export interface EntitiesResponse {
    * call and therefore worth nothing.
    */
   is_partial?: boolean
+  /** See {@link PersonaBreakdown.has_legacy_persona_buckets} — the same flag about the
+   *  same axis, on this route's `entities.personas` map. */
+  has_legacy_persona_buckets?: boolean
   entities: {
     keywords: Record<string, number>
     categories: Record<string, number>

--- a/voc-datalake/frontend/src/pages/FeedbackDetail/FeedbackDetail.test.tsx
+++ b/voc-datalake/frontend/src/pages/FeedbackDetail/FeedbackDetail.test.tsx
@@ -54,7 +54,9 @@ const mockFeedback = {
   urgency: 'low',
   rating: 5,
   persona_name: 'Happy Customer',
-  persona_type: 'loyal',
+  // A contract archetype: `loyal` is not one, and the persona axis now counts any
+  // value outside PERSONA_ARCHETYPES as `unknown`.
+  persona_type: 'advocate',
   problem_summary: null,
   problem_root_cause_hypothesis: null,
   suggested_response: 'Thank you for your feedback!',

--- a/voc-datalake/frontend/src/test/fixtures.ts
+++ b/voc-datalake/frontend/src/test/fixtures.ts
@@ -83,7 +83,11 @@ export const mockNeutralFeedbackItem: FeedbackItem = {
   urgency: 'low',
   impact_area: 'operations',
   persona_name: 'Casual User',
-  persona_type: 'standard',
+  // A value the enrichment contract declares, like the two fixtures above. `standard`
+  // was not one, and since the persona axis closed to PERSONA_ARCHETYPES an
+  // out-of-contract value is counted as `unknown` — so a fixture carrying one is a
+  // fixture developed against a value space production no longer produces.
+  persona_type: 'existing_customer',
 }
 
 /**

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -142,12 +142,16 @@ from botocore.exceptions import ClientError
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, is_conditional_check_failure
 # The persona axis, declared in the data layer because BOTH sides of it spend the
-# same three values — see the note above `counter_dimensions`.
+# same values AND the same derivation — see the note above `counter_dimensions`.
 from shared.feedback import (
     PERSONA_ARCHETYPES,
-    PERSONA_FIELD,
     PERSONA_PREFIX,
-    PERSONA_UNKNOWN,
+    # Not read by this module's code — `persona_bucket` is what spends it — but
+    # re-exported here deliberately: the LEGACY_PERSONA_UNKNOWN comment's argument is
+    # that the two empty-bucket spellings must differ, and a reader checking that
+    # should find both names in one namespace.
+    PERSONA_UNKNOWN,  # noqa: F401
+    persona_bucket,
 )
 
 # AWS Clients (using shared module for connection reuse)
@@ -222,30 +226,89 @@ SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
 # `attribute_exists(pk) AND #field >= :floor`, so a decrement against an absent or
 # already-zero row is refused, swallowed and counted as REFUSED_METRIC.
 #
-# THE FALLBACK, and why it is on this side only. The ABSENCE OF THE ROW is a
-# signal, and `update_counter` reports it (`CounterWrite.ROW_ABSENT`, told from a
-# refusal at the floor by DynamoDB itself) precisely so a caller can spend it: a
-# missing archetype row is the evidence that this image's insert did not create one,
-# so the reversal then aims at the row the old derivation names. That is
-# self-limiting — it costs one extra conditional write only when the archetype row
-# is absent, it needs no new stored field, and it stops mattering on its own as the
-# pre-deploy rows age out, at which point BOTH constants below and
-# `_reverse_a_pre_deploy_persona_row` can be deleted with no other change.
+# THE FALLBACK, and why it is on this side only. On a reversal, the item's own
+# PROCESSING TIME says which derivation its insert used: `processed_at` is stamped by
+# `processor/handler.py` when the item was written, so an item processed before the
+# axis moved was counted by the old derivation and one processed after it by the new
+# one. The reversal then aims one extra conditional write at the row the old
+# derivation names. It needs no stored state of its own, and it is deletable in one
+# piece — the constants below and `_reverse_a_pre_deploy_persona_row`.
 #
-# THE EVIDENCE IS THE ROW, NOT THE ITEM'S SHAPE. Worth stating because the shape
-# test suggests itself and is false: `processor/handler.py` has written BOTH persona
+# WHEN IT IS SAFE TO DELETE IS NOT A DATE, and the reason is a detail of
+# `update_counter`: its UpdateExpression always writes `#ttl = :ttl` with a fresh
+# `ttl_days`, DECREMENTS included, so every compatibility write RENEWS the legacy row
+# it touches for another 90 days (a row with 5 days left goes back to 90 — verified
+# against moto). A legacy row still receiving deletes therefore resets its own clock,
+# and the real bound is how long pre-deploy FEEDBACK survives to be deleted or edited,
+# not 90 days from deploy. The removal signal is the compatibility no longer firing —
+# `AggregateWriteDeclined`/the log line below in CloudWatch — rather than the
+# calendar. Leaving `#ttl` unwritten on this one path was considered and not done: it
+# is a change to the expression every counter in the module shares, and a row being
+# maintained is a row in use for every other caller.
+#
+# 🔑 WHY NOT THE ABSENT ROW, which is the signal this used to spend. An absent
+# archetype row does mean this item's insert created none, and it is where this
+# started — but it is only PRESENT as evidence on a day no post-deploy item has
+# written that bucket. Review demonstrated the gap against moto: post-deploy
+# ingestion populates `METRIC#persona#churn_risk` for the day, a pre-deploy item of
+# that day is then deleted, the decrement LANDS on the row it never contributed to,
+# and the legacy row it did contribute to is never touched. That is the busiest day
+# in the window and the ordinary cross-deploy state, so the compatibility was
+# effective exactly where the corpus was quiet. The absent row is sound evidence and
+# too rare to rely on; `processed_at` is per-ITEM, so it is available on every
+# reversal.
+#
+# THE ROW'S ABSENCE IS STILL READ, for the opposite purpose. `CounterWrite` reports
+# it, and a reversal whose archetype decrement was refused AT THE FLOOR is one whose
+# row exists — which is what a REDELIVERED remove of an already-reversed item looks
+# like. Nothing about the day tells those apart, so the fallback is skipped when the
+# archetype decrement LANDED or was refused at the floor for an item this deploy did
+# count. See `_reverse_a_pre_deploy_persona_row`.
+#
+# THE EVIDENCE IS NOT THE ITEM'S PERSONA SHAPE. Worth stating because that test
+# suggests itself and is false: `processor/handler.py` has written BOTH persona
 # fields since the initial commit, so "no `persona_type` but a `persona_name`" is
 # NOT the pre-deploy shape — an anonymous pre-deploy item carries a `persona_type`
-# and no name, exactly like a post-deploy one, and that is the 99.97% case. The
-# deploy boundary left its mark on the ROWS, so only a row can testify to it.
+# and no name, exactly like a post-deploy one, and that is the 99.97% case. What
+# separates them is WHEN the item was processed, which is a different field.
 #
 # A permanent dual-READ on the increment path was rejected, and the reason is
 # recorded: this repo has already refused that shape once (the MCP legacy-token
 # decision), because preserving a legacy path there would have meant carrying a
-# permanent extra field to serve a path with a sunset date. Here the absent-row
-# signal makes the compatibility free and confines it to the reversal, where
-# reading the old field cannot affect which bucket anything is COUNTED in.
+# permanent extra field to serve a path with a sunset date. Here the timestamp is a
+# field the processor already writes for its own reasons, and the compatibility is
+# confined to the reversal, where reading the old field cannot affect which bucket
+# anything is COUNTED in.
 LEGACY_PERSONA_FIELD = 'persona_name'
+# The item field that says which derivation counted it: `processor/handler.py` stamps
+# `processed_at` with the moment it wrote the item, so it is the item's own record of
+# which deploy was live then. Read rather than `date`, which is the day the feedback
+# belongs to and can be BACKDATED by an import — a pre-deploy `date` on an item
+# processed today is exactly the case a date-based test would get wrong.
+#
+# An item carrying NO `processed_at` is treated as pre-deploy: only legacy or
+# hand-written rows lack it, and those are pre-deploy by construction.
+LEGACY_PERSONA_STAMP_FIELD = 'processed_at'
+# The deploy boundary. Items processed at or after this instant were counted by the
+# archetype derivation; items before it were counted by the name derivation, so their
+# reversal needs the fallback.
+#
+# ⚠️ SET THIS TO THE DEPLOY TIME. It is a UTC ISO-8601 instant, PARSED rather than
+# compared as text: `processed_at` carries microseconds and this does not, and while
+# the two happen to order correctly as strings today that is a property of one
+# format's punctuation rather than something to depend on.
+#
+# The default is the date the axis move landed. An instant EARLIER than the real
+# deploy makes the compatibility inert for items processed in between — the behaviour
+# before this fix existed, an inflated legacy row. One LATER makes it fire for
+# post-deploy items, which drains a legacy row for an item that never touched it.
+# Erring early is the safer direction, so the default is the day the change landed
+# rather than an estimate of when it will be deployed.
+#
+# Environment-overridable so a deployment whose real cutover differs can correct it
+# without a code change, and because a test cannot otherwise place an item on either
+# side of a hardcoded instant.
+LEGACY_PERSONA_CUTOVER = os.environ.get('PERSONA_AXIS_CUTOVER_AT', '2026-08-22T00:00:00+00:00')
 # The bespoke empty bucket the old derivation used — deliberately capitalised the
 # way it was written, because this constant's whole job is to name rows that ALREADY
 # EXIST. It is not a value anything writes fresh: `counter_dimensions` spells the
@@ -258,9 +321,13 @@ LEGACY_PERSONA_FIELD = 'persona_name'
 # on the current axis. The two are also not symmetric in kind: `unknown` is a value
 # the enrichment contract declares, while `Unknown` was a label the old derivation
 # invented, so the new one must never be substituted for the old. Asserted by
-# test_a_post_deploy_image_whose_row_is_gone_writes_nothing_more, and the collision
-# it protects against is the general case
-# `_reverse_a_pre_deploy_persona_row` refuses via PERSONA_ARCHETYPES.
+# test_a_post_deploy_image_whose_row_is_gone_writes_nothing_more.
+#
+# The GENERAL form of that collision is closed by code rather than by this
+# capitalisation. `_reverse_a_pre_deploy_persona_row` declines when the legacy value
+# is a member of PERSONA_ARCHETYPES, and `persona_bucket` is what makes that set the
+# whole space of rows this deploy writes — so a populated `persona_name` equal to any
+# live bucket is refused too, which the capitalisation alone never covered.
 LEGACY_PERSONA_UNKNOWN = 'Unknown'
 
 # Client error codes worth failing OPEN for without shouting: a blip, a throttle, a
@@ -287,31 +354,35 @@ class CounterWrite(Enum):
     🔑 THREE OUTCOMES, NOT TWO, because "the write was refused" is two different
     facts and the difference is load-bearing for exactly one caller. A decrement's
     condition is `attribute_exists(pk) AND #field >= :floor`, so a refusal means
-    EITHER there was no row at all OR the row is at zero — and
-    `_reverse_a_pre_deploy_persona_row` acts only on the first. A bool cannot carry
-    that, which is what made the fallback fire on a redelivered REMOVE of an
-    ordinary post-deploy item whose row had merely reached zero.
+    EITHER there was no row at all OR the row is at zero, and
+    `_reverse_a_pre_deploy_persona_row` must not act on the second: a row sitting at
+    zero EXISTS, which is proof this deploy's derivation counted the item, so there
+    is no legacy row owed a `-1`. A bool cannot carry that, which is what made the
+    fallback fire on a redelivered REMOVE of an ordinary post-deploy item.
 
     DynamoDB is the one that knows, and it will say so for free:
     `ReturnValuesOnConditionCheckFailure='ALL_OLD'` returns the refused item, or no
-    item when there was none. So this distinction is OBSERVED rather than inferred
-    — which matters, because the plausible-looking alternative is to infer it from
-    the item's shape ("no `persona_type` but a `persona_name` means pre-deploy"),
-    and that inference is simply false: `processor/handler.py` has written BOTH
-    persona fields since the initial commit, so a pre-deploy anonymous item — the
-    99.97% case this compatibility exists for — is shape-identical to a post-deploy
-    one. Only the ROW's existence separates them.
+    item when there was none. So the distinction is OBSERVED rather than inferred.
+
+    WHAT IT IS NOT EVIDENCE OF, since it was read that way for one round: an absent
+    row is not the general test for "this item's insert predated the axis move". It
+    is sound when it happens, and it only happens on a day no post-deploy item has
+    written that bucket — so on the busiest day in the window it never fires, which
+    is where the pre-deploy over-count is largest. That test is per-ITEM
+    (`LEGACY_PERSONA_STAMP_FIELD`); this enum's job on that path is the narrower one
+    of ruling the fallback OUT.
     """
 
     LANDED = 'landed'
     # The row exists; the floor refused this decrement because the counter is at
-    # zero. An ordinary outcome of a redelivered REMOVE, and NOT evidence about
-    # which deploy the item's insert ran under: the row being there is proof its
-    # insert created it.
+    # zero. An ordinary outcome of a redelivered REMOVE, and proof that this deploy's
+    # derivation is the one that counted the item — so no legacy row is owed anything.
+    # Also the outcome of a refusal whose response could not be read, because this is
+    # the one no caller acts on.
     REFUSED_AT_FLOOR = 'refused_at_floor'
-    # There is no such row: `attribute_exists(pk)` failed. Either it aged out under
-    # its TTL, or this item's insert never created it — which is the evidence the
-    # persona compatibility runs on.
+    # There is no such row: `attribute_exists(pk)` failed, and DynamoDB said so with a
+    # readable response carrying no item. Either it aged out under its TTL, or this
+    # item's insert never created it.
     ROW_ABSENT = 'row_absent'
 
     def __bool__(self) -> bool:
@@ -405,6 +476,10 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1,
     to write, or nothing at all if there was no item. That is the ONE authoritative
     answer to "was this row absent, or merely at the floor?", and it costs no extra
     request — see `CounterWrite.ROW_ABSENT` for the caller that needs it.
+
+    A refusal whose response cannot be read is reported as `REFUSED_AT_FLOOR`, the
+    outcome no caller acts on. `ROW_ABSENT` is a conclusion with a write attached, so
+    it is drawn only from a readable response that positively lacks an item.
     """
     ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
 
@@ -443,13 +518,23 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1,
         if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
         _log_refusal(f'decrement of {field}', pk, sk)
-        # `Item` present means the row exists and the FLOOR refused this; absent
-        # means there was no row. DynamoDB reports it, so nothing here infers it
-        # from the item's shape — see `CounterWrite.ROW_ABSENT`.
-        response = e.response if isinstance(e.response, Mapping) else {}
-        if response.get('Item'):
-            return CounterWrite.REFUSED_AT_FLOOR
-        return CounterWrite.ROW_ABSENT
+        # WHICH half of the condition failed, when the response can be read.
+        #
+        # 🔑 `ROW_ABSENT` REQUIRES POSITIVE EVIDENCE, not the absence of evidence. It
+        # is the conclusion a caller ACTS on, so an unreadable or unexpected payload
+        # has to resolve to the do-nothing outcome instead. That is reachable rather
+        # than theoretical: `is_conditional_check_failure` recognises this exception
+        # by TYPE NAME as well as by code precisely because it arrives with no
+        # `response` payload on some paths, and `e.response is None` would otherwise
+        # have read as "there was no row" — the fail-OPEN direction, where open means
+        # issuing a write. `_day_has_aggregates` fails open too but says so at
+        # `error`; this one would have been silent.
+        response = e.response if isinstance(e.response, Mapping) else None
+        if response is not None and 'Item' not in response:
+            # A well-formed conditional-failure response with no item: DynamoDB is
+            # saying the row was not there. The one case that is real evidence.
+            return CounterWrite.ROW_ABSENT
+        return CounterWrite.REFUSED_AT_FLOOR
     return CounterWrite.LANDED
 
 
@@ -620,12 +705,22 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     unconditionally, because each read has a non-empty default — a reader asking
     "which of these might be absent?" gets one answer, not two.
 
-    The persona field is read through PERSONA_FIELD, and
-    test_persona_field_lockstep.py pins that name against the field
+    The persona bucket comes from `shared.feedback.persona_bucket`, the one
+    derivation this Lambda and `metrics_handler`'s scan path share, and
+    test_persona_field_lockstep.py pins the field it reads against the field
     `processor/handler.py` actually writes. Prose could not hold that: reading a
     different field here than the insert path read makes every DECREMENT miss the
     row its insert created, so the two must move together, and "fix it in one
     place" is only true while something fails when they diverge.
+
+    THAT DERIVATION IS ALSO WHAT CLOSES THE AXIS. It buckets a value outside
+    PERSONA_ARCHETYPES as PERSONA_UNKNOWN, so every persona row this deploy writes
+    is named by a member of that set — which the reversal's collision guard relies
+    on to tell a legacy row from a live one, and which nothing could guarantee while
+    `persona_type` reached the pk verbatim. Review found a live `METRIC#persona#loyal`
+    row (this repo's own fixtures use that value, and `PUT /data-explorer/feedback`
+    accepts the field with no allowlist) decremented for an item counted elsewhere,
+    precisely because the axis was open.
 
     🔑 THE PERSONA AXIS BUCKETS BY ARCHETYPE (`persona_type`), NOT BY NAME. It
     bucketed by `persona_name` until an audit found 99.97% of a 6,239-item corpus
@@ -660,9 +755,9 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     keeps that from being worse than wrong-by-one — its
     `attribute_exists(pk) AND #field >= :floor` condition refuses a decrement
     against an absent or zeroed row, so no counter goes negative and no expired row
-    is resurrected; the refusal is counted as REFUSED_METRIC. But a refusal is also
-    the EVIDENCE that this image's insert wrote no archetype row, and
-    `apply_counter_keys` spends it: see LEGACY_PERSONA_FIELD and
+    is resurrected; the refusal is counted as REFUSED_METRIC. What tells the reversal
+    that it is looking at such an item is the item's own `processed_at`, compared
+    against the deploy boundary — see LEGACY_PERSONA_FIELD and
     `_reverse_a_pre_deploy_persona_row`, which is the whole of the compatibility and
     is deletable once the pre-deploy rows have aged out.
     """
@@ -670,9 +765,11 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     category = item.get('category', 'other')
     sentiment_label = item.get('sentiment_label', 'neutral')
     urgency = item.get('urgency', 'low')
-    # `or`, not a `.get` default: a stripped item can carry an explicit None, and
-    # `METRIC#persona#None` is a bucket nothing else would ever write to.
-    persona = item.get(PERSONA_FIELD) or PERSONA_UNKNOWN
+    # `persona_bucket`, the ONE derivation, shared with `metrics_handler`'s scan
+    # path: it is what makes every row this deploy writes a member of
+    # PERSONA_ARCHETYPES, which the reversal's collision guard depends on being a
+    # fact rather than an expectation. See that function.
+    persona = persona_bucket(item)
 
     dimensions = [
         # DAILY_TOTAL_PK, not the literal: `_day_has_aggregates` reads this same
@@ -717,42 +814,77 @@ def counter_keys(item: dict, date: str) -> set[tuple[str, str, str]]:
     return {(pk, date, field) for pk, field in counter_dimensions(item)}
 
 
-def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int) -> tuple[int, set[tuple[str, str, str]]]:
+def apply_counter_keys(
+    keys: set[tuple[str, str, str]], sign: int,
+) -> tuple[int, dict[tuple[str, str, str], 'CounterWrite']]:
     """Move every named counter by `sign`.
 
     The ONE place a counter key is unpacked into an `update_counter` call, so
     there is exactly one line in this module deciding what a counter's sort key
     is. Sorted only to make the write order deterministic for tests and logs.
 
-    Returns `(writes that LANDED, the keys whose row was found to be ABSENT)`.
+    Returns `(writes that LANDED, how each key's write ended)`.
 
     Landed, not attempted: a caller counting attempts would report that aggregates
     moved for an edit whose every write was refused by its condition.
 
-    🔑 THE SECOND MEMBER IS NARROWER THAN "REFUSED", and the narrowing is the point.
-    Only `CounterWrite.ROW_ABSENT` is collected — not a refusal at the floor —
-    because the one caller that reads these keys treats them as EVIDENCE that this
-    image's insert never created the row, and a row sitting at zero is proof of the
-    opposite: it exists, so its insert did create it. Handing that caller every
-    refusal made it act on a redelivered REMOVE of an ordinary post-deploy item,
-    which is the defect this signature now makes unrepresentable. See
-    `_reverse_a_pre_deploy_persona_row` and `CounterWrite`.
-
-    Reported as the KEYS rather than as a count so that caller cannot guess which
-    row was absent, and cannot aim its follow-up write at a day the refusal did not
-    concern.
+    🔑 THE OUTCOMES ARE RETURNED PER KEY, which is what lets the persona
+    compatibility aim a follow-up write at the DAY the write it is correcting
+    concerned — read out of the key rather than re-derived, so a follow-up can never
+    land on another day. A count could not carry that. See
+    `_reverse_a_pre_deploy_persona_row`.
     """
-    landed, absent = 0, set()
+    landed, outcomes = 0, {}
+    # Unpacked in the `for`, not from a `key` local, because
+    # test_streaming_categories_lockstep.py pins the small set of expressions a
+    # counter's sort key may be bound from — `sorted(keys)` is one of them and an
+    # intermediate name is not, deliberately, since that is where a suffix could be
+    # appended unnoticed.
     for pk, date, field in sorted(keys):
         outcome = update_counter(pk, date, field, increment=sign)
+        outcomes[(pk, date, field)] = outcome
         if outcome is CounterWrite.LANDED:
             landed += 1
-        elif outcome is CounterWrite.ROW_ABSENT:
-            absent.add((pk, date, field))
-    return landed, absent
+    return landed, outcomes
 
 
-def _reverse_a_pre_deploy_persona_row(item: dict, absent: set[tuple[str, str, str]]) -> int:
+def _was_counted_by_the_old_persona_axis(item: dict) -> bool:
+    """Did THIS item's insert bucket it by name rather than by archetype?
+
+    The item's own `processed_at` against the deploy boundary, which is the only
+    per-item fact that answers the question — see LEGACY_PERSONA_STAMP_FIELD and
+    LEGACY_PERSONA_CUTOVER.
+
+    An UNREADABLE or ABSENT stamp answers True, i.e. pre-deploy. Only legacy or
+    hand-written items lack `processed_at` (the processor has always written it), so
+    the fail direction matches what such an item almost certainly is — and the
+    consequence of being wrong here is bounded on both sides: the follow-up write is
+    conditional, and PERSONA_ARCHETYPES already refuses any legacy pk this deploy
+    could have written, so a false True costs at most one refused write against a
+    legacy row that does not exist.
+    """
+    stamp = item.get(LEGACY_PERSONA_STAMP_FIELD)
+    if not isinstance(stamp, str):
+        return True
+    try:
+        processed = datetime.fromisoformat(stamp)
+    except ValueError:
+        logger.warning(
+            f"Could not read `{LEGACY_PERSONA_STAMP_FIELD}` ({stamp!r}); treating the "
+            f"item as pre-deploy for the persona axis"
+        )
+        return True
+    if processed.tzinfo is None:
+        # The processor writes an aware timestamp; a naive one can only come from a
+        # hand-written row. UTC is the only reading consistent with everything else
+        # in this table.
+        processed = processed.replace(tzinfo=timezone.utc)
+    return processed < datetime.fromisoformat(LEGACY_PERSONA_CUTOVER)
+
+
+def _reverse_a_pre_deploy_persona_row(
+    item: dict, outcomes: dict[tuple[str, str, str], 'CounterWrite'],
+) -> int:
     """Bring down the persona row an item's PRE-DEPLOY insert really created.
 
     The whole of the persona axis's write-side compatibility, and the only place
@@ -760,65 +892,93 @@ def _reverse_a_pre_deploy_persona_row(item: dict, absent: set[tuple[str, str, st
     is:
 
     `counter_dimensions` is one description spent by both directions, so a reversal
-    names `METRIC#persona#<persona_type>`. For an item inserted before the axis
-    moved, no such row was ever created — the insert counted it under the old
-    derivation's bucket — and `update_counter`'s `attribute_exists(pk)` half refuses
-    the decrement, reporting `CounterWrite.ROW_ABSENT`. That is the evidence, and
-    the follow-up write is aimed at the row the old derivation names, on the DAY the
-    refusal concerned (read out of the refused key, not re-derived, so a follow-up
-    can never land on another day).
+    names `METRIC#persona#<archetype>`. For an item inserted before the axis moved,
+    that row is not the one its insert created — the insert counted it under the old
+    derivation's bucket — so the reversal follows the archetype decrement with one
+    conditional write to the row the old derivation names, on the DAY the decrement
+    concerned (read out of the key, not re-derived, so a follow-up can never land on
+    another day).
 
-    🔑 THE TRIGGER IS "THE ROW WAS ABSENT", NOT "THE WRITE WAS REFUSED". Those are
-    different propositions, and this function only ever had a right to the first.
-    A decrement is also refused when the row EXISTS at zero, which is the ordinary
-    outcome of a redelivered REMOVE of a post-deploy item — and acting on that took
-    a `-1` off a legacy row the item never contributed to, silently and on a healthy
-    corpus. `apply_counter_keys` therefore hands this function absent-row keys only;
-    a row at the floor is proof its insert DID create it, so it is proof this
-    function must do nothing. That the distinction is observed from DynamoDB rather
-    than inferred from the item's shape matters — see `CounterWrite`, since the
-    shape-based test that suggests itself is false for the majority case.
+    🔑 THE TRIGGER IS THE ITEM'S `processed_at`, NOT THE ARCHETYPE ROW'S ABSENCE.
+    Both readings have been tried, and the difference decides whether the
+    compatibility works on the days that matter:
 
-    NOTHING IS ATTEMPTED AGAINST A ROW THIS DEPLOY WRITES. `legacy_pk` is built from
-    a free-text, LLM-produced name, so it is the one pk in this module not derived
-    from a closed value space, and a name that happens to equal an archetype
-    (`unknown` is entirely plausible for anonymous feedback, and is the axis's
-    largest bucket) would aim this `-1` at a LIVE row for an item counted under a
-    different archetype. Conditional writes cannot catch that: the row exists and is
-    above the floor, so the write lands cleanly and corrupts a current number. A
-    missed legacy `-1` is the right way to be wrong here, which is the judgement
-    `process_deleted_feedback` already makes for a dateless image.
+    * an ABSENT archetype row is sound evidence — this item's insert created no such
+      row — but it is only *available* on a day no post-deploy item has written that
+      bucket. On a day the new axis has already populated, a pre-deploy item's
+      decrement LANDS on a row it never contributed to and the legacy row is never
+      touched. That is the ordinary cross-deploy state and the busiest day in the
+      window, so the fallback was inert exactly where the over-count was largest;
+    * `processed_at` is per-ITEM, so it is available on every reversal, and it is the
+      item's own record of which deploy wrote it.
 
-    WHEN THE TWO DERIVATIONS NAME ONE ROW, nothing is attempted either. That is not
-    a saving; it is required. A second write to the row whose decrement was just
-    refused would be the identical refused write (harmless), and if it were not
-    refused it would be a SECOND decrement of one row for one deletion.
+    THE ROW'S OUTCOME IS STILL READ, to rule the fallback OUT. `CounterWrite`
+    distinguishes a decrement refused because the row was ABSENT from one refused at
+    the FLOOR, and a row at the floor exists — which is what an already-reversed item
+    looks like on redelivery. So a stamped-pre-deploy item whose archetype row exists
+    at zero is left alone: something counted it there, and one deletion must not
+    decrement two rows on the strength of a stamp.
+
+    NOTHING IS ATTEMPTED AGAINST A ROW THIS DEPLOY WRITES. `legacy_pk` is built from a
+    free-text, LLM-produced name — the one pk in this module not derived from a closed
+    value space — and a name equal to a bucket this deploy writes would aim this `-1`
+    at a LIVE row for an item counted under a different archetype. Conditional writes
+    cannot catch that: the row exists and is above the floor, so it lands cleanly and
+    corrupts a current number. PERSONA_ARCHETYPES is the whole space of rows this
+    deploy writes — `persona_bucket` is what makes that true, by bucketing anything
+    outside the set as the empty value — so membership is a complete test, which it
+    was not while `persona_type` reached the pk verbatim. A missed legacy `-1` is the
+    right way to be wrong here, the judgement `process_deleted_feedback` already makes
+    for a dateless image.
+
+    THE TWO DERIVATIONS CANNOT NAME ONE ROW HERE, so there is no separate guard for
+    it, and the reason is worth stating because an earlier round of this function had
+    one. A second decrement of the row this reversal just decremented would be one
+    deletion taking two counts off it — but that requires the legacy value to equal
+    the archetype value, the archetype value is always a member of PERSONA_ARCHETYPES
+    (`persona_bucket` guarantees it), and the collision guard above already declines
+    every legacy value in that set. So the case is refused one line earlier, by a
+    guard that exists for a stronger reason.
 
     It is CONDITIONAL like every other decrement, so the compatibility cannot
     resurrect a legacy row or drive one negative: if the old row has also aged out,
     this is refused in turn and counted as REFUSED_METRIC.
 
-    REDELIVERY, now that the trigger is the absent row: a redelivered REMOVE reaches
-    this only while the archetype row is still ABSENT, i.e. only for an item whose
-    insert really did predate the move, and every such delivery is draining a row
-    that is inflated by exactly those items. It is bounded by the floor and by the
-    same 90-day TTL as the rows themselves. The module's general redelivery residual
-    is unchanged and unrelocated: a post-deploy item's redelivered REMOVE now does
-    here what it did before this function existed, which is nothing.
+    REDELIVERY: a redelivered REMOVE of a pre-deploy item decrements the legacy row
+    again, which is the module's general at-least-once residual rather than a new one
+    — the same is true of every counter this module writes, and the direction is
+    toward the truth, since the legacy row is inflated by exactly those items. It is
+    bounded by the floor. A POST-deploy item's redelivered REMOVE does not reach here
+    at all, because its stamp says so.
 
-    Returns how many writes landed (0 or 1 per absent persona key).
+    Returns how many writes landed.
     """
-    # `keys`, and `sorted(keys)` below, because these ARE counter keys and
-    # test_streaming_categories_lockstep.py pins the small set of expressions
+    # Only the persona keys, and only those whose write did not LAND on the archetype
+    # row this deploy would have created. `sorted` below because these ARE counter
+    # keys and test_streaming_categories_lockstep.py pins the small set of expressions
     # allowed to produce a counter's sort key — the bare item date, never anything
     # composite, because the streaming reader sums a window with `sk BETWEEN`.
-    keys = {key for key in absent if key[0].startswith(PERSONA_PREFIX)}
+    keys = {key for key in outcomes if key[0].startswith(PERSONA_PREFIX)}
+    if not keys or not _was_counted_by_the_old_persona_axis(item):
+        return 0
+
+    # A row at the FLOOR exists, so something counted this item there and a second
+    # decrement for one deletion is not owed. Absent or landed both leave the legacy
+    # row still to bring down: absent means the insert created nothing here, and
+    # landed means this deploy's derivation was decremented for an item the OLD one
+    # counted, which is the busy-day case the stamp exists to reach.
+    keys = {key for key in keys if outcomes[key] is not CounterWrite.REFUSED_AT_FLOOR}
     if not keys:
         return 0
 
     # The old derivation, reproduced exactly — including its bespoke `Unknown`,
     # which is a row name that already EXISTS rather than one anything writes fresh.
     legacy_value = item.get(LEGACY_PERSONA_FIELD) or LEGACY_PERSONA_UNKNOWN
+    # The earliest day the reversal concerned, so a log or a decline names a real day
+    # rather than one recomputed here. `min` over the DATES, not over the keys: `min`
+    # on (pk, date, field) tuples orders by pk first, which is the day belonging to
+    # the smallest pk and not the earliest day at all.
+    earliest_day = min(date for _, date, _ in keys)
     if legacy_value in PERSONA_ARCHETYPES:
         # A free-text name that collides with the current value space. This deploy
         # writes that row, so a `-1` on it is a live number corrupted rather than a
@@ -828,9 +988,7 @@ def _reverse_a_pre_deploy_persona_row(item: dict, absent: set[tuple[str, str, st
         # could not see it.
         _log_decline(
             'the pre-deploy persona reversal', f'{PERSONA_PREFIX}{legacy_value}',
-            # The earliest day the refusal concerned, so the decline names a real
-            # day rather than one recomputed here.
-            min(keys)[1],
+            earliest_day,
             f'`{LEGACY_PERSONA_FIELD}` is `{legacy_value}`, which is one of the '
             f'archetypes this deploy actively writes, so that row cannot be '
             f'distinguished from a live one and must not be decremented',
@@ -840,12 +998,9 @@ def _reverse_a_pre_deploy_persona_row(item: dict, absent: set[tuple[str, str, st
     legacy_pk = f'{PERSONA_PREFIX}{legacy_value}'
     landed = 0
     for pk, date, field in sorted(keys):
-        if pk == legacy_pk:
-            # One row, two derivations agreeing on it: see the docstring.
-            continue
         logger.info(
-            f"Persona decrement on {pk}/{date} found no row; reversing "
-            f"{legacy_pk} instead, the row this item's pre-deploy insert created"
+            f"Persona decrement on {pk}/{date} was for an item processed before the "
+            f"axis moved; also reversing {legacy_pk}, the row its insert created"
         )
         if update_counter(legacy_pk, date, field, increment=-1):
             landed += 1
@@ -854,14 +1009,14 @@ def _reverse_a_pre_deploy_persona_row(item: dict, absent: set[tuple[str, str, st
 
 def apply_feedback(item: dict, sign: int, date: str):
     """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`."""
-    _, absent = apply_counter_keys(counter_keys(item, date), sign)
+    _, outcomes = apply_counter_keys(counter_keys(item, date), sign)
     if sign < 0:
         # Reversal only. Reading the old persona field on the INCREMENT path would
-        # make the axis permanently dual-sourced to serve a path with a sunset date,
-        # which this repo has rejected before; here the refusal makes it free and
-        # confines it to a direction that cannot change which bucket anything is
-        # COUNTED in. See `_reverse_a_pre_deploy_persona_row`.
-        _reverse_a_pre_deploy_persona_row(item, absent)
+        # make the axis permanently dual-SOURCED to serve a path with a sunset date,
+        # which this repo has rejected before; on the reversal it can only change
+        # which row a `-1` lands on, never which bucket anything is COUNTED in. See
+        # `_reverse_a_pre_deploy_persona_row`.
+        _reverse_a_pre_deploy_persona_row(item, outcomes)
 
     # Daily sentiment score average
     sentiment_score = _image_score(item)
@@ -1001,7 +1156,7 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
 
     writes = 0
     if old_live:
-        landed, absent = apply_counter_keys(decrements, -1)
+        landed, outcomes = apply_counter_keys(decrements, -1)
         writes += landed
         # The same pre-deploy compatibility the REMOVE path gets, for the same
         # reason: this decrement reads an OLD IMAGE, which may be an image whose
@@ -1019,7 +1174,7 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
         # distinction DECLINED_METRIC and REFUSED_METRIC exist to keep — a metric
         # that gates on a count is a consumer of the count, not just a reader.
         # Logged instead, so the compatibility is observable without being conflated.
-        compatibility_writes = _reverse_a_pre_deploy_persona_row(old_item, absent)
+        compatibility_writes = _reverse_a_pre_deploy_persona_row(old_item, outcomes)
         if compatibility_writes:
             logger.info(
                 f"Also brought down {compatibility_writes} pre-deploy persona row(s) "

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -135,9 +135,24 @@ Known residuals
   populated it, a pre-deploy item's REMOVE decrements the archetype row it never
   contributed to, and the legacy row it did contribute to stays inflated until its
   90-day TTL. Exactly one counter still moves per deletion, which is the property
-  that matters and the one a wall-clock trigger broke; telling the two items apart
-  on a busy day is undecidable from the images and needs new stored state, so this
-  is left as a residual — see `_reverse_a_pre_deploy_persona_row`.
+  that matters and the one a wall-clock trigger broke.
+  ⚠️ NOT because the images cannot decide it. `processed_at` IS on the old image
+  (the processor writes it, the stream is NEW_AND_OLD_IMAGES), so a module constant
+  naming the axis-move instant plus EXCLUSIVE routing — legacy row or archetype
+  row, never both — would be correct on a busy day, with no env var and no CDK
+  change. It is not taken because it is not correct either, only differently
+  wrong: it misreads an item written just before the deploy whose INSERT was
+  aggregated just after it, and for that item it would skip the archetype
+  decrement that IS holding its count, leaving that row inflated permanently
+  rather than for 90 days. A date in the code buying a permanent error in place of
+  an ageing one is the trade this declines — see
+  `_reverse_a_pre_deploy_persona_row`.
+* THE ABSENT ROW IS NOT PROOF OF VINTAGE, only of "no live row here". A
+  post-deploy INSERT whose stream record never landed — a batch failure, a window
+  where this function was erroring — leaves no archetype row either, so deleting
+  that item aims one `-1` at the bucket its free-text name spells. Bounded by the
+  same condition (at most one count, in a row that is ageing out), self-limiting
+  once the legacy rows are gone, and strictly smaller than the over-count above.
 """
 import os
 from collections.abc import Mapping
@@ -233,10 +248,17 @@ SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
 # REFUSED_METRIC. No second clamp is needed anywhere, on either write.
 #
 # THE TRIGGER IS THE ARCHETYPE DECREMENT REPORTING `ROW_ABSENT` — the one outcome
-# meaning NO counter moved for that bucket, which answers "did this deploy's
-# derivation ever count this item?" directly. No clock, no environment variable, no
+# meaning NO counter moved for that bucket. No clock, no environment variable, no
 # CDK change, no cutover date: nothing to configure, and nothing to un-configure
 # later, since the fallback stops firing on its own as pre-deploy rows disappear.
+# ⚠️ WHAT IT IS EVIDENCE OF is "no live row under this bucket", which is NOT the
+# same fact as "this item's insert predates the axis move". They come apart when a
+# post-deploy INSERT produced no row at all — a stream record lost to a batch
+# failure, or a window where this function was erroring — and then the fallback
+# aims one `-1` at the bucket that item's free-text name spells. Bounded by the
+# same condition and self-limiting as the legacy rows expire; recorded with the
+# other residuals in the module docstring rather than guarded against, because the
+# guard would be the stored state this design is declining to add.
 # WHEN IT IS SAFE TO DELETE IS STILL NOT A DATE, though: `update_counter` writes a
 # fresh `#ttl` on every write, decrements included, so each compatibility write
 # RENEWS the legacy row it touches for another 90 days. The signal that this is
@@ -248,10 +270,14 @@ SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
 # populated it, a pre-deploy item's REMOVE decrements the archetype row — one it never
 # contributed to — and the legacy row it did contribute to is never brought down,
 # ageing out on its 90-day TTL. Accepted deliberately: exactly one counter moves per
-# deletion either way, the property a wall-clock stamp broke, and no reading of the
-# two images can tell a pre-deploy item from a post-deploy one on a busy day without
-# new stored state. A missed `-1` is the direction this module already errs in — see
-# `process_deleted_feedback` on a dateless image.
+# deletion either way, the property a wall-clock stamp broke. Deciding the busy day
+# correctly is POSSIBLE — `processed_at` is on the old image — and declined anyway,
+# because a constant naming the deploy instant is only differently wrong: it
+# misreads an item written just before the deploy and aggregated just after it, and
+# skips the archetype decrement that is really holding that item's count, leaving
+# that row inflated permanently instead of for 90 days. A missed `-1` is the
+# direction this module already errs in — see `process_deleted_feedback` on a
+# dateless image — and an ageing error beats a permanent one.
 #
 # A permanent dual-READ on the INCREMENT path was rejected: this repo refused that
 # shape once already, for the MCP legacy-token decision, where preserving a legacy
@@ -823,10 +849,13 @@ def _reverse_a_pre_deploy_persona_row(
     🔑 THE TRIGGER IS THAT DECREMENT REPORTING `ROW_ABSENT`. It is the only outcome
     that means NO counter moved for the bucket, so it is at once the evidence that
     this deploy's derivation never counted the item and what holds one deletion to one
-    decrement. Its limitation is named rather than hidden: an absent row is observable
-    only on a day no post-deploy item has written the bucket, so on a busy day a
-    pre-deploy item's decrement lands on the archetype row and the legacy row stays
-    inflated until its TTL. Recorded as a residual in the module docstring.
+    decrement. Its two limitations are named rather than hidden, and both are recorded
+    as residuals in the module docstring: an absent row is observable only on a day no
+    post-deploy item has written the bucket, so on a busy day a pre-deploy item's
+    decrement lands on the archetype row and the legacy row stays inflated until its
+    TTL; and an absent row means "no live row here" rather than "this insert was
+    pre-deploy", so a post-deploy INSERT that never reached this function makes its
+    item look pre-deploy on deletion.
 
     NOTHING IS ATTEMPTED AGAINST A ROW THIS DEPLOY WRITES. `legacy_pk` is built from a
     free-text, LLM-produced name — the one pk in this module not derived from a closed

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -320,8 +320,13 @@ LEGACY_PERSONA_CUTOVER = os.environ.get('PERSONA_AXIS_CUTOVER_AT', '2026-08-22T0
 # `unknown` archetype row instead of the legacy bucket, which is the largest bucket
 # on the current axis. The two are also not symmetric in kind: `unknown` is a value
 # the enrichment contract declares, while `Unknown` was a label the old derivation
-# invented, so the new one must never be substituted for the old. Asserted by
-# test_a_post_deploy_image_whose_row_is_gone_writes_nothing_more.
+# invented, so the new one must never be substituted for the old. Unifying them was
+# RUN, not predicted: it fails
+# test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_already_populated,
+# test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
+# and test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing
+# — the collision guard swallows the reversal entirely, because `unknown` IS an
+# archetype, so the majority shape stops being reversed at all.
 #
 # The GENERAL form of that collision is closed by code rather than by this
 # capitalisation. `_reverse_a_pre_deploy_persona_row` declines when the legacy value

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -78,11 +78,13 @@ OLD IMAGE of an item whose insert may predate that move — so the row named by
 today's derivation was never created for it, while the row that WAS created is left
 inflated. The floor-and-existence condition means this cannot go negative or
 resurrect anything, but it would leave a persistent over-count in one dimension for
-every delete or edit of pre-deploy feedback. The refusal is the evidence, so the
-reversal path (and the decrement half of a rebucket) follows a refused persona
-decrement with one conditional write to the row the old derivation names. It is
-confined to the reversal direction, needs no stored state, and is deletable once the
-pre-deploy rows have aged out — see `LEGACY_PERSONA_FIELD` and
+every delete or edit of pre-deploy feedback. The ABSENT ROW is the evidence — a
+refusal is two facts and only "there was no such row" is the trigger, never "the row
+is sitting at its floor" — so the reversal path (and the decrement half of a
+rebucket) follows an archetype decrement that found NO row with one conditional
+write to the row the old derivation names. It is confined to the reversal direction,
+needs no stored state and nothing configured, and is deletable once the pre-deploy
+rows have aged out — see `LEGACY_PERSONA_FIELD` and
 `_reverse_a_pre_deploy_persona_row`.
 
 A reversal also refuses to GUESS a date. `_image_date` falls back to today when an
@@ -127,6 +129,15 @@ Known residuals
   `test_a_cross_day_arrival_onto_an_expired_average_still_fragments_it` pinning
   today's behaviour. The same-day case IS closed, because there the refused reversal
   is the evidence.
+* THE PRE-DEPLOY PERSONA FALLBACK IS INERT ON A BUSY DAY. It triggers on the
+  archetype decrement finding NO row, which is only observable on a day no
+  post-deploy item has written that bucket. On a day the new axis has already
+  populated it, a pre-deploy item's REMOVE decrements the archetype row it never
+  contributed to, and the legacy row it did contribute to stays inflated until its
+  90-day TTL. Exactly one counter still moves per deletion, which is the property
+  that matters and the one a wall-clock trigger broke; telling the two items apart
+  on a busy day is undecidable from the images and needs new stored state, so this
+  is left as a residual — see `_reverse_a_pre_deploy_persona_row`.
 """
 import os
 from collections.abc import Mapping
@@ -213,102 +224,40 @@ SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
 # reads the OLD IMAGE of an item whose insert may have run under the previous
 # deploy. That insert created `METRIC#persona#<persona_name, or Unknown>`; this
 # deploy's decrement names `METRIC#persona#<persona_type>`, a row that item never
-# contributed to. Two things follow, and neither is read staleness:
+# contributed to. So the row today's derivation names was never created for it, while
+# the row that WAS created is left inflated.
 #
-#   * the row the insert DID create is never brought down, so it stays inflated
-#     until its 90-day TTL expires — a delete or an edit of pre-deploy feedback
-#     leaves a persistent OVER-count in this dimension;
-#   * the archetype row is decremented for an item it never counted, which
-#     UNDERSTATES it while post-deploy items are populating it.
+# What this is NOT: it cannot drive a counter negative or resurrect an expired row.
+# Every decrement is guarded by `attribute_exists(pk) AND #field >= :floor`, so one
+# aimed at an absent or already-zero row is refused, swallowed and counted as
+# REFUSED_METRIC. No second clamp is needed anywhere, on either write.
 #
-# What this is NOT: it cannot drive a counter negative or resurrect an expired
-# row. `update_counter` guards every decrement with
-# `attribute_exists(pk) AND #field >= :floor`, so a decrement against an absent or
-# already-zero row is refused, swallowed and counted as REFUSED_METRIC.
+# THE TRIGGER IS THE ARCHETYPE DECREMENT REPORTING `ROW_ABSENT` — the one outcome
+# meaning NO counter moved for that bucket, which answers "did this deploy's
+# derivation ever count this item?" directly. No clock, no environment variable, no
+# CDK change, no cutover date: nothing to configure, and nothing to un-configure
+# later, since the fallback stops firing on its own as pre-deploy rows disappear.
+# WHEN IT IS SAFE TO DELETE IS STILL NOT A DATE, though: `update_counter` writes a
+# fresh `#ttl` on every write, decrements included, so each compatibility write
+# RENEWS the legacy row it touches for another 90 days. The signal that this is
+# deletable is `AggregateWriteDeclined` and the log line below going quiet, not the
+# calendar.
 #
-# THE FALLBACK, and why it is on this side only. On a reversal, the item's own
-# PROCESSING TIME says which derivation its insert used: `processed_at` is stamped by
-# `processor/handler.py` when the item was written, so an item processed before the
-# axis moved was counted by the old derivation and one processed after it by the new
-# one. The reversal then aims one extra conditional write at the row the old
-# derivation names. It needs no stored state of its own, and it is deletable in one
-# piece — the constants below and `_reverse_a_pre_deploy_persona_row`.
+# THE RESIDUAL, unsoftened. An absent archetype row is available as evidence ONLY on
+# a day no post-deploy item has written that bucket. On a day the new axis has
+# populated it, a pre-deploy item's REMOVE decrements the archetype row — one it never
+# contributed to — and the legacy row it did contribute to is never brought down,
+# ageing out on its 90-day TTL. Accepted deliberately: exactly one counter moves per
+# deletion either way, the property a wall-clock stamp broke, and no reading of the
+# two images can tell a pre-deploy item from a post-deploy one on a busy day without
+# new stored state. A missed `-1` is the direction this module already errs in — see
+# `process_deleted_feedback` on a dateless image.
 #
-# WHEN IT IS SAFE TO DELETE IS NOT A DATE, and the reason is a detail of
-# `update_counter`: its UpdateExpression always writes `#ttl = :ttl` with a fresh
-# `ttl_days`, DECREMENTS included, so every compatibility write RENEWS the legacy row
-# it touches for another 90 days (a row with 5 days left goes back to 90 — verified
-# against moto). A legacy row still receiving deletes therefore resets its own clock,
-# and the real bound is how long pre-deploy FEEDBACK survives to be deleted or edited,
-# not 90 days from deploy. The removal signal is the compatibility no longer firing —
-# `AggregateWriteDeclined`/the log line below in CloudWatch — rather than the
-# calendar. Leaving `#ttl` unwritten on this one path was considered and not done: it
-# is a change to the expression every counter in the module shares, and a row being
-# maintained is a row in use for every other caller.
-#
-# 🔑 WHY NOT THE ABSENT ROW, which is the signal this used to spend. An absent
-# archetype row does mean this item's insert created none, and it is where this
-# started — but it is only PRESENT as evidence on a day no post-deploy item has
-# written that bucket. Review demonstrated the gap against moto: post-deploy
-# ingestion populates `METRIC#persona#churn_risk` for the day, a pre-deploy item of
-# that day is then deleted, the decrement LANDS on the row it never contributed to,
-# and the legacy row it did contribute to is never touched. That is the busiest day
-# in the window and the ordinary cross-deploy state, so the compatibility was
-# effective exactly where the corpus was quiet. The absent row is sound evidence and
-# too rare to rely on; `processed_at` is per-ITEM, so it is available on every
-# reversal.
-#
-# THE ROW'S ABSENCE IS STILL READ, for the opposite purpose. `CounterWrite` reports
-# it, and a reversal whose archetype decrement was refused AT THE FLOOR is one whose
-# row exists — which is what a REDELIVERED remove of an already-reversed item looks
-# like. Nothing about the day tells those apart, so the fallback is skipped when the
-# archetype decrement LANDED or was refused at the floor for an item this deploy did
-# count. See `_reverse_a_pre_deploy_persona_row`.
-#
-# THE EVIDENCE IS NOT THE ITEM'S PERSONA SHAPE. Worth stating because that test
-# suggests itself and is false: `processor/handler.py` has written BOTH persona
-# fields since the initial commit, so "no `persona_type` but a `persona_name`" is
-# NOT the pre-deploy shape — an anonymous pre-deploy item carries a `persona_type`
-# and no name, exactly like a post-deploy one, and that is the 99.97% case. What
-# separates them is WHEN the item was processed, which is a different field.
-#
-# A permanent dual-READ on the increment path was rejected, and the reason is
-# recorded: this repo has already refused that shape once (the MCP legacy-token
-# decision), because preserving a legacy path there would have meant carrying a
-# permanent extra field to serve a path with a sunset date. Here the timestamp is a
-# field the processor already writes for its own reasons, and the compatibility is
-# confined to the reversal, where reading the old field cannot affect which bucket
-# anything is COUNTED in.
+# A permanent dual-READ on the INCREMENT path was rejected: this repo refused that
+# shape once already, for the MCP legacy-token decision, where preserving a legacy
+# path would have meant carrying a permanent extra field to serve a path with a
+# sunset date.
 LEGACY_PERSONA_FIELD = 'persona_name'
-# The item field that says which derivation counted it: `processor/handler.py` stamps
-# `processed_at` with the moment it wrote the item, so it is the item's own record of
-# which deploy was live then. Read rather than `date`, which is the day the feedback
-# belongs to and can be BACKDATED by an import — a pre-deploy `date` on an item
-# processed today is exactly the case a date-based test would get wrong.
-#
-# An item carrying NO `processed_at` is treated as pre-deploy: only legacy or
-# hand-written rows lack it, and those are pre-deploy by construction.
-LEGACY_PERSONA_STAMP_FIELD = 'processed_at'
-# The deploy boundary. Items processed at or after this instant were counted by the
-# archetype derivation; items before it were counted by the name derivation, so their
-# reversal needs the fallback.
-#
-# ⚠️ SET THIS TO THE DEPLOY TIME. It is a UTC ISO-8601 instant, PARSED rather than
-# compared as text: `processed_at` carries microseconds and this does not, and while
-# the two happen to order correctly as strings today that is a property of one
-# format's punctuation rather than something to depend on.
-#
-# The default is the date the axis move landed. An instant EARLIER than the real
-# deploy makes the compatibility inert for items processed in between — the behaviour
-# before this fix existed, an inflated legacy row. One LATER makes it fire for
-# post-deploy items, which drains a legacy row for an item that never touched it.
-# Erring early is the safer direction, so the default is the day the change landed
-# rather than an estimate of when it will be deployed.
-#
-# Environment-overridable so a deployment whose real cutover differs can correct it
-# without a code change, and because a test cannot otherwise place an item on either
-# side of a hardcoded instant.
-LEGACY_PERSONA_CUTOVER = os.environ.get('PERSONA_AXIS_CUTOVER_AT', '2026-08-22T00:00:00+00:00')
 # The bespoke empty bucket the old derivation used — deliberately capitalised the
 # way it was written, because this constant's whole job is to name rows that ALREADY
 # EXIST. It is not a value anything writes fresh: `counter_dimensions` spells the
@@ -321,12 +270,11 @@ LEGACY_PERSONA_CUTOVER = os.environ.get('PERSONA_AXIS_CUTOVER_AT', '2026-08-22T0
 # on the current axis. The two are also not symmetric in kind: `unknown` is a value
 # the enrichment contract declares, while `Unknown` was a label the old derivation
 # invented, so the new one must never be substituted for the old. Unifying them was
-# RUN, not predicted: it fails
-# test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_already_populated,
+# RUN, not predicted: the collision guard below then swallows the reversal entirely,
+# because `unknown` IS an archetype, so the majority shape stops being reversed at
+# all. Setting this to PERSONA_UNKNOWN fails
 # test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
-# and test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing
-# — the collision guard swallows the reversal entirely, because `unknown` IS an
-# archetype, so the majority shape stops being reversed at all.
+# and test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing.
 #
 # The GENERAL form of that collision is closed by code rather than by this
 # capitalisation. `_reverse_a_pre_deploy_persona_row` declines when the legacy value
@@ -369,25 +317,27 @@ class CounterWrite(Enum):
     `ReturnValuesOnConditionCheckFailure='ALL_OLD'` returns the refused item, or no
     item when there was none. So the distinction is OBSERVED rather than inferred.
 
-    WHAT IT IS NOT EVIDENCE OF, since it was read that way for one round: an absent
-    row is not the general test for "this item's insert predated the axis move". It
-    is sound when it happens, and it only happens on a day no post-deploy item has
-    written that bucket — so on the busiest day in the window it never fires, which
-    is where the pre-deploy over-count is largest. That test is per-ITEM
-    (`LEGACY_PERSONA_STAMP_FIELD`); this enum's job on that path is the narrower one
-    of ruling the fallback OUT.
+    WHAT THE ABSENT ROW IS FOR: it is what the pre-deploy persona fallback TRIGGERS
+    on, being the only outcome that means no counter moved for that bucket. Its known
+    limitation is that it is observable only on a day no post-deploy item has written
+    the bucket — on a busier day a pre-deploy item's decrement LANDS on the archetype
+    row it never contributed to and the legacy row it did contribute to is left
+    inflated until its TTL. Accepted, and recorded as a residual: see
+    `_reverse_a_pre_deploy_persona_row` and the module docstring.
     """
 
     LANDED = 'landed'
     # The row exists; the floor refused this decrement because the counter is at
-    # zero. An ordinary outcome of a redelivered REMOVE, and proof that this deploy's
-    # derivation is the one that counted the item — so no legacy row is owed anything.
+    # zero. An ordinary outcome of a redelivered REMOVE, and a row that exists is a
+    # row a counter for this bucket already sits in — so the pre-deploy fallback must
+    # not add a second `-1` for one deletion, and no legacy row is owed anything.
     # Also the outcome of a refusal whose response could not be read, because this is
     # the one no caller acts on.
     REFUSED_AT_FLOOR = 'refused_at_floor'
     # There is no such row: `attribute_exists(pk)` failed, and DynamoDB said so with a
     # readable response carrying no item. Either it aged out under its TTL, or this
-    # item's insert never created it.
+    # item's insert never created it — and the second is what the pre-deploy persona
+    # fallback triggers on.
     ROW_ABSENT = 'row_absent'
 
     def __bool__(self) -> bool:
@@ -761,10 +711,10 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     `attribute_exists(pk) AND #field >= :floor` condition refuses a decrement
     against an absent or zeroed row, so no counter goes negative and no expired row
     is resurrected; the refusal is counted as REFUSED_METRIC. What tells the reversal
-    that it is looking at such an item is the item's own `processed_at`, compared
-    against the deploy boundary — see LEGACY_PERSONA_FIELD and
-    `_reverse_a_pre_deploy_persona_row`, which is the whole of the compatibility and
-    is deletable once the pre-deploy rows have aged out.
+    that it is looking at such an item is that decrement finding NO row to move — see
+    LEGACY_PERSONA_FIELD and `_reverse_a_pre_deploy_persona_row`, which is the whole
+    of the compatibility, needs nothing configured, and is deletable once the
+    pre-deploy rows have aged out.
     """
     source_platform = item.get('source_platform', 'unknown')
     category = item.get('category', 'other')
@@ -853,40 +803,6 @@ def apply_counter_keys(
     return landed, outcomes
 
 
-def _was_counted_by_the_old_persona_axis(item: dict) -> bool:
-    """Did THIS item's insert bucket it by name rather than by archetype?
-
-    The item's own `processed_at` against the deploy boundary, which is the only
-    per-item fact that answers the question — see LEGACY_PERSONA_STAMP_FIELD and
-    LEGACY_PERSONA_CUTOVER.
-
-    An UNREADABLE or ABSENT stamp answers True, i.e. pre-deploy. Only legacy or
-    hand-written items lack `processed_at` (the processor has always written it), so
-    the fail direction matches what such an item almost certainly is — and the
-    consequence of being wrong here is bounded on both sides: the follow-up write is
-    conditional, and PERSONA_ARCHETYPES already refuses any legacy pk this deploy
-    could have written, so a false True costs at most one refused write against a
-    legacy row that does not exist.
-    """
-    stamp = item.get(LEGACY_PERSONA_STAMP_FIELD)
-    if not isinstance(stamp, str):
-        return True
-    try:
-        processed = datetime.fromisoformat(stamp)
-    except ValueError:
-        logger.warning(
-            f"Could not read `{LEGACY_PERSONA_STAMP_FIELD}` ({stamp!r}); treating the "
-            f"item as pre-deploy for the persona axis"
-        )
-        return True
-    if processed.tzinfo is None:
-        # The processor writes an aware timestamp; a naive one can only come from a
-        # hand-written row. UTC is the only reading consistent with everything else
-        # in this table.
-        processed = processed.replace(tzinfo=timezone.utc)
-    return processed < datetime.fromisoformat(LEGACY_PERSONA_CUTOVER)
-
-
 def _reverse_a_pre_deploy_persona_row(
     item: dict, outcomes: dict[tuple[str, str, str], 'CounterWrite'],
 ) -> int:
@@ -904,25 +820,13 @@ def _reverse_a_pre_deploy_persona_row(
     concerned (read out of the key, not re-derived, so a follow-up can never land on
     another day).
 
-    🔑 THE TRIGGER IS THE ITEM'S `processed_at`, NOT THE ARCHETYPE ROW'S ABSENCE.
-    Both readings have been tried, and the difference decides whether the
-    compatibility works on the days that matter:
-
-    * an ABSENT archetype row is sound evidence — this item's insert created no such
-      row — but it is only *available* on a day no post-deploy item has written that
-      bucket. On a day the new axis has already populated, a pre-deploy item's
-      decrement LANDS on a row it never contributed to and the legacy row is never
-      touched. That is the ordinary cross-deploy state and the busiest day in the
-      window, so the fallback was inert exactly where the over-count was largest;
-    * `processed_at` is per-ITEM, so it is available on every reversal, and it is the
-      item's own record of which deploy wrote it.
-
-    THE ROW'S OUTCOME IS STILL READ, to rule the fallback OUT. `CounterWrite`
-    distinguishes a decrement refused because the row was ABSENT from one refused at
-    the FLOOR, and a row at the floor exists — which is what an already-reversed item
-    looks like on redelivery. So a stamped-pre-deploy item whose archetype row exists
-    at zero is left alone: something counted it there, and one deletion must not
-    decrement two rows on the strength of a stamp.
+    🔑 THE TRIGGER IS THAT DECREMENT REPORTING `ROW_ABSENT`. It is the only outcome
+    that means NO counter moved for the bucket, so it is at once the evidence that
+    this deploy's derivation never counted the item and what holds one deletion to one
+    decrement. Its limitation is named rather than hidden: an absent row is observable
+    only on a day no post-deploy item has written the bucket, so on a busy day a
+    pre-deploy item's decrement lands on the archetype row and the legacy row stays
+    inflated until its TTL. Recorded as a residual in the module docstring.
 
     NOTHING IS ATTEMPTED AGAINST A ROW THIS DEPLOY WRITES. `legacy_pk` is built from a
     free-text, LLM-produced name — the one pk in this module not derived from a closed
@@ -936,43 +840,35 @@ def _reverse_a_pre_deploy_persona_row(
     right way to be wrong here, the judgement `process_deleted_feedback` already makes
     for a dateless image.
 
-    THE TWO DERIVATIONS CANNOT NAME ONE ROW HERE, so there is no separate guard for
-    it, and the reason is worth stating because an earlier round of this function had
-    one. A second decrement of the row this reversal just decremented would be one
-    deletion taking two counts off it — but that requires the legacy value to equal
-    the archetype value, the archetype value is always a member of PERSONA_ARCHETYPES
-    (`persona_bucket` guarantees it), and the collision guard above already declines
-    every legacy value in that set. So the case is refused one line earlier, by a
-    guard that exists for a stronger reason.
-
     It is CONDITIONAL like every other decrement, so the compatibility cannot
     resurrect a legacy row or drive one negative: if the old row has also aged out,
     this is refused in turn and counted as REFUSED_METRIC.
 
-    REDELIVERY: a redelivered REMOVE of a pre-deploy item decrements the legacy row
-    again, which is the module's general at-least-once residual rather than a new one
-    — the same is true of every counter this module writes, and the direction is
-    toward the truth, since the legacy row is inflated by exactly those items. It is
-    bounded by the floor. A POST-deploy item's redelivered REMOVE does not reach here
-    at all, because its stamp says so.
+    REDELIVERY: a redelivered REMOVE of a pre-deploy item whose legacy `-1` already
+    landed sees `ROW_ABSENT` on the archetype bucket again, and so decrements the
+    legacy row a second time. That is the module's general at-least-once residual
+    rather than a new one — the same is true of every counter this module writes — it
+    is bounded by the floor, and the direction is toward the truth, since the legacy
+    row is inflated by exactly those items.
 
     Returns how many writes landed.
     """
-    # Only the persona keys, and only those whose write did not LAND on the archetype
-    # row this deploy would have created. `sorted` below because these ARE counter
-    # keys and test_streaming_categories_lockstep.py pins the small set of expressions
-    # allowed to produce a counter's sort key — the bare item date, never anything
-    # composite, because the streaming reader sums a window with `sk BETWEEN`.
-    keys = {key for key in outcomes if key[0].startswith(PERSONA_PREFIX)}
-    if not keys or not _was_counted_by_the_old_persona_axis(item):
-        return 0
-
-    # A row at the FLOOR exists, so something counted this item there and a second
-    # decrement for one deletion is not owed. Absent or landed both leave the legacy
-    # row still to bring down: absent means the insert created nothing here, and
-    # landed means this deploy's derivation was decremented for an item the OLD one
-    # counted, which is the busy-day case the stamp exists to reach.
-    keys = {key for key in keys if outcomes[key] is not CounterWrite.REFUSED_AT_FLOOR}
+    # 🔑 ONLY THE PERSONA KEYS WHOSE WRITE FOUND NO ROW. `ROW_ABSENT` is the one
+    # outcome that means NO counter moved for this bucket, so it is at once the
+    # evidence that this deploy's derivation never counted the item AND what keeps one
+    # deletion to one decrement. The other two are excluded for the same reason:
+    # `LANDED` means a counter already moved for this bucket, and `REFUSED_AT_FLOOR`
+    # means the row exists at zero (the redelivered-REMOVE shape) — so in both cases a
+    # row exists under the archetype bucket, and a second `-1` would take two counts
+    # off one deletion.
+    #
+    # `sorted` below because these ARE counter keys and
+    # test_streaming_categories_lockstep.py pins the small set of expressions allowed
+    # to produce a counter's sort key — the bare item date, never anything composite,
+    # because the streaming reader sums a window with `sk BETWEEN`.
+    keys = {key for key in outcomes
+            if key[0].startswith(PERSONA_PREFIX)
+            and outcomes[key] is CounterWrite.ROW_ABSENT}
     if not keys:
         return 0
 
@@ -1004,8 +900,8 @@ def _reverse_a_pre_deploy_persona_row(
     landed = 0
     for pk, date, field in sorted(keys):
         logger.info(
-            f"Persona decrement on {pk}/{date} was for an item processed before the "
-            f"axis moved; also reversing {legacy_pk}, the row its insert created"
+            f"Persona decrement on {pk}/{date} found no row, so this item's insert "
+            f"ran before the axis moved; also reversing {legacy_pk}, the row it created"
         )
         if update_counter(legacy_pk, date, field, increment=-1):
             landed += 1

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -127,6 +127,9 @@ from botocore.exceptions import ClientError
 # Shared module imports
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, is_conditional_check_failure
+# The persona axis, declared in the data layer because BOTH sides of it spend the
+# same two values — see the note above `counter_dimensions`.
+from shared.feedback import PERSONA_FIELD, PERSONA_UNKNOWN
 
 # AWS Clients (using shared module for connection reuse)
 dynamodb = get_dynamodb_resource()
@@ -166,21 +169,9 @@ REBUCKETED_METRIC = "AggregatesRebucketed"
 REFUSED_METRIC = "AggregateWriteRefused"
 DECLINED_METRIC = "AggregateWriteDeclined"
 
-# The feedback field the persona counter buckets by, as a constant so that
-# test_persona_field_lockstep.py can pin it against the field the PROCESSOR
-# writes. It is a constant rather than an inline `item.get('persona_name')` for
-# one reason: this name has to change on both sides of the stream at once. A
-# decrement reads it out of the OLD image of an item whose insert read it out of
-# the new one, so "fix" it here alone and every reversal misses the row its own
-# insert created — the counter goes up and never comes down, which is the shape of
-# the bug this module was just repaired for. The processor writes `persona_name`
-# AND `persona_type` (`processor/handler.py`), so either is a real field; the
-# lockstep is about the two sides agreeing, not about which of the two wins.
-PERSONA_FIELD = 'persona_name'
-
 # The two aggregate rows this module names outside `counter_dimensions`, hoisted
-# for the reason PERSONA_FIELD is: a second unmarked copy of one of these strings
-# is what makes an argument elsewhere in the file true or false.
+# for the reason PERSONA_FIELD is named: a second unmarked copy of one of these
+# strings is what makes an argument elsewhere in the file true or false.
 #
 # DAILY_TOTAL_PK is the sentinel `_day_has_aggregates` reads, and that read is only
 # a sound test of "is this day still here?" because this is the ONE counter every
@@ -482,6 +473,28 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     different field here than the insert path read makes every DECREMENT miss the
     row its insert created, so the two must move together, and "fix it in one
     place" is only true while something fails when they diverge.
+
+    🔑 THE PERSONA AXIS BUCKETS BY ARCHETYPE (`persona_type`), NOT BY NAME. It
+    bucketed by `persona_name` until an audit found 99.97% of a 6,239-item corpus
+    in one `Unknown` bucket — a dimension useless while looking populated. The
+    cause was NOT a field nothing writes: the processor writes both persona fields,
+    and the enrichment contract declares `persona.name` as "string or null"
+    precisely because this platform's corpus is scraped reviews and mostly
+    anonymous form submissions. An anonymous item HAS no name to give, the
+    processor strips None before writing, and so `persona_name` is legitimately
+    absent on almost every item. A null name is therefore correct model output, and
+    the axis was the thing that was wrong: `persona_type` is populated, and it is a
+    closed enum (`existing_customer|prospect|churn_risk|advocate|unknown`), which
+    is what a dimension you group by has to be — a person's name is an identifier,
+    not an archetype. The `METRIC#persona#` prefix is deliberately unchanged, so
+    `get_metric_type`, the `metric_type` GSI and every read path are untouched;
+    only the source field moved.
+
+    That move is FORWARD-ONLY. Rows already written keep their `Unknown` bucket, so
+    a window spanning the deploy shows old `Unknown` alongside the new enum values;
+    aggregate rows carry a 90-day TTL, so the axis becomes fully correct within 90
+    days with no backfill. Nothing rewrites stored rows — a rewrite would have to
+    re-derive each row from feedback the row no longer references.
     """
     source_platform = item.get('source_platform', 'unknown')
     category = item.get('category', 'other')
@@ -489,7 +502,7 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     urgency = item.get('urgency', 'low')
     # `or`, not a `.get` default: a stripped item can carry an explicit None, and
     # `METRIC#persona#None` is a bucket nothing else would ever write to.
-    persona = item.get(PERSONA_FIELD) or 'Unknown'
+    persona = item.get(PERSONA_FIELD) or PERSONA_UNKNOWN
 
     dimensions = [
         # DAILY_TOTAL_PK, not the literal: `_day_has_aggregates` reads this same

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -132,6 +132,7 @@ import os
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
+from enum import Enum
 from typing import Any
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, batch_processor
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBRecord
@@ -142,7 +143,12 @@ from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, is_conditional_check_failure
 # The persona axis, declared in the data layer because BOTH sides of it spend the
 # same three values — see the note above `counter_dimensions`.
-from shared.feedback import PERSONA_FIELD, PERSONA_PREFIX, PERSONA_UNKNOWN
+from shared.feedback import (
+    PERSONA_ARCHETYPES,
+    PERSONA_FIELD,
+    PERSONA_PREFIX,
+    PERSONA_UNKNOWN,
+)
 
 # AWS Clients (using shared module for connection reuse)
 dynamodb = get_dynamodb_resource()
@@ -216,15 +222,22 @@ SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
 # `attribute_exists(pk) AND #field >= :floor`, so a decrement against an absent or
 # already-zero row is refused, swallowed and counted as REFUSED_METRIC.
 #
-# THE FALLBACK, and why it is on this side only. That refusal is a SIGNAL, and
-# `update_counter` returns a bool precisely so a caller can tell a write that
-# landed from one that was declined: an absent archetype row is the evidence that
-# this image's insert did not create one, so the reversal then aims at the row the
-# old derivation names. That is self-limiting — it costs one extra conditional
-# write only when the archetype decrement was refused, it needs no new stored
-# field, and it stops mattering on its own as the pre-deploy rows age out, at
-# which point BOTH constants below and `_reverse_a_pre_deploy_persona_row` can be
-# deleted with no other change.
+# THE FALLBACK, and why it is on this side only. The ABSENCE OF THE ROW is a
+# signal, and `update_counter` reports it (`CounterWrite.ROW_ABSENT`, told from a
+# refusal at the floor by DynamoDB itself) precisely so a caller can spend it: a
+# missing archetype row is the evidence that this image's insert did not create one,
+# so the reversal then aims at the row the old derivation names. That is
+# self-limiting — it costs one extra conditional write only when the archetype row
+# is absent, it needs no new stored field, and it stops mattering on its own as the
+# pre-deploy rows age out, at which point BOTH constants below and
+# `_reverse_a_pre_deploy_persona_row` can be deleted with no other change.
+#
+# THE EVIDENCE IS THE ROW, NOT THE ITEM'S SHAPE. Worth stating because the shape
+# test suggests itself and is false: `processor/handler.py` has written BOTH persona
+# fields since the initial commit, so "no `persona_type` but a `persona_name`" is
+# NOT the pre-deploy shape — an anonymous pre-deploy item carries a `persona_type`
+# and no name, exactly like a post-deploy one, and that is the 99.97% case. The
+# deploy boundary left its mark on the ROWS, so only a row can testify to it.
 #
 # A permanent dual-READ on the increment path was rejected, and the reason is
 # recorded: this repo has already refused that shape once (the MCP legacy-token
@@ -237,6 +250,17 @@ LEGACY_PERSONA_FIELD = 'persona_name'
 # way it was written, because this constant's whole job is to name rows that ALREADY
 # EXIST. It is not a value anything writes fresh: `counter_dimensions` spells the
 # empty bucket PERSONA_UNKNOWN, the enum's way.
+#
+# 🔑 THE CASE IS A CORRECTNESS PROPERTY, not only fidelity to how the old rows were
+# spelled. `PERSONA_UNKNOWN` is `unknown`; unify the two and every reversal of an
+# anonymous pre-deploy image — the majority shape — would decrement the LIVE
+# `unknown` archetype row instead of the legacy bucket, which is the largest bucket
+# on the current axis. The two are also not symmetric in kind: `unknown` is a value
+# the enrichment contract declares, while `Unknown` was a label the old derivation
+# invented, so the new one must never be substituted for the old. Asserted by
+# test_a_post_deploy_image_whose_row_is_gone_writes_nothing_more, and the collision
+# it protects against is the general case
+# `_reverse_a_pre_deploy_persona_row` refuses via PERSONA_ARCHETYPES.
 LEGACY_PERSONA_UNKNOWN = 'Unknown'
 
 # Client error codes worth failing OPEN for without shouting: a blip, a throttle, a
@@ -255,6 +279,49 @@ _TRANSIENT_READ_ERRORS = frozenset({
     'RequestTimeoutException',
     'TransactionConflictException',
 })
+
+
+class CounterWrite(Enum):
+    """How one `update_counter` call ended.
+
+    🔑 THREE OUTCOMES, NOT TWO, because "the write was refused" is two different
+    facts and the difference is load-bearing for exactly one caller. A decrement's
+    condition is `attribute_exists(pk) AND #field >= :floor`, so a refusal means
+    EITHER there was no row at all OR the row is at zero — and
+    `_reverse_a_pre_deploy_persona_row` acts only on the first. A bool cannot carry
+    that, which is what made the fallback fire on a redelivered REMOVE of an
+    ordinary post-deploy item whose row had merely reached zero.
+
+    DynamoDB is the one that knows, and it will say so for free:
+    `ReturnValuesOnConditionCheckFailure='ALL_OLD'` returns the refused item, or no
+    item when there was none. So this distinction is OBSERVED rather than inferred
+    — which matters, because the plausible-looking alternative is to infer it from
+    the item's shape ("no `persona_type` but a `persona_name` means pre-deploy"),
+    and that inference is simply false: `processor/handler.py` has written BOTH
+    persona fields since the initial commit, so a pre-deploy anonymous item — the
+    99.97% case this compatibility exists for — is shape-identical to a post-deploy
+    one. Only the ROW's existence separates them.
+    """
+
+    LANDED = 'landed'
+    # The row exists; the floor refused this decrement because the counter is at
+    # zero. An ordinary outcome of a redelivered REMOVE, and NOT evidence about
+    # which deploy the item's insert ran under: the row being there is proof its
+    # insert created it.
+    REFUSED_AT_FLOOR = 'refused_at_floor'
+    # There is no such row: `attribute_exists(pk)` failed. Either it aged out under
+    # its TTL, or this item's insert never created it — which is the evidence the
+    # persona compatibility runs on.
+    ROW_ABSENT = 'row_absent'
+
+    def __bool__(self) -> bool:
+        """`LANDED` is truthy, both refusals falsy.
+
+        So that `if update_counter(...)` keeps reading as "did it land?" at the call
+        sites that only need that, and so that widening the return from a bool could
+        not silently invert a caller that had not been updated.
+        """
+        return self is CounterWrite.LANDED
 
 
 def get_metric_type(pk: str) -> str | None:
@@ -296,15 +363,21 @@ def _log_decline(what: str, pk: str, sk: str, because: str):
     metrics.add_metric(name=DECLINED_METRIC, unit="Count", value=1)
 
 
-def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: int = 90) -> bool:
+def update_counter(pk: str, sk: str, field: str, increment: int = 1,
+                   ttl_days: int = 90) -> 'CounterWrite':
     """Atomically update a counter in the aggregates table.
 
-    Returns whether the write LANDED. False means a condition refused it, which is
-    an ordinary outcome for a decrement and never happens to an increment (they
-    carry no condition). Callers that must know the difference: the rebucket, whose
-    two halves have to stand or fall together, and the metric that claims
-    "aggregates moved" — a count of writes ATTEMPTED would make that claim false
-    for an edit whose every write was refused.
+    Returns HOW the write ended, as one of the three `CounterWrite` outcomes —
+    landed, or refused for one of the two distinguishable reasons. Not a bool,
+    because "refused" is two different facts and one caller has to tell them apart:
+    see that enum. Callers that only need landed-or-not compare against
+    `CounterWrite.LANDED`.
+
+    A refusal is an ordinary outcome for a decrement and never happens to an
+    increment (they carry no condition). Callers that must know the difference: the
+    rebucket, whose two halves have to stand or fall together, and the metric that
+    claims "aggregates moved" — a count of writes ATTEMPTED would make that claim
+    false for an edit whose every write was refused.
 
     An increment may create the row — that is how a date's first item registers,
     and it stays true for a REBUCKET, because the first item edited into a category
@@ -326,6 +399,12 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
 
     ConditionalCheckFailedException is therefore an expected, benign outcome of a
     decrement with nothing to decrement, and is swallowed (and counted).
+
+    `ReturnValuesOnConditionCheckFailure='ALL_OLD'` is what makes the two refusals
+    distinguishable: on a conditional failure DynamoDB returns the item it refused
+    to write, or nothing at all if there was no item. That is the ONE authoritative
+    answer to "was this row absent, or merely at the floor?", and it costs no extra
+    request — see `CounterWrite.ROW_ABSENT` for the caller that needs it.
     """
     ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
 
@@ -348,6 +427,9 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
     if increment < 0:
         kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #field >= :floor'
         attr_values[':floor'] = -increment
+        # Ask for the refused item, so a refusal can say WHICH half of the condition
+        # failed. Only on the conditional path: an increment cannot be refused.
+        kwargs['ReturnValuesOnConditionCheckFailure'] = 'ALL_OLD'
 
     try:
         aggregates_table.update_item(
@@ -361,8 +443,14 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1, ttl_days: i
         if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
             raise
         _log_refusal(f'decrement of {field}', pk, sk)
-        return False
-    return True
+        # `Item` present means the row exists and the FLOOR refused this; absent
+        # means there was no row. DynamoDB reports it, so nothing here infers it
+        # from the item's shape — see `CounterWrite.ROW_ABSENT`.
+        response = e.response if isinstance(e.response, Mapping) else {}
+        if response.get('Item'):
+            return CounterWrite.REFUSED_AT_FLOOR
+        return CounterWrite.ROW_ABSENT
+    return CounterWrite.LANDED
 
 
 def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90,
@@ -636,29 +724,35 @@ def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int) -> tuple[int,
     there is exactly one line in this module deciding what a counter's sort key
     is. Sorted only to make the write order deterministic for tests and logs.
 
-    Returns `(writes that LANDED, the keys whose write was REFUSED)`.
+    Returns `(writes that LANDED, the keys whose row was found to be ABSENT)`.
 
     Landed, not attempted: a caller counting attempts would report that aggregates
     moved for an edit whose every write was refused by its condition.
 
-    The refusals are returned rather than only counted because for one dimension a
-    refusal is EVIDENCE, not merely an outcome: an absent persona row on a reversal
-    says this image's insert ran before the axis moved, which is the one thing that
-    distinguishes a pre-deploy item from a post-deploy one — see
-    `_reverse_a_pre_deploy_persona_row`. Reported as the KEYS rather than as a
-    count so that caller cannot guess which row was refused, and cannot aim its
-    follow-up write at a day the refusal did not concern.
+    🔑 THE SECOND MEMBER IS NARROWER THAN "REFUSED", and the narrowing is the point.
+    Only `CounterWrite.ROW_ABSENT` is collected — not a refusal at the floor —
+    because the one caller that reads these keys treats them as EVIDENCE that this
+    image's insert never created the row, and a row sitting at zero is proof of the
+    opposite: it exists, so its insert did create it. Handing that caller every
+    refusal made it act on a redelivered REMOVE of an ordinary post-deploy item,
+    which is the defect this signature now makes unrepresentable. See
+    `_reverse_a_pre_deploy_persona_row` and `CounterWrite`.
+
+    Reported as the KEYS rather than as a count so that caller cannot guess which
+    row was absent, and cannot aim its follow-up write at a day the refusal did not
+    concern.
     """
-    landed, refused = 0, set()
+    landed, absent = 0, set()
     for pk, date, field in sorted(keys):
-        if update_counter(pk, date, field, increment=sign):
+        outcome = update_counter(pk, date, field, increment=sign)
+        if outcome is CounterWrite.LANDED:
             landed += 1
-        else:
-            refused.add((pk, date, field))
-    return landed, refused
+        elif outcome is CounterWrite.ROW_ABSENT:
+            absent.add((pk, date, field))
+    return landed, absent
 
 
-def _reverse_a_pre_deploy_persona_row(item: dict, refused: set[tuple[str, str, str]]) -> int:
+def _reverse_a_pre_deploy_persona_row(item: dict, absent: set[tuple[str, str, str]]) -> int:
     """Bring down the persona row an item's PRE-DEPLOY insert really created.
 
     The whole of the persona axis's write-side compatibility, and the only place
@@ -668,50 +762,89 @@ def _reverse_a_pre_deploy_persona_row(item: dict, refused: set[tuple[str, str, s
     `counter_dimensions` is one description spent by both directions, so a reversal
     names `METRIC#persona#<persona_type>`. For an item inserted before the axis
     moved, no such row was ever created — the insert counted it under the old
-    derivation's bucket — and `update_counter`'s
-    `attribute_exists(pk) AND #field >= :floor` condition refuses the decrement.
-    That refusal is the evidence, and the follow-up write is aimed at the row the
-    old derivation names, on the DAY the refusal concerned (read out of the refused
-    key, not re-derived, so a follow-up can never land on another day).
+    derivation's bucket — and `update_counter`'s `attribute_exists(pk)` half refuses
+    the decrement, reporting `CounterWrite.ROW_ABSENT`. That is the evidence, and
+    the follow-up write is aimed at the row the old derivation names, on the DAY the
+    refusal concerned (read out of the refused key, not re-derived, so a follow-up
+    can never land on another day).
 
-    It is CONDITIONAL like every other decrement, so the compatibility cannot
-    resurrect a legacy row or drive one negative either: if the old row has also
-    aged out, this is refused in turn and counted as REFUSED_METRIC.
+    🔑 THE TRIGGER IS "THE ROW WAS ABSENT", NOT "THE WRITE WAS REFUSED". Those are
+    different propositions, and this function only ever had a right to the first.
+    A decrement is also refused when the row EXISTS at zero, which is the ordinary
+    outcome of a redelivered REMOVE of a post-deploy item — and acting on that took
+    a `-1` off a legacy row the item never contributed to, silently and on a healthy
+    corpus. `apply_counter_keys` therefore hands this function absent-row keys only;
+    a row at the floor is proof its insert DID create it, so it is proof this
+    function must do nothing. That the distinction is observed from DynamoDB rather
+    than inferred from the item's shape matters — see `CounterWrite`, since the
+    shape-based test that suggests itself is false for the majority case.
 
-    WHEN THE TWO DERIVATIONS NAME ONE ROW, nothing is attempted. That is not a
-    saving; it is required. A second write to the row whose decrement was just
+    NOTHING IS ATTEMPTED AGAINST A ROW THIS DEPLOY WRITES. `legacy_pk` is built from
+    a free-text, LLM-produced name, so it is the one pk in this module not derived
+    from a closed value space, and a name that happens to equal an archetype
+    (`unknown` is entirely plausible for anonymous feedback, and is the axis's
+    largest bucket) would aim this `-1` at a LIVE row for an item counted under a
+    different archetype. Conditional writes cannot catch that: the row exists and is
+    above the floor, so the write lands cleanly and corrupts a current number. A
+    missed legacy `-1` is the right way to be wrong here, which is the judgement
+    `process_deleted_feedback` already makes for a dateless image.
+
+    WHEN THE TWO DERIVATIONS NAME ONE ROW, nothing is attempted either. That is not
+    a saving; it is required. A second write to the row whose decrement was just
     refused would be the identical refused write (harmless), and if it were not
     refused it would be a SECOND decrement of one row for one deletion.
 
-    THE RESIDUAL, which is the redelivery residual this module already documents,
-    relocated rather than added: Streams are at-least-once, so a REMOVE redelivered
-    after the archetype row has reached zero is refused there too, and this then
-    takes one count off the legacy row instead. The direction of that error is
-    toward the truth — the legacy row is inflated by exactly the pre-deploy items
-    being deleted — and it is bounded by the same 90-day TTL as the rows themselves.
-    A redelivered REMOVE already moved counters twice before this existed; what is
-    new is only which row the second one lands on.
+    It is CONDITIONAL like every other decrement, so the compatibility cannot
+    resurrect a legacy row or drive one negative: if the old row has also aged out,
+    this is refused in turn and counted as REFUSED_METRIC.
 
-    Returns how many writes landed (0 or 1 per refused persona key).
+    REDELIVERY, now that the trigger is the absent row: a redelivered REMOVE reaches
+    this only while the archetype row is still ABSENT, i.e. only for an item whose
+    insert really did predate the move, and every such delivery is draining a row
+    that is inflated by exactly those items. It is bounded by the floor and by the
+    same 90-day TTL as the rows themselves. The module's general redelivery residual
+    is unchanged and unrelocated: a post-deploy item's redelivered REMOVE now does
+    here what it did before this function existed, which is nothing.
+
+    Returns how many writes landed (0 or 1 per absent persona key).
     """
     # `keys`, and `sorted(keys)` below, because these ARE counter keys and
     # test_streaming_categories_lockstep.py pins the small set of expressions
     # allowed to produce a counter's sort key — the bare item date, never anything
     # composite, because the streaming reader sums a window with `sk BETWEEN`.
-    keys = {key for key in refused if key[0].startswith(PERSONA_PREFIX)}
+    keys = {key for key in absent if key[0].startswith(PERSONA_PREFIX)}
     if not keys:
         return 0
 
     # The old derivation, reproduced exactly — including its bespoke `Unknown`,
     # which is a row name that already EXISTS rather than one anything writes fresh.
-    legacy_pk = f'{PERSONA_PREFIX}{item.get(LEGACY_PERSONA_FIELD) or LEGACY_PERSONA_UNKNOWN}'
+    legacy_value = item.get(LEGACY_PERSONA_FIELD) or LEGACY_PERSONA_UNKNOWN
+    if legacy_value in PERSONA_ARCHETYPES:
+        # A free-text name that collides with the current value space. This deploy
+        # writes that row, so a `-1` on it is a live number corrupted rather than a
+        # legacy one corrected — and it cannot be told apart from a legitimate
+        # legacy row by anything at this point. Declined, and counted as such: a
+        # write never issued gives DynamoDB nothing to refuse, so REFUSED_METRIC
+        # could not see it.
+        _log_decline(
+            'the pre-deploy persona reversal', f'{PERSONA_PREFIX}{legacy_value}',
+            # The earliest day the refusal concerned, so the decline names a real
+            # day rather than one recomputed here.
+            min(keys)[1],
+            f'`{LEGACY_PERSONA_FIELD}` is `{legacy_value}`, which is one of the '
+            f'archetypes this deploy actively writes, so that row cannot be '
+            f'distinguished from a live one and must not be decremented',
+        )
+        return 0
+
+    legacy_pk = f'{PERSONA_PREFIX}{legacy_value}'
     landed = 0
     for pk, date, field in sorted(keys):
         if pk == legacy_pk:
             # One row, two derivations agreeing on it: see the docstring.
             continue
         logger.info(
-            f"Persona decrement on {pk}/{date} was refused; reversing "
+            f"Persona decrement on {pk}/{date} found no row; reversing "
             f"{legacy_pk} instead, the row this item's pre-deploy insert created"
         )
         if update_counter(legacy_pk, date, field, increment=-1):
@@ -721,14 +854,14 @@ def _reverse_a_pre_deploy_persona_row(item: dict, refused: set[tuple[str, str, s
 
 def apply_feedback(item: dict, sign: int, date: str):
     """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`."""
-    _, refused = apply_counter_keys(counter_keys(item, date), sign)
+    _, absent = apply_counter_keys(counter_keys(item, date), sign)
     if sign < 0:
         # Reversal only. Reading the old persona field on the INCREMENT path would
         # make the axis permanently dual-sourced to serve a path with a sunset date,
         # which this repo has rejected before; here the refusal makes it free and
         # confines it to a direction that cannot change which bucket anything is
         # COUNTED in. See `_reverse_a_pre_deploy_persona_row`.
-        _reverse_a_pre_deploy_persona_row(item, refused)
+        _reverse_a_pre_deploy_persona_row(item, absent)
 
     # Daily sentiment score average
     sentiment_score = _image_score(item)
@@ -868,7 +1001,7 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
 
     writes = 0
     if old_live:
-        landed, refused = apply_counter_keys(decrements, -1)
+        landed, absent = apply_counter_keys(decrements, -1)
         writes += landed
         # The same pre-deploy compatibility the REMOVE path gets, for the same
         # reason: this decrement reads an OLD IMAGE, which may be an image whose
@@ -877,7 +1010,21 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
         # alone cancels in the symmetric difference and issues no persona write at
         # all, so there is nothing to be refused. Derived from `old_item`, because
         # the row to bring down is the one the OLD image's insert created.
-        writes += _reverse_a_pre_deploy_persona_row(old_item, refused)
+        #
+        # 🔑 DELIBERATELY NOT ADDED TO `writes`, which is this function's claim that
+        # THIS EDIT moved aggregates — `record_handler` gates REBUCKETED_METRIC on
+        # it. This write is not one the edit asked for: it corrects a row a previous
+        # deploy created. Folding it in would let that metric fire for an edit whose
+        # own decrements and increments were every one refused, which is the same
+        # distinction DECLINED_METRIC and REFUSED_METRIC exist to keep — a metric
+        # that gates on a count is a consumer of the count, not just a reader.
+        # Logged instead, so the compatibility is observable without being conflated.
+        compatibility_writes = _reverse_a_pre_deploy_persona_row(old_item, absent)
+        if compatibility_writes:
+            logger.info(
+                f"Also brought down {compatibility_writes} pre-deploy persona row(s) "
+                f"for this edit; not counted as aggregates the edit itself moved"
+            )
     elif decrements:
         logger.info(f"Not decrementing {len(decrements)} counter(s) on the aged-out {old_date}")
     if new_live:

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -72,6 +72,19 @@ average row's is refreshed only by scored ones. A write declined by that rule is
 counted as DECLINED_METRIC — REFUSED_METRIC cannot cover it, since a write never
 issued gives DynamoDB nothing to refuse. See `_rebucket_average`.
 
+A reversal may also have to reverse a row THIS DEPLOY WOULD NOT HAVE WRITTEN. The
+persona axis moved from `persona_name` to `persona_type`, and a decrement reads the
+OLD IMAGE of an item whose insert may predate that move — so the row named by
+today's derivation was never created for it, while the row that WAS created is left
+inflated. The floor-and-existence condition means this cannot go negative or
+resurrect anything, but it would leave a persistent over-count in one dimension for
+every delete or edit of pre-deploy feedback. The refusal is the evidence, so the
+reversal path (and the decrement half of a rebucket) follows a refused persona
+decrement with one conditional write to the row the old derivation names. It is
+confined to the reversal direction, needs no stored state, and is deletable once the
+pre-deploy rows have aged out — see `LEGACY_PERSONA_FIELD` and
+`_reverse_a_pre_deploy_persona_row`.
+
 A reversal also refuses to GUESS a date. `_image_date` falls back to today when an
 image carries no `date` field, which is defensible for an INSERT (today is at
 least the day the row was created) and arbitrary for a REMOVE: an undated item
@@ -128,8 +141,8 @@ from botocore.exceptions import ClientError
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, is_conditional_check_failure
 # The persona axis, declared in the data layer because BOTH sides of it spend the
-# same two values — see the note above `counter_dimensions`.
-from shared.feedback import PERSONA_FIELD, PERSONA_UNKNOWN
+# same three values — see the note above `counter_dimensions`.
+from shared.feedback import PERSONA_FIELD, PERSONA_PREFIX, PERSONA_UNKNOWN
 
 # AWS Clients (using shared module for connection reuse)
 dynamodb = get_dynamodb_resource()
@@ -181,6 +194,51 @@ DECLINED_METRIC = "AggregateWriteDeclined"
 DAILY_TOTAL_PK = 'METRIC#daily_total'
 SENTIMENT_AVG_PK = 'METRIC#daily_sentiment_avg'
 
+# --- Reversing an item whose INSERT ran before the persona axis moved ---------
+# 🔑 THE ONE PLACE THE OLD PERSONA AXIS IS STILL READ, and only in the direction
+# that cannot be got wrong by reading it.
+#
+# `counter_dimensions` is a single description spent by BOTH directions, which is
+# what stops the increment and the decrement from drifting — but the decrement
+# reads the OLD IMAGE of an item whose insert may have run under the previous
+# deploy. That insert created `METRIC#persona#<persona_name, or Unknown>`; this
+# deploy's decrement names `METRIC#persona#<persona_type>`, a row that item never
+# contributed to. Two things follow, and neither is read staleness:
+#
+#   * the row the insert DID create is never brought down, so it stays inflated
+#     until its 90-day TTL expires — a delete or an edit of pre-deploy feedback
+#     leaves a persistent OVER-count in this dimension;
+#   * the archetype row is decremented for an item it never counted, which
+#     UNDERSTATES it while post-deploy items are populating it.
+#
+# What this is NOT: it cannot drive a counter negative or resurrect an expired
+# row. `update_counter` guards every decrement with
+# `attribute_exists(pk) AND #field >= :floor`, so a decrement against an absent or
+# already-zero row is refused, swallowed and counted as REFUSED_METRIC.
+#
+# THE FALLBACK, and why it is on this side only. That refusal is a SIGNAL, and
+# `update_counter` returns a bool precisely so a caller can tell a write that
+# landed from one that was declined: an absent archetype row is the evidence that
+# this image's insert did not create one, so the reversal then aims at the row the
+# old derivation names. That is self-limiting — it costs one extra conditional
+# write only when the archetype decrement was refused, it needs no new stored
+# field, and it stops mattering on its own as the pre-deploy rows age out, at
+# which point BOTH constants below and `_reverse_a_pre_deploy_persona_row` can be
+# deleted with no other change.
+#
+# A permanent dual-READ on the increment path was rejected, and the reason is
+# recorded: this repo has already refused that shape once (the MCP legacy-token
+# decision), because preserving a legacy path there would have meant carrying a
+# permanent extra field to serve a path with a sunset date. Here the absent-row
+# signal makes the compatibility free and confines it to the reversal, where
+# reading the old field cannot affect which bucket anything is COUNTED in.
+LEGACY_PERSONA_FIELD = 'persona_name'
+# The bespoke empty bucket the old derivation used — deliberately capitalised the
+# way it was written, because this constant's whole job is to name rows that ALREADY
+# EXIST. It is not a value anything writes fresh: `counter_dimensions` spells the
+# empty bucket PERSONA_UNKNOWN, the enum's way.
+LEGACY_PERSONA_UNKNOWN = 'Unknown'
+
 # Client error codes worth failing OPEN for without shouting: a blip, a throttle, a
 # retryable server-side fault. Anything outside this set is a misconfiguration
 # (`AccessDeniedException`, `ValidationException`, `ResourceNotFoundException`), and
@@ -200,10 +258,17 @@ _TRANSIENT_READ_ERRORS = frozenset({
 
 
 def get_metric_type(pk: str) -> str | None:
-    """Extract metric type from pk for GSI indexing."""
+    """Extract metric type from pk for GSI indexing.
+
+    The persona prefix comes from PERSONA_PREFIX rather than a literal: this tag is
+    what puts the row on the `metric_type` GSI that both of `metrics_handler`'s
+    aggregates branches query, so a prefix spelled here and differently where the pk
+    is BUILT would leave every persona row untagged and the dimension empty with
+    every count still computed correctly.
+    """
     if pk.startswith('METRIC#daily_source#'):
         return 'source'
-    elif pk.startswith('METRIC#persona#'):
+    elif pk.startswith(PERSONA_PREFIX):
         return 'persona'
     return None
 
@@ -490,11 +555,28 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     `get_metric_type`, the `metric_type` GSI and every read path are untouched;
     only the source field moved.
 
-    That move is FORWARD-ONLY. Rows already written keep their `Unknown` bucket, so
-    a window spanning the deploy shows old `Unknown` alongside the new enum values;
-    aggregate rows carry a 90-day TTL, so the axis becomes fully correct within 90
-    days with no backfill. Nothing rewrites stored rows — a rewrite would have to
+    That move is FORWARD-ONLY on the READ side. Rows already written keep their
+    `Unknown` bucket, so a window spanning the deploy shows old `Unknown` alongside
+    the new enum values; aggregate rows carry a 90-day TTL
+    (`AGGREGATE_RETENTION_DAYS`), so the axis becomes fully correct within 90 days
+    with no backfill. Nothing rewrites stored rows — a rewrite would have to
     re-derive each row from feedback the row no longer references.
+
+    THE WRITE SIDE HAS ONE EXCEPTION, because forward-only is not enough there. A
+    REMOVE (or the decrement half of a rebucket) reads the OLD IMAGE of an item
+    whose insert may have run before this deploy, and that insert counted it under
+    the row the OLD derivation names. A decrement derived from this function alone
+    would therefore name a row the item never contributed to: the row its insert
+    really created is never brought down and stays inflated for up to 90 days, while
+    the archetype row is decremented for an item it never counted. `update_counter`
+    keeps that from being worse than wrong-by-one — its
+    `attribute_exists(pk) AND #field >= :floor` condition refuses a decrement
+    against an absent or zeroed row, so no counter goes negative and no expired row
+    is resurrected; the refusal is counted as REFUSED_METRIC. But a refusal is also
+    the EVIDENCE that this image's insert wrote no archetype row, and
+    `apply_counter_keys` spends it: see LEGACY_PERSONA_FIELD and
+    `_reverse_a_pre_deploy_persona_row`, which is the whole of the compatibility and
+    is deletable once the pre-deploy rows have aged out.
     """
     source_platform = item.get('source_platform', 'unknown')
     category = item.get('category', 'other')
@@ -512,7 +594,10 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
         (f'METRIC#daily_source#{source_platform}', 'count'),
         (f'METRIC#daily_category#{category}', 'count'),
         (f'METRIC#daily_sentiment#{sentiment_label}', 'count'),
-        (f'METRIC#persona#{persona}', 'count'),
+        # PERSONA_PREFIX, not the literal: `get_metric_type` tags this row for the
+        # `metric_type` GSI by the same prefix and `metrics_handler` strips it back
+        # off, across two Lambdas that cannot import each other.
+        (f'{PERSONA_PREFIX}{persona}', 'count'),
     ]
 
     # Urgency counts (for alerts) — only urgent items have a row at all, so a
@@ -544,25 +629,106 @@ def counter_keys(item: dict, date: str) -> set[tuple[str, str, str]]:
     return {(pk, date, field) for pk, field in counter_dimensions(item)}
 
 
-def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int) -> int:
-    """Move every named counter by `sign`, returning how many writes LANDED.
+def apply_counter_keys(keys: set[tuple[str, str, str]], sign: int) -> tuple[int, set[tuple[str, str, str]]]:
+    """Move every named counter by `sign`.
 
     The ONE place a counter key is unpacked into an `update_counter` call, so
     there is exactly one line in this module deciding what a counter's sort key
     is. Sorted only to make the write order deterministic for tests and logs.
 
+    Returns `(writes that LANDED, the keys whose write was REFUSED)`.
+
     Landed, not attempted: a caller counting attempts would report that aggregates
     moved for an edit whose every write was refused by its condition.
+
+    The refusals are returned rather than only counted because for one dimension a
+    refusal is EVIDENCE, not merely an outcome: an absent persona row on a reversal
+    says this image's insert ran before the axis moved, which is the one thing that
+    distinguishes a pre-deploy item from a post-deploy one — see
+    `_reverse_a_pre_deploy_persona_row`. Reported as the KEYS rather than as a
+    count so that caller cannot guess which row was refused, and cannot aim its
+    follow-up write at a day the refusal did not concern.
     """
-    return sum(
-        1 for pk, date, field in sorted(keys)
-        if update_counter(pk, date, field, increment=sign)
-    )
+    landed, refused = 0, set()
+    for pk, date, field in sorted(keys):
+        if update_counter(pk, date, field, increment=sign):
+            landed += 1
+        else:
+            refused.add((pk, date, field))
+    return landed, refused
+
+
+def _reverse_a_pre_deploy_persona_row(item: dict, refused: set[tuple[str, str, str]]) -> int:
+    """Bring down the persona row an item's PRE-DEPLOY insert really created.
+
+    The whole of the persona axis's write-side compatibility, and the only place
+    LEGACY_PERSONA_FIELD is read. See that constant for the argument; the mechanism
+    is:
+
+    `counter_dimensions` is one description spent by both directions, so a reversal
+    names `METRIC#persona#<persona_type>`. For an item inserted before the axis
+    moved, no such row was ever created — the insert counted it under the old
+    derivation's bucket — and `update_counter`'s
+    `attribute_exists(pk) AND #field >= :floor` condition refuses the decrement.
+    That refusal is the evidence, and the follow-up write is aimed at the row the
+    old derivation names, on the DAY the refusal concerned (read out of the refused
+    key, not re-derived, so a follow-up can never land on another day).
+
+    It is CONDITIONAL like every other decrement, so the compatibility cannot
+    resurrect a legacy row or drive one negative either: if the old row has also
+    aged out, this is refused in turn and counted as REFUSED_METRIC.
+
+    WHEN THE TWO DERIVATIONS NAME ONE ROW, nothing is attempted. That is not a
+    saving; it is required. A second write to the row whose decrement was just
+    refused would be the identical refused write (harmless), and if it were not
+    refused it would be a SECOND decrement of one row for one deletion.
+
+    THE RESIDUAL, which is the redelivery residual this module already documents,
+    relocated rather than added: Streams are at-least-once, so a REMOVE redelivered
+    after the archetype row has reached zero is refused there too, and this then
+    takes one count off the legacy row instead. The direction of that error is
+    toward the truth — the legacy row is inflated by exactly the pre-deploy items
+    being deleted — and it is bounded by the same 90-day TTL as the rows themselves.
+    A redelivered REMOVE already moved counters twice before this existed; what is
+    new is only which row the second one lands on.
+
+    Returns how many writes landed (0 or 1 per refused persona key).
+    """
+    # `keys`, and `sorted(keys)` below, because these ARE counter keys and
+    # test_streaming_categories_lockstep.py pins the small set of expressions
+    # allowed to produce a counter's sort key — the bare item date, never anything
+    # composite, because the streaming reader sums a window with `sk BETWEEN`.
+    keys = {key for key in refused if key[0].startswith(PERSONA_PREFIX)}
+    if not keys:
+        return 0
+
+    # The old derivation, reproduced exactly — including its bespoke `Unknown`,
+    # which is a row name that already EXISTS rather than one anything writes fresh.
+    legacy_pk = f'{PERSONA_PREFIX}{item.get(LEGACY_PERSONA_FIELD) or LEGACY_PERSONA_UNKNOWN}'
+    landed = 0
+    for pk, date, field in sorted(keys):
+        if pk == legacy_pk:
+            # One row, two derivations agreeing on it: see the docstring.
+            continue
+        logger.info(
+            f"Persona decrement on {pk}/{date} was refused; reversing "
+            f"{legacy_pk} instead, the row this item's pre-deploy insert created"
+        )
+        if update_counter(legacy_pk, date, field, increment=-1):
+            landed += 1
+    return landed
 
 
 def apply_feedback(item: dict, sign: int, date: str):
     """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`."""
-    apply_counter_keys(counter_keys(item, date), sign)
+    _, refused = apply_counter_keys(counter_keys(item, date), sign)
+    if sign < 0:
+        # Reversal only. Reading the old persona field on the INCREMENT path would
+        # make the axis permanently dual-sourced to serve a path with a sunset date,
+        # which this repo has rejected before; here the refusal makes it free and
+        # confines it to a direction that cannot change which bucket anything is
+        # COUNTED in. See `_reverse_a_pre_deploy_persona_row`.
+        _reverse_a_pre_deploy_persona_row(item, refused)
 
     # Daily sentiment score average
     sentiment_score = _image_score(item)
@@ -702,11 +868,20 @@ def process_modified_feedback(old_item: dict, new_item: dict) -> int | None:
 
     writes = 0
     if old_live:
-        writes += apply_counter_keys(decrements, -1)
+        landed, refused = apply_counter_keys(decrements, -1)
+        writes += landed
+        # The same pre-deploy compatibility the REMOVE path gets, for the same
+        # reason: this decrement reads an OLD IMAGE, which may be an image whose
+        # insert ran before the persona axis moved. It is reached only by an edit
+        # that CHANGES the archetype (or the date) — an edit leaving `persona_type`
+        # alone cancels in the symmetric difference and issues no persona write at
+        # all, so there is nothing to be refused. Derived from `old_item`, because
+        # the row to bring down is the one the OLD image's insert created.
+        writes += _reverse_a_pre_deploy_persona_row(old_item, refused)
     elif decrements:
         logger.info(f"Not decrementing {len(decrements)} counter(s) on the aged-out {old_date}")
     if new_live:
-        writes += apply_counter_keys(increments, 1)
+        writes += apply_counter_keys(increments, 1)[0]
     elif increments:
         # The half the `or` used to let through. These are unconditional writes, so
         # nothing but this branch stops them creating the day.

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -147,6 +147,15 @@ Known residuals
   rather than for 90 days. A date in the code buying a permanent error in place of
   an ageing one is the trade this declines — see
   `_reverse_a_pre_deploy_persona_row`.
+* A REDELIVERED REMOVE DRAINS THE LEGACY PERSONA ROW AGAIN. The compatibility runs
+  per reversal EVENT while the debt is per ITEM, and a refused decrement creates
+  nothing, so the evidence is unchanged on the second delivery. The LEGITIMATE
+  multi-reversal cases are bounded by the trigger itself (the first reversal's
+  increment creates the archetype row, so later decrements land and never reach the
+  fallback — measured in TestOneItemOwesOneLegacyDecrement); redelivery is not, and is
+  accepted as an instance of the at-least-once residual above rather than closed for
+  one row. Cost, exactly: the first drain per item moves toward the truth and any
+  further one makes that row UNDERSTATE, bounded below by the floor.
 * THE ABSENT ROW IS NOT PROOF OF VINTAGE, only of "no live row here". A
   post-deploy INSERT whose stream record never landed — a batch failure, a window
   where this function was erroring — leaves no archetype row either, so deleting
@@ -873,12 +882,27 @@ def _reverse_a_pre_deploy_persona_row(
     resurrect a legacy row or drive one negative: if the old row has also aged out,
     this is refused in turn and counted as REFUSED_METRIC.
 
-    REDELIVERY: a redelivered REMOVE of a pre-deploy item whose legacy `-1` already
-    landed sees `ROW_ABSENT` on the archetype bucket again, and so decrements the
-    legacy row a second time. That is the module's general at-least-once residual
-    rather than a new one — the same is true of every counter this module writes — it
-    is bounded by the floor, and the direction is toward the truth, since the legacy
-    row is inflated by exactly those items.
+    🔑 ONE ITEM OWES ONE `-1`, AND THE TRIGGER BOUNDS THE LEGITIMATE CASES BY
+    CONSTRUCTION. This runs per reversal EVENT, while the debt is per ITEM — and one
+    item can be reversed many times (each edit that changes its archetype or date, then
+    its delete). It settles once anyway: the first reversal's INCREMENT creates the
+    archetype row for the item's new bucket, so every later decrement of that row LANDS
+    and never reaches here. Nothing was added to get that; it falls out of triggering on
+    "no counter moved" rather than on a fact about the item. Measured against moto in
+    TestOneItemOwesOneLegacyDecrement — three successive edits drain the legacy row
+    ONCE, and an edit followed by the delete once.
+
+    ⚠️ REDELIVERY IS THE EXCEPTION, and is accepted rather than closed. A refused
+    decrement creates nothing, so a redelivered REMOVE sees `ROW_ABSENT` again and
+    decrements the legacy row again — N deliveries, N writes. That is the module's
+    general at-least-once residual rather than one this path invents (every counter here
+    behaves the same way; see the module docstring, and closing it means routing
+    `eventID` through `shared/idempotency.py`, a CDK change as well as a code one), so
+    fixing it for this row alone would be a special case of a module-wide gap.
+    Its cost, stated exactly: the direction is toward the truth for the FIRST drain of
+    each item only. Past that the legacy row UNDERSTATES — it is bounded below by the
+    floor, never negative, but it is a row `/metrics/personas` still serves for a window
+    overlapping the move.
 
     Returns how many writes landed.
     """

--- a/voc-datalake/lambda/aggregator/test/conftest.py
+++ b/voc-datalake/lambda/aggregator/test/conftest.py
@@ -26,7 +26,12 @@ def sample_feedback_item():
         'sentiment_label': 'positive',
         'sentiment_score': Decimal('0.85'),
         'urgency': 'low',
+        # Both persona fields, because the processor writes both — and the metrics
+        # axis buckets by the ARCHETYPE (`persona_type`), so a fixture carrying
+        # only a name would agree with the aggregator about a field production
+        # rarely produces. See test_persona_field_lockstep.py.
         'persona_name': 'Happy Customer',
+        'persona_type': 'advocate',
     }
 
 
@@ -44,6 +49,33 @@ def sample_urgent_feedback_item():
         'sentiment_score': Decimal('-0.75'),
         'urgency': 'high',
         'persona_name': 'Frustrated Customer',
+        'persona_type': 'churn_risk',
+    }
+
+
+@pytest.fixture
+def sample_anonymous_feedback_item():
+    """The shape of nearly every item this platform really ingests.
+
+    An archetype and NO name: the enrichment contract declares `persona.name` as
+    "string or null", the corpus is scraped reviews and mostly anonymous form
+    submissions, and the processor strips None before writing — so an anonymous item
+    arrives with no `persona_name` key at all. Bucketing the persona axis by that
+    field put 99.97% of a 6,239-item corpus in one `Unknown` bucket, which is why
+    the axis buckets by `persona_type`. A fixture, because the two fixtures above
+    both carry a name and so cannot tell the two fields apart.
+    """
+    return {
+        'pk': 'SOURCE#webscraper',
+        'sk': 'FEEDBACK#anon1',
+        'feedback_id': 'anon1',
+        'date': '2025-01-15',
+        'source_platform': 'webscraper',
+        'category': 'delivery',
+        'sentiment_label': 'negative',
+        'sentiment_score': Decimal('-0.4'),
+        'urgency': 'low',
+        'persona_type': 'churn_risk',
     }
 
 

--- a/voc-datalake/lambda/aggregator/test/conftest.py
+++ b/voc-datalake/lambda/aggregator/test/conftest.py
@@ -1,22 +1,13 @@
 """Shared pytest fixtures for aggregator tests."""
 import pytest
 from unittest.mock import MagicMock
-from datetime import datetime, timedelta
 from decimal import Decimal
 
-from aggregator.handler import LEGACY_PERSONA_CUTOVER
-
-# `processed_at` values on either side of the persona axis's deploy boundary
-# (`aggregator/handler.py::LEGACY_PERSONA_CUTOVER`). Derived from that constant rather
-# than written out, so moving the boundary moves the fixtures with it and a fixture
-# cannot end up on the side its name denies.
-#
-# The stamp is what tells a reversal which derivation counted the item, so an item
-# WITHOUT one is treated as pre-deploy — which means omitting it is not neutral. Every
-# fixture below therefore says which side of the boundary it is on.
-_CUTOVER = datetime.fromisoformat(LEGACY_PERSONA_CUTOVER)
-PROCESSED_AFTER_THE_AXIS_MOVED = (_CUTOVER + timedelta(days=1)).isoformat()
-PROCESSED_BEFORE_THE_AXIS_MOVED = (_CUTOVER - timedelta(days=1)).isoformat()
+# NO FIXTURE HERE SAYS WHICH DEPLOY WROTE IT, and that is the point. Whether an
+# item's insert ran before the persona axis moved is not a property of the item at
+# all — it is whether the archetype row its decrement names EXISTS, which
+# `update_counter` reports back and a test arranges on the table. See
+# `_reverse_a_pre_deploy_persona_row`.
 
 
 @pytest.fixture
@@ -47,10 +38,6 @@ def sample_feedback_item():
         # rarely produces. See test_persona_field_lockstep.py.
         'persona_name': 'Happy Customer',
         'persona_type': 'advocate',
-        # Processed AFTER the axis moved, so this ordinary item's reversal is the
-        # plain one — no pre-deploy compatibility. Omitting the stamp would make
-        # every fixture here a pre-deploy item, which is the opposite of ordinary.
-        'processed_at': PROCESSED_AFTER_THE_AXIS_MOVED,
     }
 
 
@@ -69,7 +56,6 @@ def sample_urgent_feedback_item():
         'urgency': 'high',
         'persona_name': 'Frustrated Customer',
         'persona_type': 'churn_risk',
-        'processed_at': PROCESSED_AFTER_THE_AXIS_MOVED,
     }
 
 
@@ -85,10 +71,10 @@ def sample_anonymous_feedback_item():
     the axis buckets by `persona_type`. A fixture, because the two fixtures above
     both carry a name and so cannot tell the two fields apart.
 
-    Processed AFTER the axis moved: this is the ordinary anonymous item, whose
-    reversal needs no compatibility. `sample_pre_deploy_feedback_item` is the same
-    shape on the other side of the boundary, which is the pair that shows the stamp
-    rather than the shape is what decides.
+    Also the shape that shows the pre-deploy fallback is not triggered by an item's
+    PERSONA SHAPE: an anonymous item written before the axis moved looks exactly like
+    this one, and its insert still counted it under the old default. What separates
+    them is whether the archetype row exists, which is a fact about the table.
     """
     return {
         'pk': 'SOURCE#webscraper',
@@ -101,30 +87,24 @@ def sample_anonymous_feedback_item():
         'sentiment_score': Decimal('-0.4'),
         'urgency': 'low',
         'persona_type': 'churn_risk',
-        'processed_at': PROCESSED_AFTER_THE_AXIS_MOVED,
     }
 
 
 @pytest.fixture
 def sample_pre_deploy_feedback_item():
-    """An item PROCESSED before the persona axis moved to the archetype.
+    """An old image arranged so the two persona derivations name DIFFERENT rows.
 
-    🔑 WHAT MAKES IT PRE-DEPLOY IS `processed_at`, not its persona fields. The stamp
-    is the item's own record of which deploy wrote it, so it is the only thing a
-    reversal can read to know which derivation counted it — see
-    `LEGACY_PERSONA_STAMP_FIELD`. The fields below are arranged so a test can also
-    tell WHICH row a write went to: a `persona_name` and no `persona_type` makes the
-    two derivations name different rows, which an item carrying both cannot do.
+    A `persona_name` and no `persona_type`, which is what lets a test see WHICH row a
+    write went to — an item carrying both cannot, because then only the value differs
+    and not the derivation.
 
-    ⚠️ THAT ARRANGEMENT IS NOT THE PRE-DEPLOY SHAPE, and reading it as one is a
-    mistake this fixture has already invited once. `processor/handler.py` has written
-    both persona fields since the initial commit, so the axis move changed only the
-    READER: a real pre-deploy item usually carries a `persona_type` too, the dominant
-    one being `sample_anonymous_feedback_item`'s shape exactly, and a trigger that
-    tested for "a name but no archetype" would be silently inert for 99.97% of the
-    corpus. `sample_pre_deploy_anonymous_feedback_item` is that case, and
-    test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
-    is where it is pinned.
+    ⚠️ THIS IS NOT "THE PRE-DEPLOY SHAPE", and reading it as one is a mistake this
+    fixture has invited before. `processor/handler.py` has written both persona fields
+    since the initial commit, so the axis move changed only the READER: a real
+    pre-deploy item usually carries a `persona_type` too, the dominant one being
+    `sample_anonymous_feedback_item`'s shape exactly. Nothing on an item says which
+    deploy inserted it, which is why the fallback triggers on the archetype ROW being
+    absent instead — a fact about the table, arranged per test.
 
     The subject of TestAPreDeployImageIsReversedOnTheRowItsInsertCreated in
     test_handler.py — the only case in which the reversal reads the old field, and
@@ -144,26 +124,7 @@ def sample_pre_deploy_feedback_item():
         # needing to be filtered out of every assertion.
         'urgency': 'low',
         'persona_name': 'Veronica Chen',
-        'processed_at': PROCESSED_BEFORE_THE_AXIS_MOVED,
     }
-
-
-@pytest.fixture
-def sample_pre_deploy_anonymous_feedback_item(sample_anonymous_feedback_item):
-    """The 99.97% pre-deploy item: an archetype, no name, and an OLD stamp.
-
-    Byte-identical to `sample_anonymous_feedback_item` but for `processed_at`, which
-    is the whole point — these two are the pair that shows the compatibility's trigger
-    has to be the stamp. A shape-based trigger cannot tell them apart at all, and the
-    absence of the archetype ROW only tells them apart on a day no post-deploy item
-    has written that bucket, which is not the day the corpus is busiest.
-
-    Its insert counted it under the OLD default (`METRIC#persona#Unknown`, the row
-    holding most of the pre-deploy corpus), because it had no name to be counted
-    under.
-    """
-    return {**sample_anonymous_feedback_item,
-            'processed_at': PROCESSED_BEFORE_THE_AXIS_MOVED}
 
 
 @pytest.fixture

--- a/voc-datalake/lambda/aggregator/test/conftest.py
+++ b/voc-datalake/lambda/aggregator/test/conftest.py
@@ -80,6 +80,38 @@ def sample_anonymous_feedback_item():
 
 
 @pytest.fixture
+def sample_pre_deploy_feedback_item():
+    """An item as it was written BEFORE the persona axis moved to the archetype.
+
+    A `persona_name` and NO `persona_type`, which is the shape of a stream OLD IMAGE
+    whose insert ran under the previous deploy: that insert counted the item under
+    `METRIC#persona#<the name>`, a row today's derivation never names. This is the
+    subject of TestAPreDeployImageIsReversedOnTheArchetype in test_handler.py — the
+    only case in which the reversal reads the old field, and the reason it may.
+
+    Distinct from `sample_anonymous_feedback_item` (an archetype and no name), which
+    is the POST-deploy production shape. The two are opposites on purpose: an item
+    carrying both fields, as the other fixtures do, cannot tell the two derivations
+    apart, which is how the original defect stayed green.
+    """
+    return {
+        'pk': 'SOURCE#webscraper',
+        'sk': 'FEEDBACK#legacy1',
+        'feedback_id': 'legacy1',
+        'date': '2025-01-15',
+        'source_platform': 'webscraper',
+        'category': 'delivery',
+        'sentiment_label': 'neutral',
+        # No `sentiment_score`. `apply_feedback` writes the running average only for
+        # a scored item, so leaving it off keeps this fixture's writes to the
+        # counters — which is all its tests are about — without an average write
+        # needing to be filtered out of every assertion.
+        'urgency': 'low',
+        'persona_name': 'Veronica Chen',
+    }
+
+
+@pytest.fixture
 def sample_dynamodb_stream_record(sample_feedback_item):
     """Create a sample DynamoDB stream record."""
     # Convert to DynamoDB format

--- a/voc-datalake/lambda/aggregator/test/conftest.py
+++ b/voc-datalake/lambda/aggregator/test/conftest.py
@@ -1,7 +1,22 @@
 """Shared pytest fixtures for aggregator tests."""
 import pytest
 from unittest.mock import MagicMock
+from datetime import datetime, timedelta
 from decimal import Decimal
+
+from aggregator.handler import LEGACY_PERSONA_CUTOVER
+
+# `processed_at` values on either side of the persona axis's deploy boundary
+# (`aggregator/handler.py::LEGACY_PERSONA_CUTOVER`). Derived from that constant rather
+# than written out, so moving the boundary moves the fixtures with it and a fixture
+# cannot end up on the side its name denies.
+#
+# The stamp is what tells a reversal which derivation counted the item, so an item
+# WITHOUT one is treated as pre-deploy — which means omitting it is not neutral. Every
+# fixture below therefore says which side of the boundary it is on.
+_CUTOVER = datetime.fromisoformat(LEGACY_PERSONA_CUTOVER)
+PROCESSED_AFTER_THE_AXIS_MOVED = (_CUTOVER + timedelta(days=1)).isoformat()
+PROCESSED_BEFORE_THE_AXIS_MOVED = (_CUTOVER - timedelta(days=1)).isoformat()
 
 
 @pytest.fixture
@@ -32,6 +47,10 @@ def sample_feedback_item():
         # rarely produces. See test_persona_field_lockstep.py.
         'persona_name': 'Happy Customer',
         'persona_type': 'advocate',
+        # Processed AFTER the axis moved, so this ordinary item's reversal is the
+        # plain one — no pre-deploy compatibility. Omitting the stamp would make
+        # every fixture here a pre-deploy item, which is the opposite of ordinary.
+        'processed_at': PROCESSED_AFTER_THE_AXIS_MOVED,
     }
 
 
@@ -50,6 +69,7 @@ def sample_urgent_feedback_item():
         'urgency': 'high',
         'persona_name': 'Frustrated Customer',
         'persona_type': 'churn_risk',
+        'processed_at': PROCESSED_AFTER_THE_AXIS_MOVED,
     }
 
 
@@ -64,6 +84,11 @@ def sample_anonymous_feedback_item():
     field put 99.97% of a 6,239-item corpus in one `Unknown` bucket, which is why
     the axis buckets by `persona_type`. A fixture, because the two fixtures above
     both carry a name and so cannot tell the two fields apart.
+
+    Processed AFTER the axis moved: this is the ordinary anonymous item, whose
+    reversal needs no compatibility. `sample_pre_deploy_feedback_item` is the same
+    shape on the other side of the boundary, which is the pair that shows the stamp
+    rather than the shape is what decides.
     """
     return {
         'pk': 'SOURCE#webscraper',
@@ -76,32 +101,34 @@ def sample_anonymous_feedback_item():
         'sentiment_score': Decimal('-0.4'),
         'urgency': 'low',
         'persona_type': 'churn_risk',
+        'processed_at': PROCESSED_AFTER_THE_AXIS_MOVED,
     }
 
 
 @pytest.fixture
 def sample_pre_deploy_feedback_item():
-    """An item as it was written BEFORE the persona axis moved to the archetype.
+    """An item PROCESSED before the persona axis moved to the archetype.
 
-    A `persona_name` and NO `persona_type`, so that the two derivations name
-    DIFFERENT rows and a test can tell which one a write went to: that item's insert
-    counted it under `METRIC#persona#<the name>`, a row today's derivation never
-    names. The subject of
-    TestAPreDeployImageIsReversedOnTheRowItsInsertCreated in test_handler.py — the
-    only case in which the reversal reads the old field, and the reason it may.
+    🔑 WHAT MAKES IT PRE-DEPLOY IS `processed_at`, not its persona fields. The stamp
+    is the item's own record of which deploy wrote it, so it is the only thing a
+    reversal can read to know which derivation counted it — see
+    `LEGACY_PERSONA_STAMP_FIELD`. The fields below are arranged so a test can also
+    tell WHICH row a write went to: a `persona_name` and no `persona_type` makes the
+    two derivations name different rows, which an item carrying both cannot do.
 
-    ⚠️ THIS SHAPE IS NOT WHAT MAKES AN IMAGE PRE-DEPLOY, and the fixture's name says
-    when its insert ran, not how it is recognised. `processor/handler.py` has written
+    ⚠️ THAT ARRANGEMENT IS NOT THE PRE-DEPLOY SHAPE, and reading it as one is a
+    mistake this fixture has already invited once. `processor/handler.py` has written
     both persona fields since the initial commit, so the axis move changed only the
-    reader and a real pre-deploy item usually carries a `persona_type` too — the
-    dominant one being `sample_anonymous_feedback_item`'s shape exactly. What tells
-    the two apart in production is whether the ARCHETYPE ROW EXISTS, which is why the
-    trigger is `CounterWrite.ROW_ABSENT` and not a test on these keys; see
-    test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current.
+    READER: a real pre-deploy item usually carries a `persona_type` too, the dominant
+    one being `sample_anonymous_feedback_item`'s shape exactly, and a trigger that
+    tested for "a name but no archetype" would be silently inert for 99.97% of the
+    corpus. `sample_pre_deploy_anonymous_feedback_item` is that case, and
+    test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
+    is where it is pinned.
 
-    Distinct from `sample_anonymous_feedback_item` (an archetype and no name) because
-    an item carrying both fields, as the other fixtures do, cannot tell the two
-    derivations apart, which is how the original defect stayed green.
+    The subject of TestAPreDeployImageIsReversedOnTheRowItsInsertCreated in
+    test_handler.py — the only case in which the reversal reads the old field, and
+    the reason it may.
     """
     return {
         'pk': 'SOURCE#webscraper',
@@ -117,7 +144,26 @@ def sample_pre_deploy_feedback_item():
         # needing to be filtered out of every assertion.
         'urgency': 'low',
         'persona_name': 'Veronica Chen',
+        'processed_at': PROCESSED_BEFORE_THE_AXIS_MOVED,
     }
+
+
+@pytest.fixture
+def sample_pre_deploy_anonymous_feedback_item(sample_anonymous_feedback_item):
+    """The 99.97% pre-deploy item: an archetype, no name, and an OLD stamp.
+
+    Byte-identical to `sample_anonymous_feedback_item` but for `processed_at`, which
+    is the whole point — these two are the pair that shows the compatibility's trigger
+    has to be the stamp. A shape-based trigger cannot tell them apart at all, and the
+    absence of the archetype ROW only tells them apart on a day no post-deploy item
+    has written that bucket, which is not the day the corpus is busiest.
+
+    Its insert counted it under the OLD default (`METRIC#persona#Unknown`, the row
+    holding most of the pre-deploy corpus), because it had no name to be counted
+    under.
+    """
+    return {**sample_anonymous_feedback_item,
+            'processed_at': PROCESSED_BEFORE_THE_AXIS_MOVED}
 
 
 @pytest.fixture

--- a/voc-datalake/lambda/aggregator/test/conftest.py
+++ b/voc-datalake/lambda/aggregator/test/conftest.py
@@ -83,16 +83,25 @@ def sample_anonymous_feedback_item():
 def sample_pre_deploy_feedback_item():
     """An item as it was written BEFORE the persona axis moved to the archetype.
 
-    A `persona_name` and NO `persona_type`, which is the shape of a stream OLD IMAGE
-    whose insert ran under the previous deploy: that insert counted the item under
-    `METRIC#persona#<the name>`, a row today's derivation never names. This is the
-    subject of TestAPreDeployImageIsReversedOnTheArchetype in test_handler.py — the
+    A `persona_name` and NO `persona_type`, so that the two derivations name
+    DIFFERENT rows and a test can tell which one a write went to: that item's insert
+    counted it under `METRIC#persona#<the name>`, a row today's derivation never
+    names. The subject of
+    TestAPreDeployImageIsReversedOnTheRowItsInsertCreated in test_handler.py — the
     only case in which the reversal reads the old field, and the reason it may.
 
-    Distinct from `sample_anonymous_feedback_item` (an archetype and no name), which
-    is the POST-deploy production shape. The two are opposites on purpose: an item
-    carrying both fields, as the other fixtures do, cannot tell the two derivations
-    apart, which is how the original defect stayed green.
+    ⚠️ THIS SHAPE IS NOT WHAT MAKES AN IMAGE PRE-DEPLOY, and the fixture's name says
+    when its insert ran, not how it is recognised. `processor/handler.py` has written
+    both persona fields since the initial commit, so the axis move changed only the
+    reader and a real pre-deploy item usually carries a `persona_type` too — the
+    dominant one being `sample_anonymous_feedback_item`'s shape exactly. What tells
+    the two apart in production is whether the ARCHETYPE ROW EXISTS, which is why the
+    trigger is `CounterWrite.ROW_ABSENT` and not a test on these keys; see
+    test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current.
+
+    Distinct from `sample_anonymous_feedback_item` (an archetype and no name) because
+    an item carrying both fields, as the other fixtures do, cannot tell the two
+    derivations apart, which is how the original defect stayed green.
     """
     return {
         'pk': 'SOURCE#webscraper',

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -1147,12 +1147,28 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     delete leaves that row inflated for up to 90 days while decrementing an archetype
     row the item never contributed to.
 
-    WHAT IS NOT WRONG WITH IT, since a review of this PR claimed otherwise: it cannot
-    drive a counter negative or resurrect an expired row. `update_counter` guards
-    every decrement with `attribute_exists(pk) AND #field >= :floor`, pinned by
-    TestADecrementCannotCreateOrGoNegative against a real DynamoDB. The damage was a
-    persistent OVER-count of a legacy row, not a negative one — and that refusal is
-    also the evidence the fallback runs on.
+    NO COUNTER GOES NEGATIVE AND NO EXPIRED ROW IS RESURRECTED, here or anywhere
+    else on this path: `update_counter` guards every decrement with
+    `attribute_exists(pk) AND #field >= :floor`, pinned against a real DynamoDB by
+    TestADecrementCannotCreateOrGoNegative. The damage this fallback repairs was a
+    persistent OVER-count of a legacy row, not a negative one.
+
+    🔑 THE TRIGGER IS THE ABSENCE OF THE ARCHETYPE ROW, WHICH IS NARROWER THAN A
+    REFUSED WRITE, and the difference is the whole subject of half this class. A
+    decrement is refused for two distinguishable reasons — no row, or a row at zero
+    — and only the first is evidence that this image's insert predated the axis move.
+    A row sitting at zero is proof of the opposite: it exists, so its insert created
+    it, and that is the ordinary state of a REDELIVERED remove of a healthy
+    post-deploy item. Acting on it took a `-1` off a legacy row the item never
+    contributed to. `CounterWrite` carries the distinction, DynamoDB supplies it, and
+    test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone is
+    the case that would go wrong without it.
+
+    IT IS ALSO NOT ALLOWED TO NAME A ROW THIS DEPLOY WRITES. `legacy_pk` is built out
+    of a free-text LLM-produced name, the one pk in the module not drawn from a
+    closed value space, so a name equal to an archetype would aim the `-1` at a LIVE
+    bucket — and a conditional write cannot catch that, because the row exists and is
+    above the floor. PERSONA_ARCHETYPES is what refuses it.
 
     The fallback is CONFINED to the reversal direction. Reading the old field on the
     increment path would make the axis permanently dual-sourced to serve a path with
@@ -1163,10 +1179,17 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
       * Delete `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` — fails
         test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down and
         test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too.
-      * Run it for a POST-deploy image whose archetype row merely sat at zero — that
-        is what test_a_post_deploy_image_does_not_touch_the_legacy_row is the
-        positive control against; it is the case that makes the fallback's trigger
-        "the row was refused" rather than "a decrement happened".
+      * Trigger on any refusal rather than on the absent row — i.e. have
+        `apply_counter_keys` collect `CounterWrite.REFUSED_AT_FLOOR` keys too, or
+        make `update_counter` return one undifferentiated refusal — fails
+        test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone
+        and
+        test_a_redelivered_remove_of_an_anonymous_item_does_not_drain_the_legacy_default.
+      * Drop the PERSONA_ARCHETYPES guard — fails
+        test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row.
+      * Run it for a POST-deploy image whose archetype decrement LANDED — that is
+        what test_a_post_deploy_image_does_not_touch_the_legacy_row is the positive
+        control against.
       * Make the axis dual-SOURCED on the way in
         (`item.get(PERSONA_FIELD) or item.get(LEGACY_PERSONA_FIELD) or ...` in
         `counter_dimensions`) — fails
@@ -1179,16 +1202,26 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         test_the_fallback_cannot_resurrect_an_aged_out_legacy_row, which is
         moto-backed of necessity: a mock cannot refuse a write.
 
+    WHY THE TRIGGER IS NOT THE ITEM'S SHAPE, recorded because it is the fix that
+    suggests itself for the redelivery case above and it does not work: "no
+    `persona_type`, but a `persona_name`" looks like a pre-deploy image and is not
+    one. `processor/handler.py` has written BOTH persona fields since the initial
+    commit, so the axis move changed only the READER — an anonymous pre-deploy item
+    carries a `persona_type` and no name, exactly like a post-deploy one, and that is
+    the 99.97% case this compatibility exists for. A shape test would therefore be
+    silently inert for the majority of the corpus while looking like a tightening;
+    test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
+    is the case that fails under it.
+
     TWO MUTATIONS THAT DO NOT FAIL ANYTHING, run and recorded rather than asserted
-    into existence, since a REVERT MAP naming a failure that does not happen is the
-    defect this PR's review found in the sibling file:
-      * `if sign < 0` → `if True` in `apply_feedback`: 130 passed. An increment
-        carries no ConditionExpression, so it cannot be refused, so `refused` is
-        empty and the fallback has nothing to act on. The guard STATES that rather
+    into existence, because a REVERT MAP is only worth what its citations are:
+      * `if sign < 0` → `if True` in `apply_feedback`: passes. An increment carries
+        no ConditionExpression, so it cannot be refused, so no key is ever reported
+        absent and the fallback has nothing to act on. The guard STATES that rather
         than depending on it — cheaper to read than to re-derive, and it keeps the
         compatibility legible as reversal-only.
       * reading the date from `_image_date(item)` instead of out of the refused key:
-        130 passed, because for one reversal every refused key carries the very date
+        passes, because for one reversal every refused key carries the very date
         `counter_keys` was given. Reading it out of the key is structural rather than
         observable: it makes it impossible for a future caller to hand this function
         keys from one day and an item naming another, which is the failure
@@ -1226,20 +1259,32 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         return personas[0]
 
     @staticmethod
-    def _refuse(mock_table, *, unless_pk: str | None = None):
+    def _refuse(mock_table, *, unless_pk: str | None = None, at_floor: bool = False):
         """Make the mocked table refuse EVERY conditional write, or all but one.
 
         A decrement against a row that does not exist is what production really
         answers with, and an unconfigured mock accepts everything — so without this
         the fallback could never be reached and the tests below would pass with it
         deleted.
+
+        `at_floor` picks WHICH refusal is mimicked, and the two are not
+        interchangeable. DynamoDB reports a conditional failure with the refused item
+        attached when there was one (`ReturnValuesOnConditionCheckFailure='ALL_OLD'`),
+        and with no item when the row was absent — which is how `update_counter`
+        tells a row that never existed from one sitting at zero. A helper that
+        answered only one of the two would make one of those cases untestable, and it
+        is the difference the fallback's trigger now turns on.
         """
+        floor_item = {'pk': {'S': 'set-below'}, 'sk': {'S': 'd'}, 'count': {'N': '0'}}
+
         def update_item(**kwargs):
             if 'ConditionExpression' in kwargs and kwargs['Key']['pk'] != unless_pk:
-                raise ClientError(
-                    {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'gone'}},
-                    'UpdateItem',
-                )
+                response = {
+                    'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'no'},
+                }
+                if at_floor:
+                    response['Item'] = {**floor_item, 'pk': {'S': kwargs['Key']['pk']}}
+                raise ClientError(response, 'UpdateItem')
             return {}
 
         mock_table.update_item.side_effect = update_item
@@ -1385,6 +1430,140 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         days = {sk for pk, sk, _, _ in self._persona_writes(mock_table)}
         assert days == {'2024-11-02'}, days
 
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone(
+        self, mock_table, sample_feedback_item
+    ):
+        """A refused decrement is not evidence of a pre-deploy insert.
+
+        Streams are at-least-once, so a REMOVE is redelivered after its counters have
+        already come down — and the archetype row then sits at ZERO, where the floor
+        refuses the second decrement. That row EXISTS, which is proof its insert
+        created it, so this image owes the legacy bucket nothing. Triggering on "the
+        write was refused" instead of "the row was absent" took a `-1` off a free-text
+        row belonging to a different customer, on a healthy post-deploy corpus.
+        """
+        from aggregator.handler import record_handler
+
+        # Every conditional write refused BY THE FLOOR: the rows are all there.
+        self._refuse(mock_table, at_floor=True)
+        item = sample_feedback_item
+        assert item.get('persona_name') and item.get('persona_type'), (
+            'the subject must carry BOTH fields, or the two derivations agree and '
+            'the `pk == legacy_pk` branch would hide the defect'
+        )
+
+        record_handler(_record('REMOVE', old=item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._archetype_pk(item), '2025-01-15', 'count', -1)
+        ], (
+            'a redelivered REMOVE of a post-deploy item must attempt its archetype '
+            'row and stop there. The row being at zero says the row exists, so the '
+            'insert created it, so there is no pre-deploy row to bring down.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_redelivered_remove_of_an_anonymous_item_does_not_drain_the_legacy_default(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        """The same case in the shape production actually has, which is the costly one.
+
+        An anonymous item derives the legacy bucket from the OLD DEFAULT, so a stray
+        decrement lands on `METRIC#persona#Unknown` — the single row holding ~99.97%
+        of the pre-deploy corpus. Every redelivered REMOVE would have taken a count
+        off it, for items it never held.
+        """
+        from aggregator.handler import (
+            LEGACY_PERSONA_UNKNOWN,
+            PERSONA_PREFIX,
+            record_handler,
+        )
+
+        self._refuse(mock_table, at_floor=True)
+
+        record_handler(_record('REMOVE', old=sample_anonymous_feedback_item))
+
+        legacy_default = f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}'
+        written = [pk for pk, *_ in self._persona_writes(mock_table)]
+        assert legacy_default not in written, written
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """`legacy_pk` is the one pk built out of free text, so it can collide.
+
+        `persona_name` is an LLM-produced person name, and nothing constrains it to
+        the value space this axis now uses — `unknown` is entirely plausible for
+        anonymous feedback, and it names the axis's LARGEST live bucket. A `-1` there
+        is a current number corrupted rather than a legacy one corrected, and no
+        condition expression can refuse it: that row exists and is above the floor.
+        A missed legacy decrement is the right way to be wrong, the judgement
+        `process_deleted_feedback` already makes for a dateless image.
+        """
+        from aggregator.handler import (
+            PERSONA_ARCHETYPES,
+            PERSONA_PREFIX,
+            record_handler,
+        )
+
+        self._refuse(mock_table)
+        colliding = {**sample_pre_deploy_feedback_item,
+                     'persona_name': 'unknown', 'persona_type': 'advocate'}
+        assert 'unknown' in PERSONA_ARCHETYPES, (
+            'the arrangement depends on this name being a value the current axis '
+            'writes; if the enum changes, pick another member of it'
+        )
+
+        record_handler(_record('REMOVE', old=colliding))
+
+        written = [pk for pk, *_ in self._persona_writes(mock_table)]
+        assert written == [f'{PERSONA_PREFIX}advocate'], (
+            f'{written}: only the archetype decrement may be attempted. The name '
+            f'`unknown` names a bucket THIS deploy writes, so it cannot be told '
+            f'apart from a live row and must be left alone.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        """The 99.97% case, and the reason the trigger cannot be the item's SHAPE.
+
+        `processor/handler.py` has written both persona fields since the initial
+        commit, so the axis move changed only the reader: a pre-deploy anonymous item
+        carries a `persona_type` and no name, which is byte-identical to a post-deploy
+        one. Only the ROW tells them apart — here the archetype row is ABSENT, because
+        that insert counted the item under the old default instead.
+
+        A shape test (`PERSONA_FIELD not in item and LEGACY_PERSONA_FIELD in item`)
+        would fail this, which is what makes it worth pinning: it looks like a
+        tightening and would silently switch the compatibility off for the majority
+        of the corpus it exists for.
+        """
+        from aggregator.handler import (
+            LEGACY_PERSONA_UNKNOWN,
+            PERSONA_FIELD,
+            PERSONA_PREFIX,
+            record_handler,
+        )
+
+        self._refuse(mock_table)
+        item = sample_anonymous_feedback_item
+        assert PERSONA_FIELD in item and 'persona_name' not in item, (
+            'the arrangement is the point: this is the shape a shape-based trigger '
+            'would read as post-deploy'
+        )
+
+        record_handler(_record('REMOVE', old=item))
+
+        assert (f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', '2025-01-15', 'count', -1) \
+            in self._persona_writes(mock_table), (
+            'an anonymous item deleted after the deploy must bring down the old '
+            'default bucket its insert really incremented.'
+        )
+
     def test_the_fallback_cannot_resurrect_an_aged_out_legacy_row(
         self, real_aggregates_table
     ):
@@ -1407,6 +1586,35 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
             'every write of this reversal — the archetype decrement and the legacy '
             'fallback alike — is conditional, so a day whose rows have expired must '
             'come out of it with no rows at all.'
+        )
+
+    def test_a_real_dynamodb_tells_a_row_at_zero_from_a_row_that_is_not_there(
+        self, real_aggregates_table
+    ):
+        """The distinction the trigger rests on, against the thing that supplies it.
+
+        `update_counter` reads it out of `ReturnValuesOnConditionCheckFailure`, so it
+        is a property of DynamoDB's response rather than of this repo's code — and a
+        mock cannot establish it: the mocked refusals elsewhere in this class are
+        hand-built to carry an item or not, which pins how the two are HANDLED but
+        assumes DynamoDB draws the distinction at all. This is the assumption.
+        """
+        from aggregator.handler import CounterWrite, update_counter
+
+        real_aggregates_table.put_item(
+            Item={'pk': 'METRIC#persona#advocate', 'sk': '2025-01-15', 'count': Decimal(0)}
+        )
+
+        at_floor = update_counter('METRIC#persona#advocate', '2025-01-15', 'count',
+                                  increment=-1)
+        absent = update_counter('METRIC#persona#nothing_here', '2025-01-15', 'count',
+                                increment=-1)
+
+        assert at_floor is CounterWrite.REFUSED_AT_FLOOR, at_floor
+        assert absent is CounterWrite.ROW_ABSENT, absent
+        assert not at_floor and not absent, (
+            'both are refusals, so both must stay falsy — the callers that only ask '
+            '"did it land?" read this value as a boolean.'
         )
 
     def test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too(
@@ -2526,6 +2734,65 @@ class TestEachBehaviourEmitsItsOwnMetric:
 
         # The refusal is visible; the rebucket is not claimed.
         assert self._names(mock_metrics) == [REFUSED_METRIC]
+
+    @patch('aggregator.handler.metrics')
+    def test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing(
+        self, mock_metrics, real_aggregates_table, sample_pre_deploy_feedback_item
+    ):
+        """REBUCKETED_METRIC claims THIS EDIT moved aggregates.
+
+        The pre-deploy persona compatibility is a write the edit did not ask for: it
+        corrects a row a previous deploy created. Folding it into the same total would
+        make the metric fire for an edit whose own decrements and increments were
+        every one refused — so an operator reading it would see an edit that moved
+        nothing reported as one that did, which is the distinction REFUSED_METRIC and
+        DECLINED_METRIC already exist to keep.
+
+        Moto-backed of necessity: the arrangement needs a live day whose archetype row
+        is genuinely ABSENT while the legacy row is genuinely present, and a mock
+        cannot refuse the one and accept the other on the strength of the real
+        condition.
+
+        THE ARRANGEMENT, because it takes some doing to leave an edit with no landing
+        write of its own: increments carry no condition, so they always land — the
+        edit therefore has to move the item ONTO AN AGED-OUT DAY, where the increments
+        are declined rather than attempted. On the day it leaves, `daily_total` is
+        present at ZERO, which keeps the day live for `_day_has_aggregates` while the
+        floor refuses its decrement; every other row it names is absent.
+        """
+        from aggregator.handler import (
+            LEGACY_PERSONA_UNKNOWN,
+            PERSONA_PREFIX,
+            REBUCKETED_METRIC,
+            record_handler,
+        )
+
+        old = {k: v for k, v in sample_pre_deploy_feedback_item.items()
+               if k != 'persona_name'}
+        real_aggregates_table.put_item(
+            Item={'pk': 'METRIC#daily_total', 'sk': '2025-01-15', 'count': Decimal(0)}
+        )
+        real_aggregates_table.put_item(Item={
+            'pk': f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', 'sk': '2025-01-15',
+            'count': Decimal(3),
+        })
+        mock_metrics.reset_mock()
+
+        record_handler(_record('MODIFY', old=old, new={**old, 'date': '2024-01-01'}))
+
+        legacy = real_aggregates_table.get_item(Key={
+            'pk': f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', 'sk': '2025-01-15',
+        })['Item']
+        assert legacy['count'] == Decimal(2), (
+            'the arrangement requires the compatibility write to have LANDED, or this '
+            'test would pass for want of anything to count'
+        )
+        assert REBUCKETED_METRIC not in self._names(mock_metrics), (
+            f'{self._names(mock_metrics)}: the edit moved none of the aggregates it '
+            f'names, so it must not be reported as having rebucketed. The only write '
+            f'that landed was the pre-deploy compatibility, which the edit did not '
+            f'ask for.'
+        )
 
     @patch('aggregator.handler.metrics')
     def test_an_edit_that_did_move_a_counter_still_counts_as_rebucketed(

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -60,6 +60,18 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       `test_the_two_directions_name_one_row_and_only_the_sign_differs` as soon as
       the two copies disagree, which is what a half-moved field name is.
 
+  TestAPreDeployImageIsReversedOnTheRowItsInsertCreated
+    — the class above cannot see a cross-deploy image, because both of its images are
+      built by the same deployed code. A REMOVE whose INSERT ran before the persona
+      axis moved was counted under the OLD derivation's bucket, so a decrement from
+      the shared description alone leaves that row inflated for up to 90 days while
+      decrementing an archetype row the item never contributed to. Deleting
+      `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` fails two of
+      these; deleting it in `process_modified_feedback` fails
+      `test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too`. The
+      class's own REVERT MAP has the rest, including two mutations that do NOT fail
+      and why.
+
   TestAReversalRefusesToGuessTheDay
     — `_image_date`'s today-fallback is safe for an arrival and arbitrary for a
       reversal. Having `process_deleted_feedback` or `process_modified_feedback`
@@ -1122,6 +1134,308 @@ class TestBothDirectionsAgreeOnThePersonaBucket:
         assert _dimensions(inserted) == _dimensions(removed)
         assert [delta for *_, delta in inserted] == [1]
         assert [delta for *_, delta in removed] == [-1]
+
+
+class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
+    """The one case in which the reversal reads the OLD persona field.
+
+    The class above is the property for images written by THIS deploy, and it cannot
+    see this case: both of its images are built by the same deployed code, so both
+    derive the same bucket. A REMOVE whose INSERT ran before the axis moved is
+    different — that insert counted the item under `METRIC#persona#<persona_name, or
+    Unknown>`, a row today's derivation never names — and without a fallback the
+    delete leaves that row inflated for up to 90 days while decrementing an archetype
+    row the item never contributed to.
+
+    WHAT IS NOT WRONG WITH IT, since a review of this PR claimed otherwise: it cannot
+    drive a counter negative or resurrect an expired row. `update_counter` guards
+    every decrement with `attribute_exists(pk) AND #field >= :floor`, pinned by
+    TestADecrementCannotCreateOrGoNegative against a real DynamoDB. The damage was a
+    persistent OVER-count of a legacy row, not a negative one — and that refusal is
+    also the evidence the fallback runs on.
+
+    The fallback is CONFINED to the reversal direction. Reading the old field on the
+    increment path would make the axis permanently dual-sourced to serve a path with
+    a sunset date, which this repo has rejected before; here it changes only which
+    row a `-1` lands on, never which bucket anything is counted in.
+
+    REVERT MAP for this class
+      * Delete `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` — fails
+        test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down and
+        test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too.
+      * Run it for a POST-deploy image whose archetype row merely sat at zero — that
+        is what test_a_post_deploy_image_does_not_touch_the_legacy_row is the
+        positive control against; it is the case that makes the fallback's trigger
+        "the row was refused" rather than "a decrement happened".
+      * Make the axis dual-SOURCED on the way in
+        (`item.get(PERSONA_FIELD) or item.get(LEGACY_PERSONA_FIELD) or ...` in
+        `counter_dimensions`) — fails
+        test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down here and
+        test_a_name_alone_does_not_decide_the_bucket in
+        test_persona_field_lockstep.py. That is the shape this change is careful NOT
+        to be, so it is worth a named failure.
+      * Have it write unconditionally (increment=-1 with no floor, i.e. dropping
+        `update_counter`'s condition) — fails
+        test_the_fallback_cannot_resurrect_an_aged_out_legacy_row, which is
+        moto-backed of necessity: a mock cannot refuse a write.
+
+    TWO MUTATIONS THAT DO NOT FAIL ANYTHING, run and recorded rather than asserted
+    into existence, since a REVERT MAP naming a failure that does not happen is the
+    defect this PR's review found in the sibling file:
+      * `if sign < 0` → `if True` in `apply_feedback`: 130 passed. An increment
+        carries no ConditionExpression, so it cannot be refused, so `refused` is
+        empty and the fallback has nothing to act on. The guard STATES that rather
+        than depending on it — cheaper to read than to re-derive, and it keeps the
+        compatibility legible as reversal-only.
+      * reading the date from `_image_date(item)` instead of out of the refused key:
+        130 passed, because for one reversal every refused key carries the very date
+        `counter_keys` was given. Reading it out of the key is structural rather than
+        observable: it makes it impossible for a future caller to hand this function
+        keys from one day and an item naming another, which is the failure
+        `_image_date_or_none` exists to prevent elsewhere in this module and which no
+        ConditionExpression can catch.
+        test_the_fallback_lands_on_the_day_the_refusal_concerned therefore pins the
+        OUTCOME (both writes on the item's own day) rather than the mechanism.
+    """
+
+    @staticmethod
+    def _persona_writes(mock_table) -> list[tuple[str, str, str, int]]:
+        return [w for w in _writes(mock_table) if w[0].startswith('METRIC#persona#')]
+
+    @staticmethod
+    def _legacy_pk(item: dict) -> str:
+        """The row a pre-deploy insert created, derived from the handler's own
+        constants rather than written out, so a change to either is visible here."""
+        from aggregator.handler import (
+            LEGACY_PERSONA_FIELD,
+            LEGACY_PERSONA_UNKNOWN,
+            PERSONA_PREFIX,
+        )
+
+        return f'{PERSONA_PREFIX}{item.get(LEGACY_PERSONA_FIELD) or LEGACY_PERSONA_UNKNOWN}'
+
+    @staticmethod
+    def _archetype_pk(item: dict) -> str:
+        """The row today's derivation names — from `counter_dimensions`, so nothing
+        here restates a pk."""
+        from aggregator.handler import counter_dimensions
+
+        personas = [pk for pk, _ in counter_dimensions(item)
+                    if pk.startswith('METRIC#persona#')]
+        assert len(personas) == 1, personas
+        return personas[0]
+
+    @staticmethod
+    def _refuse(mock_table, *, unless_pk: str | None = None):
+        """Make the mocked table refuse EVERY conditional write, or all but one.
+
+        A decrement against a row that does not exist is what production really
+        answers with, and an unconfigured mock accepts everything — so without this
+        the fallback could never be reached and the tests below would pass with it
+        deleted.
+        """
+        def update_item(**kwargs):
+            if 'ConditionExpression' in kwargs and kwargs['Key']['pk'] != unless_pk:
+                raise ClientError(
+                    {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'gone'}},
+                    'UpdateItem',
+                )
+            return {}
+
+        mock_table.update_item.side_effect = update_item
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The blocking half of the finding: without this, deleting pre-deploy
+        feedback leaves its persona row inflated until the row's TTL expires."""
+        from aggregator.handler import record_handler
+
+        self._refuse(mock_table)
+        item = sample_pre_deploy_feedback_item
+
+        record_handler(_record('REMOVE', old=item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._archetype_pk(item), '2025-01-15', 'count', -1),
+            (self._legacy_pk(item), '2025-01-15', 'count', -1),
+        ], (
+            'a REMOVE of a pre-deploy image must try the archetype row first (the '
+            'shared derivation, so both directions still read one description) and, '
+            'when that is refused because the insert never created it, bring down '
+            'the row the insert really did create.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_pre_deploy_image_with_no_name_either_falls_back_to_the_old_default(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The old derivation's empty bucket was a bespoke `Unknown`, which is where
+        99.97% of the corpus went — so it is the row most pre-deploy deletes have to
+        bring down, and it is spelled the OLD way on purpose: this names rows that
+        already exist, not a value anything writes fresh."""
+        from aggregator.handler import (
+            LEGACY_PERSONA_UNKNOWN,
+            PERSONA_PREFIX,
+            record_handler,
+        )
+
+        self._refuse(mock_table)
+        nameless = {k: v for k, v in sample_pre_deploy_feedback_item.items()
+                    if k != 'persona_name'}
+
+        record_handler(_record('REMOVE', old=nameless))
+
+        assert (f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', '2025-01-15', 'count', -1) \
+            in self._persona_writes(mock_table)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_post_deploy_image_does_not_touch_the_legacy_row(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        """The POSITIVE CONTROL, and the reason the trigger is the REFUSAL.
+
+        This image carries an archetype, so its insert created the archetype row —
+        and here that decrement LANDS, so nothing else may be written. Without this,
+        a fallback that fired on every reversal would pass the test above while
+        double-counting every ordinary delete against a legacy row.
+        """
+        from aggregator.handler import record_handler
+
+        item = sample_anonymous_feedback_item
+
+        record_handler(_record('REMOVE', old=item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._archetype_pk(item), '2025-01-15', 'count', -1)
+        ]
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_post_deploy_image_whose_row_is_gone_writes_nothing_more(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        """The narrow case where the two derivations agree, so there is nothing to
+        fall back TO.
+
+        An item carrying an archetype and no name derives `unknown` from the old
+        field too — but its archetype is `churn_risk`, so the two differ and the
+        fallback would fire. What must NOT happen is a second decrement of one row
+        for one deletion when they coincide, which is the case below.
+        """
+        from aggregator.handler import PERSONA_FIELD, PERSONA_UNKNOWN, record_handler
+
+        self._refuse(mock_table)
+        # Neither field: today's derivation says `unknown`, the old one says
+        # `Unknown`. Give it the archetype the old default would produce, so both
+        # name ONE row.
+        coincident = {**sample_anonymous_feedback_item,
+                      PERSONA_FIELD: 'Unknown', 'persona_name': 'Unknown'}
+        assert PERSONA_UNKNOWN != 'Unknown', (
+            'this arrangement depends on the two empty-bucket spellings differing; '
+            'if they are unified the fallback is unnecessary, not merely untested'
+        )
+
+        record_handler(_record('REMOVE', old=coincident))
+
+        writes = self._persona_writes(mock_table)
+        assert len(writes) == 1, (
+            f'{writes}: when both derivations name one row, one deletion must not '
+            f'decrement it twice.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_insert_never_writes_the_legacy_bucket(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The fallback is REVERSAL-ONLY. A dual-read on the increment path would
+        make the axis permanently two-sourced to serve a path with a sunset date."""
+        from aggregator.handler import record_handler
+
+        item = sample_pre_deploy_feedback_item
+
+        record_handler(_record('INSERT', new=item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._archetype_pk(item), '2025-01-15', 'count', 1)
+        ], (
+            'an arriving item is counted by the archetype axis and nothing else — '
+            'including an item that happens to carry only a name, which counts as '
+            'unclassified rather than under its name.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_the_fallback_lands_on_the_day_the_refusal_concerned(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The date is read out of the refused KEY, not re-derived.
+
+        A follow-up write that recomputed the day could land on another one, which is
+        the failure `_image_date_or_none` exists to prevent elsewhere in this module:
+        no ConditionExpression can catch a `-1` aimed at the wrong day, because that
+        row exists and is above the floor.
+        """
+        from aggregator.handler import record_handler
+
+        self._refuse(mock_table)
+        item = {**sample_pre_deploy_feedback_item, 'date': '2024-11-02'}
+
+        record_handler(_record('REMOVE', old=item))
+
+        days = {sk for pk, sk, _, _ in self._persona_writes(mock_table)}
+        assert days == {'2024-11-02'}, days
+
+    def test_the_fallback_cannot_resurrect_an_aged_out_legacy_row(
+        self, real_aggregates_table
+    ):
+        """Moto-backed of necessity: a mock cannot refuse a write.
+
+        The legacy row may have aged out too — it carries the same 90-day TTL — and
+        the compatibility must not create it holding `-1` any more than the ordinary
+        decrement may. It is one `update_counter` call, so it inherits that
+        condition; this asserts the inheritance rather than assuming it.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old={
+            'date': '2025-01-15', 'source_platform': 'webscraper',
+            'category': 'delivery', 'sentiment_label': 'neutral', 'urgency': 'low',
+            'persona_name': 'Veronica Chen',
+        }))
+
+        assert real_aggregates_table.scan()['Items'] == [], (
+            'every write of this reversal — the archetype decrement and the legacy '
+            'fallback alike — is conditional, so a day whose rows have expired must '
+            'come out of it with no rows at all.'
+        )
+
+    def test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too(
+        self, live_day_table, sample_pre_deploy_feedback_item
+    ):
+        """MODIFY's decrement half reads an old image as well.
+
+        Reached only by an edit that CHANGES the archetype (or the date): an edit
+        leaving `persona_type` alone cancels in the symmetric difference and issues
+        no persona write, so there is nothing to be refused — which is why the plain
+        `test_a_changed_category_moves_the_count` does not see this.
+        """
+        from aggregator.handler import record_handler
+
+        self._refuse(live_day_table, unless_pk='METRIC#daily_total')
+        old = sample_pre_deploy_feedback_item
+        new = {**old, 'persona_type': 'advocate'}
+
+        record_handler(_record('MODIFY', old=old, new=new))
+
+        writes = self._persona_writes(live_day_table)
+        assert (self._legacy_pk(old), '2025-01-15', 'count', -1) in writes, (
+            f'{writes}: an edit to a pre-deploy item must bring down the row its '
+            f'insert created, for the same reason its deletion must.'
+        )
+        assert (self._archetype_pk(new), '2025-01-15', 'count', 1) in writes, (
+            'and still count it under its new archetype — the increment path is '
+            'untouched by the compatibility.'
+        )
 
 
 class TestAReversalRefusesToGuessTheDay:

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -1509,8 +1509,10 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         # satisfied by the archetype decrement on its own, so this test used to pass
         # with the fallback deleted outright. The count is what makes it about the
         # follow-up write at all.
-        assert len(writes) == 2, f'{writes}: expected the archetype decrement and the '\
-                                 f'legacy follow-up, not one of them'
+        assert len(writes) == 2, (
+            f'{writes}: expected the archetype decrement and the legacy follow-up, '
+            f'not one of them'
+        )
         assert {sk for _, sk, _, _ in writes} == {'2024-11-02'}, writes
 
     @patch('aggregator.handler.aggregates_table')

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -201,6 +201,7 @@ reason:
     tests that delete without one.
 """
 import boto3
+import itertools
 import pytest
 from botocore.exceptions import ClientError
 from collections.abc import Mapping
@@ -2011,7 +2012,7 @@ class TestOneItemOwesOneLegacyDecrement:
         self._seed(real_aggregates_table, busy=False)
         walk = ['churn_risk', 'prospect', 'advocate', 'churn_risk']
 
-        for old, new in zip(walk, walk[1:]):
+        for old, new in itertools.pairwise(walk):
             process_modified_feedback(self._anonymous_pre_deploy(old),
                                       self._anonymous_pre_deploy(new))
 
@@ -2027,7 +2028,10 @@ class TestOneItemOwesOneLegacyDecrement:
         `apply_feedback`), so a bound that held only inside one of them would pass the
         test above.
         """
-        from aggregator.handler import process_deleted_feedback, process_modified_feedback
+        from aggregator.handler import (
+            process_deleted_feedback,
+            process_modified_feedback,
+        )
 
         self._seed(real_aggregates_table, busy=False)
 
@@ -2068,7 +2072,10 @@ class TestOneItemOwesOneLegacyDecrement:
         alike. The legacy row is left inflated to age out on its TTL. Asserted over all
         three arrangements at once, because on a busy day they are one observable.
         """
-        from aggregator.handler import process_deleted_feedback, process_modified_feedback
+        from aggregator.handler import (
+            process_deleted_feedback,
+            process_modified_feedback,
+        )
 
         self._seed(real_aggregates_table, busy=True)
 

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -52,11 +52,19 @@ decisions inside it that a naive implementation gets wrong. The revert map:
     — the persona axis buckets by `persona_type` (the archetype), not by
       `persona_name`: a null name is correct output for anonymous feedback, which is
       most of this corpus, so the name-based axis put 99.97% of it in one `Unknown`
-      bucket. Pointing `PERSONA_FIELD` back at `persona_name` fails
-      `test_an_anonymous_items_insert_writes_the_bucket_counter_dimensions_names`
-      and its delete counterpart — the subject item carries an archetype and NO
-      name, the production shape. Naming the bucket in a second place instead of
-      through `counter_dimensions` fails
+      bucket. ⚠️ NOT CAUGHT BY THIS CLASS, and an earlier version of this map
+      claimed it was: pointing `PERSONA_FIELD` back at `persona_name` fails ELEVEN
+      tests and NONE of them are here. `_expected_persona_pk` derives the expected
+      pk by calling `counter_dimensions` — the code under test — so moving the field
+      moves both sides of the assertion together. That is deliberate and is what
+      lets the class catch a SECOND derivation, but it is exactly what makes it
+      unable to catch a WRONG one. The field move is caught by
+      `test_persona_field_lockstep.py::TestTheAxisMeasuresTheArchetype::test_an_item_with_an_archetype_and_no_name_buckets_under_its_archetype`,
+      by `TestProcessNewFeedback::test_updates_persona_counter`, and by five tests
+      in `api/test/test_persona_dimension_lockstep.py` — which is the file that
+      compares the two SIDES rather than one side with itself. What this class does
+      catch is naming the bucket in a second place instead of through
+      `counter_dimensions`: that fails
       `test_the_two_directions_name_one_row_and_only_the_sign_differs` as soon as
       the two copies disagree, which is what a half-moved field name is.
 
@@ -70,7 +78,7 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       `ROW_ABSENT` — no counter moved for the bucket — which is a fact about the
       TABLE, so every test there arranges the table rather than the fixture.
       Deleting `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` fails
-      five of these; deleting it in `process_modified_feedback` fails
+      six of these; deleting it in `process_modified_feedback` fails
       `test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too` and
       `test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing`.
       Acting on EITHER refusal instead of only on the absent row fails the three
@@ -1190,11 +1198,15 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     REVERT MAP for this class. Every entry below was RUN against the real source and
     its citations are the tests that really failed, not the ones that ought to have.
       * Delete `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` — fails
-        test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down,
+        six: test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down,
         test_a_pre_deploy_image_with_no_name_either_falls_back_to_the_old_default,
         test_exactly_one_persona_bucket_moves_per_deletion,
-        test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too and
-        test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current.
+        test_a_name_the_closed_axis_can_no_longer_write_is_reversed_not_declined,
+        test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
+        and test_the_fallback_lands_on_the_day_the_decrement_concerned. That last one
+        survived this mutation until review found it: asserting only WHICH DAY the
+        writes landed on was satisfied by the archetype decrement alone, so it now
+        asserts the COUNT as well.
         Not the rebucket test: MODIFY has its own call, and deleting THAT one instead
         fails test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too and,
         in TestEachBehaviourEmitsItsOwnMetric,
@@ -1225,7 +1237,7 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         how the first of them was found to have gone vacuous when the trigger changed.
       * Open the axis again (have `persona_bucket` interpolate `persona_type`
         verbatim) — fails test_the_rows_this_deploy_writes_are_all_in_the_enum,
-        test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too and, outside
+        test_a_name_the_closed_axis_can_no_longer_write_is_reversed_not_declined and, outside
         this file, in api/test/test_persona_dimension_lockstep.py,
         test_an_out_of_contract_archetype_is_counted_as_unclassified — the read path
         buckets by the same derivation, so opening the axis moves both at once.
@@ -1404,8 +1416,10 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         observable. A landed decrement is equally what a PRE-deploy item deleted on a
         day the new axis has already written that bucket looks like — and then the row
         its own insert created is not brought down, and ages out on its 90-day TTL
-        instead. Nothing in the two images tells those cases apart, so closing it needs
-        new stored state; exactly one counter still moves either way
+        instead. Deciding it is possible — `processed_at` is on the old image — and
+        declined: a constant naming the deploy instant misreads an item written just
+        before the deploy and aggregated just after it, and leaves THAT row inflated
+        permanently rather than for 90 days. Either way exactly one counter moves
         (test_exactly_one_persona_bucket_moves_per_deletion). Recorded in `handler.py`
         under `Known residuals`, and this assertion is what would fail if the residual
         were ever closed — a separate test for it would assert the same call twice.
@@ -1490,8 +1504,14 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
 
         record_handler(_record('REMOVE', old=item))
 
-        days = {sk for pk, sk, _, _ in self._persona_writes(mock_table)}
-        assert days == {'2024-11-02'}, days
+        writes = self._persona_writes(mock_table)
+        # BOTH writes, not just the days they landed on: asserting the day alone was
+        # satisfied by the archetype decrement on its own, so this test used to pass
+        # with the fallback deleted outright. The count is what makes it about the
+        # follow-up write at all.
+        assert len(writes) == 2, f'{writes}: expected the archetype decrement and the '\
+                                 f'legacy follow-up, not one of them'
+        assert {sk for _, sk, _, _ in writes} == {'2024-11-02'}, writes
 
     @patch('aggregator.handler.aggregates_table')
     def test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone(
@@ -1697,7 +1717,7 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         )
 
     @patch('aggregator.handler.aggregates_table')
-    def test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too(
+    def test_a_name_the_closed_axis_can_no_longer_write_is_reversed_not_declined(
         self, mock_table, sample_pre_deploy_feedback_item
     ):
         """The half of that collision the guard used to miss, closed at the root.

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -48,6 +48,18 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       `urgency == 'high'` guard fails five tests across three classes, including
       `test_urgency_raised_to_high_adds_the_urgent_count`.
 
+  TestBothDirectionsAgreeOnThePersonaBucket
+    — the persona axis buckets by `persona_type` (the archetype), not by
+      `persona_name`: a null name is correct output for anonymous feedback, which is
+      most of this corpus, so the name-based axis put 99.97% of it in one `Unknown`
+      bucket. Pointing `PERSONA_FIELD` back at `persona_name` fails
+      `test_an_anonymous_items_insert_writes_the_bucket_counter_dimensions_names`
+      and its delete counterpart — the subject item carries an archetype and NO
+      name, the production shape. Naming the bucket in a second place instead of
+      through `counter_dimensions` fails
+      `test_the_two_directions_name_one_row_and_only_the_sign_differs` as soon as
+      the two copies disagree, which is what a half-moved field name is.
+
   TestAReversalRefusesToGuessTheDay
     — `_image_date`'s today-fallback is safe for an arrival and arbitrary for a
       reversal. Having `process_deleted_feedback` or `process_modified_feedback`
@@ -311,7 +323,7 @@ class TestGetMetricType:
         """Returns 'persona' for persona metric pk."""
         from aggregator.handler import get_metric_type
         
-        result = get_metric_type('METRIC#persona#Happy Customer')
+        result = get_metric_type('METRIC#persona#advocate')
         
         assert result == 'persona'
 
@@ -387,7 +399,7 @@ class TestUpdateCounter:
         """Includes metric_type for persona metrics (for GSI)."""
         from aggregator.handler import update_counter
         
-        update_counter('METRIC#persona#Happy Customer', '2025-01-15', 'count')
+        update_counter('METRIC#persona#advocate', '2025-01-15', 'count')
         
         call_kwargs = mock_table.update_item.call_args.kwargs
         assert ':metric_type' in call_kwargs['ExpressionAttributeValues']
@@ -517,13 +529,13 @@ class TestProcessNewFeedback:
     @patch('aggregator.handler.update_average')
     @patch('aggregator.handler.update_counter')
     def test_updates_persona_counter(self, mock_counter, mock_avg, sample_feedback_item):
-        """Updates persona counter."""
+        """Updates the persona counter, under the item's ARCHETYPE."""
         from aggregator.handler import process_new_feedback
-        
+
         process_new_feedback(sample_feedback_item)
-        
+
         calls = mock_counter.call_args_list
-        persona_call = [c for c in calls if 'persona#Happy Customer' in c.args[0]]
+        persona_call = [c for c in calls if 'persona#advocate' in c.args[0]]
         assert len(persona_call) == 1
 
     @patch('aggregator.handler.update_average')
@@ -1027,6 +1039,89 @@ class TestCounterDimensions:
 
         assert counter_dimensions({}) == counter_dimensions({'date': '2025-01-15'})
         assert ('METRIC#daily_source#unknown', 'count') in counter_dimensions({})
+
+
+class TestBothDirectionsAgreeOnThePersonaBucket:
+    """The persona row an insert creates is the row a delete comes back for.
+
+    A dimension read out of the NEW image on the way in and out of the OLD image on
+    the way back is the one place a field name can be changed on half the axis: the
+    increment lands on `METRIC#persona#<new field's value>` while the decrement
+    looks for `METRIC#persona#<old field's value>`, so the counter goes up and never
+    comes down. That is the bug this module was repaired for, and moving the field
+    is exactly the edit that could reintroduce it in this one dimension.
+
+    Both the EXPECTED bucket and the OBSERVED ones are derived — the expectation
+    from `counter_dimensions`, the observations from the writes the handler issued —
+    so nothing here restates the pk, and a second place naming the persona bucket
+    cannot pass by agreeing with a literal in this file.
+
+    The subject is the ANONYMOUS fixture (an archetype, no name), because that is
+    the shape of nearly every item in production and the shape the old field
+    bucketed as `Unknown`.
+    """
+
+    @staticmethod
+    def _expected_persona_pk(item: dict) -> str:
+        from aggregator.handler import counter_dimensions
+
+        personas = [pk for pk, _ in counter_dimensions(item)
+                    if pk.startswith('METRIC#persona#')]
+        assert len(personas) == 1, personas
+        return personas[0]
+
+    @staticmethod
+    def _persona_writes(mock_table) -> list[tuple[str, str, str, int]]:
+        return [w for w in _writes(mock_table) if w[0].startswith('METRIC#persona#')]
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_anonymous_items_insert_writes_the_bucket_counter_dimensions_names(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_anonymous_feedback_item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._expected_persona_pk(sample_anonymous_feedback_item),
+             '2025-01-15', 'count', 1)
+        ]
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_its_delete_decrements_that_same_bucket(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old=sample_anonymous_feedback_item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._expected_persona_pk(sample_anonymous_feedback_item),
+             '2025-01-15', 'count', -1)
+        ]
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_the_two_directions_name_one_row_and_only_the_sign_differs(
+        self, mock_table, sample_anonymous_feedback_item
+    ):
+        """The property, stated without either side being written down.
+
+        Compared as sets of (pk, sk, field) so the assertion is about WHICH row,
+        which is the thing a half-moved field name gets wrong; the signs are checked
+        separately, so a reversal that incremented could not pass either.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('INSERT', new=sample_anonymous_feedback_item))
+        inserted = self._persona_writes(mock_table)
+        mock_table.reset_mock()
+
+        record_handler(_record('REMOVE', old=sample_anonymous_feedback_item))
+        removed = self._persona_writes(mock_table)
+
+        assert _dimensions(inserted) == _dimensions(removed)
+        assert [delta for *_, delta in inserted] == [1]
+        assert [delta for *_, delta in removed] == [-1]
 
 
 class TestAReversalRefusesToGuessTheDay:

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -65,12 +65,18 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       built by the same deployed code. A REMOVE whose INSERT ran before the persona
       axis moved was counted under the OLD derivation's bucket, so a decrement from
       the shared description alone leaves that row inflated for up to 90 days while
-      decrementing an archetype row the item never contributed to. Deleting
-      `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` fails two of
-      these; deleting it in `process_modified_feedback` fails
-      `test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too`. The
-      class's own REVERT MAP has the rest, including two mutations that do NOT fail
-      and why.
+      decrementing an archetype row the item never contributed to. What tells the
+      reversal it is looking at such an item is that archetype decrement reporting
+      `ROW_ABSENT` — no counter moved for the bucket — which is a fact about the
+      TABLE, so every test there arranges the table rather than the fixture.
+      Deleting `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` fails
+      five of these; deleting it in `process_modified_feedback` fails
+      `test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too` and
+      `test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing`.
+      Acting on EITHER refusal instead of only on the absent row fails the three
+      redelivery tests. The class's own REVERT MAP has the rest, including the
+      accepted busy-day residual and three mutations that do NOT fail — one of them
+      a citation this map used to make and could not support.
 
   TestAReversalRefusesToGuessTheDay
     — `_image_date`'s today-fallback is safe for an arrival and arbitrary for a
@@ -1153,75 +1159,89 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     TestADecrementCannotCreateOrGoNegative. The damage this fallback repairs was a
     persistent OVER-count of a legacy row, not a negative one.
 
-    🔑 THE TRIGGER IS THE ITEM'S `processed_at`, AND HALF THIS CLASS IS ABOUT WHY IT
-    IS NOT THE ARCHETYPE ROW'S ABSENCE. Both have been tried. An absent archetype row
-    is sound evidence when it happens — this item's insert created no such row — but
-    it only HAPPENS on a day no post-deploy item has written that bucket, so on the
-    busiest day in the window the decrement simply lands on a row the item never
-    contributed to and the legacy row is never brought down. That is the ordinary
-    cross-deploy state, which made the compatibility effective exactly where the
-    corpus was quiet: test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_
-    already_populated is the case that was silently unfixed, and its positive control
-    beside it is what makes the stamp provably the deciding fact.
+    🔑 THE TRIGGER IS THE ARCHETYPE DECREMENT REPORTING `ROW_ABSENT`, AND NOTHING
+    ABOUT THE ITEM — argued at `_reverse_a_pre_deploy_persona_row`. What follows from
+    it HERE is how every test below is arranged: pre-deploy versus post-deploy is a
+    fact about the TABLE, set with `_refuse`, never a field on a fixture. No fixture in
+    conftest.py says which deploy wrote it, deliberately. That the two refusals are
+    distinguishable at all is an assumption about DynamoDB rather than about this code,
+    so it is checked against a real table by
+    test_a_real_dynamodb_tells_a_row_at_zero_from_a_row_that_is_not_there.
 
-    THE ROW'S OUTCOME IS STILL READ, to rule the fallback OUT rather than in. A
-    decrement refused AT THE FLOOR means the row exists, which is what an
-    already-reversed item looks like on redelivery — so one deletion does not
-    decrement two rows on the strength of a stamp. `CounterWrite` carries that
-    distinction and DynamoDB supplies it.
+    THE ACCEPTED RESIDUAL, recorded here rather than softened: an absent archetype row
+    is available as evidence ONLY on a day no post-deploy item has written that
+    bucket. On a busier day a pre-deploy item's decrement LANDS on the archetype row it
+    never contributed to, the fallback does not fire, and the legacy row it did
+    contribute to stays inflated until its 90-day TTL. That observable is the same one
+    test_a_post_deploy_image_does_not_touch_the_legacy_row asserts — the cases are
+    indistinguishable, which is the residual — so it is pinned there rather than in a
+    test of its own, and `handler.py`'s `Known residuals` says the same. What holds
+    either way is that EXACTLY ONE counter moves per deletion
+    (test_exactly_one_persona_bucket_moves_per_deletion), which is the property the
+    wall-clock trigger this replaced broke: it read a stamp on the item, so it issued a
+    legacy `-1` on top of a decrement that had already landed.
 
-    IT IS ALSO NOT ALLOWED TO NAME A ROW THIS DEPLOY WRITES. `legacy_pk` is built out
-    of a free-text LLM-produced name, so a name equal to a live bucket would aim the
-    `-1` at it for an item counted under a different archetype — and a conditional
-    write cannot catch that, because the row exists and is above the floor.
-    PERSONA_ARCHETYPES refuses it, and that guard is COMPLETE only because
-    `persona_bucket` closed the axis: while `persona_type` reached the pk verbatim, a
-    live `METRIC#persona#loyal` row was reachable and outside the set, so the guard
-    passed it. See test_the_rows_this_deploy_writes_are_all_in_the_enum.
+    The collision guard and the reversal-only confinement are argued where they live,
+    in `_reverse_a_pre_deploy_persona_row` — not restated here. What this class adds is
+    that the guard is COMPLETE only because `persona_bucket` closed the axis, which is
+    a property rather than an instance and so has its own test
+    (test_the_rows_this_deploy_writes_are_all_in_the_enum).
 
-    The fallback is CONFINED to the reversal direction. Reading the old field on the
-    increment path would make the axis permanently dual-sourced to serve a path with
-    a sunset date, which this repo has rejected before; here it changes only which
-    row a `-1` lands on, never which bucket anything is counted in.
-
-    REVERT MAP for this class
+    REVERT MAP for this class. Every entry below was RUN against the real source and
+    its citations are the tests that really failed, not the ones that ought to have.
       * Delete `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` — fails
-        test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down and
-        test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too.
-      * Trigger on the ABSENT ROW rather than on the stamp — i.e. filter to
-        `CounterWrite.ROW_ABSENT` keys and drop
-        `_was_counted_by_the_old_persona_axis` — fails
-        test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_already_populated,
-        the case that made this trigger change, and
-        test_a_landed_decrement_of_a_pre_deploy_item_still_reverses_the_legacy_row.
-      * Drop the stamp check but keep the absent-row filter — the round-2 behaviour —
-        additionally fails
-        test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone.
-      * Stop excluding `REFUSED_AT_FLOOR` keys — fails
-        test_a_redelivered_remove_of_a_pre_deploy_item_does_not_decrement_twice.
-      * Treat an item with no `processed_at` as post-deploy — fails
-        test_an_item_with_no_stamp_is_treated_as_pre_deploy.
-      * Drop the PERSONA_ARCHETYPES guard — fails
-        test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row.
+        test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down,
+        test_a_pre_deploy_image_with_no_name_either_falls_back_to_the_old_default,
+        test_exactly_one_persona_bucket_moves_per_deletion,
+        test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too and
+        test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current.
+        Not the rebucket test: MODIFY has its own call, and deleting THAT one instead
+        fails test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too and,
+        in TestEachBehaviourEmitsItsOwnMetric,
+        test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing.
+      * Widen the gate from `is CounterWrite.ROW_ABSENT` to `is not
+        CounterWrite.LANDED`, i.e. act on EITHER refusal — fails
+        test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone,
+        test_a_redelivered_remove_of_an_anonymous_item_does_not_drain_the_legacy_default
+        and test_a_redelivered_remove_of_a_pre_deploy_item_does_not_decrement_twice.
+        Those three are the redelivered-REMOVE shape, which is the only place the two
+        refusals differ observably.
+      * Drop the outcome condition from the gate entirely, firing for every persona
+        key — fails eight, in three classes: the three above, plus
+        test_a_post_deploy_image_does_not_touch_the_legacy_row,
+        test_exactly_one_persona_bucket_moves_per_deletion,
+        TestADeleteReversesExactlyWhatTheInsertAdded's
+        test_the_reversed_dimensions_are_exactly_the_incremented_ones, and both of
+        TestBothDirectionsAgreeOnThePersonaBucket's shared-derivation tests
+        (test_its_delete_decrements_that_same_bucket,
+        test_the_two_directions_name_one_row_and_only_the_sign_differs). A
+        compatibility that fires unconditionally is not a compatibility, and it stops
+        being a fact about ONE axis.
+      * Drop the PERSONA_ARCHETYPES collision guard — fails
+        test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row and
+        test_one_deletion_never_decrements_one_row_twice. Both need the archetype row
+        arranged ABSENT to reach the guard at all; without that `_refuse` in the
+        arrangement the gate returns early and this mutation fails nothing, which is
+        how the first of them was found to have gone vacuous when the trigger changed.
       * Open the axis again (have `persona_bucket` interpolate `persona_type`
-        verbatim) — fails test_the_rows_this_deploy_writes_are_all_in_the_enum and
-        test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too.
-      * Run it for a POST-deploy image at all — that is what
-        test_a_post_deploy_image_does_not_touch_the_legacy_row is the positive control
-        against.
-      * Make the axis dual-SOURCED on the way in
-        (`item.get(PERSONA_FIELD) or item.get(LEGACY_PERSONA_FIELD) or ...` in
-        `persona_bucket`) — fails
-        test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down here and
-        test_a_name_alone_does_not_decide_the_bucket in
-        test_persona_field_lockstep.py. That is the shape this change is careful NOT
-        to be, so it is worth a named failure.
-      * Have it write unconditionally (increment=-1 with no floor, i.e. dropping
-        `update_counter`'s condition) — fails
-        test_the_fallback_cannot_resurrect_an_aged_out_legacy_row, which is
-        moto-backed of necessity: a mock cannot refuse a write.
-      * Classify an unreadable refusal as ROW_ABSENT — fails
-        test_an_unreadable_refusal_is_not_evidence_that_a_row_was_absent.
+        verbatim) — fails test_the_rows_this_deploy_writes_are_all_in_the_enum,
+        test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too and, outside
+        this file, in api/test/test_persona_dimension_lockstep.py,
+        test_an_out_of_contract_archetype_is_counted_as_unclassified — the read path
+        buckets by the same derivation, so opening the axis moves both at once.
+      * Have `update_counter` classify an unreadable refusal as `ROW_ABSENT` instead of
+        `REFUSED_AT_FLOOR` — fails
+        test_an_unreadable_refusal_is_not_evidence_that_a_row_was_absent, and only
+        that: it is the fail direction of the one conclusion carrying a write.
+      * Drop `ReturnValuesOnConditionCheckFailure='ALL_OLD'` from `update_counter` —
+        fails test_a_real_dynamodb_tells_a_row_at_zero_from_a_row_that_is_not_there,
+        and only that, because it is the only test that asks a real table which
+        refusal it gave. Every mocked refusal in this class is hand-built, so the
+        mutation is invisible to all of them — which is exactly why that test exists.
+      * Drop `update_counter`'s decrement ConditionExpression — fails 16 across five
+        classes, of which this one's is
+        test_the_fallback_cannot_resurrect_an_aged_out_legacy_row: the compatibility is
+        one `update_counter` call and inherits the condition rather than restating it.
 
     WHY THE TRIGGER IS NOT THE ITEM'S PERSONA SHAPE, recorded because it is the fix
     that suggests itself and does not work: "no `persona_type`, but a `persona_name`"
@@ -1232,23 +1252,34 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     exists for. A shape test would therefore be silently inert for the majority of the
     corpus while looking like a tightening;
     test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
-    is the case that fails under it, and it is arranged as the SAME item as the
-    ordinary post-deploy fixture but for its stamp.
+    is the case that fails under it, and its subject is the ORDINARY post-deploy
+    fixture — the same item, reversed on the strength of the table alone.
 
     MUTATIONS THAT DO NOT FAIL ANYTHING, run and recorded rather than asserted into
     existence, because a REVERT MAP is only worth what its citations are:
       * `if sign < 0` → `if True` in `apply_feedback`: passes. An increment carries no
-        ConditionExpression and creates the row it names, so its outcome is always
-        LANDED on the row today's derivation names — and the fallback would then fire
-        for a pre-deploy image's INSERT, except that a stream INSERT of a pre-deploy
-        item cannot occur (its insert is what predates the deploy). The guard STATES
-        that the compatibility is reversal-only rather than depending on it.
-      * reading the date from `_image_date(item)` instead of out of the key: passes,
-        because for one reversal every key carries the very date `counter_keys` was
-        given. Reading it out of the key is structural rather than observable: it makes
-        it impossible for a future caller to hand this function keys from one day and
-        an item naming another, which is the failure `_image_date_or_none` exists to
-        prevent elsewhere in this module and which no ConditionExpression can catch.
+        ConditionExpression, so it can only ever report LANDED and the gate finds no
+        `ROW_ABSENT` key to act on — the guard STATES that the compatibility is
+        reversal-only rather than being what makes it so. (It was a no-op under the
+        previous wall-clock trigger too, for a weaker reason: that one relied on a
+        stream INSERT of a pre-deploy item being impossible.)
+      * MAKING THE AXIS DUAL-SOURCED — `item.get(PERSONA_FIELD) or
+        item.get('persona_name') or PERSONA_UNKNOWN` in `persona_bucket`: passes, and
+        this one is a finding rather than a formality. An earlier version of this map
+        claimed it failed two named tests; it does not. The membership filter absorbs
+        it — a free-text name is not a member of PERSONA_ARCHETYPES, so it buckets as
+        the empty value exactly as an absent field does, and every fixture and
+        assertion here uses names like `Veronica Chen`. The mutation is observable only
+        for a `persona_name` that happens to BE an archetype value with no
+        `persona_type` beside it, a shape nothing in this repo pins. Closing the axis
+        made the dual-read harmless, which is worth knowing, but it also means the
+        shape this change is careful not to be is NOT held off by a failing test.
+      * Reading the day from `_image_date(item)` instead of out of the counter key:
+        passes, because for one reversal every key carries the very date `counter_keys`
+        was given. Reading it out of the key is structural rather than observable — it
+        makes it impossible for a future caller to hand this function keys from one day
+        and an item naming another, the failure `_image_date_or_none` exists to prevent
+        elsewhere and which no ConditionExpression can catch.
         test_the_fallback_lands_on_the_day_the_decrement_concerned therefore pins the
         OUTCOME (both writes on the item's own day) rather than the mechanism.
     """
@@ -1361,13 +1392,23 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     def test_a_post_deploy_image_does_not_touch_the_legacy_row(
         self, mock_table, sample_anonymous_feedback_item
     ):
-        """The POSITIVE CONTROL for the whole class.
+        """The POSITIVE CONTROL for the whole class — and the residual, in one call.
 
-        This image was PROCESSED after the axis moved, so its insert used today's
-        derivation and there is no legacy row to bring down. Its archetype decrement
-        lands and nothing else may be written. Without this, a fallback that fired on
-        every reversal would pass the tests above while double-counting every ordinary
-        delete against a legacy row.
+        Nothing is refused, so the archetype decrement LANDS, which is what an item
+        this deploy counted looks like: a counter for that bucket has already come
+        down and no legacy row is owed a second one. Without this, a fallback that
+        fired on every reversal would pass every test above while double-counting
+        every ordinary delete against a legacy row.
+
+        🔑 IT IS ALSO THE ACCEPTED BUSY-DAY RESIDUAL, because the two are one
+        observable. A landed decrement is equally what a PRE-deploy item deleted on a
+        day the new axis has already written that bucket looks like — and then the row
+        its own insert created is not brought down, and ages out on its 90-day TTL
+        instead. Nothing in the two images tells those cases apart, so closing it needs
+        new stored state; exactly one counter still moves either way
+        (test_exactly_one_persona_bucket_moves_per_deletion). Recorded in `handler.py`
+        under `Known residuals`, and this assertion is what would fail if the residual
+        were ever closed — a separate test for it would assert the same call twice.
         """
         from aggregator.handler import record_handler
 
@@ -1460,10 +1501,9 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
 
         Streams are at-least-once, so a REMOVE is redelivered after its counters have
         already come down — and the archetype row then sits at ZERO, where the floor
-        refuses the second decrement. This item's stamp already says it was processed
-        after the move, so the fallback is out on that ground alone; the arrangement
-        also refuses at the floor so that a version triggering on ANY refusal (the
-        round-2 behaviour) fails here too.
+        refuses the second decrement. A refusal is two facts, and only "there was no
+        such row" is evidence of a pre-deploy insert: a version triggering on ANY
+        refusal fails here, which is what this arrangement is for.
         """
         from aggregator.handler import record_handler
 
@@ -1514,14 +1554,15 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     def test_a_redelivered_remove_of_a_pre_deploy_item_does_not_decrement_twice(
         self, mock_table, sample_pre_deploy_feedback_item
     ):
-        """The stamp says pre-deploy, and the row's outcome still rules it out.
+        """The ROW'S OUTCOME is the only evidence, and here it rules the fallback OUT.
 
-        A REMOVE redelivered after the legacy row has already come down finds the
-        ARCHETYPE row refused at the floor — the row exists, so something counted this
-        item there and the reversal is not owed a second write. Without the
-        `REFUSED_AT_FLOOR` exclusion the stamp alone would issue one, and every
-        redelivery of a pre-deploy REMOVE would drain the legacy row again on a day the
-        archetype row happened to exist at zero.
+        A REMOVE redelivered after this item's counters have already come down finds the
+        ARCHETYPE row refused AT THE FLOOR — and a row refused at the floor EXISTS,
+        which is a counter for that bucket already holding this item. One deletion owes
+        one `-1`, so no legacy write is due, however pre-deploy the image looks: this
+        one carries a name and no archetype, the shape most readily mistaken for a
+        trigger. Excluding `REFUSED_AT_FLOOR` alongside `LANDED` is the whole of what
+        keeps a redelivery from draining the legacy row again.
         """
         from aggregator.handler import record_handler
 
@@ -1536,101 +1577,56 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         )
 
     @patch('aggregator.handler.aggregates_table')
-    def test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_already_populated(
-        self, mock_table, sample_pre_deploy_anonymous_feedback_item
+    def test_exactly_one_persona_bucket_moves_per_deletion(
+        self, mock_table, sample_pre_deploy_feedback_item, sample_anonymous_feedback_item
     ):
-        """🔑 THE BUSY-DAY CASE, and the reason the trigger is the stamp.
+        """🔑 THE PROPERTY THE WALL-CLOCK TRIGGER BROKE, stated on its own.
 
-        Post-deploy ingestion populates `METRIC#persona#churn_risk` for the day, so
-        this pre-deploy item's archetype decrement LANDS — on a row it never
-        contributed to — and no refusal is produced at all. A trigger reading the
-        archetype row's ABSENCE therefore never fires, leaving the legacy row inflated
-        exactly on the days the corpus is busiest. Review demonstrated that against
-        moto; this is it as a test.
+        An item was counted in exactly ONE persona bucket, so exactly one persona
+        counter may move when it is deleted — whichever side of the deploy its insert
+        fell on. The trigger that read a stamp off the item lost this: it issued a
+        legacy `-1` on top of an archetype decrement that had already landed, so one
+        deletion took two counts off the axis. Reading the archetype row's outcome
+        instead makes the two mutually exclusive by construction, and this is that
+        exclusivity asserted over both arrangements rather than inferred from either.
 
-        Every conditional write is allowed to land here, which is what makes the point:
-        there is no refusal in this scenario for a row-based trigger to read.
-        """
-        from aggregator.handler import (
-            LEGACY_PERSONA_UNKNOWN,
-            PERSONA_PREFIX,
-            record_handler,
-        )
-
-        item = sample_pre_deploy_anonymous_feedback_item
-
-        record_handler(_record('REMOVE', old=item))
-
-        assert self._persona_writes(mock_table) == [
-            (self._archetype_pk(item), '2025-01-15', 'count', -1),
-            (f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', '2025-01-15', 'count', -1),
-        ], (
-            'a pre-deploy item deleted on a day the new axis has already populated '
-            'must still bring down the row its own insert created. Nothing about that '
-            'day distinguishes it, so only the item can.'
-        )
-
-    @patch('aggregator.handler.aggregates_table')
-    def test_a_landed_decrement_of_a_pre_deploy_item_still_reverses_the_legacy_row(
-        self, mock_table, sample_pre_deploy_feedback_item
-    ):
-        """The same property in the shape where the two rows are distinguishable.
-
-        The item above is anonymous, so its legacy row is the shared `Unknown` default;
-        this one carries a name, so the legacy row is its own — which shows the write
-        is aimed at the row THIS item's insert created rather than at a default that
-        happens to be there.
+        LANDED writes, not attempted ones: a refused `update_item` is still a call on
+        the table, so `_persona_writes` sees it. What did not land is what `_refuse`
+        was told to refuse, which is why the arrangement carries the pk allowed through.
         """
         from aggregator.handler import record_handler
 
-        item = sample_pre_deploy_feedback_item
+        pre_deploy, post_deploy = (sample_pre_deploy_feedback_item,
+                                   sample_anonymous_feedback_item)
+        # (what the arrangement is, the old image, the pk a conditional write may land
+        # on — None meaning nothing is refused, so every write lands.)
+        arrangements = [
+            # The archetype row this item's insert never created is ABSENT, so that
+            # decrement moves nothing and the compatibility brings down the row the
+            # insert did create.
+            ('PRE-DEPLOY, on a quiet day', pre_deploy, self._legacy_pk(pre_deploy)),
+            # The archetype row is there, so its decrement lands and the gate is never
+            # reached: no legacy write is attempted at all.
+            ('POST-DEPLOY', post_deploy, None),
+        ]
 
-        record_handler(_record('REMOVE', old=item))
+        for what, item, may_land in arrangements:
+            mock_table.reset_mock()
+            if may_land is None:
+                mock_table.update_item.side_effect = None
+            else:
+                self._refuse(mock_table, unless_pk=may_land)
 
-        assert (self._legacy_pk(item), '2025-01-15', 'count', -1) \
-            in self._persona_writes(mock_table)
+            record_handler(_record('REMOVE', old=item))
 
-    @patch('aggregator.handler.aggregates_table')
-    def test_an_item_with_no_stamp_is_treated_as_pre_deploy(self, mock_table):
-        """No `processed_at` means legacy or hand-written, so it fails that way.
-
-        The processor has always written the stamp, so an item without one predates it
-        — and the cost of being wrong is bounded: the follow-up write is conditional
-        and the collision guard already refuses every row this deploy could have
-        written, so a false pre-deploy reading costs at most one refused write.
-        """
-        from aggregator.handler import LEGACY_PERSONA_STAMP_FIELD, record_handler
-
-        unstamped = {
-            'date': '2025-01-15', 'source_platform': 'webscraper',
-            'category': 'delivery', 'sentiment_label': 'neutral', 'urgency': 'low',
-            'persona_name': 'Veronica Chen', 'persona_type': 'advocate',
-        }
-        assert LEGACY_PERSONA_STAMP_FIELD not in unstamped
-
-        record_handler(_record('REMOVE', old=unstamped))
-
-        assert (self._legacy_pk(unstamped), '2025-01-15', 'count', -1) \
-            in self._persona_writes(mock_table)
-
-    @patch('aggregator.handler.aggregates_table')
-    def test_an_unreadable_stamp_is_treated_as_pre_deploy_too(self, mock_table):
-        """A stamp that cannot be parsed is no evidence, so it fails the same way.
-
-        Reached by a hand-written row, or by any writer using another format. Warned
-        about rather than silent, because a stamp nothing can read makes the
-        compatibility fire for every such item indefinitely.
-        """
-        from aggregator.handler import record_handler
-
-        record_handler(_record('REMOVE', old={
-            'date': '2025-01-15', 'source_platform': 'webscraper',
-            'category': 'delivery', 'sentiment_label': 'neutral', 'urgency': 'low',
-            'persona_name': 'Veronica Chen', 'processed_at': 'last Tuesday',
-        }))
-
-        written = [pk for pk, *_ in self._persona_writes(mock_table)]
-        assert self._legacy_pk({'persona_name': 'Veronica Chen'}) in written, written
+            attempted = self._persona_writes(mock_table)
+            landed = [w for w in attempted if may_land is None or w[0] == may_land]
+            assert len(landed) == 1, (
+                f'{what}: persona writes attempted {attempted}, of which {landed} '
+                f'landed. The item was counted in exactly one persona bucket, so '
+                f'exactly one counter may move for its deletion.'
+            )
+            assert landed[0][3] == -1, landed
 
     def test_the_rows_this_deploy_writes_are_all_in_the_enum(self):
         """What makes the collision guard COMPLETE rather than partial.
@@ -1680,6 +1676,10 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
             record_handler,
         )
 
+        # The archetype row absent, so the fallback is REACHED and the guard is what
+        # stops it. Without this the decrement lands, the gate returns early, and this
+        # test would pass with the collision guard deleted.
+        self._refuse(mock_table)
         colliding = {**sample_pre_deploy_feedback_item,
                      'persona_name': 'unknown', 'persona_type': 'advocate'}
         assert 'unknown' in PERSONA_ARCHETYPES, (
@@ -1714,6 +1714,9 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         """
         from aggregator.handler import PERSONA_PREFIX, record_handler
 
+        # As above: the archetype row has to be absent for the fallback to be reached
+        # at all, which is what makes the assertion below about the guard.
+        self._refuse(mock_table)
         item = {**sample_pre_deploy_feedback_item,
                 'persona_name': 'loyal', 'persona_type': 'loyal'}
 
@@ -1757,43 +1760,45 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
 
     @patch('aggregator.handler.aggregates_table')
     def test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current(
-        self, mock_table, sample_pre_deploy_anonymous_feedback_item,
-        sample_anonymous_feedback_item
+        self, mock_table, sample_anonymous_feedback_item
     ):
         """The 99.97% case, and the reason the trigger cannot be the item's SHAPE.
 
-        `processor/handler.py` has written both persona fields since the initial
-        commit, so the axis move changed only the reader: a pre-deploy anonymous item
-        carries a `persona_type` and no name, which is byte-identical to a post-deploy
-        one apart from its stamp. A shape test
-        (`PERSONA_FIELD not in item and LEGACY_PERSONA_FIELD in item`) would fail
-        this, which is what makes it worth pinning: it looks like a tightening and
-        would silently switch the compatibility off for the majority of the corpus it
-        exists for.
+        `processor/handler.py` has written both persona fields since the initial commit,
+        so the axis move changed only the READER: a pre-deploy anonymous item carries a
+        `persona_type` and no name, which is byte-identical to a post-deploy one — the
+        subject here IS the ordinary post-deploy fixture, and its insert nonetheless
+        counted it under the old default bucket if it ran before the move. So "no
+        `persona_type` but a `persona_name`" is NOT the pre-deploy shape, and a shape
+        test (`PERSONA_FIELD not in item and LEGACY_PERSONA_FIELD in item`) would fail
+        this: it looks like a tightening while switching the compatibility off for the
+        majority of the corpus it exists for.
+
+        What decides instead is a fact about the TABLE — the archetype row is arranged
+        ABSENT — which the item's shape cannot contradict.
         """
         from aggregator.handler import (
-            LEGACY_PERSONA_STAMP_FIELD,
+            LEGACY_PERSONA_FIELD,
             LEGACY_PERSONA_UNKNOWN,
             PERSONA_PREFIX,
             record_handler,
         )
 
         self._refuse(mock_table)
-        item = sample_pre_deploy_anonymous_feedback_item
-        assert {k: v for k, v in item.items() if k != LEGACY_PERSONA_STAMP_FIELD} == \
-            {k: v for k, v in sample_anonymous_feedback_item.items()
-             if k != LEGACY_PERSONA_STAMP_FIELD}, (
-            'the arrangement is the point: this item must differ from the ordinary '
-            f'post-deploy one in `{LEGACY_PERSONA_STAMP_FIELD}` and NOTHING else, or '
-            'it does not show that the stamp is what decides'
+        item = sample_anonymous_feedback_item
+        assert LEGACY_PERSONA_FIELD not in item and item.get('persona_type'), (
+            'the arrangement is the point: the subject must look exactly like an item '
+            f'this deploy wrote — an archetype and no `{LEGACY_PERSONA_FIELD}` — or it '
+            'does not show that the shape is not what decides'
         )
 
         record_handler(_record('REMOVE', old=item))
 
         assert (f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', '2025-01-15', 'count', -1) \
             in self._persona_writes(mock_table), (
-            'an anonymous item deleted after the deploy must bring down the old '
-            'default bucket its insert really incremented.'
+            'an anonymous item whose archetype row was never created must bring down '
+            'the old default bucket its insert really incremented — the single row that '
+            'held ~99.97% of the pre-deploy corpus.'
         )
 
     def test_the_fallback_cannot_resurrect_an_aged_out_legacy_row(

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -1241,6 +1241,14 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         this file, in api/test/test_persona_dimension_lockstep.py,
         test_an_out_of_contract_archetype_is_counted_as_unclassified — the read path
         buckets by the same derivation, so opening the axis moves both at once.
+      * Trigger on the ITEM rather than on the row's outcome — any per-item test, a
+        `processed_at` stamp or a persona SHAPE, reduces here to "act unless refused at
+        the floor" — fails three in TestOneItemOwesOneLegacyDecrement:
+        test_three_successive_edits_of_one_item_drain_the_legacy_row_once,
+        test_an_edit_then_the_delete_drain_it_once and
+        test_a_busy_day_does_not_drain_the_legacy_row_at_all. That class is where the
+        per-ITEM bound lives; review measured 3 and 2 drains for those first two
+        arrangements under the wall-clock trigger this replaced.
       * Have `update_counter` classify an unreadable refusal as `ROW_ABSENT` instead of
         `REFUSED_AT_FLOOR` — fails
         test_an_unreadable_refusal_is_not_evidence_that_a_row_was_absent, and only
@@ -1902,6 +1910,176 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         assert (self._archetype_pk(new), '2025-01-15', 'count', 1) in writes, (
             'and still count it under its new archetype — the increment path is '
             'untouched by the compatibility.'
+        )
+
+
+class TestOneItemOwesOneLegacyDecrement:
+    """🔑 THE DEBT IS PER-ITEM; THE COMPATIBILITY FIRES PER EVENT. How many times can
+    one pre-deploy item drain the legacy row?
+
+    A pre-deploy item contributed exactly `1` to exactly one legacy row, so at most one
+    `-1` is ever owed for it — while `_reverse_a_pre_deploy_persona_row` runs on every
+    reversal, and one item can be reversed many times: each edit that changes its
+    archetype or its date, its eventual delete, and every stream redelivery of any of
+    those.
+
+    Raised in review against the WALL-CLOCK trigger, where the answer was N drains for
+    N events (the stamp is immutable, so every reversal re-read it as pre-deploy and
+    issued another `-1`). It is the property that made "self-limiting" true, so it is
+    measured here rather than argued: all moto-backed, because the answer is DynamoDB's
+    — whether the archetype row exists after the previous event is the whole mechanism.
+
+    🔑 THE ABSENT-ROW TRIGGER BOUNDS THE LEGITIMATE CASES BY CONSTRUCTION, and that is
+    the strongest argument for it. The first reversal's INCREMENT creates the archetype
+    row for the item's new bucket, so every later decrement of that row LANDS, and a
+    landed decrement never reaches the fallback. Nothing was added to get this: it falls
+    out of triggering on "no counter moved" instead of on a fact about the item.
+
+    ⚠️ REDELIVERY IS NOT BOUNDED, and is accepted rather than fixed. A REMOVE redelivered
+    N times issues N legacy decrements, because a refused decrement creates nothing — so
+    the archetype row is still absent on the second delivery and the evidence is
+    unchanged. That is the module's general at-least-once residual (see
+    TestRedeliveryMovesACounterTwice: a redelivered REMOVE double-decrements EVERY
+    counter this module writes, and closing it means routing `eventID` through
+    `shared/idempotency.py`, a CDK change as well as a code one). Fixing it for this one
+    row and no other would be a special case of a module-wide residual.
+
+    ⚠️ AND THE HONEST COST, which an earlier docstring understated by calling it "toward
+    the truth": that is only so for the FIRST drain of each item. Once the legacy row
+    holds the count its remaining pre-deploy items justify, another redelivered `-1`
+    makes it UNDERSTATE — and it is a row `/metrics/personas` still serves for any
+    window overlapping the move. Bounded below by the floor, never negative.
+
+    REVERT MAP
+      * Trigger on the item instead of on the row's outcome (any per-item test: a
+        stamp, a shape) — fails
+        test_three_successive_edits_of_one_item_drain_the_legacy_row_once and
+        test_an_edit_then_the_delete_drain_it_once, which is exactly what review
+        measured at 3 and 2 drains before the trigger moved.
+      * Fire on `LANDED` as well — fails both of those and
+        test_a_busy_day_does_not_drain_the_legacy_row_at_all.
+    """
+
+    DAY = '2025-01-15'
+    LEGACY_PK = 'METRIC#persona#Unknown'
+
+    @staticmethod
+    def _anonymous_pre_deploy(persona_type: str) -> dict:
+        """The 99.97% pre-deploy shape: an archetype, NO name, so its insert counted it
+        under the old bespoke default. Built here rather than from the conftest fixture
+        because these tests walk `persona_type` through several values."""
+        return {
+            'pk': 'SOURCE#webscraper', 'sk': 'FEEDBACK#anon1', 'feedback_id': 'anon1',
+            'date': '2025-01-15', 'source_platform': 'webscraper',
+            'category': 'delivery', 'sentiment_label': 'neutral', 'urgency': 'low',
+            'persona_type': persona_type,
+        }
+
+    @classmethod
+    def _seed(cls, table, *, busy: bool):
+        from aggregator.handler import PERSONA_ARCHETYPES
+
+        # `daily_total` is the sentinel `_day_has_aggregates` reads, so seeding it is
+        # what makes the day LIVE and lets a rebucket proceed at all.
+        table.put_item(Item={'pk': 'METRIC#daily_total', 'sk': cls.DAY,
+                             'count': Decimal(100)})
+        table.put_item(Item={'pk': cls.LEGACY_PK, 'sk': cls.DAY, 'count': Decimal(6000)})
+        if busy:
+            # A post-deploy item has already written every archetype bucket for the day,
+            # which is the state that makes the absent row unavailable as evidence.
+            for archetype in PERSONA_ARCHETYPES:
+                table.put_item(Item={'pk': f'METRIC#persona#{archetype}', 'sk': cls.DAY,
+                                     'count': Decimal(40)})
+
+    @classmethod
+    def _legacy_count(cls, table) -> int | None:
+        item = table.get_item(Key={'pk': cls.LEGACY_PK, 'sk': cls.DAY}).get('Item')
+        return None if item is None else int(item['count'])
+
+    def test_three_successive_edits_of_one_item_drain_the_legacy_row_once(
+        self, real_aggregates_table
+    ):
+        """Three legitimate archetype edits, one item, one `-1`.
+
+        Review measured THREE here against the wall-clock trigger. The first edit's
+        decrement finds no archetype row and settles the debt; its increment then
+        CREATES the row for the new bucket, so the second and third edits' decrements
+        land and never reach the fallback. No marker, no stored state, no extra guard.
+        """
+        from aggregator.handler import process_modified_feedback
+
+        self._seed(real_aggregates_table, busy=False)
+        walk = ['churn_risk', 'prospect', 'advocate', 'churn_risk']
+
+        for old, new in zip(walk, walk[1:]):
+            process_modified_feedback(self._anonymous_pre_deploy(old),
+                                      self._anonymous_pre_deploy(new))
+
+        assert self._legacy_count(real_aggregates_table) == 5999, (
+            'one item owes exactly one legacy `-1`, however many times it is edited.'
+        )
+
+    def test_an_edit_then_the_delete_drain_it_once(self, real_aggregates_table):
+        """The same property across two DIFFERENT event types.
+
+        Review measured two. Worth its own case because the edit and the delete reach
+        the fallback through different callers (`process_modified_feedback` and
+        `apply_feedback`), so a bound that held only inside one of them would pass the
+        test above.
+        """
+        from aggregator.handler import process_deleted_feedback, process_modified_feedback
+
+        self._seed(real_aggregates_table, busy=False)
+
+        process_modified_feedback(self._anonymous_pre_deploy('churn_risk'),
+                                  self._anonymous_pre_deploy('prospect'))
+        process_deleted_feedback(self._anonymous_pre_deploy('prospect'))
+
+        assert self._legacy_count(real_aggregates_table) == 5999
+
+    def test_a_redelivered_remove_drains_it_once_per_delivery(self, real_aggregates_table):
+        """⚠️ THE ACCEPTED MULTI-DRAIN, pinned so it is a decision and not an absence.
+
+        A refused decrement creates nothing, so the archetype row is still absent on the
+        second delivery and the evidence is unchanged — three deliveries, three `-1`s.
+        The module's general at-least-once residual rather than one this path invents,
+        and the direction is toward the truth for the FIRST drain only; past it the
+        legacy row understates. If this is ever closed it should be closed for every
+        counter at once, through `shared/idempotency.py`.
+        """
+        from aggregator.handler import process_deleted_feedback
+
+        self._seed(real_aggregates_table, busy=False)
+
+        for _ in range(3):
+            process_deleted_feedback(self._anonymous_pre_deploy('churn_risk'))
+
+        assert self._legacy_count(real_aggregates_table) == 5997, (
+            'three deliveries of one REMOVE take three counts off the legacy row. '
+            'Accepted: it is what every other counter in this module does under '
+            'redelivery — see TestRedeliveryMovesACounterTwice.'
+        )
+
+    def test_a_busy_day_does_not_drain_the_legacy_row_at_all(self, real_aggregates_table):
+        """The other side of the same mechanism, and the accepted busy-day residual.
+
+        With the archetype buckets already written for the day, every persona decrement
+        LANDS, so the fallback never fires — for an edit, a delete or a redelivery
+        alike. The legacy row is left inflated to age out on its TTL. Asserted over all
+        three arrangements at once, because on a busy day they are one observable.
+        """
+        from aggregator.handler import process_deleted_feedback, process_modified_feedback
+
+        self._seed(real_aggregates_table, busy=True)
+
+        process_modified_feedback(self._anonymous_pre_deploy('churn_risk'),
+                                  self._anonymous_pre_deploy('prospect'))
+        for _ in range(3):
+            process_deleted_feedback(self._anonymous_pre_deploy('prospect'))
+
+        assert self._legacy_count(real_aggregates_table) == 6000, (
+            'an absent archetype row is the only evidence this path has, and a busy '
+            'day does not offer it. Documented in `handler.py` under `Known residuals`.'
         )
 
 

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -1153,22 +1153,31 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     TestADecrementCannotCreateOrGoNegative. The damage this fallback repairs was a
     persistent OVER-count of a legacy row, not a negative one.
 
-    🔑 THE TRIGGER IS THE ABSENCE OF THE ARCHETYPE ROW, WHICH IS NARROWER THAN A
-    REFUSED WRITE, and the difference is the whole subject of half this class. A
-    decrement is refused for two distinguishable reasons — no row, or a row at zero
-    — and only the first is evidence that this image's insert predated the axis move.
-    A row sitting at zero is proof of the opposite: it exists, so its insert created
-    it, and that is the ordinary state of a REDELIVERED remove of a healthy
-    post-deploy item. Acting on it took a `-1` off a legacy row the item never
-    contributed to. `CounterWrite` carries the distinction, DynamoDB supplies it, and
-    test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone is
-    the case that would go wrong without it.
+    🔑 THE TRIGGER IS THE ITEM'S `processed_at`, AND HALF THIS CLASS IS ABOUT WHY IT
+    IS NOT THE ARCHETYPE ROW'S ABSENCE. Both have been tried. An absent archetype row
+    is sound evidence when it happens — this item's insert created no such row — but
+    it only HAPPENS on a day no post-deploy item has written that bucket, so on the
+    busiest day in the window the decrement simply lands on a row the item never
+    contributed to and the legacy row is never brought down. That is the ordinary
+    cross-deploy state, which made the compatibility effective exactly where the
+    corpus was quiet: test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_
+    already_populated is the case that was silently unfixed, and its positive control
+    beside it is what makes the stamp provably the deciding fact.
+
+    THE ROW'S OUTCOME IS STILL READ, to rule the fallback OUT rather than in. A
+    decrement refused AT THE FLOOR means the row exists, which is what an
+    already-reversed item looks like on redelivery — so one deletion does not
+    decrement two rows on the strength of a stamp. `CounterWrite` carries that
+    distinction and DynamoDB supplies it.
 
     IT IS ALSO NOT ALLOWED TO NAME A ROW THIS DEPLOY WRITES. `legacy_pk` is built out
-    of a free-text LLM-produced name, the one pk in the module not drawn from a
-    closed value space, so a name equal to an archetype would aim the `-1` at a LIVE
-    bucket — and a conditional write cannot catch that, because the row exists and is
-    above the floor. PERSONA_ARCHETYPES is what refuses it.
+    of a free-text LLM-produced name, so a name equal to a live bucket would aim the
+    `-1` at it for an item counted under a different archetype — and a conditional
+    write cannot catch that, because the row exists and is above the floor.
+    PERSONA_ARCHETYPES refuses it, and that guard is COMPLETE only because
+    `persona_bucket` closed the axis: while `persona_type` reached the pk verbatim, a
+    live `METRIC#persona#loyal` row was reachable and outside the set, so the guard
+    passed it. See test_the_rows_this_deploy_writes_are_all_in_the_enum.
 
     The fallback is CONFINED to the reversal direction. Reading the old field on the
     increment path would make the axis permanently dual-sourced to serve a path with
@@ -1179,20 +1188,30 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
       * Delete `_reverse_a_pre_deploy_persona_row`'s call in `apply_feedback` — fails
         test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down and
         test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too.
-      * Trigger on any refusal rather than on the absent row — i.e. have
-        `apply_counter_keys` collect `CounterWrite.REFUSED_AT_FLOOR` keys too, or
-        make `update_counter` return one undifferentiated refusal — fails
-        test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone
-        and
-        test_a_redelivered_remove_of_an_anonymous_item_does_not_drain_the_legacy_default.
+      * Trigger on the ABSENT ROW rather than on the stamp — i.e. filter to
+        `CounterWrite.ROW_ABSENT` keys and drop
+        `_was_counted_by_the_old_persona_axis` — fails
+        test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_already_populated,
+        the case that made this trigger change, and
+        test_a_landed_decrement_of_a_pre_deploy_item_still_reverses_the_legacy_row.
+      * Drop the stamp check but keep the absent-row filter — the round-2 behaviour —
+        additionally fails
+        test_a_redelivered_remove_of_a_post_deploy_item_leaves_the_legacy_row_alone.
+      * Stop excluding `REFUSED_AT_FLOOR` keys — fails
+        test_a_redelivered_remove_of_a_pre_deploy_item_does_not_decrement_twice.
+      * Treat an item with no `processed_at` as post-deploy — fails
+        test_an_item_with_no_stamp_is_treated_as_pre_deploy.
       * Drop the PERSONA_ARCHETYPES guard — fails
         test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row.
-      * Run it for a POST-deploy image whose archetype decrement LANDED — that is
-        what test_a_post_deploy_image_does_not_touch_the_legacy_row is the positive
-        control against.
+      * Open the axis again (have `persona_bucket` interpolate `persona_type`
+        verbatim) — fails test_the_rows_this_deploy_writes_are_all_in_the_enum and
+        test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too.
+      * Run it for a POST-deploy image at all — that is what
+        test_a_post_deploy_image_does_not_touch_the_legacy_row is the positive control
+        against.
       * Make the axis dual-SOURCED on the way in
         (`item.get(PERSONA_FIELD) or item.get(LEGACY_PERSONA_FIELD) or ...` in
-        `counter_dimensions`) — fails
+        `persona_bucket`) — fails
         test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down here and
         test_a_name_alone_does_not_decide_the_bucket in
         test_persona_field_lockstep.py. That is the shape this change is careful NOT
@@ -1201,33 +1220,36 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         `update_counter`'s condition) — fails
         test_the_fallback_cannot_resurrect_an_aged_out_legacy_row, which is
         moto-backed of necessity: a mock cannot refuse a write.
+      * Classify an unreadable refusal as ROW_ABSENT — fails
+        test_an_unreadable_refusal_is_not_evidence_that_a_row_was_absent.
 
-    WHY THE TRIGGER IS NOT THE ITEM'S SHAPE, recorded because it is the fix that
-    suggests itself for the redelivery case above and it does not work: "no
-    `persona_type`, but a `persona_name`" looks like a pre-deploy image and is not
-    one. `processor/handler.py` has written BOTH persona fields since the initial
-    commit, so the axis move changed only the READER — an anonymous pre-deploy item
-    carries a `persona_type` and no name, exactly like a post-deploy one, and that is
-    the 99.97% case this compatibility exists for. A shape test would therefore be
-    silently inert for the majority of the corpus while looking like a tightening;
+    WHY THE TRIGGER IS NOT THE ITEM'S PERSONA SHAPE, recorded because it is the fix
+    that suggests itself and does not work: "no `persona_type`, but a `persona_name`"
+    looks like a pre-deploy image and is not one. `processor/handler.py` has written
+    BOTH persona fields since the initial commit, so the axis move changed only the
+    READER — an anonymous pre-deploy item carries a `persona_type` and no name,
+    exactly like a post-deploy one, and that is the 99.97% case this compatibility
+    exists for. A shape test would therefore be silently inert for the majority of the
+    corpus while looking like a tightening;
     test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current
-    is the case that fails under it.
+    is the case that fails under it, and it is arranged as the SAME item as the
+    ordinary post-deploy fixture but for its stamp.
 
-    TWO MUTATIONS THAT DO NOT FAIL ANYTHING, run and recorded rather than asserted
-    into existence, because a REVERT MAP is only worth what its citations are:
-      * `if sign < 0` → `if True` in `apply_feedback`: passes. An increment carries
-        no ConditionExpression, so it cannot be refused, so no key is ever reported
-        absent and the fallback has nothing to act on. The guard STATES that rather
-        than depending on it — cheaper to read than to re-derive, and it keeps the
-        compatibility legible as reversal-only.
-      * reading the date from `_image_date(item)` instead of out of the refused key:
-        passes, because for one reversal every refused key carries the very date
-        `counter_keys` was given. Reading it out of the key is structural rather than
-        observable: it makes it impossible for a future caller to hand this function
-        keys from one day and an item naming another, which is the failure
-        `_image_date_or_none` exists to prevent elsewhere in this module and which no
-        ConditionExpression can catch.
-        test_the_fallback_lands_on_the_day_the_refusal_concerned therefore pins the
+    MUTATIONS THAT DO NOT FAIL ANYTHING, run and recorded rather than asserted into
+    existence, because a REVERT MAP is only worth what its citations are:
+      * `if sign < 0` → `if True` in `apply_feedback`: passes. An increment carries no
+        ConditionExpression and creates the row it names, so its outcome is always
+        LANDED on the row today's derivation names — and the fallback would then fire
+        for a pre-deploy image's INSERT, except that a stream INSERT of a pre-deploy
+        item cannot occur (its insert is what predates the deploy). The guard STATES
+        that the compatibility is reversal-only rather than depending on it.
+      * reading the date from `_image_date(item)` instead of out of the key: passes,
+        because for one reversal every key carries the very date `counter_keys` was
+        given. Reading it out of the key is structural rather than observable: it makes
+        it impossible for a future caller to hand this function keys from one day and
+        an item naming another, which is the failure `_image_date_or_none` exists to
+        prevent elsewhere in this module and which no ConditionExpression can catch.
+        test_the_fallback_lands_on_the_day_the_decrement_concerned therefore pins the
         OUTCOME (both writes on the item's own day) rather than the mechanism.
     """
 
@@ -1339,12 +1361,13 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
     def test_a_post_deploy_image_does_not_touch_the_legacy_row(
         self, mock_table, sample_anonymous_feedback_item
     ):
-        """The POSITIVE CONTROL, and the reason the trigger is the REFUSAL.
+        """The POSITIVE CONTROL for the whole class.
 
-        This image carries an archetype, so its insert created the archetype row —
-        and here that decrement LANDS, so nothing else may be written. Without this,
-        a fallback that fired on every reversal would pass the test above while
-        double-counting every ordinary delete against a legacy row.
+        This image was PROCESSED after the axis moved, so its insert used today's
+        derivation and there is no legacy row to bring down. Its archetype decrement
+        lands and nothing else may be written. Without this, a fallback that fired on
+        every reversal would pass the tests above while double-counting every ordinary
+        delete against a legacy row.
         """
         from aggregator.handler import record_handler
 
@@ -1357,37 +1380,36 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         ]
 
     @patch('aggregator.handler.aggregates_table')
-    def test_a_post_deploy_image_whose_row_is_gone_writes_nothing_more(
-        self, mock_table, sample_anonymous_feedback_item
+    def test_one_deletion_never_decrements_one_row_twice(
+        self, mock_table, sample_pre_deploy_feedback_item
     ):
-        """The narrow case where the two derivations agree, so there is nothing to
-        fall back TO.
+        """The property the removed `pk == legacy_pk` branch used to carry.
 
-        An item carrying an archetype and no name derives `unknown` from the old
-        field too — but its archetype is `churn_risk`, so the two differ and the
-        fallback would fire. What must NOT happen is a second decrement of one row
-        for one deletion when they coincide, which is the case below.
+        One deletion taking two counts off one row would need the legacy value to
+        equal the archetype value — and it cannot: the archetype is always a member of
+        PERSONA_ARCHETYPES (`persona_bucket` guarantees it) and the collision guard
+        declines every legacy value in that set, so the case is refused one line
+        earlier by a guard that exists for a stronger reason. Asserted over every
+        arrangement that could reach it rather than one, because the argument is
+        exhaustive and a single example would not show that.
         """
-        from aggregator.handler import PERSONA_FIELD, PERSONA_UNKNOWN, record_handler
+        from aggregator.handler import PERSONA_UNKNOWN, record_handler
 
-        self._refuse(mock_table)
-        # Neither field: today's derivation says `unknown`, the old one says
-        # `Unknown`. Give it the archetype the old default would produce, so both
-        # name ONE row.
-        coincident = {**sample_anonymous_feedback_item,
-                      PERSONA_FIELD: 'Unknown', 'persona_name': 'Unknown'}
-        assert PERSONA_UNKNOWN != 'Unknown', (
-            'this arrangement depends on the two empty-bucket spellings differing; '
-            'if they are unified the fallback is unnecessary, not merely untested'
-        )
+        for name in (PERSONA_UNKNOWN, 'Unknown', 'churn_risk', 'Veronica Chen'):
+            for archetype in (None, 'churn_risk', PERSONA_UNKNOWN, 'loyal'):
+                mock_table.reset_mock()
+                self._refuse(mock_table)
+                item = {**sample_pre_deploy_feedback_item, 'persona_name': name}
+                if archetype:
+                    item['persona_type'] = archetype
 
-        record_handler(_record('REMOVE', old=coincident))
+                record_handler(_record('REMOVE', old=item))
 
-        writes = self._persona_writes(mock_table)
-        assert len(writes) == 1, (
-            f'{writes}: when both derivations name one row, one deletion must not '
-            f'decrement it twice.'
-        )
+                rows = [pk for pk, *_ in self._persona_writes(mock_table)]
+                assert len(rows) == len(set(rows)), (
+                    f'{item} produced writes to {rows}: one deletion decremented one '
+                    f'row twice.'
+                )
 
     @patch('aggregator.handler.aggregates_table')
     def test_an_insert_never_writes_the_legacy_bucket(
@@ -1410,10 +1432,10 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         )
 
     @patch('aggregator.handler.aggregates_table')
-    def test_the_fallback_lands_on_the_day_the_refusal_concerned(
+    def test_the_fallback_lands_on_the_day_the_decrement_concerned(
         self, mock_table, sample_pre_deploy_feedback_item
     ):
-        """The date is read out of the refused KEY, not re-derived.
+        """The date is read out of the counter KEY, not re-derived.
 
         A follow-up write that recomputed the day could land on another one, which is
         the failure `_image_date_or_none` exists to prevent elsewhere in this module:
@@ -1438,10 +1460,10 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
 
         Streams are at-least-once, so a REMOVE is redelivered after its counters have
         already come down — and the archetype row then sits at ZERO, where the floor
-        refuses the second decrement. That row EXISTS, which is proof its insert
-        created it, so this image owes the legacy bucket nothing. Triggering on "the
-        write was refused" instead of "the row was absent" took a `-1` off a free-text
-        row belonging to a different customer, on a healthy post-deploy corpus.
+        refuses the second decrement. This item's stamp already says it was processed
+        after the move, so the fallback is out on that ground alone; the arrangement
+        also refuses at the floor so that a version triggering on ANY refusal (the
+        round-2 behaviour) fails here too.
         """
         from aggregator.handler import record_handler
 
@@ -1449,8 +1471,8 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         self._refuse(mock_table, at_floor=True)
         item = sample_feedback_item
         assert item.get('persona_name') and item.get('persona_type'), (
-            'the subject must carry BOTH fields, or the two derivations agree and '
-            'the `pk == legacy_pk` branch would hide the defect'
+            'the subject must carry BOTH fields, or the two derivations name one row '
+            'and a stray write would be invisible'
         )
 
         record_handler(_record('REMOVE', old=item))
@@ -1489,17 +1511,167 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         assert legacy_default not in written, written
 
     @patch('aggregator.handler.aggregates_table')
+    def test_a_redelivered_remove_of_a_pre_deploy_item_does_not_decrement_twice(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The stamp says pre-deploy, and the row's outcome still rules it out.
+
+        A REMOVE redelivered after the legacy row has already come down finds the
+        ARCHETYPE row refused at the floor — the row exists, so something counted this
+        item there and the reversal is not owed a second write. Without the
+        `REFUSED_AT_FLOOR` exclusion the stamp alone would issue one, and every
+        redelivery of a pre-deploy REMOVE would drain the legacy row again on a day the
+        archetype row happened to exist at zero.
+        """
+        from aggregator.handler import record_handler
+
+        self._refuse(mock_table, at_floor=True)
+
+        record_handler(_record('REMOVE', old=sample_pre_deploy_feedback_item))
+
+        written = [pk for pk, *_ in self._persona_writes(mock_table)]
+        assert written == [self._archetype_pk(sample_pre_deploy_feedback_item)], (
+            f'{written}: a row refused at the floor EXISTS, so this deploy counted the '
+            f'item there and no legacy write is owed.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_pre_deploy_item_is_reversed_on_a_day_the_new_axis_has_already_populated(
+        self, mock_table, sample_pre_deploy_anonymous_feedback_item
+    ):
+        """🔑 THE BUSY-DAY CASE, and the reason the trigger is the stamp.
+
+        Post-deploy ingestion populates `METRIC#persona#churn_risk` for the day, so
+        this pre-deploy item's archetype decrement LANDS — on a row it never
+        contributed to — and no refusal is produced at all. A trigger reading the
+        archetype row's ABSENCE therefore never fires, leaving the legacy row inflated
+        exactly on the days the corpus is busiest. Review demonstrated that against
+        moto; this is it as a test.
+
+        Every conditional write is allowed to land here, which is what makes the point:
+        there is no refusal in this scenario for a row-based trigger to read.
+        """
+        from aggregator.handler import (
+            LEGACY_PERSONA_UNKNOWN,
+            PERSONA_PREFIX,
+            record_handler,
+        )
+
+        item = sample_pre_deploy_anonymous_feedback_item
+
+        record_handler(_record('REMOVE', old=item))
+
+        assert self._persona_writes(mock_table) == [
+            (self._archetype_pk(item), '2025-01-15', 'count', -1),
+            (f'{PERSONA_PREFIX}{LEGACY_PERSONA_UNKNOWN}', '2025-01-15', 'count', -1),
+        ], (
+            'a pre-deploy item deleted on a day the new axis has already populated '
+            'must still bring down the row its own insert created. Nothing about that '
+            'day distinguishes it, so only the item can.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_a_landed_decrement_of_a_pre_deploy_item_still_reverses_the_legacy_row(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The same property in the shape where the two rows are distinguishable.
+
+        The item above is anonymous, so its legacy row is the shared `Unknown` default;
+        this one carries a name, so the legacy row is its own — which shows the write
+        is aimed at the row THIS item's insert created rather than at a default that
+        happens to be there.
+        """
+        from aggregator.handler import record_handler
+
+        item = sample_pre_deploy_feedback_item
+
+        record_handler(_record('REMOVE', old=item))
+
+        assert (self._legacy_pk(item), '2025-01-15', 'count', -1) \
+            in self._persona_writes(mock_table)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_item_with_no_stamp_is_treated_as_pre_deploy(self, mock_table):
+        """No `processed_at` means legacy or hand-written, so it fails that way.
+
+        The processor has always written the stamp, so an item without one predates it
+        — and the cost of being wrong is bounded: the follow-up write is conditional
+        and the collision guard already refuses every row this deploy could have
+        written, so a false pre-deploy reading costs at most one refused write.
+        """
+        from aggregator.handler import LEGACY_PERSONA_STAMP_FIELD, record_handler
+
+        unstamped = {
+            'date': '2025-01-15', 'source_platform': 'webscraper',
+            'category': 'delivery', 'sentiment_label': 'neutral', 'urgency': 'low',
+            'persona_name': 'Veronica Chen', 'persona_type': 'advocate',
+        }
+        assert LEGACY_PERSONA_STAMP_FIELD not in unstamped
+
+        record_handler(_record('REMOVE', old=unstamped))
+
+        assert (self._legacy_pk(unstamped), '2025-01-15', 'count', -1) \
+            in self._persona_writes(mock_table)
+
+    @patch('aggregator.handler.aggregates_table')
+    def test_an_unreadable_stamp_is_treated_as_pre_deploy_too(self, mock_table):
+        """A stamp that cannot be parsed is no evidence, so it fails the same way.
+
+        Reached by a hand-written row, or by any writer using another format. Warned
+        about rather than silent, because a stamp nothing can read makes the
+        compatibility fire for every such item indefinitely.
+        """
+        from aggregator.handler import record_handler
+
+        record_handler(_record('REMOVE', old={
+            'date': '2025-01-15', 'source_platform': 'webscraper',
+            'category': 'delivery', 'sentiment_label': 'neutral', 'urgency': 'low',
+            'persona_name': 'Veronica Chen', 'processed_at': 'last Tuesday',
+        }))
+
+        written = [pk for pk, *_ in self._persona_writes(mock_table)]
+        assert self._legacy_pk({'persona_name': 'Veronica Chen'}) in written, written
+
+    def test_the_rows_this_deploy_writes_are_all_in_the_enum(self):
+        """What makes the collision guard COMPLETE rather than partial.
+
+        The guard declines a legacy value that is a member of PERSONA_ARCHETYPES,
+        justified as "a row this deploy writes" — and that justification only holds
+        while the set really is every row this deploy can write. It was not: review
+        found a live `METRIC#persona#loyal` row (this repo's own fixtures use that
+        value, and `PUT /data-explorer/feedback` accepts `persona_type` with no
+        allowlist) decremented for an item counted elsewhere, because `loyal` reached
+        the pk verbatim and so passed the guard.
+
+        `persona_bucket` closing the axis is what fixed it, so this asserts the
+        property the guard depends on rather than one more instance of the symptom.
+        """
+        from aggregator.handler import PERSONA_ARCHETYPES, counter_dimensions
+
+        for value in ('loyal', 'VIP customer', 'power_user', '', None, 'churn_risk'):
+            personas = [pk for pk, _ in counter_dimensions({'persona_type': value})
+                        if pk.startswith('METRIC#persona#')]
+            assert len(personas) == 1, personas
+            bucket = personas[0].removeprefix('METRIC#persona#')
+            assert bucket in PERSONA_ARCHETYPES, (
+                f'persona_type={value!r} writes METRIC#persona#{bucket}, which is not '
+                f'a member of PERSONA_ARCHETYPES. The reversal\'s collision guard '
+                f'tests membership of that set to decide whether a row is live, so a '
+                f'row outside it is a live row the guard cannot recognise.'
+            )
+
+    @patch('aggregator.handler.aggregates_table')
     def test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row(
         self, mock_table, sample_pre_deploy_feedback_item
     ):
         """`legacy_pk` is the one pk built out of free text, so it can collide.
 
         `persona_name` is an LLM-produced person name, and nothing constrains it to
-        the value space this axis now uses — `unknown` is entirely plausible for
-        anonymous feedback, and it names the axis's LARGEST live bucket. A `-1` there
-        is a current number corrupted rather than a legacy one corrected, and no
-        condition expression can refuse it: that row exists and is above the floor.
-        A missed legacy decrement is the right way to be wrong, the judgement
+        the value space this axis uses — `unknown` is entirely plausible for anonymous
+        feedback, and it names the axis's LARGEST live bucket. A `-1` there is a
+        current number corrupted rather than a legacy one corrected, and no condition
+        expression can refuse it: that row exists and is above the floor. A missed
+        legacy decrement is the right way to be wrong, the judgement
         `process_deleted_feedback` already makes for a dateless image.
         """
         from aggregator.handler import (
@@ -1508,7 +1680,6 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
             record_handler,
         )
 
-        self._refuse(mock_table)
         colliding = {**sample_pre_deploy_feedback_item,
                      'persona_name': 'unknown', 'persona_type': 'advocate'}
         assert 'unknown' in PERSONA_ARCHETYPES, (
@@ -1526,34 +1697,95 @@ class TestAPreDeployImageIsReversedOnTheRowItsInsertCreated:
         )
 
     @patch('aggregator.handler.aggregates_table')
+    def test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too(
+        self, mock_table, sample_pre_deploy_feedback_item
+    ):
+        """The half of that collision the guard used to miss, closed at the root.
+
+        A legacy `persona_name` of `loyal` was NOT declined, because `loyal` is not in
+        PERSONA_ARCHETYPES — while `METRIC#persona#loyal` was nonetheless a row this
+        deploy wrote, for any item whose `persona_type` was `loyal`. Closing the axis
+        means that row can no longer be written, so decrementing it is now correct
+        rather than corrupting: it can only be a legacy row.
+
+        Asserted as the property (the write goes to the row named by the OLD
+        derivation, and the archetype row is the enum's) rather than as "no write
+        happens", because the fix removed the hazard instead of adding a second guard.
+        """
+        from aggregator.handler import PERSONA_PREFIX, record_handler
+
+        item = {**sample_pre_deploy_feedback_item,
+                'persona_name': 'loyal', 'persona_type': 'loyal'}
+
+        record_handler(_record('REMOVE', old=item))
+
+        written = [pk for pk, *_ in self._persona_writes(mock_table)]
+        assert f'{PERSONA_PREFIX}loyal' in written, (
+            f'{written}: `loyal` can no longer name a row this deploy writes, so the '
+            f'only row of that name is the legacy one this item\'s insert created.'
+        )
+        assert self._archetype_pk(item) == f'{PERSONA_PREFIX}unknown', (
+            'and the archetype side must have bucketed the out-of-contract value as '
+            'the empty one — which is what makes the legacy row unambiguous.'
+        )
+
+    def test_an_unreadable_refusal_is_not_evidence_that_a_row_was_absent(self):
+        """The fail direction of the one conclusion that carries a write.
+
+        `is_conditional_check_failure` recognises this exception by TYPE NAME as well
+        as by code, precisely because it arrives with no `response` payload on some
+        paths — and `ROW_ABSENT` was the else-branch, so an unreadable refusal read as
+        "there was no row". That is the fail-OPEN direction for a conclusion whose
+        consequence is a write, so it now resolves to the outcome no caller acts on.
+        """
+        from aggregator.handler import CounterWrite, update_counter
+
+        class ConditionalCheckFailedException(ClientError):
+            def __init__(self):
+                self.response = None
+
+        with patch('aggregator.handler.aggregates_table') as table:
+            table.update_item.side_effect = ConditionalCheckFailedException()
+            outcome = update_counter('METRIC#persona#advocate', '2025-01-15', 'count',
+                                     increment=-1)
+
+        assert outcome is CounterWrite.REFUSED_AT_FLOOR, (
+            f'{outcome}: a refusal whose response cannot be read says nothing about '
+            f'whether the row was there, and ROW_ABSENT is the conclusion that issues '
+            f'a follow-up write.'
+        )
+
+    @patch('aggregator.handler.aggregates_table')
     def test_an_anonymous_pre_deploy_image_is_still_reversed_though_its_shape_looks_current(
-        self, mock_table, sample_anonymous_feedback_item
+        self, mock_table, sample_pre_deploy_anonymous_feedback_item,
+        sample_anonymous_feedback_item
     ):
         """The 99.97% case, and the reason the trigger cannot be the item's SHAPE.
 
         `processor/handler.py` has written both persona fields since the initial
         commit, so the axis move changed only the reader: a pre-deploy anonymous item
         carries a `persona_type` and no name, which is byte-identical to a post-deploy
-        one. Only the ROW tells them apart — here the archetype row is ABSENT, because
-        that insert counted the item under the old default instead.
-
-        A shape test (`PERSONA_FIELD not in item and LEGACY_PERSONA_FIELD in item`)
-        would fail this, which is what makes it worth pinning: it looks like a
-        tightening and would silently switch the compatibility off for the majority
-        of the corpus it exists for.
+        one apart from its stamp. A shape test
+        (`PERSONA_FIELD not in item and LEGACY_PERSONA_FIELD in item`) would fail
+        this, which is what makes it worth pinning: it looks like a tightening and
+        would silently switch the compatibility off for the majority of the corpus it
+        exists for.
         """
         from aggregator.handler import (
+            LEGACY_PERSONA_STAMP_FIELD,
             LEGACY_PERSONA_UNKNOWN,
-            PERSONA_FIELD,
             PERSONA_PREFIX,
             record_handler,
         )
 
         self._refuse(mock_table)
-        item = sample_anonymous_feedback_item
-        assert PERSONA_FIELD in item and 'persona_name' not in item, (
-            'the arrangement is the point: this is the shape a shape-based trigger '
-            'would read as post-deploy'
+        item = sample_pre_deploy_anonymous_feedback_item
+        assert {k: v for k, v in item.items() if k != LEGACY_PERSONA_STAMP_FIELD} == \
+            {k: v for k, v in sample_anonymous_feedback_item.items()
+             if k != LEGACY_PERSONA_STAMP_FIELD}, (
+            'the arrangement is the point: this item must differ from the ordinary '
+            f'post-deploy one in `{LEGACY_PERSONA_STAMP_FIELD}` and NOTHING else, or '
+            'it does not show that the stamp is what decides'
         )
 
         record_handler(_record('REMOVE', old=item))

--- a/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
+++ b/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
@@ -45,10 +45,15 @@ REVERT MAP
     * Point PERSONA_FIELD at a field the processor does not write (`persona`,
       `persona_label`) — fails
       test_the_persona_field_is_one_the_processor_writes.
-    * Inline `item.get('persona_type')` back into `counter_dimensions` and drop the
-      constant — fails test_the_persona_field_is_read_through_the_constant, which
-      is what keeps the two directions reading ONE name rather than two literals
+    * Inline `item.get('persona_type')` into `shared/feedback.py::persona_bucket` and
+      drop the constant — fails test_the_persona_field_is_read_through_the_constant,
+      which is what keeps the two directions reading ONE name rather than two literals
       that happen to match today.
+    * Have `counter_dimensions` derive the bucket itself rather than calling
+      `persona_bucket` — fails test_the_aggregator_buckets_through_that_same_function,
+      and (from the API side)
+      test_neither_side_derives_the_bucket_for_itself. That pairing is what stops the
+      pin above passing over a `shared/feedback.py` nothing consults.
     * Have the processor stop writing the field this reads — fails the first test,
       from the other side.
     * Spell the empty bucket as a bespoke `Unknown` again (or anything else outside
@@ -66,6 +71,13 @@ REVERT MAP
       (`_reverse_a_pre_deploy_persona_row`) — fails
       TestAPreDeployImageIsReversedOnTheRowItsInsertCreated in test_handler.py, which
       is where the cross-deploy case is pinned.
+    * Open the axis — have `persona_bucket` interpolate `persona_type` verbatim
+      instead of bucketing a value outside PERSONA_ARCHETYPES as the empty one — fails
+      test_the_rows_this_deploy_writes_are_all_in_the_enum in test_handler.py and
+      test_an_out_of_contract_archetype_is_counted_as_unclassified in
+      lambda/api/test/test_persona_dimension_lockstep.py. That closure is what makes
+      the reversal's collision guard a COMPLETE test of "is this row live?" rather
+      than one that misses every out-of-contract value.
     * Add a value to `shared/feedback.py::PERSONA_ARCHETYPES` that the enrichment
       prompt does not admit, or drop one it does — fails
       test_the_shared_archetypes_are_the_ones_the_enrichment_enum_declares. That set
@@ -87,15 +99,17 @@ import ast
 import re
 from pathlib import Path
 
-from aggregator.handler import (
-    PERSONA_FIELD,
-    PERSONA_PREFIX,
-    PERSONA_UNKNOWN,
-    counter_dimensions,
-)
+from shared.feedback import PERSONA_FIELD, PERSONA_PREFIX, PERSONA_UNKNOWN
+
+from aggregator.handler import counter_dimensions
 
 PROCESSOR_SOURCE = 'lambda/processor/handler.py'
 AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
+# The one derivation both Lambdas call, and so the one place the field is READ. The
+# pin below follows it here rather than staying on `counter_dimensions`, which no
+# longer names the field at all — see that function for why it moved.
+SHARED_SOURCE = 'lambda/shared/feedback.py'
+BUCKET_FUNCTION = 'persona_bucket'
 DIMENSIONS_FUNCTION = 'counter_dimensions'
 
 
@@ -156,20 +170,26 @@ def _processor_persona_type_enum() -> set[str]:
     return {value for value in declarations[0].split('|') if value != 'null'}
 
 
-def _aggregator_persona_reads() -> list[str]:
-    """Every `item.get(...)` argument inside `counter_dimensions`, unparsed.
+def _persona_field_reads() -> list[str]:
+    """Every `item.get(...)` argument inside the shared `persona_bucket`, unparsed.
 
     Parsed with `ast`, scoped to the one function, so a mention in a docstring or
     another function cannot answer for it — the convention the rest of this repo's
     locksteps follow, and for the usual reason: a pattern that reads a comment as
     code fails a correct module.
+
+    Scoped to `shared/feedback.py::persona_bucket` rather than to the aggregator's
+    `counter_dimensions`, because that is where the read went when the derivation was
+    shared. The pin is unchanged in what it asserts — the field is read through the
+    constant, once — and it now covers BOTH Lambdas rather than one, since the read
+    side calls the same function.
     """
-    tree = ast.parse(_read(AGGREGATOR_SOURCE))
+    tree = ast.parse(_read(SHARED_SOURCE))
     functions = [node for node in ast.walk(tree)
                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-                 and node.name == DIMENSIONS_FUNCTION]
+                 and node.name == BUCKET_FUNCTION]
     assert len(functions) == 1, (
-        f'Expected exactly one {DIMENSIONS_FUNCTION} in {AGGREGATOR_SOURCE}; found '
+        f'Expected exactly one {BUCKET_FUNCTION} in {SHARED_SOURCE}; found '
         f'{len(functions)}. A second copy is the drift this file exists to prevent.'
     )
     reads: list[str] = []
@@ -179,6 +199,27 @@ def _aggregator_persona_reads() -> list[str]:
                     and node.func.attr == 'get' and node.args):
                 reads.append(ast.unparse(node.args[0]))
     return reads
+
+
+def _aggregator_derives_the_bucket_through_the_shared_function() -> bool:
+    """Does `counter_dimensions` get its persona bucket from `persona_bucket`?
+
+    The other half of the pin above: moving the read into `shared/` only helps while
+    the aggregator actually calls it. A `counter_dimensions` that re-derived the
+    bucket itself would leave that pin passing over a module that had drifted.
+    """
+    tree = ast.parse(_read(AGGREGATOR_SOURCE))
+    functions = [node for node in ast.walk(tree)
+                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                 and node.name == DIMENSIONS_FUNCTION]
+    assert len(functions) == 1, (
+        f'Expected exactly one {DIMENSIONS_FUNCTION} in {AGGREGATOR_SOURCE}; found '
+        f'{len(functions)}.'
+    )
+    body = functions[0].body[1:]  # drop the docstring; a mention is not a call
+    return any(isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+               and node.func.id == BUCKET_FUNCTION
+               for statement in body for node in ast.walk(statement))
 
 
 class TestThePersonaCounterReadsAFieldThatExists:
@@ -195,24 +236,38 @@ class TestThePersonaCounterReadsAFieldThatExists:
     def test_the_persona_field_is_read_through_the_constant(self):
         """One name, not two literals that happen to agree.
 
-        The increment and the decrement path both come through this function, so a
-        literal here is only one copy — but a literal is also what makes it
+        The increment and the decrement path both come through one derivation, so a
+        literal there is only one copy — but a literal is also what makes it
         possible to "fix" the field in a way that changes what the reversal looks
         for without changing what the insert created. The constant is the seam this
         lockstep and the handler share; reading the field any other way puts the
         pin and the code back out of contact.
         """
-        reads = _aggregator_persona_reads()
+        reads = _persona_field_reads()
         assert 'PERSONA_FIELD' in reads, (
-            f'{AGGREGATOR_SOURCE}::{DIMENSIONS_FUNCTION} reads {reads} — none of '
+            f'{SHARED_SOURCE}::{BUCKET_FUNCTION} reads {reads} — none of '
             f'them the PERSONA_FIELD constant this test pins. Read the field '
             f'through the constant so that changing it changes both directions at '
             f'once and this lockstep still has something to hold.'
         )
         assert PERSONA_FIELD not in reads, (
-            f'{AGGREGATOR_SOURCE}::{DIMENSIONS_FUNCTION} also reads the literal '
+            f'{SHARED_SOURCE}::{BUCKET_FUNCTION} also reads the literal '
             f'"{PERSONA_FIELD}" alongside the constant. Two spellings of one field '
             f'is the drift, whichever of them is currently right.'
+        )
+
+    def test_the_aggregator_buckets_through_that_same_function(self):
+        """The pin above only holds while the writer actually calls the derivation.
+
+        Without this, re-deriving the bucket inside `counter_dimensions` — the drift
+        that sharing the derivation exists to prevent — would leave the test above
+        passing on a `shared/feedback.py` nothing consults.
+        """
+        assert _aggregator_derives_the_bucket_through_the_shared_function(), (
+            f'{AGGREGATOR_SOURCE}::{DIMENSIONS_FUNCTION} does not call '
+            f'{BUCKET_FUNCTION}. The write side and `metrics_handler`\'s scan path '
+            f'must compute the bucket with ONE function, or the closed value space '
+            f'the reversal\'s collision guard depends on is only true on one side.'
         )
 
 

--- a/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
+++ b/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
@@ -64,15 +64,24 @@ REVERT MAP
       file, which reads the parsed CODE of the four functions that spend it.
     * Delete the reversal's pre-deploy fallback
       (`_reverse_a_pre_deploy_persona_row`) — fails
-      TestAPreDeployImageIsReversedOnTheArchetype in test_handler.py, which is where
-      the cross-deploy case is pinned.
+      TestAPreDeployImageIsReversedOnTheRowItsInsertCreated in test_handler.py, which
+      is where the cross-deploy case is pinned.
+    * Add a value to `shared/feedback.py::PERSONA_ARCHETYPES` that the enrichment
+      prompt does not admit, or drop one it does — fails
+      test_the_shared_archetypes_are_the_ones_the_enrichment_enum_declares. That set
+      is a COPY of the contract, kept for a write-side guard, so it is pinned to the
+      prompt the way the empty bucket already is.
 
-    Every name cited above was grepped against the repo and resolves. That check is
-    worth repeating on edit: review found this map naming a test
-    (`..._agree_on_one_item`) that existed nowhere, and in a repo where the REVERT
-    MAP is the index from mutation to failing test, a citation that resolves to
-    nothing is the one kind of staleness these files cannot absorb — the next reader
-    greps for it, finds nothing, and has to reconstruct whether the coverage exists.
+    Every name cited above was grepped against the repo and resolves — as of this
+    edit, by running the grep rather than by intending to. That check is worth
+    repeating on every edit, and NOT worth asserting in prose without doing: review
+    found this map naming a test (`..._agree_on_one_item`) that existed nowhere, then
+    found a class name (`...OnTheArchetype`) stale three lines above a sentence
+    claiming the check had been done. In a repo where the REVERT MAP is the index from
+    mutation to failing test, a citation that resolves to nothing is the one kind of
+    staleness these files cannot absorb — the next reader greps for it, finds nothing,
+    and has to reconstruct whether the coverage exists at all. A false assurance is
+    worse, because it stops them checking.
 """
 import ast
 import re
@@ -301,6 +310,32 @@ class TestTheDefaultBucketIsStable:
             f'contract in {PROCESSOR_SOURCE} does not admit — it admits '
             f'{sorted(admitted)}. Name it with a value the contract defines, so the '
             f'axis has no values invented outside it.'
+        )
+
+    def test_the_shared_archetypes_are_the_ones_the_enrichment_enum_declares(self):
+        """`PERSONA_ARCHETYPES` is a COPY of the contract, so it is pinned to it.
+
+        The prompt is the contract — it is what the model is told to return — and this
+        set exists only because a WRITE-side guard needs to recognise the value space
+        in code: `_reverse_a_pre_deploy_persona_row` refuses to aim its `-1` at a row
+        this deploy actively writes, which it can only know by membership. A copy that
+        drifted would break that guard in the more dangerous direction, admitting a
+        legacy decrement onto a live archetype row.
+
+        Compared as a whole set, not by membership of one value, so a value ADDED
+        here that the contract never declares fails just as loudly as one dropped.
+        """
+        from shared.feedback import PERSONA_ARCHETYPES
+
+        admitted = _processor_persona_type_enum()
+
+        assert set(PERSONA_ARCHETYPES) == admitted, (
+            f'PERSONA_ARCHETYPES is {sorted(PERSONA_ARCHETYPES)} while the enrichment '
+            f'contract in {PROCESSOR_SOURCE} admits {sorted(admitted)}. The set is a '
+            f'copy of the contract kept for the reversal\'s collision guard; if the '
+            f'prompt\'s enum moved, follow it here, and if a value was added here that '
+            f'the model is never told to return, remove it — the guard would refuse a '
+            f'legitimate legacy decrement, or admit one onto a live row.'
         )
 
     def test_the_persona_dimension_is_never_absent(self):

--- a/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
+++ b/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
@@ -23,41 +23,53 @@ WHY THIS IS A TEST AND NOT A COMMENT
 
 WHAT IS PINNED, AND WHAT IS DELIBERATELY NOT
     Pinned: the field `aggregator/handler.py::PERSONA_FIELD` names is one the
-    processor's item literal really writes. NOT pinned: WHICH of the processor's two
-    persona fields it should be. `persona_name` (the LLM's free-text name) and
-    `persona_type` (a small enum) are both real fields, and bucketing by either is
-    a defensible product decision — one gives many partitions, the other a handful.
-    Asserting a specific choice here would be this file inventing a requirement.
+    processor's item literal really writes, and the empty-bucket name is a value
+    the enrichment contract's own enum declares. NOT pinned: WHICH of the
+    processor's two persona fields it should be. That is a product decision, and
+    asserting it here would be this file inventing a requirement; what it must not
+    be is a field production does not produce.
 
-    That leaves one thing worth naming out loud, because it is the reason the
-    deferral in the PR was contentious: `persona_name` is `null` whenever the model
-    returns no name, and the processor strips None values before writing, so those
-    items carry NO `persona_name` and bucket as `Unknown`. That is a data-quality
-    property of the enrichment output, not a lockstep violation — the counter is
-    genuinely counting "items whose persona we could not name". If the product
-    decision becomes "bucket by type instead", changing PERSONA_FIELD is the whole
-    change, and this test keeps passing because `persona_type` is written too.
+    The decision itself, for the record, because it is the reason the field moved:
+    the axis buckets by `persona_type` (the archetype) and not by `persona_name`
+    (the LLM's free-text name). `persona_name` is `null` whenever the model returns
+    no name, the processor strips None values before writing, and this platform's
+    corpus is scraped reviews and mostly anonymous form submissions — so an
+    anonymous item HAS no name to give and carries no `persona_name` at all. An
+    audit found 99.97% of a 6,239-item corpus in one `Unknown` bucket as a result.
+    That was not a data-quality defect in the enrichment output (a null name for
+    anonymous feedback is correct) and not a field nothing writes; it was the wrong
+    field for the question. `persona_type` is populated and is a closed enum, which
+    is what a dimension you group by has to be.
 
 REVERT MAP
     * Point PERSONA_FIELD at a field the processor does not write (`persona`,
       `persona_label`) — fails
       test_the_persona_field_is_one_the_processor_writes.
-    * Inline `item.get('persona_name')` back into `counter_dimensions` and drop the
+    * Inline `item.get('persona_type')` back into `counter_dimensions` and drop the
       constant — fails test_the_persona_field_is_read_through_the_constant, which
       is what keeps the two directions reading ONE name rather than two literals
       that happen to match today.
     * Have the processor stop writing the field this reads — fails the first test,
       from the other side.
+    * Spell the empty bucket as a bespoke `Unknown` again (or anything else outside
+      the contract's enum) — fails
+      test_the_empty_bucket_is_a_value_the_enrichment_enum_declares.
+    * Point PERSONA_FIELD back at `persona_name` — fails
+      test_an_item_with_an_archetype_and_no_name_buckets_under_its_archetype, which
+      is the 99.97% case, and (from the API side)
+      test_the_scan_path_and_the_aggregates_path_agree_on_one_item in
+      lambda/api/test/test_persona_dimension_lockstep.py.
 """
 import ast
 import re
 from pathlib import Path
 
-from aggregator.handler import PERSONA_FIELD, counter_dimensions
+from aggregator.handler import PERSONA_FIELD, PERSONA_UNKNOWN, counter_dimensions
 
 PROCESSOR_SOURCE = 'lambda/processor/handler.py'
 AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
 DIMENSIONS_FUNCTION = 'counter_dimensions'
+PERSONA_PREFIX = 'METRIC#persona#'
 
 
 def _read(relative: str) -> str:
@@ -85,6 +97,27 @@ def _processor_persona_fields() -> set[str]:
         f'below pass for the wrong reason.'
     )
     return fields
+
+
+def _processor_persona_type_enum() -> set[str]:
+    """The values the enrichment prompt's `persona.type` contract admits.
+
+    Read out of the prompt template, because that string IS the contract: it is
+    what the model is told to return, so it is the only place that says which
+    archetype names can ever reach the counter. `null` is dropped — it is the
+    JSON contract's way of saying "no value", which is the case the bucket name
+    below stands in for, not a value the bucket could be named after.
+    """
+    source = _read(PROCESSOR_SOURCE)
+    declarations = re.findall(r'"persona":.*?"type":"([^"]+)"', source)
+    assert len(declarations) == 1, (
+        f'Expected exactly one `persona.type` declaration in the enrichment prompt '
+        f'in {PROCESSOR_SOURCE}; found {len(declarations)}. Two contracts for one '
+        f'field is drift of its own; if the prompt was restructured, follow it here '
+        f'rather than loosening the pattern — an empty match would make the '
+        f'assertion below pass for the wrong reason.'
+    )
+    return {value for value in declarations[0].split('|') if value != 'null'}
 
 
 def _aggregator_persona_reads() -> list[str]:
@@ -147,29 +180,100 @@ class TestThePersonaCounterReadsAFieldThatExists:
         )
 
 
+class TestTheAxisMeasuresTheArchetype:
+    """The 99.97% case: an anonymous item still lands in a bucket that means
+    something.
+
+    Written as an item carrying an archetype and NO name, because that is the shape
+    of nearly every item this platform ingests — scraped reviews and anonymous form
+    submissions, for which the enrichment contract returns a null `persona.name` and
+    the processor writes no `persona_name` key at all. Under the old field every one
+    of them bucketed as `Unknown`, and no assertion anywhere noticed, because the
+    fixtures agreed with the aggregator about a field production rarely produces.
+    """
+
+    def test_an_item_with_an_archetype_and_no_name_buckets_under_its_archetype(self):
+        anonymous = {'persona_type': 'churn_risk'}
+        assert 'persona_name' not in anonymous, (
+            'the arrangement is the point: this item must carry no name at all, the '
+            'way a stripped item from an anonymous review arrives'
+        )
+
+        assert (f'{PERSONA_PREFIX}churn_risk', 'count') in counter_dimensions(anonymous)
+
+    def test_a_name_alone_does_not_decide_the_bucket(self):
+        """The negative half of the same fact.
+
+        An item carrying ONLY a name has no archetype, so it belongs in the empty
+        bucket — and must not resurrect the old axis by being counted under the
+        name. Without this, pointing PERSONA_FIELD back at `persona_name` would
+        leave the test above failing but nothing asserting that the name is no
+        longer what a bucket can be called.
+        """
+        named_only = {'persona_name': 'Veronica Chen'}
+        personas = [pk for pk, _ in counter_dimensions(named_only)
+                    if pk.startswith(PERSONA_PREFIX)]
+
+        assert personas == [f'{PERSONA_PREFIX}{PERSONA_UNKNOWN}'], (
+            f'{named_only} produced {personas}. A free-text name is an identifier, '
+            f'not an archetype, and must not name a metrics bucket.'
+        )
+
+
 class TestTheDefaultBucketIsStable:
     """An item with no persona must land in a NAMED bucket, the same one in both
     directions — and never in one built out of `None`.
 
-    `METRIC#persona#None` is the failure a `.get(field, 'Unknown')` default does not
+    `METRIC#persona#None` is the failure a `.get(field, DEFAULT)` default does not
     prevent: the processor strips None values, but a stream image edited by hand, or
     any writer that stores an explicit null, delivers the key present and empty. The
-    default then does not apply, `Unknown` is not used, and the counter goes to a
-    partition nothing else writes to or reads from — invisible, and unreachable by
-    the reversal if the field is ever repopulated.
+    default then does not apply, the empty bucket name is not used, and the counter
+    goes to a partition nothing else writes to or reads from — invisible, and
+    unreachable by the reversal if the field is ever repopulated.
     """
 
-    def test_a_missing_persona_buckets_under_unknown(self):
-        assert ('METRIC#persona#Unknown', 'count') in counter_dimensions({})
+    def test_a_missing_persona_buckets_under_the_empty_value(self):
+        assert (f'{PERSONA_PREFIX}{PERSONA_UNKNOWN}', 'count') in counter_dimensions({})
 
-    def test_an_explicitly_null_persona_buckets_under_unknown_too(self):
-        assert ('METRIC#persona#Unknown', 'count') in counter_dimensions(
+    def test_an_explicitly_null_persona_buckets_under_it_too(self):
+        assert (f'{PERSONA_PREFIX}{PERSONA_UNKNOWN}', 'count') in counter_dimensions(
             {PERSONA_FIELD: None}
         )
 
-    def test_an_empty_persona_name_buckets_under_unknown_too(self):
-        assert ('METRIC#persona#Unknown', 'count') in counter_dimensions(
+    def test_an_empty_persona_value_buckets_under_it_too(self):
+        assert (f'{PERSONA_PREFIX}{PERSONA_UNKNOWN}', 'count') in counter_dimensions(
             {PERSONA_FIELD: ''}
+        )
+
+    def test_a_populated_item_does_not_bucket_under_the_empty_value(self):
+        """The POSITIVE CONTROL for the three above.
+
+        Without it, all three pass just as well if everything collapses into one
+        bucket — which is precisely the defect this change repairs, so an
+        empty-bucket assertion with no populated counterexample would be asserting
+        the bug.
+        """
+        personas = [pk for pk, _ in counter_dimensions({PERSONA_FIELD: 'prospect'})
+                    if pk.startswith(PERSONA_PREFIX)]
+
+        assert personas == [f'{PERSONA_PREFIX}prospect'], personas
+
+    def test_the_empty_bucket_is_a_value_the_enrichment_enum_declares(self):
+        """Not a bespoke label: a value the contract already defines.
+
+        The bucket was `Unknown`, which appears in no contract — so a caller reading
+        the axis got one value that was not from the enum and could not tell whether
+        it meant "the model said unknown" or "we had nothing". Spelling it the
+        enum's way makes every bucket name, once the pre-deploy rows have aged out,
+        a value the contract declares.
+        """
+        admitted = _processor_persona_type_enum()
+
+        assert PERSONA_UNKNOWN in admitted, (
+            f'the empty persona bucket is `{PERSONA_UNKNOWN}`, which the enrichment '
+            f'contract in {PROCESSOR_SOURCE} does not admit — it admits '
+            f'{sorted(admitted)}. Name it with a value the contract defines, so the '
+            f'axis has no values invented outside it.'
         )
 
     def test_the_persona_dimension_is_never_absent(self):
@@ -180,9 +284,9 @@ class TestTheDefaultBucketIsStable:
         for a reason other than the item's own value, is how one direction writes a
         row the other never comes back for.
         """
-        for item in ({}, {PERSONA_FIELD: None}, {PERSONA_FIELD: 'Happy Customer'}):
+        for item in ({}, {PERSONA_FIELD: None}, {PERSONA_FIELD: 'advocate'}):
             personas = [pk for pk, _ in counter_dimensions(item)
-                        if pk.startswith('METRIC#persona#')]
+                        if pk.startswith(PERSONA_PREFIX)]
             assert len(personas) == 1, (
                 f'{item} produced {personas}; exactly one persona counter must be '
                 f'written for every item, in both directions.'

--- a/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
+++ b/voc-datalake/lambda/aggregator/test/test_persona_field_lockstep.py
@@ -57,19 +57,37 @@ REVERT MAP
     * Point PERSONA_FIELD back at `persona_name` — fails
       test_an_item_with_an_archetype_and_no_name_buckets_under_its_archetype, which
       is the 99.97% case, and (from the API side)
-      test_the_scan_path_and_the_aggregates_path_agree_on_one_item in
+      test_the_scan_path_and_the_aggregates_path_bucket_one_item_identically in
       lambda/api/test/test_persona_dimension_lockstep.py.
+    * Spell the partition prefix here instead of importing PERSONA_PREFIX — fails
+      test_neither_side_spells_the_persona_partition_in_its_own_code, in that same
+      file, which reads the parsed CODE of the four functions that spend it.
+    * Delete the reversal's pre-deploy fallback
+      (`_reverse_a_pre_deploy_persona_row`) — fails
+      TestAPreDeployImageIsReversedOnTheArchetype in test_handler.py, which is where
+      the cross-deploy case is pinned.
+
+    Every name cited above was grepped against the repo and resolves. That check is
+    worth repeating on edit: review found this map naming a test
+    (`..._agree_on_one_item`) that existed nowhere, and in a repo where the REVERT
+    MAP is the index from mutation to failing test, a citation that resolves to
+    nothing is the one kind of staleness these files cannot absorb — the next reader
+    greps for it, finds nothing, and has to reconstruct whether the coverage exists.
 """
 import ast
 import re
 from pathlib import Path
 
-from aggregator.handler import PERSONA_FIELD, PERSONA_UNKNOWN, counter_dimensions
+from aggregator.handler import (
+    PERSONA_FIELD,
+    PERSONA_PREFIX,
+    PERSONA_UNKNOWN,
+    counter_dimensions,
+)
 
 PROCESSOR_SOURCE = 'lambda/processor/handler.py'
 AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
 DIMENSIONS_FUNCTION = 'counter_dimensions'
-PERSONA_PREFIX = 'METRIC#persona#'
 
 
 def _read(relative: str) -> str:
@@ -109,13 +127,22 @@ def _processor_persona_type_enum() -> set[str]:
     below stands in for, not a value the bucket could be named after.
     """
     source = _read(PROCESSOR_SOURCE)
-    declarations = re.findall(r'"persona":.*?"type":"([^"]+)"', source)
+    # re.DOTALL so `.` crosses newlines. Without it the pattern depended on
+    # `USER_PROMPT_TEMPLATE` staying one ~1000-character line, and wrapping it for
+    # readability — a plausible edit that changes no contract — would have found zero
+    # matches. The `len == 1` assertion below makes that loud rather than silent
+    # either way, but a pin should not be spendable on formatting at all.
+    declarations = re.findall(r'"persona":.*?"type":"([^"]+)"', source, re.DOTALL)
     assert len(declarations) == 1, (
         f'Expected exactly one `persona.type` declaration in the enrichment prompt '
         f'in {PROCESSOR_SOURCE}; found {len(declarations)}. Two contracts for one '
         f'field is drift of its own; if the prompt was restructured, follow it here '
         f'rather than loosening the pattern — an empty match would make the '
-        f'assertion below pass for the wrong reason.'
+        f'assertion below pass for the wrong reason.\n'
+        f'The remaining dependency, now that newlines are crossed: `"persona":` must '
+        f'precede its own `"type":"..."` with no other `"type":"` in between, since '
+        f'`.*?` stops at the FIRST one. A prompt that declares another object\'s '
+        f'`type` between the two would match that instead and report the wrong enum.'
     )
     return {value for value in declarations[0].split('|') if value != 'null'}
 

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -22,6 +22,7 @@ from shared.api import (
 from shared.exceptions import ValidationError
 from shared.feedback import (
     PERSONA_PREFIX,
+    has_legacy_persona_buckets,
     basis_date,
     persona_bucket,
     window_cutoff,
@@ -556,6 +557,12 @@ def get_entities():
             'period_days': days,
             'feedback_count': len(items),
             'is_partial': is_partial,
+            # Always False on this branch, and published rather than omitted for the
+            # reason `is_partial` is: a reader cannot tell an absent flag from a false
+            # one. It cannot be true here because this branch DERIVES every bucket
+            # through `persona_bucket`, which only ever emits a member of the enum —
+            # so the flag also documents the difference between the two branches.
+            'has_legacy_persona_buckets': False,
             'entities': {
                 'keywords': {},
                 'categories': dict(sorted(category_counts.items(), key=lambda x: x[1], reverse=True)),
@@ -645,6 +652,10 @@ def get_entities():
         'period_days': days,
         'feedback_count': feedback_count,
         'is_partial': is_partial,
+        # Rows written before the persona axis moved come back exactly as stored, so
+        # this window can carry free-text names and a capitalised `Unknown` beside the
+        # enum's values. Reported, never repaired — see `has_legacy_persona_buckets`.
+        'has_legacy_persona_buckets': has_legacy_persona_buckets(persona_counts),
         'entities': {
             'keywords': {},
             'categories': dict(sorted(category_counts.items(), key=lambda x: x[1], reverse=True)),
@@ -1079,6 +1090,9 @@ def get_persona_metrics():
         return {
             'period_days': days,
             'is_partial': is_partial,
+            # Cannot be true on a derived branch — see the same field in
+            # `/feedback/entities`, and published for the same reason.
+            'has_legacy_persona_buckets': False,
             'personas': dict(sorted(personas.items(), key=lambda x: x[1], reverse=True))
         }
     
@@ -1105,6 +1119,9 @@ def get_persona_metrics():
     return {
         'period_days': days,
         'is_partial': is_partial,
+        # The stored rows, as stored — so this window can mix the enum's values with
+        # buckets only the old derivation could write. See `has_legacy_persona_buckets`.
+        'has_legacy_persona_buckets': has_legacy_persona_buckets(personas),
         'personas': dict(sorted(personas.items(), key=lambda x: x[1], reverse=True))
     }
 

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -20,7 +20,13 @@ from shared.api import (
     AGGREGATE_RETENTION_DAYS,
 )
 from shared.exceptions import ValidationError
-from shared.feedback import PERSONA_FIELD, PERSONA_UNKNOWN, basis_date, window_cutoff
+from shared.feedback import (
+    PERSONA_FIELD,
+    PERSONA_PREFIX,
+    PERSONA_UNKNOWN,
+    basis_date,
+    window_cutoff,
+)
 from shared.indexes import (
     AGGREGATES_BY_METRIC_TYPE_INDEX,
     FEEDBACK_BY_CATEGORY_INDEX,
@@ -310,6 +316,13 @@ def _persona_bucket(item: dict) -> str:
 
     `or`, not a `.get` default, and for the aggregator's reason: an item can carry
     an explicit None, which a default would not replace.
+
+    WHY THE DERIVATION IS DUPLICATED HERE rather than shared alongside the two
+    constants — considered, and rejected: that `or` reasoning is a property of this
+    one expression and reads differently on each side (there, what a stream image
+    can hold; here, what the scan path answers), so a shared helper would move it
+    one import away from both readers to remove two lines that are already pinned to
+    each other. See the note beside PERSONA_UNKNOWN in `shared/feedback.py`.
     """
     return item.get(PERSONA_FIELD) or PERSONA_UNKNOWN
 
@@ -591,8 +604,11 @@ def get_entities():
     persona_counts = {}
     for item in persona_response.get('Items', []):
         if item.get('sk') in date_range:
-            persona_name = item['pk'].replace('METRIC#persona#', '')
-            persona_counts[persona_name] = persona_counts.get(persona_name, 0) + int(item.get('count', 0))
+            # PERSONA_PREFIX, shared with the aggregator that BUILT this pk: two
+            # Lambdas that cannot import each other must strip exactly what the
+            # other prepended, or the bucket names come back mangled.
+            persona = item['pk'].replace(PERSONA_PREFIX, '')
+            persona_counts[persona] = persona_counts.get(persona, 0) + int(item.get('count', 0))
 
     # Get feedback count
     total_window, total_truncated = _query_metric_window(
@@ -1082,8 +1098,10 @@ def get_persona_metrics():
 
     for item in response.get('Items', []):
         if item.get('sk') in date_range:
-            persona_name = item['pk'].replace('METRIC#persona#', '')
-            personas[persona_name] = personas.get(persona_name, 0) + int(item.get('count', 0))
+            # PERSONA_PREFIX, shared with the aggregator that BUILT this pk — see
+            # the same read in `get_entities`.
+            persona = item['pk'].replace(PERSONA_PREFIX, '')
+            personas[persona] = personas.get(persona, 0) + int(item.get('count', 0))
 
     return {
         'period_days': days,

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -20,7 +20,7 @@ from shared.api import (
     AGGREGATE_RETENTION_DAYS,
 )
 from shared.exceptions import ValidationError
-from shared.feedback import basis_date, window_cutoff
+from shared.feedback import PERSONA_FIELD, PERSONA_UNKNOWN, basis_date, window_cutoff
 from shared.indexes import (
     AGGREGATES_BY_METRIC_TYPE_INDEX,
     FEEDBACK_BY_CATEGORY_INDEX,
@@ -288,6 +288,32 @@ def _index_read_was_truncated(response: dict) -> bool:
     return bool(response.get('LastEvaluatedKey'))
 
 
+def _persona_bucket(item: dict) -> str:
+    """The persona bucket one RAW FEEDBACK item belongs to, on the scan path.
+
+    The scan path exists because aggregates are bucketed by import date only, so a
+    review-date window or a source filter has to be computed from raw items — and
+    that makes this function the read side's answer to the same question
+    `aggregator/handler.py::counter_dimensions` answers when it names a
+    `METRIC#persona#<value>` row. The two must agree, or `/metrics/personas`
+    reports one thing for `?date_basis=review` and another for the default basis
+    over the same items. One window, two code paths, two different answers is the
+    defect class this file has now been repaired for twice, so the field and the
+    empty-bucket name are IMPORTED from `shared/feedback.py` rather than spelled
+    here: the aggregator imports the same two constants, and
+    test_persona_dimension_lockstep.py fails if either side reads anything else.
+
+    Why the field is the archetype and not the name is argued where the constant is
+    declared. The short of it: `persona_name` is legitimately null for anonymous
+    feedback, which is most of this corpus, so bucketing by it put 99.97% of a
+    6,239-item corpus in one bucket.
+
+    `or`, not a `.get` default, and for the aggregator's reason: an item can carry
+    an explicit None, which a default would not replace.
+    """
+    return item.get(PERSONA_FIELD) or PERSONA_UNKNOWN
+
+
 # ============================================
 # Feedback Endpoints
 # ============================================
@@ -502,9 +528,13 @@ def get_entities():
             category_counts[category] = category_counts.get(category, 0) + 1
             src = item.get('source_platform', 'unknown')
             source_counts[src] = source_counts.get(src, 0) + 1
-            persona_name = item.get('persona_name')
-            if persona_name:
-                persona_counts[persona_name] = persona_counts.get(persona_name, 0) + 1
+            # Counted for EVERY item, including the ones with no archetype, because
+            # the aggregates branch below counts every item too — the aggregator
+            # writes exactly one persona counter per item. Skipping the empty ones
+            # here would make the two branches of one route disagree about the same
+            # window, which is what `_persona_bucket` exists to prevent.
+            persona = _persona_bucket(item)
+            persona_counts[persona] = persona_counts.get(persona, 0) + 1
             problem = item.get('problem_summary', '')
             if problem and len(problem) > 5:
                 problem_key = problem[:100].lower().strip()
@@ -1025,9 +1055,12 @@ def get_persona_metrics():
         items, is_partial = _scan_window_items(days, date_basis)
         personas = {}
         for item in items:
-            persona_name = item.get('persona_name')
-            if persona_name:
-                personas[persona_name] = personas.get(persona_name, 0) + 1
+            # Every item, empty archetype included — see `_persona_bucket` and the
+            # note in `/feedback/entities`: the aggregates branch below counts one
+            # persona row per item, so a scan branch that dropped the empty ones
+            # would answer a different question over the same window.
+            persona = _persona_bucket(item)
+            personas[persona] = personas.get(persona, 0) + 1
         return {
             'period_days': days,
             'is_partial': is_partial,

--- a/voc-datalake/lambda/api/metrics_handler.py
+++ b/voc-datalake/lambda/api/metrics_handler.py
@@ -21,10 +21,9 @@ from shared.api import (
 )
 from shared.exceptions import ValidationError
 from shared.feedback import (
-    PERSONA_FIELD,
     PERSONA_PREFIX,
-    PERSONA_UNKNOWN,
     basis_date,
+    persona_bucket,
     window_cutoff,
 )
 from shared.indexes import (
@@ -297,34 +296,34 @@ def _index_read_was_truncated(response: dict) -> bool:
 def _persona_bucket(item: dict) -> str:
     """The persona bucket one RAW FEEDBACK item belongs to, on the scan path.
 
+    A one-line delegation to `shared.feedback.persona_bucket`, kept as a named
+    function here only so that the reason the scan path needs one at all lives beside
+    the two branches that call it.
+
     The scan path exists because aggregates are bucketed by import date only, so a
     review-date window or a source filter has to be computed from raw items — and
-    that makes this function the read side's answer to the same question
+    that makes this the read side's answer to the same question
     `aggregator/handler.py::counter_dimensions` answers when it names a
     `METRIC#persona#<value>` row. The two must agree, or `/metrics/personas`
     reports one thing for `?date_basis=review` and another for the default basis
     over the same items. One window, two code paths, two different answers is the
-    defect class this file has now been repaired for twice, so the field and the
-    empty-bucket name are IMPORTED from `shared/feedback.py` rather than spelled
-    here: the aggregator imports the same two constants, and
-    test_persona_dimension_lockstep.py fails if either side reads anything else.
+    defect class this file has now been repaired for twice.
+
+    🔑 IT IS ONE FUNCTION IN `shared/`, NOT TWO EXPRESSIONS THAT AGREE. An earlier
+    round of this change duplicated the expression and pinned the two copies to each
+    other, on the reasoning that a constant two Lambdas must SPELL alike is a fact to
+    share while an expression they must COMPUTE alike is a behaviour to pin. What
+    ended that was the derivation growing a branch: it now buckets a value outside
+    PERSONA_ARCHETYPES as the empty value, so the axis is CLOSED — and "closed" is a
+    property of the derivation, which two copies could widen independently. See
+    `persona_bucket`.
 
     Why the field is the archetype and not the name is argued where the constant is
     declared. The short of it: `persona_name` is legitimately null for anonymous
     feedback, which is most of this corpus, so bucketing by it put 99.97% of a
     6,239-item corpus in one bucket.
-
-    `or`, not a `.get` default, and for the aggregator's reason: an item can carry
-    an explicit None, which a default would not replace.
-
-    WHY THE DERIVATION IS DUPLICATED HERE rather than shared alongside the two
-    constants — considered, and rejected: that `or` reasoning is a property of this
-    one expression and reads differently on each side (there, what a stream image
-    can hold; here, what the scan path answers), so a shared helper would move it
-    one import away from both readers to remove two lines that are already pinned to
-    each other. See the note beside PERSONA_UNKNOWN in `shared/feedback.py`.
     """
-    return item.get(PERSONA_FIELD) or PERSONA_UNKNOWN
+    return persona_bucket(item)
 
 
 # ============================================

--- a/voc-datalake/lambda/api/test/test_metrics_handler_date_basis.py
+++ b/voc-datalake/lambda/api/test/test_metrics_handler_date_basis.py
@@ -35,7 +35,12 @@ def _item(feedback_id: str, imported_days_ago: int, written_days_ago: int, **ove
         'sentiment_score': Decimal('0.8'),
         'category': 'delivery',
         'urgency': 'low',
+        # Both persona fields, because the processor writes both. The metrics axis
+        # buckets by the ARCHETYPE (`persona_type`) — `persona_name` is legitimately
+        # null for the anonymous feedback that is most of this corpus — so a fixture
+        # carrying only a name would agree with nothing in production.
         'persona_name': 'Loyal Customer',
+        'persona_type': 'existing_customer',
         'date': _day(imported_days_ago),
         'source_created_at': _iso(written_days_ago),
     }
@@ -231,10 +236,10 @@ class TestEntitiesDateBasis:
     ):
         items = [
             _item('a', imported_days_ago=0, written_days_ago=1,
-                  category='delivery', persona_name='Loyal Customer'),
+                  category='delivery', persona_type='existing_customer'),
             _item('b', imported_days_ago=0, written_days_ago=2,
                   category='billing', source_platform='manual_import',
-                  persona_name='New Customer'),
+                  persona_type='prospect'),
             _item('old', imported_days_ago=0, written_days_ago=900,
                   category='delivery'),
         ]
@@ -249,7 +254,7 @@ class TestEntitiesDateBasis:
         assert body['feedback_count'] == 2
         assert body['entities']['categories'] == {'delivery': 1, 'billing': 1}
         assert body['entities']['sources'] == {'webscraper': 1, 'manual_import': 1}
-        assert body['entities']['personas'] == {'Loyal Customer': 1, 'New Customer': 1}
+        assert body['entities']['personas'] == {'existing_customer': 1, 'prospect': 1}
 
 
 class TestSummaryDateBasis:
@@ -413,9 +418,12 @@ class TestPersonasDateBasis:
         self, mock_fb, mock_agg, api_gateway_event, lambda_context
     ):
         items = [
-            _item('a', imported_days_ago=0, written_days_ago=1, persona_name='Loyal Customer'),
-            _item('b', imported_days_ago=0, written_days_ago=2, persona_name='Loyal Customer'),
-            _item('old', imported_days_ago=0, written_days_ago=300, persona_name='Bargain Hunter'),
+            _item('a', imported_days_ago=0, written_days_ago=1,
+                  persona_type='existing_customer'),
+            _item('b', imported_days_ago=0, written_days_ago=2,
+                  persona_type='existing_customer'),
+            _item('old', imported_days_ago=0, written_days_ago=300,
+                  persona_type='prospect'),
         ]
         mock_fb.query.side_effect = _side_effect_for_day_loop(items, days=30)
 
@@ -425,7 +433,7 @@ class TestPersonasDateBasis:
         )
         body = json.loads(lambda_handler(event, lambda_context)['body'])
 
-        assert body['personas'] == {'Loyal Customer': 2}
+        assert body['personas'] == {'existing_customer': 2}
         mock_agg.query.assert_not_called()
 
 

--- a/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
@@ -22,13 +22,12 @@ WHY THE AXIS BUCKETS BY `persona_type`
     closed enum, which is what a dimension you group by has to be.
 
 WHAT IS PINNED HERE, AND WHAT LIVES IN THE AGGREGATOR'S OWN LOCKSTEP
-    Here: that the READ side buckets on the shared field, that the two branches of
-    one route bucket one item identically, and that neither side spells the field
-    or the empty bucket as its own literal.
+    Here: that the two branches of one route bucket one item identically, that the
+    read side gets its bucket from the SHARED derivation rather than one of its own,
+    and that the value space is closed on this side too.
     There (`lambda/aggregator/test/test_persona_field_lockstep.py`): that the field
-    is one the PROCESSOR really writes, and that `counter_dimensions` — the single
-    description the increment and the decrement path share — reads it through the
-    constant.
+    that derivation reads is one the PROCESSOR really writes, that it is read through
+    the constant, and that the aggregator calls the same derivation.
 
     The aggregator is READ AS SOURCE TEXT, not imported, following
     test_aggregate_retention_lockstep.py: importing `aggregator.handler` from an api
@@ -54,9 +53,14 @@ WHICH MUTATION MAKES EACH ASSERTION FAIL
       `feedback_count` beside. The route has two branches too, and only one of them
       was pinned until review found this.
     * Drop either side's import of the shared declaration — fails
-      test_both_sides_read_the_field_from_one_declaration. Re-spell the bucket as a
-      literal beside the constant, or derive it in a second statement, and
-      test_neither_side_spells_the_bucket_out_beside_the_constant fails.
+      test_both_sides_read_the_field_from_one_declaration. Have either side derive the
+      bucket itself instead of calling `persona_bucket` and
+      test_neither_side_derives_the_bucket_for_itself fails.
+    * Open the axis (have `persona_bucket` interpolate `persona_type` verbatim) —
+      fails test_an_out_of_contract_archetype_is_counted_as_unclassified, whose
+      positive control is test_a_populated_item_is_not_counted_under_the_empty_value.
+      That property is what makes PERSONA_ARCHETYPES the whole space of buckets either
+      branch can produce, which the aggregator's collision guard depends on.
     * Change the `METRIC#persona#` key prefix in the code of either handler — fails
       test_neither_side_spells_the_persona_partition_in_its_own_code, which is what
       keeps `get_metric_type`, the `metric_type` GSI and the read paths working while
@@ -82,13 +86,12 @@ WHAT REVIEW FOUND WRONG WITH TWO OF THESE PINS, recorded because the failures we
 """
 import ast
 import json
-import re
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import patch
 
-from shared.feedback import PERSONA_FIELD, PERSONA_PREFIX, PERSONA_UNKNOWN
+from shared.feedback import PERSONA_PREFIX, PERSONA_UNKNOWN, persona_bucket
 
 # test/ → api/ → lambda/ → voc-datalake/, then the two files that share the axis.
 _REPO = Path(__file__).resolve().parents[3]
@@ -96,13 +99,21 @@ AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
 METRICS_SOURCE = 'lambda/api/metrics_handler.py'
 SHARED_MODULE = 'shared.feedback'
 
-# The three names both sides must read from ONE declaration. PERSONA_PREFIX joined
-# the two after review found the structural pin on it was inert: it was a file-wide
-# substring search, and both files MENTION the prefix in prose, so the docstrings
-# alone satisfied it — the pin passed with both files' real code drifted to
-# `METRIC#DRIFT#`. A shared constant plus "no side spells it in code" is a pin that
-# cannot be satisfied by a comment.
-SHARED_NAMES = ('PERSONA_FIELD', 'PERSONA_UNKNOWN', 'PERSONA_PREFIX')
+# The names both sides must read from ONE declaration. PERSONA_PREFIX joined
+# PERSONA_FIELD and PERSONA_UNKNOWN after review found the structural pin on it was
+# inert: it was a file-wide substring search, and both files MENTION the prefix in
+# prose, so the docstrings alone satisfied it — the pin passed with both files' real
+# code drifted to `METRIC#DRIFT#`. A shared constant plus "no side spells it in code"
+# is a pin that cannot be satisfied by a comment.
+#
+# `persona_bucket` then replaced the two VALUE constants here, because the derivation
+# itself moved into `shared/feedback.py`: a side that calls the shared function is
+# reading the shared field and the shared empty value by construction, and it is also
+# respecting the CLOSED value space, which two copies of the expression could widen
+# independently. Neither Lambda names PERSONA_FIELD at all now — the pin on the field
+# lives where the read does, in
+# aggregator/test/test_persona_field_lockstep.py::test_the_persona_field_is_read_through_the_constant.
+SHARED_NAMES = ('persona_bucket', 'PERSONA_PREFIX')
 
 # Every function that names the persona partition, listed per side because the pin
 # below is that NONE of them spells it as its own literal. Four rather than two: the
@@ -127,13 +138,14 @@ def _read(relative: str) -> str:
     return path.read_text(encoding='utf-8')
 
 
-def _statements_deriving_the_bucket(relative: str, function: str) -> list[str]:
-    """Every statement inside `function` that reads PERSONA_FIELD, unparsed.
+def _calls_the_shared_derivation(relative: str, function: str) -> bool:
+    """Does the CODE of `function` get its persona bucket by calling `persona_bucket`?
 
     Parsed with `ast` and scoped to the one function, the convention this repo's
     other locksteps follow, and for the usual two reasons: a pattern cannot tell a
-    call from a MENTION of one (this file's own docstrings name both constants), and
-    a pattern reads only the shapes it anticipated.
+    call from a MENTION of one (this file's own docstrings name the function), and
+    a pattern reads only the shapes it anticipated. The docstring is dropped for that
+    first reason.
     """
     tree = ast.parse(_read(relative))
     functions = [node for node in ast.walk(tree)
@@ -143,12 +155,20 @@ def _statements_deriving_the_bucket(relative: str, function: str) -> list[str]:
         f'Expected exactly one {function} in {relative}; found {len(functions)}. A '
         f'second copy is the drift this file exists to prevent.'
     )
-    found: list[str] = []
-    for statement in functions[0].body:
-        names = {node.id for node in ast.walk(statement) if isinstance(node, ast.Name)}
-        if 'PERSONA_FIELD' in names:
-            found.append(ast.unparse(statement))
-    return found
+    body = functions[0].body[1:]
+    return any(isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+               and node.func.id == 'persona_bucket'
+               for statement in body for node in ast.walk(statement))
+
+
+def _persona_field_literals_in(relative: str, function: str) -> list[str]:
+    """Any persona FIELD name spelled as a literal in the code of `function`.
+
+    The negative half of the pin: a side that calls the shared derivation AND reads
+    a persona field itself is a side with two answers, which is the drift.
+    """
+    return sorted(value for value in _string_constants_in(relative, (function,))
+                  if value.startswith('persona_'))
 
 
 def _names_imported_from_the_shared_module(relative: str) -> set[str]:
@@ -249,12 +269,12 @@ def _feedback_item(**overrides) -> dict:
 def _aggregate_row_for(item: dict) -> dict:
     """The persona counter row the aggregator writes for `item`.
 
-    Assembled from the SHARED field constant plus the partition prefix both sides
-    spell — not from a hand-written pk — so that a scan path reading some other
-    field disagrees with this row instead of with a literal chosen to match it.
+    Assembled from the SHARED derivation plus the partition prefix both sides spell —
+    not from a hand-written pk — so that a scan path answering something else
+    disagrees with this row instead of with a literal chosen to match it.
     """
     return {
-        'pk': f'{PERSONA_PREFIX}{item.get(PERSONA_FIELD) or PERSONA_UNKNOWN}',
+        'pk': f'{PERSONA_PREFIX}{persona_bucket(item)}',
         'sk': _day(0),
         'count': 1,
     }
@@ -439,6 +459,32 @@ class TestTheScanPathMeasuresTheArchetype:
 
     @patch('metrics_handler.feedback_table')
     @patch('metrics_handler.aggregates_table')
+    def test_an_out_of_contract_archetype_is_counted_as_unclassified(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The axis is CLOSED, and the read side has to agree that it is.
+
+        Nothing validates `persona_type` on the way in — this repo's own frontend
+        fixtures use `loyal`, and `PUT /data-explorer/feedback` accepts the field with
+        no allowlist — so a value the enrichment contract never declares can reach a
+        stored item. `persona_bucket` counts it as the empty value, which is what makes
+        PERSONA_ARCHETYPES the whole space of buckets either branch can produce, and
+        the aggregator's collision guard depends on that being true of BOTH sides.
+
+        The positive control is its sibling below: a contract-declared archetype must
+        still get its own bucket, or "everything is unclassified" would pass this.
+        """
+        personas = _scan_personas([_feedback_item(persona_type='loyal')], mock_fb,
+                                  mock_agg, api_gateway_event, lambda_context)
+
+        assert personas == {PERSONA_UNKNOWN: 1}, (
+            f'{personas}: a `persona_type` outside the contract must not name a bucket '
+            f'of its own. A caller grouping by this axis can only enumerate its value '
+            f'space if the contract is the value space.'
+        )
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
     def test_a_populated_item_is_not_counted_under_the_empty_value(
         self, mock_agg, mock_fb, api_gateway_event, lambda_context
     ):
@@ -476,34 +522,37 @@ class TestNeitherSideKeepsItsOwnCopy:
                 f'half of it.'
             )
 
-    def test_neither_side_spells_the_bucket_out_beside_the_constant(self):
-        """The bucket is derived in ONE statement per side, and it quotes nothing.
+    def test_neither_side_derives_the_bucket_for_itself(self):
+        """Both sides CALL one derivation; neither computes an answer of its own.
 
-        Scoped to that statement rather than searched for across the file, because
-        `'unknown'` is also the `source_platform` default a few lines above the
-        aggregator's persona line: a file-wide search for the value would report a
-        correct module, which is the one thing a lockstep must never do.
+        Stronger than the pin it replaces, which required one statement per side
+        naming PERSONA_UNKNOWN and quoting nothing — that held the two expressions to
+        the same SHAPE, and shape was enough while the derivation was
+        `item.get(PERSONA_FIELD) or PERSONA_UNKNOWN`. It stopped being enough when the
+        derivation grew a membership test: the axis is now CLOSED (a value outside
+        PERSONA_ARCHETYPES buckets as the empty value), and "closed" is a property two
+        independent expressions of the same shape could each widen. So the pin is now
+        that there is one function, and each side calls it.
+
+        Scoped with `ast` to the one function and with the docstring dropped, because
+        both of these functions NAME `persona_bucket` in prose — a file-wide search
+        would report a module that had stopped calling it, which is the one thing a
+        lockstep must never do.
         """
         for relative, function in ((AGGREGATOR_SOURCE, 'counter_dimensions'),
                                    (METRICS_SOURCE, '_persona_bucket')):
-            statements = _statements_deriving_the_bucket(relative, function)
-            assert len(statements) == 1, (
-                f'{relative}::{function} derives the persona bucket in '
-                f'{len(statements)} statements: {statements}. One statement, so that '
-                f'moving the field is one edit — a second is where the two directions '
-                f'of the stream, or the two branches of the route, come apart.'
+            assert _calls_the_shared_derivation(relative, function), (
+                f'{relative}::{function} does not call `persona_bucket`. One window '
+                f'is read by both of these, so a second derivation is where the two '
+                f'directions of the stream, or the two branches of the route, come '
+                f'apart — and where the closed value space the reversal\'s collision '
+                f'guard depends on stops being true on one side.'
             )
-            statement = statements[0]
-            assert 'PERSONA_UNKNOWN' in statement, (
-                f'{relative}::{function} derives the persona bucket as `{statement}`, '
-                f'which does not name PERSONA_UNKNOWN. The empty case has to come '
-                f'from the shared declaration too, or one side keeps calling it '
-                f'something the other does not recognise.'
-            )
-            assert not re.search(r"""['"]""", statement), (
-                f'{relative}::{function} derives the persona bucket as '
-                f'`{statement}`, which quotes a value alongside the constants. Two '
-                f'spellings of one value is the drift, whichever is currently right.'
+            spelled = _persona_field_literals_in(relative, function)
+            assert not spelled, (
+                f'{relative}::{function} spells the persona field(s) {spelled} as '
+                f'literals as well as calling the shared derivation. Two answers to '
+                f'one question is the drift, whichever is currently right.'
             )
 
     def test_neither_side_spells_the_persona_partition_in_its_own_code(self):

--- a/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
@@ -47,14 +47,38 @@ WHICH MUTATION MAKES EACH ASSERTION FAIL
       sibling test_a_populated_item_is_not_counted_under_the_empty_value is the
       positive control that stops the pair passing by everything collapsing into
       one bucket.
+    * Have `/feedback/entities` skip items with no value while `/metrics/personas`
+      counts them — fails
+      test_the_entities_persona_map_sums_to_the_corpus_it_reports, which drives the
+      OTHER scan branch and asserts the sum invariant the route publishes
+      `feedback_count` beside. The route has two branches too, and only one of them
+      was pinned until review found this.
     * Drop either side's import of the shared declaration — fails
       test_both_sides_read_the_field_from_one_declaration. Re-spell the bucket as a
       literal beside the constant, or derive it in a second statement, and
       test_neither_side_spells_the_bucket_out_beside_the_constant fails.
-    * Change the `METRIC#persona#` key prefix on one side only — fails
-      test_both_sides_spell_the_persona_partition_the_same_way, which is what keeps
-      `get_metric_type`, the `metric_type` GSI and the read paths working while the
-      source field moves underneath them.
+    * Change the `METRIC#persona#` key prefix in the code of either handler — fails
+      test_neither_side_spells_the_persona_partition_in_its_own_code, which is what
+      keeps `get_metric_type`, the `metric_type` GSI and the read paths working while
+      the source field moves underneath them.
+
+WHAT REVIEW FOUND WRONG WITH TWO OF THESE PINS, recorded because the failures were
+    of the two kinds a lockstep must not have, and because the same mistakes are
+    easy to make again:
+    (Both names below are DELETED tests, named only to say what was wrong with them
+    — every live citation in the map above resolves, which is worth re-checking on
+    edit: review found this file's sibling naming a test that existed nowhere.)
+    * test_both_sides_spell_the_persona_partition_the_same_way [removed] was a file-wide
+      substring search for `METRIC#persona#`. Both handlers MENTION the prefix in
+      prose, so the docstrings satisfied it: with both files' real code drifted to
+      `METRIC#DRIFT#` and only the comments untouched, it passed. Replaced by a
+      negative pin over the parsed code of the four functions that spend the prefix,
+      plus the prefix hoisted into `shared/feedback.py` beside the other two.
+    * test_both_sides_read_the_field_from_one_declaration matched the import with a
+      line-anchored regex, so a parenthesised multi-line import — what a formatter
+      produces once the line grows — FAILED A CORRECT MODULE. Replaced by
+      `ast.ImportFrom`. That direction is the more dangerous one: a false red trains
+      the next contributor to deform correct code to appease a test.
 """
 import ast
 import json
@@ -64,7 +88,7 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import patch
 
-from shared.feedback import PERSONA_FIELD, PERSONA_UNKNOWN
+from shared.feedback import PERSONA_FIELD, PERSONA_PREFIX, PERSONA_UNKNOWN
 
 # test/ → api/ → lambda/ → voc-datalake/, then the two files that share the axis.
 _REPO = Path(__file__).resolve().parents[3]
@@ -72,10 +96,21 @@ AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
 METRICS_SOURCE = 'lambda/api/metrics_handler.py'
 SHARED_MODULE = 'shared.feedback'
 
-# The axis's key prefix, which deliberately did NOT move when the source field did:
-# `get_metric_type`, the `metric_type` GSI and every read path key off it, and the
-# axis is still "persona" — only where its value comes from changed.
-PERSONA_PREFIX = 'METRIC#persona#'
+# The three names both sides must read from ONE declaration. PERSONA_PREFIX joined
+# the two after review found the structural pin on it was inert: it was a file-wide
+# substring search, and both files MENTION the prefix in prose, so the docstrings
+# alone satisfied it — the pin passed with both files' real code drifted to
+# `METRIC#DRIFT#`. A shared constant plus "no side spells it in code" is a pin that
+# cannot be satisfied by a comment.
+SHARED_NAMES = ('PERSONA_FIELD', 'PERSONA_UNKNOWN', 'PERSONA_PREFIX')
+
+# Every function that names the persona partition, listed per side because the pin
+# below is that NONE of them spells it as its own literal. Four rather than two: the
+# aggregator both BUILDS the pk (`counter_dimensions`) and recognises it for the
+# `metric_type` GSI (`get_metric_type`), and metrics_handler strips it back off in
+# BOTH of its aggregates branches — `/metrics/personas` and `/feedback/entities`.
+AGGREGATOR_PREFIX_USERS = ('counter_dimensions', 'get_metric_type')
+METRICS_PREFIX_USERS = ('get_persona_metrics', 'get_entities')
 
 # An archetype and a name that cannot be confused for one another, so a response
 # says WHICH field produced it rather than merely how many items were counted.
@@ -114,6 +149,78 @@ def _statements_deriving_the_bucket(relative: str, function: str) -> list[str]:
         if 'PERSONA_FIELD' in names:
             found.append(ast.unparse(statement))
     return found
+
+
+def _names_imported_from_the_shared_module(relative: str) -> set[str]:
+    """Every name `relative` imports from `shared.feedback`, read by `ast`.
+
+    Parsed rather than pattern-matched, because the first version of this was
+    `^from shared.feedback import (.+)$` with re.MULTILINE — which reads only a
+    single-line import and so FAILED A CORRECT MODULE the moment the import was
+    wrapped across lines. That is the worse direction of wrong: a false red trains
+    the next contributor to unwrap an import to appease a test rather than to read
+    what it means, and this file's own docstring argues against exactly the pattern
+    that produced it. `ast.ImportFrom` is immune to wrapping, to aliasing and to a
+    comment in the middle of the list alike.
+    """
+    tree = ast.parse(_read(relative))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == SHARED_MODULE:
+            imported.update(alias.name for alias in node.names)
+    return imported
+
+
+def _string_constants_in(relative: str, functions: tuple[str, ...]) -> set[str]:
+    """Every string literal appearing in the CODE of the named functions.
+
+    Docstrings excluded, and that exclusion is the whole point: the pin this
+    replaces was `PERSONA_PREFIX in _read(relative)`, a file-wide substring search,
+    and both handlers name `METRIC#persona#` in prose — so the DOCSTRINGS satisfied
+    it and it passed with both files' real code drifted to `METRIC#DRIFT#`. Verified
+    by that mutation. A lockstep that cannot fail for the drift it names is worse
+    than none, so this reads the literals a function actually evaluates.
+    """
+    tree = ast.parse(_read(relative))
+    wanted = [node for node in ast.walk(tree)
+              if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+              and node.name in functions]
+    assert len(wanted) == len(functions), (
+        f'Expected {list(functions)} in {relative}; found '
+        f'{sorted(node.name for node in wanted)}. If one was renamed or moved, '
+        f'follow it here — a helper that reads nothing satisfies its own assertion.'
+    )
+    found: set[str] = set()
+    for function in wanted:
+        body = function.body
+        # Drop the docstring statement, which is a bare string expression first in
+        # the body. Everything after it is code.
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            body = body[1:]
+        for statement in body:
+            for node in ast.walk(statement):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    found.add(node.value)
+    return found
+
+
+def _names_read_in(relative: str, function: str) -> set[str]:
+    """Every name the CODE of `function` reads. The positive half of the prefix pin.
+
+    Docstrings excluded for the reason `_string_constants_in` gives: a mention is
+    not a use, and this file's siblings have already been caught once by a pin a
+    comment could satisfy.
+    """
+    tree = ast.parse(_read(relative))
+    wanted = [node for node in ast.walk(tree)
+              if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+              and node.name == function]
+    assert len(wanted) == 1, (
+        f'Expected exactly one {function} in {relative}; found {len(wanted)}.'
+    )
+    return {node.id for node in ast.walk(wanted[0]) if isinstance(node, ast.Name)}
 
 
 def _day(days_ago: int) -> str:
@@ -180,6 +287,87 @@ def _aggregate_personas(rows, mock_agg, event_factory, context) -> dict:
     response = lambda_handler(event, context)
     assert response['statusCode'] == 200, response['body']
     return json.loads(response['body'])['personas']
+
+
+def _scan_entities(items, mock_fb, mock_agg, event_factory, context) -> dict:
+    """`/feedback/entities` down its SCAN branch (review basis), parsed whole.
+
+    The WHOLE body rather than just the persona map, because this route publishes
+    `feedback_count` next to it — which makes "the persona map sums to the corpus"
+    an invariant a caller can check and a test can assert, and it is the invariant
+    the decision to count empty-archetype items is justified by.
+    """
+    days = 7
+    mock_fb.query.side_effect = [{'Items': items}] + [{'Items': []}] * (days - 1)
+    from metrics_handler import lambda_handler
+
+    event = event_factory(
+        method='GET', path='/feedback/entities',
+        query_params={'days': str(days), 'date_basis': 'review'},
+    )
+    response = lambda_handler(event, context)
+    assert response['statusCode'] == 200, response['body']
+    return json.loads(response['body'])
+
+
+class TestBothScanBranchesCountEveryItem:
+    """`/feedback/entities` is a branch too, and it was the unpinned one.
+
+    The one behavioural change beyond the field move is that a scan path counts
+    items with NO archetype instead of dropping them — required so the scan and the
+    aggregates branches of one window answer the same question, since the aggregator
+    writes exactly one persona row per item. That was pinned for `/metrics/personas`
+    and not for this route, and review demonstrated the gap: reinstating the
+    `if persona != PERSONA_UNKNOWN` guard in `get_entities` ALONE left the whole
+    `lambda/api` suite green, because every fixture in TestEntitiesDateBasis carries
+    a `persona_type` and the empty case never reached the line.
+    """
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_entities_persona_map_sums_to_the_corpus_it_reports(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The positive control and the sum invariant in one assertion.
+
+        One archetype-bearing item and one carrying neither persona field, so the
+        map cannot pass by everything collapsing into one bucket; and the sum
+        checked against the `feedback_count` the same response publishes, so a
+        dropped item is visible as the two disagreeing rather than only as a smaller
+        number nothing is compared to.
+
+        Fails if `get_entities` guards its `persona_counts` increment with
+        `if persona != PERSONA_UNKNOWN` (or `if persona:`) again.
+        """
+        body = _scan_entities(
+            [_feedback_item(persona_type=ARCHETYPE),
+             _feedback_item(sk='FEEDBACK#f2', feedback_id='f2')],
+            mock_fb, mock_agg, api_gateway_event, lambda_context,
+        )
+        personas = body['entities']['personas']
+
+        assert personas == {ARCHETYPE: 1, PERSONA_UNKNOWN: 1}, personas
+        assert sum(personas.values()) == body['feedback_count'], (
+            f'{personas} sums to {sum(personas.values())} over a corpus this same '
+            f'response reports as {body["feedback_count"]} items. Every item gets '
+            f'exactly one persona row from the aggregator, so this route\'s two '
+            f'branches only agree while the scan branch counts every item too.'
+        )
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_entities_scan_branch_buckets_on_the_archetype_not_the_name(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The field move, on this branch. Subject carries BOTH fields, so the two
+        are distinguishable — an item with only one would bucket the same either
+        way and this would pass over a branch left on the old field."""
+        body = _scan_entities(
+            [_feedback_item(persona_type=ARCHETYPE, persona_name=FREE_TEXT_NAME)],
+            mock_fb, mock_agg, api_gateway_event, lambda_context,
+        )
+
+        assert body['entities']['personas'] == {ARCHETYPE: 1}, body['entities']
 
 
 class TestOneRouteGivesOneAnswer:
@@ -280,13 +468,9 @@ class TestNeitherSideKeepsItsOwnCopy:
 
     def test_both_sides_read_the_field_from_one_declaration(self):
         for relative in (AGGREGATOR_SOURCE, METRICS_SOURCE):
-            source = _read(relative)
-            imports = re.findall(
-                rf'^from {re.escape(SHARED_MODULE)} import (.+)$', source, re.MULTILINE
-            )
-            imported = {name.strip() for line in imports for name in line.split(',')}
-            assert {'PERSONA_FIELD', 'PERSONA_UNKNOWN'} <= imported, (
-                f'{relative} does not import PERSONA_FIELD and PERSONA_UNKNOWN from '
+            imported = _names_imported_from_the_shared_module(relative)
+            assert set(SHARED_NAMES) <= imported, (
+                f'{relative} does not import {list(SHARED_NAMES)} from '
                 f'{SHARED_MODULE}; it imports {sorted(imported)}. Both sides of the '
                 f'axis have to read one declaration, or moving the field moves only '
                 f'half of it.'
@@ -322,17 +506,42 @@ class TestNeitherSideKeepsItsOwnCopy:
                 f'spellings of one value is the drift, whichever is currently right.'
             )
 
-    def test_both_sides_spell_the_persona_partition_the_same_way(self):
-        """The key prefix did not move, and must not move on one side alone.
+    def test_neither_side_spells_the_persona_partition_in_its_own_code(self):
+        """The key prefix did not move, and must not be movable on one side alone.
 
         `get_metric_type` tags these rows for the `metric_type` GSI by this prefix
         and both read paths strip it back off, so a prefix changed where the rows
         are WRITTEN and not where they are read leaves the GSI untagged and the
-        dimension empty — while every count is still computed correctly.
+        dimension empty — while every count is still computed correctly. No error,
+        no log, an empty axis.
+
+        This is a NEGATIVE pin — no side may spell the prefix as its own literal —
+        rather than the positive one it replaces. Review demonstrated the positive
+        form was inert: `PERSONA_PREFIX in _read(relative)` is a file-wide substring
+        search, and both handlers name the prefix in prose, so the DOCSTRINGS
+        satisfied it and it passed with both files' real code drifted to
+        `METRIC#DRIFT#`. Asserting the absence of a literal in the parsed CODE of
+        the four functions that spend the prefix is the form that cannot be
+        satisfied by a comment: with nowhere to write it, one-sided drift has to go
+        through the shared declaration, which moves both sides at once.
         """
-        for relative in (AGGREGATOR_SOURCE, METRICS_SOURCE):
-            assert PERSONA_PREFIX in _read(relative), (
-                f'{relative} no longer spells `{PERSONA_PREFIX}`. The axis is still '
-                f'"persona"; only its source field moved. If the prefix really is '
-                f'changing, it changes on both sides and here in the same commit.'
+        for relative, functions in ((AGGREGATOR_SOURCE, AGGREGATOR_PREFIX_USERS),
+                                    (METRICS_SOURCE, METRICS_PREFIX_USERS)):
+            literals = _string_constants_in(relative, functions)
+            spelled = sorted(value for value in literals if 'persona#' in value.lower())
+            assert not spelled, (
+                f'{relative} spells the persona partition as the literal(s) '
+                f'{spelled} inside {list(functions)}. It has to come from '
+                f'{SHARED_MODULE}.PERSONA_PREFIX: the aggregator builds these pks '
+                f'and tags them for the metric_type GSI, metrics_handler strips '
+                f'them back off, and the two Lambdas cannot import each other — a '
+                f'prefix changed on one side empties the dimension while every '
+                f'count stays right.'
             )
+            for function in functions:
+                assert 'PERSONA_PREFIX' in _names_read_in(relative, function), (
+                    f'{relative}::{function} does not read PERSONA_PREFIX. Every '
+                    f'place the persona partition is named must come through the '
+                    f'shared declaration, or the assertion above passes by that '
+                    f'function no longer naming the partition at all.'
+                )

--- a/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
@@ -309,6 +309,24 @@ def _aggregate_personas(rows, mock_agg, event_factory, context) -> dict:
     return json.loads(response['body'])['personas']
 
 
+def _aggregate_body(rows, mock_agg, event_factory, context) -> dict:
+    """`/metrics/personas` down its AGGREGATES branch, WHOLE body.
+
+    Separate from `_aggregate_personas` rather than widening it, because the callers of
+    that one assert on the map and reading a wider return would let a test compare a
+    dict against a body and pass on the `!=`.
+    """
+    mock_agg.query.return_value = {'Items': rows}
+    from metrics_handler import lambda_handler
+
+    event = event_factory(
+        method='GET', path='/metrics/personas', query_params={'days': '7'},
+    )
+    response = lambda_handler(event, context)
+    assert response['statusCode'] == 200, response['body']
+    return json.loads(response['body'])
+
+
 def _scan_entities(items, mock_fb, mock_agg, event_factory, context) -> dict:
     """`/feedback/entities` down its SCAN branch (review basis), parsed whole.
 
@@ -388,6 +406,137 @@ class TestBothScanBranchesCountEveryItem:
         )
 
         assert body['entities']['personas'] == {ARCHETYPE: 1}, body['entities']
+
+
+class TestTheMixedWindowSaysSoInTheRESPONSE:
+    """🔑 A QUALIFIED ANSWER MUST SAY IT IS QUALIFIED, which a comment cannot do.
+
+    For up to `AGGREGATE_RETENTION_DAYS` after the move, the aggregates branch returns
+    rows the OLD derivation wrote — free-text names and a capitalised `Unknown` — beside
+    the enum's values, and the counts are all correct. A caller reading
+    `{'churn_risk': 40, 'Unknown': 6000, 'Veronica Chen': 1}` cannot tell residue from a
+    live bucket, and an MCP caller is a model that will report on those keys.
+
+    `is_partial` is the precedent this follows: it exists because a reader cannot tell an
+    absent flag from a false one, and the same argument applies to a second dimension of
+    the same response. Before this, the transition was documented only in a comment at
+    `PERSONA_UNKNOWN` — which is the qualification living somewhere the caller cannot
+    read, the shape this repo has already rejected once.
+
+    ⚠️ IT REPORTS, IT DOES NOT REPAIR, and the negative test below is the one that
+    matters: folding a legacy key into `unknown` on read would merge real free-text
+    counts into the empty bucket, corrupting the one bucket an operator watches to judge
+    enrichment health and hiding the transition in the other direction.
+
+    REVERT MAP
+      * Drop the flag from either aggregates branch — fails
+        test_a_window_carrying_a_pre_move_row_says_so and
+        test_the_entities_route_flags_it_too.
+      * Publish it only when true (omit it otherwise) — fails
+        test_a_window_of_only_enum_buckets_leaves_it_false, which is `is_partial`'s own
+        argument: an absent flag and a false one must not look alike.
+      * Normalise legacy keys into PERSONA_UNKNOWN on read — fails
+        test_the_counts_come_back_exactly_as_stored.
+      * Derive the admitted set locally instead of from PERSONA_ARCHETYPES — caught by
+        TestNeitherSideKeepsItsOwnCopy, which is where that property already lives.
+    """
+
+    LEGACY_ROW = 'Unknown'
+
+    @staticmethod
+    def _row(bucket: str, count: int) -> dict:
+        """An aggregates row as the aggregator writes it, built from the shared prefix
+        so nothing here restates a pk."""
+        from shared.feedback import PERSONA_PREFIX
+
+        return {'pk': f'{PERSONA_PREFIX}{bucket}', 'sk': _day(0), 'count': count,
+                'metric_type': 'persona'}
+
+    @patch('metrics_handler.aggregates_table')
+    def test_a_window_of_only_enum_buckets_leaves_it_false(
+        self, mock_agg, api_gateway_event, lambda_context
+    ):
+        """Published as False rather than omitted — the `is_partial` argument."""
+        body = _aggregate_body([self._row(ARCHETYPE, 40)], mock_agg,
+                               api_gateway_event, lambda_context)
+
+        assert body['has_legacy_persona_buckets'] is False, body
+
+    @patch('metrics_handler.aggregates_table')
+    def test_a_window_carrying_a_pre_move_row_says_so(
+        self, mock_agg, api_gateway_event, lambda_context
+    ):
+        """The transition made visible to the caller instead of to a code reader."""
+        body = _aggregate_body(
+            [self._row(ARCHETYPE, 40), self._row(self.LEGACY_ROW, 6000)],
+            mock_agg, api_gateway_event, lambda_context,
+        )
+
+        assert body['has_legacy_persona_buckets'] is True, body
+
+    @patch('metrics_handler.aggregates_table')
+    def test_the_counts_come_back_exactly_as_stored(
+        self, mock_agg, api_gateway_event, lambda_context
+    ):
+        """🔑 FLAGGING IS NOT MERGING. `Unknown` and `unknown` stay two keys.
+
+        The tempting fix is to normalise the legacy bucket into the empty one, which
+        reads as tidying and is destructive: it adds 6000 pre-move items to the bucket an
+        operator watches for enrichment regressions, and makes the residue invisible.
+        """
+        from shared.feedback import PERSONA_UNKNOWN
+
+        body = _aggregate_body(
+            [self._row(PERSONA_UNKNOWN, 3), self._row(self.LEGACY_ROW, 6000)],
+            mock_agg, api_gateway_event, lambda_context,
+        )
+
+        assert body['personas'] == {self.LEGACY_ROW: 6000, PERSONA_UNKNOWN: 3}, (
+            f"{body['personas']}: the two spellings are two buckets. Reporting the "
+            f"mixed window must not silently merge them."
+        )
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_entities_route_flags_it_too(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The other aggregates branch of the same axis, for the same reason.
+
+        `/feedback/entities` publishes the persona map as well, so a flag on only one
+        route would leave the same window qualified on one path and unqualified on the
+        other — the two-answers defect this file exists to prevent, in a new field.
+        """
+        import json as _json
+
+        from metrics_handler import lambda_handler
+
+        mock_agg.query.return_value = {'Items': [self._row(self.LEGACY_ROW, 6000)]}
+        mock_fb.query.return_value = {'Items': []}
+        event = api_gateway_event(method='GET', path='/feedback/entities',
+                                  query_params={'days': '7'})
+
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200, response['body']
+        assert _json.loads(response['body'])['has_legacy_persona_buckets'] is True
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_derived_branch_publishes_it_as_false(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The SCAN branch cannot produce a legacy bucket, and still says so.
+
+        It buckets every item through `persona_bucket`, which emits only members of the
+        enum — so False here is a fact about the derivation rather than about the window,
+        and publishing it is what stops a caller reading the field's absence on one
+        branch as "not applicable".
+        """
+        body = _scan_entities([_feedback_item(persona_type=ARCHETYPE)], mock_fb,
+                              mock_agg, api_gateway_event, lambda_context)
+
+        assert body['has_legacy_persona_buckets'] is False, body
 
 
 class TestOneRouteGivesOneAnswer:

--- a/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_persona_dimension_lockstep.py
@@ -1,0 +1,338 @@
+"""`/metrics/personas` must answer ONE question, whichever path it takes.
+
+The route has two branches over the same window. The default reads the
+pre-computed `METRIC#persona#<value>` rows the aggregator writes from the stream;
+`?date_basis=review` (and, on `/feedback/entities`, `?source=`) cannot use those
+rows because aggregates are bucketed by import date only, so it buckets raw
+feedback items itself. Two code paths, one window — and until this change they
+read DIFFERENT FIELDS: the aggregator bucketed by `persona_name` and so did the
+scan, then the aggregator moved to `persona_type` while the scan was left behind.
+That is the same defect class this file's siblings closed twice (`is_partial`'s
+aggregates branch, the aggregator's non-INSERT blindness): one window, two paths,
+two answers, neither saying it disagrees with the other.
+
+WHY THE AXIS BUCKETS BY `persona_type`
+    Because `persona_name` is legitimately empty. The enrichment contract declares
+    `persona.name` as "string or null", this platform ingests scraped reviews and
+    mostly anonymous form submissions, and the processor strips None before
+    writing — so an anonymous item carries no `persona_name` at all. An audit
+    measured the consequence: 99.97% of a 6,239-item corpus under a single literal
+    `Unknown`, an axis useless while looking populated. The null name was correct
+    model output; the AXIS was what was wrong. `persona_type` is populated and is a
+    closed enum, which is what a dimension you group by has to be.
+
+WHAT IS PINNED HERE, AND WHAT LIVES IN THE AGGREGATOR'S OWN LOCKSTEP
+    Here: that the READ side buckets on the shared field, that the two branches of
+    one route bucket one item identically, and that neither side spells the field
+    or the empty bucket as its own literal.
+    There (`lambda/aggregator/test/test_persona_field_lockstep.py`): that the field
+    is one the PROCESSOR really writes, and that `counter_dimensions` — the single
+    description the increment and the decrement path share — reads it through the
+    constant.
+
+    The aggregator is READ AS SOURCE TEXT, not imported, following
+    test_aggregate_retention_lockstep.py: importing `aggregator.handler` from an api
+    test executes another Lambda package's module scope, which builds a DynamoDB
+    resource and reads `AGGREGATES_TABLE`, so the test could fail for an
+    environmental reason in exactly the same red as real drift.
+
+WHICH MUTATION MAKES EACH ASSERTION FAIL
+    * Leave the scan path on `item.get('persona_name')` — fails
+      test_the_scan_path_and_the_aggregates_path_bucket_one_item_identically (the
+      subject item carries BOTH fields with different values, so the two branches
+      answer two different things) and
+      test_an_item_with_an_archetype_and_no_name_is_counted_under_its_archetype.
+    * Have the scan path skip items with no value (`if persona:`) — fails
+      test_an_item_with_neither_field_is_counted_under_the_empty_value, whose
+      sibling test_a_populated_item_is_not_counted_under_the_empty_value is the
+      positive control that stops the pair passing by everything collapsing into
+      one bucket.
+    * Drop either side's import of the shared declaration — fails
+      test_both_sides_read_the_field_from_one_declaration. Re-spell the bucket as a
+      literal beside the constant, or derive it in a second statement, and
+      test_neither_side_spells_the_bucket_out_beside_the_constant fails.
+    * Change the `METRIC#persona#` key prefix on one side only — fails
+      test_both_sides_spell_the_persona_partition_the_same_way, which is what keeps
+      `get_metric_type`, the `metric_type` GSI and the read paths working while the
+      source field moves underneath them.
+"""
+import ast
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+from shared.feedback import PERSONA_FIELD, PERSONA_UNKNOWN
+
+# test/ → api/ → lambda/ → voc-datalake/, then the two files that share the axis.
+_REPO = Path(__file__).resolve().parents[3]
+AGGREGATOR_SOURCE = 'lambda/aggregator/handler.py'
+METRICS_SOURCE = 'lambda/api/metrics_handler.py'
+SHARED_MODULE = 'shared.feedback'
+
+# The axis's key prefix, which deliberately did NOT move when the source field did:
+# `get_metric_type`, the `metric_type` GSI and every read path key off it, and the
+# axis is still "persona" — only where its value comes from changed.
+PERSONA_PREFIX = 'METRIC#persona#'
+
+# An archetype and a name that cannot be confused for one another, so a response
+# says WHICH field produced it rather than merely how many items were counted.
+ARCHETYPE = 'churn_risk'
+FREE_TEXT_NAME = 'Veronica Chen'
+
+
+def _read(relative: str) -> str:
+    path = _REPO / relative
+    assert path.is_file(), (
+        f'{relative} not found — did the file move? If so, update the path '
+        f'constant in this test file.'
+    )
+    return path.read_text(encoding='utf-8')
+
+
+def _statements_deriving_the_bucket(relative: str, function: str) -> list[str]:
+    """Every statement inside `function` that reads PERSONA_FIELD, unparsed.
+
+    Parsed with `ast` and scoped to the one function, the convention this repo's
+    other locksteps follow, and for the usual two reasons: a pattern cannot tell a
+    call from a MENTION of one (this file's own docstrings name both constants), and
+    a pattern reads only the shapes it anticipated.
+    """
+    tree = ast.parse(_read(relative))
+    functions = [node for node in ast.walk(tree)
+                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                 and node.name == function]
+    assert len(functions) == 1, (
+        f'Expected exactly one {function} in {relative}; found {len(functions)}. A '
+        f'second copy is the drift this file exists to prevent.'
+    )
+    found: list[str] = []
+    for statement in functions[0].body:
+        names = {node.id for node in ast.walk(statement) if isinstance(node, ast.Name)}
+        if 'PERSONA_FIELD' in names:
+            found.append(ast.unparse(statement))
+    return found
+
+
+def _day(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime('%Y-%m-%d')
+
+
+def _feedback_item(**overrides) -> dict:
+    """One raw feedback item, imported and written today."""
+    item = {
+        'pk': 'SOURCE#webscraper',
+        'sk': 'FEEDBACK#f1',
+        'feedback_id': 'f1',
+        'source_platform': 'webscraper',
+        'original_text': 'review text',
+        'category': 'delivery',
+        'sentiment_label': 'negative',
+        'sentiment_score': Decimal('-0.4'),
+        'urgency': 'low',
+        'date': _day(0),
+        'source_created_at': (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+    }
+    item.update(overrides)
+    return item
+
+
+def _aggregate_row_for(item: dict) -> dict:
+    """The persona counter row the aggregator writes for `item`.
+
+    Assembled from the SHARED field constant plus the partition prefix both sides
+    spell — not from a hand-written pk — so that a scan path reading some other
+    field disagrees with this row instead of with a literal chosen to match it.
+    """
+    return {
+        'pk': f'{PERSONA_PREFIX}{item.get(PERSONA_FIELD) or PERSONA_UNKNOWN}',
+        'sk': _day(0),
+        'count': 1,
+    }
+
+
+def _scan_personas(items, mock_fb, mock_agg, event_factory, context) -> dict:
+    """`/metrics/personas` down its SCAN branch (review basis), parsed."""
+    days = 30
+    mock_fb.query.side_effect = [{'Items': items}] + [{'Items': []}] * (days - 1)
+    from metrics_handler import lambda_handler
+
+    event = event_factory(
+        method='GET', path='/metrics/personas',
+        query_params={'days': str(days), 'date_basis': 'review'},
+    )
+    response = lambda_handler(event, context)
+    assert response['statusCode'] == 200, response['body']
+    mock_agg.query.assert_not_called()
+    return json.loads(response['body'])['personas']
+
+
+def _aggregate_personas(rows, mock_agg, event_factory, context) -> dict:
+    """`/metrics/personas` down its AGGREGATES branch (default basis), parsed."""
+    mock_agg.query.return_value = {'Items': rows}
+    from metrics_handler import lambda_handler
+
+    event = event_factory(
+        method='GET', path='/metrics/personas', query_params={'days': '7'},
+    )
+    response = lambda_handler(event, context)
+    assert response['statusCode'] == 200, response['body']
+    return json.loads(response['body'])['personas']
+
+
+class TestOneRouteGivesOneAnswer:
+    """The property point 3 of the fix exists for."""
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_the_scan_path_and_the_aggregates_path_bucket_one_item_identically(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The subject carries BOTH persona fields, with different values.
+
+        That is what makes the two branches distinguishable: an item with only one
+        of the two would be bucketed the same way by either field, so a scan path
+        left on the old field would still agree and this test would pass over the
+        defect.
+        """
+        item = _feedback_item(persona_type=ARCHETYPE, persona_name=FREE_TEXT_NAME)
+
+        scanned = _scan_personas([item], mock_fb, mock_agg, api_gateway_event,
+                                 lambda_context)
+        mock_agg.reset_mock()
+        aggregated = _aggregate_personas([_aggregate_row_for(item)], mock_agg,
+                                         api_gateway_event, lambda_context)
+
+        assert scanned == aggregated == {ARCHETYPE: 1}, (
+            f'the scan path answered {scanned} and the aggregates path '
+            f'{aggregated} for the same item. One window read two ways must give '
+            f'one answer, or a caller cannot tell which of the two is the corpus.'
+        )
+        assert FREE_TEXT_NAME not in scanned, (
+            'the scan path bucketed by the free-text name — the axis it was moved '
+            'off, because that name is null for most of the corpus'
+        )
+
+
+class TestTheScanPathMeasuresTheArchetype:
+    """The 99.97% case, on the read side."""
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_an_item_with_an_archetype_and_no_name_is_counted_under_its_archetype(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        anonymous = _feedback_item(persona_type=ARCHETYPE)
+        assert 'persona_name' not in anonymous, (
+            'the arrangement is the point: an anonymous review arrives with no '
+            'name key at all, which is why the old axis reported it as Unknown'
+        )
+
+        personas = _scan_personas([anonymous], mock_fb, mock_agg, api_gateway_event,
+                                  lambda_context)
+
+        assert personas == {ARCHETYPE: 1}, personas
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_an_item_with_neither_field_is_counted_under_the_empty_value(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """Counted, not dropped: the aggregates branch counts every item, because
+        the aggregator writes exactly one persona row per item. A scan branch that
+        skipped the empty ones would report a smaller corpus than the same window's
+        aggregates for a reason nothing in the response explains."""
+        personas = _scan_personas([_feedback_item()], mock_fb, mock_agg,
+                                  api_gateway_event, lambda_context)
+
+        assert personas == {PERSONA_UNKNOWN: 1}, personas
+
+    @patch('metrics_handler.feedback_table')
+    @patch('metrics_handler.aggregates_table')
+    def test_a_populated_item_is_not_counted_under_the_empty_value(
+        self, mock_agg, mock_fb, api_gateway_event, lambda_context
+    ):
+        """The POSITIVE CONTROL for the test above.
+
+        Everything collapsing into one bucket is the defect being repaired, so an
+        empty-bucket assertion without a populated counterexample would assert it.
+        """
+        personas = _scan_personas(
+            [_feedback_item(persona_type=ARCHETYPE),
+             _feedback_item(sk='FEEDBACK#f2', feedback_id='f2')],
+            mock_fb, mock_agg, api_gateway_event, lambda_context,
+        )
+
+        assert personas == {ARCHETYPE: 1, PERSONA_UNKNOWN: 1}, personas
+
+
+class TestNeitherSideKeepsItsOwnCopy:
+    """One declaration, imported twice — not two literals that agree today.
+
+    The two Lambdas cannot import each other (each asset excludes the other's
+    directory), so the field name is exactly the kind of fact that drifts: moving it
+    on the writer while the reader keeps a literal is the defect this file was
+    written for, and it is invisible in every other test because a test's fixtures
+    tend to agree with whichever side the test drives.
+    """
+
+    def test_both_sides_read_the_field_from_one_declaration(self):
+        for relative in (AGGREGATOR_SOURCE, METRICS_SOURCE):
+            source = _read(relative)
+            imports = re.findall(
+                rf'^from {re.escape(SHARED_MODULE)} import (.+)$', source, re.MULTILINE
+            )
+            imported = {name.strip() for line in imports for name in line.split(',')}
+            assert {'PERSONA_FIELD', 'PERSONA_UNKNOWN'} <= imported, (
+                f'{relative} does not import PERSONA_FIELD and PERSONA_UNKNOWN from '
+                f'{SHARED_MODULE}; it imports {sorted(imported)}. Both sides of the '
+                f'axis have to read one declaration, or moving the field moves only '
+                f'half of it.'
+            )
+
+    def test_neither_side_spells_the_bucket_out_beside_the_constant(self):
+        """The bucket is derived in ONE statement per side, and it quotes nothing.
+
+        Scoped to that statement rather than searched for across the file, because
+        `'unknown'` is also the `source_platform` default a few lines above the
+        aggregator's persona line: a file-wide search for the value would report a
+        correct module, which is the one thing a lockstep must never do.
+        """
+        for relative, function in ((AGGREGATOR_SOURCE, 'counter_dimensions'),
+                                   (METRICS_SOURCE, '_persona_bucket')):
+            statements = _statements_deriving_the_bucket(relative, function)
+            assert len(statements) == 1, (
+                f'{relative}::{function} derives the persona bucket in '
+                f'{len(statements)} statements: {statements}. One statement, so that '
+                f'moving the field is one edit — a second is where the two directions '
+                f'of the stream, or the two branches of the route, come apart.'
+            )
+            statement = statements[0]
+            assert 'PERSONA_UNKNOWN' in statement, (
+                f'{relative}::{function} derives the persona bucket as `{statement}`, '
+                f'which does not name PERSONA_UNKNOWN. The empty case has to come '
+                f'from the shared declaration too, or one side keeps calling it '
+                f'something the other does not recognise.'
+            )
+            assert not re.search(r"""['"]""", statement), (
+                f'{relative}::{function} derives the persona bucket as '
+                f'`{statement}`, which quotes a value alongside the constants. Two '
+                f'spellings of one value is the drift, whichever is currently right.'
+            )
+
+    def test_both_sides_spell_the_persona_partition_the_same_way(self):
+        """The key prefix did not move, and must not move on one side alone.
+
+        `get_metric_type` tags these rows for the `metric_type` GSI by this prefix
+        and both read paths strip it back off, so a prefix changed where the rows
+        are WRITTEN and not where they are read leaves the GSI untagged and the
+        dimension empty — while every count is still computed correctly.
+        """
+        for relative in (AGGREGATOR_SOURCE, METRICS_SOURCE):
+            assert PERSONA_PREFIX in _read(relative), (
+                f'{relative} no longer spells `{PERSONA_PREFIX}`. The axis is still '
+                f'"persona"; only its source field moved. If the prefix really is '
+                f'changing, it changes on both sides and here in the same commit.'
+            )

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -68,8 +68,50 @@ PERSONA_FIELD = 'persona_type'
 # bespoke `Unknown`: the contract already defines a value for this exact idea, so
 # every bucket name is one the contract declares. Aggregate rows written before the
 # field moved keep their old `Unknown` bucket and age out on their 90-day TTL
-# (`AGGREGATE_RETENTION_DAYS`); the transition is forward-only by design.
+# (`AGGREGATE_RETENTION_DAYS`); the transition is forward-only by design, with one
+# exception on the REVERSAL path — see `aggregator/handler.py::LEGACY_PERSONA_FIELD`.
+#
+# WHAT THIS BUCKET CANNOT TELL YOU, said out loud because the next person to ask
+# "is enrichment healthy?" will look exactly here: it merges "the enrichment
+# classified the archetype as `unknown`" with "the field is absent, so no
+# classification was recorded at all". Both land in this one partition, so a rising
+# `unknown` does not distinguish an enrichment regression from a corpus that
+# genuinely resists classification — a quieter variant of the blindness this axis
+# was just repaired for. The trade was accepted because the alternative, a second
+# bucket for the absent case, would put back a value the enrichment contract does
+# not declare, which is the thing naming this bucket the enum's way removes. A
+# caller who needs the two apart has to read the raw `persona_type` field on the
+# feedback items (`/feedback`, `/data-explorer/feedback`), where absent and
+# `unknown` are still different.
 PERSONA_UNKNOWN = 'unknown'
+
+# The partition prefix the persona counter rows are keyed by. Shared for the same
+# reason as the two above, and one more particular to it: it is spent by FOUR
+# call sites in two Lambdas that cannot import each other —
+# `aggregator/handler.py` builds the pk with it and `get_metric_type` tags the row
+# for the `metric_type` GSI by it, while `metrics_handler` strips it back off in
+# both of its aggregates branches. A prefix changed where the rows are WRITTEN and
+# not where they are READ leaves the GSI untagged and the dimension empty while
+# every count is still computed correctly, which is the worst kind of wrong: no
+# error, no log, an empty axis.
+#
+# It deliberately did NOT move when the source field did. The axis is still
+# "persona"; only where its value comes from changed.
+PERSONA_PREFIX = 'METRIC#persona#'
+
+# WHY THE DERIVATION (`item.get(PERSONA_FIELD) or PERSONA_UNKNOWN`) IS NOT ALSO
+# HERE, since the argument above for sharing the constants seems to apply one level
+# up as well. It was considered and rejected: the `or`-rather-than-a-`.get`-default
+# reasoning is a property of that one expression, and both call sites carry it in a
+# docstring where the code is — `counter_dimensions` explains it as part of what a
+# stream image can hold, `_persona_bucket` as part of what the scan path answers. A
+# shared helper would put that reasoning one import away from both readers to
+# remove a two-line duplication that is already PINNED:
+# test_persona_dimension_lockstep.py::test_neither_side_spells_the_bucket_out_beside_the_constant
+# requires exactly one statement per side, naming PERSONA_UNKNOWN and quoting
+# nothing, so the two cannot drift while agreeing to. A constant that two Lambdas
+# must spell identically is a fact; an expression they must compute identically is
+# a behaviour, and this repo pins behaviours with tests.
 
 # Maximum number of days to look back when querying by date
 MAX_LOOKBACK_DAYS = 90

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -194,6 +194,36 @@ def persona_bucket(item: dict) -> str:
     return persona if persona in PERSONA_ARCHETYPES else PERSONA_UNKNOWN
 
 
+def has_legacy_persona_buckets(buckets) -> bool:
+    """Does this persona breakdown contain a bucket the current axis cannot write?
+
+    🔑 A READ-SIDE HONESTY FLAG, and the reason it exists is the transition note at
+    `PERSONA_UNKNOWN`: for up to `AGGREGATE_RETENTION_DAYS` the aggregates branch of
+    `/metrics/personas` and `/feedback/entities` returns rows written by the old
+    derivation — free-text names and a capitalised `Unknown` — beside the enum's
+    values, and a caller cannot tell residue from a live bucket. An MCP client is a
+    model reading these keys and reporting on them, which is precisely the case where
+    a correct-but-unqualified answer is read as a qualified one.
+
+    This is `is_partial`'s argument applied to a second dimension of the same
+    response: a qualified answer must SAY it is qualified, rather than leaving the
+    qualification in a comment or a PR body.
+
+    ⚠️ IT REPORTS, IT DOES NOT REPAIR. Normalising a legacy key into PERSONA_UNKNOWN
+    on read was considered and rejected: it would fold real free-text counts into the
+    empty bucket, which makes the transition invisible in the other direction and
+    corrupts the one bucket an operator watches to judge enrichment health. The counts
+    come back exactly as stored; only their presence is flagged.
+
+    Membership of PERSONA_ARCHETYPES is the whole test, and it is complete for the
+    same reason the aggregator's collision guard is: `persona_bucket` closes the axis,
+    so every bucket THIS deploy can write is a member. Deletable once no pre-move
+    aggregate row can survive — `AGGREGATE_RETENTION_DAYS` after the deploy — and the
+    flag going permanently false is the signal.
+    """
+    return any(bucket not in PERSONA_ARCHETYPES for bucket in buckets)
+
+
 # Maximum number of days to look back when querying by date
 MAX_LOOKBACK_DAYS = 90
 

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -38,6 +38,39 @@ def validate_date_basis(value: str | None) -> str:
         return value.strip().lower()
     return DATE_BASIS_IMPORTED
 
+# --- The persona metrics axis ------------------------------------------------
+# WHICH FIELD "PERSONA" MEANS WHEN IT IS A DIMENSION, and what an item with no
+# value for it is called. Two Lambdas bucket the same items by these values and
+# must agree, so they live here, in the data layer, beside the date-basis
+# constants and for the same reason: `aggregator/handler.py` writes the
+# `METRIC#persona#<value>` counter rows from a stream, `metrics_handler`'s scan
+# path buckets raw items itself when the caller asks for a review-date window or a
+# source filter, and neither Lambda can import the other (each asset excludes the
+# other's directory). One window read two ways answering two different things is
+# the defect class this repo has now fixed twice; a shared constant is what makes
+# "both paths read the same field" a fact rather than an intention.
+#
+# 🔑 `persona_type`, NOT `persona_name`. The processor writes both
+# (`processor/handler.py`), and the counter bucketed by `persona_name` until an
+# audit found 99.97% of a 6,239-item corpus under a single `Unknown` — an axis
+# useless while looking populated. The cause was NOT a field nothing writes: the
+# enrichment contract declares `persona.name` as "string or null" because this
+# platform ingests scraped reviews and mostly anonymous form submissions, so an
+# anonymous item HAS no name to give; the processor strips None before writing and
+# `persona_name` is simply absent. A null name is correct output for anonymous
+# feedback, so the field was not the bug — the AXIS was. `persona_type` is
+# populated and is a closed enum, which is what a dimension you group by has to
+# be; a person's name is an identifier, not an archetype.
+PERSONA_FIELD = 'persona_type'
+
+# The bucket an item with no archetype lands in, spelled as the enum spells it
+# (`existing_customer|prospect|churn_risk|advocate|unknown`) rather than as a
+# bespoke `Unknown`: the contract already defines a value for this exact idea, so
+# every bucket name is one the contract declares. Aggregate rows written before the
+# field moved keep their old `Unknown` bucket and age out on their 90-day TTL
+# (`AGGREGATE_RETENTION_DAYS`); the transition is forward-only by design.
+PERSONA_UNKNOWN = 'unknown'
+
 # Maximum number of days to look back when querying by date
 MAX_LOOKBACK_DAYS = 90
 

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -71,6 +71,19 @@ PERSONA_FIELD = 'persona_type'
 # (`AGGREGATE_RETENTION_DAYS`); the transition is forward-only by design, with one
 # exception on the REVERSAL path — see `aggregator/handler.py::LEGACY_PERSONA_FIELD`.
 #
+# ⚠️ SO FOR UP TO 90 DAYS THE TWO BRANCHES OF ONE ROUTE DISAGREE, which is worth
+# saying plainly because it is a time-bounded instance of the very defect class this
+# file exists to prevent. `/metrics/personas` and `/feedback/entities` each have a
+# SCAN branch that re-derives the bucket from raw items — so it reports the new axis
+# for every item, whatever wrote it — and an AGGREGATES branch that reports what the
+# stored rows say, which for pre-move days is legacy free text plus `Unknown`. Over a
+# window spanning the move the default basis therefore publishes `Unknown` and
+# `unknown` as two buckets meaning one thing, and `?date_basis=review` answers
+# differently for the same window. Accepted rather than papered over: folding
+# `Unknown` into this value at the two aggregates strip sites would hide the
+# disagreement without making the stored rows agree, and the write side needs the two
+# spellings to stay distinct (`LEGACY_PERSONA_UNKNOWN`).
+#
 # WHAT THIS BUCKET CANNOT TELL YOU, said out loud because the next person to ask
 # "is enrichment healthy?" will look exactly here: it merges "the enrichment
 # classified the archetype as `unknown`", "the field is absent, so no classification

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -6,6 +6,7 @@ and job Lambdas (document generator, document merger).
 
 import logging
 import re
+from collections.abc import Iterable
 from datetime import datetime, timezone, timedelta
 
 from boto3.dynamodb.conditions import Key
@@ -194,7 +195,7 @@ def persona_bucket(item: dict) -> str:
     return persona if persona in PERSONA_ARCHETYPES else PERSONA_UNKNOWN
 
 
-def has_legacy_persona_buckets(buckets) -> bool:
+def has_legacy_persona_buckets(buckets: Iterable[str]) -> bool:
     """Does this persona breakdown contain a bucket the current axis cannot write?
 
     🔑 A READ-SIDE HONESTY FLAG, and the reason it exists is the transition note at

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -73,8 +73,10 @@ PERSONA_FIELD = 'persona_type'
 #
 # WHAT THIS BUCKET CANNOT TELL YOU, said out loud because the next person to ask
 # "is enrichment healthy?" will look exactly here: it merges "the enrichment
-# classified the archetype as `unknown`" with "the field is absent, so no
-# classification was recorded at all". Both land in this one partition, so a rising
+# classified the archetype as `unknown`", "the field is absent, so no classification
+# was recorded at all", and — since `persona_bucket` closed the axis to
+# PERSONA_ARCHETYPES — "the field held a value the contract does not declare". All
+# three land in this one partition, so a rising
 # `unknown` does not distinguish an enrichment regression from a corpus that
 # genuinely resists classification — a quieter variant of the blindness this axis
 # was just repaired for. The trade was accepted because the alternative, a second
@@ -88,12 +90,29 @@ PERSONA_UNKNOWN = 'unknown'
 # The archetypes the enrichment contract admits, which is the whole value space
 # this axis can produce — `PERSONA_UNKNOWN` included, since the contract declares it.
 #
-# Declared here only because a WRITE-side guard needs it: the reversal's pre-deploy
-# compatibility (`aggregator/handler.py::_reverse_a_pre_deploy_persona_row`) builds a
-# partition key out of a free-text `persona_name`, and a name that happens to equal
-# one of these values would aim a `-1` at a row THIS deploy actively writes. The
-# guard needs to recognise its own value space to refuse that, and a set membership
-# test is the only way to say "this is not a legacy row".
+# 🔑 THIS SET IS WHAT MAKES THE AXIS CLOSED, and `persona_bucket` below is what makes
+# that true rather than hoped for. A value outside it buckets as PERSONA_UNKNOWN, so
+# the rows this deploy writes are exactly `PERSONA_PREFIX + <a member of this set>`
+# and nothing else. Two things depend on that being a FACT:
+#
+#   * the reversal's pre-deploy compatibility
+#     (`aggregator/handler.py::_reverse_a_pre_deploy_persona_row`) builds a partition
+#     key out of a free-text `persona_name` and must refuse to aim its `-1` at a row
+#     this deploy actively writes. Membership of this set is the only way it can know
+#     — and while an arbitrary `persona_type` could still reach a pk, that test was
+#     WRONG: review demonstrated a live `METRIC#persona#loyal` row (this repo's own
+#     fixtures use `persona_type: 'loyal'`, and `PUT /data-explorer/feedback` accepts
+#     the field with no allowlist) decremented 500 → 499 for an item counted
+#     elsewhere, because `loyal` is not in this set and so passed the guard;
+#   * a dimension a caller GROUPS BY is only useful if its value space is knowable.
+#     An MCP client reading these keys can enumerate them from the contract.
+#
+# WHAT CLOSING IT COSTS, stated where the closing happens: an out-of-contract
+# `persona_type` (an LLM ignoring the enum, or a hand edit through the Data Explorer)
+# is counted as unclassified rather than under its own name, so the axis cannot show
+# that the model returned something the contract does not declare. That is the same
+# trade PERSONA_UNKNOWN already makes, and the same place to look for the
+# distinction: the raw `persona_type` on the feedback items.
 #
 # 🔑 THE PROMPT IS STILL THE CONTRACT; this is a copy, and it is pinned as one.
 # `processor/handler.py`'s `USER_PROMPT_TEMPLATE` is what the model is told to
@@ -125,19 +144,42 @@ PERSONA_ARCHETYPES = frozenset({
 # "persona"; only where its value comes from changed.
 PERSONA_PREFIX = 'METRIC#persona#'
 
-# WHY THE DERIVATION (`item.get(PERSONA_FIELD) or PERSONA_UNKNOWN`) IS NOT ALSO
-# HERE, since the argument above for sharing the constants seems to apply one level
-# up as well. It was considered and rejected: the `or`-rather-than-a-`.get`-default
-# reasoning is a property of that one expression, and both call sites carry it in a
-# docstring where the code is — `counter_dimensions` explains it as part of what a
-# stream image can hold, `_persona_bucket` as part of what the scan path answers. A
-# shared helper would put that reasoning one import away from both readers to
-# remove a two-line duplication that is already PINNED:
-# test_persona_dimension_lockstep.py::test_neither_side_spells_the_bucket_out_beside_the_constant
-# requires exactly one statement per side, naming PERSONA_UNKNOWN and quoting
-# nothing, so the two cannot drift while agreeing to. A constant that two Lambdas
-# must spell identically is a fact; an expression they must compute identically is
-# a behaviour, and this repo pins behaviours with tests.
+
+def persona_bucket(item: dict) -> str:
+    """The persona bucket one feedback item belongs to. THE only derivation.
+
+    🔑 SHARED, THOUGH AN EARLIER ROUND OF THIS CHANGE ARGUED IT SHOULD NOT BE, and
+    the argument that moved it is worth keeping because it is the general one. That
+    round's reasoning was: a constant two Lambdas must SPELL alike is a fact (share
+    it), while an expression they must COMPUTE alike is a behaviour (pin it with a
+    test) — and the `or`-not-a-`.get`-default reasoning read differently on each
+    side, so each side carried it where its code was.
+
+    That held while the derivation was `item.get(PERSONA_FIELD) or PERSONA_UNKNOWN`,
+    two tokens and one operator. It stopped holding when the membership test below
+    was added: a derivation with a BRANCH in it is no longer a spelling that two
+    docstrings can keep aligned. The property the axis now rests on — every row this
+    deploy writes is named by a member of PERSONA_ARCHETYPES — is a property of the
+    DERIVATION, not of the constants, so a second copy of it is a second place the
+    value space can be widened. The write side's collision guard would then be
+    reasoning about a set the read side no longer respects.
+
+    `or`, not a `.get` default: the processor strips None before writing, but a
+    stream image edited by hand, or any writer storing an explicit null, delivers the
+    key present and empty — and a default does not apply to a present key, so
+    `METRIC#persona#None` would be a partition nothing else ever writes to or reads
+    from. Invisible, and unreachable by a later reversal.
+
+    Membership, not just non-emptiness, and the two call sites need it for different
+    halves of one reason. On the WRITE side it is what makes the rows this deploy
+    creates enumerable, which the pre-deploy collision guard depends on. On the READ
+    side it is what stops the scan branch reporting a bucket the aggregates branch
+    could not have produced for the same item — one window, two branches, two value
+    spaces, which is the defect class this axis has now been repaired for twice.
+    """
+    persona = item.get(PERSONA_FIELD) or PERSONA_UNKNOWN
+    return persona if persona in PERSONA_ARCHETYPES else PERSONA_UNKNOWN
+
 
 # Maximum number of days to look back when querying by date
 MAX_LOOKBACK_DAYS = 90

--- a/voc-datalake/lambda/shared/feedback.py
+++ b/voc-datalake/lambda/shared/feedback.py
@@ -85,6 +85,32 @@ PERSONA_FIELD = 'persona_type'
 # `unknown` are still different.
 PERSONA_UNKNOWN = 'unknown'
 
+# The archetypes the enrichment contract admits, which is the whole value space
+# this axis can produce — `PERSONA_UNKNOWN` included, since the contract declares it.
+#
+# Declared here only because a WRITE-side guard needs it: the reversal's pre-deploy
+# compatibility (`aggregator/handler.py::_reverse_a_pre_deploy_persona_row`) builds a
+# partition key out of a free-text `persona_name`, and a name that happens to equal
+# one of these values would aim a `-1` at a row THIS deploy actively writes. The
+# guard needs to recognise its own value space to refuse that, and a set membership
+# test is the only way to say "this is not a legacy row".
+#
+# 🔑 THE PROMPT IS STILL THE CONTRACT; this is a copy, and it is pinned as one.
+# `processor/handler.py`'s `USER_PROMPT_TEMPLATE` is what the model is told to
+# return, so it is the only place that DEFINES the value space, and
+# test_persona_field_lockstep.py::test_the_shared_archetypes_are_the_ones_the_enrichment_enum_declares
+# reads the enum back out of that prompt and fails if the two disagree. Without that
+# pin this would be a second declaration of the contract, which is the drift the
+# rest of this block exists to prevent. `null` is not a member: it is the contract's
+# way of saying "no value", and PERSONA_UNKNOWN is the bucket that case lands in.
+PERSONA_ARCHETYPES = frozenset({
+    'existing_customer',
+    'prospect',
+    'churn_risk',
+    'advocate',
+    PERSONA_UNKNOWN,
+})
+
 # The partition prefix the persona counter rows are keyed by. Shared for the same
 # reason as the two above, and one more particular to it: it is spent by FOUR
 # call sites in two Lambdas that cannot import each other —


### PR DESCRIPTION
## What this fixes

The persona metrics dimension bucketed on `persona_name`. That field is legitimately
empty for anonymous feedback, which is nearly all of this corpus — an audit put
**99.97% of 6,239 items in a single `Unknown` bucket**, so the dimension measured
whether a name happened to be extracted rather than who the customer was. The axis now
buckets on the `persona_type` archetype.

`PERSONA_FIELD`, `PERSONA_UNKNOWN`, `PERSONA_ARCHETYPES`, `PERSONA_PREFIX` and
`persona_bucket` are declared **once**, in `lambda/shared/feedback.py`, and both sides
read that one declaration: the aggregator's write path through `counter_dimensions`, and
`metrics_handler`'s scan path through `persona_bucket`. That symmetry is the point — the
defect class here is one window answered two ways.

A REMOVE or in-place edit of feedback whose INSERT predates the move must also bring
down the row that insert really created (`METRIC#persona#<persona_name, or Unknown>`),
not only the archetype row today's derivation names.

## Answering the last review

### The wall-clock cutover is gone

The compatibility decided "is this item pre-deploy?" from
`LEGACY_PERSONA_CUTOVER = os.environ.get('PERSONA_AXIS_CUTOVER_AT', '2026-08-22T00:00:00+00:00')`
compared against the old image's `processed_at`. Both consequences the review found were
real: the default instant is in the future relative to a deploy, so every item classified
as pre-deploy; and `PERSONA_AXIS_CUTOVER_AT` was never set in the aggregator's Lambda
environment in the CDK, so the default was what would run.

Deleted: `LEGACY_PERSONA_CUTOVER`, `PERSONA_AXIS_CUTOVER_AT`, `LEGACY_PERSONA_STAMP_FIELD`,
`_was_counted_by_the_old_persona_axis`, the conftest fixtures that stamped either side of
the boundary, and the three tests that existed only to exercise the stamp.
`grep -rn PERSONA_AXIS_CUTOVER_AT` now returns nothing.

The trigger is the signal `update_counter` already returns:

```python
    keys = {key for key in outcomes
            if key[0].startswith(PERSONA_PREFIX)
            and outcomes[key] is CounterWrite.ROW_ABSENT}
    if not keys:
        return 0
```

`ROW_ABSENT` is the one outcome meaning **no counter moved for that bucket**. No clock, no
environment variable, no CDK change, no cutover date — and nothing to un-configure later,
since the fallback stops firing on its own as pre-deploy rows disappear.

### The double decrement went with it

`LANDED` means a counter for the bucket already came down. `REFUSED_AT_FLOOR` means the
row exists at zero — the redelivered-REMOVE shape. In both, a row exists under the
archetype bucket, so a legacy `-1` would be a second count off one deletion. Excluding
both is what makes exactly one counter move per deletion, which is the property the stamp
broke: it read a field on the item, so it issued a legacy `-1` on top of a decrement that
had already landed.

`test_exactly_one_persona_bucket_moves_per_deletion` asserts it over both arrangements
(pre-deploy: archetype absent, legacy write lands; post-deploy: archetype lands, no legacy
write attempted), counting **landed** writes rather than attempted ones.

### The negative-counter half of the earlier blocker: refuted, not quietly skipped

An earlier round asked for a clamp so the new enum rows could not go negative or resurrect
expired rows. **That guard is already in the tree** and was merged in #364, which is this
PR's merge base. `update_counter` applies, on every decrement:

```python
kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #field >= :floor'
attr_values[':floor'] = -increment
```

So a decrement against an absent row fails the condition and creates nothing, and a
counter cannot be driven below zero. **No second clamp was added anywhere, and
`update_counter`'s condition is untouched by this PR.** Its only change is asking for
`ReturnValuesOnConditionCheckFailure='ALL_OLD'` on the conditional path and returning three
outcomes instead of a bool, with `__bool__` keeping `if update_counter(...)` reading as
"did it land?" at the call sites that only need that. An unreadable refusal resolves to
`REFUSED_AT_FLOOR`, the outcome no caller acts on, so the fail direction is the safe one.

### The label change, decided rather than left silent

Bucket labels move from free text to enum codes (`existing_customer`, `churn_risk`,
`unknown`), and those reach `GET /metrics/personas` and `GET /feedback/entities`.

**Decision: no label mapping in this PR, and the reasons are recorded in the code.**

- No frontend component consumes the persona breakdown. `api.getPersonas` is called only
  by its own test, and the two `/feedback/entities` consumers (`ProblemAnalysis`,
  `Categories/useCategoryAnalytics`) read only `sources`, `categories` and `issues`. So
  there is no UI regression to fix.
- For MCP callers, which are models, a stable contract enum is strictly better than free
  text — enumerability is this PR's own reason for closing the axis. The API side needs no
  change.
- A map in the API would put presentation in the data layer and would have to be undone
  when a UI does render this. `PersonaBreakdown.personas` now carries a doc comment saying
  the keys are archetype codes and must be mapped through i18n by whoever first renders
  them.
- `persona_type` was already rendered raw in `FeedbackDetail` before this PR. Pre-existing,
  out of scope here.

### Round 4's findings, dispositioned

I had been working from the converge run's intent file and missed review `5000263980`
(sha `70cb681b`) until asked. Its five findings:

**`handler.py:967` — major — "one pre-deploy item can drain the legacy row many times".**
Correct, and it split in two once measured. The compatibility runs per reversal EVENT
while the debt is per ITEM. Measured against moto at this head, beside review's own
numbers under the wall-clock trigger:

| arrangement, one pre-deploy item | review (`70cb681b`) | here | busy day |
|---|---|---|---|
| three successive archetype edits | 3 drains | **1** | 0 |
| one edit, then its delete | 2 drains | **1** | 0 |
| REMOVE redelivered three times | 3 drains | **3** | 0 |

The **legitimate** multi-reversal cases are bounded *by construction*: the first
reversal's increment creates the archetype row for the item's new bucket, so every later
decrement of it LANDS and never reaches the fallback. That needed nothing added — it
falls out of triggering on "no counter moved" instead of on a fact about the item, and it
is the strongest argument for the new trigger. Pinned by the new
`TestOneItemOwesOneLegacyDecrement` (moto-backed, four cases), and the per-item mutation
is in the class REVERT MAP: triggering on the item fails three of its four.

**Redelivery is not bounded, and is accepted rather than closed** — review's second
option, taken explicitly. A refused decrement creates nothing, so the evidence is
unchanged on the second delivery. It is the module's general at-least-once residual,
which every counter here shares (`TestRedeliveryMovesACounterTwice`) and which needs
`eventID` routed through `shared/idempotency.py` plus a CDK change to close; fixing it
for this one row would be a special case of a module-wide gap. Review was also right that
the old defence was wrong: **"the direction is toward the truth" holds for the FIRST
drain of each item only.** Past that the legacy row understates — bounded below by the
floor, never negative, but it is a row `/metrics/personas` still serves for a window
overlapping the move. The docstring now says that, and the behaviour is pinned so it is a
decision on the record rather than an absence.

**`handler.py:311` — medium — a naive or date-only `PERSONA_AXIS_CUTOVER_AT` makes every
reversal raise `TypeError`, blocking the shard.** Moot: the constant is deleted. Worth
noting the finding was correct and its blast radius argument was the sharpest case against
the wall-clock design — a misconfiguration whose only intended effect was to move a
compatibility boundary would have taken down all aggregation.

**`handler.py:887` — minor — `PERSONA_AXIS_CUTOVER_AT` never reached the aggregator's CDK
environment, so the documented override was unreachable.** Moot for the same reason, and
it was half of the blocker that removed the design.

**Two `good_point`s.** One credited `persona_bucket` closing the axis — unchanged and
still load-bearing for the collision guard. The other credited `CounterWrite`'s
`WHAT IT IS NOT EVIDENCE OF` paragraph, which argued the absent row must not be promoted
into a general pre-deploy test. That paragraph is **gone**, because the absent row is now
exactly that trigger; it is replaced by `WHAT THE ABSENT ROW IS FOR`, which states the
limitation instead of the prohibition. Flagging the inversion rather than letting a
credited comment disappear silently.

Also from that review: the PR body's ruff claim. Fixed, and the fix found a real
regression. `ruff.toml` sets no explicit `select`, so the gate `lint:python` actually runs
(`ruff check lambda plugins`) enforces more than the `F,E4,E7,E9` selection this PR had
been quoting — and the new per-item test class had added **three** findings to it
(`RUF007`, `I001` ×2), taking the total **509 → 512**, while the narrow selection went on
printing `All checks passed!` for the very file carrying them. Fixed
(`itertools.pairwise`, two imports parenthesised); total back to 509, identical at the
merge base. The table below now reports both numbers, because only the unfiltered one is a
gate.

### Every unresolved review thread, swept

All 33 threads on this PR are unresolved (nothing resolves them here); 21 are outdated.
Of the 12 still pointing at live lines, 5 are `good_point`/`question`. The substantive ones,
and where each stands:

| thread | round | state |
|---|---|---|
| `metrics_handler.py:549` — the entities branch's behaviour change is unpinned (**medium**) | 1 | closed by `8476a044` — verified by re-running the reviewer's own mutation, which now fails `test_the_entities_persona_map_sums_to_the_corpus_it_reports`; that test postdates the review |
| `feedback.py:101` — `unknown` merges two distinguishable states (minor) | 1 | closed (the `WHAT THIS BUCKET CANNOT TELL YOU` block) |
| `metrics_handler.py:1078` — the mixed window is invisible to callers (minor) | 1 | **closed in this PR's latest commit** — see below |
| `handler.py:319` — the capitalisation is load-bearing, only a test says so (minor) | 2 | closed (the citation now names the two failing tests) |
| `handler.py:936` — the collision guard only covers enum collisions (**medium**) | 3 | closed by `persona_bucket` closing the axis |
| `handler.py:967` — one item can drain the legacy row many times (**major**) | 4 | closed — see the round 4 section |

### The mixed-bucket window now says so in the response

For up to `AGGREGATE_RETENTION_DAYS` the aggregates branch returns rows the old derivation
wrote — free-text names and a capitalised `Unknown` — beside the enum's values. Correct
counts, mixed key space, and nothing said so; the transition was documented in a comment at
`PERSONA_UNKNOWN`, which is the qualification living where the caller cannot read it.

`has_legacy_persona_buckets` on both aggregates branches, from one shared predicate in
`shared/feedback.py` derived from `PERSONA_ARCHETYPES`, so the read side and the enum pin
keep sharing one declaration. Published on the scan branches too as a literal `False`, with
the reason: they derive every bucket through `persona_bucket`, so it is a fact about the
derivation rather than the window — and an absent flag must not be readable as "not
applicable". That is `is_partial`'s own argument, applied to a second dimension of the same
response.

**It reports, it does not repair**, and that is the pinned part.
`test_the_counts_come_back_exactly_as_stored` fails if a legacy key is normalised into
`unknown`, because that folds real free-text counts into the one bucket an operator watches
for enrichment regressions and hides the transition in the other direction. Mirrored into
`PersonaBreakdown` and `EntitiesResponse`, with a note that the flag is deletable once no
pre-move aggregate row can survive its TTL.

## Accepted residuals

Four, all recorded in `handler.py`'s module docstring rather than in this description
alone.

**1. The fallback is inert on a busy day.** An absent archetype row is observable only on a
day no post-deploy item has written that bucket. On a busier day a pre-deploy item's REMOVE
decrements the archetype row it never contributed to, and the legacy row it did contribute
to stays inflated until its 90-day TTL.

This is **not** because the images cannot decide it — `processed_at` is on the old image,
and an earlier draft of this text claimed otherwise, which review correctly called out. A
module constant naming the deploy instant plus exclusive routing would be correct on a busy
day with no env var and no CDK change. It is declined because it is only *differently*
wrong: it misreads an item written just before the deploy whose INSERT was aggregated just
after it, and for that item it skips the archetype decrement that is really holding its
count — leaving that row inflated **permanently** instead of for 90 days. An ageing error
beats a permanent one.

**2. An absent row is evidence of "no live row here", not of vintage.** A post-deploy INSERT
whose stream record never landed — a batch failure, a window where the function was
erroring — leaves no archetype row either, so deleting that item aims one `-1` at the bucket
its free-text name spells. Bounded by the same condition, at most one count, in a row that
is ageing out, and self-limiting once the legacy rows are gone.

**3. No backfill, and for up to 90 days the two branches of one route disagree.** Stored
rows are not rewritten. `/metrics/personas` and `/feedback/entities` each have a scan branch
that re-derives the bucket from raw items (so it reports the new axis for every item) and an
aggregates branch that reports what the stored rows say (legacy free text plus `Unknown` for
pre-move days). Over a window spanning the move the default basis publishes `Unknown` beside
`unknown`, and `?date_basis=review` answers differently for the same window. Written up at
`PERSONA_UNKNOWN`. Folding `Unknown` into `unknown` at the two aggregates strip sites would
hide the disagreement without making the stored rows agree, and the write side needs the two
spellings distinct.

## Verification

All run, not predicted.

| Check | Merge base `3d7f1057` | This branch |
|---|---|---|
| `pytest lambda -q` | **3278 passed** | **3325 passed** |
| `ruff check lambda plugins` (**the gate `lint:python` runs**) | 509 errors | **509 errors** |
| `ruff check --select F,E4,E7,E9 lambda plugins` | 4 errors | **4 errors** |
| `vitest --run` (frontend) | — | 3060 passed, 185 files |
| `tsc --noEmit` (frontend) | — | clean |

The four ruff findings are the same pre-existing `E402` sites in `lambda/conftest.py` and
`lambda/api/test/conftest.py`, which this PR does not touch. Ruff is clean on every changed
file. The repo-wide count has not risen.

### Reverts, each one run

| Revert this alone | Tests that fail |
|---|---|
| Delete the fallback's call in `apply_feedback` | 6, incl. `test_the_row_the_pre_deploy_insert_created_is_the_one_brought_down` |
| Delete the call in `process_modified_feedback` | `test_a_rebucket_of_a_pre_deploy_image_reverses_the_legacy_row_too`, `test_an_edit_whose_only_landing_write_was_the_pre_deploy_compatibility_counts_as_nothing` |
| Gate on `is not CounterWrite.LANDED` (act on either refusal) | the 3 redelivered-REMOVE tests — this is the double decrement |
| Drop the outcome condition entirely | 8, across 3 classes |
| Drop the `PERSONA_ARCHETYPES` collision guard | `test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row`, `test_one_deletion_never_decrements_one_row_twice` |
| Point `PERSONA_FIELD` back at `persona_name` | 11, incl. 5 in `test_persona_dimension_lockstep.py` |
| Open the axis (`persona_bucket` interpolates verbatim) | 3, one of them the read-side sibling |
| Spell `LEGACY_PERSONA_UNKNOWN` as `PERSONA_UNKNOWN` | 2 — the majority anonymous shape stops being reversed |
| Classify an unreadable refusal as `ROW_ABSENT` | `test_an_unreadable_refusal_is_not_evidence_that_a_row_was_absent`, and only that |
| Drop `ALL_OLD` | `test_a_real_dynamodb_tells_a_row_at_zero_from_a_row_that_is_not_there`, and only that |

Two mutations fail **nothing**, recorded in the class's `MUTATIONS THAT DO NOT FAIL
ANYTHING` rather than left as false citations:

- `if sign < 0` → `if True` in `apply_feedback`. An increment carries no
  ConditionExpression, so it can only report `LANDED` and the gate finds no `ROW_ABSENT`
  key. The guard states that the compatibility is reversal-only rather than being what
  makes it so.
- Making `persona_bucket` dual-SOURCED. The membership filter absorbs it: a free-text name
  is not in `PERSONA_ARCHETYPES`, so it buckets as the empty value exactly as an absent
  field does. **An earlier REVERT MAP claimed this failed two named tests; it does not.**
  Closing the axis made the dual-read harmless, which is worth knowing — and it means the
  shape this change is careful not to be is not held off by a failing test.

### Three test-integrity problems the trigger change exposed

Worth naming, because each was a test that looked green and was not doing its job:

1. `test_a_name_equal_to_an_archetype_does_not_aim_the_reversal_at_a_live_row` went
   **vacuous**. With nothing refused the archetype decrement lands, the gate returns early,
   and the collision guard is never reached — so deleting the guard failed nothing. Found by
   running the mutation, fixed by arranging the archetype row absent.
2. `test_a_name_equal_to_a_live_out_of_contract_row_is_declined_too` needed the same
   arrangement, and asserts the write **is** attempted, the opposite of its name. Renamed to
   `test_a_name_the_closed_axis_can_no_longer_write_is_reversed_not_declined`.
3. `test_the_fallback_lands_on_the_day_the_decrement_concerned` **passed with the fallback
   deleted outright** — asserting only which day the writes landed on was satisfied by the
   archetype decrement alone. It now asserts the write count too, and the
   `apply_feedback` revert went from 5 failures to 6.

## Size

`13 files changed, +3058 / -113` (was `9 files, +2681 / -110`).

**It went UP, and that is worth stating plainly rather than spinning.** Removing the
cutover took **~300 lines** out of `handler.py` and `conftest.py`. Against that: ~90 lines
of residual documentation that did not exist before, three test-integrity fixes, and
**~180 lines of new moto-backed tests for round 4's per-item finding** — which is the
largest single addition and the one that turns "we accept N drains" from an absence into a
decision. `handler.py` went `+535` → `+484`; `test_handler.py` went `+914` → `+1119`.

**~2,270 of the 3,058 added lines are tests** — `test_handler.py` (1,126),
`test_persona_dimension_lockstep.py` (596, new, the read side),
`test_persona_field_lockstep.py` (261) — which is the lockstep coverage the last review
asked to keep, plus the per-item pins it asked for. The four frontend files are one doc
comment and three one-line fixture corrections. If the diff should be smaller, the honest
lever is prose: ~150 lines are the 99.97%/6,239 premise restated in five places (two of
the worst duplications are already gone), not coverage.

Per file:

| File | +/- |
|---|---|
| `lambda/aggregator/test/test_handler.py` | +1126 / -6 |
| `lambda/api/test/test_persona_dimension_lockstep.py` | +596 / -0 (new) |
| `lambda/aggregator/handler.py` | +484 / -40 |
| `lambda/aggregator/test/test_persona_field_lockstep.py` | +261 / -40 |
| `lambda/shared/feedback.py` | +156 / -0 |
| `lambda/aggregator/test/conftest.py` | +80 / -0 |
| `lambda/api/metrics_handler.py` | +61 / -11 |
| `frontend/mock-server.js` | +37 / -6 |
| `lambda/api/test/test_metrics_handler_date_basis.py` | +15 / -7 |
| `frontend/src/api/types.ts` | +14 / -0 |
| `frontend/src/{api/client.test.ts, test/fixtures.ts, pages/FeedbackDetail/FeedbackDetail.test.tsx}` | +14 / -3 |

## Not done, deliberately

- **The live distribution of `persona_type` is unmeasured.** The change is justified by an
  audit of `persona_name`; nothing records what the new axis actually holds, and it is now
  closed to five contract values, so anything else collapses into `unknown`. If the corpus
  was enriched under an earlier prompt revision the axis could still be one-bucket-dominated
  and this fix would look applied while the dimension stayed useless. One
  `GET /metrics/personas` against the deployed stack settles it — **I could not run it; the
  credential available to me is rejected with HTTP 403.** Worth doing before merge.
- `metrics_handler._persona_bucket` is a one-line delegation under a long docstring, and the
  structural lockstep pins *it* rather than `get_persona_metrics` and `get_entities`.
  Deleting the wrapper and pointing the pin at the two real call sites would be fewer lines
  and a stronger pin. Left out to keep this change to the two blockers.
- The 99.97%/6,239 premise is still argued at length in more places than it needs to be.
  Two of the worst duplications are gone; the rest would be a prose-only pass.
