### PR TITLE
fix(core): give the website bucket server access logging (CKV_AWS_18)

### DIFF
--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -8,21 +8,55 @@
  * Pre-#105 environments deploy with `-c omitUserPoolUsernameConfiguration=true`
  * to keep their pool untouched; greenfield keeps case-insensitive sign-in.
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { z } from 'zod';
 import { VocCoreStack } from './core-stack';
 import { ALLOWED_MODEL_IDS, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION_PX } from '../utils/model-allowlist';
+// The same fixed synth environment the whole-app harness uses, imported rather
+// than re-declared: a second copy of the literals drifts silently, and an
+// assertion about a resolved `aws:SourceAccount` would then pin an account no
+// other suite uses. Importing costs nothing at module load — synth-app.ts only
+// shells out to `cdk synth` inside `synthApp()`.
+import { SYNTH_ACCOUNT, SYNTH_REGION } from '../test-support/synth-app';
 
-/** Fixed synth account, so resolved `aws:SourceAccount`-style values are assertable. */
-const SYNTH_ACCOUNT = '111111111111';
+/**
+ * Feature flags from cdk.json, i.e. what a real deploy of this project gets.
+ *
+ * Read rather than listed, mirroring `baseContext()` in
+ * lib/test-support/synth-app.ts, because several flags change the SHAPE of the
+ * synthesized template and not just its details. The one this file asserts
+ * about is `@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy`, which decides
+ * whether S3 log delivery is granted by a statement on the destination's bucket
+ * policy or by a `LogDeliveryWrite` ACL — both of which render an identical
+ * `LoggingConfiguration` on the source, so a bare `App` would let this file pin
+ * a grant shape no deploy produces. Reading the file keeps the test and the
+ * deploy configuration from drifting apart: flip or delete the flag in cdk.json
+ * and these assertions follow it instead of quietly describing the old world.
+ *
+ * Parsed, not cast: `context` missing or malformed would otherwise spread as
+ * nothing and silently return every template to the bare-`App` shape.
+ */
+const CDK_JSON_FEATURE_FLAGS = z
+  .object({ context: z.record(z.string(), z.unknown()) })
+  .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
+  .context;
 
 function synthCoreTemplate(context: Record<string, unknown> = {}): Template {
   // Skip asset bundling (Docker) — template assertions only need structure.
-  const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true, ...context } });
+  const app = new cdk.App({
+    context: {
+      ...CDK_JSON_FEATURE_FLAGS,
+      'aws:cdk:bundling-stacks': [],
+      skipFrontendBuildCheck: true,
+      ...context,
+    },
+  });
   const stack = new VocCoreStack(app, 'TestCoreStack', {
-    env: { account: SYNTH_ACCOUNT, region: 'us-east-1' },
+    env: { account: SYNTH_ACCOUNT, region: SYNTH_REGION },
     brandName: 'TestBrand',
   });
   return Template.fromStack(stack);
@@ -204,20 +238,21 @@ describe('VocCoreStack S3 server access logging', () => {
     cdk_nag: z.object({ rules_to_suppress: z.array(z.object({ id: z.string() })) }).optional(),
   });
 
+  /** A bucket policy resource, down to the statement list this block reads. */
+  const PolicyResourceSchema = z.object({
+    Properties: z.object({ PolicyDocument: z.object({ Statement: z.array(z.unknown()) }) }),
+  });
+
   /**
-   * The stack as a real deploy renders its S3 log-delivery grants.
+   * The access-logs bucket's retention rule.
    *
-   * `@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy` is `true` in cdk.json, but
-   * `synthCoreTemplate()` builds a bare `App` and so reads none of those feature
-   * flags. That one flag decides HOW the grant is expressed: with it CDK adds an
-   * `s3:PutObject` statement to the destination's bucket policy, without it it
-   * falls back to a `LogDeliveryWrite` bucket ACL. Both render a
-   * `LoggingConfiguration` on the source, so asserting against the bare default
-   * would pin a grant shape that no deploy of this project ever produces.
+   * `Prefix` is deliberately NOT in the schema — its ABSENCE is the property
+   * asserted below, so a rule that grows one must be read as a change rather
+   * than silently ignored by a lenient parse.
    */
-  function synthWithDeployedS3Flags(): Template {
-    return synthCoreTemplate({ '@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy': true });
-  }
+  const LifecycleSchema = z.object({
+    Rules: z.array(z.object({ ExpirationInDays: z.number(), Status: z.string() }).passthrough()),
+  });
 
   /**
    * Resolve one bucket from the template by logical-id prefix.
@@ -239,14 +274,20 @@ describe('VocCoreStack S3 server access logging', () => {
     return found[0];
   }
 
-  /** Statements on the access-logs bucket's own resource policy. */
+  /**
+   * Statements on the access-logs bucket's own resource policy.
+   *
+   * Guarantees two things before returning, as two distinct failures: exactly one
+   * `AccessLogsBucketPolicy*` resource exists, and its document carries a
+   * `Statement` array. Parsed with zod rather than cast, per `rawDataBucketCors()`
+   * above — a CDK property rename then surfaces as a schema error instead of an
+   * `undefined` that quietly satisfies every assertion downstream.
+   */
   function accessLogsPolicyStatements(template: Template): unknown[] {
     const policies = Object.entries(template.findResources('AWS::S3::BucketPolicy'))
       .filter(([logicalId]) => logicalId.startsWith('AccessLogsBucketPolicy'));
     expect(policies, 'expected exactly one AccessLogsBucket policy').toHaveLength(1);
-    const statements = policies[0][1].Properties?.PolicyDocument?.Statement;
-    expect(Array.isArray(statements), 'policy document has no Statement array').toBe(true);
-    return statements as unknown[];
+    return PolicyResourceSchema.parse(policies[0][1]).Properties.PolicyDocument.Statement;
   }
 
   // ONLY these two: the S3-import bucket is the third producer into this
@@ -263,7 +304,7 @@ describe('VocCoreStack S3 server access logging', () => {
     ['WebsiteBucket', 'website-bucket/'],
     ['RawDataBucket', 'raw-data-bucket/'],
   ])('ships %s logging into the access-logs bucket under %s', (prefix, logPrefix) => {
-    const template = synthWithDeployedS3Flags();
+    const template = synthCoreTemplate();
     const [accessLogsLogicalId] = bucketByLogicalIdPrefix(template, 'AccessLogsBucket');
     const [sourceLogicalId, bucket] = bucketByLogicalIdPrefix(template, prefix);
 
@@ -283,9 +324,13 @@ describe('VocCoreStack S3 server access logging', () => {
     // assertion every case above still passes in that state, which is the exact
     // failure this block exists to make legible.
     const grants = accessLogsPolicyStatements(template)
-      .map((statement) => LogDeliveryStatementSchema.safeParse(statement))
-      .filter((parsed) => parsed.success)
-      .map((parsed) => parsed.data)
+      .flatMap((statement) => {
+        // flatMap rather than filter+map on `success`: narrowing the safeParse
+        // union that way leans on TS 5.5+ inferred type predicates, and this
+        // reads the same without the dependency on that inference.
+        const parsed = LogDeliveryStatementSchema.safeParse(statement);
+        return parsed.success ? [parsed.data] : [];
+      })
       .filter((statement) => statement.Condition.ArnLike['aws:SourceArn']['Fn::GetAtt'][0] === sourceLogicalId);
     expect(grants, `no log-delivery grant for ${prefix} — S3 would accept the config and deliver nothing`)
       .toHaveLength(1);
@@ -307,16 +352,43 @@ describe('VocCoreStack S3 server access logging', () => {
     // the four producer prefixes do not already give.
     //
     // No suppression is missing either. cdk-nag's AwsSolutions-S1 has a fallback
-    // branch for a bucket with no loggingConfiguration: it scans every CfnBucket
-    // in the stack and returns COMPLIANT if any of them names this one as its
-    // destination. Three do, so this bucket is compliant by construction and
-    // raises no finding — AwsSolutions-VocCoreStack-NagReport.csv records it as
-    // `Compliant`. Worth stating because the tempting wrong conclusion is that
-    // some suppression elsewhere is quietly covering it; none is.
-    const template = synthWithDeployedS3Flags();
+    // branch for a bucket with no loggingConfiguration: it scans `Stack.of(node)`
+    // for a CfnBucket naming this one as its destination and returns COMPLIANT if
+    // it finds one. TWO do — RawDataBucket and WebsiteBucket — and the count is of
+    // SAME-STACK producers only, which is the part that is easy to get wrong: the
+    // S3-import bucket writes into this destination but lives in
+    // VocIngestionStack, outside the scan, and the CloudFront distribution's
+    // `cloudfront-frontend/` prefix never counts because a distribution is not a
+    // CfnBucket. So two of the four producers satisfy the rule, this bucket is
+    // compliant by construction and raises no finding —
+    // AwsSolutions-VocCoreStack-NagReport.csv records it as `Compliant`. Worth
+    // stating because the tempting wrong conclusion is that some suppression
+    // elsewhere is quietly covering it; none is. Move RawDataBucket to another
+    // stack and only WebsiteBucket would remain — move both and the rule starts
+    // firing here with nothing else changed.
+    const template = synthCoreTemplate();
     const [, accessLogs] = bucketByLogicalIdPrefix(template, 'AccessLogsBucket');
 
     expect(accessLogs.Properties ?? {}).not.toHaveProperty('LoggingConfiguration');
+  });
+
+  it('expires everything in the access-logs bucket at 90 days, with no prefix', () => {
+    // The premise two comments in this block rest on, and the reason adding a
+    // fourth producer needed no lifecycle change at all: the rule is BUCKET-WIDE,
+    // so `website-bucket/` — and `raw-data-bucket/`, `s3-import-bucket/`,
+    // `cloudfront-frontend/` — inherit the 90-day expiry without a rule of their
+    // own. The absence of `Prefix` is the load-bearing half. Add a prefix-scoped
+    // rule (the plausible next step: "keep CloudFront logs 30 days, S3 logs 90")
+    // and every unlisted prefix accumulates forever, which is invisible in a diff
+    // and would silently falsify both the comment above and this PR's claim that
+    // the destination needed no changes.
+    const [, accessLogs] = bucketByLogicalIdPrefix(synthCoreTemplate(), 'AccessLogsBucket');
+
+    const rules = LifecycleSchema.parse(accessLogs.Properties?.LifecycleConfiguration).Rules;
+    expect(rules, 'expected exactly one lifecycle rule on the access-logs bucket').toHaveLength(1);
+    expect(rules[0].ExpirationInDays).toBe(90);
+    expect(rules[0].Status).toBe('Enabled');
+    expect(rules[0]).not.toHaveProperty('Prefix');
   });
 
   it('carries no AwsSolutions-S1 suppression on the website bucket', () => {
@@ -327,7 +399,7 @@ describe('VocCoreStack S3 server access logging', () => {
     // Narrowed to this one rule on purpose: a future suppression on this bucket
     // for some OTHER finding is a legitimate act, and it must not fail a case
     // whose whole subject is AwsSolutions-S1.
-    const [, website] = bucketByLogicalIdPrefix(synthWithDeployedS3Flags(), 'WebsiteBucket');
+    const [, website] = bucketByLogicalIdPrefix(synthCoreTemplate(), 'WebsiteBucket');
 
     const suppressions = NagMetadataSchema.parse(website.Metadata ?? {}).cdk_nag?.rules_to_suppress ?? [];
     expect(suppressions.map((rule) => rule.id)).not.toContain('AwsSolutions-S1');

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -154,6 +154,69 @@ describe('VocCoreStack raw-data bucket CORS', () => {
 });
 
 /**
+ * Server access logging on the buckets that have a separate destination
+ * (Checkov CKV_AWS_18 / cdk-nag AwsSolutions-S1).
+ *
+ * The website bucket shipped without it and carried an AwsSolutions-S1
+ * suppression instead, reasoning that CloudFront's own logs covered it. They do
+ * not cover the same thing: CloudFront logs viewer requests, S3 server access
+ * logs record what actually reached the bucket — including anything that reaches
+ * it WITHOUT going through the distribution. Asserted here rather than left to
+ * the baseline hash so that removing the property reads as "the website bucket
+ * stopped logging" instead of "VocCoreStack's digest moved".
+ */
+describe('VocCoreStack S3 server access logging', () => {
+  const LoggingSchema = z.object({
+    DestinationBucketName: z.object({ Ref: z.string() }),
+    LogFilePrefix: z.string(),
+  });
+
+  /**
+   * Logical id of the access-logs bucket, resolved from the template rather than
+   * hard-coded: CDK appends an address hash to it, so the literal would need
+   * editing whenever the construct tree around it changes.
+   */
+  function bucketsByPrefix(template: Template, prefix: string) {
+    const found = Object.entries(template.findResources('AWS::S3::Bucket'))
+      .filter(([logicalId]) => logicalId.startsWith(prefix));
+    expect(found, `expected exactly one bucket named ${prefix}*`).toHaveLength(1);
+    return found[0];
+  }
+
+  it.each([
+    ['WebsiteBucket', 'website-bucket/'],
+    ['RawDataBucket', 'raw-data-bucket/'],
+  ])('ships %s logging into the access-logs bucket under %s', (prefix, logPrefix) => {
+    const template = synthCoreTemplate();
+    const [accessLogsLogicalId] = bucketsByPrefix(template, 'AccessLogsBucket');
+    const [, bucket] = bucketsByPrefix(template, prefix);
+
+    const logging = LoggingSchema.parse(bucket.Properties?.LoggingConfiguration);
+    expect(logging.DestinationBucketName.Ref).toBe(accessLogsLogicalId);
+    expect(logging.LogFilePrefix).toBe(logPrefix);
+  });
+
+  it('leaves the access-logs bucket without a destination of its own', () => {
+    // Deliberate, and the one place AwsSolutions-S1 stays unaddressed: S3 does
+    // not support a bucket delivering its own access logs to itself, so the
+    // scanner's finding here is a false positive rather than a gap.
+    const template = synthCoreTemplate();
+    const [, accessLogs] = bucketsByPrefix(template, 'AccessLogsBucket');
+
+    expect(accessLogs.Properties ?? {}).not.toHaveProperty('LoggingConfiguration');
+  });
+
+  it('carries no cdk_nag suppression on the website bucket', () => {
+    // The AwsSolutions-S1 suppression described the missing property above. With
+    // the property present the rule no longer fires, so a suppression would be
+    // dead metadata that a later audit has to re-litigate.
+    const [, website] = bucketsByPrefix(synthCoreTemplate(), 'WebsiteBucket');
+
+    expect(website.Metadata ?? {}).not.toHaveProperty('cdk_nag');
+  });
+});
+
+/**
  * Regression guards for issue #229: /avatars/* and /prototypes/* were served
  * with no viewer-side authorization at all.
  *

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -8,8 +8,6 @@
  * Pre-#105 environments deploy with `-c omitUserPoolUsernameConfiguration=true`
  * to keep their pool untouched; greenfield keeps case-insensitive sign-in.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
@@ -21,7 +19,7 @@ import { ALLOWED_MODEL_IDS, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION_PX } from '../u
 // silently. Importing costs nothing at module load — synth-app.ts only shells out
 // to `cdk synth` inside `synthApp()`, and its sole module-level work is a `join()`
 // on two path constants.
-import { SYNTH_ACCOUNT, SYNTH_REGION, committedFeatureFlags } from '../test-support/synth-app';
+import { SYNTH_ACCOUNT, SYNTH_REGION, cdkJsonContextStrict, committedFeatureFlags } from '../test-support/synth-app';
 
 /**
  * cdk.json's CDK feature flags, resolved once for every case in this file.
@@ -111,10 +109,7 @@ describe('VocCoreStack synth context', () => {
     // The first assertion is entailed by the third — if every key in
     // CDK_FEATURE_FLAGS is prefixed then no unprefixed key can be `in` it — and is
     // kept only because its failure message names the consequence.
-    const rawContext = z
-      .object({ context: z.record(z.string(), z.unknown()) })
-      .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
-      .context;
+    const rawContext = cdkJsonContextStrict();
     const projectKeys = Object.keys(rawContext).filter((key) => !key.startsWith('@aws-cdk'));
 
     expect(

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -52,7 +52,7 @@ import { SYNTH_ACCOUNT, SYNTH_REGION, committedFeatureFlags } from '../test-supp
  * KMS key policy 5 against 6. No assertion's outcome changes — the extractor's
  * S3 read and write statements have different resources and so never merge — but
  * a case that counts statements must be written against these numbers.
- * `pins the statement counts a real deploy's feature flags produce` below is what
+ * `merges IAM statements the way a real deploy's feature flags do` below is what
  * turns that from a comment into a guard.
  */
 const CDK_FEATURE_FLAGS = committedFeatureFlags();
@@ -97,10 +97,20 @@ describe('VocCoreStack synth context', () => {
     //
     // Compared against cdk.json's RAW context rather than just inspecting the
     // filtered result, which would be tautological: `committedFeatureFlags()`
-    // filters by this very prefix, so its own output trivially satisfies it. The
-    // claim worth asserting is that the filter is still THERE — so this fails
-    // exactly when a leak becomes possible, i.e. when cdk.json holds a
-    // non-`@aws-cdk` key and the filter has stopped dropping it.
+    // filters by this very prefix, so its own output trivially satisfies it.
+    //
+    // What this case does NOT do is prove the filter exists. It is a conjunction:
+    // it fails only when cdk.json holds a non-`@aws-cdk` key AND the filter has
+    // stopped dropping it. With every committed key prefixed today, deleting the
+    // filter leaves this green — so the filter's own removal is caught by
+    // `committedFeatureFlags` in lib/test-support/synth-app.test.ts, which feeds it
+    // synthetic context and therefore does not depend on what cdk.json happens to
+    // hold. This case guards the OTHER half: the day a project key is committed,
+    // it fails here rather than silently inverting a default-asserting case below.
+    //
+    // The first assertion is entailed by the third — if every key in
+    // CDK_FEATURE_FLAGS is prefixed then no unprefixed key can be `in` it — and is
+    // kept only because its failure message names the consequence.
     const rawContext = z
       .object({ context: z.record(z.string(), z.unknown()) })
       .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
@@ -119,14 +129,23 @@ describe('VocCoreStack synth context', () => {
     );
   });
 
-  it('pins the statement counts a real deploy\'s feature flags produce', () => {
+  it('merges IAM statements the way a real deploy\'s feature flags do', () => {
     // `@aws-cdk/aws-iam:minimizePolicies` merges statements that share a
     // resource set, so these three resources genuinely change shape between a
-    // bare `App` and this one (10→6, 2→1, 6→5). Breaking this case means the
-    // synth context moved: either the flag stopped arriving — which would also
-    // take the S3 log-delivery grants with it, since the same read supplies both
-    // — or a policy gained a statement. Both want reading, and neither should
-    // surface only as a baseline digest diff.
+    // bare `App` and this one (10→6, 2→1, 6→5).
+    //
+    // Named for the mechanism rather than for the numbers because the numbers
+    // move for TWO unrelated causes, and the failure gives no hint which: the
+    // flag stopped arriving (a synth-context regression, which would also take
+    // the S3 log-delivery grants with it — the same read supplies both), or one
+    // of these policies legitimately gained a statement. The assertion messages
+    // say so, since `expected 7 to be 6` after a least-privilege change would
+    // otherwise send a reader hunting through cdk.json.
+    //
+    // Worth a case at all because the flag going missing is not a digest-only
+    // event: it would fail all five app-baseline.test.ts comparisons too, whose
+    // message tells the maintainer to regenerate the baseline — exactly the wrong
+    // instruction. This is the case that names the cause.
     const template = synthCoreTemplate();
 
     const statementCount = (type: string, logicalIdPrefix: string, documentKey: string): number => {
@@ -136,9 +155,19 @@ describe('VocCoreStack synth context', () => {
       return StatementsSchema.parse(found[0][1].Properties?.[documentKey]).Statement.length;
     };
 
-    expect(statementCount('AWS::IAM::Policy', 'ProductDocExtractorLambdaServiceRoleDefaultPolicy', 'PolicyDocument')).toBe(6);
-    expect(statementCount('AWS::IAM::Policy', 'CdnSigningKeysLambdaServiceRoleDefaultPolicy', 'PolicyDocument')).toBe(1);
-    expect(statementCount('AWS::KMS::Key', 'VocKmsKey', 'KeyPolicy')).toBe(5);
+    const because = (resource: string) =>
+      `${resource}'s statement count moved: either the synth context lost `
+      + '@aws-cdk/aws-iam:minimizePolicies, or this policy gained a statement. Both want reading.';
+
+    expect(
+      statementCount('AWS::IAM::Policy', 'ProductDocExtractorLambdaServiceRoleDefaultPolicy', 'PolicyDocument'),
+      because('the doc-extractor role'),
+    ).toBe(6);
+    expect(
+      statementCount('AWS::IAM::Policy', 'CdnSigningKeysLambdaServiceRoleDefaultPolicy', 'PolicyDocument'),
+      because('the CDN signing-key role'),
+    ).toBe(1);
+    expect(statementCount('AWS::KMS::Key', 'VocKmsKey', 'KeyPolicy'), because('the KMS key')).toBe(5);
   });
 });
 
@@ -333,6 +362,16 @@ describe('VocCoreStack S3 server access logging', () => {
    * only the two expected keys and rejecting the rest means an added `Prefix`
    * fails at the parse, naming the offending key
    * (`Unrecognized key(s) in object: 'Prefix'`).
+   *
+   * That strictness is deliberately BROADER than the case's stated claim: ANY key
+   * not listed here fails the parse, including a benign one. Adding
+   * `id: 'expire-logs'` to the rule — no prefix, no retention change, the sort of
+   * edit made to reference a rule in the console — fails with
+   * `Unrecognized key(s) in object: 'Id'`, which reads like a prefix regression
+   * when nothing about prefixes moved. The remedy in that case is to ADD the key
+   * here, not to hunt a lifecycle bug. Over-rejection is the accepted trade
+   * because the alternative is worse in kind rather than degree: a lenient parse
+   * drops the key and the assertion passes while the property it guards is gone.
    */
   const LifecycleSchema = z.object({
     Rules: z.array(z.object({ ExpirationInDays: z.number(), Status: z.string() }).strict()),

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -15,11 +15,14 @@ import { z } from 'zod';
 import { VocCoreStack } from './core-stack';
 import { ALLOWED_MODEL_IDS, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION_PX } from '../utils/model-allowlist';
 
+/** Fixed synth account, so resolved `aws:SourceAccount`-style values are assertable. */
+const SYNTH_ACCOUNT = '111111111111';
+
 function synthCoreTemplate(context: Record<string, unknown> = {}): Template {
   // Skip asset bundling (Docker) — template assertions only need structure.
   const app = new cdk.App({ context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true, ...context } });
   const stack = new VocCoreStack(app, 'TestCoreStack', {
-    env: { account: '111111111111', region: 'us-east-1' },
+    env: { account: SYNTH_ACCOUNT, region: 'us-east-1' },
     brandName: 'TestBrand',
   });
   return Template.fromStack(stack);
@@ -164,6 +167,11 @@ describe('VocCoreStack raw-data bucket CORS', () => {
  * it WITHOUT going through the distribution. Asserted here rather than left to
  * the baseline hash so that removing the property reads as "the website bucket
  * stopped logging" instead of "VocCoreStack's digest moved".
+ *
+ * Each producer is checked at BOTH ends — the `LoggingConfiguration` on the
+ * source and the log-delivery grant on the destination's policy — because the
+ * source half alone can be perfectly well-formed while nothing is ever
+ * delivered.
  */
 describe('VocCoreStack S3 server access logging', () => {
   const LoggingSchema = z.object({
@@ -172,47 +180,157 @@ describe('VocCoreStack S3 server access logging', () => {
   });
 
   /**
-   * Logical id of the access-logs bucket, resolved from the template rather than
-   * hard-coded: CDK appends an address hash to it, so the literal would need
-   * editing whenever the construct tree around it changes.
+   * The log-delivery grant CDK writes onto the DESTINATION bucket's policy.
+   *
+   * `Resource` is an `Fn::Join` of the destination's Arn and `/<prefix>*`, and
+   * the condition pair is what scopes the grant to one named producer in one
+   * account rather than to any bucket anywhere that guesses the path.
    */
-  function bucketsByPrefix(template: Template, prefix: string) {
+  const LogDeliveryStatementSchema = z.object({
+    Action: z.literal('s3:PutObject'),
+    Effect: z.literal('Allow'),
+    Principal: z.object({ Service: z.literal('logging.s3.amazonaws.com') }),
+    Resource: z.object({ 'Fn::Join': z.tuple([z.literal(''), z.array(z.unknown())]) }),
+    Condition: z.object({
+      ArnLike: z.object({
+        'aws:SourceArn': z.object({ 'Fn::GetAtt': z.tuple([z.string(), z.literal('Arn')]) }),
+      }),
+      StringEquals: z.object({ 'aws:SourceAccount': z.string() }),
+    }),
+  });
+
+  /** Suppression ids on a resource, or none when the metadata block is absent. */
+  const NagMetadataSchema = z.object({
+    cdk_nag: z.object({ rules_to_suppress: z.array(z.object({ id: z.string() })) }).optional(),
+  });
+
+  /**
+   * The stack as a real deploy renders its S3 log-delivery grants.
+   *
+   * `@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy` is `true` in cdk.json, but
+   * `synthCoreTemplate()` builds a bare `App` and so reads none of those feature
+   * flags. That one flag decides HOW the grant is expressed: with it CDK adds an
+   * `s3:PutObject` statement to the destination's bucket policy, without it it
+   * falls back to a `LogDeliveryWrite` bucket ACL. Both render a
+   * `LoggingConfiguration` on the source, so asserting against the bare default
+   * would pin a grant shape that no deploy of this project ever produces.
+   */
+  function synthWithDeployedS3Flags(): Template {
+    return synthCoreTemplate({ '@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy': true });
+  }
+
+  /**
+   * Resolve one bucket from the template by logical-id prefix.
+   *
+   * By logical id and not by BucketName, per the `rawDataBucketCors()` precedent
+   * above: `uniqueDnsName()` builds names from `Aws.ACCOUNT_ID`/`Aws.REGION`
+   * pseudo-parameters, so BucketName synthesizes to an `Fn::Join` rather than a
+   * comparable string. By PREFIX because CDK appends an address hash to the id,
+   * which a hard-coded literal would have to chase every time the surrounding
+   * construct tree moves.
+   *
+   * Counts before returning, so "no such bucket" and "bucket present but
+   * malformed" surface as two distinct failures rather than one ZodError.
+   */
+  function bucketByLogicalIdPrefix(template: Template, prefix: string) {
     const found = Object.entries(template.findResources('AWS::S3::Bucket'))
       .filter(([logicalId]) => logicalId.startsWith(prefix));
     expect(found, `expected exactly one bucket named ${prefix}*`).toHaveLength(1);
     return found[0];
   }
 
+  /** Statements on the access-logs bucket's own resource policy. */
+  function accessLogsPolicyStatements(template: Template): unknown[] {
+    const policies = Object.entries(template.findResources('AWS::S3::BucketPolicy'))
+      .filter(([logicalId]) => logicalId.startsWith('AccessLogsBucketPolicy'));
+    expect(policies, 'expected exactly one AccessLogsBucket policy').toHaveLength(1);
+    const statements = policies[0][1].Properties?.PolicyDocument?.Statement;
+    expect(Array.isArray(statements), 'policy document has no Statement array').toBe(true);
+    return statements as unknown[];
+  }
+
+  // ONLY these two: the S3-import bucket is the third producer into this
+  // destination, but it is built by VocIngestionStack (`createS3ImportBucket`),
+  // so it is absent from this template and a third row here would fail on
+  // bucketByLogicalIdPrefix's count. Covering it needs a case that synthesizes
+  // the ingestion stack, and neither schema below would fit it unchanged: the
+  // destination reference becomes a cross-stack `Fn::ImportValue` rather than a
+  // `Ref`, and CDK omits the aws:SourceArn/aws:SourceAccount conditions
+  // entirely for a producer in another stack (verified against the synthesized
+  // VocCoreStack template, where the `/s3-import-bucket/*` grant carries no
+  // `Condition` at all). So this is two of three by necessity, not by oversight.
   it.each([
     ['WebsiteBucket', 'website-bucket/'],
     ['RawDataBucket', 'raw-data-bucket/'],
   ])('ships %s logging into the access-logs bucket under %s', (prefix, logPrefix) => {
-    const template = synthCoreTemplate();
-    const [accessLogsLogicalId] = bucketsByPrefix(template, 'AccessLogsBucket');
-    const [, bucket] = bucketsByPrefix(template, prefix);
+    const template = synthWithDeployedS3Flags();
+    const [accessLogsLogicalId] = bucketByLogicalIdPrefix(template, 'AccessLogsBucket');
+    const [sourceLogicalId, bucket] = bucketByLogicalIdPrefix(template, prefix);
 
     const logging = LoggingSchema.parse(bucket.Properties?.LoggingConfiguration);
     expect(logging.DestinationBucketName.Ref).toBe(accessLogsLogicalId);
     expect(logging.LogFilePrefix).toBe(logPrefix);
+
+    // The OTHER half of working server access logging, and the half that fails
+    // silently. `LoggingConfiguration` alone is a request; S3 delivers nothing
+    // unless the destination's policy also lets logging.s3.amazonaws.com PUT
+    // there. CDK writes that statement automatically, but only while the
+    // destination is a Bucket CONSTRUCT in this stack — point
+    // serverAccessLogsBucket at `Bucket.fromBucketName(...)` and the template
+    // still carries a complete-looking LoggingConfiguration with no grant behind
+    // it, announced by nothing louder than an
+    // `@aws-cdk/aws-s3:accessLogsPolicyNotAdded` warning. Without this
+    // assertion every case above still passes in that state, which is the exact
+    // failure this block exists to make legible.
+    const grants = accessLogsPolicyStatements(template)
+      .map((statement) => LogDeliveryStatementSchema.safeParse(statement))
+      .filter((parsed) => parsed.success)
+      .map((parsed) => parsed.data)
+      .filter((statement) => statement.Condition.ArnLike['aws:SourceArn']['Fn::GetAtt'][0] === sourceLogicalId);
+    expect(grants, `no log-delivery grant for ${prefix} — S3 would accept the config and deliver nothing`)
+      .toHaveLength(1);
+
+    // Scoped to this producer's own prefix, so one bucket's grant cannot be
+    // used to write over another's logs.
+    const joinParts = grants[0].Resource['Fn::Join'][1];
+    expect(joinParts.at(-1)).toBe(`/${logPrefix}*`);
+    expect(grants[0].Condition.StringEquals['aws:SourceAccount']).toBe(SYNTH_ACCOUNT);
   });
 
   it('leaves the access-logs bucket without a destination of its own', () => {
-    // Deliberate, and the one place AwsSolutions-S1 stays unaddressed: S3 does
-    // not support a bucket delivering its own access logs to itself, so the
-    // scanner's finding here is a false positive rather than a gap.
-    const template = synthCoreTemplate();
-    const [, accessLogs] = bucketsByPrefix(template, 'AccessLogsBucket');
+    // Self-targeting IS available — S3 permits the target to be the source, and
+    // in CDK a `serverAccessLogsPrefix` with no `serverAccessLogsBucket`
+    // self-targets — so this is a declined option, not an impossible one. It is
+    // declined because log deliveries themselves generate access log records:
+    // the bucket would grow on its own writes, against a lifecycle rule that is
+    // UNPREFIXED and expires everything at 90 days, and buy no visibility that
+    // the four producer prefixes do not already give.
+    //
+    // No suppression is missing either. cdk-nag's AwsSolutions-S1 has a fallback
+    // branch for a bucket with no loggingConfiguration: it scans every CfnBucket
+    // in the stack and returns COMPLIANT if any of them names this one as its
+    // destination. Three do, so this bucket is compliant by construction and
+    // raises no finding — AwsSolutions-VocCoreStack-NagReport.csv records it as
+    // `Compliant`. Worth stating because the tempting wrong conclusion is that
+    // some suppression elsewhere is quietly covering it; none is.
+    const template = synthWithDeployedS3Flags();
+    const [, accessLogs] = bucketByLogicalIdPrefix(template, 'AccessLogsBucket');
 
     expect(accessLogs.Properties ?? {}).not.toHaveProperty('LoggingConfiguration');
   });
 
-  it('carries no cdk_nag suppression on the website bucket', () => {
-    // The AwsSolutions-S1 suppression described the missing property above. With
-    // the property present the rule no longer fires, so a suppression would be
-    // dead metadata that a later audit has to re-litigate.
-    const [, website] = bucketsByPrefix(synthCoreTemplate(), 'WebsiteBucket');
+  it('carries no AwsSolutions-S1 suppression on the website bucket', () => {
+    // The retired suppression described the missing property above. With the
+    // property present the rule no longer fires, so a suppression would be dead
+    // metadata that a later audit has to re-litigate.
+    //
+    // Narrowed to this one rule on purpose: a future suppression on this bucket
+    // for some OTHER finding is a legitimate act, and it must not fail a case
+    // whose whole subject is AwsSolutions-S1.
+    const [, website] = bucketByLogicalIdPrefix(synthWithDeployedS3Flags(), 'WebsiteBucket');
 
-    expect(website.Metadata ?? {}).not.toHaveProperty('cdk_nag');
+    const suppressions = NagMetadataSchema.parse(website.Metadata ?? {}).cdk_nag?.rules_to_suppress ?? [];
+    expect(suppressions.map((rule) => rule.id)).not.toContain('AwsSolutions-S1');
   });
 });
 

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -16,40 +16,52 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { z } from 'zod';
 import { VocCoreStack } from './core-stack';
 import { ALLOWED_MODEL_IDS, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION_PX } from '../utils/model-allowlist';
-// The same fixed synth environment the whole-app harness uses, imported rather
-// than re-declared: a second copy of the literals drifts silently, and an
-// assertion about a resolved `aws:SourceAccount` would then pin an account no
-// other suite uses. Importing costs nothing at module load — synth-app.ts only
-// shells out to `cdk synth` inside `synthApp()`.
-import { SYNTH_ACCOUNT, SYNTH_REGION } from '../test-support/synth-app';
+// The same fixed synth environment and committed feature flags the whole-app
+// harness uses, imported rather than re-declared: a second copy of either drifts
+// silently. Importing costs nothing at module load — synth-app.ts only shells out
+// to `cdk synth` inside `synthApp()`, and its sole module-level work is a `join()`
+// on two path constants.
+import { SYNTH_ACCOUNT, SYNTH_REGION, committedFeatureFlags } from '../test-support/synth-app';
 
 /**
- * Feature flags from cdk.json, i.e. what a real deploy of this project gets.
+ * cdk.json's CDK feature flags, resolved once for every case in this file.
  *
- * Read rather than listed, mirroring `baseContext()` in
- * lib/test-support/synth-app.ts, because several flags change the SHAPE of the
- * synthesized template and not just its details. The one this file asserts
- * about is `@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy`, which decides
- * whether S3 log delivery is granted by a statement on the destination's bucket
- * policy or by a `LogDeliveryWrite` ACL — both of which render an identical
- * `LoggingConfiguration` on the source, so a bare `App` would let this file pin
- * a grant shape no deploy produces. Reading the file keeps the test and the
- * deploy configuration from drifting apart: flip or delete the flag in cdk.json
- * and these assertions follow it instead of quietly describing the old world.
+ * Read rather than listed because several flags change the SHAPE of the
+ * synthesized template and not just its details, so a bare `App` would let this
+ * file assert against a template no deploy of this project produces. The one the
+ * S3-logging block below depends on is
+ * `@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy`, which decides whether log
+ * delivery is granted by a statement on the destination's bucket policy or by a
+ * `LogDeliveryWrite` ACL — both of which render an identical
+ * `LoggingConfiguration` on the source, so only a destination-side assertion can
+ * tell them apart. Reading the file rather than pinning a literal keeps the test
+ * and the deploy configuration from parting company unnoticed.
  *
- * Parsed, not cast: `context` missing or malformed would otherwise spread as
- * nothing and silently return every template to the bare-`App` shape.
+ * FEATURE FLAGS ONLY — `committedFeatureFlags()` filters to `@aws-cdk`-prefixed
+ * keys, and that filter is load-bearing for this file specifically. cdk.json's
+ * `context` is also where project-level `-c` defaults would live, and several
+ * cases here assert a CDK or app DEFAULT: `sets case-insensitive sign-in by
+ * default (greenfield)` passes only while `omitUserPoolUsernameConfiguration` is
+ * unset. A project key added to cdk.json and spread in here would invert what
+ * those cases measure while they stayed green.
+ *
+ * These flags DO change this file's other blocks, which is intended and worth
+ * naming rather than discovering: `@aws-cdk/aws-iam:minimizePolicies` merges IAM
+ * statements, so the extractor role's default policy carries 6 statements here
+ * against 10 under a bare `App`, the CDN signing-key policy 1 against 2, and the
+ * KMS key policy 5 against 6. No assertion's outcome changes — the extractor's
+ * S3 read and write statements have different resources and so never merge — but
+ * a case that counts statements must be written against these numbers.
+ * `pins the statement counts a real deploy's feature flags produce` below is what
+ * turns that from a comment into a guard.
  */
-const CDK_JSON_FEATURE_FLAGS = z
-  .object({ context: z.record(z.string(), z.unknown()) })
-  .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
-  .context;
+const CDK_FEATURE_FLAGS = committedFeatureFlags();
 
 function synthCoreTemplate(context: Record<string, unknown> = {}): Template {
   // Skip asset bundling (Docker) — template assertions only need structure.
   const app = new cdk.App({
     context: {
-      ...CDK_JSON_FEATURE_FLAGS,
+      ...CDK_FEATURE_FLAGS,
       'aws:cdk:bundling-stacks': [],
       skipFrontendBuildCheck: true,
       ...context,
@@ -61,6 +73,74 @@ function synthCoreTemplate(context: Record<string, unknown> = {}): Template {
   });
   return Template.fromStack(stack);
 }
+
+/** Any policy document, down to the statement list. */
+const StatementsSchema = z.object({ Statement: z.array(z.unknown()) });
+
+/**
+ * The synth context every case in this file runs under, pinned.
+ *
+ * `synthCoreTemplate()` spreads cdk.json's feature flags, which changes the
+ * synth for EVERY describe block here and not only the S3-logging one that
+ * needs it. That is the right end state — a suite asserting about deployed
+ * behaviour should synthesize the way a deploy does — but it is a whole-file
+ * coupling, so the two properties it rests on are asserted rather than assumed:
+ * that the spread carries feature flags only, and that the statement-merging it
+ * enables lands on the counts the cases downstream were written against.
+ */
+describe('VocCoreStack synth context', () => {
+  it('spreads CDK feature flags only, never a project-level context key', () => {
+    // The barrier for every case in this file that asserts a DEFAULT. A project
+    // key in cdk.json's `context` — `omitUserPoolUsernameConfiguration` being the
+    // live example, since the issue #184 greenfield case needs it UNSET — would
+    // otherwise reach those cases and silently flip what they measure.
+    //
+    // Compared against cdk.json's RAW context rather than just inspecting the
+    // filtered result, which would be tautological: `committedFeatureFlags()`
+    // filters by this very prefix, so its own output trivially satisfies it. The
+    // claim worth asserting is that the filter is still THERE — so this fails
+    // exactly when a leak becomes possible, i.e. when cdk.json holds a
+    // non-`@aws-cdk` key and the filter has stopped dropping it.
+    const rawContext = z
+      .object({ context: z.record(z.string(), z.unknown()) })
+      .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
+      .context;
+    const projectKeys = Object.keys(rawContext).filter((key) => !key.startsWith('@aws-cdk'));
+
+    expect(
+      projectKeys.filter((key) => key in CDK_FEATURE_FLAGS),
+      'synthCoreTemplate() must not spread cdk.json project context',
+    ).toEqual([]);
+    // And that the flags themselves really do arrive, so a cdk.json that lost its
+    // `context` block cannot satisfy the assertion above by supplying nothing.
+    expect(CDK_FEATURE_FLAGS['@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy']).toBe(true);
+    expect(Object.keys(CDK_FEATURE_FLAGS)).toEqual(
+      Object.keys(rawContext).filter((key) => key.startsWith('@aws-cdk')),
+    );
+  });
+
+  it('pins the statement counts a real deploy\'s feature flags produce', () => {
+    // `@aws-cdk/aws-iam:minimizePolicies` merges statements that share a
+    // resource set, so these three resources genuinely change shape between a
+    // bare `App` and this one (10→6, 2→1, 6→5). Breaking this case means the
+    // synth context moved: either the flag stopped arriving — which would also
+    // take the S3 log-delivery grants with it, since the same read supplies both
+    // — or a policy gained a statement. Both want reading, and neither should
+    // surface only as a baseline digest diff.
+    const template = synthCoreTemplate();
+
+    const statementCount = (type: string, logicalIdPrefix: string, documentKey: string): number => {
+      const found = Object.entries(template.findResources(type))
+        .filter(([logicalId]) => logicalId.startsWith(logicalIdPrefix));
+      expect(found, `expected exactly one ${logicalIdPrefix}*`).toHaveLength(1);
+      return StatementsSchema.parse(found[0][1].Properties?.[documentKey]).Statement.length;
+    };
+
+    expect(statementCount('AWS::IAM::Policy', 'ProductDocExtractorLambdaServiceRoleDefaultPolicy', 'PolicyDocument')).toBe(6);
+    expect(statementCount('AWS::IAM::Policy', 'CdnSigningKeysLambdaServiceRoleDefaultPolicy', 'PolicyDocument')).toBe(1);
+    expect(statementCount('AWS::KMS::Key', 'VocKmsKey', 'KeyPolicy')).toBe(5);
+  });
+});
 
 describe('VocCoreStack admin bootstrap (issue #196)', () => {
   it('synthesizes deterministically — no per-synth password churn', () => {
@@ -246,12 +326,16 @@ describe('VocCoreStack S3 server access logging', () => {
   /**
    * The access-logs bucket's retention rule.
    *
-   * `Prefix` is deliberately NOT in the schema — its ABSENCE is the property
-   * asserted below, so a rule that grows one must be read as a change rather
-   * than silently ignored by a lenient parse.
+   * `.strict()` is the whole guard, and it has to be the schema rather than a
+   * separate assertion: zod STRIPS unlisted keys by default, so a rule that grew
+   * a `Prefix` would parse to an object without one and any
+   * `not.toHaveProperty('Prefix')` written below would pass vacuously. Listing
+   * only the two expected keys and rejecting the rest means an added `Prefix`
+   * fails at the parse, naming the offending key
+   * (`Unrecognized key(s) in object: 'Prefix'`).
    */
   const LifecycleSchema = z.object({
-    Rules: z.array(z.object({ ExpirationInDays: z.number(), Status: z.string() }).passthrough()),
+    Rules: z.array(z.object({ ExpirationInDays: z.number(), Status: z.string() }).strict()),
   });
 
   /**
@@ -299,7 +383,10 @@ describe('VocCoreStack S3 server access logging', () => {
   // `Ref`, and CDK omits the aws:SourceArn/aws:SourceAccount conditions
   // entirely for a producer in another stack (verified against the synthesized
   // VocCoreStack template, where the `/s3-import-bucket/*` grant carries no
-  // `Condition` at all). So this is two of three by necessity, not by oversight.
+  // `Condition` at all). So this is two of the THREE S3-BUCKET producers by
+  // necessity, not by oversight. (The comment below counts differently and is
+  // also right: four producers in total, the fourth being the CloudFront
+  // distribution's `cloudfront-frontend/` prefix, which is not a bucket.)
   it.each([
     ['WebsiteBucket', 'website-bucket/'],
     ['RawDataBucket', 'raw-data-bucket/'],
@@ -359,7 +446,8 @@ describe('VocCoreStack S3 server access logging', () => {
     // S3-import bucket writes into this destination but lives in
     // VocIngestionStack, outside the scan, and the CloudFront distribution's
     // `cloudfront-frontend/` prefix never counts because a distribution is not a
-    // CfnBucket. So two of the four producers satisfy the rule, this bucket is
+    // CfnBucket. So two of the FOUR producers in total — three buckets plus the
+    // distribution — satisfy the rule, this bucket is
     // compliant by construction and raises no finding —
     // AwsSolutions-VocCoreStack-NagReport.csv records it as `Compliant`. Worth
     // stating because the tempting wrong conclusion is that some suppression
@@ -382,13 +470,15 @@ describe('VocCoreStack S3 server access logging', () => {
     // and every unlisted prefix accumulates forever, which is invisible in a diff
     // and would silently falsify both the comment above and this PR's claim that
     // the destination needed no changes.
+    //
+    // That absence is enforced by LifecycleSchema's `.strict()`, not by an
+    // assertion here — see its comment for why the assertion form cannot work.
     const [, accessLogs] = bucketByLogicalIdPrefix(synthCoreTemplate(), 'AccessLogsBucket');
 
     const rules = LifecycleSchema.parse(accessLogs.Properties?.LifecycleConfiguration).Rules;
     expect(rules, 'expected exactly one lifecycle rule on the access-logs bucket').toHaveLength(1);
     expect(rules[0].ExpirationInDays).toBe(90);
     expect(rules[0].Status).toBe('Enabled');
-    expect(rules[0]).not.toHaveProperty('Prefix');
   });
 
   it('carries no AwsSolutions-S1 suppression on the website bucket', () => {

--- a/voc-datalake/lib/stacks/core-stack.ts
+++ b/voc-datalake/lib/stacks/core-stack.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import { Construct } from 'constructs';
 import { ALLOWED_MODEL_IDS, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION_PX, allowlistedModelArns } from '../utils/model-allowlist';
 import { NagSuppressions } from 'cdk-nag';
-import { idempotencyTableSuppressions, websiteBucketSuppressions, cloudfrontDefaultCertSuppressions, cognitoSecuritySuppressions, cdkCustomResourceSuppressions, lambdaBasicExecutionRoleSuppressions, cdnSigningKeySuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions } from '../utils/nag-suppressions';
+import { idempotencyTableSuppressions, cloudfrontDefaultCertSuppressions, cognitoSecuritySuppressions, cdkCustomResourceSuppressions, lambdaBasicExecutionRoleSuppressions, cdnSigningKeySuppressions, dynamoDbGsiSuppressions, kmsEncryptionSuppressions, s3BucketSuppressions, bedrockModelSuppressions } from '../utils/nag-suppressions';
 import { VocStack, VocStackProps } from '../utils/voc-stack';
 
 export interface VocCoreStackProps extends VocStackProps {
@@ -141,8 +141,9 @@ export class VocCoreStack extends VocStack {
       enforceSSL: true,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
+      serverAccessLogsBucket: this.accessLogsBucket,
+      serverAccessLogsPrefix: 'website-bucket/',
     });
-    NagSuppressions.addResourceSuppressions(this.websiteBucket, websiteBucketSuppressions);
 
     // ============================================
     // CLOUDFRONT DISTRIBUTIONS

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -87,7 +87,7 @@
       }
     },
     "VocCoreStack": {
-      "templateSha256": "60df5a648162ad13b2a79af56a06f1d5e02564bf98d20fbfa0df3b2803c4bdda",
+      "templateSha256": "12ddceb388eaa744402d9b135f247cfaeae1bf68b74ef6656340ebd0d63117c1",
       "names": {
         "physicalNames": [
           "AWS::Cognito::IdentityPool IdentityPoolName = voc-identity-pool-<AWS::AccountId>-<AWS::Region>",

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -20,7 +20,7 @@
  * function of the deployment prefix — the same finding must be suppressed under
  * a prefix and reported when the suppression is built for the wrong one.
  */
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import * as cdk from 'aws-cdk-lib';
@@ -28,10 +28,10 @@ import * as cx from 'aws-cdk-lib/cx-api';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { afterAll, describe, expect, it } from 'vitest';
-import { z } from 'zod';
 
 import { pluginSystemSuppressions } from '../utils/nag-suppressions';
 import {
+  cdkJsonContextStrict,
   cleanupAssemblyDirs,
   committedFeatureFlags,
   createAssemblyDir,
@@ -134,7 +134,7 @@ describe('pluginSystemSuppressions', () => {
  *
  * That distinction is the whole point of these cases. lib/stacks/core-stack.test.ts
  * asserts the filter's EFFECT against the real cdk.json, but every key committed
- * there is `@aws-cdk`-prefixed, so filtered and unfiltered reads are the same 19
+ * there is `@aws-cdk`-prefixed, so filtered and unfiltered reads return the same
  * keys and deleting the filter outright leaves that suite green — it arms only
  * once cdk.json gains a project key, which is precisely when it is too late to
  * learn the filter went missing. Passing context in makes the classification rule
@@ -172,28 +172,29 @@ describe('committedFeatureFlags', () => {
     // no project key — a claim lib/stacks/core-stack.test.ts already owns and
     // fails loudly on — so this case would double-report that one cause while
     // saying nothing extra about the read.
-    const cdkJsonContext = z
-      .object({ context: z.record(z.string(), z.unknown()) })
-      .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
-      .context;
-
-    expect(committedFeatureFlags()).toEqual(committedFeatureFlags(cdkJsonContext));
+    // `cdkJsonContextStrict()`, NOT the private `cdkJsonContext()` the default
+    // argument uses — see its doc comment. Delegating one to the other turns this
+    // into `f(x) === f(x)`.
+    expect(committedFeatureFlags()).toEqual(committedFeatureFlags(cdkJsonContextStrict()));
     // Non-empty, so a cdk.json whose `context` went missing cannot satisfy the
     // equality above by making both sides `{}`.
     expect(committedFeatureFlags()['@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy']).toBe(true);
   });
 
   it('would drop aws-cdk:enableDiffNoFail, the one CDK flag the prefix rule misses', () => {
-    // Asserting the KNOWN LIMIT, not the desired behaviour. cx-api's FLAGS holds
-    // 108 feature flags and exactly one is not `@aws-cdk`-prefixed, so this filter
-    // classifies it as project context while `baseContext()` keeps it — the two
-    // would then synthesize from different flag sets. Harmless today because the
-    // flag only selects `cdk diff`'s exit code and cannot move a template, and
-    // cdk.json does not commit it.
+    // Asserting the KNOWN LIMIT, not the desired behaviour. Exactly one flag in
+    // cx-api's FLAGS is not `@aws-cdk`-prefixed, so this filter classifies it as
+    // project context while `baseContext()` keeps it — the two would then
+    // synthesize from different flag sets. Harmless today because the flag only
+    // selects `cdk diff`'s exit code and cannot move a template, and cdk.json does
+    // not commit it.
     //
     // Here so the limit is measured rather than asserted in a comment: if a CDK
-    // upgrade adds a second unprefixed flag, or renames this one, the count below
-    // moves and someone re-reads whether the heuristic still holds.
+    // upgrade adds a second unprefixed flag, or renames this one, the list below
+    // moves and someone re-reads whether the heuristic still holds. `aws-cdk-lib`
+    // is a caret range, so that upgrade can arrive without any committed file
+    // changing — which is exactly why this is an assertion and not a figure in
+    // prose.
     const unprefixed = Object.keys(cx.FLAGS).filter((flag) => !flag.startsWith('@aws-cdk'));
     expect(unprefixed).toEqual(['aws-cdk:enableDiffNoFail']);
     expect(committedFeatureFlags({ 'aws-cdk:enableDiffNoFail': true })).toEqual({});
@@ -211,8 +212,10 @@ describe('committedFeatureFlags', () => {
     // runtime effect in aws-cdk-lib 2.261.0 — zero references in any `.js` under
     // the package, only a doc comment in aws-iam/lib/principals.d.ts describing
     // what it used to gate — because CDK v2 applies the standardized behaviour
-    // unconditionally. Removing it from the synth context leaves VocCoreStack's
-    // template byte-identical (78006 characters either way).
+    // unconditionally. Removing it from the synth context left VocCoreStack's
+    // template byte-identical — measured at 2.261.0, and left unasserted on
+    // purpose: a template length here would duplicate baseline.json's hash and
+    // would move on the next unrelated change to that stack.
     //
     // So both known edges of the prefix heuristic are inert, for different
     // reasons: `aws-cdk:enableDiffNoFail` because it only selects `cdk diff`'s

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -136,7 +136,7 @@ describe('pluginSystemSuppressions', () => {
  * Both compare a value derived from the PRIVATE `cdkJsonContext()` against this
  * read, so the comparisons mean something only while the two bodies stay separate.
  * Nothing else in the project detects a merge: rewriting `cdkJsonContextStrict()`
- * to `return cdkJsonContext()` passed all 290 cases at the parent commit,
+ * to `return cdkJsonContext()` passed the entire suite at the parent commit,
  * typechecks clean (`noUnusedParameters` is off, so the ignored path is fine) and
  * meets no ESLint leg, since none covers CDK `lib/`. This suite is the only thing
  * standing between that one-line "dedupe" and two silently vacuous comparisons.

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -24,10 +24,11 @@ import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import * as cdk from 'aws-cdk-lib';
-import * as cx from 'aws-cdk-lib/cx-api';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cx from 'aws-cdk-lib/cx-api';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { afterAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { pluginSystemSuppressions } from '../utils/nag-suppressions';
 import {
@@ -149,6 +150,10 @@ describe('cdkJsonContextStrict', () => {
     // assertion, which also catches a body that reads the wrong file or the wrong
     // key — neither of which the throw can see, since a strict read of the wrong
     // file still throws on a fixture with no context.
+    // `createAssemblyDir` for a cdk.json fixture rather than a bare `mkdtempSync`
+    // only because it registers the dir with `cleanupAssemblyDirs`, which
+    // `afterAll` above already calls. Named for its main use, generic in what it
+    // does.
     const populated = join(createAssemblyDir('voc-cdkjson-'), 'cdk.json');
     writeFileSync(populated, JSON.stringify({ context: { probe: 1 } }));
     expect(cdkJsonContextStrict(populated)).toEqual({ probe: 1 });
@@ -160,7 +165,10 @@ describe('cdkJsonContextStrict', () => {
     // by accident and this catches it by name.
     const noContext = join(createAssemblyDir('voc-cdkjson-'), 'cdk.json');
     writeFileSync(noContext, JSON.stringify({ app: 'npx ts-node bin/voc-datalake.ts' }));
-    expect(() => cdkJsonContextStrict(noContext)).toThrow();
+    // `z.ZodError`, not a bare `toThrow()`: this case's subject is a REJECTED
+    // SCHEMA, and a bare matcher also accepts the `ENOENT` a wrong fixture path
+    // raises — which would make it pass for the one reason it must not.
+    expect(() => cdkJsonContextStrict(noContext)).toThrow(z.ZodError);
 
     // And that the default argument still points at the real cdk.json, so neither
     // assertion above can pass against a fixture while production reads nothing.
@@ -236,8 +244,15 @@ describe('committedFeatureFlags', () => {
     // changing — which is exactly why this is an assertion and not a figure in
     // prose.
     const unprefixed = Object.keys(cx.FLAGS).filter((flag) => !flag.startsWith('@aws-cdk'));
-    expect(unprefixed).toEqual(['aws-cdk:enableDiffNoFail']);
-    expect(committedFeatureFlags({ 'aws-cdk:enableDiffNoFail': true })).toEqual({});
+    expect(
+      unprefixed,
+      'a CDK upgrade changed which flags are unprefixed: re-read whether the @aws-cdk '
+      + 'heuristic in committedFeatureFlags() still holds, then update this list',
+    ).toEqual(['aws-cdk:enableDiffNoFail']);
+    expect(
+      committedFeatureFlags({ 'aws-cdk:enableDiffNoFail': true }),
+      'the prefix filter must still classify the one unprefixed flag as project context',
+    ).toEqual({});
   });
 
   it('cannot use cx-api FLAGS as the predicate instead, since a committed flag has expired out of it', () => {
@@ -264,8 +279,17 @@ describe('committedFeatureFlags', () => {
     // rule that silently drops a key a project commits is unsound in general even
     // when today's instance costs nothing. That is the claim these two assertions
     // pin, and it is why the tempting swap to `key in cx.FLAGS` is a regression.
-    expect('@aws-cdk/aws-iam:standardizedServicePrincipals' in cx.FLAGS).toBe(false);
-    expect(committedFeatureFlags()).toHaveProperty('@aws-cdk/aws-iam:standardizedServicePrincipals');
+    expect(
+      '@aws-cdk/aws-iam:standardizedServicePrincipals' in cx.FLAGS,
+      'CDK re-registered this flag, so it no longer demonstrates that FLAGS is not a '
+      + 'superset of what cdk.json may commit: find another expired committed flag or '
+      + 'reconsider whether `key in cx.FLAGS` is now a safe predicate',
+    ).toBe(false);
+    expect(
+      committedFeatureFlags(),
+      'cdk.json stopped committing the expired flag this case is built on: the pair of '
+      + 'assertions no longer shows what it claims',
+    ).toHaveProperty('@aws-cdk/aws-iam:standardizedServicePrincipals');
   });
 });
 

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -201,10 +201,26 @@ describe('committedFeatureFlags', () => {
 
   it('cannot use cx-api FLAGS as the predicate instead, since a committed flag has expired out of it', () => {
     // Why the obvious fix for the case above is not a fix. The registry is not a
-    // superset of what a project commits: this one sets
+    // superset of what a project may commit: this one sets
     // `@aws-cdk/aws-iam:standardizedServicePrincipals`, which CDK has since
-    // dropped from FLAGS, so `key in cx.FLAGS` would stop passing a flag every
-    // real deploy here gets — trading a known, inert gap for a live one.
+    // dropped from FLAGS, so `key in cx.FLAGS` would classify a committed flag as
+    // project context and drop it.
+    //
+    // Dropping it would in fact be HARMLESS today, and saying otherwise would
+    // overstate the case: that flag is EXPIRED, not merely unregistered. It has no
+    // runtime effect in aws-cdk-lib 2.261.0 — zero references in any `.js` under
+    // the package, only a doc comment in aws-iam/lib/principals.d.ts describing
+    // what it used to gate — because CDK v2 applies the standardized behaviour
+    // unconditionally. Removing it from the synth context leaves VocCoreStack's
+    // template byte-identical (78006 characters either way).
+    //
+    // So both known edges of the prefix heuristic are inert, for different
+    // reasons: `aws-cdk:enableDiffNoFail` because it only selects `cdk diff`'s
+    // exit code, and this one because it has expired. Neither predicate is exact,
+    // and the prefix rule wins because it errs toward passing keys THROUGH — a
+    // rule that silently drops a key a project commits is unsound in general even
+    // when today's instance costs nothing. That is the claim these two assertions
+    // pin, and it is why the tempting swap to `key in cx.FLAGS` is a regression.
     expect('@aws-cdk/aws-iam:standardizedServicePrincipals' in cx.FLAGS).toBe(false);
     expect(committedFeatureFlags()).toHaveProperty('@aws-cdk/aws-iam:standardizedServicePrincipals');
   });

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -140,6 +140,33 @@ describe('pluginSystemSuppressions', () => {
  * learn the filter went missing. Passing context in makes the classification rule
  * itself the subject, so its removal fails a test today.
  */
+describe('cdkJsonContextStrict', () => {
+  it('throws on a cdk.json with no context block, rather than returning {}', () => {
+    // Two claims in one case, and the second is why it exists.
+    //
+    // The strictness itself: this read is the ORACLE the two cases below and
+    // `spreads CDK feature flags only…` in lib/stacks/core-stack.test.ts compare
+    // against, and an oracle that degraded to `{}` would satisfy its own
+    // comparison — `{}` filtered still equals `{}` filtered.
+    //
+    // And the independence from the private `cdkJsonContext()`. Rewriting
+    // `cdkJsonContextStrict()` to `return cdkJsonContext()` is invisible to
+    // everything else: measured, that delegation passes all 290 cases and
+    // typechecks clean, while quietly making the comparisons `f(x) === f(x)`. It
+    // fails HERE, because the delegating body ignores this path, reads the real
+    // cdk.json and returns a populated context instead of throwing. The throw is
+    // the one behaviour the two reads do not share, so it is the only thing that
+    // can pin them apart.
+    const noContext = join(createAssemblyDir('voc-cdkjson-'), 'cdk.json');
+    writeFileSync(noContext, JSON.stringify({ app: 'npx ts-node bin/voc-datalake.ts' }));
+
+    expect(() => cdkJsonContextStrict(noContext)).toThrow();
+    // The complement: the default still reads the real file, so the case above
+    // cannot pass by throwing everywhere.
+    expect(cdkJsonContextStrict()['@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy']).toBe(true);
+  });
+});
+
 describe('committedFeatureFlags', () => {
   it('keeps CDK feature flags and drops project-level context keys', () => {
     // The guarantee lib/stacks/core-stack.test.ts depends on: that suite has cases
@@ -173,8 +200,8 @@ describe('committedFeatureFlags', () => {
     // fails loudly on — so this case would double-report that one cause while
     // saying nothing extra about the read.
     // `cdkJsonContextStrict()`, NOT the private `cdkJsonContext()` the default
-    // argument uses — see its doc comment. Delegating one to the other turns this
-    // into `f(x) === f(x)`.
+    // argument uses: an independent read is what gives this comparison something to
+    // catch, and `cdkJsonContextStrict` above is what keeps it independent.
     expect(committedFeatureFlags()).toEqual(committedFeatureFlags(cdkJsonContextStrict()));
     // Non-empty, so a cdk.json whose `context` went missing cannot satisfy the
     // equality above by making both sides `{}`.

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -20,17 +20,20 @@
  * function of the deployment prefix — the same finding must be suppressed under
  * a prefix and reported when the suppression is built for the wrong one.
  */
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import * as cdk from 'aws-cdk-lib';
+import * as cx from 'aws-cdk-lib/cx-api';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { afterAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { pluginSystemSuppressions } from '../utils/nag-suppressions';
 import {
   cleanupAssemblyDirs,
+  committedFeatureFlags,
   createAssemblyDir,
   diagnostics,
   DIAGNOSTIC_ANNOTATION_TYPES,
@@ -122,6 +125,88 @@ describe('pluginSystemSuppressions', () => {
     // while suppressing findings it was never meant to.
     expect(nagFindings(synthIngestorGrant('b', undefined)).join('\n')).toContain('AwsSolutions-IAM5');
     expect(nagFindings(synthIngestorGrant(undefined, 'b')).join('\n')).toContain('AwsSolutions-IAM5');
+  });
+});
+
+/**
+ * The `@aws-cdk` filter in `committedFeatureFlags()`, tested on synthetic context
+ * rather than on cdk.json's.
+ *
+ * That distinction is the whole point of these cases. lib/stacks/core-stack.test.ts
+ * asserts the filter's EFFECT against the real cdk.json, but every key committed
+ * there is `@aws-cdk`-prefixed, so filtered and unfiltered reads are the same 19
+ * keys and deleting the filter outright leaves that suite green — it arms only
+ * once cdk.json gains a project key, which is precisely when it is too late to
+ * learn the filter went missing. Passing context in makes the classification rule
+ * itself the subject, so its removal fails a test today.
+ */
+describe('committedFeatureFlags', () => {
+  it('keeps CDK feature flags and drops project-level context keys', () => {
+    // The guarantee lib/stacks/core-stack.test.ts depends on: that suite has cases
+    // asserting a DEFAULT (`sets case-insensitive sign-in by default (greenfield)`
+    // needs `omitUserPoolUsernameConfiguration` UNSET), so a project `-c` default
+    // reaching its synth would invert what those cases measure while they stayed
+    // green. `deploymentPrefix` and `omitUserPoolUsernameConfiguration` below are
+    // the two real project keys this repo passes with `-c`.
+    expect(committedFeatureFlags({
+      '@aws-cdk/aws-iam:minimizePolicies': true,
+      '@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver': true,
+      omitUserPoolUsernameConfiguration: true,
+      deploymentPrefix: 'b',
+    })).toEqual({
+      '@aws-cdk/aws-iam:minimizePolicies': true,
+      // `@aws-cdk`, not `@aws-cdk/`: the ecs-service-extensions flag cdk.json
+      // commits lives under `@aws-cdk-containers/`, so a trailing slash in the
+      // predicate would silently drop a flag a real deploy gets.
+      '@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver': true,
+    });
+  });
+
+  it('reads cdk.json when handed no context', () => {
+    // The default argument is what every production caller uses, so it needs its
+    // own case: an injectable filter could be perfect and still be wired to the
+    // wrong file, and the cases above would not notice.
+    //
+    // Compared against the PREFIXED SUBSET rather than the whole context block on
+    // purpose. Comparing against all of it would pass only while cdk.json commits
+    // no project key — a claim lib/stacks/core-stack.test.ts already owns and
+    // fails loudly on — so this case would double-report that one cause while
+    // saying nothing extra about the read.
+    const cdkJsonContext = z
+      .object({ context: z.record(z.string(), z.unknown()) })
+      .parse(JSON.parse(readFileSync(join(__dirname, '..', '..', 'cdk.json'), 'utf8')))
+      .context;
+
+    expect(committedFeatureFlags()).toEqual(committedFeatureFlags(cdkJsonContext));
+    // Non-empty, so a cdk.json whose `context` went missing cannot satisfy the
+    // equality above by making both sides `{}`.
+    expect(committedFeatureFlags()['@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy']).toBe(true);
+  });
+
+  it('would drop aws-cdk:enableDiffNoFail, the one CDK flag the prefix rule misses', () => {
+    // Asserting the KNOWN LIMIT, not the desired behaviour. cx-api's FLAGS holds
+    // 108 feature flags and exactly one is not `@aws-cdk`-prefixed, so this filter
+    // classifies it as project context while `baseContext()` keeps it — the two
+    // would then synthesize from different flag sets. Harmless today because the
+    // flag only selects `cdk diff`'s exit code and cannot move a template, and
+    // cdk.json does not commit it.
+    //
+    // Here so the limit is measured rather than asserted in a comment: if a CDK
+    // upgrade adds a second unprefixed flag, or renames this one, the count below
+    // moves and someone re-reads whether the heuristic still holds.
+    const unprefixed = Object.keys(cx.FLAGS).filter((flag) => !flag.startsWith('@aws-cdk'));
+    expect(unprefixed).toEqual(['aws-cdk:enableDiffNoFail']);
+    expect(committedFeatureFlags({ 'aws-cdk:enableDiffNoFail': true })).toEqual({});
+  });
+
+  it('cannot use cx-api FLAGS as the predicate instead, since a committed flag has expired out of it', () => {
+    // Why the obvious fix for the case above is not a fix. The registry is not a
+    // superset of what a project commits: this one sets
+    // `@aws-cdk/aws-iam:standardizedServicePrincipals`, which CDK has since
+    // dropped from FLAGS, so `key in cx.FLAGS` would stop passing a flag every
+    // real deploy here gets — trading a known, inert gap for a live one.
+    expect('@aws-cdk/aws-iam:standardizedServicePrincipals' in cx.FLAGS).toBe(false);
+    expect(committedFeatureFlags()).toHaveProperty('@aws-cdk/aws-iam:standardizedServicePrincipals');
   });
 });
 

--- a/voc-datalake/lib/test-support/synth-app.test.ts
+++ b/voc-datalake/lib/test-support/synth-app.test.ts
@@ -129,6 +129,46 @@ describe('pluginSystemSuppressions', () => {
 });
 
 /**
+ * The oracle two suites compare `committedFeatureFlags()` against: this file's
+ * `reads cdk.json when handed no context` and `spreads CDK feature flags only…`
+ * in lib/stacks/core-stack.test.ts.
+ *
+ * Both compare a value derived from the PRIVATE `cdkJsonContext()` against this
+ * read, so the comparisons mean something only while the two bodies stay separate.
+ * Nothing else in the project detects a merge: rewriting `cdkJsonContextStrict()`
+ * to `return cdkJsonContext()` passed all 290 cases at the parent commit,
+ * typechecks clean (`noUnusedParameters` is off, so the ignored path is fine) and
+ * meets no ESLint leg, since none covers CDK `lib/`. This suite is the only thing
+ * standing between that one-line "dedupe" and two silently vacuous comparisons.
+ */
+describe('cdkJsonContextStrict', () => {
+  it('reads the file it is handed, and throws when that file has no context block', () => {
+    // The injectable path is the lever, not the throw: a delegating body ignores
+    // the argument and returns cdk.json's real context, so ANY fixture whose
+    // context differs from it separates the two. Hence the first
+    // assertion, which also catches a body that reads the wrong file or the wrong
+    // key — neither of which the throw can see, since a strict read of the wrong
+    // file still throws on a fixture with no context.
+    const populated = join(createAssemblyDir('voc-cdkjson-'), 'cdk.json');
+    writeFileSync(populated, JSON.stringify({ context: { probe: 1 } }));
+    expect(cdkJsonContextStrict(populated)).toEqual({ probe: 1 });
+
+    // The throw pins the strictness — a lenient oracle degrading to `{}` would
+    // satisfy its own comparison, `{}` filtered being `{}` filtered. A direct
+    // guard rather than the only one: the non-emptiness assertions in the two
+    // consuming cases already fail on a missing block. Kept because they catch it
+    // by accident and this catches it by name.
+    const noContext = join(createAssemblyDir('voc-cdkjson-'), 'cdk.json');
+    writeFileSync(noContext, JSON.stringify({ app: 'npx ts-node bin/voc-datalake.ts' }));
+    expect(() => cdkJsonContextStrict(noContext)).toThrow();
+
+    // And that the default argument still points at the real cdk.json, so neither
+    // assertion above can pass against a fixture while production reads nothing.
+    expect(cdkJsonContextStrict()['@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy']).toBe(true);
+  });
+});
+
+/**
  * The `@aws-cdk` filter in `committedFeatureFlags()`, tested on synthetic context
  * rather than on cdk.json's.
  *
@@ -140,33 +180,6 @@ describe('pluginSystemSuppressions', () => {
  * learn the filter went missing. Passing context in makes the classification rule
  * itself the subject, so its removal fails a test today.
  */
-describe('cdkJsonContextStrict', () => {
-  it('throws on a cdk.json with no context block, rather than returning {}', () => {
-    // Two claims in one case, and the second is why it exists.
-    //
-    // The strictness itself: this read is the ORACLE the two cases below and
-    // `spreads CDK feature flags only…` in lib/stacks/core-stack.test.ts compare
-    // against, and an oracle that degraded to `{}` would satisfy its own
-    // comparison — `{}` filtered still equals `{}` filtered.
-    //
-    // And the independence from the private `cdkJsonContext()`. Rewriting
-    // `cdkJsonContextStrict()` to `return cdkJsonContext()` is invisible to
-    // everything else: measured, that delegation passes all 290 cases and
-    // typechecks clean, while quietly making the comparisons `f(x) === f(x)`. It
-    // fails HERE, because the delegating body ignores this path, reads the real
-    // cdk.json and returns a populated context instead of throwing. The throw is
-    // the one behaviour the two reads do not share, so it is the only thing that
-    // can pin them apart.
-    const noContext = join(createAssemblyDir('voc-cdkjson-'), 'cdk.json');
-    writeFileSync(noContext, JSON.stringify({ app: 'npx ts-node bin/voc-datalake.ts' }));
-
-    expect(() => cdkJsonContextStrict(noContext)).toThrow();
-    // The complement: the default still reads the real file, so the case above
-    // cannot pass by throwing everywhere.
-    expect(cdkJsonContextStrict()['@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy']).toBe(true);
-  });
-});
-
 describe('committedFeatureFlags', () => {
   it('keeps CDK feature flags and drops project-level context keys', () => {
     // The guarantee lib/stacks/core-stack.test.ts depends on: that suite has cases

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -39,7 +39,20 @@ export interface Baseline {
   stacks: Record<string, { templateSha256: string; names: NameInventory }>;
 }
 
-/** The `context` block cdk.json commits, or `{}` if it is absent or malformed. */
+/**
+ * The `context` block cdk.json commits.
+ *
+ * Two subjects, two behaviours, and they are easy to conflate: `{}` is returned
+ * when the `context` KEY is absent or is not an object, but an error PROPAGATES
+ * when cdk.json ITSELF cannot be read or parsed — a missing file throws `ENOENT`
+ * and unparseable JSON throws `SyntaxError`.
+ *
+ * Throwing there is deliberate, so do not wrap this in a try/catch. A silent `{}`
+ * would send every dependent synth back to the bare-`App` context shape, which is
+ * exactly the state the S3 log-delivery and IAM statement-count assertions in
+ * lib/stacks/core-stack.test.ts exist to rule out: both would then describe a
+ * template no deploy of this project produces, and both would still pass.
+ */
 function cdkJsonContext(): Record<string, unknown> {
   const cdkJson: unknown = JSON.parse(readFileSync(join(PROJECT_ROOT, 'cdk.json'), 'utf8'));
   return isRecord(cdkJson) && isRecord(cdkJson.context) ? cdkJson.context : {};
@@ -72,14 +85,21 @@ function cdkJsonContext(): Record<string, unknown> {
  *    `aws-cdk:enableDiffNoFail`, is not `@aws-cdk`-prefixed. Were cdk.json to
  *    commit it, this filter would drop it as project context while
  *    {@link baseContext} kept it, so the two would synthesize from different flag
- *    sets. That divergence is LATENT rather than live: the flag selects
- *    `cdk diff`'s exit code and cannot alter a synthesized template, so no
- *    assertion in lib/stacks/core-stack.test.ts would move.
- * 2. Filtering by `key in cx.FLAGS` instead is not a fix, it is a different gap.
+ *    sets. Inert: the flag only selects `cdk diff`'s exit code and cannot alter a
+ *    synthesized template, so no assertion in lib/stacks/core-stack.test.ts moves.
+ * 2. Filtering by `key in cx.FLAGS` instead is not a fix, because the registry is
+ *    not a superset of what a project may commit:
  *    `@aws-cdk/aws-iam:standardizedServicePrincipals` IS committed here but has
- *    expired out of the registry (18 of the 19 keys are recognized), so a
- *    registry filter would stop passing a flag this project does set. Neither
- *    rule is exact; this one errs toward passing flags through.
+ *    expired out of `FLAGS` (18 of the 19 keys are recognized), so a registry
+ *    predicate would drop it. Inert too — the flag has no runtime effect in
+ *    aws-cdk-lib 2.261.0 (zero references in any `.js` under the package, only a
+ *    doc comment in aws-iam/lib/principals.d.ts; CDK v2 applies the standardized
+ *    behaviour unconditionally), and removing it leaves VocCoreStack's template
+ *    byte-identical at 78006 characters.
+ *
+ * So BOTH edges are inert, for different reasons, and neither predicate is exact.
+ * The prefix rule is preferred because it errs toward passing keys THROUGH — not
+ * because a registry predicate would break a real deploy.
  *
  * @param context context to filter, defaulting to cdk.json's. Injectable so the
  *                filter itself is directly testable — with cdk.json holding no

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -63,21 +63,34 @@ function cdkJsonContext(): Record<string, unknown> {
 /**
  * The same block, read strictly, for the two suites that use it as an ORACLE.
  *
- * MUST NOT be rewritten to delegate to {@link cdkJsonContext}. Both callers
- * compare a value {@link committedFeatureFlags} derives FROM `cdkJsonContext()`
- * against this read, so a delegating body reduces them to `f(x) === f(x)` — green
- * even if the default argument were wired to cdk.context.json. The independent
- * body is the whole mechanism; exported so there is one of it rather than the
- * byte-identical copy each suite used to hold.
+ * A second body rather than a delegation to {@link cdkJsonContext}, and the
+ * independence is load-bearing: both callers compare a value
+ * {@link committedFeatureFlags} derives FROM `cdkJsonContext()` against this read,
+ * so `return cdkJsonContext()` here would reduce them to `f(x) === f(x)`.
+ * Exported so there is one such body rather than the byte-identical copy each
+ * suite used to hold.
  *
- * Strict because an oracle that degrades to `{}` satisfies its own comparison.
+ * That delegation passed all 290 cases when measured, which is why the throw below
+ * is asserted rather than merely described — `cdkJsonContextStrict` in
+ * synth-app.test.ts is what now catches it, via the one behaviour the two reads do
+ * not share. Strict at all because an oracle that degrades to `{}` satisfies its
+ * own comparison.
+ *
  * Shares `PROJECT_ROOT`, so the pair catches a wrong file, key or default — not a
  * wrong root.
+ *
+ * @param cdkJsonPath file to read, defaulting to the project's cdk.json.
+ *                    Injectable for the same reason {@link committedFeatureFlags}
+ *                    takes its context: a fixture without a `context` block is the
+ *                    only way to exercise the throw, and no production caller can
+ *                    supply one.
  */
-export function cdkJsonContextStrict(): Record<string, unknown> {
+export function cdkJsonContextStrict(
+  cdkJsonPath: string = join(PROJECT_ROOT, 'cdk.json'),
+): Record<string, unknown> {
   return z
     .object({ context: z.record(z.string(), z.unknown()) })
-    .parse(JSON.parse(readFileSync(join(PROJECT_ROOT, 'cdk.json'), 'utf8')))
+    .parse(JSON.parse(readFileSync(cdkJsonPath, 'utf8')))
     .context;
 }
 

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -68,22 +68,20 @@ function cdkJsonContext(): Record<string, unknown> {
  * {@link committedFeatureFlags} derives FROM `cdkJsonContext()` against this read,
  * so `return cdkJsonContext()` here would reduce them to `f(x) === f(x)`.
  * Exported so there is one such body rather than the byte-identical copy each
- * suite used to hold.
+ * suite used to hold — which is also what makes the merge tempting now that both
+ * live in this file.
  *
- * That delegation passed all 290 cases when measured, which is why the throw below
- * is asserted rather than merely described — `cdkJsonContextStrict` in
- * synth-app.test.ts is what now catches it, via the one behaviour the two reads do
- * not share. Strict at all because an oracle that degrades to `{}` satisfies its
- * own comparison.
- *
- * Shares `PROJECT_ROOT`, so the pair catches a wrong file, key or default — not a
- * wrong root.
+ * That merge passed all 290 cases when measured, and typechecks and lints clean.
+ * Hence `cdkJsonContextStrict` in synth-app.test.ts, which is what now catches it.
+ * Strict at all because an oracle that degrades to `{}` satisfies its own
+ * comparison.
  *
  * @param cdkJsonPath file to read, defaulting to the project's cdk.json.
  *                    Injectable for the same reason {@link committedFeatureFlags}
- *                    takes its context: a fixture without a `context` block is the
- *                    only way to exercise the throw, and no production caller can
- *                    supply one.
+ *                    takes its context, and it is the seam that makes the merge
+ *                    detectable: a delegating body ignores this argument, so any
+ *                    fixture whose `context` differs from the committed one
+ *                    diverges. No production caller passes it.
  */
 export function cdkJsonContextStrict(
   cdkJsonPath: string = join(PROJECT_ROOT, 'cdk.json'),
@@ -112,14 +110,18 @@ export function cdkJsonContextStrict(
  * project `-c` default reaching them would silently invert what they measure.
  *
  * The `@aws-cdk` prefix is a deliberate HEURISTIC for "is a feature flag", NOT a
- * structural guarantee. It is a no-op on today's cdk.json — every committed key is
- * `@aws-cdk`-prefixed, and `synthCoreTemplate() must not spread cdk.json project
- * context` in lib/stacks/core-stack.test.ts goes red the day one is not — and a
- * barrier against a project key added later, but it has two known edges, both
- * recorded because a reader who takes the rule as exact draws the wrong conclusion
- * at either one. No count appears below on purpose: `aws-cdk-lib` is a caret
- * range, so any figure here goes stale on an `npm update` with no committed file
- * changing, and each claim is instead either asserted or dated.
+ * structural guarantee. It is a no-op on cdk.json as committed today — every key
+ * there is `@aws-cdk`-prefixed — and a barrier against a project key added later.
+ * That no-op is a MEASUREMENT, not something a test holds: the assertion in
+ * `spreads CDK feature flags only…` is a conjunction, failing only once cdk.json
+ * holds an unprefixed key AND this filter has stopped dropping it, so a project
+ * key committed on its own leaves that suite green. Its own comment says so.
+ *
+ * Two known edges below, both recorded because a reader who takes the rule as
+ * exact draws the wrong conclusion at either one. No count appears in them on
+ * purpose: `aws-cdk-lib` is a caret range, so any figure would go stale on an
+ * `npm update` with no committed file changing. Each claim is instead either
+ * pointed at the assertion that pins it or dated as a measurement.
  *
  * 1. Exactly one flag in `cx-api`'s `FLAGS` registry, `aws-cdk:enableDiffNoFail`,
  *    is not `@aws-cdk`-prefixed. Were cdk.json to commit it, this filter would

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -62,13 +62,36 @@ function cdkJsonContext(): Record<string, unknown> {
  * (greenfield)` relies on `omitUserPoolUsernameConfiguration` being unset — and a
  * project `-c` default reaching them would silently invert what they measure.
  *
- * The `@aws-cdk` filter is what makes that guarantee structural rather than a
- * coincidence of today's cdk.json holding nothing else: every one of its 19 keys
- * is `@aws-cdk`-prefixed, so the filter is a no-op now and a barrier later.
+ * The `@aws-cdk` prefix is a deliberate HEURISTIC for "is a feature flag", NOT a
+ * structural guarantee. It is a no-op on today's cdk.json — all 19 committed keys
+ * are `@aws-cdk`-prefixed — and a barrier against a project key added later, but
+ * it has two known edges, both recorded because a reader who takes the rule as
+ * exact draws the wrong conclusion at either one:
+ *
+ * 1. `cx-api`'s `FLAGS` registry holds 108 feature flags and exactly one,
+ *    `aws-cdk:enableDiffNoFail`, is not `@aws-cdk`-prefixed. Were cdk.json to
+ *    commit it, this filter would drop it as project context while
+ *    {@link baseContext} kept it, so the two would synthesize from different flag
+ *    sets. That divergence is LATENT rather than live: the flag selects
+ *    `cdk diff`'s exit code and cannot alter a synthesized template, so no
+ *    assertion in lib/stacks/core-stack.test.ts would move.
+ * 2. Filtering by `key in cx.FLAGS` instead is not a fix, it is a different gap.
+ *    `@aws-cdk/aws-iam:standardizedServicePrincipals` IS committed here but has
+ *    expired out of the registry (18 of the 19 keys are recognized), so a
+ *    registry filter would stop passing a flag this project does set. Neither
+ *    rule is exact; this one errs toward passing flags through.
+ *
+ * @param context context to filter, defaulting to cdk.json's. Injectable so the
+ *                filter itself is directly testable — with cdk.json holding no
+ *                project key, deleting the filter changes nothing observable, so
+ *                a test that reads only the real file cannot detect its removal.
+ *                See `committedFeatureFlags` in synth-app.test.ts.
  */
-export function committedFeatureFlags(): Record<string, unknown> {
+export function committedFeatureFlags(
+  context: Record<string, unknown> = cdkJsonContext(),
+): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(cdkJsonContext()).filter(([key]) => key.startsWith('@aws-cdk')),
+    Object.entries(context).filter(([key]) => key.startsWith('@aws-cdk')),
   );
 }
 

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -71,7 +71,7 @@ function cdkJsonContext(): Record<string, unknown> {
  * suite used to hold — which is also what makes the merge tempting now that both
  * live in this file.
  *
- * That merge passed all 290 cases when measured, and typechecks and lints clean.
+ * That merge passed the ENTIRE suite when measured, and typechecks and lints clean.
  * Hence `cdkJsonContextStrict` in synth-app.test.ts, which is what now catches it.
  * Strict at all because an oracle that degrades to `{}` satisfies its own
  * comparison.

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -39,19 +39,54 @@ export interface Baseline {
   stacks: Record<string, { templateSha256: string; names: NameInventory }>;
 }
 
+/** The `context` block cdk.json commits, or `{}` if it is absent or malformed. */
+function cdkJsonContext(): Record<string, unknown> {
+  const cdkJson: unknown = JSON.parse(readFileSync(join(PROJECT_ROOT, 'cdk.json'), 'utf8'));
+  return isRecord(cdkJson) && isRecord(cdkJson.context) ? cdkJson.context : {};
+}
+
+/**
+ * Only the CDK FEATURE FLAGS cdk.json commits — no project-level context.
+ *
+ * Read rather than listed because several flags change the SHAPE of a
+ * synthesized template and not merely its details: `@aws-cdk/aws-iam:minimizePolicies`
+ * merges IAM statements, and `@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy`
+ * decides whether S3 log delivery is granted by a statement on the destination's
+ * bucket policy or by a `LogDeliveryWrite` ACL. A synth that omits them asserts
+ * against a template no deploy of this project produces, and a synth that
+ * hard-codes a copy of them drifts from cdk.json with nothing failing.
+ *
+ * Exported for lib/stacks/core-stack.test.ts, which wants exactly this and
+ * deliberately NOT the project context {@link baseContext} adds: that suite has
+ * cases asserting CDK's own DEFAULTS — `sets case-insensitive sign-in by default
+ * (greenfield)` relies on `omitUserPoolUsernameConfiguration` being unset — and a
+ * project `-c` default reaching them would silently invert what they measure.
+ *
+ * The `@aws-cdk` filter is what makes that guarantee structural rather than a
+ * coincidence of today's cdk.json holding nothing else: every one of its 19 keys
+ * is `@aws-cdk`-prefixed, so the filter is a no-op now and a barrier later.
+ */
+export function committedFeatureFlags(): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(cdkJsonContext()).filter(([key]) => key.startsWith('@aws-cdk')),
+  );
+}
+
 /**
  * Context every synth here uses. Mirrors cdk.json + cdk.context.json (the
  * committed project defaults, i.e. what a real deploy gets) plus the two
  * escape hatches template assertions always want: no Docker bundling and no
  * frontend-freshness check.
+ *
+ * Unfiltered on purpose, unlike {@link committedFeatureFlags}: this one models a
+ * real deploy of the whole app, so a project key committed to either file has to
+ * reach it.
  */
 function baseContext(): Record<string, unknown> {
-  const cdkJson: unknown = JSON.parse(readFileSync(join(PROJECT_ROOT, 'cdk.json'), 'utf8'));
   const committed: unknown = JSON.parse(readFileSync(join(PROJECT_ROOT, 'cdk.context.json'), 'utf8'));
-  const featureFlags = isRecord(cdkJson) && isRecord(cdkJson.context) ? cdkJson.context : {};
   const projectContext = isRecord(committed) ? committed : {};
   return {
-    ...featureFlags,
+    ...cdkJsonContext(),
     ...projectContext,
     'aws:cdk:bundling-stacks': [],
     skipFrontendBuildCheck: true,

--- a/voc-datalake/lib/test-support/synth-app.ts
+++ b/voc-datalake/lib/test-support/synth-app.ts
@@ -13,6 +13,8 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { z } from 'zod';
+
 import type { NameInventory } from './name-inventory';
 
 const PROJECT_ROOT = join(__dirname, '..', '..');
@@ -59,6 +61,27 @@ function cdkJsonContext(): Record<string, unknown> {
 }
 
 /**
+ * The same block, read strictly, for the two suites that use it as an ORACLE.
+ *
+ * MUST NOT be rewritten to delegate to {@link cdkJsonContext}. Both callers
+ * compare a value {@link committedFeatureFlags} derives FROM `cdkJsonContext()`
+ * against this read, so a delegating body reduces them to `f(x) === f(x)` — green
+ * even if the default argument were wired to cdk.context.json. The independent
+ * body is the whole mechanism; exported so there is one of it rather than the
+ * byte-identical copy each suite used to hold.
+ *
+ * Strict because an oracle that degrades to `{}` satisfies its own comparison.
+ * Shares `PROJECT_ROOT`, so the pair catches a wrong file, key or default — not a
+ * wrong root.
+ */
+export function cdkJsonContextStrict(): Record<string, unknown> {
+  return z
+    .object({ context: z.record(z.string(), z.unknown()) })
+    .parse(JSON.parse(readFileSync(join(PROJECT_ROOT, 'cdk.json'), 'utf8')))
+    .context;
+}
+
+/**
  * Only the CDK FEATURE FLAGS cdk.json commits — no project-level context.
  *
  * Read rather than listed because several flags change the SHAPE of a
@@ -76,26 +99,36 @@ function cdkJsonContext(): Record<string, unknown> {
  * project `-c` default reaching them would silently invert what they measure.
  *
  * The `@aws-cdk` prefix is a deliberate HEURISTIC for "is a feature flag", NOT a
- * structural guarantee. It is a no-op on today's cdk.json — all 19 committed keys
- * are `@aws-cdk`-prefixed — and a barrier against a project key added later, but
- * it has two known edges, both recorded because a reader who takes the rule as
- * exact draws the wrong conclusion at either one:
+ * structural guarantee. It is a no-op on today's cdk.json — every committed key is
+ * `@aws-cdk`-prefixed, and `synthCoreTemplate() must not spread cdk.json project
+ * context` in lib/stacks/core-stack.test.ts goes red the day one is not — and a
+ * barrier against a project key added later, but it has two known edges, both
+ * recorded because a reader who takes the rule as exact draws the wrong conclusion
+ * at either one. No count appears below on purpose: `aws-cdk-lib` is a caret
+ * range, so any figure here goes stale on an `npm update` with no committed file
+ * changing, and each claim is instead either asserted or dated.
  *
- * 1. `cx-api`'s `FLAGS` registry holds 108 feature flags and exactly one,
- *    `aws-cdk:enableDiffNoFail`, is not `@aws-cdk`-prefixed. Were cdk.json to
- *    commit it, this filter would drop it as project context while
- *    {@link baseContext} kept it, so the two would synthesize from different flag
- *    sets. Inert: the flag only selects `cdk diff`'s exit code and cannot alter a
- *    synthesized template, so no assertion in lib/stacks/core-stack.test.ts moves.
+ * 1. Exactly one flag in `cx-api`'s `FLAGS` registry, `aws-cdk:enableDiffNoFail`,
+ *    is not `@aws-cdk`-prefixed. Were cdk.json to commit it, this filter would
+ *    drop it as project context while {@link baseContext} kept it, so the two
+ *    would synthesize from different flag sets. Inert: the flag only selects
+ *    `cdk diff`'s exit code and cannot alter a synthesized template, so no
+ *    assertion in lib/stacks/core-stack.test.ts moves. The "exactly one" is
+ *    ASSERTED — `would drop aws-cdk:enableDiffNoFail…` in synth-app.test.ts — so a
+ *    CDK upgrade that adds a second unprefixed flag fails there rather than
+ *    leaving this paragraph quietly wrong.
  * 2. Filtering by `key in cx.FLAGS` instead is not a fix, because the registry is
  *    not a superset of what a project may commit:
  *    `@aws-cdk/aws-iam:standardizedServicePrincipals` IS committed here but has
- *    expired out of `FLAGS` (18 of the 19 keys are recognized), so a registry
- *    predicate would drop it. Inert too — the flag has no runtime effect in
- *    aws-cdk-lib 2.261.0 (zero references in any `.js` under the package, only a
- *    doc comment in aws-iam/lib/principals.d.ts; CDK v2 applies the standardized
- *    behaviour unconditionally), and removing it leaves VocCoreStack's template
- *    byte-identical at 78006 characters.
+ *    expired out of `FLAGS`, so a registry predicate would drop it. Also asserted,
+ *    by `cannot use cx-api FLAGS as the predicate instead…`. Inert too — the flag
+ *    has no runtime effect in aws-cdk-lib 2.261.0 (zero references in any `.js`
+ *    under the package, only a doc comment in aws-iam/lib/principals.d.ts; CDK v2
+ *    applies the standardized behaviour unconditionally), and dropping it left
+ *    VocCoreStack's template byte-identical. That last one is a MEASUREMENT taken
+ *    at 2.261.0, not an assertion: pinning the template here would duplicate what
+ *    baseline.json's hash already guards, and would move on the next unrelated
+ *    change to this stack.
  *
  * So BOTH edges are inert, for different reasons, and neither predicate is exact.
  * The prefix rule is preferred because it errs toward passing keys THROUGH — not

--- a/voc-datalake/lib/utils/nag-suppressions.ts
+++ b/voc-datalake/lib/utils/nag-suppressions.ts
@@ -23,14 +23,6 @@ export const idempotencyTableSuppressions: NagPackSuppression[] = [
   },
 ];
 
-// S3 access logging for CloudFront-fronted buckets
-export const websiteBucketSuppressions: NagPackSuppression[] = [
-  {
-    id: 'AwsSolutions-S1',
-    reason: 'Website bucket is served exclusively through CloudFront - CloudFront access logs provide traffic visibility',
-  },
-];
-
 // AWSLambdaBasicExecutionRole - AWS managed policy for Lambda CloudWatch logging
 export const lambdaBasicExecutionRoleSuppressions: NagPackSuppression[] = [
   {


### PR DESCRIPTION
## Summary

`WebsiteBucket` was the only one of the three buckets in `core-stack.ts` without server access logging. It now carries the same pair as its two siblings:

```ts
serverAccessLogsBucket: this.accessLogsBucket,
serverAccessLogsPrefix: 'website-bucket/',
```

`AccessLogsBucket` is a fourth producer on an existing destination — it already receives the raw-data bucket's logs, the S3-import bucket's logs and the CloudFront distribution logs — so no new bucket, no new lifecycle rule, no new IAM principal.

**The `AwsSolutions-S1` suppression is retired in the same commit.** That rule is cdk-nag's check for exactly this missing property, so with the property present the suppression describes a condition that has gone. All three pieces are removed:

- the one-entry `websiteBucketSuppressions` export in `lib/utils/nag-suppressions.ts`
- the `NagSuppressions.addResourceSuppressions(this.websiteBucket, …)` call
- the now-unused name from `core-stack.ts`'s import list

**cdk-nag reports nothing new on that bucket in its place.** I checked directly rather than inferring it from a green suite: a full-app synth reports `0` diagnostics (`aws:cdk:warning` + `aws:cdk:error`) across all five stacks, with `readsRealAnnotations: true` so the empty list means "clean" rather than "the collector parsed nothing". No fresh suppression was needed or added.

### Severity is the scanner's rating, not ours

Worth stating plainly for a reviewer weighing this against the other findings in this file: **this bucket is reachable only through CloudFront with origin access control, and all four public-access blocks are on.** The practical value here is uniformity and a quiet scanner rather than new visibility. It is not a live exposure.

The one substantive thing the new logs add over the existing CloudFront logs is coverage of requests that reach the bucket *without* going through the distribution — CloudFront logs viewer requests, S3 server access logs record what actually arrived at the bucket. That is a real difference, but a small one given the access controls above.

### `AccessLogsBucket` deliberately still logs nowhere

Left exactly as it was, as instructed. The scanner raises the same rule against it and that one is a false positive: S3 does not support a bucket delivering its own access logs to itself. That is now an *assertion* rather than an unstated assumption, so a later well-meaning "fix all the S1 findings" pass fails a test instead of shipping a self-referential destination.

### Test added

Five cases in `lib/stacks/core-stack.test.ts` (not `api-stack.test.ts` — that file is owned by another in-flight change):

- `WebsiteBucket` and `RawDataBucket` each log into the access-logs bucket under their documented prefix. The destination logical id is resolved *from the template* rather than hard-coded, since CDK appends an address hash to it.
- `AccessLogsBucket` carries no `LoggingConfiguration`, with the reason in a comment.
- `WebsiteBucket` carries no `cdk_nag` metadata.

I verified the new assertion is not vacuous by removing the two properties again and re-running: exactly one case fails (`ships WebsiteBucket logging into the access-logs bucket under website-bucket/`), and it fails for the right reason.

### Baseline regenerated

`lib/test-support/baseline.json` needed regenerating — the whole point of that guard is that an intended template change is a deliberate act. I reviewed the delta before regenerating rather than after:

- `LoggingConfiguration` added to the website bucket
- one `s3:PutObject` statement added to the access-logs bucket policy for `logging.s3.amazonaws.com`, conditioned on `aws:SourceArn` of the website bucket and `aws:SourceAccount`
- the `cdk_nag` metadata block removed from the website bucket

Nothing else. **The `names` inventory is byte-identical** — only `templateSha256` for `VocCoreStack` moved — so no table, bucket or user pool is renamed and no deployed resource is replaced.

## Build and test results

Run from `voc-datalake/`:

| Gate | Result |
|---|---|
| `npm run test:cdk` | **283 passed, 0 failed** (17 files) |
| `npm run typecheck:cdk` | **clean**, exit 0 |
| `npx cdk synth VocCoreStack` | **succeeds** |
| `npm run lint:frontend` | clean, exit 0 (unaffected, run as a sanity check) |

`test:cdk` went 278→283 with the five new cases. As the task predicted, a fresh checkout has no `frontend/dist`, so I ran `cd frontend && npm run build` first (`✓ built in 8.34s`); `node_modules` was absent in both `voc-datalake/` and `voc-datalake/frontend/`, so both needed `npm ci`.

### Synth output, quoted in full

`npx cdk synth VocCoreStack` prints **zero warnings**. It emits one informational notice:

> `64 feature flags are not configured. Run 'cdk flags --unstable=flags' to learn more.`

**That notice is pre-existing and unrelated** — I confirmed it by stashing my changes and re-running: byte-identical output on the pristine tree. It is a CDK CLI notice about the repo's `cdk.json` feature-flag set, not a finding against this change. The full-app annotation check described above is the stronger statement: 0 warnings, 0 errors.

One environment note: bare `npx cdk synth VocCoreStack` fails in this container with `spawnSync docker ENOENT`, because CDK synthesizes the whole app and `VocIngestionStack`'s `IngestionDepsLayer` bundles in a container. This is **not** caused by my change — it reproduces identically on unmodified `development`. `--exclusively` scopes synth to the one stack and succeeds. Anyone with Docker/finch available gets the plain command working.

## Decisions made

- **Prefix `'website-bucket/'`**, matching the `'raw-data-bucket/'` / `'s3-import-bucket/'` style, as specified.
- **Test placement**: `core-stack.test.ts`, per the instruction to keep out of `api-stack.test.ts`. `lib/stacks/api-stack.ts` and `api-stack.test.ts` are untouched — confirmed with `git diff --name-only`.
- **Regenerating the baseline** was the one judgement call not spelled out in the task. It is unavoidable — the change alters the default template by design, which is what that guard measures — but the script header is emphatic that regenerating to turn a red test green defeats it. So I diffed the two synthesized templates first and confirmed the delta is only the three expected items, and that the name inventory did not move at all. The `it.each` case for `RawDataBucket` is included partly so that this property has a readable assertion behind it and not just a digest.
- **`RemovalPolicy` and IAM statements left alone**, per scope. The one policy statement that did change is the access-logs bucket policy, which CDK generates automatically from `serverAccessLogsBucket` — not a hand-written statement.

Scope: four files, all under `voc-datalake/lib/`.

## Agent notes

**What went well.** The task was precisely specified — two properties, three deletions, a named prefix — so there was no design judgement to make. The interesting work was all verification: proving cdk-nag really reports nothing new (rather than assuming a green suite implied it), and proving the new assertion fails without the change.

**What was difficult, and two traps worth recording.**

1. **The baseline hash is the real gate, not the obvious one.** My first full run was 278 passed / 1 failed, and the single failure was `app-baseline.test.ts` comparing `VocCoreStack`'s template digest. The failure message is well-written and points at `scripts/generate-baseline.ts`, but the script header explicitly warns against regenerating to make a red test green. The right move is to diff the before/after templates *first*, and specifically to check whether the `names` inventory moved — a hash change with an unchanged inventory means "shape changed", while a hash change *with* an inventory change could mean a CloudFormation replacement of a table or bucket. Future changes touching any stack should expect this and budget for reviewing the delta.

2. **`git stash push <path>` from a subdirectory silently mangles the pathspec.** Running it with `voc-datalake/...` paths while cwd was `voc-datalake/` produced `voc-datalake/voc-datalake/...` and failed. Worse, my first attempt to prove the new test non-vacuous by stashing `core-stack.ts` alone made *every* case in the file fail — because the stashed version still imports the export I had deleted, so it was a compile error, not a meaningful test result. Reverting just the two property lines in place is the technique that actually isolates the assertion. Both are easy to misread as "the change is broken".

3. **`aws:cdk:bundling-stacks` cannot be passed via `--context` or `CDK_CONTEXT_JSON`** (`User-provided context cannot use keys prefixed with 'aws:'`, and putting it in `cdk.json` earns a reserved-key warning). The test harness sets it through `synth-app.ts` instead. For a CLI synth without Docker, `--exclusively` is the clean workaround.

**Conventions observed.** Comments in this repo explain *why*, often citing the issue number and the failure mode that motivated the code — `core-stack.test.ts` is a good model, and I wrote the new block to match: each assertion says what breaking it would mean operationally. The existing tests also consistently **count before they parse** (`expect(found).toHaveLength(1)` before reading properties) so that "resource missing" and "resource malformed" report as different failures, and they match on **logical id rather than physical name**, because `uniqueName()` builds names from `Aws.ACCOUNT_ID`/`Aws.REGION` pseudo-parameters and so synthesizes to `Fn::Join` objects. Several tests also deliberately assert the *complement* of a claim so it cannot pass vacuously — worth imitating. Commits are conventional with a required scope and an issue reference where one exists.

**Suggestions for future tasks.**

- Setup in a fresh container is heavier than it looks: `npm ci` is needed in `voc-datalake/` **and** `voc-datalake/frontend/`, and `frontend/dist` must exist or ~43 CDK cases fail on `CannotFindAsset`. Doing all three up front avoids a confusing first run.
- There is no `mise` task in this repo; gates run through the root `package.json`, which delegates via `--prefix`.
- The remaining audit findings in `core-stack.ts` (the `RemovalPolicy` set, the IAM statements) are separately owned but would each want this same treatment — check whether a suppression describes the very property being added, and retire it in the same commit.
- Consider whether `AccessLogsBucket`'s own `AwsSolutions-S1` finding deserves an explicit, documented suppression. Today it is unsuppressed and unexplained in code; my new test records the reasoning, but a reader running Checkov will still meet the finding with nothing pointing at the rationale.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

```abca-verify
no-ui
```