### PR TITLE
fix(integrations): admin-gate the mutating app-config and source-schedule routes

### DIFF
--- a/voc-datalake/frontend/public/locales/de/scrapers.json
+++ b/voc-datalake/frontend/public/locales/de/scrapers.json
@@ -161,12 +161,24 @@
     "titlePlaceholder": "Bewertungstitel (optional)"
   },
   "pluginConfig": {
+    "adminRequired": "Administratorzugriff erforderlich",
+    "addApp": "App hinzufügen",
+    "addFirstApp": "Erste App hinzufügen",
+    "addNewApp": "Neue App hinzufügen",
+    "cancel": "Abbrechen",
+    "configuredApps": "Konfigurierte Apps",
     "automaticSchedule": "Automatischer Zeitplan",
     "close": "Schließen",
     "configuration": "Konfiguration",
+    "deleteAppMessage": "Möchten Sie diese App-Konfiguration wirklich entfernen?",
+    "deleteAppTitle": "App löschen",
+    "delete": "Löschen",
     "disabled": "Deaktiviert",
+    "edit": "Bearbeiten",
+    "editApp": "App bearbeiten",
     "enabled": "Aktiviert",
     "hide": "Ausblenden",
+    "noAppsConfigured": "Noch keine Apps konfiguriert",
     "runNow": "Jetzt ausführen",
     "runTriggered": "Ausführung gestartet",
     "save": "Speichern",
@@ -174,7 +186,8 @@
     "scheduleDescription": "Diese Quelle nach konfiguriertem Zeitplan ausführen",
     "select": "Auswählen...",
     "show": "Anzeigen",
-    "test": "Testen"
+    "test": "Testen",
+    "unnamedApp": "Unbenannte App"
   },
   "refresh": "Aktualisieren",
   "status": {

--- a/voc-datalake/frontend/public/locales/en/scrapers.json
+++ b/voc-datalake/frontend/public/locales/en/scrapers.json
@@ -161,12 +161,24 @@
     "titlePlaceholder": "Review title (optional)"
   },
   "pluginConfig": {
+    "adminRequired": "Admin access required",
+    "addApp": "Add App",
+    "addFirstApp": "Add your first app",
+    "addNewApp": "Add New App",
+    "cancel": "Cancel",
+    "configuredApps": "Configured Apps",
     "automaticSchedule": "Automatic Schedule",
     "close": "Close",
     "configuration": "Configuration",
+    "deleteAppMessage": "Are you sure you want to remove this app configuration?",
+    "deleteAppTitle": "Delete App",
+    "delete": "Delete",
     "disabled": "Disabled",
+    "edit": "Edit",
+    "editApp": "Edit App",
     "enabled": "Enabled",
     "hide": "Hide",
+    "noAppsConfigured": "No apps configured yet",
     "runNow": "Run Now",
     "runTriggered": "Run triggered",
     "save": "Save",
@@ -174,7 +186,8 @@
     "scheduleDescription": "Run this source on its configured schedule",
     "select": "Select...",
     "show": "Show",
-    "test": "Test"
+    "test": "Test",
+    "unnamedApp": "Unnamed App"
   },
   "refresh": "Refresh",
   "status": {

--- a/voc-datalake/frontend/public/locales/es/scrapers.json
+++ b/voc-datalake/frontend/public/locales/es/scrapers.json
@@ -172,12 +172,24 @@
     "titlePlaceholder": "Título de la reseña (opcional)"
   },
   "pluginConfig": {
+    "adminRequired": "Se requiere acceso de administrador",
+    "addApp": "Agregar app",
+    "addFirstApp": "Agrega tu primera app",
+    "addNewApp": "Agregar nueva app",
+    "cancel": "Cancelar",
+    "configuredApps": "Apps configuradas",
     "automaticSchedule": "Programación automática",
     "close": "Cerrar",
     "configuration": "Configuración",
+    "deleteAppMessage": "¿Seguro que quieres eliminar esta configuración de app?",
+    "deleteAppTitle": "Eliminar app",
+    "delete": "Eliminar",
     "disabled": "Deshabilitado",
+    "edit": "Editar",
+    "editApp": "Editar app",
     "enabled": "Habilitado",
     "hide": "Ocultar",
+    "noAppsConfigured": "Aún no hay apps configuradas",
     "runNow": "Ejecutar ahora",
     "runTriggered": "Ejecución iniciada",
     "save": "Guardar",
@@ -185,7 +197,8 @@
     "scheduleDescription": "Ejecutar esta fuente según su programación configurada",
     "select": "Seleccionar...",
     "show": "Mostrar",
-    "test": "Probar"
+    "test": "Probar",
+    "unnamedApp": "App sin nombre"
   },
   "refresh": "Actualizar",
   "status": {

--- a/voc-datalake/frontend/public/locales/fr/scrapers.json
+++ b/voc-datalake/frontend/public/locales/fr/scrapers.json
@@ -172,12 +172,24 @@
     "titlePlaceholder": "Titre de l'avis (optionnel)"
   },
   "pluginConfig": {
+    "adminRequired": "Accès administrateur requis",
+    "addApp": "Ajouter une application",
+    "addFirstApp": "Ajoutez votre première application",
+    "addNewApp": "Ajouter une nouvelle application",
+    "cancel": "Annuler",
+    "configuredApps": "Applications configurées",
     "automaticSchedule": "Planification automatique",
     "close": "Fermer",
     "configuration": "Paramétrage",
+    "deleteAppMessage": "Voulez-vous vraiment supprimer cette configuration d'application ?",
+    "deleteAppTitle": "Supprimer l'application",
+    "delete": "Supprimer",
     "disabled": "Désactivé",
+    "edit": "Modifier",
+    "editApp": "Modifier l'application",
     "enabled": "Activé",
     "hide": "Masquer",
+    "noAppsConfigured": "Aucune application configurée",
     "runNow": "Exécuter maintenant",
     "runTriggered": "Exécution lancée",
     "save": "Enregistrer",
@@ -185,7 +197,8 @@
     "scheduleDescription": "Exécuter cette source selon sa planification configurée",
     "select": "Sélectionner...",
     "show": "Afficher",
-    "test": "Tester"
+    "test": "Tester",
+    "unnamedApp": "Application sans nom"
   },
   "refresh": "Actualiser",
   "status": {

--- a/voc-datalake/frontend/public/locales/ja/scrapers.json
+++ b/voc-datalake/frontend/public/locales/ja/scrapers.json
@@ -161,12 +161,24 @@
     "titlePlaceholder": "レビュータイトル（オプション）"
   },
   "pluginConfig": {
+    "adminRequired": "管理者アクセスが必要です",
+    "addApp": "アプリを追加",
+    "addFirstApp": "最初のアプリを追加",
+    "addNewApp": "新しいアプリを追加",
+    "cancel": "キャンセル",
+    "configuredApps": "設定済みアプリ",
     "automaticSchedule": "自動スケジュール",
     "close": "閉じる",
     "configuration": "設定",
+    "deleteAppMessage": "このアプリ設定を削除してもよろしいですか？",
+    "deleteAppTitle": "アプリを削除",
+    "delete": "削除",
     "disabled": "無効",
+    "edit": "編集",
+    "editApp": "アプリを編集",
     "enabled": "有効",
     "hide": "非表示",
+    "noAppsConfigured": "アプリはまだ設定されていません",
     "runNow": "今すぐ実行",
     "runTriggered": "実行が開始されました",
     "save": "保存",
@@ -174,7 +186,8 @@
     "scheduleDescription": "設定されたスケジュールでこのソースを実行",
     "select": "選択...",
     "show": "表示",
-    "test": "テスト"
+    "test": "テスト",
+    "unnamedApp": "名前のないアプリ"
   },
   "refresh": "更新",
   "status": {

--- a/voc-datalake/frontend/public/locales/ko/scrapers.json
+++ b/voc-datalake/frontend/public/locales/ko/scrapers.json
@@ -161,12 +161,24 @@
     "titlePlaceholder": "리뷰 제목 (선택사항)"
   },
   "pluginConfig": {
+    "adminRequired": "관리자 권한이 필요합니다",
+    "addApp": "앱 추가",
+    "addFirstApp": "첫 앱 추가",
+    "addNewApp": "새 앱 추가",
+    "cancel": "취소",
+    "configuredApps": "구성된 앱",
     "automaticSchedule": "자동 일정",
     "close": "닫기",
     "configuration": "구성",
+    "deleteAppMessage": "이 앱 구성을 제거하시겠습니까?",
+    "deleteAppTitle": "앱 삭제",
+    "delete": "삭제",
     "disabled": "비활성화됨",
+    "edit": "편집",
+    "editApp": "앱 편집",
     "enabled": "활성화됨",
     "hide": "숨기기",
+    "noAppsConfigured": "아직 구성된 앱이 없습니다",
     "runNow": "지금 실행",
     "runTriggered": "실행이 시작되었습니다",
     "save": "저장",
@@ -174,7 +186,8 @@
     "scheduleDescription": "구성된 일정에 따라 이 소스 실행",
     "select": "선택...",
     "show": "표시",
-    "test": "테스트"
+    "test": "테스트",
+    "unnamedApp": "이름 없는 앱"
   },
   "refresh": "새로고침",
   "status": {

--- a/voc-datalake/frontend/public/locales/pt/scrapers.json
+++ b/voc-datalake/frontend/public/locales/pt/scrapers.json
@@ -172,12 +172,24 @@
     "titlePlaceholder": "Título da avaliação (opcional)"
   },
   "pluginConfig": {
+    "adminRequired": "Acesso de administrador necessário",
+    "addApp": "Adicionar app",
+    "addFirstApp": "Adicione seu primeiro app",
+    "addNewApp": "Adicionar novo app",
+    "cancel": "Cancelar",
+    "configuredApps": "Apps configurados",
     "automaticSchedule": "Agendamento automático",
     "close": "Fechar",
     "configuration": "Configuração",
+    "deleteAppMessage": "Tem certeza de que deseja remover esta configuração de app?",
+    "deleteAppTitle": "Excluir app",
+    "delete": "Excluir",
     "disabled": "Desabilitado",
+    "edit": "Editar",
+    "editApp": "Editar app",
     "enabled": "Habilitado",
     "hide": "Ocultar",
+    "noAppsConfigured": "Nenhum app configurado ainda",
     "runNow": "Executar agora",
     "runTriggered": "Execução iniciada",
     "save": "Salvar",
@@ -185,7 +197,8 @@
     "scheduleDescription": "Executar esta fonte no agendamento configurado",
     "select": "Selecionar...",
     "show": "Mostrar",
-    "test": "Testar"
+    "test": "Testar",
+    "unnamedApp": "App sem nome"
   },
   "refresh": "Atualizar",
   "status": {

--- a/voc-datalake/frontend/public/locales/zh/scrapers.json
+++ b/voc-datalake/frontend/public/locales/zh/scrapers.json
@@ -161,12 +161,24 @@
     "titlePlaceholder": "评论标题（可选）"
   },
   "pluginConfig": {
+    "adminRequired": "需要管理员权限",
+    "addApp": "添加应用",
+    "addFirstApp": "添加第一个应用",
+    "addNewApp": "添加新应用",
+    "cancel": "取消",
+    "configuredApps": "已配置的应用",
     "automaticSchedule": "自动计划",
     "close": "关闭",
     "configuration": "配置",
+    "deleteAppMessage": "确定要移除此应用配置吗？",
+    "deleteAppTitle": "删除应用",
+    "delete": "删除",
     "disabled": "已禁用",
+    "edit": "编辑",
+    "editApp": "编辑应用",
     "enabled": "已启用",
     "hide": "隐藏",
+    "noAppsConfigured": "尚未配置应用",
     "runNow": "立即运行",
     "runTriggered": "运行已触发",
     "save": "保存",
@@ -174,7 +186,8 @@
     "scheduleDescription": "按配置的计划运行此源",
     "select": "选择...",
     "show": "显示",
-    "test": "测试"
+    "test": "测试",
+    "unnamedApp": "未命名应用"
   },
   "refresh": "刷新",
   "status": {

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AppConfigCard } from './AppConfigComponents'
+import type { PluginManifest } from '../../plugins/types'
+
+const plugin: PluginManifest = {
+  id: 'app_reviews_android',
+  name: 'Android App Reviews',
+  icon: 'Android',
+  description: 'Collect reviews from Google Play Store',
+  category: 'reviews',
+  config: [],
+  hasIngestor: true,
+  hasWebhook: false,
+  hasS3Trigger: false,
+  version: '1.0.0',
+  enabled: true,
+}
+
+const app = {
+  id: 'app-1',
+  app_name: 'Zara',
+  package_name: 'com.inditex.zara',
+  frequency_minutes: '1440',
+  max_reviews_per_run: '500',
+}
+
+function renderCard(canManage: boolean) {
+  return render(
+    <AppConfigCard
+      app={app}
+      plugin={plugin}
+      canManage={canManage}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onRun={vi.fn()}
+      isRunning={false}
+    />,
+  )
+}
+
+describe('AppConfigCard', () => {
+  it('shows edit and delete actions for admins', () => {
+    renderCard(true)
+    expect(screen.getByTestId('app-config-edit')).toBeInTheDocument()
+    expect(screen.getByTestId('app-config-delete')).toBeInTheDocument()
+    expect(screen.getByTestId('app-config-run').getAttribute('aria-label')).toBeTruthy()
+  })
+
+  it('hides edit and delete actions for non-admins but keeps Run Now', () => {
+    renderCard(false)
+    expect(screen.queryByTestId('app-config-edit')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('app-config-delete')).not.toBeInTheDocument()
+    expect(screen.getByTestId('app-config-run')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
@@ -10,6 +10,7 @@ import {
 import {
   getAppIdentifier, getFrequencyLabel,
 } from './scraper-helpers'
+import { useTranslation } from 'react-i18next'
 import type { PluginManifest } from '../../plugins/types'
 
 type AppConfig = Record<string, string>
@@ -66,16 +67,18 @@ function AppRunStatusBar({ status }: Readonly<{ status: RunStatusInfo }>) {
 }
 
 export function AppConfigCard({
-  app, plugin, onEdit, onDelete, onRun, isRunning, runStatus,
+  app, plugin, canManage, onEdit, onDelete, onRun, isRunning, runStatus,
 }: Readonly<{
   app: AppConfig
   plugin: PluginManifest
+  canManage: boolean
   onEdit: () => void
   onDelete: () => void
   onRun: () => void
   isRunning: boolean
   runStatus?: RunStatusInfo
 }>) {
+  const { t } = useTranslation('scrapers')
   const frequencyMinutes = Number.parseInt(app.frequency_minutes === '' ? '1440' : app.frequency_minutes, 10)
   const frequencyLabel = getFrequencyLabel(frequencyMinutes)
 
@@ -85,16 +88,16 @@ export function AppConfigCard({
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 rounded-lg bg-purple-100 text-purple-600 flex items-center justify-center"><Smartphone size={20} /></div>
           <div>
-            <h3 className="font-semibold">{app.app_name === '' ? 'Unnamed App' : app.app_name}</h3>
+            <h3 className="font-semibold">{app.app_name === '' ? t('pluginConfig.unnamedApp') : app.app_name}</h3>
             <p className="text-sm text-gray-500">{getAppIdentifier(app, plugin.id)}</p>
           </div>
         </div>
         <div className="flex items-center gap-1">
-          <button onClick={onRun} disabled={isRunning} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title="Run now">
+          <button data-testid="app-config-run" aria-label={t('pluginConfig.runNow')} onClick={onRun} disabled={isRunning} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title={t('pluginConfig.runNow')}>
             {isRunning ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
           </button>
-          <button onClick={onEdit} className="p-2 hover:bg-gray-100 rounded" title="Edit"><Settings size={16} className="text-gray-500" /></button>
-          <button onClick={onDelete} className="p-2 hover:bg-gray-100 rounded text-red-500" title="Delete"><Trash2 size={16} /></button>
+          {canManage && <button data-testid="app-config-edit" aria-label={t('pluginConfig.edit')} onClick={onEdit} className="p-2 hover:bg-gray-100 rounded" title={t('pluginConfig.edit')}><Settings size={16} className="text-gray-500" /></button>}
+          {canManage && <button data-testid="app-config-delete" aria-label={t('pluginConfig.delete')} onClick={onDelete} className="p-2 hover:bg-gray-100 rounded text-red-500" title={t('pluginConfig.delete')}><Trash2 size={16} /></button>}
         </div>
       </div>
       <div className="grid grid-cols-3 gap-4 text-sm">

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
@@ -177,7 +177,7 @@ export default function GeneratorConfigModal({
           <button
             onClick={() => generateMutation.mutate()}
             disabled={isBusy || !hasRequired || !isAdmin}
-            title={!isAdmin ? 'Admin access required' : undefined}
+            title={!isAdmin ? t('pluginConfig.adminRequired') : undefined}
             className="btn btn-primary flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isBusy ? <Loader2 size={16} className="animate-spin" /> : <Sparkles size={16} />}

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
@@ -59,13 +59,13 @@ describe('PluginConfigModal', () => {
   })
 
   it('renders plugin name and description', () => {
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     expect(screen.getByText('Android App Reviews')).toBeInTheDocument()
     expect(screen.getByText('Collect reviews from Google Play Store')).toBeInTheDocument()
   })
 
   it('displays configured apps after loading', async () => {
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => {
       expect(screen.getByText('Zara')).toBeInTheDocument()
       expect(screen.getByText('H&M')).toBeInTheDocument()
@@ -74,13 +74,13 @@ describe('PluginConfigModal', () => {
 
   it('shows empty state when no apps configured', async () => {
     mockGetAppConfigs.mockResolvedValue({ apps: [] })
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('No apps configured yet')).toBeInTheDocument() })
   })
 
   it('opens add form when Add App clicked', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     await user.click(screen.getByRole('button', { name: /add app/i }))
     expect(screen.getByText('Add New App')).toBeInTheDocument()
@@ -88,7 +88,7 @@ describe('PluginConfigModal', () => {
 
   it('saves new app config when form submitted', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     await user.click(screen.getByRole('button', { name: /add app/i }))
     await user.type(screen.getByPlaceholderText('my-app'), 'Nike')
@@ -101,41 +101,74 @@ describe('PluginConfigModal', () => {
 
   it('shows delete confirmation when delete clicked', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
-    const deleteButtons = screen.getAllByTitle('Delete')
+    const deleteButtons = screen.getAllByTestId('plugin-app-delete')
     await user.click(deleteButtons[0])
     expect(screen.getByText('Delete App')).toBeInTheDocument()
   })
 
   it('calls close when Close button clicked', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await user.click(screen.getByRole('button', { name: /close/i }))
     // eslint-disable-next-line vitest/prefer-called-with
     expect(onClose).toHaveBeenCalled()
   })
 
   it('shows Run Now when apps exist', async () => {
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     expect(screen.getByRole('button', { name: /run now/i })).toBeInTheDocument()
   })
 
   it('hides Run Now when no apps', async () => {
     mockGetAppConfigs.mockResolvedValue({ apps: [] })
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('No apps configured yet')).toBeInTheDocument() })
     expect(screen.queryByRole('button', { name: /run now/i })).not.toBeInTheDocument()
   })
 
   it('cancels add form without saving', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     await user.click(screen.getByRole('button', { name: /add app/i }))
     await user.click(screen.getByRole('button', { name: /cancel/i }))
     expect(screen.queryByText('Add New App')).not.toBeInTheDocument()
     expect(mockSaveAppConfig).not.toHaveBeenCalled()
+  })
+
+  describe('as a non-admin (issue #359 admin gates)', () => {
+    it('disables the schedule toggle and explains why', async () => {
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+      const toggle = screen.getByRole('checkbox')
+      expect(toggle).toBeDisabled()
+      const hint = screen.getByText('Admin access required')
+      expect(hint).toBeTruthy()
+      expect(toggle.getAttribute('aria-describedby')).toBe(hint.id)
+    })
+
+    it('hides the add/edit/delete affordances for app configs', async () => {
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+      expect(screen.queryByTestId('plugin-add-app')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('plugin-app-edit')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('plugin-app-delete')).not.toBeInTheDocument()
+    })
+
+    it('hides the empty-state add link for non-admins', async () => {
+      mockGetAppConfigs.mockResolvedValue({ apps: [] })
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('No apps configured yet')).toBeInTheDocument() })
+      expect(screen.queryByTestId('plugin-add-first-app')).not.toBeInTheDocument()
+    })
+
+    it('keeps the read-only view and Run Now reachable', async () => {
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+      expect(screen.getByRole('button', { name: /run now/i })).toBeInTheDocument()
+    })
   })
 })

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.tsx
@@ -15,7 +15,7 @@ import {
   Save, Loader2, Play, AlertCircle, CheckCircle2, Plus, Trash2, Pencil, Smartphone,
 } from 'lucide-react'
 import {
-  useState, useEffect,
+  useState, useEffect, useId,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
@@ -31,6 +31,7 @@ type AppConfig = Record<string, string>
 interface PluginConfigModalProps {
   readonly plugin: PluginManifest
   readonly onClose: () => void
+  readonly isAdmin: boolean
 }
 
 function ResultMessage({
@@ -48,22 +49,26 @@ function ResultMessage({
 }
 
 function ScheduleToggle({
-  scheduleLoading, scheduleEnabled, onToggle,
+  scheduleLoading, scheduleEnabled, isAdmin, onToggle,
 }: {
   readonly scheduleLoading: boolean
   readonly scheduleEnabled: boolean
+  readonly isAdmin: boolean
   readonly onToggle: (enabled: boolean) => void
 }) {
   const { t } = useTranslation('scrapers')
+  const adminRequiredId = useId()
+
   return (
     <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
       <div>
         <p className="text-sm font-medium">{t('pluginConfig.automaticSchedule')}</p>
         <p className="text-xs text-gray-500">{t('pluginConfig.scheduleDescription')}</p>
+        {!scheduleLoading && !isAdmin ? <p id={adminRequiredId} className="text-xs text-amber-700">{t('pluginConfig.adminRequired')}</p> : null}
       </div>
       {scheduleLoading ? <Loader2 size={16} className="animate-spin text-blue-600" /> : (
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input type="checkbox" checked={scheduleEnabled} onChange={(e) => onToggle(e.target.checked)} className="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+        <label className={clsx('flex items-center gap-2', isAdmin ? 'cursor-pointer' : 'cursor-not-allowed')}>
+          <input type="checkbox" checked={scheduleEnabled} disabled={!isAdmin} aria-describedby={!isAdmin ? adminRequiredId : undefined} onChange={(e) => onToggle(e.target.checked)} className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50" />
           <span className="text-sm text-gray-600">{scheduleEnabled ? t('pluginConfig.enabled') : t('pluginConfig.disabled')}</span>
         </label>
       )}
@@ -72,25 +77,28 @@ function ScheduleToggle({
 }
 
 function AppCard({
-  app, pluginId, onEdit, onDelete,
+  app, pluginId, canManage, onEdit, onDelete,
 }: {
   readonly app: AppConfig;
   readonly pluginId: string;
+  readonly canManage: boolean;
   readonly onEdit: () => void;
   readonly onDelete: () => void
 }) {
+  const { t } = useTranslation('scrapers')
+
   return (
     <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50">
       <div className="flex items-center gap-3 min-w-0">
         <div className="w-9 h-9 rounded-lg bg-purple-100 text-purple-600 flex items-center justify-center flex-shrink-0"><Smartphone size={18} /></div>
         <div className="min-w-0">
-          <p className="text-sm font-medium truncate">{app.app_name === '' ? 'Unnamed App' : app.app_name}</p>
+          <p className="text-sm font-medium truncate">{app.app_name === '' ? t('pluginConfig.unnamedApp') : app.app_name}</p>
           <p className="text-xs text-gray-500 truncate">{getAppIdentifier(app, pluginId)}</p>
         </div>
       </div>
       <div className="flex items-center gap-1 flex-shrink-0">
-        <button onClick={onEdit} className="p-1.5 hover:bg-gray-200 rounded" title="Edit"><Pencil size={14} className="text-gray-500" /></button>
-        <button onClick={onDelete} className="p-1.5 hover:bg-gray-200 rounded" title="Delete"><Trash2 size={14} className="text-red-500" /></button>
+        {canManage && <button data-testid="plugin-app-edit" onClick={onEdit} className="p-1.5 hover:bg-gray-200 rounded" title={t('pluginConfig.edit')}><Pencil size={14} className="text-gray-500" /></button>}
+        {canManage && <button data-testid="plugin-app-delete" onClick={onDelete} className="p-1.5 hover:bg-gray-200 rounded" title={t('pluginConfig.delete')}><Trash2 size={14} className="text-red-500" /></button>}
       </div>
     </div>
   )
@@ -105,13 +113,14 @@ function AppEditorForm({
   readonly onCancel: () => void;
   readonly isPending: boolean
 }) {
+  const { t } = useTranslation('scrapers')
   const [values, setValues] = useState<AppConfig>(initialValues)
   const isEditing = initialValues.id != null && initialValues.id !== ''
   const hasRequired = plugin.config.filter((f) => f.required === true).every((f) => (values[f.key] ?? '').trim() !== '')
 
   return (
     <div className="space-y-4 p-4 border border-blue-200 bg-blue-50/30 rounded-lg">
-      <h4 className="text-sm font-semibold text-gray-700">{isEditing ? 'Edit App' : 'Add New App'}</h4>
+      <h4 className="text-sm font-semibold text-gray-700">{isEditing ? t('pluginConfig.editApp') : t('pluginConfig.addNewApp')}</h4>
       <div className="grid gap-3">
         {plugin.config.map((field) => (
           <PluginField key={field.key} field={field} value={values[field.key] ?? ''} showSecrets={false} onChange={(v) => setValues((prev) => ({
@@ -123,16 +132,16 @@ function AppEditorForm({
       <div className="flex items-center gap-2">
         <button onClick={() => onSave({ ...values })} disabled={isPending || !hasRequired} className="btn btn-primary flex items-center gap-2 text-sm">
           {isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
-          {isEditing ? 'Save' : 'Add App'}
+          {isEditing ? t('pluginConfig.save') : t('pluginConfig.addApp')}
         </button>
-        <button onClick={onCancel} className="btn btn-secondary text-sm">Cancel</button>
+        <button onClick={onCancel} className="btn btn-secondary text-sm">{t('pluginConfig.cancel')}</button>
       </div>
     </div>
   )
 }
 
 function AppListSection({
-  plugin, apps, appsLoading, showEditor, editorInitialValues, savePending, onStartAdd, onStartEdit, onDelete, onSaveApp, onCancelEditor,
+  plugin, apps, appsLoading, showEditor, editorInitialValues, savePending, canManage, onStartAdd, onStartEdit, onDelete, onSaveApp, onCancelEditor,
 }: {
   readonly plugin: PluginManifest;
   readonly apps: AppConfig[];
@@ -140,29 +149,31 @@ function AppListSection({
   readonly showEditor: boolean
   readonly editorInitialValues: AppConfig;
   readonly savePending: boolean
+  readonly canManage: boolean;
   readonly onStartAdd: () => void;
   readonly onStartEdit: (app: AppConfig) => void;
   readonly onDelete: (id: string) => void
   readonly onSaveApp: (v: AppConfig) => void;
   readonly onCancelEditor: () => void
 }) {
+  const { t } = useTranslation('scrapers')
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h4 className="text-sm font-semibold text-gray-700">Configured Apps</h4>
-        {!showEditor && <button onClick={onStartAdd} className="btn btn-primary flex items-center gap-1.5 text-xs px-3 py-1.5"><Plus size={14} /> Add App</button>}
+        <h4 className="text-sm font-semibold text-gray-700">{t('pluginConfig.configuredApps')}</h4>
+        {!showEditor && canManage && <button data-testid="plugin-add-app" onClick={onStartAdd} className="btn btn-primary flex items-center gap-1.5 text-xs px-3 py-1.5"><Plus size={14} /> {t('pluginConfig.addApp')}</button>}
       </div>
       {appsLoading ? <div className="flex items-center justify-center py-6"><Loader2 className="animate-spin h-6 w-6 text-blue-500" /></div> : null}
       {!appsLoading && apps.length === 0 && !showEditor && (
         <div className="text-center py-6 text-gray-400 text-sm">
           <Smartphone className="mx-auto h-8 w-8 mb-2 opacity-50" />
-          <p>No apps configured yet</p>
-          <button onClick={onStartAdd} className="text-blue-600 hover:underline text-sm mt-1">Add your first app</button>
+          <p>{t('pluginConfig.noAppsConfigured')}</p>
+          {canManage && <button data-testid="plugin-add-first-app" onClick={onStartAdd} className="text-blue-600 hover:underline text-sm mt-1">{t('pluginConfig.addFirstApp')}</button>}
         </div>
       )}
       {!appsLoading && apps.length > 0 && (
         <div className="space-y-2">
-          {apps.map((app) => <AppCard key={app.id} app={app} pluginId={plugin.id} onEdit={() => onStartEdit(app)} onDelete={() => onDelete(app.id)} />)}
+          {apps.map((app) => <AppCard key={app.id} app={app} pluginId={plugin.id} canManage={canManage} onEdit={() => onStartEdit(app)} onDelete={() => onDelete(app.id)} />)}
         </div>
       )}
       {showEditor ? <AppEditorForm plugin={plugin} initialValues={editorInitialValues} onSave={onSaveApp} onCancel={onCancelEditor} isPending={savePending} /> : null}
@@ -172,7 +183,7 @@ function AppListSection({
 
 // eslint-disable-next-line complexity
 export default function PluginConfigModal({
-  plugin, onClose,
+  plugin, onClose, isAdmin,
 }: PluginConfigModalProps) {
   const { t } = useTranslation('scrapers')
   const queryClient = useQueryClient()
@@ -222,6 +233,7 @@ export default function PluginConfigModal({
       setDeleteAppId(null)
     },
   })
+  // Phase 3 (#359): decide whether non-admin viewers may trigger source runs.
   const runMutation = useMutation({ mutationFn: () => api.runSource(plugin.id) })
 
   const handleToggleSchedule = async (enabled: boolean) => {
@@ -251,8 +263,8 @@ export default function PluginConfigModal({
           <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl">&times;</button>
         </div>
         <div className="p-4 overflow-y-auto flex-1 space-y-5">
-          <ScheduleToggle scheduleLoading={scheduleLoading} scheduleEnabled={scheduleEnabled} onToggle={(e) => void handleToggleSchedule(e)} />
-          <AppListSection plugin={plugin} apps={apps} appsLoading={appsLoading} showEditor={showEditor} editorInitialValues={editingApp ?? {}} savePending={saveMutation.isPending}
+          <ScheduleToggle scheduleLoading={scheduleLoading} scheduleEnabled={scheduleEnabled} isAdmin={isAdmin} onToggle={(e) => void handleToggleSchedule(e)} />
+          <AppListSection plugin={plugin} apps={apps} appsLoading={appsLoading} showEditor={showEditor} editorInitialValues={editingApp ?? {}} savePending={saveMutation.isPending} canManage={isAdmin}
             onStartAdd={() => {
               setEditingApp(null); setIsAdding(true)
             }} onStartEdit={(app) => {
@@ -276,7 +288,7 @@ export default function PluginConfigModal({
           <button onClick={onClose} className="btn btn-secondary w-full text-sm">{t('pluginConfig.close')}</button>
         </div>
       </div>
-      {deleteAppId == null || deleteAppId === '' ? null : <ConfirmModal isOpen title="Delete App" message="Are you sure you want to remove this app configuration?" confirmLabel="Delete" onConfirm={() => {
+      {deleteAppId == null || deleteAppId === '' ? null : <ConfirmModal isOpen title={t('pluginConfig.deleteAppTitle')} message={t('pluginConfig.deleteAppMessage')} confirmLabel={t('pluginConfig.delete')} onConfirm={() => {
         deleteMutation.mutate(deleteAppId)
       }} onCancel={() => setDeleteAppId(null)} />}
     </div>

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -21,6 +21,7 @@ import { useIsAdmin } from '../../store/authStore'
 import { useConfigStore } from '../../store/configStore'
 import { useManualImportStore } from '../../store/manualImportStore'
 import { AppConfigCard } from './AppConfigComponents'
+import { appConfigsQueryKey } from './app-config-query'
 import GeneratorConfigModal from './GeneratorConfigModal'
 import JsonUploadModal from './JsonUploadModal'
 import CsvUploadModal from './CsvUploadModal'
@@ -43,10 +44,11 @@ function getAppConfigPlugins(): PluginManifest[] {
   return getPluginManifests().filter((p) => p.id !== 'webscraper' && p.id !== 's3_import' && p.category !== 'synthetic' && p.hasIngestor)
 }
 
-function AppConfigList({
-  plugins, onEditPlugin, onDeleteApp, onRunApp,
+export function AppConfigList({
+  plugins, isAdmin, onEditPlugin, onDeleteApp, onRunApp,
 }: {
   readonly plugins: PluginManifest[];
+  readonly isAdmin: boolean
   readonly onEditPlugin: (p: PluginManifest) => void
   readonly onDeleteApp: (pluginId: string, appId: string) => void;
   readonly onRunApp: (pluginId: string, appIdentifier: string) => void
@@ -105,6 +107,7 @@ function AppConfigList({
   }, [runningApps])
 
   const handleRun = (pluginId: string, appIdentifier: string) => {
+    // Phase 3 (#359): decide whether non-admin viewers may trigger source runs.
     const appKey = `${pluginId}-${appIdentifier}`
     setRunningApps((prev) => new Set(prev).add(appKey))
     setRunStatuses((prev) => ({
@@ -121,7 +124,7 @@ function AppConfigList({
   const {
     data: allAppConfigs, isLoading: isLoadingApps,
   } = useQuery({
-    queryKey: ['all-app-configs', plugins.map((p) => p.id).join(',')],
+    queryKey: appConfigsQueryKey(plugins),
     queryFn: async () => {
       const emptyApps: AppConfig[] = []
       const results = await Promise.all(plugins.map(async (plugin) => {
@@ -173,6 +176,7 @@ function AppConfigList({
         app, plugin,
       }) => (
         <AppConfigCard key={`${plugin.id}-${app.id}`} app={app} plugin={plugin}
+          canManage={isAdmin}
           onEdit={() => onEditPlugin(plugin)} onDelete={() => onDeleteApp(plugin.id, app.id)}
           onRun={() => handleRun(plugin.id, getAppIdentifier(app, plugin.id))}
           isRunning={runningApps.has(`${plugin.id}-${getAppIdentifier(app, plugin.id)}`)}
@@ -219,12 +223,13 @@ function useScraperMutations() {
 }
 
 function ScrapersContent({
-  scrapers, isLoading, appConfigPlugins, syntheticPlugins, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
+  scrapers, isLoading, appConfigPlugins, syntheticPlugins, isAdmin, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
 }: {
   readonly scrapers: ScraperConfig[]
   readonly isLoading: boolean
   readonly appConfigPlugins: PluginManifest[]
   readonly syntheticPlugins: PluginManifest[]
+  readonly isAdmin: boolean
   readonly onRefresh: () => void
   readonly onShowTemplates: () => void
   readonly onEdit: (s: ScraperConfig) => void
@@ -257,7 +262,7 @@ function ScrapersContent({
       {isLoading ? <div className="flex items-center justify-center py-12"><Loader2 className="animate-spin h-8 w-8 text-blue-500" /></div> : null}
       {!isLoading && (
         <div className="grid gap-4">
-          <AppConfigList plugins={appConfigPlugins} onEditPlugin={onEditPlugin} onDeleteApp={onDeleteApp} onRunApp={onRunApp} />
+          <AppConfigList plugins={appConfigPlugins} isAdmin={isAdmin} onEditPlugin={onEditPlugin} onDeleteApp={onDeleteApp} onRunApp={onRunApp} />
           {scrapers.map((scraper) => (
             <ScraperCard key={scraper.id} scraper={scraper} onEdit={() => onEdit(scraper)} onDelete={() => onDelete(scraper.id)} onRun={() => onRun(scraper.id)} />
           ))}
@@ -380,6 +385,7 @@ export default function Scrapers() {
         isLoading={isLoading}
         appConfigPlugins={appConfigPlugins}
         syntheticPlugins={syntheticPlugins}
+        isAdmin={isAdmin}
         onRefresh={() => void refetch()}
         onShowTemplates={() => setShowTemplates(true)}
         onEdit={setEditingScraper}
@@ -410,6 +416,7 @@ export default function Scrapers() {
 
       {selectedPlugin == null ? null : <PluginConfigModal
         plugin={selectedPlugin}
+        isAdmin={isAdmin}
         onClose={() => setSelectedPlugin(null)}
       />}
 
@@ -436,9 +443,9 @@ export default function Scrapers() {
 
       {deleteAppInfo == null ? null : <ConfirmModal
         isOpen
-        title="Delete App"
-        message="Are you sure you want to remove this app configuration?"
-        confirmLabel="Delete"
+        title={t('pluginConfig.deleteAppTitle')}
+        message={t('pluginConfig.deleteAppMessage')}
+        confirmLabel={t('pluginConfig.delete')}
         onConfirm={() => {
           deleteAppMutation.mutate(deleteAppInfo)
         }}

--- a/voc-datalake/frontend/src/pages/Scrapers/ScrapersAppConfigList.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScrapersAppConfigList.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AppConfigList } from './Scrapers'
+import { appConfigsQueryKey } from './app-config-query'
+import { useConfigStore } from '../../store/configStore'
+import type { PluginManifest } from '../../plugins/types'
+
+const initialConfig = useConfigStore.getState().config
+
+const pluginWithApp = {
+  id: 'app_reviews_android',
+  name: 'Android reviews',
+  description: 'Review importer',
+  icon: '📱',
+  category: 'reviews',
+  enabled: true,
+  hasIngestor: true,
+  hasWebhook: false,
+  hasS3Trigger: false,
+  config: [],
+  apps: [
+    {
+      id: 'a1',
+      app_name: 'Zara',
+      package_name: 'com.inditex.zara',
+      country: 'us',
+      schedule_enabled: true,
+    },
+  ],
+} satisfies PluginManifest
+
+afterEach(() => {
+  useConfigStore.setState({ config: initialConfig })
+})
+
+function renderList(isAdmin: boolean) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  useConfigStore.setState((state) => ({
+    config: { ...state.config, apiEndpoint: 'https://api.example.com' },
+  }))
+  qc.setQueryData(appConfigsQueryKey([pluginWithApp]), [{
+    pluginId: pluginWithApp.id,
+    apps: pluginWithApp.apps,
+  }])
+  render(
+    <QueryClientProvider client={qc}>
+      <AppConfigList
+        plugins={[pluginWithApp]}
+        isAdmin={isAdmin}
+        onEditPlugin={vi.fn()}
+        onDeleteApp={vi.fn()}
+        onRunApp={vi.fn()}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AppConfigList admin wiring', () => {
+  it('forwards admin access to app cards', () => {
+    renderList(true)
+    expect(screen.getByTestId('app-config-edit')).toBeTruthy()
+    expect(screen.getByTestId('app-config-delete')).toBeTruthy()
+    expect(screen.getByTestId('app-config-run')).toBeTruthy()
+  })
+
+  it('forwards non-admin read-only access to app cards', () => {
+    renderList(false)
+    expect(screen.queryByTestId('app-config-edit')).toBeNull()
+    expect(screen.queryByTestId('app-config-delete')).toBeNull()
+    expect(screen.getByTestId('app-config-run')).toBeTruthy()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/app-config-query.ts
+++ b/voc-datalake/frontend/src/pages/Scrapers/app-config-query.ts
@@ -1,0 +1,5 @@
+import type { PluginManifest } from '../../plugins/types'
+
+export function appConfigsQueryKey(plugins: readonly Pick<PluginManifest, 'id'>[]) {
+  return ['all-app-configs', plugins.map((p) => p.id).join(',')] as const
+}

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -420,11 +420,23 @@ def update_credentials(source: str):
 # ============================================
 
 APP_CONFIG_PLUGINS = {'app_reviews_ios', 'app_reviews_android'}
+APP_CONFIG_SECRET_FIELDS: dict[str, set[str]] = {
+    'app_reviews_ios': set(),
+    'app_reviews_android': set(),
+}
 
 
 def _get_app_configs_key(source: str) -> str:
     """Get the Secrets Manager key for a plugin's app configs array."""
     return f"{source}_configs"
+
+
+def _redact_app_config_secrets(source: str, configs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove secret app-config fields before returning viewer-readable configs."""
+    secret_fields = APP_CONFIG_SECRET_FIELDS.get(source, set())
+    if not secret_fields:
+        return configs
+    return [{key: value for key, value in config.items() if key not in secret_fields} for config in configs]
 
 
 @app.get("/integrations/<source>/apps")
@@ -441,7 +453,7 @@ def list_app_configs(source: str):
         secrets = json.loads(response.get('SecretString', '{}'))
         configs_key = _get_app_configs_key(source)
         configs = json.loads(secrets.get(configs_key, '[]'))
-        return {'apps': configs}
+        return {'apps': _redact_app_config_secrets(source, configs)}
     except (ConfigurationError, ValidationError):
         raise
     except Exception as e:
@@ -453,6 +465,7 @@ def list_app_configs(source: str):
 @tracer.capture_method
 def save_app_config(source: str):
     """Save (create or update) an app configuration for a multi-instance plugin."""
+    require_admin(app.current_event.raw_event)
     if source not in APP_CONFIG_PLUGINS:
         raise ValidationError(f'Source {source} does not support multiple app configs')
     if not SECRETS_ARN:
@@ -496,6 +509,7 @@ def save_app_config(source: str):
 @tracer.capture_method
 def delete_app_config(source: str, app_id: str):
     """Delete an app configuration from a multi-instance plugin."""
+    require_admin(app.current_event.raw_event)
     if source not in APP_CONFIG_PLUGINS:
         raise ValidationError(f'Source {source} does not support multiple app configs')
     if not SECRETS_ARN:
@@ -525,6 +539,7 @@ def run_source(source: str):
     Optionally accepts a JSON body with `app_id` to run a single app
     config instead of all configs for the source.
     """
+    # Phase 3 (#359): decide whether this authenticated write should require admin.
     from datetime import datetime, timezone
 
     from shared.tables import get_aggregates_table
@@ -646,6 +661,7 @@ def get_sources_status():
 @tracer.capture_method
 def enable_source(source: str):
     """Enable a data source schedule."""
+    require_admin(app.current_event.raw_event)
     rule_name = _build_rule_name(source)
     try:
         events_client.enable_rule(Name=rule_name)
@@ -659,6 +675,7 @@ def enable_source(source: str):
 @tracer.capture_method
 def disable_source(source: str):
     """Disable a data source schedule."""
+    require_admin(app.current_event.raw_event)
     rule_name = _build_rule_name(source)
     try:
         events_client.disable_rule(Name=rule_name)

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -286,7 +286,8 @@ class TestAdminGateOnCredentialsRoutes:
         body = json.loads(response['body'])
         assert body.get('success') is False
 
-    def test_non_admin_write_rejected(self, api_gateway_event, lambda_context):
+    @patch('integrations_handler.secretsmanager')
+    def test_non_admin_write_rejected(self, mock_secrets, api_gateway_event, lambda_context):
         """Non-admin caller gets 403 on PUT /integrations/<source>/credentials.
 
         Regression: test_non_admin_write_rejected
@@ -306,6 +307,8 @@ class TestAdminGateOnCredentialsRoutes:
         )
         body = json.loads(response['body'])
         assert body.get('success') is False
+        mock_secrets.get_secret_value.assert_not_called()
+        mock_secrets.put_secret_value.assert_not_called()
 
     @patch('integrations_handler.secretsmanager')
     def test_admin_read_succeeds(self, mock_secrets, api_gateway_event, lambda_context):
@@ -344,6 +347,8 @@ class TestAdminGateOnCredentialsRoutes:
         )
         response = lambda_handler(event, lambda_context)
         assert response['statusCode'] == 200
+        written = json.loads(mock_secrets.put_secret_value.call_args.kwargs['SecretString'])
+        assert written['webscraper_api_key'] == 'new-value'
 
     def test_non_admin_status_rejected(self, api_gateway_event, lambda_context):
         """Non-admin caller gets 403 on GET /integrations/status.
@@ -406,6 +411,256 @@ class TestAdminGateOnCredentialsRoutes:
         # Each value above differs from its seeded default, so each source is configured.
         for plugin_id in PLUGIN_IDS:
             assert body[plugin_id]['configured'] is True, plugin_id
+
+
+class TestAdminGateOnAppConfigRoutes:
+    """
+    Admin gate: non-admin callers must receive 403 on the write (POST) and
+    delete (DELETE) /integrations/<source>/apps routes.
+
+    Both routes mutate the same shared Secrets Manager blob that the
+    credentials routes write, so they carry the same gate that #307 applied
+    to PUT .../credentials.
+
+    Reverting the require_admin call in either handler causes the
+    corresponding test to return 200/other status instead of 403.
+    """
+
+    @patch.dict('integrations_handler.APP_CONFIG_SECRET_FIELDS', {'app_reviews_android': {'api_token'}}, clear=False)
+    @patch('integrations_handler.secretsmanager')
+    def test_non_admin_list_app_configs_allowed(self, mock_secrets, api_gateway_event, lambda_context):
+        """Non-admin viewers can read app configs, with secret fields redacted."""
+        stored_configs = [
+            {
+                'id': 'a1',
+                'app_name': 'Zara',
+                'package_name': 'com.inditex.zara',
+                'api_token': 'do-not-return',
+            },
+        ]
+        expected_configs = [
+            {'id': 'a1', 'app_name': 'Zara', 'package_name': 'com.inditex.zara'},
+        ]
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({
+                'app_reviews_android_configs': json.dumps(stored_configs)
+            })
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='GET',
+            path='/integrations/app_reviews_android/apps',
+            path_params={'source': 'app_reviews_android'},
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['apps'] == expected_configs
+        mock_secrets.get_secret_value.assert_called_once()
+
+    def test_app_config_secret_field_denylist_matches_manifest(self):
+        """Future secret app-config fields must be added to the redaction denylist."""
+        from pathlib import Path
+
+        from integrations_handler import APP_CONFIG_PLUGINS, APP_CONFIG_SECRET_FIELDS
+
+        manifest_path = Path(__file__).resolve().parents[3] / 'frontend' / 'src' / 'plugins' / 'manifests.json'
+        manifests = json.loads(manifest_path.read_text())
+        missing: dict[str, list[str]] = {}
+        for plugin in manifests:
+            plugin_id = plugin.get('id')
+            if plugin_id not in APP_CONFIG_PLUGINS:
+                continue
+            secret_fields = {
+                field['key'] for field in plugin.get('config', []) if field.get('secret') is True
+            }
+            uncovered = secret_fields - APP_CONFIG_SECRET_FIELDS.get(plugin_id, set())
+            if uncovered:
+                missing[plugin_id] = sorted(uncovered)
+
+        assert not missing, f'app-config secret fields missing backend redaction coverage: {missing}'
+
+    @patch('integrations_handler.secretsmanager')
+    def test_non_admin_save_app_config_rejected_and_secret_untouched(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        """Non-admin caller gets 403 on POST and the secret is never read or written."""
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='POST',
+            path='/integrations/app_reviews_android/apps',
+            path_params={'source': 'app_reviews_android'},
+            body={'app': {'id': 'abc12345', 'app_name': 'Zara'}},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 403, (
+            f"Expected 403 for non-admin POST apps, got {response['statusCode']}"
+        )
+        body = json.loads(response['body'])
+        assert body.get('success') is False
+        mock_secrets.get_secret_value.assert_not_called()
+        mock_secrets.put_secret_value.assert_not_called()
+
+    @patch('integrations_handler.secretsmanager')
+    def test_non_admin_delete_rejected_and_secret_untouched(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        """Non-admin caller gets 403 on DELETE and the secret is never read or written."""
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='DELETE',
+            path='/integrations/app_reviews_android/apps/abc12345',
+            path_params={'source': 'app_reviews_android', 'app_id': 'abc12345'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 403, (
+            f"Expected 403 for non-admin DELETE apps, got {response['statusCode']}"
+        )
+        body = json.loads(response['body'])
+        assert body.get('success') is False
+        mock_secrets.get_secret_value.assert_not_called()
+        mock_secrets.put_secret_value.assert_not_called()
+
+    @patch('integrations_handler.secretsmanager')
+    def test_admin_write_app_config_succeeds(self, mock_secrets, api_gateway_event, lambda_context):
+        """Admin caller can save and persist an app config."""
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({})
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST',
+            path='/integrations/app_reviews_android/apps',
+            path_params={'source': 'app_reviews_android'},
+            body={'app': {'app_name': 'Zara'}},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['success'] is True
+
+        written = json.loads(mock_secrets.put_secret_value.call_args.kwargs['SecretString'])
+        apps = json.loads(written['app_reviews_android_configs'])
+        assert len(apps) == 1
+        assert apps[0]['app_name'] == 'Zara'
+        assert apps[0]['id'] != ''
+
+    @patch('integrations_handler.secretsmanager')
+    def test_admin_delete_succeeds(self, mock_secrets, api_gateway_event, lambda_context):
+        """Admin caller can delete an app config (positive-path control)."""
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({
+                'app_reviews_android_configs': json.dumps([
+                    {'id': 'abc12345', 'app_name': 'Zara'},
+                ]),
+            })
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='DELETE',
+            path='/integrations/app_reviews_android/apps/abc12345',
+            path_params={'source': 'app_reviews_android', 'app_id': 'abc12345'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 200
+
+        written = json.loads(mock_secrets.put_secret_value.call_args.kwargs['SecretString'])
+        assert json.loads(written['app_reviews_android_configs']) == []
+
+
+class TestAdminGateOnSourceScheduleRoutes:
+    """
+    Admin gate: non-admin callers must receive 403 on PUT /sources/<source>/enable
+    and PUT /sources/<source>/disable.
+
+    Disabling a source stops all ingestion for it, which is not a
+    viewer-level action (issue #359).
+
+    Reverting the require_admin call in either handler causes the
+    corresponding test to return 200 instead of 403.
+    """
+
+    def test_non_admin_enable_rejected(self, api_gateway_event, lambda_context):
+        """Non-admin caller gets 403 on PUT /sources/<source>/enable."""
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='PUT',
+            path='/sources/webscraper/enable',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 403, (
+            f"Expected 403 for non-admin enable, got {response['statusCode']}"
+        )
+        body = json.loads(response['body'])
+        assert body.get('success') is False
+
+    @patch('integrations_handler.events_client')
+    def test_non_admin_disable_rejected_and_rule_untouched(
+        self, mock_events, api_gateway_event, lambda_context
+    ):
+        """Non-admin caller gets 403 on disable and the EventBridge rule is untouched."""
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='PUT',
+            path='/sources/webscraper/disable',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 403, (
+            f"Expected 403 for non-admin disable, got {response['statusCode']}"
+        )
+        body = json.loads(response['body'])
+        assert body.get('success') is False
+        mock_events.disable_rule.assert_not_called()
+
+    @patch('integrations_handler.events_client')
+    def test_admin_enable_succeeds(self, mock_events, api_gateway_event, lambda_context):
+        """Admin caller can enable a schedule (positive-path control)."""
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/sources/webscraper/enable',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['enabled'] is True
+        mock_events.enable_rule.assert_called_once()
+
+    @patch('integrations_handler.events_client')
+    def test_admin_disable_succeeds(self, mock_events, api_gateway_event, lambda_context):
+        """Admin caller can disable a schedule (positive-path control)."""
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/sources/webscraper/disable',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['enabled'] is False
+        mock_events.disable_rule.assert_called_once()
 
 
 class TestFreshDeployReportsNothingConfigured:


### PR DESCRIPTION
Addresses phases 1 and 2 of #359. Phase 3 remains open for the product decision in the issue.

Backend:
- Added `require_admin(app.current_event.raw_event)` as the first statement in `POST /integrations/<source>/apps`, `DELETE /integrations/<source>/apps/<app_id>`, `PUT /sources/<source>/enable`, and `PUT /sources/<source>/disable`.
- Added negative tests for non-admin writes, positive admin controls that assert persistence, no-touch assertions for Secrets Manager and EventBridge, and a non-admin GET app-config read test.
- Redacts configured secret app-config fields before returning GET app-config payloads, plus a manifest lockstep test so future secret fields must be added to redaction coverage.
- Left `POST /sources/<source>/run` ungated with an inline phase 3 comment.

Frontend:
- Non-admin users keep read-only Scrapers access, but app-config add/edit/delete and schedule toggles are hidden or disabled.
- App-config control copy uses `pluginConfig.*` i18n keys across all eight locales.
- Added `PluginConfigModal`, `AppConfigCard`, and `AppConfigList` wiring coverage, with store reset in the new test.

Verification on final SHA `44f550e`:
- API suite: 2142 passed.
- Frontend suite: 187 files, 3068 tests passed.
- `npm run typecheck`: exit 0.
- `npm run lint -- --max-warnings 0`: exit 0.
- `ruff check` on touched backend files: all checks passed.
- Focused locale assertion: new `pluginConfig.*` app-control keys are present in all Scrapers locales.
- `git diff --check`: clean. No em dashes or truncation artifacts in diff/published text.
