### PR TITLE
Fix BEDROCK_MODEL_ID bypassing model resolution

### DIFF
--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -12,7 +12,8 @@ from botocore.exceptions import ClientError
 
 # Shared module imports
 from shared.logging import logger, tracer, metrics
-from shared.aws import get_dynamodb_resource, get_bedrock_client, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource, get_bedrock_client
+from shared.model_config import get_active_model_id
 from shared.api import validate_days, MAX_PERSONAS_PER_GENERATION
 from shared.converse import converse_chain
 from shared.exceptions import (
@@ -789,7 +790,7 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
                 'created_at': now,
                 'updated_at': now,
                 'llm_metadata': {
-                    'model': BEDROCK_MODEL_ID,
+                    'model': get_active_model_id('documents'),
                     'prompt_version': PERSONA_PROMPT_VERSION,
                     'generation_time_ms': llm_time
                 },

--- a/voc-datalake/lambda/api/projects.py
+++ b/voc-datalake/lambda/api/projects.py
@@ -656,8 +656,18 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
         logger.info("[PERSONA] Step 4/6: Executing LLM chain (this may take several minutes)...")
         update_progress(20, 'executing_llm_chain')
         
+        # Resolved once and passed to converse_chain so the recorded
+        # llm_metadata.model below can never drift from what actually ran,
+        # even if the surface's active model changes between this call and
+        # the read at persona-save time.
+        persona_model_id = get_active_model_id('documents')
         try:
-            results = converse_chain(chain_steps, progress_callback=lambda p, s: update_progress(p, s), surface='documents')
+            results = converse_chain(
+                chain_steps,
+                progress_callback=lambda p, s: update_progress(p, s),
+                surface='documents',
+                model_id=persona_model_id,
+            )
             logger.info(f"[PERSONA] LLM chain returned {len(results)} results")
         except Exception as e:
             logger.error(f"[PERSONA] LLM chain execution failed: {e}")
@@ -790,7 +800,7 @@ def generate_personas(project_id: str, filters: dict, progress_callback: callabl
                 'created_at': now,
                 'updated_at': now,
                 'llm_metadata': {
-                    'model': get_active_model_id('documents'),
+                    'model': persona_model_id,
                     'prompt_version': PERSONA_PROMPT_VERSION,
                     'generation_time_ms': llm_time
                 },

--- a/voc-datalake/lambda/api/test/test_persona_model_id_consistency.py
+++ b/voc-datalake/lambda/api/test/test_persona_model_id_consistency.py
@@ -1,0 +1,87 @@
+"""
+Regression test for the persona-generation model-id drift fix (PR #372).
+
+``generate_personas`` used to call ``get_active_model_id('documents')`` twice:
+once implicitly inside ``converse_chain`` (per step) and again, independently,
+when stamping ``llm_metadata.model`` on each saved persona. If the surface's
+active model changed between those two reads, the stored metadata would name
+a model that never actually produced the persona. The fix resolves the model
+once and threads it into both ``converse_chain`` and the saved metadata.
+
+This test forces `get_active_model_id` to return a different value on each
+call, which would make the drift observable if the single-resolution fix were
+reverted: the metadata would then record the second call's value instead of
+the one actually passed to ``converse_chain``.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+
+MINIMAL_PERSONA_JSON = json.dumps([{
+    "name": "TestUser",
+    "tagline": "a tester",
+    "confidence": "high",
+    "feedback_count": 10,
+    "identity": {},
+    "goals_motivations": {},
+    "pain_points": {},
+    "behaviors": {},
+    "context_environment": {},
+    "quotes": [],
+    "scenario": {},
+    "supporting_evidence": [],
+}])
+
+
+def _make_feedback_item(i):
+    return {
+        "feedback_id": f"fb-{i}",
+        "original_text": f"Feedback item {i}.",
+        "source_platform": "app_store",
+        "sentiment": "neutral",
+        "category": "general",
+    }
+
+
+def test_persona_llm_metadata_matches_model_used_for_generation():
+    import projects
+
+    mock_table = MagicMock()
+    mock_table.query.return_value = {"Items": []}
+    batch_writer = MagicMock()
+    batch_writer.__enter__ = MagicMock(return_value=MagicMock())
+    batch_writer.__exit__ = MagicMock(return_value=False)
+    mock_table.batch_writer.return_value = batch_writer
+
+    chain_results = ["Research analysis text.", MINIMAL_PERSONA_JSON]
+    converse_chain_mock = MagicMock(return_value=chain_results)
+
+    # Two distinct values: the fix must resolve the model ONCE and reuse it,
+    # not call get_active_model_id again when writing llm_metadata.
+    model_ids = ["model-at-generation-time", "model-that-changed-afterward"]
+
+    with patch("projects.projects_table", mock_table), \
+         patch("projects.get_feedback_context",
+               return_value=[_make_feedback_item(i) for i in range(5)]), \
+         patch("projects.converse_chain", converse_chain_mock), \
+         patch("projects.get_active_model_id", side_effect=model_ids), \
+         patch("projects.generate_persona_avatar",
+               return_value={"avatar_url": None, "avatar_prompt": None}):
+        projects.generate_personas(
+            "proj-test",
+            {"persona_count": 1, "generate_avatars": False},
+        )
+
+    assert converse_chain_mock.called, "generate_personas did not invoke converse_chain"
+    _, chain_kwargs = converse_chain_mock.call_args
+    assert chain_kwargs.get("model_id") == "model-at-generation-time", (
+        "converse_chain must receive the model resolved for this generation, "
+        f"got {chain_kwargs.get('model_id')!r}"
+    )
+
+    assert mock_table.put_item.called, "generate_personas did not save any persona"
+    saved_item = mock_table.put_item.call_args.kwargs["Item"]
+    assert saved_item["llm_metadata"]["model"] == "model-at-generation-time", (
+        "llm_metadata.model drifted from the model that actually generated "
+        f"the persona, got {saved_item['llm_metadata']['model']!r}"
+    )

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -12,7 +12,8 @@ from boto3.dynamodb.conditions import Key
 
 # Shared module imports
 from shared.logging import logger, tracer
-from shared.aws import get_dynamodb_resource, BEDROCK_MODEL_ID
+from shared.aws import get_dynamodb_resource
+from shared.model_config import get_active_model_id
 from shared.api import api_handler
 from shared.converse import converse, BedrockThrottlingError
 from shared.prompts import (
@@ -46,7 +47,7 @@ PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
 feedback_table = None
 projects_table = None
 
-MODEL_ID = BEDROCK_MODEL_ID
+MODEL_ID = get_active_model_id('documents')
 def _get_feedback_table():
     """Get feedback table, initializing if needed."""
     global feedback_table

--- a/voc-datalake/lambda/research/research_step_handler.py
+++ b/voc-datalake/lambda/research/research_step_handler.py
@@ -13,7 +13,6 @@ from boto3.dynamodb.conditions import Key
 # Shared module imports
 from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource
-from shared.model_config import get_active_model_id
 from shared.api import api_handler
 from shared.converse import converse, BedrockThrottlingError
 from shared.prompts import (
@@ -47,7 +46,6 @@ PROJECTS_TABLE = os.environ.get('PROJECTS_TABLE', '')
 feedback_table = None
 projects_table = None
 
-MODEL_ID = get_active_model_id('documents')
 def _get_feedback_table():
     """Get feedback table, initializing if needed."""
     global feedback_table

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -555,10 +555,11 @@ def converse_chain(
     progress_callback: Callable[[int, str], None] | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
     surface: str = DEFAULT_SURFACE,
+    model_id: str | None = None,
 ) -> list[str]:
     """
     Execute a chain of LLM calls, each building on the previous.
-    
+
     Each step can have:
         - system: System prompt
         - user: User message (use {previous} to inject previous result)
@@ -567,14 +568,19 @@ def converse_chain(
         - step_name: Optional name for progress reporting
         - surface: Optional per-step AI surface override (defaults to the
           chain-level `surface`)
-    
+
     Args:
         steps: List of step configurations
         progress_callback: Optional callback(progress: int, step: str) to report progress
         max_retries: Maximum retry attempts for throttling (default: 5)
         surface: AI surface whose configured model the steps resolve to when
             they don't set their own model (default: the neutral fallback).
-    
+        model_id: Explicit model ID override applied to every step. When None,
+            each step resolves its own model from `surface` independently, the
+            same as calling `converse` directly. Pass this when the caller
+            needs to record which model produced the chain's output (e.g. in
+            stored metadata) so that record can't drift from what actually ran.
+
     Returns:
         List of results from each step
     """
@@ -615,6 +621,7 @@ def converse_chain(
                 system_prompt=system,
                 max_tokens=max_tokens,
                 thinking_budget=thinking_budget,
+                model_id=step.get('model_id', model_id),
                 surface=step.get('surface', surface),
                 max_retries=max_retries,
                 step_name=step_name,


### PR DESCRIPTION
Fixes #273 by replacing direct usages of \BEDROCK_MODEL_ID\ with \get_active_model_id('documents')\. This ensures that model resolution logic and per-surface overrides are correctly applied during persona generation and research steps.