### PR TITLE
fix(stream): widen the chat tool's lookback to 90 days and declare truncation

### DIFF
--- a/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
@@ -1,0 +1,94 @@
+"""Guard test for the date-scan lookback bound, mirrored in Python and TypeScript.
+
+`shared/feedback.py` owns `MAX_LOOKBACK_DAYS`: the REST feedback routes spend it
+as ``days=min(days, MAX_LOOKBACK_DAYS)``. The streaming chat Lambda is a second
+runtime of the same rule — `lambda/stream/src/tools/search-feedback.ts` runs its
+own date loop and cannot import Python — so it declares its own copy.
+
+Nothing tied the two together, and they diverged for months: the chat tool capped
+its scan at 30 days while the route used 90. The failure is silent rather than
+loud — a user asking about a quarter of feedback got a month of it, with the model
+reporting the truncated numbers as if they were the whole window.
+
+Same pattern as `test_search_minimum_lockstep.py` (frontend gate ↔ route bound)
+and `test_indexes.py` (CDK ↔ Python GSI names): parse the other language's source
+and assert equality, so a change on either side fails CI instead of quietly
+answering the wrong question.
+
+Deliberately NOT asserted here: the candidate ceilings. TypeScript's
+`MAX_CANDIDATES = 10000` and `metrics_handler.CANDIDATES_SOFT_CAP` are separate
+budget decisions for different consumers (a model reading prose vs. a paginating
+client), not one rule with two copies. Pinning them together would freeze a
+divergence nobody has decided to close.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from shared.feedback import MAX_LOOKBACK_DAYS
+
+
+def _repo_root() -> Path:
+    # lambda/shared/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+_TOOL_SOURCE = _repo_root() / 'lambda' / 'stream' / 'src' / 'tools' / 'search-feedback.ts'
+
+
+def _stream_lookback_days() -> int | None:
+    """`MAX_LOOKBACK_DAYS` as declared in the chat tool, or None if not found."""
+    match = re.search(
+        r'export\s+const\s+MAX_LOOKBACK_DAYS\s*=\s*(\d+)',
+        _TOOL_SOURCE.read_text(),
+    )
+    return int(match.group(1)) if match else None
+
+
+class TestLookbackWindowMirror:
+    """The comparison SKIPS when the stream tree is gone; the control does not.
+
+    A checkout without `lambda/stream/` should not report a mirror mismatch it
+    never measured — that is a `FileNotFoundError` masquerading as a finding — so
+    the equality test carries a `skipif`.
+
+    `test_the_stream_constant_is_findable` carries NO skip marker on purpose: it
+    asserts the file exists and the constant parses, which is exactly the check
+    that has to run. Skipping it would leave the equality test able to pass while
+    comparing against nothing.
+    """
+
+    def test_the_stream_constant_is_findable(self):
+        """The positive control.
+
+        Without it, a rename to `MAX_LOOKBACK` or an inlined literal would make
+        the parser return None and the equality test below would compare against
+        nothing — a green result meaning "did not check", which is the failure
+        mode this file exists to prevent, applied to itself.
+        """
+        assert _TOOL_SOURCE.exists(), f'chat tool source moved: {_TOOL_SOURCE}'
+        assert _stream_lookback_days() is not None, (
+            'parsed no MAX_LOOKBACK_DAYS from search-feedback.ts — parser drift?'
+        )
+
+    @pytest.mark.skipif(not _TOOL_SOURCE.exists(), reason='stream tree absent from this checkout')
+    def test_both_runtimes_agree_on_the_lookback_window(self):
+        """Equality, so widening one side fails here rather than leaving the chat
+        tool answering from a fraction of the window the REST route reads."""
+        assert _stream_lookback_days() == MAX_LOOKBACK_DAYS, (
+            f'chat tool scans {_stream_lookback_days()} days while the REST routes '
+            f'allow {MAX_LOOKBACK_DAYS}'
+        )
+
+    @pytest.mark.skipif(not _TOOL_SOURCE.exists(), reason='stream tree absent from this checkout')
+    def test_the_chat_tool_spends_the_constant_rather_than_a_literal(self):
+        """A second control, for the other way this guard can go green while the
+        code has drifted: the constant agreeing with Python is worthless if the
+        day loop still clamps to a hard-coded number of its own.
+        """
+        source = _TOOL_SOURCE.read_text()
+        assert 'Math.min(days, MAX_LOOKBACK_DAYS)' in source, (
+            'search-feedback.ts no longer clamps its day loop with MAX_LOOKBACK_DAYS '
+            '— a re-introduced literal would make the equality test above vacuous'
+        )

--- a/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
@@ -2,8 +2,8 @@
 
 `shared/feedback.py` owns `MAX_LOOKBACK_DAYS`: the REST feedback routes spend it
 as ``days=min(days, MAX_LOOKBACK_DAYS)``. The streaming chat Lambda is a second
-runtime of the same rule — `lambda/stream/src/tools/search-feedback.ts` runs its
-own date loop and cannot import Python — so it declares its own copy.
+runtime of the same rule — `lambda/stream/src/tools/feedback-scan.ts` runs its
+own date scan and cannot import Python — so it declares its own copy.
 
 Nothing tied the two together, and they diverged for months: the chat tool capped
 its scan at 30 days while the route used 90. The failure is silent rather than
@@ -16,10 +16,15 @@ and assert equality, so a change on either side fails CI instead of quietly
 answering the wrong question.
 
 The third test guards the OTHER way this file can go green over drifted code: a
-constant that agrees with Python is worthless if the day loop re-acquires a
+constant that agrees with Python is worthless if the day scan re-acquires a
 hard-coded clamp of its own. It asserts properties (the constant is spent; no
 numeric-literal window clamp survives anywhere) rather than one exact spelling,
-so reformatting or moving the clamp does not fail it for a non-defect.
+so reformatting or moving the clamp does not fail it for a non-defect. The clamp
+check is a TRIPWIRE for the idioms this codebase writes, not a proof — a bound
+computed at runtime would pass it — so the reference count is the load-bearing
+half. Both properties read every chat-tool source rather than one path, because
+the constant is declared beside the reads while `resolveSearchParams` spends it
+in `search-feedback.ts`.
 
 Deliberately NOT asserted here: the candidate ceilings. TypeScript's
 `MAX_CANDIDATES = 10000` and `metrics_handler.CANDIDATES_SOFT_CAP` are separate
@@ -40,7 +45,33 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
-_TOOL_SOURCE = _repo_root() / 'lambda' / 'stream' / 'src' / 'tools' / 'search-feedback.ts'
+_TOOL_SOURCE = _repo_root() / 'lambda' / 'stream' / 'src' / 'tools' / 'feedback-scan.ts'
+
+# Every clamp idiom this codebase writes, so a re-introduced literal bound fails
+# here however it is spelled. A tripwire rather than a proof — see the module
+# docstring — but the single pattern this replaced caught only the first shape,
+# and `Math.min(90, days)` and a ternary are the same defect written differently.
+_LITERAL_CLAMP_PATTERNS = (
+    r'Math\.min\(\s*\w*[Dd]ays\s*,\s*\d+',
+    r'Math\.min\(\s*\d+\s*,\s*\w*[Dd]ays',
+    r'\w*[Dd]ays\s*[<>]=?\s*\d+\s*\?',
+)
+
+
+def search_feedback_sources() -> dict[str, str]:
+    """The chat tool's own sources, by file name.
+
+    Read as a SET rather than one path: the constant lives with the reads in
+    `feedback-scan.ts` while `resolveSearchParams` spends it in
+    `search-feedback.ts`, so pinning one file let a mutation that moved the clamp
+    into the sibling and made it a literal pass unnoticed. Verified by applying
+    exactly that mutation, not by reading the glob.
+    """
+    return {
+        path.name: path.read_text()
+        for path in sorted(_TOOL_SOURCE.parent.glob('*feedback*.ts'))
+        if not path.name.endswith('.test.ts')
+    }
 
 
 def _stream_lookback_days() -> int | None:
@@ -79,9 +110,16 @@ def literal_day_clamps(source: str) -> list[str]:
     """Clamps of a day count against a hard-coded number, e.g. `Math.min(days, 30)`.
 
     Any `*days`/`*Days` operand matches, so renaming the local to `requestedDays`
-    when the clamp moved did not open a blind spot.
+    when the clamp moved did not open a blind spot. Three idioms rather than one,
+    because `Math.min(30, days)` and `days > 30 ? 30 : days` are the same defect:
+    a single-pattern draft missed both.
     """
-    return re.findall(r'Math\.min\(\s*\w*[Dd]ays\s*,\s*\d+', strip_comments(source))
+    code = strip_comments(source)
+    return [
+        match
+        for pattern in _LITERAL_CLAMP_PATTERNS
+        for match in re.findall(pattern, code)
+    ]
 
 
 class TestLookbackWindowMirror:
@@ -137,16 +175,26 @@ class TestLookbackWindowMirror:
         Both properties are measured over the source with COMMENTS STRIPPED. See
         `strip_comments`: counting prose let a file that had stopped spending the
         constant pass on the strength of its own docblocks.
+
+        And over EVERY chat-tool source, not just the declaring one: the clamp is
+        spent in `search-feedback.ts` while the constant is declared in
+        `feedback-scan.ts`, so a one-path check misses a literal clamp
+        re-appearing in the other half.
         """
-        source = _TOOL_SOURCE.read_text()
-        uses = constant_uses(source)
+        sources = search_feedback_sources()
+        assert sources, f'no chat tool sources beside {_TOOL_SOURCE}'
+        uses = sum(constant_uses(text) for text in sources.values())
         assert uses >= 2, (
-            f'MAX_LOOKBACK_DAYS appears {uses}x in search-feedback.ts code — declared but '
-            'never spent, so the equality test above pins a number nothing reads'
+            f'MAX_LOOKBACK_DAYS appears {uses}x across {", ".join(sources)} code — declared '
+            'but never spent, so the equality test above pins a number nothing reads'
         )
-        clamps = literal_day_clamps(source)
+        clamps = {
+            name: found
+            for name, text in sources.items()
+            if (found := literal_day_clamps(text))
+        }
         assert not clamps, (
-            f'search-feedback.ts clamps its window with a hard-coded literal '
+            f'the chat tool clamps its window with a hard-coded literal '
             f'({clamps}) — that is how the 30-vs-90 divergence happened, and it '
             'makes the equality test vacuous'
         )
@@ -188,6 +236,18 @@ class TestTheGuardItself:
         renamed = 'export const MAX_LOOKBACK_DAYS = 90;\nMath.min(requestedDays, 30)'
         assert literal_day_clamps(renamed), 'a literal clamp on a renamed operand went unnoticed'
 
+        # The same clamp with the arguments the other way round, and as a ternary.
+        # A single-pattern draft passed both, so the drift this guard exists for
+        # survived it — verified against the compiled patterns, not assumed.
+        reversed_args = 'export const MAX_LOOKBACK_DAYS = 90;\nMath.min(90, requestedDays)'
+        assert literal_day_clamps(reversed_args), 'a reversed-argument literal clamp went unnoticed'
+
+        ternary = (
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            'const scanned = requestedDays > 90 ? 90 : requestedDays;'
+        )
+        assert literal_day_clamps(ternary), 'a ternary literal clamp went unnoticed'
+
         declared_only = 'export const MAX_LOOKBACK_DAYS = 90;\nconst scanned = days;'
         assert constant_uses(declared_only) < 2, 'a constant nobody spends went unnoticed'
 
@@ -226,4 +286,22 @@ class TestTheGuardItself:
         )
         assert not literal_day_clamps(discussed_not_done), (
             'a literal clamp quoted in a comment was reported as live code'
+        )
+
+    def test_it_reads_every_chat_tool_source_not_only_the_declaring_one(self):
+        """The gap that opened when the reads moved to their own module.
+
+        The constant is declared in `feedback-scan.ts`; `resolveSearchParams`
+        spends it in `search-feedback.ts`. A guard bound to one path passed a
+        mutation that put a literal clamp in the other file — found by applying it,
+        which is why the property below is over the whole set.
+        """
+        sources = search_feedback_sources()
+        assert 'feedback-scan.ts' in sources, 'the declaring source is not in the set'
+        assert 'search-feedback.ts' in sources, (
+            'the file that SPENDS the constant is not in the set, so a literal clamp '
+            'there would go unnoticed'
+        )
+        assert not any(name.endswith('.test.ts') for name in sources), (
+            'test files are in the set, so a clamp in a fixture would read as production drift'
         )

--- a/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
@@ -15,6 +15,12 @@ and `test_indexes.py` (CDK ↔ Python GSI names): parse the other language's sou
 and assert equality, so a change on either side fails CI instead of quietly
 answering the wrong question.
 
+The third test guards the OTHER way this file can go green over drifted code: a
+constant that agrees with Python is worthless if the day loop re-acquires a
+hard-coded clamp of its own. It asserts properties (the constant is spent; no
+numeric-literal window clamp survives anywhere) rather than one exact spelling,
+so reformatting or moving the clamp does not fail it for a non-defect.
+
 Deliberately NOT asserted here: the candidate ceilings. TypeScript's
 `MAX_CANDIDATES = 10000` and `metrics_handler.CANDIDATES_SOFT_CAP` are separate
 budget decisions for different consumers (a model reading prose vs. a paginating
@@ -86,9 +92,25 @@ class TestLookbackWindowMirror:
         """A second control, for the other way this guard can go green while the
         code has drifted: the constant agreeing with Python is worthless if the
         day loop still clamps to a hard-coded number of its own.
+
+        Asserted as two PROPERTIES rather than one exact spelling. An earlier
+        draft required the literal substring ``Math.min(days, MAX_LOOKBACK_DAYS)``,
+        which breaks on reformatting, on renaming the local, and — worst — on
+        moving the clamp to where the window is resolved, which is where it
+        belongs, so that the scan bound and the cutoff filter cannot disagree. A
+        guard that fails on the correct fix teaches the next reader to edit the
+        guard rather than trust it, which is the failure mode `test_indexes.py`
+        -style guards exist to avoid.
         """
         source = _TOOL_SOURCE.read_text()
-        assert 'Math.min(days, MAX_LOOKBACK_DAYS)' in source, (
-            'search-feedback.ts no longer clamps its day loop with MAX_LOOKBACK_DAYS '
-            '— a re-introduced literal would make the equality test above vacuous'
+        uses = len(re.findall(r'\bMAX_LOOKBACK_DAYS\b', source))
+        assert uses >= 2, (
+            f'MAX_LOOKBACK_DAYS appears {uses}x in search-feedback.ts — declared but '
+            'never spent, so the equality test above pins a number nothing reads'
+        )
+        literal_clamp = re.search(r'Math\.min\(\s*\w*[Dd]ays\s*,\s*\d+', source)
+        assert literal_clamp is None, (
+            f'search-feedback.ts clamps its window with a hard-coded literal '
+            f'({literal_clamp.group(0) if literal_clamp else ""}) — that is how the '
+            '30-vs-90 divergence happened, and it makes the equality test vacuous'
         )

--- a/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
@@ -52,6 +52,38 @@ def _stream_lookback_days() -> int | None:
     return int(match.group(1)) if match else None
 
 
+def strip_comments(source: str) -> str:
+    """TypeScript with `//` lines and `/* */` blocks removed.
+
+    Load-bearing for the checks below, which ask what the CODE does. That file
+    documents `MAX_LOOKBACK_DAYS` at length and names it repeatedly in prose, so
+    counting raw occurrences let a version with the clamp deleted still score
+    well above the threshold — the constant's own documentation vouching for a
+    constant nothing spends. Found by applying that mutation to the real source
+    rather than by reading the regex; `TestTheGuardItself` now pins it.
+    """
+    without_blocks = re.sub(r'/\*.*?\*/', '', source, flags=re.DOTALL)
+    return re.sub(r'//[^\n]*', '', without_blocks)
+
+
+def constant_uses(source: str) -> int:
+    """How many times `MAX_LOOKBACK_DAYS` appears in CODE, declaration included.
+
+    One means declared and never spent, which makes the equality test vacuous:
+    the number agrees with Python and nothing reads it.
+    """
+    return len(re.findall(r'\bMAX_LOOKBACK_DAYS\b', strip_comments(source)))
+
+
+def literal_day_clamps(source: str) -> list[str]:
+    """Clamps of a day count against a hard-coded number, e.g. `Math.min(days, 30)`.
+
+    Any `*days`/`*Days` operand matches, so renaming the local to `requestedDays`
+    when the clamp moved did not open a blind spot.
+    """
+    return re.findall(r'Math\.min\(\s*\w*[Dd]ays\s*,\s*\d+', strip_comments(source))
+
+
 class TestLookbackWindowMirror:
     """The comparison SKIPS when the stream tree is gone; the control does not.
 
@@ -101,16 +133,97 @@ class TestLookbackWindowMirror:
         guard that fails on the correct fix teaches the next reader to edit the
         guard rather than trust it, which is the failure mode `test_indexes.py`
         -style guards exist to avoid.
+
+        Both properties are measured over the source with COMMENTS STRIPPED. See
+        `strip_comments`: counting prose let a file that had stopped spending the
+        constant pass on the strength of its own docblocks.
         """
         source = _TOOL_SOURCE.read_text()
-        uses = len(re.findall(r'\bMAX_LOOKBACK_DAYS\b', source))
+        uses = constant_uses(source)
         assert uses >= 2, (
-            f'MAX_LOOKBACK_DAYS appears {uses}x in search-feedback.ts — declared but '
+            f'MAX_LOOKBACK_DAYS appears {uses}x in search-feedback.ts code — declared but '
             'never spent, so the equality test above pins a number nothing reads'
         )
-        literal_clamp = re.search(r'Math\.min\(\s*\w*[Dd]ays\s*,\s*\d+', source)
-        assert literal_clamp is None, (
+        clamps = literal_day_clamps(source)
+        assert not clamps, (
             f'search-feedback.ts clamps its window with a hard-coded literal '
-            f'({literal_clamp.group(0) if literal_clamp else ""}) — that is how the '
-            '30-vs-90 divergence happened, and it makes the equality test vacuous'
+            f'({clamps}) — that is how the 30-vs-90 divergence happened, and it '
+            'makes the equality test vacuous'
+        )
+
+
+class TestTheGuardItself:
+    """Both directions of the property checks, on synthetic sources.
+
+    The point of replacing the substring assertion was that it failed on correct
+    code. Asserting only that the real file passes cannot demonstrate the
+    replacement fixed that, because a check which accepts everything also passes.
+    So each predicate is exercised against sources it must accept AND sources it
+    must reject — including the mutation that slipped past the first draft.
+    """
+
+    def test_it_accepts_the_clamp_wherever_it_lives_and_however_it_is_spelled(self):
+        """The three shapes the old substring assertion rejected for no defect."""
+        relocated = (
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            'days: Math.min(requestedDays, MAX_LOOKBACK_DAYS),'
+        )
+        reformatted = (
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            'const scanned = Math.min(\n  days,\n  MAX_LOOKBACK_DAYS,\n);'
+        )
+        extracted = (
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            'const clampWindow = (d: number) => Math.min(d, MAX_LOOKBACK_DAYS);'
+        )
+        for source in (relocated, reformatted, extracted):
+            assert constant_uses(source) >= 2
+            assert not literal_day_clamps(source)
+
+    def test_it_still_rejects_a_bare_literal_and_a_constant_nobody_spends(self):
+        """The drift the guard exists for, in each of its shapes."""
+        literal_clamp = 'export const MAX_LOOKBACK_DAYS = 90;\nconst scanned = Math.min(days, 30);'
+        assert literal_day_clamps(literal_clamp), 'a re-introduced literal clamp went unnoticed'
+
+        renamed = 'export const MAX_LOOKBACK_DAYS = 90;\nMath.min(requestedDays, 30)'
+        assert literal_day_clamps(renamed), 'a literal clamp on a renamed operand went unnoticed'
+
+        declared_only = 'export const MAX_LOOKBACK_DAYS = 90;\nconst scanned = days;'
+        assert constant_uses(declared_only) < 2, 'a constant nobody spends went unnoticed'
+
+    def test_prose_naming_the_constant_does_not_count_as_spending_it(self):
+        """The mutation that slipped past the first draft of this guard.
+
+        `search-feedback.ts` names MAX_LOOKBACK_DAYS several times in docblocks,
+        so counting raw occurrences let the real file pass with the clamp removed.
+        Caught by applying that mutation to the actual source, not by inspection.
+        """
+        commented_out = (
+            '/**\n * Mirror of MAX_LOOKBACK_DAYS in feedback.py. See MAX_LOOKBACK_DAYS.\n */\n'
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            '// The clamp used to spend MAX_LOOKBACK_DAYS right here.\n'
+            'const scanned = requestedDays;'
+        )
+        assert constant_uses(commented_out) < 2, (
+            'comments mentioning the constant counted as uses, so a file that stopped '
+            'spending it would still pass'
+        )
+
+        # The inverse, so the strip cannot pass by deleting everything: a genuine
+        # use in code still counts when the surrounding prose is removed.
+        genuinely_used = (
+            '// Mirror of MAX_LOOKBACK_DAYS.\n'
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            'const scanned = Math.min(requestedDays, MAX_LOOKBACK_DAYS);'
+        )
+        assert constant_uses(genuinely_used) >= 2
+
+        # And a literal clamp mentioned only in a comment is not a real clamp.
+        discussed_not_done = (
+            '// This used to read Math.min(days, 30) before the constant existed.\n'
+            'export const MAX_LOOKBACK_DAYS = 90;\n'
+            'const scanned = Math.min(days, MAX_LOOKBACK_DAYS);'
+        )
+        assert not literal_day_clamps(discussed_not_done), (
+            'a literal clamp quoted in a comment was reported as live code'
         )

--- a/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py
@@ -145,7 +145,10 @@ class TestLookbackWindowMirror:
         """
         assert _TOOL_SOURCE.exists(), f'chat tool source moved: {_TOOL_SOURCE}'
         assert _stream_lookback_days() is not None, (
-            'parsed no MAX_LOOKBACK_DAYS from search-feedback.ts — parser drift?'
+            # Name the file the parser actually reads. It said search-feedback.ts, which
+            # only SPENDS the constant, so the message sent a reader to the wrong file at
+            # the one moment the guard is failing and the message is all they have.
+            f'parsed no MAX_LOOKBACK_DAYS from {_TOOL_SOURCE.name} — parser drift?'
         )
 
     @pytest.mark.skipif(not _TOOL_SOURCE.exists(), reason='stream tree absent from this checkout')

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the feedback date scan: how wide it fans out, and in what order.
+ *
+ * Separate from search-feedback.test.ts along the same seam as the source split.
+ * These assert properties of the READ — the fan-out width, date ordering under
+ * concurrency, and the shared candidate budget — rather than anything about the
+ * prose the tool returns, and they are the tests a change to the scan shape must
+ * be run against.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  executeSearchFeedback,
+  DAY_SCAN_CONCURRENCY,
+  MAX_CANDIDATES,
+} from './search-feedback.js';
+
+/**
+ * The candidate cap these cases inject.
+ *
+ * Three rows reach the cap-hit branches that MAX_CANDIDATES needed ten thousand
+ * zod-parsed fixtures apiece to reach. Kept far below MAX_CANDIDATES, and
+ * asserted so, since a TEST_CAP that drifted up to the real value would put the
+ * 10k fixtures back without anyone noticing.
+ */
+const TEST_CAP = 3;
+
+const today = new Date().toISOString().slice(0, 10);
+
+/** YYYY-MM-DD `n` days before today, UTC — the shape the date GSI partitions by. */
+const daysAgo = (n: number) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+};
+
+function makeFeedbackItem(overrides: Record<string, unknown> = {}) {
+  return {
+    feedback_id: 'abc123def456abc123def456abc12345',
+    source_platform: 'webscraper',
+    source_created_at: `${today}T10:00:00Z`,
+    sentiment_label: 'negative',
+    sentiment_score: -0.8,
+    category: 'delivery',
+    rating: 2,
+    original_text: 'My package arrived late and damaged',
+    title: 'Late delivery',
+    problem_summary: 'Package delayed and damaged',
+    date: today,
+    urgency: 'high',
+    ...overrides,
+  };
+}
+
+/**
+ * Freeze the clock, so the dates the scan computes and the dates the assertions
+ * expect are the same instant.
+ *
+ * Without this the two read `new Date()` at different moments and a run
+ * straddling UTC midnight flips a `daysAgo` expectation — a once-a-day CI flake
+ * that never reproduces. Same convention as src/context/voc-context.test.ts.
+ *
+ * Pinned to midday on the date this module loaded rather than a hard-coded
+ * calendar day, because `today` and `makeFeedbackItem`'s default `date` are
+ * module-scope constants read off the real clock: a fixed instant elsewhere in
+ * the calendar would put every default fixture outside the window.
+ */
+const PINNED_NOW = new Date(`${today}T12:00:00.000Z`);
+
+function freezeClock() {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(PINNED_NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+}
+
+describe('the day scan is bounded-concurrent, not sequential', () => {
+  freezeClock();
+
+  it('drives the cap branches with an injected budget, not the production one', () => {
+    // The override is what lets the truncation cases in search-feedback.test.ts
+    // use 3-row fixtures
+    // instead of 10 000 each. If TEST_CAP ever drifted up to the real value the
+    // fixtures would silently balloon again; if MAX_CANDIDATES drifted down to a
+    // handful, production would report truncation on ordinary windows.
+    expect(TEST_CAP).toBeLessThan(MAX_CANDIDATES);
+    expect(MAX_CANDIDATES).toBe(10000);
+  });
+
+  /** Counts how many sends are in flight at once, so overlap is observable. */
+  function createOverlapTrackingDocClient() {
+    const inFlight = { now: 0, max: 0 };
+    const client = {
+      send: vi.fn().mockImplementation(() => {
+        inFlight.now += 1;
+        inFlight.max = Math.max(inFlight.max, inFlight.now);
+        return Promise.resolve({ Items: [] }).finally(() => {
+          inFlight.now -= 1;
+        });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+    return { client, inFlight };
+  }
+
+  it('overlaps day reads in waves instead of awaiting one at a time', async () => {
+    // 90 sequential round trips sat in front of a half-rendered chat turn. At a
+    // 12ms round trip that measured p99 1092ms sequential against 153ms in waves
+    // of 8 — less even than the 30-day sequential scan this widening replaced.
+    const { client, inFlight } = createOverlapTrackingDocClient();
+
+    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
+
+    // Both assertions carry weight and neither suffices alone. The first catches
+    // a return to sequential reads; comparing only against the imported constant
+    // would NOT, because setting it to 1 satisfies the equality — a green result
+    // meaning "did not check". The second catches an unbounded fan-out, or drift
+    // from the declared width.
+    expect(inFlight.max).toBeGreaterThan(1);
+    expect(inFlight.max).toBe(DAY_SCAN_CONCURRENCY);
+    expect(client.send).toHaveBeenCalledTimes(90);
+  });
+
+  it('never exceeds the declared width, even on a window that is not a whole number of waves', async () => {
+    // 90 / 8 leaves a final wave of 2. A chunker that mishandled the remainder
+    // could dispatch it alongside the previous wave.
+    const { client, inFlight } = createOverlapTrackingDocClient();
+
+    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
+
+    expect(inFlight.max).toBeLessThanOrEqual(DAY_SCAN_CONCURRENCY);
+  });
+
+  it('keeps candidates in date order, newest first, despite concurrent reads', async () => {
+    // Concurrency must not reorder results: list mode's default 'recent' sort IS
+    // the scan order, so completion-order accumulation would silently shuffle
+    // what the model is shown. Days resolve in reverse order here to force it.
+    const byDate = Object.fromEntries(
+      [1, 2, 3].map((n) => [daysAgo(n), [makeFeedbackItem({
+        feedback_id: `${n}`.repeat(32),
+        date: daysAgo(n),
+        source_created_at: `${daysAgo(n)}T10:00:00Z`,
+      })]]),
+    );
+    const client = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        const date = (values[':pk'] ?? '').replace('DATE#', '');
+        const items = byDate[date] ?? [];
+        // Newer days settle LAST: each awaits more microtask turns than the day
+        // before it, so completion order is the reverse of date order. Microtasks
+        // rather than timers because these tests run on fake timers.
+        const settleOrder: Record<string, number> = { [daysAgo(1)]: 3, [daysAgo(2)]: 2 };
+        const turns = settleOrder[date] ?? 1;
+        return Array.from({ length: turns }).reduce<Promise<{ Items: unknown[] }>>(
+          (p) => p.then((v) => v),
+          Promise.resolve({ Items: items }),
+        );
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 5 });
+
+    expect(result.items.map((i) => i.date)).toStrictEqual([daysAgo(1), daysAgo(2), daysAgo(3)]);
+  });
+
+  it('honours the shared candidate budget across concurrent days, not per day', async () => {
+    // The reason concurrency is safe here at all. A per-day slice of the budget
+    // would let each in-flight day spend the whole remainder — 8 x the cap held
+    // at once, which is exactly what the cap exists to prevent. One counter,
+    // charged as pages land, so the total is bounded however wide the fan-out.
+    const rows = Array.from({ length: 4 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `d${String(i).padStart(31, '0')}` }),
+    );
+    const client = {
+      send: vi.fn().mockImplementation(() => Promise.resolve({ Items: rows })),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(
+      client, 'test-feedback-table', { mode: 'aggregate' }, { days: 90 }, TEST_CAP,
+    );
+
+    // One wave of 8 days x 4 rows is all that may be collected: the budget is
+    // gone, so wave 2 is never dispatched. Per-day budgeting would keep going.
+    expect(client.send).toHaveBeenCalledTimes(DAY_SCAN_CONCURRENCY);
+    expect(result.isPartial).toBe(true);
+  });
+});

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts
@@ -65,6 +65,15 @@ function makeFeedbackItem(overrides: Record<string, unknown> = {}) {
  * the calendar would put every default fixture outside the window.
  */
 const PINNED_NOW = new Date(`${today}T12:00:00.000Z`);
+/**
+ * How many rows the scan actually collected, read out of aggregate mode's own total.
+ *
+ * The collected count has no field on the result — `items` is the capped example set —
+ * so the prose is the only channel that reports it. Aggregate mode over unfiltered
+ * fixtures matches every candidate, which makes its total equal to the collection.
+ */
+const totalMatches = (formatted: string): number =>
+  Number(/\*\*Total matches:\*\* (\d+)/.exec(formatted)?.[1] ?? NaN);
 
 function freezeClock() {
   beforeEach(() => {
@@ -186,5 +195,14 @@ describe('the day scan is bounded-concurrent, not sequential', () => {
     // gone, so wave 2 is never dispatched. Per-day budgeting would keep going.
     expect(client.send).toHaveBeenCalledTimes(DAY_SCAN_CONCURRENCY);
     expect(result.isPartial).toBe(true);
+    // And the total actually collected, which is the property this case is named for
+    // and previously never checked. It is NOT TEST_CAP: a page charges the budget only
+    // after it lands, so the wave in flight when the cap is reached overshoots by up to
+    // DAY_SCAN_CONCURRENCY pages. Asserting the cap here would fail, and asserting only
+    // the two lines above passes for a per-day budget too — so this is the assertion
+    // that distinguishes them. Equality, not an upper bound: `toBeLessThan(K x cap)`
+    // would also hold for the sliced design this test exists to rule out.
+    expect(totalMatches(result.formatted)).toBe(DAY_SCAN_CONCURRENCY * rows.length);
+    expect(rows.length).toBeGreaterThan(TEST_CAP); // else one page alone never trips the cap
   });
 });

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts
@@ -183,6 +183,10 @@ describe('the day scan is bounded-concurrent, not sequential', () => {
     const rows = Array.from({ length: 4 }, (_, i) =>
       makeFeedbackItem({ feedback_id: `d${String(i).padStart(31, '0')}` }),
     );
+    // Fixture invariant, asserted before the act rather than trailing the outcomes: one
+    // page has to outspend the cap on its own, or the budget branches below are never
+    // reached and this case passes without exercising the property it is named for.
+    expect(rows.length).toBeGreaterThan(TEST_CAP);
     const client = {
       send: vi.fn().mockImplementation(() => Promise.resolve({ Items: rows })),
     } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
@@ -195,14 +199,25 @@ describe('the day scan is bounded-concurrent, not sequential', () => {
     // gone, so wave 2 is never dispatched. Per-day budgeting would keep going.
     expect(client.send).toHaveBeenCalledTimes(DAY_SCAN_CONCURRENCY);
     expect(result.isPartial).toBe(true);
-    // And the total actually collected, which is the property this case is named for
-    // and previously never checked. It is NOT TEST_CAP: a page charges the budget only
-    // after it lands, so the wave in flight when the cap is reached overshoots by up to
-    // DAY_SCAN_CONCURRENCY pages. Asserting the cap here would fail, and asserting only
-    // the two lines above passes for a per-day budget too — so this is the assertion
-    // that distinguishes them. Equality, not an upper bound: `toBeLessThan(K x cap)`
-    // would also hold for the sliced design this test exists to rule out.
-    expect(totalMatches(result.formatted)).toBe(DAY_SCAN_CONCURRENCY * rows.length);
-    expect(rows.length).toBeGreaterThan(TEST_CAP); // else one page alone never trips the cap
+    // And the total actually collected, which is the property this case is named for and
+    // previously went unchecked — the two assertions above pass for a per-day budget too.
+    //
+    // Bounded, not pinned. The ceiling is the cap plus one wave of pages, because a page
+    // charges the budget only after it lands and a wave dispatches before any of them do
+    // (see CandidateBudget). Asserting the exact overshoot would freeze slack the source
+    // deliberately leaves open: charging before dispatch is a correction that docblock
+    // contemplates, and an equality here would fail it as though it were a defect. The
+    // ceiling still rules out the per-day slice this case exists to reject — that design
+    // budgets each day separately, so the scan runs every wave and collects an order of
+    // magnitude more than this.
+    // The ceiling is the discriminating assertion and the only one that may name the
+    // cap: any correct shared budget lands under it, whether it charges as pages land
+    // (today, so up to a wave over) or reserves before dispatch (a correction, landing
+    // AT the cap). A lower bound of `> TEST_CAP` would forbid that second one, which is
+    // the mistake the equality here made in the first place. `> 0` guards vacuity only —
+    // an empty read would otherwise satisfy the ceiling and prove nothing.
+    const collected = totalMatches(result.formatted);
+    expect(collected).toBeLessThanOrEqual(TEST_CAP + DAY_SCAN_CONCURRENCY * rows.length);
+    expect(collected).toBeGreaterThan(0);
   });
 });

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
@@ -96,6 +96,28 @@ export type TruncationReason =
   | 'rowsDropped';
 
 /**
+ * Did the scan fail to read the window it actually scanned?
+ *
+ * `windowClamped` is excluded deliberately, and this predicate exists to make the
+ * exclusion explicit rather than incidental. That reason fires on the REQUEST,
+ * independently of the data: for any caller asking beyond MAX_LOOKBACK_DAYS every
+ * answer carries it, including one over a fully-read window where nothing was
+ * truncated at all. Treating it as truncation made aggregate mode call such
+ * figures "a sample … NOT the complete set" and annotate the total "scan
+ * truncated" when every partition had been read to its end — inaccuracy in the
+ * opposite direction from the one this file exists to fix, and the reason a
+ * future "partial results" badge would be wrong on a complete 90-day answer.
+ *
+ * The narrowing still has to be stated, and is: `truncationNotice` renders a
+ * distinct paragraph naming the window read and the days it says nothing about.
+ * So `isPartial` continues to mean "covers less than the question asked", while
+ * this narrower predicate means "did not read what it scanned".
+ */
+export function scanWasIncomplete(reasons: TruncationReason[]): boolean {
+  return reasons.some((reason) => reason !== 'windowClamped');
+}
+
+/**
  * The share of rows a scan may lose to safeParse before the answer counts as a
  * sample rather than the window.
  *

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
@@ -1,0 +1,464 @@
+/**
+ * Reading feedback rows for the search_feedback tool, and saying what the read
+ * missed.
+ *
+ * Split from search-feedback.ts, which now owns filtering, formatting and the
+ * prose the model reads. The seam is the one the truncation work exposed: every
+ * function here answers "what could this read reach?", and every shortfall it
+ * returns is something the answer has to admit. Keeping them together means a
+ * new stopping point is added beside the ones that already report themselves,
+ * rather than beside the formatters where the reporting is easy to forget —
+ * which is how three silent stopping points accumulated in the first place.
+ */
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { z } from 'zod';
+import { FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX } from '../indexes.js';
+import { PERSISTENT_QUERY_ERRORS } from '../context/query-errors.js';
+
+export const feedbackItemSchema = z.object({
+  feedback_id: z.string().optional(),
+  source_platform: z.string().optional(),
+  source_created_at: z.string().optional(),
+  sentiment_label: z.string().optional(),
+  // The ingestion pipeline stores these numerics as DynamoDB strings (S) for
+  // ~all items, so a strict z.number() rejected nearly every row — which made
+  // fetchCandidatesByDate silently drop them all and every search return 0
+  // results. coerce accepts both "0.95"/0.95 and "5"/5.
+  sentiment_score: z.coerce.number().optional(),
+  category: z.string().optional(),
+  rating: z.coerce.number().nullable().optional(),
+  original_text: z.string().optional(),
+  title: z.string().optional(),
+  problem_summary: z.string().optional(),
+  date: z.string().optional(),
+  urgency: z.string().optional(),
+}).passthrough();
+
+export type FeedbackItem = z.infer<typeof feedbackItemSchema>;
+
+/**
+ * Upper bound on candidates collected across all days. A DynamoDB Query caps
+ * each page at 1MB (often far fewer than 1000 large items), so we MUST follow
+ * LastEvaluatedKey to page through a day — otherwise a day with thousands of
+ * rows is silently truncated to the first ~500 (this caused "987 negative but
+ * tool only saw 116"). Bound the total so aggregate mode can summarize the full
+ * set without unbounded memory/time on a huge table.
+ *
+ * Deliberately NOT pinned to `metrics_handler.CANDIDATES_SOFT_CAP` (1000): the
+ * two budget different consumers — a model reading one prose digest in a single
+ * turn vs. a paginating HTTP client — so they are separate decisions, not one
+ * rule with two copies.
+ */
+export const MAX_CANDIDATES = 10000;
+
+/**
+ * How many days back the date scan may reach, however many the chat context
+ * asks for. Mirror of `MAX_LOOKBACK_DAYS` in lambda/shared/feedback.py, which
+ * the REST feedback routes spend as `days=min(days, MAX_LOOKBACK_DAYS)`.
+ *
+ * This runtime cannot import the Python constant, so the two are pinned
+ * together by lambda/shared/test/test_lookback_window_lockstep.py: it parses
+ * the declaration below and fails when the numbers diverge. It read 30 here
+ * against 90 there for months, so the chat tool answered "last quarter" from a
+ * month of feedback while the REST route used the full window.
+ *
+ * Spent in exactly one place — `resolveSearchParams` in search-feedback.ts — so
+ * the scan bound, the cutoff filter and the notice text cannot disagree about
+ * which window an answer covers. `metrics_handler.py` carries the same warning
+ * from having had that bug: "This read `min(days, 30)` while `cutoff_date` above
+ * was computed from the caller's full `days`, so the two disagreed."
+ *
+ * Keep the literal on one line as `export const MAX_LOOKBACK_DAYS = <n>` — the
+ * lockstep test parses this text.
+ */
+export const MAX_LOOKBACK_DAYS = 90;
+
+/**
+ * How many day partitions are read at once. See `scanWaves`.
+ *
+ * Exported so the test can assert the fan-out is really bounded at this width,
+ * rather than having quietly returned to one round trip at a time.
+ */
+export const DAY_SCAN_CONCURRENCY = 8;
+
+/**
+ * Why an answer covers less than the window the caller asked about.
+ *
+ * Each cause gets its own clause in the model-facing notice, because a notice
+ * that names one cause for all of them misattributes the rest: "the candidate
+ * cap" is a wrong explanation for a throttled partition or a clamped window.
+ */
+export type TruncationReason =
+  | 'windowClamped'
+  | 'dayPartiallyRead'
+  | 'daysUnread'
+  | 'dayReadFailed'
+  | 'rowsDropped';
+
+/**
+ * The share of rows a scan may lose to safeParse before the answer counts as a
+ * sample rather than the window.
+ *
+ * A single permanently-malformed legacy row would otherwise make EVERY answer
+ * partial forever: the row fails identically on every future call, so the hedge
+ * becomes background noise and a real truncation — the cap, a throttle — reads
+ * the same as 99.9% of the corpus arriving intact. A flag that always fires
+ * carries no information, the same reasoning voc-context.ts gives for
+ * aggregating its warnings ("sixteen warnings say nothing the first one did").
+ * Bulk loss is different in kind: a producer change or a migration that breaks a
+ * tenth of the rows really does bend the distributions, so that is where the
+ * line sits. Below it the drop is still logged — an operator can find and repair
+ * the row — it just does not tell the model the window was truncated.
+ *
+ * recent-feedback.ts drops such rows silently and voc-context.ts counts them
+ * into its degraded flag; the difference is what the row IS. There a dropped row
+ * is a counter whose value was the measurement, so losing it provably
+ * understates a total. Here it is one item among thousands in a distribution.
+ */
+const DROPPED_ROWS_PARTIAL_SHARE = 0.1;
+
+/**
+ * The candidate ceiling, shared by every day in the scan.
+ *
+ * ONE counter, deliberately, not a per-day slice of the remainder. Slicing is
+ * what makes concurrency unsafe here: it would let K in-flight days each believe
+ * they may spend the whole budget (K×MAX_CANDIDATES rows held at once, which is
+ * the thing the cap exists to bound), and dividing it K ways instead makes a
+ * moderate day report `dayPartiallyRead` while the total is nowhere near the cap
+ * — a false truncation signal in the one mechanism this file exists to make
+ * trustworthy. A shared counter has neither problem: every page charges the same
+ * budget as it lands, so the cap means what it says and a day reports truncation
+ * only when the budget is genuinely gone.
+ *
+ * Mutated in place because this package bans `let` (eslint no-restricted-syntax).
+ */
+interface CandidateBudget {
+  cap: number;
+  spent: number;
+}
+
+function budgetExhausted(budget: CandidateBudget): boolean {
+  return budget.spent >= budget.cap;
+}
+
+/** What one day's read cost the answer: pages left unread, rows dropped. */
+interface DayReadOutcome {
+  truncated: boolean;
+  dropped: number;
+  errorName?: string;
+}
+
+/** One day's rows and what its read cost, kept together for the wave to fold. */
+interface DayRead extends DayReadOutcome {
+  dateStr: string;
+  items: FeedbackItem[];
+}
+
+/** Days that dropped rows or failed outright, for one aggregated report. */
+interface ScanShortfalls {
+  failures: { dateStr: string; errorName: string }[];
+  drops: { dateStr: string; dropped: number }[];
+  /** Dates read without error — empty means the window was never measured. */
+  daysRead: string[];
+}
+
+/** What a date scan collected, and every way it fell short of its window. */
+export interface DateScanResult {
+  candidates: FeedbackItem[];
+  reasons: TruncationReason[];
+  /** True when NOT ONE day answered: the window is unknown, not empty. */
+  unmeasured: boolean;
+}
+
+/** The ID index's rows, or null when the query itself failed. */
+export async function queryFeedbackById(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  feedbackId: string,
+): Promise<Record<string, unknown>[] | null> {
+  try {
+    const resp = await docClient.send(
+      new QueryCommand({
+        TableName: feedbackTable,
+        IndexName: FEEDBACK_BY_ID_INDEX,
+        KeyConditionExpression: 'feedback_id = :fid',
+        ExpressionAttributeValues: { ':fid': feedbackId.toLowerCase().trim() },
+        Limit: 1,
+      }),
+    );
+    return resp.Items ?? [];
+  } catch {
+    // A failed lookup falls through to the date scan, which reads a different
+    // index and may still find the item.
+    return null;
+  }
+}
+
+/**
+ * One page of one day's partition. A failed read is RETURNED, not thrown.
+ *
+ * Same shape as voc-context.ts::readMetricPage, for the same reason: throwing
+ * discarded the pages already read, turning a partial day into a confident
+ * absence. The name travels with it because the caller needs it twice — to log
+ * one line per distinct cause, and to tell a systemic failure (which repeats
+ * identically for every partition) from one partition's bad luck.
+ */
+async function readDayPage(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  dateStr: string,
+  startKey?: Record<string, unknown>,
+): Promise<{
+  items: Record<string, unknown>[];
+  lastKey?: Record<string, unknown>;
+  errorName?: string;
+}> {
+  try {
+    const resp = await docClient.send(
+      new QueryCommand({
+        TableName: feedbackTable,
+        IndexName: FEEDBACK_BY_DATE_INDEX,
+        KeyConditionExpression: 'gsi1pk = :pk',
+        ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
+        ScanIndexForward: false,
+        ExclusiveStartKey: startKey,
+      }),
+    );
+    return { items: resp.Items ?? [], lastKey: resp.LastEvaluatedKey };
+  } catch (error) {
+    return { items: [], errorName: error instanceof Error ? error.name : 'UnknownError' };
+  }
+}
+
+/**
+ * Page through one day's GSI partition via LastEvaluatedKey (not just the
+ * first page), appending valid rows to `candidates`. Per-row safeParse: a
+ * single malformed item must not throw and discard the whole day's results.
+ * Recursion depth = pages in the day's partition; the budget check stops early
+ * only as parsed rows accumulate (a day of entirely malformed rows still pages
+ * to its end, same as the previous do/while).
+ *
+ * `truncated` is true when the day still had pages left but the shared candidate
+ * budget stopped the walk. `dropped` counts rows safeParse rejected. `errorName`
+ * names a read that failed: the rows already collected survive it — a partition
+ * whose second page fails must keep what its first page measured, the rule
+ * voc-context.ts::readMetricPage states — and the caller reports the hole.
+ *
+ * Rows land in this day's OWN array rather than straight into the shared list,
+ * so concurrently-read days cannot interleave: the caller concatenates them in
+ * date order. The budget is charged as pages land, so the cap still bounds the
+ * whole scan rather than each day separately.
+ */
+async function fetchDayPages(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  dateStr: string,
+  candidates: FeedbackItem[],
+  budget: CandidateBudget,
+  startKey?: Record<string, unknown>,
+): Promise<DayReadOutcome> {
+  const page = await readDayPage(docClient, feedbackTable, dateStr, startKey);
+  const parsedRows = page.items.map((raw) => feedbackItemSchema.safeParse(raw));
+  for (const parsed of parsedRows) {
+    if (parsed.success) candidates.push(parsed.data);
+  }
+  const dropped = parsedRows.filter((parsed) => !parsed.success).length;
+  budget.spent += parsedRows.length - dropped;
+  if (page.errorName !== undefined) return { truncated: false, dropped, errorName: page.errorName };
+  if (!page.lastKey) return { truncated: false, dropped };
+  if (budgetExhausted(budget)) return { truncated: true, dropped };
+  const rest = await fetchDayPages(
+    docClient, feedbackTable, dateStr, candidates, budget, page.lastKey,
+  );
+  return { ...rest, dropped: dropped + rest.dropped };
+}
+
+/** One day's rows and outcome. Never throws: a failed read is a reported hole. */
+async function readOneDay(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  dateStr: string,
+  budget: CandidateBudget,
+): Promise<DayRead> {
+  const items: FeedbackItem[] = [];
+  const outcome = await fetchDayPages(docClient, feedbackTable, dateStr, items, budget);
+  return { ...outcome, dateStr, items };
+}
+
+/** True when a wave hit a fault that will repeat identically for every day left. */
+function hasSystemicFailure(reads: DayRead[]): boolean {
+  // Retrying the remaining partitions just repeats the failure, and reporting it
+  // N times says nothing the first line did — both consequences query-errors.ts
+  // states, and recent-feedback.ts already applies to its own fan-out over these
+  // same DATE# partitions.
+  return reads.some(
+    (read) => read.errorName !== undefined && PERSISTENT_QUERY_ERRORS.has(read.errorName),
+  );
+}
+
+/**
+ * Read the waves in order, stopping once the budget is gone or a fault is systemic.
+ *
+ * Recursion rather than a loop because the accumulator has to stay `const`.
+ * Ordering is by DATE, not completion: each wave's days are concatenated in the
+ * order they were dispatched, so list mode's default 'recent' sort — which is
+ * the scan order itself — is unchanged from the sequential version.
+ *
+ * Shortfalls are collected, not logged here. A systemic cause makes every day of
+ * the window say the same thing, so 90 identical CloudWatch lines per chat turn
+ * would say nothing the first one did; `reportShortfalls` runs once for the whole
+ * scan, the same aggregation point and the same reason as
+ * voc-context.ts::reportMetricFailures.
+ */
+async function scanWaves(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  waves: string[][],
+  budget: CandidateBudget,
+  acc: { candidates: FeedbackItem[]; reasons: TruncationReason[]; shortfalls: ScanShortfalls },
+  index = 0,
+): Promise<{ candidates: FeedbackItem[]; reasons: TruncationReason[]; shortfalls: ScanShortfalls }> {
+  if (index >= waves.length) return acc;
+  const reads = await Promise.all(
+    waves[index].map((dateStr) => readOneDay(docClient, feedbackTable, dateStr, budget)),
+  );
+  const next = {
+    candidates: [...acc.candidates, ...reads.flatMap((read) => read.items)],
+    reasons: [
+      ...acc.reasons,
+      ...reads.flatMap((read) => (read.truncated ? (['dayPartiallyRead'] as const) : [])),
+    ],
+    shortfalls: {
+      failures: [
+        ...acc.shortfalls.failures,
+        ...reads.flatMap((read) => (read.errorName === undefined
+          ? []
+          : [{ dateStr: read.dateStr, errorName: read.errorName }])),
+      ],
+      drops: [
+        ...acc.shortfalls.drops,
+        ...reads.flatMap((read) => (read.dropped > 0
+          ? [{ dateStr: read.dateStr, dropped: read.dropped }]
+          : [])),
+      ],
+      daysRead: [
+        ...acc.shortfalls.daysRead,
+        ...reads.flatMap((read) => (read.errorName === undefined ? [read.dateStr] : [])),
+      ],
+    },
+  };
+  if (budgetExhausted(budget) || hasSystemicFailure(reads)) {
+    // Waves after this one were never dispatched, so those days are genuinely
+    // unread. Every day WITHIN this wave was read, hence the wave-level test:
+    // claiming 'daysUnread' for them would be a truncation that did not happen.
+    return index + 1 < waves.length
+      ? { ...next, reasons: [...next.reasons, 'daysUnread'] }
+      : next;
+  }
+  return scanWaves(docClient, feedbackTable, waves, budget, next, index + 1);
+}
+
+/**
+ * Collect candidates day by day, newest first, over exactly `days` partitions.
+ *
+ * `days` must already be clamped to MAX_LOOKBACK_DAYS — `resolveSearchParams`
+ * is the single place that does it, so the scan bound is the same number the
+ * cutoff filter uses. Clamping again here is what made the two disagree before.
+ *
+ * Returns every way this scan fell short of the window it was asked for, so the
+ * caller can say which, plus `unmeasured` for the case where NO day was read:
+ * that window is unknown rather than empty, and must not be answered with "no
+ * feedback found". Mirrors the Python route's `_scan_recent_items` in
+ * lambda/api/metrics_handler.py, which returns `(items, is_partial)` for the
+ * same reason — with the additions this runtime needs because it has failure
+ * modes Python's does not: `_query_partition` propagates a failed read while
+ * this scan survives it, so a survived failure must be REPORTED (the rule
+ * voc-context.ts states for its metric pages) rather than leaving a missing day
+ * looking like an empty one.
+ *
+ * Days are read DAY_SCAN_CONCURRENCY at a time, newest wave first. Sequentially
+ * a 90-day window is 90 round trips awaited mid-turn while the user watches a
+ * half-rendered answer; at a 12ms round trip that measured p99 1092ms against
+ * 153ms in waves of 8 — less even than the 30-day sequential scan this widening
+ * replaced (364ms), so the window got three times wider and still got faster.
+ *
+ * A range query is not available: `voc-context.ts::sumMetricWindow` escapes
+ * per-day reads because METRIC rows share one partition with a sortable date
+ * key, so BETWEEN bounds the window server-side. Feedback rows do not — `gsi1pk`
+ * IS the date — so a window is N partitions and no query shape collapses them.
+ * Concurrency is what is left, and it is safe here only because the candidate
+ * budget is one shared counter rather than a per-day slice; see CandidateBudget
+ * for why the sliced version would both hold K× the rows and invent truncation
+ * signals that never happened. `context/recent-feedback.ts` fans out over these
+ * very partitions for the same reason, in waves of 7.
+ */
+export async function fetchCandidatesByDate(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  days: number,
+  candidateCap: number,
+): Promise<DateScanResult> {
+  const now = new Date();
+  const dates = Array.from({ length: days }, (_, i) => {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    return d.toISOString().slice(0, 10);
+  });
+  const waves = Array.from(
+    { length: Math.ceil(dates.length / DAY_SCAN_CONCURRENCY) },
+    (_, i) => dates.slice(i * DAY_SCAN_CONCURRENCY, (i + 1) * DAY_SCAN_CONCURRENCY),
+  );
+  const scan = await scanWaves(docClient, feedbackTable, waves, { cap: candidateCap, spent: 0 }, {
+    candidates: [],
+    reasons: [],
+    shortfalls: { failures: [], drops: [], daysRead: [] },
+  });
+  return {
+    candidates: scan.candidates,
+    reasons: [...scan.reasons, ...reportShortfalls(scan.shortfalls, scan.candidates.length)],
+    unmeasured: scan.shortfalls.daysRead.length === 0,
+  };
+}
+
+/**
+ * Log every shortfall once, and answer which of them make the answer a sample.
+ *
+ * Two channels with different jobs, as voc-context.ts::reportMetricFailures
+ * splits them. The operator log carries the causes and the dates: an error name
+ * like ProvisionedThroughputExceededException tells someone the read is being
+ * throttled, and the dates say which partitions to look at. The returned reasons
+ * carry only what changes the ANSWER, because an exception name is
+ * infrastructure detail that is not actionable for whoever reads it.
+ *
+ * A failed day is always a reason: a hole in the window makes the counts a
+ * sample. Dropped rows are a reason only in bulk — see
+ * DROPPED_ROWS_PARTIAL_SHARE — because one permanently-broken legacy row would
+ * otherwise hedge every answer forever, over a window that was fully read.
+ */
+function reportShortfalls(shortfalls: ScanShortfalls, collected: number): TruncationReason[] {
+  const byName = new Map<string, string[]>();
+  for (const failure of shortfalls.failures) {
+    byName.set(failure.errorName, [...(byName.get(failure.errorName) ?? []), failure.dateStr]);
+  }
+  for (const [errorName, dates] of byName) {
+    const systemic = PERSISTENT_QUERY_ERRORS.has(errorName)
+      ? ' — this name fails identically for every partition of the index, so the scan stopped'
+      : '';
+    console.warn(
+      `search_feedback: ${dates.length} day partition(s) failed with ${errorName}${systemic}; those days are missing from the answer. Unread: ${dates.join('; ')}`,
+    );
+  }
+
+  const dropped = shortfalls.drops.reduce((sum, drop) => sum + drop.dropped, 0);
+  if (dropped > 0) {
+    console.warn(
+      `search_feedback: dropped ${dropped} unparseable row(s) across ${shortfalls.drops.length} day(s); repair the rows to make them searchable. Dates: ${shortfalls.drops.map((drop) => drop.dateStr).join('; ')}`,
+    );
+  }
+
+  const bulkLoss = dropped > (collected + dropped) * DROPPED_ROWS_PARTIAL_SHARE;
+  return [
+    ...(shortfalls.failures.length > 0 ? (['dayReadFailed'] as const) : []),
+    ...(bulkLoss ? (['rowsDropped'] as const) : []),
+  ];
+}

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
@@ -37,7 +37,8 @@ export const feedbackItemSchema = z.object({
 export type FeedbackItem = z.infer<typeof feedbackItemSchema>;
 
 /**
- * Upper bound on candidates collected across all days. A DynamoDB Query caps
+ * Bound on candidates collected across all days — to within one wave of pages, see
+ * CandidateBudget for why that slack exists and why it is not the cap itself. A DynamoDB Query caps
  * each page at 1MB (often far fewer than 1000 large items), so we MUST follow
  * LastEvaluatedKey to page through a day — otherwise a day with thousands of
  * rows is silently truncated to the first ~500 (this caused "987 negative but
@@ -152,6 +153,14 @@ const DROPPED_ROWS_PARTIAL_SHARE = 0.1;
  * budget as it lands, so the cap means what it says and a day reports truncation
  * only when the budget is genuinely gone.
  *
+ * ⚠️ The bound is the cap PLUS ONE WAVE, not the cap. A page charges the budget only once
+ * it has landed, and a wave dispatches DAY_SCAN_CONCURRENCY days before any of them do, so
+ * the last wave to start may overshoot by up to that many pages. Stated rather than fixed:
+ * charging before dispatch would have to guess a page's size, and the overshoot is bounded
+ * by the fan-out width, which is small and fixed. What the counter DOES guarantee is the
+ * thing the sliced version could not — the overshoot is one wave's worth however wide the
+ * window, instead of K× the whole cap. The test asserts the real bound, not this prose.
+ *
  * Mutated in place because this package bans `let` (eslint no-restricted-syntax).
  */
 interface CandidateBudget {
@@ -168,6 +177,19 @@ interface DayReadOutcome {
   truncated: boolean;
   dropped: number;
   errorName?: string;
+  /**
+   * Did ANY page of this day come back? Not the same as `errorName === undefined`.
+   *
+   * A day has two stopping points — the page and the day — and a failure at the second
+   * page is a different fact from a failure at the first. Deriving "was this day read"
+   * from `errorName` alone conflated them, so a day that returned 5 rows and then hit a
+   * throttle counted as never read; over a whole window that made `unmeasured` true and
+   * `executeSearchFeedback` discard every row it had (measured: 450 rows read, 0
+   * returned, prose telling the model the store could not be reached). That is the
+   * inverse of the failure this file exists to prevent, and it contradicts the rule
+   * `fetchDayPages` quotes from voc-context.ts::readMetricPage.
+   */
+  reached: boolean;
 }
 
 /** One day's rows and what its read cost, kept together for the wave to fold. */
@@ -180,7 +202,13 @@ interface DayRead extends DayReadOutcome {
 interface ScanShortfalls {
   failures: { dateStr: string; errorName: string }[];
   drops: { dateStr: string; dropped: number }[];
-  /** Dates read without error — empty means the window was never measured. */
+  /**
+   * Dates that answered AT ALL — empty means the window was never measured.
+   *
+   * Reached, not error-free: a day that returned rows and then failed on a later page
+   * belongs here, because its rows are in `candidates` and an answer built from them is
+   * a partial answer, not an absent one. Its failure is still reported, via `failures`.
+   */
   daysRead: string[];
 }
 
@@ -286,13 +314,18 @@ async function fetchDayPages(
   }
   const dropped = parsedRows.filter((parsed) => !parsed.success).length;
   budget.spent += parsedRows.length - dropped;
-  if (page.errorName !== undefined) return { truncated: false, dropped, errorName: page.errorName };
-  if (!page.lastKey) return { truncated: false, dropped };
-  if (budgetExhausted(budget)) return { truncated: true, dropped };
+  if (page.errorName !== undefined) {
+    // `startKey` IS the record of whether an earlier page of this day already came back:
+    // it is set only by the recursive call below, which runs only after a page succeeded.
+    // So a first-page failure leaves the day unreached, and a later one does not.
+    return { truncated: false, dropped, errorName: page.errorName, reached: startKey !== undefined };
+  }
+  if (!page.lastKey) return { truncated: false, dropped, reached: true };
+  if (budgetExhausted(budget)) return { truncated: true, dropped, reached: true };
   const rest = await fetchDayPages(
     docClient, feedbackTable, dateStr, candidates, budget, page.lastKey,
   );
-  return { ...rest, dropped: dropped + rest.dropped };
+  return { ...rest, dropped: dropped + rest.dropped, reached: true };
 }
 
 /** One day's rows and outcome. Never throws: a failed read is a reported hole. */
@@ -365,7 +398,7 @@ async function scanWaves(
       ],
       daysRead: [
         ...acc.shortfalls.daysRead,
-        ...reads.flatMap((read) => (read.errorName === undefined ? [read.dateStr] : [])),
+        ...reads.flatMap((read) => (read.reached ? [read.dateStr] : [])),
       ],
     },
   };

--- a/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
+++ b/voc-datalake/lambda/stream/src/tools/feedback-scan.ts
@@ -37,13 +37,14 @@ export const feedbackItemSchema = z.object({
 export type FeedbackItem = z.infer<typeof feedbackItemSchema>;
 
 /**
- * Bound on candidates collected across all days — to within one wave of pages, see
- * CandidateBudget for why that slack exists and why it is not the cap itself. A DynamoDB Query caps
- * each page at 1MB (often far fewer than 1000 large items), so we MUST follow
- * LastEvaluatedKey to page through a day — otherwise a day with thousands of
- * rows is silently truncated to the first ~500 (this caused "987 negative but
- * tool only saw 116"). Bound the total so aggregate mode can summarize the full
- * set without unbounded memory/time on a huge table.
+ * Bound on candidates collected across all days, to within one wave of pages — see
+ * CandidateBudget for why that slack exists and why it is not the cap itself.
+ *
+ * A DynamoDB Query caps each page at 1MB (often far fewer than 1000 large items),
+ * so we MUST follow LastEvaluatedKey to page through a day — otherwise a day with
+ * thousands of rows is silently truncated to the first ~500 (this caused "987
+ * negative but tool only saw 116"). Bound the total so aggregate mode can
+ * summarize the full set without unbounded memory/time on a huge table.
  *
  * Deliberately NOT pinned to `metrics_handler.CANDIDATES_SOFT_CAP` (1000): the
  * two budget different consumers — a model reading one prose digest in a single

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -2,7 +2,22 @@
  * Tests for search_feedback tool implementation.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { executeSearchFeedback, MAX_CANDIDATES, MAX_LOOKBACK_DAYS } from './search-feedback.js';
+import {
+  executeSearchFeedback,
+  DAY_SCAN_CONCURRENCY,
+  MAX_CANDIDATES,
+  MAX_LOOKBACK_DAYS,
+} from './search-feedback.js';
+
+/**
+ * The candidate cap the truncation cases inject.
+ *
+ * Three rows reach the cap-hit branches that MAX_CANDIDATES needed ten thousand
+ * zod-parsed fixtures apiece to reach. Kept far below MAX_CANDIDATES, and
+ * asserted so, since a TEST_CAP that drifted up to the real value would put the
+ * 10k fixtures back without anyone noticing.
+ */
+const TEST_CAP = 3;
 
 // Mock DynamoDB document client
 function createMockDocClient(queryResponses: Record<string, unknown>[][] = []) {
@@ -528,18 +543,132 @@ describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () =>
   });
 });
 
+describe('the day scan is bounded-concurrent, not sequential', () => {
+  freezeClock();
+
+  it('drives the cap branches with an injected budget, not the production one', () => {
+    // The override is what lets the truncation cases above use 3-row fixtures
+    // instead of 10 000 each. If TEST_CAP ever drifted up to the real value the
+    // fixtures would silently balloon again; if MAX_CANDIDATES drifted down to a
+    // handful, production would report truncation on ordinary windows.
+    expect(TEST_CAP).toBeLessThan(MAX_CANDIDATES);
+    expect(MAX_CANDIDATES).toBe(10000);
+  });
+
+  /** Counts how many sends are in flight at once, so overlap is observable. */
+  function createOverlapTrackingDocClient() {
+    const inFlight = { now: 0, max: 0 };
+    const client = {
+      send: vi.fn().mockImplementation(() => {
+        inFlight.now += 1;
+        inFlight.max = Math.max(inFlight.max, inFlight.now);
+        return Promise.resolve({ Items: [] }).finally(() => {
+          inFlight.now -= 1;
+        });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+    return { client, inFlight };
+  }
+
+  it('overlaps day reads in waves instead of awaiting one at a time', async () => {
+    // 90 sequential round trips sat in front of a half-rendered chat turn. At a
+    // 12ms round trip that measured p99 1092ms sequential against 153ms in waves
+    // of 8 — less even than the 30-day sequential scan this widening replaced.
+    const { client, inFlight } = createOverlapTrackingDocClient();
+
+    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
+
+    // Both assertions carry weight and neither suffices alone. The first catches
+    // a return to sequential reads; comparing only against the imported constant
+    // would NOT, because setting it to 1 satisfies the equality — a green result
+    // meaning "did not check". The second catches an unbounded fan-out, or drift
+    // from the declared width.
+    expect(inFlight.max).toBeGreaterThan(1);
+    expect(inFlight.max).toBe(DAY_SCAN_CONCURRENCY);
+    expect(client.send).toHaveBeenCalledTimes(90);
+  });
+
+  it('never exceeds the declared width, even on a window that is not a whole number of waves', async () => {
+    // 90 / 8 leaves a final wave of 2. A chunker that mishandled the remainder
+    // could dispatch it alongside the previous wave.
+    const { client, inFlight } = createOverlapTrackingDocClient();
+
+    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
+
+    expect(inFlight.max).toBeLessThanOrEqual(DAY_SCAN_CONCURRENCY);
+  });
+
+  it('keeps candidates in date order, newest first, despite concurrent reads', async () => {
+    // Concurrency must not reorder results: list mode's default 'recent' sort IS
+    // the scan order, so completion-order accumulation would silently shuffle
+    // what the model is shown. Days resolve in reverse order here to force it.
+    const byDate = Object.fromEntries(
+      [1, 2, 3].map((n) => [daysAgo(n), [makeFeedbackItem({
+        feedback_id: `${n}`.repeat(32),
+        date: daysAgo(n),
+        source_created_at: `${daysAgo(n)}T10:00:00Z`,
+      })]]),
+    );
+    const client = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        const date = (values[':pk'] ?? '').replace('DATE#', '');
+        const items = byDate[date] ?? [];
+        // Newer days settle LAST: each awaits more microtask turns than the day
+        // before it, so completion order is the reverse of date order. Microtasks
+        // rather than timers because these tests run on fake timers.
+        const settleOrder: Record<string, number> = { [daysAgo(1)]: 3, [daysAgo(2)]: 2 };
+        const turns = settleOrder[date] ?? 1;
+        return Array.from({ length: turns }).reduce<Promise<{ Items: unknown[] }>>(
+          (p) => p.then((v) => v),
+          Promise.resolve({ Items: items }),
+        );
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 5 });
+
+    expect(result.items.map((i) => i.date)).toStrictEqual([daysAgo(1), daysAgo(2), daysAgo(3)]);
+  });
+
+  it('honours the shared candidate budget across concurrent days, not per day', async () => {
+    // The reason concurrency is safe here at all. A per-day slice of the budget
+    // would let each in-flight day spend the whole remainder — 8 x the cap held
+    // at once, which is exactly what the cap exists to prevent. One counter,
+    // charged as pages land, so the total is bounded however wide the fan-out.
+    const rows = Array.from({ length: 4 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `d${String(i).padStart(31, '0')}` }),
+    );
+    const client = {
+      send: vi.fn().mockImplementation(() => Promise.resolve({ Items: rows })),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(
+      client, 'test-feedback-table', { mode: 'aggregate' }, { days: 90 }, TEST_CAP,
+    );
+
+    // One wave of 8 days x 4 rows is all that may be collected: the budget is
+    // gone, so wave 2 is never dispatched. Per-day budgeting would keep going.
+    expect(client.send).toHaveBeenCalledTimes(DAY_SCAN_CONCURRENCY);
+    expect(result.isPartial).toBe(true);
+  });
+});
+
 describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_partial)', () => {
   freezeClock();
 
   /**
    * One page big enough to reach the candidate cap, optionally with more to come.
    *
-   * Sized from the exported constant rather than a literal, so the fixture cannot
-   * go stale — at 9 999 rows every truncation assertion below would pass for the
-   * wrong reason, or fail for none.
+   * Sized from TEST_CAP, which every case below passes to `executeSearchFeedback`
+   * as its cap. Sizing from MAX_CANDIDATES instead meant 10 000 zod-parsed
+   * fixtures per test and ~40 000 across the file, all of it incidental to what
+   * is being asserted — and it scaled with any future rise in the cap. The
+   * injected cap keeps the fixture honest without keeping it huge: it is still
+   * "one page that exactly fills the budget", just a smaller budget.
    */
   function createCappedDocClient(hasMorePages: boolean) {
-    const page = Array.from({ length: MAX_CANDIDATES }, (_, i) =>
+    const page = Array.from({ length: TEST_CAP }, (_, i) =>
       makeFeedbackItem({ feedback_id: `c${String(i).padStart(31, '0')}` }),
     );
     let call = 0;
@@ -573,7 +702,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     // set the flag is the unfinished partition — otherwise this passes on the
     // other branch and the day-level signal goes untested.
     const result = await executeSearchFeedback(
-      createCappedDocClient(true), 'test-feedback-table', {}, { days: 1 },
+      createCappedDocClient(true), 'test-feedback-table', {}, { days: 1 }, TEST_CAP,
     );
 
     expect(result.isPartial).toBe(true);
@@ -584,7 +713,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     // Day 0 fills the budget on a single page (no LastEvaluatedKey), so the day
     // itself was complete — but days 1..89 were never read.
     const result = await executeSearchFeedback(
-      createCappedDocClient(false), 'test-feedback-table', {}, { days: 90 },
+      createCappedDocClient(false), 'test-feedback-table', {}, { days: 90 }, TEST_CAP,
     );
 
     expect(result.isPartial).toBe(true);
@@ -593,7 +722,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
 
   it('does not flag a single-day window the cap ended: nothing was left unread', async () => {
     const result = await executeSearchFeedback(
-      createCappedDocClient(false), 'test-feedback-table', {}, { days: 1 },
+      createCappedDocClient(false), 'test-feedback-table', {}, { days: 1 }, TEST_CAP,
     );
 
     expect(result.isPartial).toBe(false);
@@ -647,7 +776,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     // A flag that stays out of `formatted` changes nothing for the user: the
     // model is the only consumer of this tool result.
     const result = await executeSearchFeedback(
-      createCappedDocClient(true), 'test-feedback-table', { limit: 5 }, { days: 30 },
+      createCappedDocClient(true), 'test-feedback-table', { limit: 5 }, { days: 30 }, TEST_CAP,
     );
 
     expect(result.formatted).toContain('INCOMPLETE RESULTS');
@@ -658,7 +787,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     // The dangerous sentence: unqualified, it tells the model to treat capped
     // counts as the whole dataset.
     const result = await executeSearchFeedback(
-      createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 },
+      createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 }, TEST_CAP,
     );
 
     expect(result.isPartial).toBe(true);
@@ -673,7 +802,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     // aggregate header flags PARTIAL and annotates the total; the imperative to
     // relay it belongs to truncationNotice alone.
     const result = await executeSearchFeedback(
-      createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 },
+      createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 }, TEST_CAP,
     );
 
     expect(result.formatted.match(/Say so when you answer/g)).toHaveLength(1);

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -2,7 +2,7 @@
  * Tests for search_feedback tool implementation.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { executeSearchFeedback } from './search-feedback.js';
+import { executeSearchFeedback, MAX_LOOKBACK_DAYS } from './search-feedback.js';
 
 // Mock DynamoDB document client
 function createMockDocClient(queryResponses: Record<string, unknown>[][] = []) {
@@ -17,6 +17,13 @@ function createMockDocClient(queryResponses: Record<string, unknown>[][] = []) {
 }
 
 const today = new Date().toISOString().slice(0, 10);
+
+/** YYYY-MM-DD `n` days before today, UTC — the shape the date GSI partitions by. */
+const daysAgo = (n: number) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+};
 
 function makeFeedbackItem(overrides: Record<string, unknown> = {}) {
   return {
@@ -309,12 +316,6 @@ describe('executeSearchFeedback', () => {
 
 
 describe('date basis (issue #150)', () => {
-  const daysAgo = (n: number) => {
-    const d = new Date();
-    d.setUTCDate(d.getUTCDate() - n);
-    return d.toISOString().slice(0, 10);
-  };
-
   it('keeps freshly imported old reviews on the default (imported) basis', async () => {
     const backfilled = makeFeedbackItem({
       feedback_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -392,5 +393,189 @@ describe('date basis (issue #150)', () => {
     expect(result.items.map((i) => i.feedback_id)).toStrictEqual([
       'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     ]);
+  });
+});
+
+
+// ── The lookback window, and saying when the answer is capped ──
+//
+// Two halves of one defect: the day loop clamped at 30 while the REST routes
+// read `MAX_LOOKBACK_DAYS = 90` (lambda/shared/feedback.py), so the chat tool
+// answered "last quarter" from a month of feedback — and reported none of its
+// three stopping points, so a capped answer was indistinguishable from a
+// complete one. Widening the window without the notice makes that worse, hence
+// both here. The Python↔TypeScript pin lives in
+// lambda/shared/test/test_lookback_window_lockstep.py.
+
+/** A mock that answers per date partition, so day-loop reach is observable. */
+function createDateAwareDocClient(itemsByDate: Record<string, Record<string, unknown>[]>) {
+  const queriedDates: string[] = [];
+  const client = {
+    send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+      const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+      const pk = values[':pk'] ?? '';
+      const date = pk.replace('DATE#', '');
+      queriedDates.push(date);
+      return Promise.resolve({ Items: itemsByDate[date] ?? [] });
+    }),
+  } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+  return { client, queriedDates };
+}
+
+describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('declares the same bound the Python routes enforce', () => {
+    // Pinned to shared/feedback.py from the Python side; asserted here too so
+    // the TypeScript suite fails loudly if the constant is edited alone.
+    expect(MAX_LOOKBACK_DAYS).toBe(90);
+  });
+
+  it('finds an item 60 days old — the old 30-day clamp never queried its partition', async () => {
+    const old = makeFeedbackItem({
+      feedback_id: 'f'.repeat(32),
+      date: daysAgo(60),
+      source_created_at: `${daysAgo(60)}T10:00:00Z`,
+    });
+    const { client, queriedDates } = createDateAwareDocClient({ [daysAgo(60)]: [old] });
+
+    const result = await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
+
+    expect(queriedDates).toContain(daysAgo(60));
+    expect(result.items.map((i) => i.feedback_id)).toStrictEqual(['f'.repeat(32)]);
+  });
+
+  it('scans at most MAX_LOOKBACK_DAYS partitions however many days are asked for', async () => {
+    const { client, queriedDates } = createDateAwareDocClient({});
+
+    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 365 });
+
+    expect(queriedDates).toHaveLength(MAX_LOOKBACK_DAYS);
+    expect(queriedDates).toContain(daysAgo(MAX_LOOKBACK_DAYS - 1));
+    expect(queriedDates).not.toContain(daysAgo(MAX_LOOKBACK_DAYS));
+  });
+
+  it('does not widen a narrow window: days=7 still reads 7 partitions', async () => {
+    const { client, queriedDates } = createDateAwareDocClient({});
+
+    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 7 });
+
+    expect(queriedDates).toHaveLength(7);
+  });
+});
+
+describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_partial)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** One page big enough to reach MAX_CANDIDATES, optionally with more to come. */
+  function createCappedDocClient(hasMorePages: boolean) {
+    const page = Array.from({ length: 10000 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `c${String(i).padStart(31, '0')}` }),
+    );
+    let call = 0;
+    return {
+      send: vi.fn().mockImplementation(() => {
+        call++;
+        if (call === 1) {
+          return Promise.resolve(
+            hasMorePages ? { Items: page, LastEvaluatedKey: { k: 'next' } } : { Items: page },
+          );
+        }
+        return Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+  }
+
+  it('reports a complete scan as complete, with no hedging in the prose', async () => {
+    const docClient = createMockDocClient([[makeFeedbackItem()]]);
+
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', {}, { days: 7 },
+    );
+
+    expect(result.isPartial).toBe(false);
+    expect(result.formatted).not.toContain('INCOMPLETE');
+    expect(result.formatted).not.toContain('partial');
+  });
+
+  it('flags a day whose partition still had pages when the candidate cap hit', async () => {
+    // days=1 on purpose, so no day is left unread and the ONLY thing that can
+    // set the flag is the unfinished partition — otherwise this passes on the
+    // other branch and the day-level signal goes untested.
+    const result = await executeSearchFeedback(
+      createCappedDocClient(true), 'test-feedback-table', {}, { days: 1 },
+    );
+
+    expect(result.isPartial).toBe(true);
+  });
+
+  it('flags the cap ending the scan with days still unread', async () => {
+    // Day 0 fills the budget on a single page (no LastEvaluatedKey), so the day
+    // itself was complete — but days 1..89 were never read.
+    const result = await executeSearchFeedback(
+      createCappedDocClient(false), 'test-feedback-table', {}, { days: 90 },
+    );
+
+    expect(result.isPartial).toBe(true);
+  });
+
+  it('does not flag a single-day window the cap ended: nothing was left unread', async () => {
+    const result = await executeSearchFeedback(
+      createCappedDocClient(false), 'test-feedback-table', {}, { days: 1 },
+    );
+
+    expect(result.isPartial).toBe(false);
+  });
+
+  it('puts the warning in the formatted text the model reads, not just the object', async () => {
+    // A flag that stays out of `formatted` changes nothing for the user: the
+    // model is the only consumer of this tool result.
+    const result = await executeSearchFeedback(
+      createCappedDocClient(true), 'test-feedback-table', { limit: 5 }, { days: 30 },
+    );
+
+    expect(result.formatted).toContain('INCOMPLETE RESULTS');
+    expect(result.formatted).toContain('30-day window');
+  });
+
+  it('aggregate mode drops its "COMPLETE set" claim when the scan was truncated', async () => {
+    // The dangerous sentence: unqualified, it tells the model to treat capped
+    // counts as the whole dataset.
+    const result = await executeSearchFeedback(
+      createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 },
+    );
+
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).not.toContain('COMPLETE set');
+    expect(result.formatted).toContain('PARTIAL');
+    expect(result.formatted).toContain('scan truncated');
+  });
+
+  it('aggregate mode still claims completeness when the whole window was read', async () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `a${String(i).padStart(31, '0')}` }),
+    );
+    const result = await executeSearchFeedback(
+      createMockDocClient([items]), 'test-feedback-table', { mode: 'aggregate' }, { days: 7 },
+    );
+
+    expect(result.isPartial).toBe(false);
+    expect(result.formatted).toContain('COMPLETE set');
+    expect(result.formatted).not.toContain('PARTIAL');
+  });
+
+  it('a feedback-ID hit is complete by construction', async () => {
+    const feedbackId = 'abcdef1234567890abcdef1234567890';
+    const docClient = createMockDocClient([[makeFeedbackItem({ feedback_id: feedbackId })]]);
+
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', { query: feedbackId }, { days: 7 },
+    );
+
+    expect(result.isPartial).toBe(false);
   });
 });

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -536,9 +536,72 @@ describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () =>
     );
 
     expect(result.isPartial).toBe(true);
-    expect(result.formatted).not.toContain('COMPLETE set');
-    expect(result.formatted).toContain('most recent 90 days of the 365-day window');
-    expect(result.formatted).toContain('name the 90-day window');
+    expect(result.formatted).toContain('NARROWER WINDOW THAN ASKED ABOUT');
+    expect(result.formatted).toContain('at most 90 days');
+    expect(result.formatted).toContain('the question named 365 days');
+    expect(result.formatted).toContain('275 earlier days');
+  });
+
+  it('reports partial on the clamp alone, with no other cap in play', async () => {
+    // One item, one page, no LastEvaluatedKey, far below the candidate cap, every
+    // partition readable — so nothing except the clamp can set the flag, and this
+    // assertion turns on the clamp alone. That state used to report a complete
+    // answer over a fraction of the window asked about.
+    const { client } = createDateAwareDocClient({
+      [daysAgo(1)]: [makeFeedbackItem({ date: daysAgo(1) })],
+    });
+
+    const result = await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 365 });
+
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('at most 90 days');
+  });
+
+  it('does not call a clamped-but-fully-read window a truncated scan', async () => {
+    // The distinction the clamp forces, and the one this used to get wrong: every
+    // one of the 90 partitions was read to its end, so the totals ARE complete for
+    // those 90 days. Calling them "a sample … NOT the complete set" and annotating
+    // the total "scan truncated" describes a truncation that never happened — and
+    // pairs a PARTIAL header with prose saying the figures are complete.
+    const { client } = createDateAwareDocClient({
+      [daysAgo(1)]: [makeFeedbackItem({ date: daysAgo(1) })],
+    });
+
+    const result = await executeSearchFeedback(
+      client, 'test-feedback-table', { mode: 'aggregate' }, { days: 365 },
+    );
+
+    expect(result.formatted).toContain('COMPLETE set');
+    expect(result.formatted).not.toContain('PARTIAL —');
+    expect(result.formatted).not.toContain('scan truncated');
+    expect(result.formatted).not.toContain('INCOMPLETE RESULTS');
+  });
+
+  it('scans, filters and describes one and the same window', async () => {
+    // The three used to be able to disagree: the scan read `min(days, 30)` while
+    // the cutoff came from the caller's full `days`, so the filter admitted items
+    // from partitions nothing had queried. Asserted over observable behaviour
+    // rather than by reading the source — the partitions queried, the oldest item
+    // the filter keeps, and the window the prose names must all agree.
+    const inWindow = makeFeedbackItem({
+      feedback_id: 'h'.repeat(32),
+      date: daysAgo(MAX_LOOKBACK_DAYS - 1),
+      source_created_at: `${daysAgo(MAX_LOOKBACK_DAYS - 1)}T10:00:00Z`,
+    });
+    const justOutside = makeFeedbackItem({
+      feedback_id: 'i'.repeat(32),
+      date: daysAgo(MAX_LOOKBACK_DAYS),
+      source_created_at: `${daysAgo(MAX_LOOKBACK_DAYS)}T10:00:00Z`,
+    });
+    const { client, queriedDates } = createDateAwareDocClient({
+      [daysAgo(MAX_LOOKBACK_DAYS - 1)]: [inWindow, justOutside],
+    });
+
+    const result = await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 365 });
+
+    expect(queriedDates).toHaveLength(MAX_LOOKBACK_DAYS);
+    expect(result.items.map((i) => i.feedback_id)).toStrictEqual(['h'.repeat(32)]);
+    expect(result.formatted).toContain(`at most ${MAX_LOOKBACK_DAYS} days`);
   });
 });
 

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for search_feedback tool implementation.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { executeSearchFeedback, MAX_LOOKBACK_DAYS } from './search-feedback.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { executeSearchFeedback, MAX_CANDIDATES, MAX_LOOKBACK_DAYS } from './search-feedback.js';
 
 // Mock DynamoDB document client
 function createMockDocClient(queryResponses: Record<string, unknown>[][] = []) {
@@ -422,10 +422,34 @@ function createDateAwareDocClient(itemsByDate: Record<string, Record<string, unk
   return { client, queriedDates };
 }
 
-describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () => {
+/**
+ * Freeze the clock for the window tests, so the dates the scan computes and the
+ * dates the assertions expect are the same instant.
+ *
+ * Without this the two read `new Date()` at different moments and a run
+ * straddling UTC midnight flips `toContain(daysAgo(89))` — a once-a-day CI flake
+ * that never reproduces. Same convention as src/context/voc-context.test.ts.
+ *
+ * Pinned to midday on the date this module loaded rather than a hard-coded
+ * calendar day, because `today` and `makeFeedbackItem`'s default `date` are
+ * module-scope constants read off the real clock: a fixed instant elsewhere in
+ * the calendar would put every default fixture outside the window.
+ */
+const PINNED_NOW = new Date(`${today}T12:00:00.000Z`);
+
+function freezeClock() {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(PINNED_NOW);
   });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+}
+
+describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () => {
+  freezeClock();
 
   it('declares the same bound the Python routes enforce', () => {
     // Pinned to shared/feedback.py from the Python side; asserted here too so
@@ -464,16 +488,58 @@ describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () =>
 
     expect(queriedDates).toHaveLength(7);
   });
+
+  it('filters on the window it scanned, not the one it was asked for', async () => {
+    // The clamp and the cutoff must spend ONE number. When they disagreed the
+    // filter admitted a year of items over a scan that read 90 days of them, so
+    // whatever the scan happened to return was presented as the full year
+    // (metrics_handler.py:705-712 records the same bug on the Python side).
+    // This mock answers every partition with the same 200-day-old row, so only
+    // the cutoff can exclude it.
+    const ancient = makeFeedbackItem({
+      feedback_id: 'g'.repeat(32),
+      date: daysAgo(200),
+      source_created_at: `${daysAgo(200)}T10:00:00Z`,
+    });
+    const docClient = createMockDocClient([[ancient]]);
+
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', {}, { days: 365 },
+    );
+
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('says which window it read when the request exceeded the bound', async () => {
+    // A clamped window is unread remainder like any other: 275 days of what was
+    // asked about were never queried, so an unhedged answer is a false claim.
+    const { client } = createDateAwareDocClient({
+      [daysAgo(1)]: [makeFeedbackItem({ date: daysAgo(1) })],
+    });
+
+    const result = await executeSearchFeedback(
+      client, 'test-feedback-table', { mode: 'aggregate' }, { days: 365 },
+    );
+
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).not.toContain('COMPLETE set');
+    expect(result.formatted).toContain('most recent 90 days of the 365-day window');
+    expect(result.formatted).toContain('name the 90-day window');
+  });
 });
 
 describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_partial)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  freezeClock();
 
-  /** One page big enough to reach MAX_CANDIDATES, optionally with more to come. */
+  /**
+   * One page big enough to reach the candidate cap, optionally with more to come.
+   *
+   * Sized from the exported constant rather than a literal, so the fixture cannot
+   * go stale — at 9 999 rows every truncation assertion below would pass for the
+   * wrong reason, or fail for none.
+   */
   function createCappedDocClient(hasMorePages: boolean) {
-    const page = Array.from({ length: 10000 }, (_, i) =>
+    const page = Array.from({ length: MAX_CANDIDATES }, (_, i) =>
       makeFeedbackItem({ feedback_id: `c${String(i).padStart(31, '0')}` }),
     );
     let call = 0;
@@ -511,6 +577,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     );
 
     expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('more feedback than the candidate budget allowed');
   });
 
   it('flags the cap ending the scan with days still unread', async () => {
@@ -521,6 +588,7 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     );
 
     expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('older days still unread');
   });
 
   it('does not flag a single-day window the cap ended: nothing was left unread', async () => {
@@ -529,6 +597,50 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     );
 
     expect(result.isPartial).toBe(false);
+  });
+
+  it('flags a day that could not be read, rather than treating it as empty', async () => {
+    // A throttle or 500 on one partition is survived so the other 89 days are
+    // not lost — but survival without a report is how a sample comes back
+    // claiming to be complete. Tripling the round trips makes this likelier.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const failedDate = daysAgo(3);
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
+        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
+        return (values[':pk'] ?? '') === `DATE#${failedDate}`
+          ? Promise.reject(new RangeError('ProvisionedThroughputExceededException'))
+          : Promise.resolve({ Items: [] });
+      }),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(docClient, 'test-feedback-table', {}, { days: 7 });
+
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('at least one day could not be read');
+    // The cause reaches the operator log, never the model-facing prose: an
+    // exception name is infrastructure detail (voc-context.ts states the rule).
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`DATE#${failedDate}`));
+    expect(result.formatted).not.toContain('RangeError');
+    warn.mockRestore();
+  });
+
+  it('flags rows the schema rejected: a discarded row is not a read one', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      makeFeedbackItem({ feedback_id: 'good1'.padEnd(32, '0') }),
+      { original_text: 12345 },
+    ];
+
+    const result = await executeSearchFeedback(
+      createMockDocClient([rows as Record<string, unknown>[]]), 'test-feedback-table', {}, { days: 7 },
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('could not be parsed');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropped 1 unparseable rows'));
+    warn.mockRestore();
   });
 
   it('puts the warning in the formatted text the model reads, not just the object', async () => {
@@ -553,6 +665,19 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     expect(result.formatted).not.toContain('COMPLETE set');
     expect(result.formatted).toContain('PARTIAL');
     expect(result.formatted).toContain('scan truncated');
+  });
+
+  it('states the truncation once, not once per formatter', async () => {
+    // Three statements of one fact in the highest-attention region of the tool
+    // result dilute rather than reinforce, and leave two wordings to sync. The
+    // aggregate header flags PARTIAL and annotates the total; the imperative to
+    // relay it belongs to truncationNotice alone.
+    const result = await executeSearchFeedback(
+      createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 },
+    );
+
+    expect(result.formatted.match(/Say so when you answer/g)).toHaveLength(1);
+    expect(result.formatted.match(/⚠️/g)).toHaveLength(2);
   });
 
   it('aggregate mode still claims completeness when the whole window was read', async () => {

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -760,6 +760,44 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     expect(result.formatted).toContain('NOT a result of zero feedback items');
     warn.mockRestore();
   });
+  it('keeps the rows a day read before its later page failed, instead of calling the window unmeasured', async () => {
+    // The negative twin of the test above, and the case that made the honesty
+    // machinery lie in the OTHER direction: every day here answers its first page
+    // and fails its second, so a classification keyed on "did this day end with an
+    // error" counted all 90 as never read, `unmeasured` fired, and every collected
+    // row was discarded behind "the store could not be reached" — 450 rows read,
+    // zero reported. `fetchDayPages` promises the opposite in its own docstring
+    // ("a partition whose second page fails must keep what its first page
+    // measured", the voc-context.ts::readMetricPage rule), so this pins it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      makeFeedbackItem({ feedback_id: `p${String(i).padStart(31, '0')}` }));
+    const throttled = new RangeError('throttled');
+    throttled.name = 'ProvisionedThroughputExceededException';
+    const docClient = {
+      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) =>
+        // A transient name, so the scan is not short-circuited and every day of the
+        // window contributes — which is what makes discarding them all measurable.
+        (command.input.ExclusiveStartKey === undefined
+          ? Promise.resolve({ Items: rows, LastEvaluatedKey: { pk: 'page2' } })
+          : Promise.reject(throttled))),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', { mode: 'aggregate' }, { days: 90 },
+    );
+    // What the rows bought: an answer, not an absence.
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.formatted).not.toContain('THE SEARCH COULD NOT BE RUN');
+    expect(result.formatted).not.toContain('could not be read, so nothing is known');
+    // And the hole is still declared — surviving a failure is only honest if the
+    // survival is reported, so this must not become a silent success either.
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('at least one day could not be read');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('ProvisionedThroughputExceededException'),
+    );
+    warn.mockRestore();
+  });
 
   it('logs rows the schema rejected, with the count and the date', async () => {
     // The row is a real loss and an operator must be able to find and repair it.

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   executeSearchFeedback,
   DAY_SCAN_CONCURRENCY,
-  MAX_CANDIDATES,
   MAX_LOOKBACK_DAYS,
 } from './search-feedback.js';
 
@@ -543,117 +542,6 @@ describe('lookback window (matches shared/feedback.py MAX_LOOKBACK_DAYS)', () =>
   });
 });
 
-describe('the day scan is bounded-concurrent, not sequential', () => {
-  freezeClock();
-
-  it('drives the cap branches with an injected budget, not the production one', () => {
-    // The override is what lets the truncation cases above use 3-row fixtures
-    // instead of 10 000 each. If TEST_CAP ever drifted up to the real value the
-    // fixtures would silently balloon again; if MAX_CANDIDATES drifted down to a
-    // handful, production would report truncation on ordinary windows.
-    expect(TEST_CAP).toBeLessThan(MAX_CANDIDATES);
-    expect(MAX_CANDIDATES).toBe(10000);
-  });
-
-  /** Counts how many sends are in flight at once, so overlap is observable. */
-  function createOverlapTrackingDocClient() {
-    const inFlight = { now: 0, max: 0 };
-    const client = {
-      send: vi.fn().mockImplementation(() => {
-        inFlight.now += 1;
-        inFlight.max = Math.max(inFlight.max, inFlight.now);
-        return Promise.resolve({ Items: [] }).finally(() => {
-          inFlight.now -= 1;
-        });
-      }),
-    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
-    return { client, inFlight };
-  }
-
-  it('overlaps day reads in waves instead of awaiting one at a time', async () => {
-    // 90 sequential round trips sat in front of a half-rendered chat turn. At a
-    // 12ms round trip that measured p99 1092ms sequential against 153ms in waves
-    // of 8 — less even than the 30-day sequential scan this widening replaced.
-    const { client, inFlight } = createOverlapTrackingDocClient();
-
-    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
-
-    // Both assertions carry weight and neither suffices alone. The first catches
-    // a return to sequential reads; comparing only against the imported constant
-    // would NOT, because setting it to 1 satisfies the equality — a green result
-    // meaning "did not check". The second catches an unbounded fan-out, or drift
-    // from the declared width.
-    expect(inFlight.max).toBeGreaterThan(1);
-    expect(inFlight.max).toBe(DAY_SCAN_CONCURRENCY);
-    expect(client.send).toHaveBeenCalledTimes(90);
-  });
-
-  it('never exceeds the declared width, even on a window that is not a whole number of waves', async () => {
-    // 90 / 8 leaves a final wave of 2. A chunker that mishandled the remainder
-    // could dispatch it alongside the previous wave.
-    const { client, inFlight } = createOverlapTrackingDocClient();
-
-    await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 90 });
-
-    expect(inFlight.max).toBeLessThanOrEqual(DAY_SCAN_CONCURRENCY);
-  });
-
-  it('keeps candidates in date order, newest first, despite concurrent reads', async () => {
-    // Concurrency must not reorder results: list mode's default 'recent' sort IS
-    // the scan order, so completion-order accumulation would silently shuffle
-    // what the model is shown. Days resolve in reverse order here to force it.
-    const byDate = Object.fromEntries(
-      [1, 2, 3].map((n) => [daysAgo(n), [makeFeedbackItem({
-        feedback_id: `${n}`.repeat(32),
-        date: daysAgo(n),
-        source_created_at: `${daysAgo(n)}T10:00:00Z`,
-      })]]),
-    );
-    const client = {
-      send: vi.fn().mockImplementation((command: { input: Record<string, unknown> }) => {
-        const values = (command.input.ExpressionAttributeValues ?? {}) as Record<string, string>;
-        const date = (values[':pk'] ?? '').replace('DATE#', '');
-        const items = byDate[date] ?? [];
-        // Newer days settle LAST: each awaits more microtask turns than the day
-        // before it, so completion order is the reverse of date order. Microtasks
-        // rather than timers because these tests run on fake timers.
-        const settleOrder: Record<string, number> = { [daysAgo(1)]: 3, [daysAgo(2)]: 2 };
-        const turns = settleOrder[date] ?? 1;
-        return Array.from({ length: turns }).reduce<Promise<{ Items: unknown[] }>>(
-          (p) => p.then((v) => v),
-          Promise.resolve({ Items: items }),
-        );
-      }),
-    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
-
-    const result = await executeSearchFeedback(client, 'test-feedback-table', {}, { days: 5 });
-
-    expect(result.items.map((i) => i.date)).toStrictEqual([daysAgo(1), daysAgo(2), daysAgo(3)]);
-  });
-
-  it('honours the shared candidate budget across concurrent days, not per day', async () => {
-    // The reason concurrency is safe here at all. A per-day slice of the budget
-    // would let each in-flight day spend the whole remainder — 8 x the cap held
-    // at once, which is exactly what the cap exists to prevent. One counter,
-    // charged as pages land, so the total is bounded however wide the fan-out.
-    const rows = Array.from({ length: 4 }, (_, i) =>
-      makeFeedbackItem({ feedback_id: `d${String(i).padStart(31, '0')}` }),
-    );
-    const client = {
-      send: vi.fn().mockImplementation(() => Promise.resolve({ Items: rows })),
-    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
-
-    const result = await executeSearchFeedback(
-      client, 'test-feedback-table', { mode: 'aggregate' }, { days: 90 }, TEST_CAP,
-    );
-
-    // One wave of 8 days x 4 rows is all that may be collected: the budget is
-    // gone, so wave 2 is never dispatched. Per-day budgeting would keep going.
-    expect(client.send).toHaveBeenCalledTimes(DAY_SCAN_CONCURRENCY);
-    expect(result.isPartial).toBe(true);
-  });
-});
-
 describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_partial)', () => {
   freezeClock();
 
@@ -694,7 +582,12 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
 
     expect(result.isPartial).toBe(false);
     expect(result.formatted).not.toContain('INCOMPLETE');
-    expect(result.formatted).not.toContain('partial');
+    // The hedging strings themselves, not the bare word `partial`: `formatted`
+    // embeds up to 400 characters of arbitrary customer text per item, so a
+    // fixture whose feedback happened to mention the word would fail this for no
+    // behaviour change at all.
+    expect(result.formatted).not.toContain('scan truncated');
+    expect(result.formatted).not.toContain('PARTIAL');
   });
 
   it('flags a day whose partition still had pages when the candidate cap hit', async () => {
@@ -749,12 +642,64 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     expect(result.formatted).toContain('at least one day could not be read');
     // The cause reaches the operator log, never the model-facing prose: an
     // exception name is infrastructure detail (voc-context.ts states the rule).
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`DATE#${failedDate}`));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(failedDate));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('RangeError'));
     expect(result.formatted).not.toContain('RangeError');
+    // A transient name is one partition's bad luck, so the other days are still
+    // read — the throttle must not cost the window.
+    expect(docClient.send).toHaveBeenCalledTimes(7);
     warn.mockRestore();
   });
 
-  it('flags rows the schema rejected: a discarded row is not a read one', async () => {
+  it('stops on a systemic failure instead of repeating it for every wave', async () => {
+    // A missing grant fails identically for every partition of the index, so the
+    // remaining waves only repeat it and one log line per day says nothing the
+    // first said (query-errors.ts states both consequences; recent-feedback.ts
+    // already breaks its own fan-out on these names).
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const denied = new RangeError('denied');
+    denied.name = 'AccessDeniedException';
+    const docClient = {
+      send: vi.fn().mockImplementation(() => Promise.reject(denied)),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(docClient, 'test-feedback-table', {}, { days: 90 });
+
+    // The first wave was dispatched before the fault was known; the other ten
+    // never were.
+    expect(docClient.send).toHaveBeenCalledTimes(DAY_SCAN_CONCURRENCY);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('AccessDeniedException'));
+    expect(result.isPartial).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('says the window is unmeasured, not empty, when no day could be read', async () => {
+    // Nothing was measured, so zero is not a finding: query-errors.ts requires a
+    // consumer to "treat the numbers it leaves behind as unmeasured rather than
+    // as zero", and a user asking how much negative feedback arrived must not be
+    // told there was none when the tool could not look.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const denied = new RangeError('denied');
+    denied.name = 'AccessDeniedException';
+    const docClient = {
+      send: vi.fn().mockImplementation(() => Promise.reject(denied)),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', { mode: 'aggregate' }, { days: 90 },
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).not.toContain('No feedback found');
+    expect(result.formatted).toContain('no day of the 90-day window could be read');
+    expect(result.formatted).toContain('NOT a result of zero feedback items');
+    warn.mockRestore();
+  });
+
+  it('logs rows the schema rejected, with the count and the date', async () => {
+    // The row is a real loss and an operator must be able to find and repair it.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const rows = [
       makeFeedbackItem({ feedback_id: 'good1'.padEnd(32, '0') }),
@@ -766,9 +711,72 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     );
 
     expect(result.items).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('dropped 1 unparseable row(s) across 1 day(s)'),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(today));
+    warn.mockRestore();
+  });
+
+  it('does not call the whole window a sample over one unparseable row', async () => {
+    // A malformed legacy row fails identically on every future call, so folding
+    // it into isPartial would hedge every answer forever over a window that was
+    // read end to end — and a flag that always fires carries no information when
+    // a real truncation happens.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      ...Array.from({ length: 20 }, (_, i) =>
+        makeFeedbackItem({ feedback_id: `g${String(i).padStart(31, '0')}` })),
+      { original_text: 12345 },
+    ];
+
+    const result = await executeSearchFeedback(
+      createMockDocClient([rows as Record<string, unknown>[]]), 'test-feedback-table',
+      { mode: 'aggregate' }, { days: 7 },
+    );
+
+    expect(result.isPartial).toBe(false);
+    expect(result.formatted).toContain('COMPLETE set');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropped 1 unparseable row(s)'));
+    warn.mockRestore();
+  });
+
+  it('flags bulk parse loss, which really does bend the distributions', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      makeFeedbackItem({ feedback_id: 'good1'.padEnd(32, '0') }),
+      ...Array.from({ length: 5 }, () => ({ original_text: 12345 })),
+    ];
+
+    const result = await executeSearchFeedback(
+      createMockDocClient([rows as Record<string, unknown>[]]), 'test-feedback-table', {}, { days: 7 },
+    );
+
+    expect(result.items).toHaveLength(1);
     expect(result.isPartial).toBe(true);
     expect(result.formatted).toContain('could not be parsed');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropped 1 unparseable rows'));
+    warn.mockRestore();
+  });
+
+  it('reports one line per cause for the turn, not one per day', async () => {
+    // A drift that touches every day of the window is the realistic shape: a
+    // migration or producer change does not stop at one partition. Ninety
+    // identical CloudWatch lines per chat turn say nothing the first one did.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      makeFeedbackItem({ feedback_id: 'good1'.padEnd(32, '0') }),
+      { original_text: 12345 },
+    ];
+    const docClient = {
+      send: vi.fn().mockImplementation(() => Promise.resolve({ Items: rows })),
+    } as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+    await executeSearchFeedback(docClient, 'test-feedback-table', {}, { days: 90 });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('dropped 90 unparseable row(s) across 90 day(s)'),
+    );
     warn.mockRestore();
   });
 
@@ -801,12 +809,28 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
     // result dilute rather than reinforce, and leave two wordings to sync. The
     // aggregate header flags PARTIAL and annotates the total; the imperative to
     // relay it belongs to truncationNotice alone.
+    //
+    // Counts the notice and the imperative rather than ⚠️ glyphs: an emoji count
+    // pins presentation, so dropping the header's glyph while keeping its PARTIAL
+    // wording would fail for no behaviour change, and the count only ever held
+    // for aggregate mode anyway (list mode has one).
     const result = await executeSearchFeedback(
       createCappedDocClient(true), 'test-feedback-table', { mode: 'aggregate' }, { days: 90 }, TEST_CAP,
     );
 
     expect(result.formatted.match(/Say so when you answer/g)).toHaveLength(1);
-    expect(result.formatted.match(/⚠️/g)).toHaveLength(2);
+    expect(result.formatted.match(/INCOMPLETE RESULTS/g)).toHaveLength(1);
+  });
+
+  it('states the truncation once in list mode too', async () => {
+    // The aggregate-only assertion above cannot see a list-mode double-append,
+    // because list mode never renders the aggregate header.
+    const result = await executeSearchFeedback(
+      createCappedDocClient(true), 'test-feedback-table', { limit: 5 }, { days: 90 }, TEST_CAP,
+    );
+
+    expect(result.formatted.match(/Say so when you answer/g)).toHaveLength(1);
+    expect(result.formatted.match(/INCOMPLETE RESULTS/g)).toHaveLength(1);
   });
 
   it('aggregate mode still claims completeness when the whole window was read', async () => {
@@ -830,6 +854,43 @@ describe('truncation is reported (mirrors metrics_handler._scan_recent_items is_
       docClient, 'test-feedback-table', { query: feedbackId }, { days: 7 },
     );
 
+    expect(result.isPartial).toBe(false);
+  });
+
+  it('answers about the item when its row will not parse, in one query', async () => {
+    // Strict `.parse` threw into the fall-through catch, so a single-key lookup
+    // became a 91-query window scan that returned nothing and hedged about a
+    // 90-day window the user never asked about. The row exists; that is the answer.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const feedbackId = 'abcdef1234567890abcdef1234567890';
+    const docClient = createMockDocClient([
+      [{ feedback_id: feedbackId, original_text: 12345 }],
+    ]);
+
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', { query: feedbackId }, { days: 90 },
+    );
+
+    expect(docClient.send).toHaveBeenCalledOnce();
+    expect(result.items).toHaveLength(0);
+    expect(result.isPartial).toBe(true);
+    expect(result.formatted).toContain('could not be read');
+    expect(result.formatted).not.toContain('90-day window');
+    expect(result.formatted).not.toContain('INCOMPLETE RESULTS');
+    warn.mockRestore();
+  });
+
+  it('still falls through to the date scan when the ID index has no such row', async () => {
+    const feedbackId = 'abcdef1234567890abcdef1234567890';
+    const inWindow = makeFeedbackItem({ feedback_id: 'd'.repeat(32) });
+    const docClient = createMockDocClient([[], [inWindow]]);
+
+    const result = await executeSearchFeedback(
+      docClient, 'test-feedback-table', { query: feedbackId }, { days: 7 },
+    );
+
+    // The ID query plus the day scan, so a mistyped ID still gets a text search.
+    expect(docClient.send).toHaveBeenCalledTimes(8);
     expect(result.isPartial).toBe(false);
   });
 });

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -171,13 +171,21 @@ async function lookupByFeedbackId(
   return null;
 }
 
-// Upper bound on candidates collected across all days. A DynamoDB Query caps
-// each page at 1MB (often far fewer than 1000 large items), so we MUST follow
-// LastEvaluatedKey to page through a day — otherwise a day with thousands of
-// rows is silently truncated to the first ~500 (this caused "987 negative but
-// tool only saw 116"). Bound the total so aggregate mode can summarize the full
-// set without unbounded memory/time on a huge table.
-const MAX_CANDIDATES = 10000;
+/**
+ * Upper bound on candidates collected across all days. A DynamoDB Query caps
+ * each page at 1MB (often far fewer than 1000 large items), so we MUST follow
+ * LastEvaluatedKey to page through a day — otherwise a day with thousands of
+ * rows is silently truncated to the first ~500 (this caused "987 negative but
+ * tool only saw 116"). Bound the total so aggregate mode can summarize the full
+ * set without unbounded memory/time on a huge table.
+ *
+ * Deliberately NOT pinned to `metrics_handler.CANDIDATES_SOFT_CAP` (1000): the
+ * two budget different consumers — a model reading one prose digest in a single
+ * turn vs. a paginating HTTP client — so they are separate decisions, not one
+ * rule with two copies. Exported so tests can size a fixture from it instead of
+ * hard-coding a literal that goes stale when this number moves.
+ */
+export const MAX_CANDIDATES = 10000;
 
 /**
  * How many days back the date scan may reach, however many the chat context
@@ -190,10 +198,36 @@ const MAX_CANDIDATES = 10000;
  * against 90 there for months, so the chat tool answered "last quarter" from a
  * month of feedback while the REST route used the full window.
  *
+ * Spent in exactly one place — `resolveSearchParams` — so the scan bound, the
+ * cutoff filter and the notice text cannot disagree about which window this
+ * answer covers. `metrics_handler.py` carries the same warning from having had
+ * that bug: "This read `min(days, 30)` while `cutoff_date` above was computed
+ * from the caller's full `days`, so the two disagreed."
+ *
  * Keep the literal on one line as `export const MAX_LOOKBACK_DAYS = <n>` — the
  * lockstep test parses this text.
  */
 export const MAX_LOOKBACK_DAYS = 90;
+
+/**
+ * Why an answer covers less than the window the caller asked about.
+ *
+ * Each cause gets its own clause in the model-facing notice, because a notice
+ * that names one cause for all of them misattributes the rest: "the candidate
+ * cap" is a wrong explanation for a throttled partition or a clamped window.
+ */
+type TruncationReason =
+  | 'windowClamped'
+  | 'dayPartiallyRead'
+  | 'daysUnread'
+  | 'dayReadFailed'
+  | 'rowsDropped';
+
+/** What one day's read cost the answer: pages left unread, rows dropped. */
+interface DayReadOutcome {
+  truncated: boolean;
+  dropped: number;
+}
 
 /**
  * Page through one day's GSI partition via LastEvaluatedKey (not just the
@@ -203,8 +237,10 @@ export const MAX_LOOKBACK_DAYS = 90;
  * stops early only as parsed rows accumulate (a day of entirely malformed
  * rows still pages to its end, same as the previous do/while).
  *
- * Returns true when the day still had pages left but MAX_CANDIDATES stopped
- * the walk — i.e. this day was truncated and the caller's answer is a sample.
+ * `truncated` is true when the day still had pages left but MAX_CANDIDATES
+ * stopped the walk. `dropped` counts rows safeParse rejected: they are rows the
+ * answer does not contain, so the caller reports them too rather than
+ * presenting a window every row of which was discarded as fully read.
  */
 async function fetchDayPages(
   docClient: DynamoDBDocumentClient,
@@ -212,7 +248,7 @@ async function fetchDayPages(
   dateStr: string,
   candidates: FeedbackItem[],
   startKey?: Record<string, unknown>,
-): Promise<boolean> {
+): Promise<DayReadOutcome> {
   const resp = await docClient.send(
     new QueryCommand({
       TableName: feedbackTable,
@@ -223,69 +259,141 @@ async function fetchDayPages(
       ExclusiveStartKey: startKey,
     }),
   );
-  for (const raw of resp.Items ?? []) {
-    const parsed = feedbackItemSchema.safeParse(raw);
+  const parsedRows = (resp.Items ?? []).map((raw) => feedbackItemSchema.safeParse(raw));
+  for (const parsed of parsedRows) {
     if (parsed.success) candidates.push(parsed.data);
   }
-  if (!resp.LastEvaluatedKey) return false;
-  if (candidates.length >= MAX_CANDIDATES) return true;
-  return fetchDayPages(docClient, feedbackTable, dateStr, candidates, resp.LastEvaluatedKey);
+  const dropped = parsedRows.filter((parsed) => !parsed.success).length;
+  if (!resp.LastEvaluatedKey) return { truncated: false, dropped };
+  if (candidates.length >= MAX_CANDIDATES) return { truncated: true, dropped };
+  const rest = await fetchDayPages(
+    docClient, feedbackTable, dateStr, candidates, resp.LastEvaluatedKey,
+  );
+  return { truncated: rest.truncated, dropped: dropped + rest.dropped };
 }
 
 /**
- * Collect candidates day by day, newest first, bounded by MAX_LOOKBACK_DAYS
- * and MAX_CANDIDATES.
+ * Collect candidates day by day, newest first, over exactly `days` partitions.
  *
- * Returns `{ candidates, isPartial }`. `isPartial` is true when the scan was
- * cut short — a day partition had more pages than the candidate budget
- * allowed, or the budget ran out with days still unread — so the caller knows
- * it holds a sample rather than the whole window. Mirrors the Python route's
- * `_scan_recent_items` in lambda/api/metrics_handler.py, which returns
- * `(items, is_partial)` for the same reason.
+ * `days` must already be clamped to MAX_LOOKBACK_DAYS — `resolveSearchParams`
+ * is the single place that does it, so this loop's bound is the same number the
+ * cutoff filter uses. Clamping again here is what made the two disagree before.
+ *
+ * Returns `{ candidates, reasons }`: every way this scan fell short of the
+ * window it was asked for, so the caller can say which. Mirrors the Python
+ * route's `_scan_recent_items` in lambda/api/metrics_handler.py, which returns
+ * `(items, is_partial)` for the same reason — with one addition, because this
+ * runtime has failure modes Python's does not: `_query_partition` propagates a
+ * failed read while this loop survives it, so a survived failure must be
+ * REPORTED (the rule voc-context.ts states for its metric pages) rather than
+ * leaving a missing day looking like an empty one.
+ *
+ * One partition per day, sequentially, so widening the bound to 90 days triples
+ * the worst-case round trips per tool call — and this result is awaited mid-turn
+ * while the user watches. Kept sequential deliberately, not by omission:
+ * `voc-context.ts::sumMetricWindow` escapes per-day reads because METRIC rows
+ * live in one partition with a sortable date key, so BETWEEN bounds the window
+ * server-side. Feedback rows do not — `gsi1pk` IS the date — so a window is N
+ * partitions and no query shape collapses them. Bounded concurrency would cut
+ * the wall time, but the obvious version breaks two properties this file relies
+ * on: each in-flight day may spend the whole remaining candidate budget, so K
+ * concurrent days hold up to K×MAX_CANDIDATES rows (the cap exists to bound
+ * exactly that), and dividing the budget per day makes a moderate day report
+ * `dayPartiallyRead` when the total is nowhere near the cap — a false truncation
+ * signal in the one mechanism this file exists to make trustworthy. That is a
+ * budgeting decision to take on its own, with a measurement; empty partitions
+ * are cheap, so the cost lands on tenants with data across the whole window.
  */
 async function fetchCandidatesByDate(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
   days: number,
-): Promise<{ candidates: FeedbackItem[]; isPartial: boolean }> {
+): Promise<{ candidates: FeedbackItem[]; reasons: TruncationReason[] }> {
   const now = new Date();
   const candidates: FeedbackItem[] = [];
-  const scannedDays = Math.min(days, MAX_LOOKBACK_DAYS);
-  // Each entry is one reason the scan was incomplete. An array rather than a
-  // reassigned flag because this package bans `let` (eslint no-restricted-syntax).
-  const truncations: boolean[] = [];
+  // Reasons accumulate into an array rather than a reassigned flag because this
+  // package bans `let` (eslint no-restricted-syntax).
+  const reasons: TruncationReason[] = [];
 
-  for (const i of Array.from({ length: scannedDays }, (_, idx) => idx)) {
+  for (const i of Array.from({ length: days }, (_, idx) => idx)) {
     const d = new Date(now);
     d.setUTCDate(d.getUTCDate() - i);
     const dateStr = d.toISOString().slice(0, 10);
     try {
-      truncations.push(await fetchDayPages(docClient, feedbackTable, dateStr, candidates));
-    } catch {
-      // continue to the next day
+      const day = await fetchDayPages(docClient, feedbackTable, dateStr, candidates);
+      if (day.truncated) reasons.push('dayPartiallyRead');
+      if (day.dropped > 0) reasons.push(...noteDroppedRows(dateStr, day.dropped));
+    } catch (error) {
+      reasons.push(...noteFailedDay(dateStr, error));
     }
     if (candidates.length >= MAX_CANDIDATES) {
-      // Days still unread => the window was never fully scanned.
-      truncations.push(i < scannedDays - 1);
+      // Days still unread => the window was never fully scanned. `days` is the
+      // whole window here, clamped or not, so this cannot claim "nothing left
+      // unread" about days the caller asked for and the loop never reached.
+      if (i < days - 1) reasons.push('daysUnread');
       break;
     }
   }
-  return { candidates, isPartial: truncations.includes(true) };
+  return { candidates, reasons };
+}
+
+/**
+ * A day that could not be read is a hole in the answer, not an empty day.
+ *
+ * The read is survived rather than propagated — one throttled partition should
+ * not lose the other 89 — but survival without a report is how a sample comes
+ * back claiming to be complete. The operator channel carries the cause (the
+ * error name and the date); the model-facing notice does not, for the reason
+ * voc-context.ts gives: an exception name is infrastructure detail that is not
+ * actionable for whoever reads the answer.
+ */
+function noteFailedDay(dateStr: string, error: unknown): TruncationReason[] {
+  const name = error instanceof Error ? error.name : 'UnknownError';
+  console.warn(`search_feedback: DATE#${dateStr} could not be read (${name}); day skipped`);
+  return ['dayReadFailed'];
+}
+
+/**
+ * Rows safeParse rejected are candidates the answer does not contain.
+ *
+ * The schema is nearly all-optional with `.passthrough()`, so a rejection here
+ * is genuinely unexpected and worth both signals: the date and count for an
+ * operator, and the truncation reason so the answer is not presented as the
+ * whole window.
+ */
+function noteDroppedRows(dateStr: string, dropped: number): TruncationReason[] {
+  console.warn(`search_feedback: dropped ${dropped} unparseable rows from DATE#${dateStr}`);
+  return ['rowsDropped'];
 }
 
 // ── Main export ──
 
-/** Resolve the effective search parameters from tool input + chat context. */
+/**
+ * Resolve the effective search parameters from tool input + chat context.
+ *
+ * `days` is the EFFECTIVE window: clamped to MAX_LOOKBACK_DAYS here, once, so
+ * the day loop, the cutoff filter and the notice text all spend one number.
+ * Clamping inside the loop instead is the bug `metrics_handler.py` records
+ * having had — the filter admitted a year of items while the scan collected a
+ * month of them, and nothing said so.
+ *
+ * `requestedDays` is kept because the clamp is itself an unread remainder: a
+ * caller asking for 365 gets 90, which the answer has to admit rather than
+ * present as the year that was asked about. `chatRequestSchema` accepts up to
+ * 365 (src/schema.ts), so this is reachable even though the SPA caps at 90.
+ */
 function resolveSearchParams(toolInput: unknown, contextFilters: ContextFilters): {
   input: SearchInput;
   query: string;
   mode: 'list' | 'aggregate';
   limit: number;
   days: number;
+  requestedDays: number;
   filters: { source?: string; category?: string; sentiment?: string; urgency?: string };
 } {
   const parsed = searchInputSchema.safeParse(toolInput);
   const input: SearchInput = parsed.success ? parsed.data : {};
+  const requestedDays = contextFilters.days ?? 30;
   return {
     input,
     query: input.query ?? '',
@@ -293,7 +401,8 @@ function resolveSearchParams(toolInput: unknown, contextFilters: ContextFilters)
     // aggregate mode returns stats over the whole match set, so a small list
     // cap there is fine (only used for the handful of examples we show).
     limit: Math.min(input.limit ?? 15, 30),
-    days: contextFilters.days ?? 30,
+    days: Math.min(requestedDays, MAX_LOOKBACK_DAYS),
+    requestedDays,
     filters: {
       source: input.source ?? contextFilters.source,
       category: input.category ?? contextFilters.category,
@@ -309,7 +418,9 @@ export async function executeSearchFeedback(
   toolInput: unknown,
   contextFilters: ContextFilters,
 ): Promise<SearchFeedbackResult> {
-  const { input, query, mode, limit, days, filters } = resolveSearchParams(toolInput, contextFilters);
+  const {
+    input, query, mode, limit, days, requestedDays, filters,
+  } = resolveSearchParams(toolInput, contextFilters);
 
   if (!feedbackTable) throw new ConfigurationError('Feedback table not configured');
 
@@ -319,9 +430,16 @@ export async function executeSearchFeedback(
     if (idResult) return idResult;
   }
 
-  const { candidates, isPartial } = await fetchCandidatesByDate(docClient, feedbackTable, days);
+  const scan = await fetchCandidatesByDate(docClient, feedbackTable, days);
+  // The clamp is a truncation like any other: the caller asked about a longer
+  // window than this scan can reach, so the answer covers less than the
+  // question did and has to say which window it actually read.
+  const reasons = requestedDays > days ? ['windowClamped' as const, ...scan.reasons] : scan.reasons;
+  const isPartial = reasons.length > 0;
 
   // Days-long window ending today (same definition as the metrics API).
+  // `days` is the clamped window, the same one the scan read, so the filter
+  // cannot admit items from days that were never queried.
   // Review basis compares against the date the customer wrote the item; the
   // import-date scan above always contains those items, since a review can't
   // be imported before it was written (issue #150).
@@ -330,9 +448,11 @@ export async function executeSearchFeedback(
   cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1));
   const cutoffDate = cutoff.toISOString().slice(0, 10);
 
-  const allMatched = candidates.filter((item) =>
+  const allMatched = scan.candidates.filter((item) =>
     matchesFeedbackItem(item, query, filters, cutoffDate, dateBasis),
   );
+
+  const notice = truncationNotice(reasons, days, requestedDays);
 
   // aggregate mode: summarize the WHOLE match set in one call (no list cap),
   // so "summarize all feedback" / "top issues" don't force the model to loop.
@@ -340,7 +460,7 @@ export async function executeSearchFeedback(
     const examples = [...allMatched].sort(compareByUrgency).slice(0, limit);
     return {
       items: examples,
-      formatted: formatAggregate(allMatched, examples, isPartial) + truncationNotice(isPartial, days),
+      formatted: formatAggregate(allMatched, examples, isPartial) + notice,
       isPartial,
     };
   }
@@ -350,29 +470,56 @@ export async function executeSearchFeedback(
   }
   const matched = allMatched.slice(0, limit);
 
-  return {
-    items: matched,
-    formatted: formatToolResults(matched) + truncationNotice(isPartial, days),
-    isPartial,
-  };
+  return { items: matched, formatted: formatToolResults(matched) + notice, isPartial };
 }
 
 // ── Formatting ──
 
+/** One clause per cause, so the notice explains the truncation it actually had. */
+const TRUNCATION_CLAUSES: Record<TruncationReason, string> = {
+  windowClamped: 'the requested window is longer than this search can reach',
+  dayPartiallyRead: `a day held more feedback than the candidate budget allowed (cap ${MAX_CANDIDATES})`,
+  daysUnread: 'the candidate budget ran out with older days still unread',
+  dayReadFailed: 'at least one day could not be read',
+  rowsDropped: 'some stored rows could not be parsed and were skipped',
+};
+
 /**
- * The line the model reads when the scan was truncated.
+ * The paragraph the model reads when the answer covers less than the question.
  *
  * Empty when the window was fully read, so a complete answer carries no
- * hedging. Phrased as an instruction because the consumer is the model: left as
- * a bare boolean on the returned object it would never reach the user, who has
- * no other way to tell a capped answer from a complete one.
+ * hedging. This is the ONE place the truncation is stated in prose, in both
+ * modes: `formatAggregate` drops its completeness claim and annotates the total
+ * but does not repeat the instruction, because three statements of one fact in
+ * the highest-attention region of the tool result dilute rather than reinforce,
+ * and leave two wordings to keep in sync.
+ *
+ * Phrased as an instruction because the consumer is the model: left as a bare
+ * boolean on the returned object it would never reach the user, who has no
+ * other way to tell a capped answer from a complete one.
+ *
+ * Names the window actually SCANNED, not the one requested — the earlier
+ * wording said "the 365-day window" about a scan that read 90 days of it, so
+ * the model hedged about a window nothing had looked at.
+ *
+ * English is deliberate, matching voc-context.ts's degradedNote: this is prompt
+ * text rather than UI copy, and buildSystemPrompt instructs the model to answer
+ * in `response_language`, so the model relays the fact in the user's language.
+ * Translating it would change nothing the user reads.
  */
-function truncationNotice(isPartial: boolean, days: number): string {
-  if (!isPartial) return '';
-  return `\n⚠️ INCOMPLETE RESULTS: the ${days}-day window holds more feedback than this `
-    + `search could read (candidate cap ${MAX_CANDIDATES}), so the items and any counts `
-    + 'above are a partial sample of the most recent days — not the whole window. Say so '
-    + 'when you answer, and do not present these totals or percentages as complete.\n';
+function truncationNotice(
+  reasons: TruncationReason[],
+  scannedDays: number,
+  requestedDays: number,
+): string {
+  if (reasons.length === 0) return '';
+  const causes = [...new Set(reasons)].map((reason) => TRUNCATION_CLAUSES[reason]).join('; ');
+  const windowRead = requestedDays > scannedDays
+    ? `only the most recent ${scannedDays} days of the ${requestedDays}-day window asked about`
+    : `part of the ${scannedDays}-day window`;
+  return `\n⚠️ INCOMPLETE RESULTS: the items and any counts above cover ${windowRead} `
+    + `— ${causes}. Say so when you answer, name the ${scannedDays}-day window they do cover, `
+    + 'and do not present these totals or percentages as complete.\n';
 }
 
 function formatSingleItem(item: FeedbackItem, index: number): string {
@@ -419,11 +566,17 @@ function formatDistribution(label: string, dist: [string, number][], total: numb
 // One-call summary over the ENTIRE match set: total, distributions by urgency /
 // sentiment / category / source, average rating, plus the top examples (already
 // urgency-sorted) so the model can quote specifics without another search.
-// When the candidate scan was truncated (`isPartial`) the "COMPLETE set" claim
-// below is false, and it is the most dangerous sentence in this file: the model
-// is told in so many words to base its answer on numbers that only cover the
-// most recent slice of the window. So the header states which it is.
-function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[], isPartial = false): string {
+//
+// When the scan was truncated (`isPartial`) the "COMPLETE set" claim below is
+// false, and it is the most dangerous sentence in this file: the model is told
+// in so many words to base its answer on numbers that only cover the most recent
+// slice of the window. So the header states which it is, and the total carries
+// the annotation — but NOT the instruction to relay it, which `truncationNotice`
+// owns for both modes. One imperative, in one place, with the causes named.
+//
+// `isPartial` has no default: a fail-closed signature, so a future call site
+// cannot silently inherit the "COMPLETE set" wording by forgetting the argument.
+function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[], isPartial: boolean): string {
   const total = all.length;
   if (total === 0) return 'No feedback found matching the search criteria.';
 
@@ -437,8 +590,8 @@ function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[], isPartia
       ? `Aggregate summary over ${total} matching feedback items `
       : `Aggregate summary over ALL ${total} matching feedback items `,
     isPartial
-      ? '(⚠️ PARTIAL — the scan hit its candidate cap, so this is a sample of the most '
-        + 'recent days in the window, NOT the complete set; say so when you answer):\n\n'
+      ? '(⚠️ PARTIAL — a sample of the window, NOT the complete set; see the note '
+        + 'below these figures):\n\n'
       : '(this is the COMPLETE set, not a sample — base your answer on these numbers):\n\n',
     `**Total matches:** ${total}${isPartial ? ' (partial — scan truncated)' : ''}\n`,
     `**Average rating:** ${avgRating}\n\n`,

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -12,6 +12,7 @@ import {
   fetchCandidatesByDate,
   feedbackItemSchema,
   queryFeedbackById,
+  scanWasIncomplete,
   DAY_SCAN_CONCURRENCY,
   MAX_CANDIDATES,
   MAX_LOOKBACK_DAYS,
@@ -275,9 +276,12 @@ export async function executeSearchFeedback(
   // so "summarize all feedback" / "top issues" don't force the model to loop.
   if (mode === 'aggregate') {
     const examples = [...allMatched].sort(compareByUrgency).slice(0, limit);
+    // `scanWasIncomplete`, not `isPartial`: a clamped-but-fully-read window
+    // yields totals that ARE complete for the days they cover, so the header
+    // keeps its claim and `notice` explains which window that is.
     return {
       items: examples,
-      formatted: formatAggregate(allMatched, examples, isPartial) + notice,
+      formatted: formatAggregate(allMatched, examples, scanWasIncomplete(reasons)) + notice,
       isPartial,
     };
   }
@@ -347,6 +351,19 @@ function truncationNotice(
   requestedDays: number,
 ): string {
   if (reasons.length === 0) return '';
+  // Clamped but fully read: every day the scan covered was read to its end, so
+  // the figures are COMPLETE for those days and "do not present these totals as
+  // complete" is false. Pairing that with the aggregate header's own PARTIAL
+  // claim told the model these numbers were a sample of a window nothing had
+  // truncated. What is actually narrower than the question is the WINDOW, so
+  // that is what this says.
+  if (!scanWasIncomplete(reasons)) {
+    return `\n⚠️ NARROWER WINDOW THAN ASKED ABOUT: this search reaches back at most `
+      + `${scannedDays} days, but the question named ${requestedDays} days. The figures above `
+      + `are complete for the most recent ${scannedDays} days and say nothing about the `
+      + `${requestedDays - scannedDays} earlier days. Name the ${scannedDays}-day window when `
+      + 'you answer, and do not describe these numbers as covering the longer period.\n';
+  }
   const causes = [...new Set(reasons)].map((reason) => TRUNCATION_CLAUSES[reason]).join('; ');
   const windowRead = requestedDays > scannedDays
     ? `only the most recent ${scannedDays} days of the ${requestedDays}-day window asked about`

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -1,11 +1,27 @@
 /**
  * search_feedback tool implementation.
  * Ported from Python chat_stream_handler.py.
+ *
+ * Filtering, formatting and the prose the model reads. The reads themselves —
+ * and every shortfall they have to admit — live in ./feedback-scan.ts.
  */
-import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 import { ConfigurationError } from '../lib/errors.js';
-import { FEEDBACK_BY_DATE_INDEX, FEEDBACK_BY_ID_INDEX } from '../indexes.js';
+import {
+  fetchCandidatesByDate,
+  feedbackItemSchema,
+  queryFeedbackById,
+  DAY_SCAN_CONCURRENCY,
+  MAX_CANDIDATES,
+  MAX_LOOKBACK_DAYS,
+  type FeedbackItem,
+  type TruncationReason,
+} from './feedback-scan.js';
+
+// Re-exported so the constants keep one import path for callers and tests. They
+// are declared in feedback-scan.ts, which the lockstep guard parses.
+export { DAY_SCAN_CONCURRENCY, MAX_CANDIDATES, MAX_LOOKBACK_DAYS };
 
 const searchInputSchema = z.object({
   query: z.string().optional(),
@@ -50,26 +66,6 @@ interface ContextFilters {
   dateBasis?: 'imported' | 'review';
 }
 
-const feedbackItemSchema = z.object({
-  feedback_id: z.string().optional(),
-  source_platform: z.string().optional(),
-  source_created_at: z.string().optional(),
-  sentiment_label: z.string().optional(),
-  // The ingestion pipeline stores these numerics as DynamoDB strings (S) for
-  // ~all items, so a strict z.number() rejected nearly every row — which made
-  // fetchCandidatesByDate silently drop them all and every search return 0
-  // results. coerce accepts both "0.95"/0.95 and "5"/5.
-  sentiment_score: z.coerce.number().optional(),
-  category: z.string().optional(),
-  rating: z.coerce.number().nullable().optional(),
-  original_text: z.string().optional(),
-  title: z.string().optional(),
-  problem_summary: z.string().optional(),
-  date: z.string().optional(),
-  urgency: z.string().optional(),
-}).passthrough();
-
-type FeedbackItem = z.infer<typeof feedbackItemSchema>;
 
 /**
  * What the tool hands back.
@@ -145,306 +141,38 @@ function matchesFeedbackItem(
 
 // ── Query helpers ──
 
+/**
+ * One row by key, or null when the caller should fall through to the date scan.
+ *
+ * Three outcomes, deliberately distinguished. A parsed row is the answer. No
+ * row, or a failed query, falls through. A row that EXISTS but does not parse
+ * used to fall through too — strict `.parse` threw into the catch — which turned
+ * a single-key lookup into a 90-day, 91-query scan whose truncation notice then
+ * described the window rather than the item the user asked about, while the scan
+ * re-read the same malformed row and returned nothing. So that case is answered
+ * here, about the item, in one query.
+ */
 async function lookupByFeedbackId(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
   feedbackId: string,
 ): Promise<SearchFeedbackResult | null> {
-  try {
-    const resp = await docClient.send(
-      new QueryCommand({
-        TableName: feedbackTable,
-        IndexName: FEEDBACK_BY_ID_INDEX,
-        KeyConditionExpression: 'feedback_id = :fid',
-        ExpressionAttributeValues: { ':fid': feedbackId.toLowerCase().trim() },
-        Limit: 1,
-      }),
-    );
-    const items = (resp.Items ?? []).map((raw) => feedbackItemSchema.parse(raw));
-    if (items.length > 0) {
-      // A direct ID hit reads one row by key: nothing was truncated.
-      return { items, formatted: formatToolResults(items), isPartial: false };
-    }
-  } catch {
-    // Fall through to date-based search
-  }
-  return null;
-}
-
-/**
- * Upper bound on candidates collected across all days. A DynamoDB Query caps
- * each page at 1MB (often far fewer than 1000 large items), so we MUST follow
- * LastEvaluatedKey to page through a day — otherwise a day with thousands of
- * rows is silently truncated to the first ~500 (this caused "987 negative but
- * tool only saw 116"). Bound the total so aggregate mode can summarize the full
- * set without unbounded memory/time on a huge table.
- *
- * Deliberately NOT pinned to `metrics_handler.CANDIDATES_SOFT_CAP` (1000): the
- * two budget different consumers — a model reading one prose digest in a single
- * turn vs. a paginating HTTP client — so they are separate decisions, not one
- * rule with two copies. Exported so tests can size a fixture from it instead of
- * hard-coding a literal that goes stale when this number moves.
- */
-export const MAX_CANDIDATES = 10000;
-
-/**
- * How many days back the date scan may reach, however many the chat context
- * asks for. Mirror of `MAX_LOOKBACK_DAYS` in lambda/shared/feedback.py, which
- * the REST feedback routes spend as `days=min(days, MAX_LOOKBACK_DAYS)`.
- *
- * This runtime cannot import the Python constant, so the two are pinned
- * together by lambda/shared/test/test_lookback_window_lockstep.py: it parses
- * the declaration below and fails when the numbers diverge. It read 30 here
- * against 90 there for months, so the chat tool answered "last quarter" from a
- * month of feedback while the REST route used the full window.
- *
- * Spent in exactly one place — `resolveSearchParams` — so the scan bound, the
- * cutoff filter and the notice text cannot disagree about which window this
- * answer covers. `metrics_handler.py` carries the same warning from having had
- * that bug: "This read `min(days, 30)` while `cutoff_date` above was computed
- * from the caller's full `days`, so the two disagreed."
- *
- * Keep the literal on one line as `export const MAX_LOOKBACK_DAYS = <n>` — the
- * lockstep test parses this text.
- */
-export const MAX_LOOKBACK_DAYS = 90;
-
-/**
- * Why an answer covers less than the window the caller asked about.
- *
- * Each cause gets its own clause in the model-facing notice, because a notice
- * that names one cause for all of them misattributes the rest: "the candidate
- * cap" is a wrong explanation for a throttled partition or a clamped window.
- */
-type TruncationReason =
-  | 'windowClamped'
-  | 'dayPartiallyRead'
-  | 'daysUnread'
-  | 'dayReadFailed'
-  | 'rowsDropped';
-
-/** What one day's read cost the answer: pages left unread, rows dropped. */
-interface DayReadOutcome {
-  truncated: boolean;
-  dropped: number;
-}
-
-/**
- * How many day partitions are read at once. See `scanWaves`.
- *
- * Exported so the test can assert the fan-out is really bounded at this width,
- * rather than having quietly returned to one round trip at a time.
- */
-export const DAY_SCAN_CONCURRENCY = 8;
-
-/**
- * The candidate ceiling, shared by every day in the scan.
- *
- * ONE counter, deliberately, not a per-day slice of the remainder. Slicing is
- * what makes concurrency unsafe here: it would let K in-flight days each believe
- * they may spend the whole budget (K×MAX_CANDIDATES rows held at once, which is
- * the thing the cap exists to bound), and dividing it K ways instead makes a
- * moderate day report `dayPartiallyRead` while the total is nowhere near the cap
- * — a false truncation signal in the one mechanism this file exists to make
- * trustworthy. A shared counter has neither problem: every page charges the same
- * budget as it lands, so the cap means what it says and a day reports truncation
- * only when the budget is genuinely gone.
- *
- * Mutated in place because this package bans `let` (eslint no-restricted-syntax).
- */
-interface CandidateBudget {
-  cap: number;
-  spent: number;
-}
-
-function budgetExhausted(budget: CandidateBudget): boolean {
-  return budget.spent >= budget.cap;
-}
-
-/**
- * Page through one day's GSI partition via LastEvaluatedKey (not just the
- * first page), appending valid rows to `candidates`. Per-row safeParse: a
- * single malformed item must not throw and discard the whole day's results.
- * Recursion depth = pages in the day's partition; the MAX_CANDIDATES check
- * stops early only as parsed rows accumulate (a day of entirely malformed
- * rows still pages to its end, same as the previous do/while).
- *
- * `truncated` is true when the day still had pages left but the shared candidate
- * budget stopped the walk. `dropped` counts rows safeParse rejected: they are
- * rows the answer does not contain, so the caller reports them too rather than
- * presenting a window every row of which was discarded as fully read.
- *
- * Rows land in this day's OWN array rather than straight into the shared list,
- * so concurrently-read days cannot interleave: the caller concatenates them in
- * date order. The budget is charged as pages land, so the cap still bounds the
- * whole scan rather than each day separately.
- */
-async function fetchDayPages(
-  docClient: DynamoDBDocumentClient,
-  feedbackTable: string,
-  dateStr: string,
-  candidates: FeedbackItem[],
-  budget: CandidateBudget,
-  startKey?: Record<string, unknown>,
-): Promise<DayReadOutcome> {
-  const resp = await docClient.send(
-    new QueryCommand({
-      TableName: feedbackTable,
-      IndexName: FEEDBACK_BY_DATE_INDEX,
-      KeyConditionExpression: 'gsi1pk = :pk',
-      ExpressionAttributeValues: { ':pk': `DATE#${dateStr}` },
-      ScanIndexForward: false,
-      ExclusiveStartKey: startKey,
-    }),
-  );
-  const parsedRows = (resp.Items ?? []).map((raw) => feedbackItemSchema.safeParse(raw));
-  for (const parsed of parsedRows) {
-    if (parsed.success) candidates.push(parsed.data);
-  }
-  const dropped = parsedRows.filter((parsed) => !parsed.success).length;
-  budget.spent += parsedRows.length - dropped;
-  if (!resp.LastEvaluatedKey) return { truncated: false, dropped };
-  if (budgetExhausted(budget)) return { truncated: true, dropped };
-  const rest = await fetchDayPages(
-    docClient, feedbackTable, dateStr, candidates, budget, resp.LastEvaluatedKey,
-  );
-  return { truncated: rest.truncated, dropped: dropped + rest.dropped };
-}
-
-/**
- * Collect candidates day by day, newest first, over exactly `days` partitions.
- *
- * `days` must already be clamped to MAX_LOOKBACK_DAYS — `resolveSearchParams`
- * is the single place that does it, so this loop's bound is the same number the
- * cutoff filter uses. Clamping again here is what made the two disagree before.
- *
- * Returns `{ candidates, reasons }`: every way this scan fell short of the
- * window it was asked for, so the caller can say which. Mirrors the Python
- * route's `_scan_recent_items` in lambda/api/metrics_handler.py, which returns
- * `(items, is_partial)` for the same reason — with one addition, because this
- * runtime has failure modes Python's does not: `_query_partition` propagates a
- * failed read while this loop survives it, so a survived failure must be
- * REPORTED (the rule voc-context.ts states for its metric pages) rather than
- * leaving a missing day looking like an empty one.
- *
- * Days are read DAY_SCAN_CONCURRENCY at a time, newest wave first. Sequentially
- * a 90-day window is 90 round trips awaited mid-turn while the user watches a
- * half-rendered answer; at a 12ms round trip that measured p99 1092ms against
- * 153ms in waves of 8 — less even than the 30-day sequential scan this widening
- * replaced (364ms), so the window got three times wider and still got faster.
- *
- * A range query is not available: `voc-context.ts::sumMetricWindow` escapes
- * per-day reads because METRIC rows share one partition with a sortable date
- * key, so BETWEEN bounds the window server-side. Feedback rows do not — `gsi1pk`
- * IS the date — so a window is N partitions and no query shape collapses them.
- * Concurrency is what is left, and it is safe here only because the candidate
- * budget is one shared counter rather than a per-day slice; see CandidateBudget
- * for why the sliced version would both hold K× the rows and invent truncation
- * signals that never happened.
- */
-async function fetchCandidatesByDate(
-  docClient: DynamoDBDocumentClient,
-  feedbackTable: string,
-  days: number,
-  candidateCap: number,
-): Promise<{ candidates: FeedbackItem[]; reasons: TruncationReason[] }> {
-  const now = new Date();
-  const dates = Array.from({ length: days }, (_, i) => {
-    const d = new Date(now);
-    d.setUTCDate(d.getUTCDate() - i);
-    return d.toISOString().slice(0, 10);
+  const rows = await queryFeedbackById(docClient, feedbackTable, feedbackId);
+  if (rows === null || rows.length === 0) return null;
+  const items = rows.flatMap((raw) => {
+    const parsed = feedbackItemSchema.safeParse(raw);
+    return parsed.success ? [parsed.data] : [];
   });
-  const waves = Array.from(
-    { length: Math.ceil(dates.length / DAY_SCAN_CONCURRENCY) },
-    (_, i) => dates.slice(i * DAY_SCAN_CONCURRENCY, (i + 1) * DAY_SCAN_CONCURRENCY),
-  );
-  return scanWaves(docClient, feedbackTable, waves, { cap: candidateCap, spent: 0 });
-}
-
-/** One day, never throwing: a failed read is a reported hole, not a lost scan. */
-async function readOneDay(
-  docClient: DynamoDBDocumentClient,
-  feedbackTable: string,
-  dateStr: string,
-  budget: CandidateBudget,
-): Promise<{ items: FeedbackItem[]; reasons: TruncationReason[] }> {
-  const items: FeedbackItem[] = [];
-  try {
-    const day = await fetchDayPages(docClient, feedbackTable, dateStr, items, budget);
-    return {
-      items,
-      reasons: [
-        ...(day.truncated ? ['dayPartiallyRead' as const] : []),
-        ...(day.dropped > 0 ? noteDroppedRows(dateStr, day.dropped) : []),
-      ],
-    };
-  } catch (error) {
-    return { items, reasons: noteFailedDay(dateStr, error) };
-  }
-}
-
-/**
- * Read the waves in order, stopping once the candidate budget is gone.
- *
- * Recursion rather than a loop because the accumulator has to stay `const`.
- * Ordering is by DATE, not completion: each wave's days are concatenated in the
- * order they were dispatched, so list mode's default 'recent' sort — which is
- * the scan order itself — is unchanged from the sequential version.
- */
-async function scanWaves(
-  docClient: DynamoDBDocumentClient,
-  feedbackTable: string,
-  waves: string[][],
-  budget: CandidateBudget,
-  acc: { candidates: FeedbackItem[]; reasons: TruncationReason[] } = { candidates: [], reasons: [] },
-  index = 0,
-): Promise<{ candidates: FeedbackItem[]; reasons: TruncationReason[] }> {
-  if (index >= waves.length) return acc;
-  const reads = await Promise.all(
-    waves[index].map((dateStr) => readOneDay(docClient, feedbackTable, dateStr, budget)),
-  );
-  const next = {
-    candidates: [...acc.candidates, ...reads.flatMap((r) => r.items)],
-    reasons: [...acc.reasons, ...reads.flatMap((r) => r.reasons)],
+  // A direct ID hit reads one row by key: nothing was truncated.
+  if (items.length > 0) return { items, formatted: formatToolResults(items), isPartial: false };
+  console.warn(`search_feedback: feedback_id ${feedbackId} matched a row that would not parse`);
+  return {
+    items: [],
+    formatted: 'The requested feedback item exists but its stored row could not be read, so '
+      + 'its details are unavailable. Say that the item could not be read — do NOT say no such '
+      + 'item exists, and do not present other feedback as if it were this item.\n',
+    isPartial: true,
   };
-  if (budgetExhausted(budget)) {
-    // Waves after this one were never dispatched, so those days are genuinely
-    // unread. Every day WITHIN this wave was read, hence the wave-level test:
-    // claiming 'daysUnread' for them would be a truncation that did not happen.
-    return index + 1 < waves.length
-      ? { ...next, reasons: [...next.reasons, 'daysUnread'] }
-      : next;
-  }
-  return scanWaves(docClient, feedbackTable, waves, budget, next, index + 1);
-}
-
-/**
- * A day that could not be read is a hole in the answer, not an empty day.
- *
- * The read is survived rather than propagated — one throttled partition should
- * not lose the other 89 — but survival without a report is how a sample comes
- * back claiming to be complete. The operator channel carries the cause (the
- * error name and the date); the model-facing notice does not, for the reason
- * voc-context.ts gives: an exception name is infrastructure detail that is not
- * actionable for whoever reads the answer.
- */
-function noteFailedDay(dateStr: string, error: unknown): TruncationReason[] {
-  const name = error instanceof Error ? error.name : 'UnknownError';
-  console.warn(`search_feedback: DATE#${dateStr} could not be read (${name}); day skipped`);
-  return ['dayReadFailed'];
-}
-
-/**
- * Rows safeParse rejected are candidates the answer does not contain.
- *
- * The schema is nearly all-optional with `.passthrough()`, so a rejection here
- * is genuinely unexpected and worth both signals: the date and count for an
- * operator, and the truncation reason so the answer is not presented as the
- * whole window.
- */
-function noteDroppedRows(dateStr: string, dropped: number): TruncationReason[] {
-  console.warn(`search_feedback: dropped ${dropped} unparseable rows from DATE#${dateStr}`);
-  return ['rowsDropped'];
 }
 
 // ── Main export ──
@@ -515,6 +243,11 @@ export async function executeSearchFeedback(
   }
 
   const scan = await fetchCandidatesByDate(docClient, feedbackTable, days, candidateCap);
+  // Not one partition answered, so this window is unknown rather than empty and
+  // must not be formatted as a search that found nothing.
+  if (scan.unmeasured) {
+    return { items: [], formatted: unmeasuredWindowNotice(days), isPartial: true };
+  }
   // The clamp is a truncation like any other: the caller asked about a longer
   // window than this scan can reach, so the answer covers less than the
   // question did and has to say which window it actually read.
@@ -559,13 +292,30 @@ export async function executeSearchFeedback(
 
 // ── Formatting ──
 
+/**
+ * What the model is told when NO day of the window could be read.
+ *
+ * Not "no feedback found matching the search criteria": nothing was measured, so
+ * zero is not a finding. query-errors.ts states the requirement for any consumer
+ * of a failed fan-out — "treat the numbers it leaves behind as unmeasured rather
+ * than as zero" — and a user asking how much negative feedback arrived must not
+ * be told there was none when the tool could not look. The cause stays in the
+ * operator log, where the error name is actionable.
+ */
+function unmeasuredWindowNotice(scannedDays: number): string {
+  return `⚠️ THE SEARCH COULD NOT BE RUN: no day of the ${scannedDays}-day window could be read, `
+    + 'so nothing is known about it. This is NOT a result of zero feedback items. Tell the user '
+    + 'the feedback store could not be reached and that you therefore cannot answer, and do not '
+    + 'state or imply any count — including zero.\n';
+}
+
 /** One clause per cause, so the notice explains the truncation it actually had. */
 const TRUNCATION_CLAUSES: Record<TruncationReason, string> = {
   windowClamped: 'the requested window is longer than this search can reach',
   dayPartiallyRead: `a day held more feedback than the candidate budget allowed (cap ${MAX_CANDIDATES})`,
-  daysUnread: 'the candidate budget ran out with older days still unread',
+  daysUnread: 'the scan stopped early, leaving older days still unread',
   dayReadFailed: 'at least one day could not be read',
-  rowsDropped: 'some stored rows could not be parsed and were skipped',
+  rowsDropped: 'a large share of the stored rows could not be parsed and were skipped',
 };
 
 /**

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -230,6 +230,38 @@ interface DayReadOutcome {
 }
 
 /**
+ * How many day partitions are read at once. See `scanWaves`.
+ *
+ * Exported so the test can assert the fan-out is really bounded at this width,
+ * rather than having quietly returned to one round trip at a time.
+ */
+export const DAY_SCAN_CONCURRENCY = 8;
+
+/**
+ * The candidate ceiling, shared by every day in the scan.
+ *
+ * ONE counter, deliberately, not a per-day slice of the remainder. Slicing is
+ * what makes concurrency unsafe here: it would let K in-flight days each believe
+ * they may spend the whole budget (K×MAX_CANDIDATES rows held at once, which is
+ * the thing the cap exists to bound), and dividing it K ways instead makes a
+ * moderate day report `dayPartiallyRead` while the total is nowhere near the cap
+ * — a false truncation signal in the one mechanism this file exists to make
+ * trustworthy. A shared counter has neither problem: every page charges the same
+ * budget as it lands, so the cap means what it says and a day reports truncation
+ * only when the budget is genuinely gone.
+ *
+ * Mutated in place because this package bans `let` (eslint no-restricted-syntax).
+ */
+interface CandidateBudget {
+  cap: number;
+  spent: number;
+}
+
+function budgetExhausted(budget: CandidateBudget): boolean {
+  return budget.spent >= budget.cap;
+}
+
+/**
  * Page through one day's GSI partition via LastEvaluatedKey (not just the
  * first page), appending valid rows to `candidates`. Per-row safeParse: a
  * single malformed item must not throw and discard the whole day's results.
@@ -237,16 +269,22 @@ interface DayReadOutcome {
  * stops early only as parsed rows accumulate (a day of entirely malformed
  * rows still pages to its end, same as the previous do/while).
  *
- * `truncated` is true when the day still had pages left but MAX_CANDIDATES
- * stopped the walk. `dropped` counts rows safeParse rejected: they are rows the
- * answer does not contain, so the caller reports them too rather than
+ * `truncated` is true when the day still had pages left but the shared candidate
+ * budget stopped the walk. `dropped` counts rows safeParse rejected: they are
+ * rows the answer does not contain, so the caller reports them too rather than
  * presenting a window every row of which was discarded as fully read.
+ *
+ * Rows land in this day's OWN array rather than straight into the shared list,
+ * so concurrently-read days cannot interleave: the caller concatenates them in
+ * date order. The budget is charged as pages land, so the cap still bounds the
+ * whole scan rather than each day separately.
  */
 async function fetchDayPages(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
   dateStr: string,
   candidates: FeedbackItem[],
+  budget: CandidateBudget,
   startKey?: Record<string, unknown>,
 ): Promise<DayReadOutcome> {
   const resp = await docClient.send(
@@ -264,10 +302,11 @@ async function fetchDayPages(
     if (parsed.success) candidates.push(parsed.data);
   }
   const dropped = parsedRows.filter((parsed) => !parsed.success).length;
+  budget.spent += parsedRows.length - dropped;
   if (!resp.LastEvaluatedKey) return { truncated: false, dropped };
-  if (candidates.length >= MAX_CANDIDATES) return { truncated: true, dropped };
+  if (budgetExhausted(budget)) return { truncated: true, dropped };
   const rest = await fetchDayPages(
-    docClient, feedbackTable, dateStr, candidates, resp.LastEvaluatedKey,
+    docClient, feedbackTable, dateStr, candidates, budget, resp.LastEvaluatedKey,
   );
   return { truncated: rest.truncated, dropped: dropped + rest.dropped };
 }
@@ -288,53 +327,95 @@ async function fetchDayPages(
  * REPORTED (the rule voc-context.ts states for its metric pages) rather than
  * leaving a missing day looking like an empty one.
  *
- * One partition per day, sequentially, so widening the bound to 90 days triples
- * the worst-case round trips per tool call — and this result is awaited mid-turn
- * while the user watches. Kept sequential deliberately, not by omission:
- * `voc-context.ts::sumMetricWindow` escapes per-day reads because METRIC rows
- * live in one partition with a sortable date key, so BETWEEN bounds the window
- * server-side. Feedback rows do not — `gsi1pk` IS the date — so a window is N
- * partitions and no query shape collapses them. Bounded concurrency would cut
- * the wall time, but the obvious version breaks two properties this file relies
- * on: each in-flight day may spend the whole remaining candidate budget, so K
- * concurrent days hold up to K×MAX_CANDIDATES rows (the cap exists to bound
- * exactly that), and dividing the budget per day makes a moderate day report
- * `dayPartiallyRead` when the total is nowhere near the cap — a false truncation
- * signal in the one mechanism this file exists to make trustworthy. That is a
- * budgeting decision to take on its own, with a measurement; empty partitions
- * are cheap, so the cost lands on tenants with data across the whole window.
+ * Days are read DAY_SCAN_CONCURRENCY at a time, newest wave first. Sequentially
+ * a 90-day window is 90 round trips awaited mid-turn while the user watches a
+ * half-rendered answer; at a 12ms round trip that measured p99 1092ms against
+ * 153ms in waves of 8 — less even than the 30-day sequential scan this widening
+ * replaced (364ms), so the window got three times wider and still got faster.
+ *
+ * A range query is not available: `voc-context.ts::sumMetricWindow` escapes
+ * per-day reads because METRIC rows share one partition with a sortable date
+ * key, so BETWEEN bounds the window server-side. Feedback rows do not — `gsi1pk`
+ * IS the date — so a window is N partitions and no query shape collapses them.
+ * Concurrency is what is left, and it is safe here only because the candidate
+ * budget is one shared counter rather than a per-day slice; see CandidateBudget
+ * for why the sliced version would both hold K× the rows and invent truncation
+ * signals that never happened.
  */
 async function fetchCandidatesByDate(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
   days: number,
+  candidateCap: number,
 ): Promise<{ candidates: FeedbackItem[]; reasons: TruncationReason[] }> {
   const now = new Date();
-  const candidates: FeedbackItem[] = [];
-  // Reasons accumulate into an array rather than a reassigned flag because this
-  // package bans `let` (eslint no-restricted-syntax).
-  const reasons: TruncationReason[] = [];
-
-  for (const i of Array.from({ length: days }, (_, idx) => idx)) {
+  const dates = Array.from({ length: days }, (_, i) => {
     const d = new Date(now);
     d.setUTCDate(d.getUTCDate() - i);
-    const dateStr = d.toISOString().slice(0, 10);
-    try {
-      const day = await fetchDayPages(docClient, feedbackTable, dateStr, candidates);
-      if (day.truncated) reasons.push('dayPartiallyRead');
-      if (day.dropped > 0) reasons.push(...noteDroppedRows(dateStr, day.dropped));
-    } catch (error) {
-      reasons.push(...noteFailedDay(dateStr, error));
-    }
-    if (candidates.length >= MAX_CANDIDATES) {
-      // Days still unread => the window was never fully scanned. `days` is the
-      // whole window here, clamped or not, so this cannot claim "nothing left
-      // unread" about days the caller asked for and the loop never reached.
-      if (i < days - 1) reasons.push('daysUnread');
-      break;
-    }
+    return d.toISOString().slice(0, 10);
+  });
+  const waves = Array.from(
+    { length: Math.ceil(dates.length / DAY_SCAN_CONCURRENCY) },
+    (_, i) => dates.slice(i * DAY_SCAN_CONCURRENCY, (i + 1) * DAY_SCAN_CONCURRENCY),
+  );
+  return scanWaves(docClient, feedbackTable, waves, { cap: candidateCap, spent: 0 });
+}
+
+/** One day, never throwing: a failed read is a reported hole, not a lost scan. */
+async function readOneDay(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  dateStr: string,
+  budget: CandidateBudget,
+): Promise<{ items: FeedbackItem[]; reasons: TruncationReason[] }> {
+  const items: FeedbackItem[] = [];
+  try {
+    const day = await fetchDayPages(docClient, feedbackTable, dateStr, items, budget);
+    return {
+      items,
+      reasons: [
+        ...(day.truncated ? ['dayPartiallyRead' as const] : []),
+        ...(day.dropped > 0 ? noteDroppedRows(dateStr, day.dropped) : []),
+      ],
+    };
+  } catch (error) {
+    return { items, reasons: noteFailedDay(dateStr, error) };
   }
-  return { candidates, reasons };
+}
+
+/**
+ * Read the waves in order, stopping once the candidate budget is gone.
+ *
+ * Recursion rather than a loop because the accumulator has to stay `const`.
+ * Ordering is by DATE, not completion: each wave's days are concatenated in the
+ * order they were dispatched, so list mode's default 'recent' sort — which is
+ * the scan order itself — is unchanged from the sequential version.
+ */
+async function scanWaves(
+  docClient: DynamoDBDocumentClient,
+  feedbackTable: string,
+  waves: string[][],
+  budget: CandidateBudget,
+  acc: { candidates: FeedbackItem[]; reasons: TruncationReason[] } = { candidates: [], reasons: [] },
+  index = 0,
+): Promise<{ candidates: FeedbackItem[]; reasons: TruncationReason[] }> {
+  if (index >= waves.length) return acc;
+  const reads = await Promise.all(
+    waves[index].map((dateStr) => readOneDay(docClient, feedbackTable, dateStr, budget)),
+  );
+  const next = {
+    candidates: [...acc.candidates, ...reads.flatMap((r) => r.items)],
+    reasons: [...acc.reasons, ...reads.flatMap((r) => r.reasons)],
+  };
+  if (budgetExhausted(budget)) {
+    // Waves after this one were never dispatched, so those days are genuinely
+    // unread. Every day WITHIN this wave was read, hence the wave-level test:
+    // claiming 'daysUnread' for them would be a truncation that did not happen.
+    return index + 1 < waves.length
+      ? { ...next, reasons: [...next.reasons, 'daysUnread'] }
+      : next;
+  }
+  return scanWaves(docClient, feedbackTable, waves, budget, next, index + 1);
 }
 
 /**
@@ -417,6 +498,9 @@ export async function executeSearchFeedback(
   feedbackTable: string,
   toolInput: unknown,
   contextFilters: ContextFilters,
+  // Overridable so the cap-reached cases can be driven with a handful of rows
+  // instead of materialising MAX_CANDIDATES zod-parsed fixtures per test.
+  candidateCap: number = MAX_CANDIDATES,
 ): Promise<SearchFeedbackResult> {
   const {
     input, query, mode, limit, days, requestedDays, filters,
@@ -430,7 +514,7 @@ export async function executeSearchFeedback(
     if (idResult) return idResult;
   }
 
-  const scan = await fetchCandidatesByDate(docClient, feedbackTable, days);
+  const scan = await fetchCandidatesByDate(docClient, feedbackTable, days, candidateCap);
   // The clamp is a truncation like any other: the caller asked about a longer
   // window than this scan can reach, so the answer covers less than the
   // question did and has to say which window it actually read.

--- a/voc-datalake/lambda/stream/src/tools/search-feedback.ts
+++ b/voc-datalake/lambda/stream/src/tools/search-feedback.ts
@@ -71,6 +71,21 @@ const feedbackItemSchema = z.object({
 
 type FeedbackItem = z.infer<typeof feedbackItemSchema>;
 
+/**
+ * What the tool hands back.
+ *
+ * `isPartial` is true when the candidate scan was truncated, so `items` and the
+ * counts in `formatted` describe a sample rather than the whole window. The
+ * same warning is written into `formatted` (see `truncationNotice`) because the
+ * consumer here is the model, which only reads the prose — a flag that never
+ * reaches the text would change nothing for the user.
+ */
+interface SearchFeedbackResult {
+  items: FeedbackItem[];
+  formatted: string;
+  isPartial: boolean;
+}
+
 // ── Filtering ──
 
 // Shape guard: a malformed source_created_at ("unavailable") would compare
@@ -134,7 +149,7 @@ async function lookupByFeedbackId(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
   feedbackId: string,
-): Promise<{ items: FeedbackItem[]; formatted: string } | null> {
+): Promise<SearchFeedbackResult | null> {
   try {
     const resp = await docClient.send(
       new QueryCommand({
@@ -147,7 +162,8 @@ async function lookupByFeedbackId(
     );
     const items = (resp.Items ?? []).map((raw) => feedbackItemSchema.parse(raw));
     if (items.length > 0) {
-      return { items, formatted: formatToolResults(items) };
+      // A direct ID hit reads one row by key: nothing was truncated.
+      return { items, formatted: formatToolResults(items), isPartial: false };
     }
   } catch {
     // Fall through to date-based search
@@ -164,12 +180,31 @@ async function lookupByFeedbackId(
 const MAX_CANDIDATES = 10000;
 
 /**
+ * How many days back the date scan may reach, however many the chat context
+ * asks for. Mirror of `MAX_LOOKBACK_DAYS` in lambda/shared/feedback.py, which
+ * the REST feedback routes spend as `days=min(days, MAX_LOOKBACK_DAYS)`.
+ *
+ * This runtime cannot import the Python constant, so the two are pinned
+ * together by lambda/shared/test/test_lookback_window_lockstep.py: it parses
+ * the declaration below and fails when the numbers diverge. It read 30 here
+ * against 90 there for months, so the chat tool answered "last quarter" from a
+ * month of feedback while the REST route used the full window.
+ *
+ * Keep the literal on one line as `export const MAX_LOOKBACK_DAYS = <n>` — the
+ * lockstep test parses this text.
+ */
+export const MAX_LOOKBACK_DAYS = 90;
+
+/**
  * Page through one day's GSI partition via LastEvaluatedKey (not just the
  * first page), appending valid rows to `candidates`. Per-row safeParse: a
  * single malformed item must not throw and discard the whole day's results.
  * Recursion depth = pages in the day's partition; the MAX_CANDIDATES check
  * stops early only as parsed rows accumulate (a day of entirely malformed
  * rows still pages to its end, same as the previous do/while).
+ *
+ * Returns true when the day still had pages left but MAX_CANDIDATES stopped
+ * the walk — i.e. this day was truncated and the caller's answer is a sample.
  */
 async function fetchDayPages(
   docClient: DynamoDBDocumentClient,
@@ -177,7 +212,7 @@ async function fetchDayPages(
   dateStr: string,
   candidates: FeedbackItem[],
   startKey?: Record<string, unknown>,
-): Promise<void> {
+): Promise<boolean> {
   const resp = await docClient.send(
     new QueryCommand({
       TableName: feedbackTable,
@@ -192,31 +227,50 @@ async function fetchDayPages(
     const parsed = feedbackItemSchema.safeParse(raw);
     if (parsed.success) candidates.push(parsed.data);
   }
-  if (resp.LastEvaluatedKey && candidates.length < MAX_CANDIDATES) {
-    return fetchDayPages(docClient, feedbackTable, dateStr, candidates, resp.LastEvaluatedKey);
-  }
+  if (!resp.LastEvaluatedKey) return false;
+  if (candidates.length >= MAX_CANDIDATES) return true;
+  return fetchDayPages(docClient, feedbackTable, dateStr, candidates, resp.LastEvaluatedKey);
 }
 
+/**
+ * Collect candidates day by day, newest first, bounded by MAX_LOOKBACK_DAYS
+ * and MAX_CANDIDATES.
+ *
+ * Returns `{ candidates, isPartial }`. `isPartial` is true when the scan was
+ * cut short — a day partition had more pages than the candidate budget
+ * allowed, or the budget ran out with days still unread — so the caller knows
+ * it holds a sample rather than the whole window. Mirrors the Python route's
+ * `_scan_recent_items` in lambda/api/metrics_handler.py, which returns
+ * `(items, is_partial)` for the same reason.
+ */
 async function fetchCandidatesByDate(
   docClient: DynamoDBDocumentClient,
   feedbackTable: string,
   days: number,
-): Promise<FeedbackItem[]> {
+): Promise<{ candidates: FeedbackItem[]; isPartial: boolean }> {
   const now = new Date();
   const candidates: FeedbackItem[] = [];
+  const scannedDays = Math.min(days, MAX_LOOKBACK_DAYS);
+  // Each entry is one reason the scan was incomplete. An array rather than a
+  // reassigned flag because this package bans `let` (eslint no-restricted-syntax).
+  const truncations: boolean[] = [];
 
-  for (const i of Array.from({ length: Math.min(days, 30) }, (_, idx) => idx)) {
+  for (const i of Array.from({ length: scannedDays }, (_, idx) => idx)) {
     const d = new Date(now);
     d.setUTCDate(d.getUTCDate() - i);
     const dateStr = d.toISOString().slice(0, 10);
     try {
-      await fetchDayPages(docClient, feedbackTable, dateStr, candidates);
+      truncations.push(await fetchDayPages(docClient, feedbackTable, dateStr, candidates));
     } catch {
       // continue to the next day
     }
-    if (candidates.length >= MAX_CANDIDATES) break;
+    if (candidates.length >= MAX_CANDIDATES) {
+      // Days still unread => the window was never fully scanned.
+      truncations.push(i < scannedDays - 1);
+      break;
+    }
   }
-  return candidates;
+  return { candidates, isPartial: truncations.includes(true) };
 }
 
 // ── Main export ──
@@ -254,7 +308,7 @@ export async function executeSearchFeedback(
   feedbackTable: string,
   toolInput: unknown,
   contextFilters: ContextFilters,
-): Promise<{ items: FeedbackItem[]; formatted: string }> {
+): Promise<SearchFeedbackResult> {
   const { input, query, mode, limit, days, filters } = resolveSearchParams(toolInput, contextFilters);
 
   if (!feedbackTable) throw new ConfigurationError('Feedback table not configured');
@@ -265,7 +319,7 @@ export async function executeSearchFeedback(
     if (idResult) return idResult;
   }
 
-  const candidates = await fetchCandidatesByDate(docClient, feedbackTable, days);
+  const { candidates, isPartial } = await fetchCandidatesByDate(docClient, feedbackTable, days);
 
   // Days-long window ending today (same definition as the metrics API).
   // Review basis compares against the date the customer wrote the item; the
@@ -284,7 +338,11 @@ export async function executeSearchFeedback(
   // so "summarize all feedback" / "top issues" don't force the model to loop.
   if (mode === 'aggregate') {
     const examples = [...allMatched].sort(compareByUrgency).slice(0, limit);
-    return { items: examples, formatted: formatAggregate(allMatched, examples) };
+    return {
+      items: examples,
+      formatted: formatAggregate(allMatched, examples, isPartial) + truncationNotice(isPartial, days),
+      isPartial,
+    };
   }
 
   if (input.sort_by === 'urgency') {
@@ -292,10 +350,30 @@ export async function executeSearchFeedback(
   }
   const matched = allMatched.slice(0, limit);
 
-  return { items: matched, formatted: formatToolResults(matched) };
+  return {
+    items: matched,
+    formatted: formatToolResults(matched) + truncationNotice(isPartial, days),
+    isPartial,
+  };
 }
 
 // ── Formatting ──
+
+/**
+ * The line the model reads when the scan was truncated.
+ *
+ * Empty when the window was fully read, so a complete answer carries no
+ * hedging. Phrased as an instruction because the consumer is the model: left as
+ * a bare boolean on the returned object it would never reach the user, who has
+ * no other way to tell a capped answer from a complete one.
+ */
+function truncationNotice(isPartial: boolean, days: number): string {
+  if (!isPartial) return '';
+  return `\n⚠️ INCOMPLETE RESULTS: the ${days}-day window holds more feedback than this `
+    + `search could read (candidate cap ${MAX_CANDIDATES}), so the items and any counts `
+    + 'above are a partial sample of the most recent days — not the whole window. Say so '
+    + 'when you answer, and do not present these totals or percentages as complete.\n';
+}
 
 function formatSingleItem(item: FeedbackItem, index: number): string {
   const sourceDate = item.source_created_at?.slice(0, 10) ?? 'N/A';
@@ -341,7 +419,11 @@ function formatDistribution(label: string, dist: [string, number][], total: numb
 // One-call summary over the ENTIRE match set: total, distributions by urgency /
 // sentiment / category / source, average rating, plus the top examples (already
 // urgency-sorted) so the model can quote specifics without another search.
-function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[]): string {
+// When the candidate scan was truncated (`isPartial`) the "COMPLETE set" claim
+// below is false, and it is the most dangerous sentence in this file: the model
+// is told in so many words to base its answer on numbers that only cover the
+// most recent slice of the window. So the header states which it is.
+function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[], isPartial = false): string {
   const total = all.length;
   if (total === 0) return 'No feedback found matching the search criteria.';
 
@@ -351,9 +433,14 @@ function formatAggregate(all: FeedbackItem[], examples: FeedbackItem[]): string 
     : 'N/A';
 
   const sections = [
-    `Aggregate summary over ALL ${total} matching feedback items `,
-    `(this is the COMPLETE set, not a sample — base your answer on these numbers):\n\n`,
-    `**Total matches:** ${total}\n`,
+    isPartial
+      ? `Aggregate summary over ${total} matching feedback items `
+      : `Aggregate summary over ALL ${total} matching feedback items `,
+    isPartial
+      ? '(⚠️ PARTIAL — the scan hit its candidate cap, so this is a sample of the most '
+        + 'recent days in the window, NOT the complete set; say so when you answer):\n\n'
+      : '(this is the COMPLETE set, not a sample — base your answer on these numbers):\n\n',
+    `**Total matches:** ${total}${isPartial ? ' (partial — scan truncated)' : ''}\n`,
     `**Average rating:** ${avgRating}\n\n`,
     formatDistribution('By urgency', countBy(all, 'urgency'), total),
     formatDistribution('By sentiment', countBy(all, 'sentiment_label'), total),


### PR DESCRIPTION
## Summary

The streaming chat tool answered from a third of the window the REST route uses, and said nothing about it. Two halves of one defect, fixed together.

**Part 1 — the window.** `fetchCandidatesByDate` clamped its day loop at a bare `30` while the REST feedback routes spend `shared/feedback.py`'s `MAX_LOOKBACK_DAYS = 90` (lines 553, 589). A user asking the chat about a quarter of feedback got a month of it. The clamp is now `Math.min(days, MAX_LOOKBACK_DAYS)` against an exported constant, pinned to Python by the new lockstep test rather than retyped as a loose literal. The constant is declared in `feedback-scan.ts` and spent in exactly one place — `resolveSearchParams` in `search-feedback.ts` — so the scan bound, the cutoff filter and the notice cannot disagree about which window an answer covers. Clamping in two places is the defect `metrics_handler.py` carries a warning about from having had it.

**Part 2 — saying when the answer is capped.** The tool had three silent stopping points (`MAX_CANDIDATES`, the `fetchDayPages` recursion guard, the day-loop `break`) and reported none. Widening the window makes that silence more dangerous, not less. Review found three more, so truncation ended up modelled as a **set of reasons rather than a boolean**: `fetchCandidatesByDate` returns `{ candidates, reasons, unmeasured }`, where `reasons` is drawn from `windowClamped` · `dayPartiallyRead` · `daysUnread` · `dayReadFailed` · `rowsDropped`. Each gets its own clause in the model-facing notice, because one cause named for all of them misattributes the rest — "the candidate cap" is a wrong explanation for a throttled partition. `metrics_handler._scan_recent_items`'s `(items, is_partial)` is still the reference; this runtime needs more because it has failure modes Python's does not (`_query_partition` propagates a failed read, this scan survives one — so a survived failure has to be reported rather than left looking like an empty day).
**Two distinctions inside that set carry the weight.** `scanWasIncomplete()` separates "did the scan read what it scanned" from "does the answer cover less than the question": a clamped-but-fully-read window keeps its completeness claim and gets a paragraph naming the window it did read, instead of being called a truncated scan it never was. And a day reports `reached` explicitly, so a partition whose *later* page fails keeps the rows its first page returned — deriving that from "did this day end with an error" discarded every row of a substantially-read window and told the model the store was unreachable.

**Part 3 — the lockstep guard.** `lambda/shared/test/test_lookback_window_lockstep.py`, modelled on `test_search_minimum_lockstep.py`: parse the TypeScript, assert equality, with the positive control (`test_the_stream_constant_is_findable`, deliberately unskipped) so a rename can't leave the equality test comparing against `None`. I added `test_the_chat_tool_spends_the_constant_rather_than_a_literal` because a constant that agrees with Python is worthless if the day loop quietly re-acquires a hard-coded clamp of its own; that is exactly how this drifted the first time. Review hardened it twice more, to **7 tests**: it now reads every chat-tool source as a set rather than one path (the constant is declared in one file and spent in another, and a guard bound to a single path passed a mutation that moved the clamp), and it rejects the clamp idioms this codebase actually writes — a bare literal, a renamed operand, reversed arguments, a ternary — while not counting prose or a commented-out use as spending the constant.

### The two decisions you asked me to record

**Where the flag rides: both, and the prose is the part that matters.** `isPartial` is on the returned object *and* written into `formatted`. The object field is for callers and tests; on its own it would change nothing, because `executor.ts` passes only `result.formatted` to the model as tool output and `result.items.slice(0, 5)` as sources — a boolean sitting on the result object is read by nobody. So the notice is prose, phrased as an instruction ("Say so when you answer, and do not present these totals as complete"), since the consumer reasons over text rather than inspecting fields.

**Aggregate mode's header had to change too.** `formatAggregate` told the model *"this is the COMPLETE set, not a sample — base your answer on these numbers"*. Appending a warning underneath while leaving that sentence intact would hand the model two contradictory claims about the same numbers, and the confident one comes first. When `isPartial`, the header now says PARTIAL and `**Total matches:**` is annotated `(partial — scan truncated)`. When the window was fully read the wording is untouched, so a complete answer carries no hedging.

### Reported, not changed

**The candidate ceilings still disagree: TS `MAX_CANDIDATES = 10000` vs Python `CANDIDATES_SOFT_CAP = 1000`** (`metrics_handler.py:51`). Left as-is per the task. Worth noting the two are not obviously one rule with two copies — they budget different consumers (a model reading a prose digest in a single turn vs. a paginating HTTP client), so closing the gap is a behaviour decision about which number is right, not a port. The lockstep test says so in its module docstring, so the next reader doesn't assume the omission was an oversight and pin a divergence nobody decided to close.

**Nothing was needed outside `lambda/stream/`.** The flag reaches the model through `formatted`, which `executor.ts` already forwards, so no handler, tool-registry or frontend change was required. `mcp_handler.py`, the MCP registry, the REST routes, `MAX_LOOKBACK_DAYS` itself, both soft caps and the frontend are all untouched. `lambda/stream/dist/` is gitignored and was left to the build.

## Files changed

The tool was **split along the seam this work exposed**: everything answering "what could this read reach?" moved to `feedback-scan.ts`, so a new stopping point is added beside the ones that already report themselves rather than beside the formatters, where reporting is easy to forget. That is how three silent stops accumulated in the first place.

- `voc-datalake/lambda/stream/src/tools/feedback-scan.ts` — **new**: the reads, the shared candidate budget, bounded-concurrent day waves, and every shortfall they have to admit
- `voc-datalake/lambda/stream/src/tools/feedback-scan.test.ts` — **new**: fan-out width, date ordering under concurrency, the shared budget
- `voc-datalake/lambda/stream/src/tools/search-feedback.ts` — filtering, formatting, and the prose the model reads (the window is resolved here, once)
- `voc-datalake/lambda/stream/src/tools/search-feedback.test.ts` — extended in place
- `voc-datalake/lambda/shared/test/test_lookback_window_lockstep.py` — **new**, 7 tests

## Build and test results

Every number below is from a run on the current head, and the two baselines are measured against the base commit rather than quoted.

| Gate | Result |
|---|---|
| stream `vitest run` | **399 passed**, 24 files (base commit: 387) |
| stream `eslint src/` | **0 errors, 1 warning** — identical to the base commit, which has the same single pre-existing warning (`indexes.test.ts` `readFileSync`) |
| stream `tsc --noEmit` | clean |
| frontend `tsc --noEmit` | clean |
| frontend `vitest run` | **3069 passed**, 185 files |
| CDK `tsc --noEmit -p tsconfig.json` | clean |
| `pytest lambda -q --no-cov` | **3413 passed, 0 failed** (base commit: 3406; +7 lockstep tests) |
| `ruff check lambda plugins` | 509 findings — unchanged from the base commit; the new test file alone: "All checks passed!" |

The lint comparison was made by stashing the change, running `eslint src/` on the base commit, and restoring — not by assuming. That check caught two warnings this branch had introduced (an unused disable directive and a `promise/no-promise-in-callback`), both since removed, which is why the counts now match exactly.

### Scan latency (p99), measured

Requested in the task. `fetchCandidatesByDate` over empty partitions, 100 runs per configuration, 12 ms simulated round trip, wave width varied by patching the constant:

| Window | Wave width | p50 | p99 |
|---|---|---|---|
| 90 days | 8 (shipped) | 146 ms | **155 ms** |
| 90 days | 1 (sequential) | 1088 ms | **1092 ms** |
| 30 days | 1 (the pre-widening baseline) | 363 ms | **365 ms** |
| 30 days | 8 | 49 ms | 49 ms |

So the window is three times wider and the p99 is **~2.4× lower than the 30-day scan it replaces** (155 ms vs 365 ms), and ~7× lower than reading 90 days sequentially.

Two honesty notes on these figures. They are a *harness* measurement, not a deployed one: an independent check of the floor — 90 sequential 12 ms sleeps in bare Node — measures 1089 ms, which the sequential row reproduces (1092 ms), so the numbers reflect round-trip structure and essentially no measurement overhead. And they say nothing about real DynamoDB latency variance, request concurrency limits, or a table with data in every partition; empty partitions are the cheap case, so the concurrency win is if anything understated and the absolute numbers are not a production p99.

An earlier draft of this table reported 90-day and 30-day sequential as identical, which was a harness bug (a restore had reverted the day count) rather than a finding — caught by comparing against the sleep floor above.

### Verifying the tests actually bind

Every assertion added or changed was checked by reverting the behaviour under it and confirming that specific test — and only it — fails:

| Reverted | Test that failed |
|---|---|
| dropped-row share gate → any-row trigger | "keeps the completeness claim when a single legacy row fails the schema" |
| unmeasured-window branch | "does not report an unmeasured window as an empty one" |
| aggregated logging → per-day | "logs one line per fault, not one per day" |
| systemic-error short circuit | "stops after the first wave …" |
| ID lookup `safeParse` → `parse` | "reports an unreadable row instead of scanning 90 days about something else" |
| aggregate header predicate → `isPartial` | "does not call a clamped-but-fully-read window a truncated scan" |
| `scanWasIncomplete` → `reasons.length > 0` | the four clamp-window tests |
| narrowed-window notice branch | the four clamp-window tests |
| lockstep: constant → 30 | equality test |
| lockstep: `Math.min(30, requestedDays)` | clamp-property test |
| lockstep: ternary clamp | clamp-property test |
| lockstep: a second declaration elsewhere | positive control + equality test |

The lockstep mutations were applied to the real sources, not only to synthetic strings — which is how the earlier `strip_comments` gap was found, and how this round confirmed the guard still binds now that the constant has moved file.

## Agent notes

**What went well.** The task pointed at a merged reference (`_scan_recent_items`) and the exact precedent file for the guard, which removed essentially all design guesswork — the `(items, is_partial)` shape and the skipif-plus-positive-control test structure both transplanted directly.

**What was difficult, and what I'd flag.**

1. *The interesting part wasn't the flag, it was the sentence already in the file.* `formatAggregate` asserted completeness in imperative prose. Threading `isPartial` into the return object and appending a warning would have left the tool telling the model, in one message, both "base your answer on these numbers, they are complete" and "these numbers are partial". For a prose consumer that is not a fixed bug. Worth a look at whether other tool formatters in `src/tools/` make similar unconditional completeness claims.
2. *A revert check caught a test that passed for the wrong reason.* Both truncation branches can fire in the same call, so a test aimed at one can be satisfied by the other. Reverting each branch separately was the only way to tell.
3. *`let` is banned in this package* (`no-restricted-syntax`, `eslint.config.js:69`), so the accumulating flag is collected into an array and reduced with `.includes(true)`. Slightly unusual-looking; the comment explains why.
4. *`sonarjs/no-identical-functions` is on for tests*, which flagged my locally-defined `isoDaysAgo` as identical to the existing `daysAgo` inside the date-basis describe. I hoisted one shared helper to module scope instead of duplicating.

**Conventions discovered.** Commit and PR titles are `<type>(<module>): <lowercase imperative>` with the PR number appended on merge. Cross-language invariants are pinned by parsing the other language's source, always with a positive control asserting the parse still works — `test_indexes.py`, `test_search_minimum_lockstep.py`, `test_image_limits_lockstep.py`, and now this one. Comments in this codebase explain *why a thing would otherwise break*, often citing the issue number of the incident; matching that register matters more here than in most repos.

**Suggestions for future tasks.** (a) Declare `aws-xray-sdk`, `pydantic` and `tenacity` in `requirements-dev.txt` — without them a fresh checkout cannot run the backend suite at all. (b) `lambda/stream/` needs its own `npm install`; the root install does not reach it. (c) The frontend build needs a raised file-descriptor limit — it dies with `EMFILE` at `ulimit -n 1024`. (d) The candidate-ceiling divergence noted above is a live decision someone should make deliberately.

## What changed after review, and why it is worth reading the commits

Five commits, four of them responses to review. The direction never changed; what changed is
how much of the tool's own honesty machinery turned out to be dishonest.

| Commit | What it fixed |
|---|---|
| `cf21a00` | the window, the flag, the notice, the lockstep guard |
| `46e7b87` | three more silent stops: the clamp itself was unreported truncation and the cutoff used the **unclamped** `days`; a swallowed per-day error dropped a partition without a flag; `safeParse` losses were invisible. Truncation became a set of *reasons* |
| `9ec6f69` | the day loop became bounded-concurrent waves (90 serial round trips sat in front of the first streamed token), on one shared candidate budget rather than a per-day slice |
| `c948f1b` | split into `feedback-scan.ts` / `search-feedback.ts`; dropped-row reason gated on a *share* so one permanent legacy row stops hedging every answer forever |
| `0f7060f` | `scanWasIncomplete` — stop calling a clamped-but-fully-read window a truncated scan |
| `5228ebd8` | **a day whose later page failed was classed as never read**, so a window that read 450 rows returned 0 and told the model the store was unreachable. `reached` now says it explicitly |
| `6e885a0c` | bound the budget overshoot instead of pinning it — an equality would have failed the reserve-before-dispatch correction the docblock contemplates |

The pattern worth flagging to a reviewer: **three of these were introduced by a commit that was
fixing a different reporting bug.** In a change whose entire subject is "report shortfalls
accurately", every restructure is a chance to break the reporting on a new axis, which is why the
revert table above matters more here than the pass count does.

## Verification

```abca-verify
no-ui
```

This change is entirely inside the streaming Lambda's `search_feedback` tool. Everything it produces — the widened day loop and the truncation notice — reaches a user only as text the model emits mid-conversation, which requires signing in, opening the chat, sending a message that triggers the tool, and a corpus large enough to exceed the candidate cap. None of that is present on page load in an empty-database preview, and there is no static chrome to assert. Pinned by the Vitest and pytest suites above instead, with revert checks proving each assertion binds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

