### PR TITLE
fix(aggregator): make an arrival idempotent under stream redelivery (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
 ### Fixed
 
+- Feedback aggregation is now idempotent under DynamoDB Streams redelivery: the aggregate counter
+  updates and a per-stream-event claim commit in one DynamoDB transaction, so replaying an event is
+  a no-op instead of moving every counter a second time. `AggregateRecordReplayed` reports those
+  skips and `AggregateTransactionConflicted` reports bounded in-process retries on hot rows.
 - Shared modal dialogs now honour Escape and keep Tab inside themselves while focus is in a nested
   same-origin `<iframe>`. Keys pressed inside a frame are raised in the frame's own document and
   never reached the dialog, so any modal embedding one (the prototype overlay above) could not be

--- a/docs/processing-pipeline.md
+++ b/docs/processing-pipeline.md
@@ -263,21 +263,31 @@ refused.
 
 Two prices, both accepted deliberately:
 
-- **DynamoDB bills a transactional write at 2× the WCU** of the same write sent on its
-  own, so an arrival's writes cost double what they did as independent `update_item`
-  calls. The aggregates table is `PAY_PER_REQUEST`, so this is a bill rather than a
-  ceiling to breach.
+- **An arrival's write capacity is a little over double.** Two separate effects, and
+  conflating them understates it: DynamoDB charges a transactional write at **2× the
+  WCU** of the same write sent on its own, *and* the transaction adds a write that did
+  not exist before — the dedupe claim, which also lands in a second table. So an
+  arrival that was one write per dimension plus the average is now
+  `(dimensions + 2) × 2` WCU rather than `dimensions + 1`. Expressed against
+  `counter_dimensions` rather than as a fixed multiple, because the dimension count is
+  meant to grow. The aggregates table is `PAY_PER_REQUEST`, so this is a bill rather
+  than a ceiling to breach.
 - **Same-date records now contend.** Every record of a date moves
   `METRIC#daily_total`, and `TransactWriteItems` conflicts on a contended item where
   two plain `update_item`s would simply have serialised. A bulk import (the
   `s3_import` plugin, or `TRIM_HORIZON` after a redeploy) is the shape that produces
-  this at volume.
+  this at volume — and the same shape produces throttling, which for a transaction
+  arrives as a cancellation carrying a `ThrottlingError` *reason* rather than as a
+  throttling error, so botocore's own retry policies never match it.
 
 Contention converges rather than losing records, and it is bounded in three places:
-the transaction is re-attempted in process with a jittered backoff
-(`TRANSACT_WRITE_ATTEMPTS = 3`, matching `ballots_handler`'s `BALLOT_WRITE_ATTEMPTS`
-for the same DynamoDB reason), past that bound the stream redelivers the record, and
-the claim makes every one of those retries a no-op if an earlier attempt landed.
+the transaction is re-attempted in process with a jittered backoff whenever the
+cancellation is **transient** — contention or throttling, the reasons named in
+`_RETRYABLE_CANCELLATION_REASONS`, and never a validation failure that would fail
+identically on the next attempt (`TRANSACT_WRITE_ATTEMPTS = 3`, the same value as
+`ballots_handler`'s `BALLOT_WRITE_ATTEMPTS` for the same DynamoDB reason, though
+nothing couples the two); past that bound the stream redelivers the record; and the
+claim makes every one of those retries a no-op if an earlier attempt landed.
 
 `AggregateTransactionConflicted` in CloudWatch is the number to watch, since a retry
 that succeeds is otherwise invisible. If it climbs during an import, the levers are the
@@ -351,6 +361,7 @@ insert):
 | `AggregateWriteRefused` | Conditional writes DynamoDB refused (nothing to correct) |
 | `AggregateWriteDeclined` | Writes the handler chose not to attempt |
 | `AggregateRecordReplayed` | Redelivered stream records the dedupe claim refused |
+| `AggregateTransactionConflicted` | Transactions re-attempted after contention or throttling on a shared row |
 
 ### Logs
 

--- a/docs/processing-pipeline.md
+++ b/docs/processing-pipeline.md
@@ -231,7 +231,9 @@ AWS Lambda Powertools idempotency:
 
 ### Aggregator (DynamoDB Streams)
 
-The aggregator applies eight counter updates plus a running average per feedback
+The aggregator applies one counter update per dimension (`counter_dimensions` in
+`voc-datalake/lambda/aggregator/handler.py` — seven for a fully-populated item today,
+and designed to be extended) plus a running average per feedback
 record. Its event source is configured with `retryAttempts: 3` and
 `reportBatchItemFailures: true`, so a batch that partially fails re-presents records
 whose writes already landed — and because these counters are only ever incremented,
@@ -256,6 +258,33 @@ refused item cancels the whole transaction. So a redelivered reversal still decr
 a second time, bounded by that floor: no counter goes negative and no expired row is
 resurrected. `AggregateRecordReplayed` in CloudWatch counts the arrivals the claim
 refused.
+
+#### What a transaction costs, and where contention shows up
+
+Two prices, both accepted deliberately:
+
+- **DynamoDB bills a transactional write at 2× the WCU** of the same write sent on its
+  own, so an arrival's writes cost double what they did as independent `update_item`
+  calls. The aggregates table is `PAY_PER_REQUEST`, so this is a bill rather than a
+  ceiling to breach.
+- **Same-date records now contend.** Every record of a date moves
+  `METRIC#daily_total`, and `TransactWriteItems` conflicts on a contended item where
+  two plain `update_item`s would simply have serialised. A bulk import (the
+  `s3_import` plugin, or `TRIM_HORIZON` after a redeploy) is the shape that produces
+  this at volume.
+
+Contention converges rather than losing records, and it is bounded in three places:
+the transaction is re-attempted in process with a jittered backoff
+(`TRANSACT_WRITE_ATTEMPTS = 3`, matching `ballots_handler`'s `BALLOT_WRITE_ATTEMPTS`
+for the same DynamoDB reason), past that bound the stream redelivers the record, and
+the claim makes every one of those retries a no-op if an earlier attempt landed.
+
+`AggregateTransactionConflicted` in CloudWatch is the number to watch, since a retry
+that succeeds is otherwise invisible. If it climbs during an import, the levers are the
+event source's `batchSize` and `parallelizationFactor` in
+`voc-datalake/lib/stacks/processing-stack-consolidated.ts` — not a wider transaction,
+which would put the conditional reversal writes inside it and disable the aged-out-day
+protections described above.
 
 ## Rebuilding aggregates for a window
 

--- a/docs/processing-pipeline.md
+++ b/docs/processing-pipeline.md
@@ -218,11 +218,85 @@ Errors are logged to DynamoDB (`LOGS#processing#{source}`) and visible in Settin
 
 ## Idempotency
 
-The processor uses AWS Lambda Powertools idempotency to prevent duplicate processing:
+Both consumers deduplicate, against the same DynamoDB table, for the same reason:
+their event sources deliver at-least-once.
+
+### Processor (SQS)
+
+AWS Lambda Powertools idempotency:
 
 - Idempotency key: `{source_platform}:{source_id}`
 - Records cached for 1 hour
 - Prevents duplicate writes on SQS retries
+
+### Aggregator (DynamoDB Streams)
+
+The aggregator applies eight counter updates plus a running average per feedback
+record. Its event source is configured with `retryAttempts: 3` and
+`reportBatchItemFailures: true`, so a batch that partially fails re-presents records
+whose writes already landed — and because these counters are only ever incremented,
+that divergence is permanent.
+
+An **arrival** (`INSERT`) therefore claims the stream record's `eventID` in the
+idempotency table inside the *same* `TransactWriteItems` as its counters:
+
+- Idempotency key: `aggregator#stream#{eventID}` (namespaced, since the table is
+  shared with the processor)
+- Claims expire after 48 hours, comfortably outliving the 24 hours a stream record
+  can survive
+- A redelivered record cancels the transaction and moves nothing
+- A record that fails partway leaves *nothing* applied, so the daily total can never
+  disagree with the sum of the per-category counts
+
+A **reversal** (`REMOVE`, and the decrement half of a `MODIFY`) is *not* transacted,
+and this is deliberate. Every decrement is a conditional write
+(`attribute_exists(pk) AND #field >= :floor`) whose refusal the code above it reads to
+decide what to do next, while `TransactWriteItems` reports no per-item outcome — one
+refused item cancels the whole transaction. So a redelivered reversal still decrements
+a second time, bounded by that floor: no counter goes negative and no expired row is
+resurrected. `AggregateRecordReplayed` in CloudWatch counts the arrivals the claim
+refused.
+
+## Rebuilding aggregates for a window
+
+Aggregate rows are pre-computed counters, so any drift already stored stays stored —
+the idempotency above stops new drift arriving but repairs nothing written earlier.
+There is no scheduled reconciliation job; the procedure below is the supported repair,
+and it is short enough that a job would be out of proportion to how rarely it is
+needed.
+
+**Write absolute values. Never replay deltas.** The counter updates use
+`SET #field = if_not_exists(#field, :zero) + :inc`, so a delta replayed against a row
+that has aged out of its 90-day TTL *recreates* that row under a fresh TTL — holding a
+negative count for a date whose real totals are long gone, which
+`/metrics/summary` would then serve as that day's figures. An absolute `PUT` cannot do
+that: it either overwrites a row that is there or writes the correct value for a row
+that is not.
+
+For each date `D` in the window:
+
+1. **Recompute from source.** Query the feedback table for the items of `D` and count
+   them per dimension — total, `source_platform`, `category`, `sentiment_label`,
+   `persona_type` bucket, `urgency == 'high'`, and the category+sentiment pair. The
+   dimensions and their pk spellings are defined in one place,
+   `counter_dimensions` in `voc-datalake/lambda/aggregator/handler.py`; read them from
+   there rather than re-deriving, since a rebuild that buckets differently from the
+   writer produces rows the read path cannot find.
+2. **Write each row with `put_item`**, not `update_item`: `{pk, sk: D, count: <the
+   recomputed number>, ttl: <now + 90 days>, updated_at: <now>}`, plus
+   `metric_type` for the source and persona partitions (the `metric_type` GSI is how
+   `/metrics/sources` and `/metrics/personas` find them). For the average row, write
+   `sum` and `count` from the scored items of `D`.
+3. **Skip dates outside retention.** Aggregate rows live 90 days
+   (`AGGREGATE_RETENTION_DAYS`), and rebuilding a date older than that plants rows for
+   a day whose neighbours no longer exist — `/metrics/trends` would show one populated
+   day in an empty stretch. Rebuild only within the retention window.
+4. **Delete rows the rebuild did not write** for a date it did rebuild. A bucket that
+   has legitimately dropped to zero items still has a row holding its old count, and
+   writing only the buckets that now have items leaves that stale row behind.
+
+Do this against a copy of the table first if the window is wide: step 2 is
+destructive by design, and it is the only step that is.
 
 ## Monitoring
 
@@ -236,6 +310,18 @@ The processor uses AWS Lambda Powertools idempotency to prevent duplicate proces
 | `ValidationFailures` | Messages that failed validation |
 | `DuplicatesSkipped` | Duplicate items skipped |
 | `BedrockThrottleRetry` | Bedrock throttling events |
+
+Aggregator metrics (one per behaviour, so a reversal is not invisible behind an
+insert):
+
+| Metric | Description |
+|--------|-------------|
+| `AggregatesUpdated` | Arrivals applied |
+| `AggregatesReversed` | Deletions reversed out |
+| `AggregatesRebucketed` | Edits that moved a counter |
+| `AggregateWriteRefused` | Conditional writes DynamoDB refused (nothing to correct) |
+| `AggregateWriteDeclined` | Writes the handler chose not to attempt |
+| `AggregateRecordReplayed` | Redelivered stream records the dedupe claim refused |
 
 ### Logs
 

--- a/docs/processing-pipeline.md
+++ b/docs/processing-pipeline.md
@@ -263,15 +263,19 @@ refused.
 
 Two prices, both accepted deliberately:
 
-- **An arrival's write capacity is a little over double.** Two separate effects, and
-  conflating them understates it: DynamoDB charges a transactional write at **2× the
-  WCU** of the same write sent on its own, *and* the transaction adds a write that did
-  not exist before — the dedupe claim, which also lands in a second table. So an
-  arrival that was one write per dimension plus the average is now
-  `(dimensions + 2) × 2` WCU rather than `dimensions + 1`. Expressed against
+- **An arrival's write capacity is a little over double, and it is billed on two
+  tables, not one.** Two separate effects, and conflating them understates it:
+  DynamoDB charges a transactional write at **2× the WCU** of the same write sent on
+  its own, *and* the transaction adds a write that did not exist before. That second
+  write is the dedupe claim, and it lands in the **idempotency table**, not the
+  aggregates table the counters live in — so the two effects are also two separate
+  bills. On the **aggregates table**: one write per dimension plus the average, at 2×
+  WCU, is `(counter_dimensions + 1) × 2`. On the **idempotency table**: one write, at
+  2× WCU, is `1 × 2`. Together, `(counter_dimensions + 2) × 2` WCU is the arrival's
+  total cost rather than either table's bill alone. Expressed against
   `counter_dimensions` rather than as a fixed multiple, because the dimension count is
-  meant to grow. The aggregates table is `PAY_PER_REQUEST`, so this is a bill rather
-  than a ceiling to breach.
+  meant to grow. Both tables are `PAY_PER_REQUEST`, so this is a bill rather than a
+  ceiling to breach.
 - **Same-date records now contend.** Every record of a date moves
   `METRIC#daily_total`, and `TransactWriteItems` conflicts on a contended item where
   two plain `update_item`s would simply have serialised. A bulk import (the

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -131,12 +131,14 @@ Known residuals
   point above and is recorded rather than hidden. TWO separate effects, and
   conflating them understates the bill: DynamoDB charges a transactional write at
   TWICE the WCU of the same write sent alone, AND the transaction adds a write that
-  did not exist before — the dedupe claim, which also lands in a second table. So an
-  arrival that was one write per dimension plus the average is now
-  `(dimensions + 2) x 2` WCU rather than `dimensions + 1`: a little over double, not
-  double. Stated in terms of `counter_dimensions` rather than as a fixed multiple
-  because the dimension count is meant to grow. The aggregates table is
-  PAY_PER_REQUEST, so this is a bill and not a ceiling. And every record of a date
+  did not exist before — the dedupe claim, which lands in the IDEMPOTENCY table, not
+  this one. So the aggregates table pays `(dimensions + 1) x 2` and the idempotency
+  table pays `1 x 2`, for an arrival total of `(dimensions + 2) x 2` WCU rather than
+  `dimensions + 1`: a little over double, not double. Stated in terms of
+  `counter_dimensions` rather than as a fixed multiple because the dimension count is
+  meant to grow. Both tables are PAY_PER_REQUEST, so this is a bill and not a
+  ceiling — see docs/processing-pipeline.md for the same split spelled out per table.
+  And every record of a date
   moves `METRIC#daily_total`, so same-date records in one batch now CONTEND on it
   where two plain `update_item`s would simply have serialised — a bulk import
   through the `s3_import` plugin is exactly the shape that produces this, and the

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -1213,8 +1213,9 @@ def _claimed_transaction(dedupe_key: str, items: list[dict[str, Any]]) -> bool:
     # this loop would be INDISTINGUISHABLE FROM A REDELIVERY: `False` here means "the
     # record was already applied", which `record_handler` reports as a success and
     # never retries — so a bound of 0 would silently drop every record's aggregates
-    # while reporting the batch clean. `test_the_attempt_bound_leaves_at_least_one`
-    # pins the bound; this is the guard for the case where it stops holding anyway.
+    # while reporting the batch clean.
+    # `test_the_attempt_bound_leaves_at_least_one_attempt` pins the bound; this is the
+    # guard for the case where it stops holding anyway.
     raise RuntimeError(
         'TRANSACT_WRITE_ATTEMPTS is not at least 1, so no aggregate transaction was '
         'attempted. Raising rather than reporting a record that was never applied.'

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -128,13 +128,20 @@ Known residuals
   negative counter, with the tests in TestRedeliveryMovesACounterTwice pinning
   the reversal behaviour so this note and the code cannot drift apart.
 * AN ARRIVAL COSTS MORE AND CONTENDS MORE THAN IT DID, which is the price of the
-  point above and is recorded rather than hidden. DynamoDB bills a transactional
-  write at TWICE the WCU of the same write sent alone, so an arrival's writes cost
-  double what they did as independent `update_item` calls; the aggregates table is
+  point above and is recorded rather than hidden. TWO separate effects, and
+  conflating them understates the bill: DynamoDB charges a transactional write at
+  TWICE the WCU of the same write sent alone, AND the transaction adds a write that
+  did not exist before — the dedupe claim, which also lands in a second table. So an
+  arrival that was one write per dimension plus the average is now
+  `(dimensions + 2) x 2` WCU rather than `dimensions + 1`: a little over double, not
+  double. Stated in terms of `counter_dimensions` rather than as a fixed multiple
+  because the dimension count is meant to grow. The aggregates table is
   PAY_PER_REQUEST, so this is a bill and not a ceiling. And every record of a date
   moves `METRIC#daily_total`, so same-date records in one batch now CONTEND on it
   where two plain `update_item`s would simply have serialised — a bulk import
-  through the `s3_import` plugin is exactly the shape that produces this. Bounded
+  through the `s3_import` plugin is exactly the shape that produces this, and the
+  same shape produces throttling, which arrives as a cancellation too (see
+  `_RETRYABLE_CANCELLATION_REASONS`, and why botocore cannot absorb it). Bounded
   in three places, none of them accidental: the transaction is re-attempted in
   process with a jittered backoff (`TRANSACT_WRITE_ATTEMPTS`, and
   CONFLICTED_METRIC is what makes the rate visible), past that bound the stream
@@ -417,13 +424,57 @@ _TRANSIENT_READ_ERRORS = frozenset({
 # looks exactly like a system under no contention.
 TRANSACTION_CONFLICT_REASON = 'TransactionConflict'
 
+# The reason code DynamoDB uses for an item that caused no failure. Every cancelled
+# transaction's reasons list has one entry per item, so most entries are this — which
+# is why `_conflicted` has to treat it as "says nothing" rather than as unretryable.
+NO_CANCELLATION_REASON = 'None'
+
+# Every cancellation reason a re-attempt can plausibly clear, as the reason-code
+# spellings DynamoDB puts INSIDE `CancellationReasons`.
+#
+# 🔑 THROTTLING BELONGS HERE BECAUSE NOTHING ELSE ABSORBS IT. Botocore's throttling
+# retry policies match on the TOP-LEVEL `service_error_code`, and a throttled
+# transaction's top-level code is `TransactionCanceledException` — the throttle lives
+# one level down, in the reasons. DynamoDB's only per-service policies in
+# `botocore/data/_retry.json` are `ReplicatedWriteConflictException`,
+# `TransactionInProgressException` and `crc32`, none of which match. So a throttled
+# arrival that is not retried here gets ONE attempt, then spends the event source's
+# `retryAttempts: 3`, and past that is dropped with its aggregates lost permanently.
+#
+# These are the same conditions `_TRANSIENT_READ_ERRORS` already calls transient on the
+# READ side, spelled as the reasons list spells them. ⚠️ AND THE SPELLINGS ARE NOT
+# DERIVABLE FROM EACH OTHER: `TransactionConflict` and `ProvisionedThroughputExceeded`
+# do take the `Exception` suffix, but the throttle is `ThrottlingError` here and
+# `ThrottlingException` there — so no suffix rule relates the two vocabularies and both
+# sets have to be written out in full. `test_every_retryable_reason_is_transient_on_the
+# _read_path_too` holds the pairing as an explicit table for that reason. The two paths
+# must not reach opposite conclusions about one condition, and a bulk import through
+# `s3_import` is exactly the shape that produces both at volume.
+#
+# A `ValidationError` is deliberately NOT here: it will fail identically on the next
+# attempt, so re-sending it only spends the invocation and delays the record.
+_RETRYABLE_CANCELLATION_REASONS = frozenset({
+    TRANSACTION_CONFLICT_REASON,
+    'ThrottlingError',
+    'ProvisionedThroughputExceeded',
+})
+
 # How many times an aggregate transaction is re-attempted in process, and how long it
-# waits first. The reasoning is `_claimed_transaction`'s; the numbers are
-# `ballots_handler`'s (BALLOT_WRITE_ATTEMPTS / BALLOT_WRITE_BACKOFF_SECONDS), and
-# deliberately so — both are a small bounded budget for contention on ONE hot item,
-# and there is no reason for this Lambda to make a different guess. Three attempts
-# spans ~150ms of backoff at most, which is nothing against a 30-second batching
-# window and far less than a stream redelivery of the whole batch.
+# waits first. The reasoning is `_claimed_transaction`'s; the numbers equal
+# `ballots_handler`'s (BALLOT_WRITE_ATTEMPTS / BALLOT_WRITE_BACKOFF_SECONDS) because
+# both are a small bounded budget for contention on ONE hot item and there is no reason
+# for this Lambda to guess differently.
+#
+# ⚠️ THEY ARE NOT COUPLED. Nothing keeps the two pairs in step: the modules cannot
+# import each other (`api` and `aggregator` bundle separately, each excluding the
+# other), and no lockstep compares them — two tuning numbers did not seem worth a
+# shared constant in `shared/`. So they agree today by judgement, not by construction,
+# and tuning one does NOT tune the other. If they should diverge, they may.
+#
+# Three attempts means two waits, and the jitter is one-sided — see
+# `_claimed_transaction`, where the multiplier spans [0.5, 1.0) — so the total backoff
+# is 75–150ms, at most ~150ms and never more. Nothing against a 30-second batching
+# window, and far less than a stream redelivery of the whole batch.
 TRANSACT_WRITE_ATTEMPTS = 3
 TRANSACT_WRITE_BACKOFF_SECONDS = 0.05
 
@@ -1141,16 +1192,19 @@ def _claimed_transaction(dedupe_key: str, items: list[dict[str, Any]]) -> bool:
     what gets it retried — and a transaction that failed for a reason this function
     cannot name has NOT applied anything, so a retry is the correct response.
 
-    🔑 A `TransactionConflict` IS RE-ATTEMPTED IN PROCESS, up to
+    🔑 A TRANSIENT CANCELLATION IS RE-ATTEMPTED IN PROCESS, up to
     `TRANSACT_WRITE_ATTEMPTS` times with a jittered backoff, and this is the one place
     the aggregator's calculus is worth stating because `ballots_handler._write_ballot`
     reaches the same conclusion from the same DynamoDB fact for its own reasons.
+    Transient means `_RETRYABLE_CANCELLATION_REASONS`: contention and throttling, which
+    are the two conditions botocore leaves to us because it matches the top-level error
+    code and a cancelled transaction's is always `TransactionCanceledException`.
     `METRIC#daily_total` is written by EVERY record of a date, `batchSize` is 100, and
     botocore does NOT auto-retry `TransactionCanceledException` (only
     `TransactionInProgressException` and `ReplicatedWriteConflictException` carry retry
-    policies), so contention that a plain `update_item` used to absorb invisibly at the
-    request level now arrives here as a cancellation. Left to propagate it becomes a
-    reported record failure, and the record has only the event source's
+    policies), so contention and throttling that a plain `update_item` used to absorb
+    invisibly at the request level now arrive here as a cancellation. Left to propagate
+    it becomes a reported record failure, and the record has only the event source's
     `retryAttempts: 3` left before it is DROPPED and its aggregates lost for good —
     which is strictly worse than the double-count this whole change exists to remove.
     Retrying is safe by construction: nothing was written, and if a concurrent attempt
@@ -1199,12 +1253,17 @@ def _claimed_transaction(dedupe_key: str, items: list[dict[str, Any]]) -> bool:
                 # should see it at the moment the wait began rather than after it.
                 metrics.add_metric(name=CONFLICTED_METRIC, unit="Count", value=1)
                 logger.warning(
-                    f"Aggregate transaction for {dedupe_key} hit a write conflict; "
-                    f"retrying (attempt {attempt + 2} of {TRANSACT_WRITE_ATTEMPTS})"
+                    f"Aggregate transaction for {dedupe_key} was cancelled for a "
+                    f"transient reason (contention or throttling); retrying "
+                    f"(attempt {attempt + 2} of {TRANSACT_WRITE_ATTEMPTS})"
                 )
                 delay = TRANSACT_WRITE_BACKOFF_SECONDS * (2 ** attempt)
-                # Jittered, so records that collided once do not re-collide having
-                # waited the same interval.
+                # HALF JITTER: the multiplier spans [0.5, 1.0), so the wait is 50–100%
+                # of the nominal delay above — 25–50ms, then 50–100ms — and never
+                # longer than it. Decorrelating records that collided once matters more
+                # here than the absolute wait, which is why the range is one-sided
+                # rather than the symmetric [0.5, 1.5) `randbelow(1000)` would give.
+                # `_write_ballot` jitters the same way, for the same reason.
                 time.sleep(delay * (0.5 + secrets.randbelow(500) / 1000))
                 continue
             raise
@@ -1256,26 +1315,40 @@ def _claim_was_refused(error: ClientError) -> bool:
 
 
 def _conflicted(error: ClientError) -> bool:
-    """Was this cancellation contention on one of the rows, and nothing else?
+    """Is EVERY reason this cancellation gives one a re-attempt could clear?
 
-    The one cancellation worth re-attempting in process, and the reason is that it is
-    ORDINARY rather than exceptional: every record of a date moves
-    `METRIC#daily_total`, so same-day records arriving in one batch contend by design.
+    🔑 "AND NOTHING ELSE" IS THE WHOLE PREDICATE, and it is `all` rather than `any`
+    deliberately — review found the two disagreeing, with the docstring claiming a
+    scope the `any` did not enforce. One retryable reason alongside a permanent one
+    meant a cancellation that CANNOT succeed was re-attempted to the full bound: the
+    exact cost `test_a_validation_failure_is_not_retried` exists to prevent, reached
+    whenever the two coincide. That is reachable, not theoretical — a poison row is a
+    `ValidationError` on one item, and if that record also collides on
+    `METRIC#daily_total` the request now carries both.
+
+    So a reason that names a PERMANENT failure vetoes the retry even if another names
+    contention. Nothing is lost by that: the transaction wrote nothing either way, and
+    the permanent item will refuse every re-attempt identically, so the only thing a
+    retry could add is delay before the same failure is reported.
+
+    What licenses a re-attempt is `_RETRYABLE_CANCELLATION_REASONS` — contention and
+    throttling, which are the reason-code spellings of conditions
+    `_TRANSIENT_READ_ERRORS` already treats as transient on the read side. See that
+    constant for why botocore cannot absorb the throttles for us. Contention is the
+    ORDINARY one: every record of a date moves `METRIC#daily_total`, so same-day
+    records arriving in one batch contend by design.
+
+    `NO_CANCELLATION_REASON` is not a failure at all — a cancelled transaction reports
+    one reason per item and most items simply did not fail — so it says nothing and
+    cannot veto. A reasons list of nothing BUT those would mean no item failed, which
+    is not a cancellation this can explain, so at least one real retryable reason is
+    still required.
+
     Read from the reasons rather than from the exception, exactly as
-    `_claim_was_refused` is, because the decision it drives is different — a retry
-    versus reporting the record failed — and only one code licenses it.
-
-    ANY reason being unreadable answers False, which routes to the raise. That is the
-    same fail-toward-the-stream direction the claim check takes: the stream redelivers
-    and the claim makes that safe, so declining to retry costs a round trip, while
-    retrying a cancellation this cannot name would spend the invocation's time on a
-    request that will fail identically (a `ValidationException` does not become valid).
-
-    `_TRANSIENT_READ_ERRORS` already names `TransactionConflictException` for the day
-    read; the spelling HERE is the reason code DynamoDB puts in `CancellationReasons`,
-    which is `TransactionConflict` without the suffix — two different strings for the
-    same condition, one per API surface, which is why neither can be derived from the
-    other.
+    `_claim_was_refused` is, and unreadable ANYTHING answers False — the same
+    fail-toward-the-stream direction: the stream redelivers and the claim makes that
+    safe, so declining to retry costs a round trip, while retrying a cancellation this
+    cannot name spends the invocation on a request that may fail identically.
     """
     response = error.response if isinstance(error.response, Mapping) else None
     if response is None:
@@ -1285,9 +1358,14 @@ def _conflicted(error: ClientError) -> bool:
     reasons = response.get('CancellationReasons')
     if not isinstance(reasons, list) or not reasons:
         return False
-    return any(isinstance(reason, Mapping)
-               and reason.get('Code') == TRANSACTION_CONFLICT_REASON
-               for reason in reasons)
+    # An unreadable entry is not `NO_CANCELLATION_REASON` and not retryable, so it
+    # vetoes here rather than needing its own check.
+    codes = [reason.get('Code') if isinstance(reason, Mapping) else None
+             for reason in reasons]
+    blocking = [code for code in codes if code != NO_CANCELLATION_REASON]
+    if not blocking:
+        return False
+    return all(code in _RETRYABLE_CANCELLATION_REASONS for code in blocking)
 
 
 def _reverse_a_pre_deploy_persona_row(

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -109,7 +109,7 @@ Known residuals
   records whose writes already landed — permanently, since nothing recomputes a
   counter from source. An INSERT now claims the record's `eventID` in the shared
   idempotency table INSIDE the same `TransactWriteItems` as its counters
-  (`apply_feedback_once`), which closes both halves at once: a redelivery moves
+  (`apply_arrival_once`), which closes both halves at once: a redelivery moves
   nothing, and a record that dies partway leaves no partial application for the
   retry to land on top of.
   ⚠️ A REVERSAL (REMOVE, and the decrement half of a MODIFY) IS NOT TRANSACTED, so
@@ -127,6 +127,22 @@ Known residuals
   guarantee for those paths is what they always did: no resurrected row, and no
   negative counter, with the tests in TestRedeliveryMovesACounterTwice pinning
   the reversal behaviour so this note and the code cannot drift apart.
+* AN ARRIVAL COSTS MORE AND CONTENDS MORE THAN IT DID, which is the price of the
+  point above and is recorded rather than hidden. DynamoDB bills a transactional
+  write at TWICE the WCU of the same write sent alone, so an arrival's writes cost
+  double what they did as independent `update_item` calls; the aggregates table is
+  PAY_PER_REQUEST, so this is a bill and not a ceiling. And every record of a date
+  moves `METRIC#daily_total`, so same-date records in one batch now CONTEND on it
+  where two plain `update_item`s would simply have serialised — a bulk import
+  through the `s3_import` plugin is exactly the shape that produces this. Bounded
+  in three places, none of them accidental: the transaction is re-attempted in
+  process with a jittered backoff (`TRANSACT_WRITE_ATTEMPTS`, and
+  CONFLICTED_METRIC is what makes the rate visible), past that bound the stream
+  redelivers, and the claim makes every one of those retries a no-op if an earlier
+  attempt landed. So contention converges rather than losing records — but if
+  CONFLICTED_METRIC climbs under import, the lever is the event source's
+  `parallelizationFactor` and `batchSize` in
+  `lib/stacks/processing-stack-consolidated.ts`, not a wider transaction.
 * NO RECONCILIATION JOB. Nothing recomputes a stored aggregate from the feedback
   table, so drift already written stays written — the point above only stops new
   drift arriving. A rebuild has to write ABSOLUTE values rather than replay
@@ -184,6 +200,8 @@ Known residuals
   once the legacy rows are gone, and strictly smaller than the over-count above.
 """
 import os
+import secrets
+import time
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -263,12 +281,23 @@ processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
 # the condition this change exists to make survivable. Distinct from REFUSED and
 # DECLINED because it is neither a write DynamoDB rejected nor one this module
 # declined to attempt: it is a whole record correctly doing nothing.
+#
+# CONFLICTED_METRIC counts a transaction re-attempted after contention, and it is the
+# one metric here that measures a COST rather than a behaviour. Two records of the same
+# date both move `METRIC#daily_total`, and a transaction cancelled by that contention is
+# retried in process (see `_claimed_transaction`) — invisibly, since the retry then
+# succeeds. So without this the trade the retry makes is unmeasurable: a rising count
+# is contention the batch size or the parallelization factor is creating, and it is the
+# number that says whether the bound of three attempts is still generous. Not folded
+# into REFUSED_METRIC, which counts a condition DynamoDB was right to enforce; a
+# conflict is nobody being wrong.
 UPDATED_METRIC = "AggregatesUpdated"
 REVERSED_METRIC = "AggregatesReversed"
 REBUCKETED_METRIC = "AggregatesRebucketed"
 REFUSED_METRIC = "AggregateWriteRefused"
 DECLINED_METRIC = "AggregateWriteDeclined"
 REPLAYED_METRIC = "AggregateRecordReplayed"
+CONFLICTED_METRIC = "AggregateTransactionConflicted"
 
 # The two aggregate rows this module names outside `counter_dimensions`, hoisted
 # for the reason PERSONA_FIELD is named: a second unmarked copy of one of these
@@ -378,6 +407,26 @@ _TRANSIENT_READ_ERRORS = frozenset({
     'TransactionConflictException',
 })
 
+# --- Contention on the rows every record of a date shares ----------------------
+# 🔑 THE CODE DYNAMODB PUTS IN `CancellationReasons` FOR A CONTENDED ITEM, which is
+# `TransactionConflict` — NOT the `TransactionConflictException` in the set above.
+# Those are two spellings of one condition, one per API surface: the exception code on
+# a plain request, the reason code inside a cancelled transaction. Neither is
+# derivable from the other, so both are named, and this one is a constant because
+# matching it wrongly is silent — an unmatched reason simply never retries, which
+# looks exactly like a system under no contention.
+TRANSACTION_CONFLICT_REASON = 'TransactionConflict'
+
+# How many times an aggregate transaction is re-attempted in process, and how long it
+# waits first. The reasoning is `_claimed_transaction`'s; the numbers are
+# `ballots_handler`'s (BALLOT_WRITE_ATTEMPTS / BALLOT_WRITE_BACKOFF_SECONDS), and
+# deliberately so — both are a small bounded budget for contention on ONE hot item,
+# and there is no reason for this Lambda to make a different guess. Three attempts
+# spans ~150ms of backoff at most, which is nothing against a 30-second batching
+# window and far less than a stream redelivery of the whole batch.
+TRANSACT_WRITE_ATTEMPTS = 3
+TRANSACT_WRITE_BACKOFF_SECONDS = 0.05
+
 
 class CounterWrite(Enum):
     """How one `update_counter` call ended.
@@ -474,47 +523,108 @@ def _counter_request(pk: str, sk: str, field: str, increment: int,
     🔑 THE ONE PLACE A COUNTER'S UPDATE EXPRESSION IS WRITTEN, spent by both issuers:
     `update_counter`, which sends it on its own and reports how it ended, and
     `_counter_transaction_item`, which wraps the identical arguments for
-    `TransactWriteItems`. The transaction is what makes the INSERT path's eight
-    writes all-or-nothing (issue #264), and building its expression separately would
-    have meant two copies of `if_not_exists(#field, :zero) + :inc` — with the drift
-    landing on whichever path had fewer tests, which is exactly the failure mode
-    `counter_dimensions` exists to prevent one level up.
+    `TransactWriteItems`. The transaction is what makes an arrival's writes — one
+    counter per dimension, plus the average — all-or-nothing (issue #264), and
+    building its expression separately would have meant two copies of
+    `if_not_exists(#field, :zero) + :inc`, with the drift landing on whichever path
+    had fewer tests. That is exactly the failure mode `counter_dimensions` exists to
+    prevent one level up.
 
     Both callers are inside this module, so the `Key`/`UpdateExpression` shape is the
     interface rather than the argument names: `transact_write_items` spells its
     fields the same way `update_item` does, which is what lets one dict serve both
     with a rename rather than a rebuild.
+
+    THE RETURNED DICT IS COMPLETE AT THE LITERAL THAT BUILDS IT. The conditional
+    half used to be added by mutating `attr_values` through the local alias after it
+    had already been embedded, which worked (one object, two names) and meant the
+    request was not described by the expression that constructs it. It is decided
+    first and merged once now, because this is the single source of BOTH paths'
+    counter expression and the transactional one cannot report a per-item outcome —
+    so how it was assembled is the only thing a reader has to go on.
     """
-    ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
+    now = datetime.now(timezone.utc)
+    ttl = int(now.timestamp() + ttl_days * 24 * 60 * 60)
 
     # Build update expression - include metric_type for GSI if applicable
     metric_type = get_metric_type(pk)
-    update_expr = 'SET #field = if_not_exists(#field, :zero) + :inc, #ttl = :ttl, updated_at = :now'
-    attr_names = {'#field': field, '#ttl': 'ttl'}
-    attr_values: dict[str, Any] = {
-        ':inc': increment,
-        ':zero': 0,
-        ':ttl': ttl,
-        ':now': datetime.now(timezone.utc).isoformat()
-    }
+    metric_type_values = {':metric_type': metric_type} if metric_type else {}
+    # A DEcrement may not create a row and may not go below zero — see
+    # `update_counter`. Decided here rather than bolted on afterwards, so the
+    # condition, its `:floor` and the refused-item request travel together.
+    #
+    # `ReturnValuesOnConditionCheckFailure` asks for the refused item, so a refusal
+    # can say WHICH half of the condition failed. Only on the conditional path: an
+    # increment carries no condition and so cannot be refused.
+    conditional: dict[str, Any] = {
+        'ConditionExpression': 'attribute_exists(pk) AND #field >= :floor',
+        'ReturnValuesOnConditionCheckFailure': 'ALL_OLD',
+    } if increment < 0 else {}
+    floor_value = {':floor': -increment} if increment < 0 else {}
 
-    if metric_type:
-        update_expr += ', metric_type = :metric_type'
-        attr_values[':metric_type'] = metric_type
-
-    request: dict[str, Any] = {
+    return {
         'Key': {'pk': pk, 'sk': sk},
-        'UpdateExpression': update_expr,
-        'ExpressionAttributeNames': attr_names,
-        'ExpressionAttributeValues': attr_values,
+        'UpdateExpression': (
+            'SET #field = if_not_exists(#field, :zero) + :inc, #ttl = :ttl, '
+            'updated_at = :now'
+            + (', metric_type = :metric_type' if metric_type else '')
+        ),
+        'ExpressionAttributeNames': {'#field': field, '#ttl': 'ttl'},
+        'ExpressionAttributeValues': {
+            ':inc': increment,
+            ':zero': 0,
+            ':ttl': ttl,
+            ':now': now.isoformat(),
+            **metric_type_values,
+            **floor_value,
+        },
+        **conditional,
     }
-    if increment < 0:
-        request['ConditionExpression'] = 'attribute_exists(pk) AND #field >= :floor'
-        attr_values[':floor'] = -increment
-        # Ask for the refused item, so a refusal can say WHICH half of the condition
-        # failed. Only on the conditional path: an increment cannot be refused.
-        request['ReturnValuesOnConditionCheckFailure'] = 'ALL_OLD'
-    return request
+
+
+def _average_request(pk: str, sk: str, value: Decimal, ttl_days: int,
+                     sign: int) -> dict[str, Any]:
+    """One movement of a running average, as `update_item` arguments.
+
+    🔑 THE ONE PLACE THE AVERAGE'S UPDATE EXPRESSION IS WRITTEN, and the counterpart
+    of `_counter_request` for the row that misleads most: `get_summary` divides
+    `sum/count` per date and weights it into the headline `avg_sentiment`, so the two
+    attributes have to move together or the day asserts an average no item justifies.
+
+    Both issuers spend it — `update_average`, which sends it alone and reports whether
+    it landed, and `_average_transaction_item`, which wraps it for
+    `TransactWriteItems`. It was spelled out twice when the arrival path became
+    transactional (issue #264), which put `#sum`/`#count`/`#ttl` in two places on
+    paths with very different test coverage: the retention lockstep compared only the
+    `ttl_days` defaults, so an attribute NAME could have drifted between the two
+    writers with nothing failing, and a transactional row writing `total` where the
+    reader looks for `sum` reads as a day with no average at all.
+
+    `sign` carries the direction, exactly as `update_average`'s does: `:val` is
+    negated for a reversal and `:one` IS the count movement, so `sign=-1` subtracts
+    the score and decrements the count. The CONDITION for a reversal is the caller's
+    to add — see `update_average`, which is the only issuer that may make a
+    conditional average write, and `_average_transaction_item` for why a transaction
+    may not.
+    """
+    now = datetime.now(timezone.utc)
+    ttl = int(now.timestamp() + ttl_days * 24 * 60 * 60)
+    return {
+        'Key': {'pk': pk, 'sk': sk},
+        'UpdateExpression': (
+            'SET #sum = if_not_exists(#sum, :zero) + :val, '
+            '#count = if_not_exists(#count, :zero) + :one, '
+            '#ttl = :ttl, updated_at = :now'
+        ),
+        'ExpressionAttributeNames': {'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'},
+        'ExpressionAttributeValues': {
+            ':val': value if sign > 0 else -value,
+            ':one': sign,
+            ':zero': Decimal('0'),
+            ':ttl': ttl,
+            ':now': now.isoformat(),
+        },
+    }
 
 
 def update_counter(pk: str, sk: str, field: str, increment: int = 1,
@@ -551,7 +661,7 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1,
     The floor is not idempotency, and this function is the path that does not have
     any: a redelivered REMOVE against a counter at 3 still lands on 2 and then 1.
     Redelivery is closed for ARRIVALS, by claiming the record's `eventID` in the same
-    transaction as its writes — see `apply_feedback_once`, and the module docstring
+    transaction as its writes — see `apply_arrival_once`, and the module docstring
     for why a conditional decrement cannot join that transaction.
 
     ConditionalCheckFailedException is therefore an expected, benign outcome of a
@@ -636,38 +746,27 @@ def update_average(pk: str, sk: str, value: Decimal, ttl_days: int = 90,
     bug this module exists to remove. The coherent fix is to store per-item
     contributions so a reversal subtracts what was actually added; that is a schema
     change, and out of scope here. Recorded in the module docstring as a residual.
+
+    THE EXPRESSION IS BUILT ELSEWHERE — `_average_request` — for the reason
+    `update_counter`'s is: an arrival now sends the same movement as one
+    `TransactWriteItems` entry, and two spellings of `if_not_exists(#sum, :zero) +
+    :val` would be two sets of attribute names to keep in step, with `sum` and `count`
+    being exactly the names `get_summary` reads back. This function is the SINGLE-WRITE
+    issuer, and the only one that may make the write CONDITIONAL: a refusal is
+    information `_rebucket_average` reads, and a transaction has no per-item outcome to
+    report it with.
     """
-    ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
-
-    attr_values: dict[str, Any] = {
-        ':val': value if sign > 0 else -value,
-        ':one': sign,
-        ':zero': Decimal('0'),
-        ':ttl': ttl,
-        ':now': datetime.now(timezone.utc).isoformat()
-    }
-
-    kwargs: dict[str, Any] = {}
-    if sign < 0:
+    request = _average_request(pk, sk, value, ttl_days, sign)
+    conditional = sign < 0
+    if conditional:
         # A distinct :floor rather than reusing :one, which is -1 here.
-        kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #count >= :floor'
-        attr_values[':floor'] = 1
+        request['ConditionExpression'] = 'attribute_exists(pk) AND #count >= :floor'
+        request['ExpressionAttributeValues'][':floor'] = 1
 
     try:
-        aggregates_table.update_item(
-            Key={'pk': pk, 'sk': sk},
-            UpdateExpression='''
-                SET #sum = if_not_exists(#sum, :zero) + :val,
-                    #count = if_not_exists(#count, :zero) + :one,
-                    #ttl = :ttl,
-                    updated_at = :now
-            ''',
-            ExpressionAttributeNames={'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'},
-            ExpressionAttributeValues=attr_values,
-            **kwargs
-        )
+        aggregates_table.update_item(**request)
     except ClientError as e:
-        if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
+        if not conditional or not is_conditional_check_failure(e):
             raise
         _log_refusal('reversal of average', pk, sk)
         return False
@@ -765,12 +864,25 @@ def counter_dimensions(item: dict) -> list[tuple[str, str]]:
     path, because the two drifting apart is the failure mode this fix exists to
     remove: a dimension added to the insert path only would go up forever and
     never come back down — precisely the shape of the original bug, just narrower.
-    This replaces eight hardcoded `update_counter` calls; an inverted copy of
-    those eight would have re-created that hazard on day one.
+    This replaces a hardcoded `update_counter` call per dimension; an inverted copy
+    of that list would have re-created the hazard on day one.
 
     URGENCY IS THE ONLY CONDITIONAL DIMENSION. Every other item below is appended
     unconditionally, because each read has a non-empty default — a reader asking
-    "which of these might be absent?" gets one answer, not two.
+    "which of these might be absent?" gets one answer, not two. So this returns SEVEN
+    dimensions for an urgent item and six otherwise; no docstring in this module states
+    the number, deliberately, because the list below is designed to be extended and a
+    count restated in prose is a fact that goes stale where nothing checks it.
+
+    ⚠️ A SECOND DIMENSION ON AN EXISTING pk IS NOW A TRANSACTION-BREAKING CHANGE.
+    `counter_keys` turns each entry into `(pk, date, field)`, and an arrival sends every
+    one of them as an entry of a single `TransactWriteItems` — where DynamoDB rejects
+    two operations on ONE item outright, failing the whole request. Two dimensions
+    sharing a pk with different FIELDS are two distinct entries here and one DynamoDB
+    item there, so adding such a pair would fail every ingested record rather than
+    counting one dimension oddly. Harmless on the single-write reversal path, which
+    issues them sequentially. `test_the_transaction_names_each_item_once` is the guard;
+    a dimension on a NEW pk, which is what every entry below is, needs nothing.
 
     The persona bucket comes from `shared.feedback.persona_bucket`, the one
     derivation this Lambda and `metrics_handler`'s scan path share, and
@@ -916,14 +1028,23 @@ def apply_counter_keys(
 
 
 def counter_transaction_items(
-    keys: set[tuple[str, str, str]], sign: int,
+    keys: set[tuple[str, str, str]],
 ) -> list[dict[str, Any]]:
-    """Every named counter's movement, as `TransactWriteItems` entries.
+    """Every named counter's INCREMENT, as `TransactWriteItems` entries.
 
     `apply_counter_keys`' counterpart for the transactional path, and it is a
     FUNCTION rather than a comprehension at the call site for the same reason that one
     is: it is the ONE place a counter key is unpacked into a transactional write, so
     there is exactly one line here deciding what a counter's sort key is.
+
+    NO `sign`, and that is the scope of the whole transactional path made structural.
+    It took one until review pointed out that the parameter was only half honoured —
+    threaded into the counters and dropped for the average, which hardcodes `+1` — so
+    a `sign=-1` call decremented every counter while INCREMENTING the average, and the
+    transaction then guaranteed that inconsistent state committed whole. Taking the
+    parameter away is what makes "reversals do not come through here" a fact about the
+    signature rather than a sentence in a docstring; see `apply_arrival_once` for why
+    a conditional decrement cannot join a transaction at all.
 
     🔑 THE UNPACKING IS SPELLED `for pk, date, field in sorted(keys)` DELIBERATELY.
     `test_streaming_categories_lockstep.py` pins the small set of expressions a
@@ -936,23 +1057,36 @@ def counter_transaction_items(
     catch. Sorted for the same reason `apply_counter_keys` sorts: a deterministic
     order for tests and logs, and here it also fixes which item a cancellation reason
     refers to.
+
+    ⚠️ ONE ENTRY PER `(pk, sk)`, WHICH IS DYNAMODB'S RULE AND NOT A PREFERENCE. See
+    `_claimed_transaction`; `counter_dimensions` is the function that decides it, and
+    `test_the_transaction_names_each_item_once` fails if it stops holding.
     """
-    return [_counter_transaction_item(pk, date, field, sign)
+    return [_counter_transaction_item(pk, date, field)
             for pk, date, field in sorted(keys)]
 
 
-def _counter_transaction_item(pk: str, sk: str, field: str, increment: int,
+def _counter_transaction_item(pk: str, sk: str, field: str, increment: int = 1,
                               ttl_days: int = 90) -> dict[str, Any]:
-    """One counter movement as a `TransactWriteItems` entry.
+    """One counter INCREMENT as a `TransactWriteItems` entry.
 
     The same request `update_counter` issues on its own — `_counter_request` builds
-    it, so the expression exists once — with the table name added and the whole thing
-    wrapped in the `{'Update': ...}` shape the transaction API takes.
+    it, so the expression exists once, including the `metric_type` tag the
+    `gsi1-by-metric-type` GSI needs on the source and persona rows — with the table
+    name added and the whole thing wrapped in the `{'Update': ...}` shape the
+    transaction API takes.
+
+    `increment` defaults to 1 and every caller leaves it there. It is still a
+    parameter because `_counter_request` reads its SIGN to decide whether the write
+    carries the floor condition, and a builder that could not express that would have
+    to re-derive the condition rather than forward it — but a NEGATIVE value must not
+    reach here, and `counter_transaction_items` no longer offers a way to pass one.
+    See `apply_arrival_once`: a decrement's refusal is information, and a transaction
+    cannot report it.
 
     `ttl_days` defaults here as it does on every other writer, and
-    `test_aggregate_retention_lockstep.py` reads the defaults of `update_counter` and
-    `update_average` because those are the two functions that STAMP a row. This one
-    only forwards, and it forwards the same number.
+    `test_aggregate_retention_lockstep.py` reads the default of all four writers
+    because every one of them stamps a row's TTL from its own copy of the number.
     """
     return {'Update': {'TableName': AGGREGATES_TABLE,
                        **_counter_request(pk, sk, field, increment, ttl_days)}}
@@ -962,36 +1096,24 @@ def _average_transaction_item(pk: str, sk: str, value: Decimal,
                               ttl_days: int = 90) -> dict[str, Any]:
     """The running average's INCREMENT half as a `TransactWriteItems` entry.
 
-    Increment only, and that is a scope statement rather than an omission. The
-    transaction exists for the INSERT path, whose average write is unconditional;
-    every DECREMENT of the average is a conditional write whose refusal
-    `_rebucket_average` has to observe to decide the pairing, and a transaction
-    reports no per-item outcome — a refused item cancels the whole transaction
-    instead. Putting a reversal in here would therefore replace a rule that reads
-    "the reversal was refused, so do not re-apply" with "the edit wrote nothing at
-    all", which is a different behaviour and not the one that class pins.
+    Increment only, and that is a scope statement rather than an omission — enforced
+    by taking no `sign` at all rather than by this paragraph. The transaction exists
+    for the arrival path, whose average write is unconditional; every DECREMENT of the
+    average is a conditional write whose refusal `_rebucket_average` has to observe to
+    decide the pairing, and a transaction reports no per-item outcome — a refused item
+    cancels the whole transaction instead. Putting a reversal in here would therefore
+    replace a rule that reads "the reversal was refused, so do not re-apply" with "the
+    edit wrote nothing at all", which is a different behaviour and not the one that
+    class pins.
 
-    The expression is `update_average`'s, spelled once here because the sign is fixed
-    at +1 on this path: `:one` is the count movement, so an increment is literally 1.
+    The expression is `update_average`'s because `_average_request` builds both: the
+    `sum`/`count` attribute names are what `get_summary` reads back, so a second
+    spelling of them here would be free to drift into a row the read path cannot see —
+    the retention lockstep compares the TTL defaults and would not have noticed.
+    `sign=1` is passed as the literal it is, since this path has no other direction.
     """
-    ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
-    return {'Update': {
-        'TableName': AGGREGATES_TABLE,
-        'Key': {'pk': pk, 'sk': sk},
-        'UpdateExpression': (
-            'SET #sum = if_not_exists(#sum, :zero) + :val, '
-            '#count = if_not_exists(#count, :zero) + :one, '
-            '#ttl = :ttl, updated_at = :now'
-        ),
-        'ExpressionAttributeNames': {'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'},
-        'ExpressionAttributeValues': {
-            ':val': value,
-            ':one': 1,
-            ':zero': Decimal('0'),
-            ':ttl': ttl,
-            ':now': datetime.now(timezone.utc).isoformat(),
-        },
-    }}
+    return {'Update': {'TableName': AGGREGATES_TABLE,
+                       **_average_request(pk, sk, value, ttl_days, 1)}}
 
 
 def _claimed_transaction(dedupe_key: str, items: list[dict[str, Any]]) -> bool:
@@ -1019,31 +1141,84 @@ def _claimed_transaction(dedupe_key: str, items: list[dict[str, Any]]) -> bool:
     what gets it retried — and a transaction that failed for a reason this function
     cannot name has NOT applied anything, so a retry is the correct response.
 
-    A `TransactWriteItems` is limited to 100 items; one feedback record produces at
-    most eight counters plus the average plus the marker, so the limit is not
-    reachable from here and is not defended against — a batch is applied one record
-    at a time, deliberately, since the alternative would make one poison record fail
-    every other record's writes with it.
+    🔑 A `TransactionConflict` IS RE-ATTEMPTED IN PROCESS, up to
+    `TRANSACT_WRITE_ATTEMPTS` times with a jittered backoff, and this is the one place
+    the aggregator's calculus is worth stating because `ballots_handler._write_ballot`
+    reaches the same conclusion from the same DynamoDB fact for its own reasons.
+    `METRIC#daily_total` is written by EVERY record of a date, `batchSize` is 100, and
+    botocore does NOT auto-retry `TransactionCanceledException` (only
+    `TransactionInProgressException` and `ReplicatedWriteConflictException` carry retry
+    policies), so contention that a plain `update_item` used to absorb invisibly at the
+    request level now arrives here as a cancellation. Left to propagate it becomes a
+    reported record failure, and the record has only the event source's
+    `retryAttempts: 3` left before it is DROPPED and its aggregates lost for good —
+    which is strictly worse than the double-count this whole change exists to remove.
+    Retrying is safe by construction: nothing was written, and if a concurrent attempt
+    of the SAME record landed, the claim refuses the re-attempt. Bounded and jittered
+    rather than unbounded, because a Lambda holding concurrency in a tight loop is its
+    own outage; past the bound the record is reported failed and the stream redelivers,
+    which the claim also makes safe. CONFLICTED_METRIC is what makes the contention
+    observable rather than merely survivable.
+
+    ⚠️ EVERY ITEM MUST NAME A DIFFERENT `(pk, sk)`. DynamoDB rejects a transaction
+    containing two operations on ONE item with a `ValidationException` — the whole
+    request, so every ingested record would fail, an outage rather than a drift — and
+    what decides it is `counter_dimensions`: `counter_keys` returns `(pk, date, field)`
+    tuples, so two dimensions sharing a pk with DIFFERENT fields deduplicate to two set
+    members naming one DynamoDB item. Harmless on the single-write path (two sequential
+    `update_item`s), fatal here. Today every dimension names its pk once;
+    `test_the_transaction_names_each_item_once` is what fails if a new one stops doing
+    so, rather than production.
+
+    The 100-item cap, by contrast, is NOT reachable and is not defended against: one
+    record produces one counter per dimension, plus the average, plus the marker. A
+    batch is applied one record at a time, deliberately, since the alternative would
+    make one poison record fail every other record's writes with it.
     """
-    now = int(datetime.now(timezone.utc).timestamp())
-    try:
-        aggregates_table.meta.client.transact_write_items(
-            # The claim FIRST, so that a cancellation naming index 0 is the
-            # redelivery case and the reasons list lines up with `items` from 1.
-            TransactItems=[
-                dedupe_claim_item(IDEMPOTENCY_TABLE, dedupe_key, now), *items,
-            ],
-        )
-    except ClientError as e:
-        if not _claim_was_refused(e):
+    for attempt in range(TRANSACT_WRITE_ATTEMPTS):
+        now = int(datetime.now(timezone.utc).timestamp())
+        try:
+            aggregates_table.meta.client.transact_write_items(
+                # The claim FIRST, so that a cancellation naming index 0 is the
+                # redelivery case and the reasons list lines up with `items` from 1.
+                TransactItems=[
+                    dedupe_claim_item(IDEMPOTENCY_TABLE, dedupe_key, now), *items,
+                ],
+            )
+        except ClientError as e:
+            if _claim_was_refused(e):
+                logger.info(
+                    f"Stream record {dedupe_key} was already applied; leaving "
+                    f"{len(items)} aggregate write(s) alone"
+                )
+                metrics.add_metric(name=REPLAYED_METRIC, unit="Count", value=1)
+                return False
+            if _conflicted(e) and attempt + 1 < TRANSACT_WRITE_ATTEMPTS:
+                # Logged BEFORE the sleep, as `_write_ballot` logs its own: the line
+                # records the DECISION to re-attempt, and someone timing a slow record
+                # should see it at the moment the wait began rather than after it.
+                metrics.add_metric(name=CONFLICTED_METRIC, unit="Count", value=1)
+                logger.warning(
+                    f"Aggregate transaction for {dedupe_key} hit a write conflict; "
+                    f"retrying (attempt {attempt + 2} of {TRANSACT_WRITE_ATTEMPTS})"
+                )
+                delay = TRANSACT_WRITE_BACKOFF_SECONDS * (2 ** attempt)
+                # Jittered, so records that collided once do not re-collide having
+                # waited the same interval.
+                time.sleep(delay * (0.5 + secrets.randbelow(500) / 1000))
+                continue
             raise
-        logger.info(
-            f"Stream record {dedupe_key} was already applied; leaving "
-            f"{len(items)} aggregate write(s) alone"
-        )
-        metrics.add_metric(name=REPLAYED_METRIC, unit="Count", value=1)
-        return False
-    return True
+        return True
+    # UNREACHABLE while TRANSACT_WRITE_ATTEMPTS >= 1, and kept because falling out of
+    # this loop would be INDISTINGUISHABLE FROM A REDELIVERY: `False` here means "the
+    # record was already applied", which `record_handler` reports as a success and
+    # never retries — so a bound of 0 would silently drop every record's aggregates
+    # while reporting the batch clean. `test_the_attempt_bound_leaves_at_least_one`
+    # pins the bound; this is the guard for the case where it stops holding anyway.
+    raise RuntimeError(
+        'TRANSACT_WRITE_ATTEMPTS is not at least 1, so no aggregate transaction was '
+        'attempted. Raising rather than reporting a record that was never applied.'
+    )
 
 
 def _claim_was_refused(error: ClientError) -> bool:
@@ -1077,6 +1252,41 @@ def _claim_was_refused(error: ClientError) -> bool:
         return False
     first = reasons[0]
     return isinstance(first, Mapping) and first.get('Code') == 'ConditionalCheckFailed'
+
+
+def _conflicted(error: ClientError) -> bool:
+    """Was this cancellation contention on one of the rows, and nothing else?
+
+    The one cancellation worth re-attempting in process, and the reason is that it is
+    ORDINARY rather than exceptional: every record of a date moves
+    `METRIC#daily_total`, so same-day records arriving in one batch contend by design.
+    Read from the reasons rather than from the exception, exactly as
+    `_claim_was_refused` is, because the decision it drives is different — a retry
+    versus reporting the record failed — and only one code licenses it.
+
+    ANY reason being unreadable answers False, which routes to the raise. That is the
+    same fail-toward-the-stream direction the claim check takes: the stream redelivers
+    and the claim makes that safe, so declining to retry costs a round trip, while
+    retrying a cancellation this cannot name would spend the invocation's time on a
+    request that will fail identically (a `ValidationException` does not become valid).
+
+    `_TRANSIENT_READ_ERRORS` already names `TransactionConflictException` for the day
+    read; the spelling HERE is the reason code DynamoDB puts in `CancellationReasons`,
+    which is `TransactionConflict` without the suffix — two different strings for the
+    same condition, one per API surface, which is why neither can be derived from the
+    other.
+    """
+    response = error.response if isinstance(error.response, Mapping) else None
+    if response is None:
+        return False
+    if (response.get('Error') or {}).get('Code') != 'TransactionCanceledException':
+        return False
+    reasons = response.get('CancellationReasons')
+    if not isinstance(reasons, list) or not reasons:
+        return False
+    return any(isinstance(reason, Mapping)
+               and reason.get('Code') == TRANSACTION_CONFLICT_REASON
+               for reason in reasons)
 
 
 def _reverse_a_pre_deploy_persona_row(
@@ -1202,9 +1412,8 @@ def _reverse_a_pre_deploy_persona_row(
     return landed
 
 
-def apply_feedback_once(item: dict, sign: int, date: str, dedupe_key: str) -> bool:
-    """`apply_feedback`, but every write of it in ONE transaction keyed on
-    `dedupe_key`.
+def apply_arrival_once(item: dict, date: str, dedupe_key: str) -> bool:
+    """One ARRIVAL's every write, in ONE transaction keyed on `dedupe_key`.
 
     🔑 THE PATH THAT IS IDEMPOTENT, and it is the arrival path because that is the one
     whose writes are all unconditional and so can all be transacted. Two properties,
@@ -1214,15 +1423,26 @@ def apply_feedback_once(item: dict, sign: int, date: str, dedupe_key: str) -> bo
       the transaction cancels, and every counter stays where the first delivery left
       it — where the floor at zero could only ever no-op a decrement that was already
       at zero.
-    * A RECORD THAT FAILED PARTWAY LEAVES NOTHING PARTIAL. Eight counters plus the
-      average commit at once, so a daily total can never disagree with the sum of its
-      per-category counts. This is the half a marker alone does not fix: a marker
-      written before the writes records a half-applied record as done, and one written
-      after leaves the half-application to be re-applied on top.
+    * A RECORD THAT FAILED PARTWAY LEAVES NOTHING PARTIAL. One counter per dimension
+      plus the average commit at once, so a daily total can never disagree with the sum
+      of its per-category counts. This is the half a marker alone does not fix: a
+      marker written before the writes records a half-applied record as done, and one
+      written after leaves the half-application to be re-applied on top.
 
     Returns whether the writes were applied — False for a redelivery, which is a
     success from the batch processor's point of view and must not be reported as a
     failed record (that would redeliver it forever).
+
+    🔑 NAMED FOR THE ARRIVAL, AND TAKES NO `sign`, WHICH IS THE POINT OF THE NAME. It
+    was `apply_feedback_once(item, sign, ...)` and threaded that sign into the counters
+    while the average builder hardcoded `+1` — so a `sign=-1` call decremented every
+    counter, INCREMENTED the average, and the transaction then guaranteed the
+    inconsistent state committed whole: strictly worse than the non-transactional split
+    it exists to prevent. Nothing raised, because a half-honoured parameter has nothing
+    to raise about. The paragraph below always said reversals must not come through
+    here; the signature now says it too, which is the difference between a rule and a
+    note, and the next person to attempt transacting a reversal meets a missing
+    argument rather than a green test suite.
 
     THE REVERSAL PATHS DO NOT COME THROUGH HERE, and that is a scope decision rather
     than an oversight. Every decrement is a conditional write whose refusal the code
@@ -1236,7 +1456,7 @@ def apply_feedback_once(item: dict, sign: int, date: str, dedupe_key: str) -> bo
     already had; what they do not get is redelivery protection, which is recorded as a
     residual in the module docstring rather than half-implemented here.
     """
-    items = counter_transaction_items(counter_keys(item, date), sign)
+    items = counter_transaction_items(counter_keys(item, date))
 
     sentiment_score = _image_score(item)
     if sentiment_score:
@@ -1256,7 +1476,7 @@ def apply_feedback(item: dict, sign: int, date: str):
     """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`.
 
     The NON-transactional issuer, now reached only by the reversal paths — see
-    `apply_feedback_once` for which writes may be transacted and why a decrement may
+    `apply_arrival_once` for which writes may be transacted and why a decrement may
     not be. Kept as one function serving both signs because the shared description in
     `counter_dimensions` is what stops the two directions drifting, and that argument
     is about the DIMENSIONS rather than about how the writes are issued.
@@ -1290,7 +1510,7 @@ def process_new_feedback(item: dict, dedupe_key: str | None = None) -> bool:
     already been applied, which is a redelivery and an ordinary success.
 
     `dedupe_key` is the stream record's `eventID`, unique per record, and it is what
-    makes this path idempotent — see `apply_feedback_once`. It is OPTIONAL, and None
+    makes this path idempotent — see `apply_arrival_once`. It is OPTIONAL, and None
     routes to the non-transactional path deliberately: the function must still work
     when `IDEMPOTENCY_TABLE` is unset (a CDK regression must degrade to the pre-#264
     behaviour rather than stop aggregating), and the two dozen callers in the test
@@ -1299,7 +1519,7 @@ def process_new_feedback(item: dict, dedupe_key: str | None = None) -> bool:
     """
     date = _image_date(item)
     if dedupe_key and IDEMPOTENCY_TABLE:
-        return apply_feedback_once(item, 1, date, dedupe_key)
+        return apply_arrival_once(item, date, dedupe_key)
     apply_feedback(item, 1, date)
     return True
 

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -101,22 +101,42 @@ Known residuals
 ---------------
 * NO BACKFILL. Aggregate rows written before this change carry the drift from
   every past deletion; nothing here repairs stored values, it only stops new
-  drift. Repairing them needs a rebuild-from-scan path that does not exist.
-* NOT IDEMPOTENT UNDER REDELIVERY. DynamoDB Streams deliver at-least-once, and
-  the event source is configured with `retryAttempts: 3` and
+  drift. Repairing them means the rebuild-from-scan procedure recorded below.
+* REDELIVERY IS CLOSED ON THE ARRIVAL PATH ONLY, and the asymmetry is a
+  consequence of the conditions above rather than an unfinished job. Streams
+  deliver at-least-once and the event source carries `retryAttempts: 3` with
   `reportBatchItemFailures: true`, so a batch that partially fails re-presents
-  records whose writes already landed. A redelivered REMOVE decrements a second
-  time (the floor at zero only makes that a no-op when the counter is ALREADY at
-  zero — against a counter at 3 it lands on 1, not 2), and a redelivered MODIFY
-  moves the count twice in both directions. What the conditions do guarantee is
-  narrower and still worth having: no resurrected row, and no negative counter.
-  Fixing this properly means recording each record's `eventID`/`sequence_number`
-  through `shared/idempotency.py` — the shared `processingRole` is already granted
-  the idempotency table, but this function is not given its name in the
-  environment, so it is a CDK change as well as a code one, and it buys a write
-  per stream record on the hot path. Deliberately left for its own change, with
-  the tests in TestRedeliveryMovesACounterTwice pinning today's behaviour so this
-  note and the code cannot drift apart.
+  records whose writes already landed — permanently, since nothing recomputes a
+  counter from source. An INSERT now claims the record's `eventID` in the shared
+  idempotency table INSIDE the same `TransactWriteItems` as its counters
+  (`apply_feedback_once`), which closes both halves at once: a redelivery moves
+  nothing, and a record that dies partway leaves no partial application for the
+  retry to land on top of.
+  ⚠️ A REVERSAL (REMOVE, and the decrement half of a MODIFY) IS NOT TRANSACTED, so
+  a redelivered one still decrements a second time. Not an omission: every
+  decrement is a CONDITIONAL write whose refusal the code above it reads —
+  `_reverse_a_pre_deploy_persona_row` triggers on `ROW_ABSENT`, `_rebucket_average`
+  pairs on a refused reversal — and `TransactWriteItems` reports no per-item
+  outcome, cancelling the whole transaction on one refused item instead. Moving
+  them in would turn "this decrement had nothing to correct, so carry on" into
+  "the edit wrote nothing at all", which silently disables the aged-out-day
+  protections that exist BY observing a refusal. Closing it properly needs a
+  dedupe claim that is not a transaction participant — a claim written first, then
+  compensated if the writes fail — which is new failure machinery rather than a
+  wider transaction, and it is out of scope here. What the conditions still
+  guarantee for those paths is what they always did: no resurrected row, and no
+  negative counter, with the tests in TestRedeliveryMovesACounterTwice pinning
+  the reversal behaviour so this note and the code cannot drift apart.
+* NO RECONCILIATION JOB. Nothing recomputes a stored aggregate from the feedback
+  table, so drift already written stays written — the point above only stops new
+  drift arriving. A rebuild has to write ABSOLUTE values rather than replay
+  deltas: `if_not_exists(#field, :zero) + :inc` against a row that aged out of its
+  90-day TTL recreates that row under a fresh TTL, so a replayed delta is exactly
+  the negative-count resurrection the decrement condition exists to prevent. The
+  procedure is written up in `docs/processing-pipeline.md` ("Rebuilding aggregates
+  for a window") rather than shipped as a job, because it is a rare operator action
+  on a table the API already reads and a scheduled job would be a new Lambda, a new
+  role and a new schedule for it.
 * `update_average` FLOORS `count`, NOT `sum` — see its docstring for why adding a
   bound on `sum` would refuse legitimate reversals rather than fix anything.
 * AN EDIT THAT MOVES AN ITEM ONTO A LIVE DAY WHOSE AVERAGE ROW HAS EXPIRED still
@@ -176,6 +196,7 @@ from botocore.exceptions import ClientError
 # Shared module imports
 from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, is_conditional_check_failure
+from shared.idempotency import dedupe_claim_item
 # The persona axis, declared in the data layer because BOTH sides of it spend the
 # same values AND the same derivation — see the note above `counter_dimensions`.
 from shared.feedback import (
@@ -195,6 +216,18 @@ dynamodb = get_dynamodb_resource()
 # Configuration
 AGGREGATES_TABLE = os.environ['AGGREGATES_TABLE']
 aggregates_table = dynamodb.Table(AGGREGATES_TABLE)
+
+# The dedupe table for stream records (issue #264). Empty when the function has not
+# been given it, which is not fatal: the aggregates are still written, exactly as
+# they were before that change, and the warning below is what says the protection is
+# off. The shared `processingRole` is already granted this table for the processor,
+# so what an unset value really means is a CDK regression rather than a permission.
+IDEMPOTENCY_TABLE = os.environ.get('IDEMPOTENCY_TABLE', '')
+if not IDEMPOTENCY_TABLE:
+    logger.warning(
+        "IDEMPOTENCY_TABLE not configured - a redelivered stream record will move "
+        "these counters a second time"
+    )
 
 processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
 
@@ -221,11 +254,21 @@ processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
 # because the two need different responses — a refusal is DynamoDB reporting there
 # was nothing to correct, a decline is this code declining to make a row
 # inconsistent, and only the second is a decision an operator can argue with.
+# REPLAYED_METRIC is the one that says the dedupe claim EARNED its write. A stream
+# record whose key was already claimed is a redelivery, which is ordinary and is
+# supposed to happen — but "ordinary" is the reason it needs a metric rather than a
+# reason it does not: at zero, the protection has never fired and a reviewer cannot
+# tell a working guard from an inert one (the shape `_day_has_aggregates` logs at
+# `error` for), and a spike is the batch failing and re-presenting records, which is
+# the condition this change exists to make survivable. Distinct from REFUSED and
+# DECLINED because it is neither a write DynamoDB rejected nor one this module
+# declined to attempt: it is a whole record correctly doing nothing.
 UPDATED_METRIC = "AggregatesUpdated"
 REVERSED_METRIC = "AggregatesReversed"
 REBUCKETED_METRIC = "AggregatesRebucketed"
 REFUSED_METRIC = "AggregateWriteRefused"
 DECLINED_METRIC = "AggregateWriteDeclined"
+REPLAYED_METRIC = "AggregateRecordReplayed"
 
 # The two aggregate rows this module names outside `counter_dimensions`, hoisted
 # for the reason PERSONA_FIELD is named: a second unmarked copy of one of these
@@ -424,6 +467,56 @@ def _log_decline(what: str, pk: str, sk: str, because: str):
     metrics.add_metric(name=DECLINED_METRIC, unit="Count", value=1)
 
 
+def _counter_request(pk: str, sk: str, field: str, increment: int,
+                     ttl_days: int) -> dict[str, Any]:
+    """One counter movement, as `update_item` arguments.
+
+    🔑 THE ONE PLACE A COUNTER'S UPDATE EXPRESSION IS WRITTEN, spent by both issuers:
+    `update_counter`, which sends it on its own and reports how it ended, and
+    `_counter_transaction_item`, which wraps the identical arguments for
+    `TransactWriteItems`. The transaction is what makes the INSERT path's eight
+    writes all-or-nothing (issue #264), and building its expression separately would
+    have meant two copies of `if_not_exists(#field, :zero) + :inc` — with the drift
+    landing on whichever path had fewer tests, which is exactly the failure mode
+    `counter_dimensions` exists to prevent one level up.
+
+    Both callers are inside this module, so the `Key`/`UpdateExpression` shape is the
+    interface rather than the argument names: `transact_write_items` spells its
+    fields the same way `update_item` does, which is what lets one dict serve both
+    with a rename rather than a rebuild.
+    """
+    ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
+
+    # Build update expression - include metric_type for GSI if applicable
+    metric_type = get_metric_type(pk)
+    update_expr = 'SET #field = if_not_exists(#field, :zero) + :inc, #ttl = :ttl, updated_at = :now'
+    attr_names = {'#field': field, '#ttl': 'ttl'}
+    attr_values: dict[str, Any] = {
+        ':inc': increment,
+        ':zero': 0,
+        ':ttl': ttl,
+        ':now': datetime.now(timezone.utc).isoformat()
+    }
+
+    if metric_type:
+        update_expr += ', metric_type = :metric_type'
+        attr_values[':metric_type'] = metric_type
+
+    request: dict[str, Any] = {
+        'Key': {'pk': pk, 'sk': sk},
+        'UpdateExpression': update_expr,
+        'ExpressionAttributeNames': attr_names,
+        'ExpressionAttributeValues': attr_values,
+    }
+    if increment < 0:
+        request['ConditionExpression'] = 'attribute_exists(pk) AND #field >= :floor'
+        attr_values[':floor'] = -increment
+        # Ask for the refused item, so a refusal can say WHICH half of the condition
+        # failed. Only on the conditional path: an increment cannot be refused.
+        request['ReturnValuesOnConditionCheckFailure'] = 'ALL_OLD'
+    return request
+
+
 def update_counter(pk: str, sk: str, field: str, increment: int = 1,
                    ttl_days: int = 90) -> 'CounterWrite':
     """Atomically update a counter in the aggregates table.
@@ -455,8 +548,11 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1,
       far back would then serve;
     * the floor at zero keeps a decrement from driving a counter NEGATIVE.
 
-    The floor is not idempotency: a redelivered REMOVE against a counter at 3 still
-    lands on 2 and then 1 — see the module docstring's known residuals.
+    The floor is not idempotency, and this function is the path that does not have
+    any: a redelivered REMOVE against a counter at 3 still lands on 2 and then 1.
+    Redelivery is closed for ARRIVALS, by claiming the record's `eventID` in the same
+    transaction as its writes — see `apply_feedback_once`, and the module docstring
+    for why a conditional decrement cannot join that transaction.
 
     ConditionalCheckFailedException is therefore an expected, benign outcome of a
     decrement with nothing to decrement, and is swallowed (and counted).
@@ -470,42 +566,23 @@ def update_counter(pk: str, sk: str, field: str, increment: int = 1,
     A refusal whose response cannot be read is reported as `REFUSED_AT_FLOOR`, the
     outcome no caller acts on. `ROW_ABSENT` is a conclusion with a write attached, so
     it is drawn only from a readable response that positively lacks an item.
+
+    THE EXPRESSION IS BUILT ELSEWHERE — `_counter_request` — because the INSERT path
+    now sends the same writes as ONE `TransactWriteItems` and a transaction item
+    carries the identical expression. Two spellings of `if_not_exists(#field, :zero)
+    + :inc` would be two increments to keep in step, and the one that drifted would
+    be the one no test covers. This function is the SINGLE-WRITE issuer of that
+    request, and the only one that can report a per-key outcome: a transaction has no
+    per-item outcome to report, which is why the conditional paths still come through
+    here. See `apply_counter_keys`.
     """
-    ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
-
-    # Build update expression - include metric_type for GSI if applicable
-    metric_type = get_metric_type(pk)
-    update_expr = 'SET #field = if_not_exists(#field, :zero) + :inc, #ttl = :ttl, updated_at = :now'
-    attr_names = {'#field': field, '#ttl': 'ttl'}
-    attr_values = {
-        ':inc': increment,
-        ':zero': 0,
-        ':ttl': ttl,
-        ':now': datetime.now(timezone.utc).isoformat()
-    }
-
-    if metric_type:
-        update_expr += ', metric_type = :metric_type'
-        attr_values[':metric_type'] = metric_type
-
-    kwargs: dict[str, Any] = {}
-    if increment < 0:
-        kwargs['ConditionExpression'] = 'attribute_exists(pk) AND #field >= :floor'
-        attr_values[':floor'] = -increment
-        # Ask for the refused item, so a refusal can say WHICH half of the condition
-        # failed. Only on the conditional path: an increment cannot be refused.
-        kwargs['ReturnValuesOnConditionCheckFailure'] = 'ALL_OLD'
+    request = _counter_request(pk, sk, field, increment, ttl_days)
+    conditional = 'ConditionExpression' in request
 
     try:
-        aggregates_table.update_item(
-            Key={'pk': pk, 'sk': sk},
-            UpdateExpression=update_expr,
-            ExpressionAttributeNames=attr_names,
-            ExpressionAttributeValues=attr_values,
-            **kwargs
-        )
+        aggregates_table.update_item(**request)
     except ClientError as e:
-        if 'ConditionExpression' not in kwargs or not is_conditional_check_failure(e):
+        if not conditional or not is_conditional_check_failure(e):
             raise
         _log_refusal(f'decrement of {field}', pk, sk)
         # WHICH half of the condition failed, when the response can be read.
@@ -838,6 +915,144 @@ def apply_counter_keys(
     return landed, outcomes
 
 
+def _counter_transaction_item(pk: str, sk: str, field: str, increment: int,
+                              ttl_days: int = 90) -> dict[str, Any]:
+    """One counter movement as a `TransactWriteItems` entry.
+
+    The same request `update_counter` issues on its own — `_counter_request` builds
+    it, so the expression exists once — with the table name added and the whole thing
+    wrapped in the `{'Update': ...}` shape the transaction API takes.
+
+    `ttl_days` defaults here as it does on every other writer, and
+    `test_aggregate_retention_lockstep.py` reads the defaults of `update_counter` and
+    `update_average` because those are the two functions that STAMP a row. This one
+    only forwards, and it forwards the same number.
+    """
+    return {'Update': {'TableName': AGGREGATES_TABLE,
+                       **_counter_request(pk, sk, field, increment, ttl_days)}}
+
+
+def _average_transaction_item(pk: str, sk: str, value: Decimal,
+                              ttl_days: int = 90) -> dict[str, Any]:
+    """The running average's INCREMENT half as a `TransactWriteItems` entry.
+
+    Increment only, and that is a scope statement rather than an omission. The
+    transaction exists for the INSERT path, whose average write is unconditional;
+    every DECREMENT of the average is a conditional write whose refusal
+    `_rebucket_average` has to observe to decide the pairing, and a transaction
+    reports no per-item outcome — a refused item cancels the whole transaction
+    instead. Putting a reversal in here would therefore replace a rule that reads
+    "the reversal was refused, so do not re-apply" with "the edit wrote nothing at
+    all", which is a different behaviour and not the one that class pins.
+
+    The expression is `update_average`'s, spelled once here because the sign is fixed
+    at +1 on this path: `:one` is the count movement, so an increment is literally 1.
+    """
+    ttl = int(datetime.now(timezone.utc).timestamp() + ttl_days * 24 * 60 * 60)
+    return {'Update': {
+        'TableName': AGGREGATES_TABLE,
+        'Key': {'pk': pk, 'sk': sk},
+        'UpdateExpression': (
+            'SET #sum = if_not_exists(#sum, :zero) + :val, '
+            '#count = if_not_exists(#count, :zero) + :one, '
+            '#ttl = :ttl, updated_at = :now'
+        ),
+        'ExpressionAttributeNames': {'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'},
+        'ExpressionAttributeValues': {
+            ':val': value,
+            ':one': 1,
+            ':zero': Decimal('0'),
+            ':ttl': ttl,
+            ':now': datetime.now(timezone.utc).isoformat(),
+        },
+    }}
+
+
+def _claimed_transaction(dedupe_key: str, items: list[dict[str, Any]]) -> bool:
+    """Apply `items` and claim `dedupe_key`, together or not at all.
+
+    🔑 THE WHOLE OF THE IDEMPOTENCY, and it is one request. The marker's `Put` carries
+    `attribute_not_exists(id)`, so on a SECOND delivery of the same stream record that
+    item is refused — and a refused item cancels the entire transaction, leaving every
+    counter in it exactly where the first delivery left it. On a FIRST delivery
+    everything commits at once, so there is no window in which some counters have
+    moved and the record is not yet recorded as applied.
+
+    That second property is the one the floor could never give. `retryAttempts: 3`
+    with `reportBatchItemFailures: true` means a record that dies on its fifth write
+    comes back with four applied, and those four are a daily total that no longer
+    equals the sum of its per-category counts — permanently, since nothing recomputes
+    a counter from source. Transacting them removes the partial state itself rather
+    than compensating for it, which is why this is a transaction and not just a
+    marker: a marker alone still leaves the half-applied record, and would then
+    RECORD it as done.
+
+    Returns whether the writes were applied. False means the key was already claimed,
+    which is the ordinary redelivery outcome and not an error. Any other cancellation
+    reason is re-raised, because the batch processor reporting the record failed is
+    what gets it retried — and a transaction that failed for a reason this function
+    cannot name has NOT applied anything, so a retry is the correct response.
+
+    A `TransactWriteItems` is limited to 100 items; one feedback record produces at
+    most eight counters plus the average plus the marker, so the limit is not
+    reachable from here and is not defended against — a batch is applied one record
+    at a time, deliberately, since the alternative would make one poison record fail
+    every other record's writes with it.
+    """
+    now = int(datetime.now(timezone.utc).timestamp())
+    try:
+        aggregates_table.meta.client.transact_write_items(
+            # The claim FIRST, so that a cancellation naming index 0 is the
+            # redelivery case and the reasons list lines up with `items` from 1.
+            TransactItems=[
+                dedupe_claim_item(IDEMPOTENCY_TABLE, dedupe_key, now), *items,
+            ],
+        )
+    except ClientError as e:
+        if not _claim_was_refused(e):
+            raise
+        logger.info(
+            f"Stream record {dedupe_key} was already applied; leaving "
+            f"{len(items)} aggregate write(s) alone"
+        )
+        metrics.add_metric(name=REPLAYED_METRIC, unit="Count", value=1)
+        return False
+    return True
+
+
+def _claim_was_refused(error: ClientError) -> bool:
+    """Was this cancellation the dedupe claim, or something else?
+
+    The distinction decides whether the record is DONE or has to be retried, so it is
+    drawn from the claim's own cancellation reason rather than from the exception
+    being a cancellation at all. A transaction can also be cancelled by a
+    TransactionConflictException on a counter row (two records of the same day
+    arriving together, which is ordinary), and calling that "already applied" would
+    silently drop a record's aggregates: nothing was written, and reporting success
+    means nothing ever will be.
+
+    The claim is item 0 by construction — see `_claimed_transaction` — and its reason
+    is `ConditionalCheckFailed` when and only when the key was already there.
+    Cancellation reasons are positional and complete, so index 0 is the claim's.
+
+    A cancellation whose reasons cannot be read is NOT treated as a refused claim.
+    That is the fail-toward-retry direction: a retry of an unapplied record is
+    correct, and a retry of an applied one is refused by the claim it already holds —
+    so being wrong here costs nothing, whereas the other direction would drop
+    aggregates on any response shape this could not parse.
+    """
+    response = error.response if isinstance(error.response, Mapping) else None
+    if response is None:
+        return False
+    if (response.get('Error') or {}).get('Code') != 'TransactionCanceledException':
+        return False
+    reasons = response.get('CancellationReasons')
+    if not isinstance(reasons, list) or not reasons:
+        return False
+    first = reasons[0]
+    return isinstance(first, Mapping) and first.get('Code') == 'ConditionalCheckFailed'
+
+
 def _reverse_a_pre_deploy_persona_row(
     item: dict, outcomes: dict[tuple[str, str, str], 'CounterWrite'],
 ) -> int:
@@ -961,8 +1176,66 @@ def _reverse_a_pre_deploy_persona_row(
     return landed
 
 
+def apply_feedback_once(item: dict, sign: int, date: str, dedupe_key: str) -> bool:
+    """`apply_feedback`, but every write of it in ONE transaction keyed on
+    `dedupe_key`.
+
+    🔑 THE PATH THAT IS IDEMPOTENT, and it is the arrival path because that is the one
+    whose writes are all unconditional and so can all be transacted. Two properties,
+    and the acceptance criteria of issue #264 name both:
+
+    * A REDELIVERED RECORD MOVES NOTHING. The claim's `attribute_not_exists` refuses,
+      the transaction cancels, and every counter stays where the first delivery left
+      it — where the floor at zero could only ever no-op a decrement that was already
+      at zero.
+    * A RECORD THAT FAILED PARTWAY LEAVES NOTHING PARTIAL. Eight counters plus the
+      average commit at once, so a daily total can never disagree with the sum of its
+      per-category counts. This is the half a marker alone does not fix: a marker
+      written before the writes records a half-applied record as done, and one written
+      after leaves the half-application to be re-applied on top.
+
+    Returns whether the writes were applied — False for a redelivery, which is a
+    success from the batch processor's point of view and must not be reported as a
+    failed record (that would redeliver it forever).
+
+    THE REVERSAL PATHS DO NOT COME THROUGH HERE, and that is a scope decision rather
+    than an oversight. Every decrement is a conditional write whose refusal the code
+    ABOVE it reads — `_reverse_a_pre_deploy_persona_row` triggers on `ROW_ABSENT`, and
+    `_rebucket_average` pairs on a refused reversal — and a transaction reports no
+    per-item outcome: one refused item cancels the whole thing. Transacting them would
+    replace "this decrement had nothing to correct, so carry on" with "the edit wrote
+    nothing at all", which is a different behaviour from the one those classes pin,
+    and it would silently disable the aged-out-day protections that depend on
+    observing a refusal. What those paths keep is the floor-and-existence guard they
+    already had; what they do not get is redelivery protection, which is recorded as a
+    residual in the module docstring rather than half-implemented here.
+    """
+    items = [_counter_transaction_item(pk, date_, field, sign)
+             for pk, date_, field in sorted(counter_keys(item, date))]
+
+    sentiment_score = _image_score(item)
+    if sentiment_score:
+        items.append(_average_transaction_item(SENTIMENT_AVG_PK, date, sentiment_score))
+
+    if not _claimed_transaction(dedupe_key, items):
+        return False
+
+    logger.info(
+        f"Updated aggregates for source={item.get('source_platform', 'unknown')}, "
+        f"category={item.get('category', 'other')}"
+    )
+    return True
+
+
 def apply_feedback(item: dict, sign: int, date: str):
-    """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`."""
+    """Add (`sign=1`) or reverse (`sign=-1`) one item's contribution on `date`.
+
+    The NON-transactional issuer, now reached only by the reversal paths — see
+    `apply_feedback_once` for which writes may be transacted and why a decrement may
+    not be. Kept as one function serving both signs because the shared description in
+    `counter_dimensions` is what stops the two directions drifting, and that argument
+    is about the DIMENSIONS rather than about how the writes are issued.
+    """
     _, outcomes = apply_counter_keys(counter_keys(item, date), sign)
     if sign < 0:
         # Reversal only. Reading the old persona field on the INCREMENT path would
@@ -985,10 +1258,25 @@ def apply_feedback(item: dict, sign: int, date: str):
 
 
 @tracer.capture_method
-def process_new_feedback(item: dict):
-    """Update aggregates for a new feedback item."""
+def process_new_feedback(item: dict, dedupe_key: str | None = None) -> bool:
+    """Update aggregates for a new feedback item.
+
+    Returns whether the writes were applied. False means this stream record had
+    already been applied, which is a redelivery and an ordinary success.
+
+    `dedupe_key` is the stream record's `eventID`, unique per record, and it is what
+    makes this path idempotent — see `apply_feedback_once`. It is OPTIONAL, and None
+    routes to the non-transactional path deliberately: the function must still work
+    when `IDEMPOTENCY_TABLE` is unset (a CDK regression must degrade to the pre-#264
+    behaviour rather than stop aggregating), and the two dozen callers in the test
+    suite that ask "which counters does an arrival move?" are asking a question the
+    dedupe key is not part of.
+    """
     date = _image_date(item)
+    if dedupe_key and IDEMPOTENCY_TABLE:
+        return apply_feedback_once(item, 1, date, dedupe_key)
     apply_feedback(item, 1, date)
+    return True
 
 
 @tracer.capture_method
@@ -1334,6 +1622,34 @@ def _event_name(record: DynamoDBRecord) -> str | None:
     return str(record.event_name).split('.')[-1] if record.event_name else None
 
 
+def _dedupe_key(record: DynamoDBRecord) -> str | None:
+    """The identity of ONE stream record, for the dedupe claim (issue #264).
+
+    `eventID` is the right field: the stream API documents it as a unique identifier
+    for the record, so a redelivery of the SAME record carries the SAME value while
+    two genuinely different edits of one item do not — which `sequence_number` also
+    gives, and which the feedback_id could not (an item edited twice would look like
+    one record and the second edit would be dropped).
+
+    NAMESPACED, because the idempotency table is shared with the processor, whose keys
+    are `{source_platform}:{source_id}`. A prefix is what keeps a stream `eventID`
+    from ever being mistaken for one of those, and keeps this Lambda's markers
+    identifiable in a table two functions write to.
+
+    Read from `raw_event` for the reason `_event_name` is: it is the EVENT's field, and
+    the older tests build records from raw dicts. Returns None when the record carries
+    no readable id — in which case the caller applies the writes non-transactionally
+    rather than dropping them. That is the fail-open direction, and it is the same one
+    `is_ttl_expiry` and `_day_has_aggregates` take: aggregating a record twice is
+    recoverable, never aggregating it is not.
+    """
+    raw = getattr(record, 'raw_event', None)
+    if not isinstance(raw, Mapping):
+        return None
+    event_id = raw.get('eventID')
+    return f'aggregator#stream#{event_id}' if isinstance(event_id, str) and event_id else None
+
+
 def record_handler(record: DynamoDBRecord) -> dict:
     """Process a single DynamoDB Stream record.
 
@@ -1396,7 +1712,14 @@ def record_handler(record: DynamoDBRecord) -> dict:
     item = deserialize_image(new_image)
 
     logger.info(f"Processing feedback: date={item.get('date')}, source={item.get('source_platform')}")
-    process_new_feedback(item)
+    if not process_new_feedback(item, _dedupe_key(record)):
+        # Already applied by an earlier delivery of this same record. A SUCCESS, and
+        # emphatically not a failure: reporting it failed under
+        # `reportBatchItemFailures: true` would redeliver it until it aged out of the
+        # stream, and Streams preserve per-shard order, so that record would block its
+        # partition. UPDATED_METRIC is not emitted either — nothing was updated, and a
+        # metric claiming otherwise is what made the original bug invisible.
+        return {"status": "skipped", "reason": "already applied"}
     metrics.add_metric(name=UPDATED_METRIC, unit="Count", value=1)
 
     return {"status": "success"}

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -915,6 +915,32 @@ def apply_counter_keys(
     return landed, outcomes
 
 
+def counter_transaction_items(
+    keys: set[tuple[str, str, str]], sign: int,
+) -> list[dict[str, Any]]:
+    """Every named counter's movement, as `TransactWriteItems` entries.
+
+    `apply_counter_keys`' counterpart for the transactional path, and it is a
+    FUNCTION rather than a comprehension at the call site for the same reason that one
+    is: it is the ONE place a counter key is unpacked into a transactional write, so
+    there is exactly one line here deciding what a counter's sort key is.
+
+    🔑 THE UNPACKING IS SPELLED `for pk, date, field in sorted(keys)` DELIBERATELY.
+    `test_streaming_categories_lockstep.py` pins the small set of expressions a
+    counter's sort key may be bound from, because the streaming reader sums a window
+    with `sk BETWEEN :oldest AND :newest` and a composite sort key sorts INSIDE a date
+    window it is unrelated to. That lockstep reads the name `date` bound from
+    `sorted(keys)`; writing this as a comprehension over `date_` (which it was first)
+    would have left this path's sort keys outside the guard entirely — a second,
+    unpinned way to key a counter, which is exactly the drift the guard exists to
+    catch. Sorted for the same reason `apply_counter_keys` sorts: a deterministic
+    order for tests and logs, and here it also fixes which item a cancellation reason
+    refers to.
+    """
+    return [_counter_transaction_item(pk, date, field, sign)
+            for pk, date, field in sorted(keys)]
+
+
 def _counter_transaction_item(pk: str, sk: str, field: str, increment: int,
                               ttl_days: int = 90) -> dict[str, Any]:
     """One counter movement as a `TransactWriteItems` entry.
@@ -1210,8 +1236,7 @@ def apply_feedback_once(item: dict, sign: int, date: str, dedupe_key: str) -> bo
     already had; what they do not get is redelivery protection, which is recorded as a
     residual in the module docstring rather than half-implemented here.
     """
-    items = [_counter_transaction_item(pk, date_, field, sign)
-             for pk, date_, field in sorted(counter_keys(item, date))]
+    items = counter_transaction_items(counter_keys(item, date), sign)
 
     sentiment_score = _image_score(item)
     if sentiment_score:

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -138,8 +138,8 @@ Known residuals
   `counter_dimensions` rather than as a fixed multiple because the dimension count is
   meant to grow. Both tables are PAY_PER_REQUEST, so this is a bill and not a
   ceiling — see docs/processing-pipeline.md for the same split spelled out per table.
-  And every record of a date
-  moves `METRIC#daily_total`, so same-date records in one batch now CONTEND on it
+  And every record of a date moves `METRIC#daily_total`, so same-date records in one
+  batch now CONTEND on it
   where two plain `update_item`s would simply have serialised — a bulk import
   through the `s3_import` plugin is exactly the shape that produces this, and the
   same shape produces throttling, which arrives as a cancellation too (see

--- a/voc-datalake/lambda/aggregator/handler.py
+++ b/voc-datalake/lambda/aggregator/handler.py
@@ -446,10 +446,11 @@ NO_CANCELLATION_REASON = 'None'
 # DERIVABLE FROM EACH OTHER: `TransactionConflict` and `ProvisionedThroughputExceeded`
 # do take the `Exception` suffix, but the throttle is `ThrottlingError` here and
 # `ThrottlingException` there — so no suffix rule relates the two vocabularies and both
-# sets have to be written out in full. `test_every_retryable_reason_is_transient_on_the
-# _read_path_too` holds the pairing as an explicit table for that reason. The two paths
-# must not reach opposite conclusions about one condition, and a bulk import through
-# `s3_import` is exactly the shape that produces both at volume.
+# sets have to be written out in full.
+# `test_every_retryable_reason_is_transient_on_the_read_path_too` holds the pairing as
+# an explicit table for that reason. The two paths must not reach opposite conclusions
+# about one condition, and a bulk import through `s3_import` is exactly the shape that
+# produces both at volume.
 #
 # A `ValidationError` is deliberately NOT here: it will fail identically on the next
 # attempt, so re-sending it only spends the invocation and delays the record.

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -3034,7 +3034,7 @@ class TestARedeliveredArrivalMovesNothing:
     REVERT MAP. Each entry was RUN against the source, and cites the tests that
     really failed:
       * Drop the dedupe claim from `_claimed_transaction`'s TransactItems (or route
-        `process_new_feedback` past `apply_feedback_once`) — fails
+        `process_new_feedback` past `apply_arrival_once`) — fails
         test_a_redelivered_record_leaves_every_counter_where_the_first_delivery_left_it,
         test_the_second_delivery_is_reported_as_a_skip_not_a_failure,
         test_a_replayed_record_is_counted_so_the_guard_is_not_silently_inert and
@@ -3446,6 +3446,492 @@ class TestARedeliveredArrivalMovesNothing:
         key = idempotency.scan()['Items'][0][IDEMPOTENCY_KEY_ATTRIBUTE]
         assert key.startswith('aggregator#'), key
         assert self.ID in key, key
+
+
+class TestTheTransactionIsAnArrivalAndOnlyAnArrival:
+    """What the transactional path may build, asserted on the REQUEST it assembles.
+
+    Review of #264 found three ways this path could be right today and wrong after an
+    ordinary-looking change, all of them silent, and none of them reachable through
+    `record_handler` — so they are pinned where they are decided.
+
+    REVERT MAP, each entry RUN:
+      * Give `counter_transaction_items` or `_average_transaction_item` a `sign` again
+        and thread it — fails test_no_transaction_builder_offers_a_direction. The
+        original defect: the sign reached the counters and the average hardcoded `+1`,
+        so `sign=-1` decremented seven counters while INCREMENTING the average, and the
+        transaction guaranteed that inconsistent state committed whole. Nothing raised.
+      * Add a `counter_dimensions` entry on an EXISTING pk with a different field —
+        fails test_the_transaction_names_each_item_once, where production would answer
+        `ValidationException` for every ingested record.
+      * Strip `metric_type` from `_counter_request`, or build the transaction items
+        without going through it — fails test_an_arrival_tags_the_rows_the_gsi_reads.
+      * Spell the average's attribute names a second time in
+        `_average_transaction_item` and rename one (`total` for `sum`, say) — fails
+        test_both_average_writers_spend_one_expression, where the day would simply
+        read as having no average.
+    """
+
+    DATE = '2025-01-15'
+
+    def _items(self, item) -> list[dict]:
+        from aggregator.handler import (
+            SENTIMENT_AVG_PK,
+            _average_transaction_item,
+            _image_score,
+            counter_keys,
+            counter_transaction_items,
+        )
+
+        items = counter_transaction_items(counter_keys(item, self.DATE))
+        score = _image_score(item)
+        if score:
+            items.append(_average_transaction_item(SENTIMENT_AVG_PK, self.DATE, score))
+        return items
+
+    def test_no_transaction_builder_offers_a_direction(self):
+        """🔑 A `sign=-1` MUST NOT BE EXPRESSIBLE HERE, and the check is on the
+        signatures rather than on a call, because the defect was a parameter that
+        existed and was half honoured — the counters took it, the average ignored it.
+        A test calling with `-1` would have to assert the resulting mixed-direction
+        request is "wrong", which is a judgement; a builder that takes no direction
+        cannot produce one, which is a fact.
+
+        `_counter_transaction_item` keeps `increment` (`_counter_request` reads its SIGN
+        to decide the floor condition), so what is asserted of it is that it DEFAULTS to
+        an increment — the pair `counter_transaction_items` no longer passes.
+        """
+        from inspect import signature
+
+        from aggregator.handler import (
+            _average_transaction_item,
+            _counter_transaction_item,
+            counter_transaction_items,
+        )
+
+        for builder in (counter_transaction_items, _average_transaction_item):
+            assert 'sign' not in signature(builder).parameters, (
+                f'{builder.__name__} takes a direction again. Only the counters can '
+                f'honour one — the average row moves `sum` and `count` — so a '
+                f'reversal built here commits the counters DOWN and the average UP, '
+                f'atomically, which is worse than the split it replaced. Reversals '
+                f'stay on the single-write path; see apply_arrival_once.'
+            )
+
+        increment = signature(_counter_transaction_item).parameters['increment']
+        assert increment.default == 1, (
+            'the transactional counter builder no longer defaults to an increment, so '
+            'a decrement can reach a transaction — where its refusal, which '
+            '_reverse_a_pre_deploy_persona_row reads, cancels every other write '
+            'instead of being reported'
+        )
+
+    def test_the_transaction_names_each_item_once(self, sample_urgent_feedback_item):
+        """DynamoDB refuses two operations on ONE item, and it refuses the whole request.
+
+        So this is not a drift but an outage: every ingested record would fail with
+        `ValidationException`. What decides it is `counter_dimensions` — `counter_keys`
+        returns `(pk, date, field)`, so two dimensions on one pk with different fields
+        are two entries here and one item there. The urgent fixture, so every dimension
+        is present.
+        """
+        keys = {(item['Update']['TableName'],
+                 item['Update']['Key']['pk'],
+                 item['Update']['Key']['sk'])
+                for item in self._items(sample_urgent_feedback_item)}
+        items = self._items(sample_urgent_feedback_item)
+
+        assert len(keys) == len(items), (
+            f'{len(items)} transaction entries name only {len(keys)} distinct '
+            f'(table, pk, sk) triples. DynamoDB rejects a transaction containing two '
+            f'operations on one item and rejects the WHOLE request, so every ingested '
+            f'record would fail. If a new counter_dimensions entry shares a pk with '
+            f'an existing one, that dimension has to be a new pk or the two fields '
+            f'have to be one write.'
+        )
+        # The denominator: an empty list would satisfy the equality above.
+        assert len(items) >= 2, items
+
+    def test_an_arrival_tags_the_rows_the_gsi_reads(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """`metric_type` is what puts a row on `gsi1-by-metric-type`, and the existing
+        assertions for it inspect `update_item` kwargs — i.e. the path an arrival NO
+        LONGER TAKES.
+
+        It is written correctly today because `_counter_transaction_item` delegates to
+        the shared `_counter_request`. This is the test that fails if a future
+        transaction builder stops doing so: `/metrics/sources` and `/metrics/personas`
+        would then read an empty GSI while every count stayed correct — the "dimension
+        useless while looking populated" shape `counter_dimensions` describes at length.
+        `_counts` projects to `{pk: count}` and drops the tag, so the redelivery tests
+        cannot catch it.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        record_handler(_record('INSERT', new=sample_feedback_item, event_id='tagged'))
+
+        tags = {row['pk']: row.get('metric_type')
+                for row in aggregates.scan()['Items']}
+        source = next(pk for pk in tags if pk.startswith('METRIC#daily_source#'))
+        persona = next(pk for pk in tags if pk.startswith('METRIC#persona#'))
+
+        assert tags[source] == 'source', tags
+        assert tags[persona] == 'persona', tags
+        # And nothing else is tagged: a builder that stamped every row would put the
+        # daily total on the GSI, which both metrics routes would then double-count.
+        assert tags['METRIC#daily_total'] is None, tags
+
+    def test_both_average_writers_spend_one_expression(self):
+        """The average's attribute names exist once, as the counter's already did.
+
+        `sum` and `count` are what `get_summary` reads back, and the retention lockstep
+        compares only the writers' `ttl_days` defaults — so a second spelling here was
+        free to rename an attribute with nothing failing, and a transactional row
+        holding `total` reads as a day with no average at all. Compared as the REQUESTS
+        the two writers build, since that is the thing that must agree.
+        """
+        from aggregator.handler import (
+            SENTIMENT_AVG_PK,
+            _average_request,
+            _average_transaction_item,
+        )
+
+        transactional = _average_transaction_item(
+            SENTIMENT_AVG_PK, self.DATE, Decimal('0.5'),
+        )['Update']
+        single = _average_request(SENTIMENT_AVG_PK, self.DATE, Decimal('0.5'), 90, 1)
+
+        assert transactional['UpdateExpression'] == single['UpdateExpression']
+        assert (transactional['ExpressionAttributeNames']
+                == single['ExpressionAttributeNames']
+                == {'#sum': 'sum', '#count': 'count', '#ttl': 'ttl'})
+        # `:one` is the COUNT movement, so an arrival's is +1 in both.
+        assert transactional['ExpressionAttributeValues'][':one'] == 1
+        assert single['ExpressionAttributeValues'][':one'] == 1
+
+    def test_an_arrival_moves_the_average_in_the_same_direction_as_its_counters(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The end-to-end statement of the same thing, over the DATA.
+
+        The original defect was expressible precisely because nothing compared the two
+        directions: the counters went down while the average went up. An arrival is the
+        only direction this path has, so both must move UP together.
+        """
+        from aggregator.handler import SENTIMENT_AVG_PK, record_handler
+
+        aggregates, _ = deduped_tables
+        record_handler(_record('INSERT', new=sample_feedback_item, event_id='forwards'))
+
+        average = aggregates.get_item(
+            Key={'pk': SENTIMENT_AVG_PK, 'sk': self.DATE},
+        )['Item']
+        assert _counts(aggregates)['METRIC#daily_total'] == Decimal(1)
+        assert average['count'] == Decimal(1)
+        assert average['sum'] > Decimal(0), average
+
+    def test_the_two_arrival_paths_write_the_same_rows(
+        self, deduped_tables, sample_urgent_feedback_item
+    ):
+        """🔑 PARITY, because there are now TWO implementations of an arrival and the
+        default test path is the OLD one.
+
+        `_record(...)` omits `event_id` by default — deliberately, so the two dozen
+        "which counters does an arrival move?" tests measure dimensions rather than the
+        claim — which means every one of them exercises `apply_feedback`, the
+        non-transactional path production no longer takes for an INSERT. A dimension
+        reachable from one and not the other would be green in both directions.
+
+        Compared on the ROWS, not on the calls: `updated_at` and the TTL are stamped
+        from the clock, so the comparison is over (pk, sk, count) and the average's
+        (sum, count). Two separate fixtures would be cleaner but cannot share one moto
+        table; the same table is used twice with the day cleared between, which is why
+        the dates differ rather than the rows being deleted.
+        """
+        from aggregator.handler import SENTIMENT_AVG_PK, record_handler
+
+        aggregates, _ = deduped_tables
+
+        # The transactional path: a record carrying an eventID.
+        record_handler(_record('INSERT', new=sample_urgent_feedback_item,
+                               event_id='transactional'))
+        transactional = _counts(aggregates)
+        transactional_average = aggregates.get_item(
+            Key={'pk': SENTIMENT_AVG_PK, 'sk': self.DATE})['Item']
+
+        for pk in list(transactional) + [SENTIMENT_AVG_PK]:
+            aggregates.delete_item(Key={'pk': pk, 'sk': self.DATE})
+
+        # The single-write path: the same item, no eventID.
+        record_handler(_record('INSERT', new=sample_urgent_feedback_item))
+        single = _counts(aggregates)
+        single_average = aggregates.get_item(
+            Key={'pk': SENTIMENT_AVG_PK, 'sk': self.DATE})['Item']
+
+        assert transactional == single, (
+            'the transactional and single-write arrival paths write different counter '
+            'rows for one item, so the dimension tests — which take the single-write '
+            'path — no longer describe what production does'
+        )
+        assert (transactional_average['sum'], transactional_average['count']) == (
+            single_average['sum'], single_average['count'],
+        )
+        # The denominator, so an implementation that wrote nothing on both paths could
+        # not satisfy the equality.
+        assert transactional['METRIC#daily_total'] == Decimal(1), transactional
+        assert len(transactional) == 7, transactional
+
+
+class TestAWriteConflictIsRetriedRatherThanReported:
+    """Contention on `METRIC#daily_total` must not cost a record (review of #264).
+
+    Every record of a date moves that one row, `batchSize` is 100, and botocore does
+    NOT auto-retry `TransactionCanceledException` — so contention a plain `update_item`
+    used to absorb at the request level now arrives as a cancellation. Left to
+    propagate it is a reported record failure with only `retryAttempts: 3` left before
+    the record is DROPPED and its aggregates lost permanently, which is strictly worse
+    than the double-count the transaction was introduced to remove.
+
+    `ballots_handler._write_ballot` faces the same DynamoDB fact and reaches the same
+    answer for a different reason (a voter who cannot resubmit); the aggregator's is
+    that the stream would otherwise be the only retry budget. Both use three attempts.
+
+    REVERT MAP, each entry RUN:
+      * Delete the `_conflicted` branch from `_claimed_transaction` — fails
+        test_a_conflicted_transaction_is_re_attempted and
+        test_a_conflict_that_clears_leaves_the_record_applied.
+      * Retry ANY cancellation (drop the reason check in `_conflicted`) — fails
+        test_a_validation_failure_is_not_retried, whose subject is that a request
+        which will fail identically must not be re-sent: it spends the invocation and
+        delays the record.
+      * Retry forever — fails test_the_attempts_are_bounded, which is what keeps a
+        contended shard from holding Lambda concurrency in a tight loop.
+      * Set TRANSACT_WRITE_ATTEMPTS to 0 — fails
+        test_the_attempt_bound_leaves_at_least_one_attempt, where a record would
+        otherwise be reported "already applied" having never been written.
+    """
+
+    ID = 'a-contended-record'
+
+    @staticmethod
+    def _conflict() -> ClientError:
+        """The response shape DynamoDB sends for a contended item.
+
+        Reasons are POSITIONAL and the claim is item 0, so the conflict is placed on a
+        counter — index 1 — which is where contention really happens: the claim's key
+        is unique per record and cannot be contended by another record at all.
+        """
+        return ClientError(
+            {
+                'Error': {'Code': 'TransactionCanceledException',
+                          'Message': 'cancelled'},
+                'CancellationReasons': [
+                    {'Code': 'None'},
+                    {'Code': 'TransactionConflict', 'Message': 'conflict'},
+                ],
+            },
+            'TransactWriteItems',
+        )
+
+    def test_a_conflicted_transaction_is_re_attempted(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The first conflict is retried rather than raised, and the retry is what
+        writes the record. Without it this record is reported failed on its first
+        collision with another record of the same day."""
+        from aggregator.handler import TRANSACT_WRITE_ATTEMPTS, record_handler
+
+        aggregates, _ = deduped_tables
+        real = aggregates.meta.client.transact_write_items
+        # Conflict once, then let the real transaction through.
+        attempts = iter([self._conflict()])
+
+        def flaky(**kwargs):
+            failure = next(attempts, None)
+            if failure is not None:
+                raise failure
+            return real(**kwargs)
+
+        with patch.object(aggregates.meta.client, 'transact_write_items', flaky), \
+                patch('aggregator.handler.time.sleep') as slept:
+            assert record_handler(
+                _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+            ) == {"status": "success"}
+
+        assert _counts(aggregates)['METRIC#daily_total'] == Decimal(1)
+        # It WAITED, and it did not wait zero: a retry with no backoff re-collides.
+        assert slept.call_count == 1
+        assert slept.call_args.args[0] > 0
+        assert TRANSACT_WRITE_ATTEMPTS >= 2, 'the arrangement needs a retry to exist'
+
+    def test_a_conflict_that_clears_leaves_the_record_applied_exactly_once(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The counters are not applied twice by the retry, which is the property that
+        makes retrying safe at all: nothing was written by the cancelled attempt.
+
+        The positive control for the test above — an implementation that retried by
+        re-issuing only PART of the transaction would pass that one and fail this.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, idempotency = deduped_tables
+        real = aggregates.meta.client.transact_write_items
+        attempts = iter([self._conflict()])
+
+        def flaky(**kwargs):
+            failure = next(attempts, None)
+            if failure is not None:
+                raise failure
+            return real(**kwargs)
+
+        with patch.object(aggregates.meta.client, 'transact_write_items', flaky), \
+                patch('aggregator.handler.time.sleep'):
+            record_handler(_record('INSERT', new=sample_feedback_item, event_id=self.ID))
+
+        counts = _counts(aggregates)
+        categories = sum(v for pk, v in counts.items()
+                         if pk.startswith('METRIC#daily_category#'))
+        assert counts['METRIC#daily_total'] == categories == Decimal(1), counts
+        assert idempotency.scan()['Count'] == 1
+
+    def test_the_attempts_are_bounded(self, deduped_tables, sample_feedback_item):
+        """A shard that is permanently contended must not hold concurrency forever.
+
+        Past the bound the record is reported failed and the STREAM redelivers it,
+        which the claim makes safe — so the in-process budget is a small optimisation
+        over that, not a replacement for it.
+        """
+        from aggregator.handler import TRANSACT_WRITE_ATTEMPTS, record_handler
+
+        aggregates, _ = deduped_tables
+        with patch.object(aggregates.meta.client, 'transact_write_items',
+                          side_effect=self._conflict()) as attempted, \
+                patch('aggregator.handler.time.sleep'):
+            with pytest.raises(ClientError):
+                record_handler(_record('INSERT', new=sample_feedback_item,
+                                       event_id=self.ID))
+
+        assert attempted.call_count == TRANSACT_WRITE_ATTEMPTS, (
+            'a permanently conflicted transaction was attempted a different number of '
+            'times than the bound allows'
+        )
+
+    def test_a_conflict_is_counted_so_the_contention_is_visible(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """A retry that succeeds is invisible, which is exactly why it needs a metric.
+
+        CONFLICTED_METRIC is how an operator sees that the batch size or the
+        parallelization factor is creating contention on the day's hot row — the trade
+        this retry makes, rather than the behaviour it produces.
+        """
+        from aggregator.handler import CONFLICTED_METRIC, record_handler
+
+        aggregates, _ = deduped_tables
+        real = aggregates.meta.client.transact_write_items
+        attempts = iter([self._conflict()])
+
+        def flaky(**kwargs):
+            failure = next(attempts, None)
+            if failure is not None:
+                raise failure
+            return real(**kwargs)
+
+        with patch.object(aggregates.meta.client, 'transact_write_items', flaky), \
+                patch('aggregator.handler.time.sleep'), \
+                patch('aggregator.handler.metrics') as mock_metrics:
+            record_handler(_record('INSERT', new=sample_feedback_item, event_id=self.ID))
+
+        emitted = [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list]
+        assert CONFLICTED_METRIC in emitted, emitted
+
+    def test_a_validation_failure_is_not_retried(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """Only a CONFLICT is transient. A `ValidationException` will fail identically
+        on the next attempt, so re-sending it spends the invocation's time and delays
+        the record for nothing — the same reason `_write_ballot` does not retry a row
+        that has gone away.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        permanent = ClientError(
+            {
+                'Error': {'Code': 'TransactionCanceledException',
+                          'Message': 'cancelled'},
+                'CancellationReasons': [
+                    {'Code': 'None'},
+                    {'Code': 'ValidationError', 'Message': 'not a number'},
+                ],
+            },
+            'TransactWriteItems',
+        )
+        with patch.object(aggregates.meta.client, 'transact_write_items',
+                          side_effect=permanent) as attempted:
+            with pytest.raises(ClientError):
+                record_handler(_record('INSERT', new=sample_feedback_item,
+                                       event_id=self.ID))
+
+        assert attempted.call_count == 1, (
+            'a cancellation no contention caused was re-attempted; it will fail the '
+            'same way and the record is delayed by every wait'
+        )
+
+    def test_a_redelivery_is_still_a_skip_and_not_a_retry(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The claim's refusal must be read BEFORE the conflict check, or a redelivery
+        would be retried until the bound and then reported failed — a stalled shard in
+        place of a harmless duplicate, which is the outcome this whole change is meant
+        to avoid.
+        """
+        from aggregator.handler import record_handler
+
+        record = _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+        assert record_handler(record) == {"status": "success"}
+
+        with patch('aggregator.handler.time.sleep') as slept:
+            assert record_handler(record) == {
+                "status": "skipped", "reason": "already applied",
+            }
+        assert slept.call_count == 0, 'a redelivery waited, so it was treated as a conflict'
+
+    def test_the_attempt_bound_leaves_at_least_one_attempt(self):
+        """The bound is a tuning number, so the assumption is a test rather than a hope.
+
+        At 0 the loop yields nothing and the function falls through — where returning
+        False would be read as "already applied", i.e. a record silently dropped and
+        the batch reported clean. `_claimed_transaction` raises there instead; this
+        pins the bound so that guard stays unreachable.
+        """
+        from aggregator.handler import TRANSACT_WRITE_ATTEMPTS
+
+        assert TRANSACT_WRITE_ATTEMPTS >= 1, (
+            'no aggregate transaction would be attempted at all, and a record never '
+            'written would be reported as one already applied'
+        )
+
+    def test_the_conflict_reason_is_not_the_exception_code(self):
+        """Two spellings of one condition, and neither is derivable from the other.
+
+        DynamoDB reports a contended item as `TransactionConflict` inside
+        `CancellationReasons` and as `TransactionConflictException` when a plain
+        request fails. Matching the wrong one here is SILENT — the retry simply never
+        fires, which looks identical to a system under no contention — so both
+        spellings are named in the module and this says why they differ.
+        """
+        from aggregator.handler import (
+            TRANSACTION_CONFLICT_REASON,
+            _TRANSIENT_READ_ERRORS,
+        )
+
+        assert TRANSACTION_CONFLICT_REASON == 'TransactionConflict'
+        assert TRANSACTION_CONFLICT_REASON not in _TRANSIENT_READ_ERRORS
+        assert f'{TRANSACTION_CONFLICT_REASON}Exception' in _TRANSIENT_READ_ERRORS
 
 
 class TestAnUnrecognizedEventIsSkippedRatherThanFatal:

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -155,10 +155,23 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       fails 13 tests; logging a non-transient read failure at `warning` fails
       `test_a_denied_day_read_fails_open_but_is_logged_as_an_error`.
 
+  TestARedeliveredArrivalMovesNothing
+    — issue #264. An INSERT claims the stream record's `eventID` in the SAME
+      `TransactWriteItems` as its counters, which closes both halves of the defect:
+      a redelivered record moves nothing, and a record that dies partway leaves no
+      partial application for the retry to land on top of. Deleting the claim from
+      the transaction fails four; applying the counters as separate writes with the
+      claim merely written first or last — a marker without a transaction — fails
+      the partial-application pair, which is the half that produces internally
+      inconsistent metrics. That class's own revert map has the rest, including
+      which mutation each citation was measured against and the one test there
+      that passes in both states and why that is correct.
+
   TestRedeliveryMovesACounterTwice
-    — the KNOWN RESIDUAL, pinned at what the code really does rather than at what
-      would be nice. These fail if idempotency is ever added, which is the point:
-      the module docstring's residual note and the behaviour cannot drift apart.
+    — the residual that REMAINS after that: a REVERSAL is not transacted, because
+      every decrement is a conditional write whose refusal the code above it READS
+      and a transaction reports no per-item outcome. These pin that, so the module
+      docstring's remaining residual and the behaviour cannot drift apart.
 
   TestAnUnrecognizedEventIsSkippedRatherThanFatal
     — restoring `str(record.event_name)` in place of the `raw_event` read fails
@@ -228,11 +241,22 @@ def _to_ddb(item: dict) -> dict:
     return out
 
 
-def _record(event_name: str, *, new=None, old=None, user_identity=None) -> DynamoDBRecord:
+def _record(event_name: str, *, new=None, old=None, user_identity=None,
+            event_id=None) -> DynamoDBRecord:
     """A real Powertools stream record, not a MagicMock.
 
     A MagicMock answers any attribute, so `record.user_identity` on one would be
     a truthy mock and the TTL branch could never be exercised honestly.
+
+    `event_id` is the stream's own `eventID`, which the aggregator claims to make an
+    arrival idempotent (issue #264). OMITTED BY DEFAULT, and that default is a
+    statement about what the other tests here are for: they ask which counters a
+    given event moves, and a dedupe claim would make the SECOND record built by a
+    test — a redelivery as far as the handler is concerned — write nothing, so every
+    such test would be measuring the claim instead of the dimensions. A record with
+    no id routes to the non-transactional path, exactly as it does in production when
+    `IDEMPOTENCY_TABLE` is unset, so those tests keep asserting what they always did.
+    The idempotency behaviour has its own class, where the id is passed explicitly.
     """
     body: dict = {'eventName': event_name, 'eventSource': 'aws:dynamodb', 'dynamodb': {}}
     if new is not None:
@@ -241,6 +265,8 @@ def _record(event_name: str, *, new=None, old=None, user_identity=None) -> Dynam
         body['dynamodb']['OldImage'] = _to_ddb(old)
     if user_identity is not None:
         body['userIdentity'] = user_identity
+    if event_id is not None:
+        body['eventID'] = event_id
     return DynamoDBRecord(body)
 
 
@@ -333,6 +359,84 @@ def real_aggregates_table():
         )
         with patch('aggregator.handler.aggregates_table', table):
             yield table
+
+
+@pytest.fixture
+def deduped_tables():
+    """The aggregates table AND the dedupe table, as production has them.
+
+    The claim and the counter updates go out as one `TransactWriteItems` across two
+    tables, so a fixture with only the aggregates table cannot exercise the
+    idempotency at all — the transaction would be rejected for a missing table, which
+    would look like a failing handler rather than a missing arrangement.
+
+    `AGGREGATES_TABLE` is patched as well as `aggregates_table`, because the
+    transaction item names the table by STRING while the single-write path names it by
+    resource. The module reads that env var once at import, so the name it holds is
+    whatever `lambda/conftest.py` set — and a transaction built with a different name
+    than the fixture created would fail for a reason no test is about.
+
+    Yields (aggregates, idempotency), both moto-backed: the point of the whole design
+    is a condition DynamoDB evaluates and a cancellation it reports, neither of which
+    a mock can do.
+
+    ⚠️ THE MODULE ATTRIBUTES ARE PATCHED ONLY IF THEY EXIST, which is what lets this
+    class be run against the UNFIXED handler to see it red. `patch` raises
+    AttributeError for a name a module does not define, so a fixture that named
+    `IDEMPOTENCY_TABLE` unconditionally would turn every test in the class into a
+    setup ERROR when the attribute is absent — and an error on the arrangement is not
+    evidence about the behaviour. Skipping the absent ones lets each test reach its own
+    assertion and fail on the counter it is really about.
+    """
+    with mock_aws():
+        resource = boto3.resource('dynamodb', region_name='us-east-1')
+        aggregates = resource.create_table(
+            TableName='test-aggregates',
+            KeySchema=[
+                {'AttributeName': 'pk', 'KeyType': 'HASH'},
+                {'AttributeName': 'sk', 'KeyType': 'RANGE'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'pk', 'AttributeType': 'S'},
+                {'AttributeName': 'sk', 'AttributeType': 'S'},
+            ],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        idempotency = resource.create_table(
+            TableName='test-idempotency',
+            KeySchema=[{'AttributeName': 'id', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'id', 'AttributeType': 'S'}],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        from aggregator import handler
+
+        names = {
+            'aggregates_table': aggregates,
+            'AGGREGATES_TABLE': 'test-aggregates',
+            'IDEMPOTENCY_TABLE': 'test-idempotency',
+        }
+        patches = [patch.object(handler, name, value)
+                   for name, value in names.items() if hasattr(handler, name)]
+        for one in patches:
+            one.start()
+        try:
+            yield aggregates, idempotency
+        finally:
+            for one in patches:
+                one.stop()
+
+
+def _counts(table) -> dict[str, Decimal]:
+    """Every COUNTER row's value, by pk. One day per test, so the pk identifies it.
+
+    The running average is excluded although it too has a `count` attribute: it holds
+    a `count` of SCORES beside a `sum`, which is a different quantity from a bucket's
+    item count and does not belong in a total. Including it made an assertion about
+    "how many counter rows are there" read one high, in a way that looked like an
+    off-by-one in the handler rather than in the helper.
+    """
+    return {item['pk']: item['count'] for item in table.scan()['Items']
+            if 'count' in item and 'sum' not in item}
 
 
 class TestGetMetricType:
@@ -2850,14 +2954,30 @@ class TestUpdateAverageReportsWhetherItLanded:
 
 
 class TestRedeliveryMovesACounterTwice:
-    """The known residual, pinned at the value the code really produces.
+    """The residual that REMAINS after issue #264, pinned at what the code really does.
 
     Streams deliver at-least-once and the event source carries `retryAttempts: 3`
     with `reportBatchItemFailures: true`, so a batch that partially fails
     re-presents records whose writes already landed. The floor at zero is NOT
     idempotency — it only no-ops a redelivered REMOVE when the counter is already at
-    zero. These tests exist so the module docstring's residual and the behaviour
-    cannot drift apart: if idempotency is ever added, they fail and say so.
+    zero.
+
+    ⚠️ THE ARRIVAL PATH IS NOW CLOSED, and these tests are deliberately about the
+    REVERSAL paths only — see TestARedeliveredArrivalMovesNothing for the half that
+    was fixed. A decrement cannot join the transaction that closes it: every one is a
+    conditional write whose refusal the code above it READS (the pre-deploy persona
+    fallback triggers on `ROW_ABSENT`, the average's pairing rule on a refused
+    reversal), and `TransactWriteItems` reports no per-item outcome — one refused item
+    cancels the whole transaction instead. So transacting a reversal would turn "this
+    decrement had nothing to correct, so carry on" into "the edit wrote nothing at
+    all", disabling the aged-out-day protections that exist BY observing a refusal.
+
+    These therefore stay as they are, and they are what stops the module docstring's
+    remaining residual from drifting from the code. Note that both arrangements below
+    INSERT without an `event_id`, so their setup uses the non-transactional path
+    too — the subject is the reversal, and a claimed insert would make the second
+    insert of `test_a_redelivered_modify_moves_the_count_twice` a no-op for a reason
+    that has nothing to do with what it measures.
     """
 
     def test_a_redelivered_remove_decrements_again_above_zero(
@@ -2873,8 +2993,9 @@ class TestRedeliveryMovesACounterTwice:
 
         counts = {i['pk']: i['count'] for i in real_aggregates_table.scan()['Items']}
         # 2 is the true value: three inserts, one deletion. 1 is what redelivery
-        # produces, and what the module docstring records as a residual. If this
-        # starts failing with 2, idempotency was added — delete the residual note.
+        # produces, and what the module docstring records as the residual that
+        # remains. If this starts failing with 2, the reversal path was closed too —
+        # update that note.
         assert counts['METRIC#daily_total'] == Decimal(1)
 
     def test_a_redelivered_modify_moves_the_count_twice(
@@ -2894,6 +3015,437 @@ class TestRedeliveryMovesACounterTwice:
         # True values after one edit: product_quality 0, billing 2.
         assert counts['METRIC#daily_category#product_quality'] == Decimal(0)
         assert counts['METRIC#daily_category#billing'] == Decimal(3)
+
+
+class TestARedeliveredArrivalMovesNothing:
+    """Issue #264: the same stream record delivered twice leaves every counter alone.
+
+    Streams are at-least-once, and `retryAttempts: 3` with
+    `reportBatchItemFailures: true` means a batch that partially fails re-presents
+    records whose writes already landed. Because these counters are only ever
+    incremented and nothing recomputes them from source, that divergence is
+    PERMANENT — which is why it is closed with a claim rather than compensated for.
+
+    Every test here is moto-backed of necessity: the mechanism is a condition
+    DynamoDB evaluates (`attribute_not_exists(id)`) and a cancellation it reports,
+    and a mock can do neither — against one, a redelivery would "succeed" and every
+    assertion below would pass with the claim deleted.
+
+    REVERT MAP. Each entry was RUN against the source, and cites the tests that
+    really failed:
+      * Drop the dedupe claim from `_claimed_transaction`'s TransactItems (or route
+        `process_new_feedback` past `apply_feedback_once`) — fails
+        test_a_redelivered_record_leaves_every_counter_where_the_first_delivery_left_it,
+        test_the_second_delivery_is_reported_as_a_skip_not_a_failure,
+        test_a_replayed_record_is_counted_so_the_guard_is_not_silently_inert and
+        test_the_second_delivery_of_a_record_writes_nothing_at_all.
+      * Apply the counters as separate `update_item` calls with the claim written
+        first or last, i.e. a marker without a transaction — fails
+        test_a_record_that_fails_partway_leaves_no_counter_moved, which is the
+        partial-application half and the one that produces internally inconsistent
+        metrics.
+      * Treat ANY TransactionCanceledException as an already-applied record (drop
+        `_claim_was_refused`'s reason check) — fails
+        test_a_cancellation_that_is_not_the_claim_is_raised_for_retry, whose subject
+        is that a conflict on a counter row must be retried rather than reported
+        done: nothing was written, so calling it success loses the record.
+      * Claim a key that is not per-RECORD — the feedback id, say — fails
+        test_two_different_records_for_one_item_are_both_applied.
+      * Leave `IDEMPOTENCY_TABLE` out of the aggregator's CDK environment: caught in
+        `lib/stacks/processing-stack-consolidated.test.ts`, not here, and
+        test_an_unconfigured_dedupe_table_still_aggregates is the code side of the
+        same question — the protection degrades, the aggregation does not stop.
+
+    RED BEFORE, GREEN AFTER, measured rather than asserted: run against the pre-#264
+    handler, THIRTEEN of the fourteen tests here fail on their own assertions (not on
+    setup — the fixture patches only the module attributes that exist, deliberately, so
+    each test reaches its subject). The fourteenth,
+    test_a_record_with_no_event_id_is_applied_rather_than_dropped, PASSES both ways and
+    is recorded as such rather than dressed up: it is the fail-open control, and what
+    it guards against is a future over-correction — dropping a record that carries no
+    id. A test whose subject is "this did not change" passing before the change is the
+    correct outcome for it, and pretending otherwise is the citation problem this
+    file's revert maps exist to avoid.
+    """
+
+    ID = 'a-single-stream-record'
+
+    # A counter row that arithmetic cannot touch, used to fail one write of a record
+    # PARTWAY through it. `if_not_exists(#field, :zero) + :inc` against a string is a
+    # ValidationException, which cancels the transaction.
+    #
+    # 🔑 THE PK IS CHOSEN FOR WHERE IT SORTS. Keys are applied in sorted order, so
+    # `METRIC#daily_sentiment#negative` falls after `METRIC#daily_category#...` and
+    # before `METRIC#daily_total` — which against eight independent writes leaves the
+    # category count applied and the daily total not, the internally inconsistent
+    # state the issue names. A poison row at either END of that order would let the
+    # partial-application tests pass against the very defect they are written for.
+    _POISON_PK = 'METRIC#daily_sentiment#negative'
+    _POISON_SK = '2025-01-15'
+
+    @classmethod
+    def _poison(cls, aggregates):
+        aggregates.put_item(Item={
+            'pk': cls._POISON_PK, 'sk': cls._POISON_SK, 'count': 'not a number',
+        })
+
+    @classmethod
+    def _unpoison(cls, aggregates):
+        aggregates.delete_item(Key={'pk': cls._POISON_PK, 'sk': cls._POISON_SK})
+
+    def test_a_redelivered_record_leaves_every_counter_where_the_first_delivery_left_it(
+        self, deduped_tables, sample_urgent_feedback_item
+    ):
+        """🔑 THE ACCEPTANCE CRITERION, over EVERY counter rather than one of them.
+
+        The urgent fixture, so all eight dimensions are present — the urgent row is
+        the one conditional dimension, and a claim that covered seven writes of eight
+        is the shape this asserts against by comparing the whole table.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        record = _record('INSERT', new=sample_urgent_feedback_item, event_id=self.ID)
+
+        record_handler(record)
+        after_first = _counts(aggregates)
+        record_handler(record)
+
+        assert _counts(aggregates) == after_first, (
+            'a redelivered stream record moved a counter; the dedupe claim did not '
+            'refuse the second delivery'
+        )
+        # The denominator: an assertion that both states are EMPTY would pass with
+        # the handler doing nothing at all.
+        assert after_first['METRIC#daily_total'] == Decimal(1)
+        assert len(after_first) == 7, after_first
+
+    def test_the_second_delivery_of_a_record_writes_nothing_at_all(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """Not "writes and then corrects": the transaction never commits.
+
+        Distinct from the test above, which compares values. This one compares the
+        whole item — `updated_at` and `ttl` are restamped by any write that lands, so
+        an unchanged item is evidence that no write reached the row, which a count
+        alone cannot give. A redelivery that renewed a row's 90-day TTL would be a
+        real defect: it would keep an aged-out day alive for the day sentinel.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        record = _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+
+        record_handler(record)
+        before = sorted(aggregates.scan()['Items'], key=lambda i: (i['pk'], i['sk']))
+        record_handler(record)
+
+        assert sorted(aggregates.scan()['Items'], key=lambda i: (i['pk'], i['sk'])) == before
+
+    def test_the_average_is_not_applied_twice_either(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The average is in the transaction too, and it is the row that misleads most.
+
+        `get_summary` divides `sum/count` per date and weights it by count into the
+        headline `avg_sentiment`, so a double-applied score is served-data corruption
+        rather than an off-by-one in a counter nobody reads.
+        """
+        from aggregator.handler import SENTIMENT_AVG_PK, record_handler
+
+        aggregates, _ = deduped_tables
+        record = _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+
+        record_handler(record)
+        record_handler(record)
+
+        row = aggregates.get_item(Key={'pk': SENTIMENT_AVG_PK, 'sk': '2025-01-15'})['Item']
+        assert (row['count'], row['sum']) == (Decimal(1), Decimal('0.85'))
+
+    def test_the_second_delivery_is_reported_as_a_skip_not_a_failure(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """🔑 IT MUST NOT RAISE, and that is not a cosmetic preference.
+
+        `reportBatchItemFailures: true` means a record that raises is reported failed
+        and redelivered — and Streams preserve per-shard order, so a record that fails
+        forever blocks its partition. An idempotency guard that reported "already
+        done" as an error would therefore convert a harmless redelivery into a stalled
+        shard: strictly worse than the double-count it was added to prevent.
+        """
+        from aggregator.handler import record_handler
+
+        record = _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+
+        assert record_handler(record) == {"status": "success"}
+        assert record_handler(record) == {"status": "skipped", "reason": "already applied"}
+
+    def test_a_replayed_record_is_counted_so_the_guard_is_not_silently_inert(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """At zero, a working guard and a deleted one look identical from outside.
+
+        REPLAYED_METRIC is what tells them apart, and it is also the signal that a
+        batch is failing and re-presenting records — the condition this change exists
+        to make survivable. UPDATED_METRIC must NOT fire for the replay: nothing was
+        updated, and a metric claiming otherwise is the blindness the per-behaviour
+        metrics exist to remove.
+        """
+        from aggregator.handler import REPLAYED_METRIC, UPDATED_METRIC, record_handler
+
+        record = _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+        record_handler(record)
+
+        with patch('aggregator.handler.metrics') as mock_metrics:
+            record_handler(record)
+
+        assert [c.kwargs['name'] for c in mock_metrics.add_metric.call_args_list] == [
+            REPLAYED_METRIC,
+        ]
+        assert UPDATED_METRIC != REPLAYED_METRIC
+
+    def test_two_different_records_for_one_item_are_both_applied(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The claim is per RECORD, and the positive control for the whole class.
+
+        Keying on anything about the ITEM — its feedback_id, its source id — would
+        pass every test above while dropping the second of two genuine stream records
+        about one item. `eventID` is unique per record, which is what makes the guard
+        a redelivery test rather than a de-duplication of the feedback itself.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, idempotency = deduped_tables
+
+        record_handler(_record('INSERT', new=sample_feedback_item, event_id='first'))
+        record_handler(_record('INSERT', new=sample_feedback_item, event_id='second'))
+
+        assert _counts(aggregates)['METRIC#daily_total'] == Decimal(2)
+        assert idempotency.scan()['Count'] == 2
+
+    def test_a_record_that_fails_partway_leaves_no_counter_moved(
+        self, deduped_tables, sample_urgent_feedback_item
+    ):
+        """🔑 THE PARTIAL-APPLICATION CRITERION, which the claim alone does not meet.
+
+        This is the case that produces INTERNALLY INCONSISTENT metrics: with eight
+        independent `update_item` calls, a record that dies on its fifth has applied
+        four, so the daily total no longer equals the sum of the per-category counts —
+        and the retry applies all eight on top of those four. A marker written before
+        the writes records the half-application as done; written after, it leaves it to
+        be re-applied. Only transacting them removes the partial state itself.
+
+        ⚠️ THE FAILURE IS INJECTED MID-WAY THROUGH THE WRITES, and that is what makes
+        the arrangement honest. `_POISON_PK` sorts BETWEEN the per-category counter and
+        `METRIC#daily_total`, so against the unfixed code the category count lands, the
+        daily total does not, and the two disagree — the exact state the issue
+        describes. Poisoning the LAST write instead (the average) was the first
+        version and it proved nothing: every counter had already been applied by then,
+        so the totals agreed and the test passed against the defect it was written for.
+
+        The assertion is the one the acceptance criteria state — the daily total agrees
+        with the sum of the per-category counts — asserted over the aggregates rather
+        than over a call count, so it is about the DATA and not the shape of a request.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, idempotency = deduped_tables
+        self._poison(aggregates)
+
+        with pytest.raises(ClientError):
+            record_handler(_record('INSERT', new=sample_urgent_feedback_item,
+                                   event_id=self.ID))
+
+        # The poison row itself is excluded: the test PUT it, so its presence says
+        # nothing about what the handler wrote, and leaving it in made the assertion
+        # fail on the arrangement rather than on the behaviour.
+        counts = {pk: value for pk, value in _counts(aggregates).items()
+                  if pk != self._POISON_PK}
+        assert counts == {}, (
+            f'{counts}: some counters moved while the record failed, so the daily '
+            f'total and the per-category counts now describe different sets of items '
+            f'— the internally inconsistent state a transaction exists to prevent'
+        )
+        # And the record is NOT recorded as applied, so the retry can do the whole of
+        # it. A claim that survived the failure would be worse than no claim at all.
+        assert idempotency.scan()['Count'] == 0
+
+    def test_the_retry_of_that_record_applies_it_exactly_once(
+        self, deduped_tables, sample_urgent_feedback_item
+    ):
+        """The other half of the criterion: after the retry, the totals AGREE.
+
+        The positive control for the test above — an implementation that failed
+        closed by writing nothing ever would pass that one and fail this.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        self._poison(aggregates)
+        record = _record('INSERT', new=sample_urgent_feedback_item, event_id=self.ID)
+        with pytest.raises(ClientError):
+            record_handler(record)
+
+        # The bad row is cleared and the record is re-presented, which is what
+        # `reportBatchItemFailures: true` does.
+        self._unpoison(aggregates)
+        assert record_handler(record) == {"status": "success"}
+
+        counts = _counts(aggregates)
+        categories = sum(v for pk, v in counts.items()
+                         if pk.startswith('METRIC#daily_category#'))
+        assert counts['METRIC#daily_total'] == categories == Decimal(1), counts
+
+    def test_a_cancellation_that_is_not_the_claim_is_raised_for_retry(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """A conflict on a counter row is NOT an already-applied record.
+
+        Two records of the same day arriving together really do produce
+        `TransactionConflictException`, and calling that "already applied" would
+        silently lose the record's aggregates: nothing was written, and reporting
+        success means nothing ever will be. So the decision reads the CLAIM's own
+        cancellation reason rather than the exception being a cancellation.
+
+        Built as the response shape DynamoDB sends — reasons are positional, the claim
+        is item 0 — rather than by arranging a real conflict, which moto cannot
+        produce on demand.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        conflict = ClientError(
+            {
+                'Error': {'Code': 'TransactionCanceledException', 'Message': 'cancelled'},
+                'CancellationReasons': [
+                    {'Code': 'None'},
+                    {'Code': 'TransactionConflict', 'Message': 'conflict'},
+                ],
+            },
+            'TransactWriteItems',
+        )
+        with patch.object(aggregates.meta.client, 'transact_write_items',
+                          side_effect=conflict):
+            with pytest.raises(ClientError):
+                record_handler(_record('INSERT', new=sample_feedback_item,
+                                       event_id=self.ID))
+
+    def test_a_cancellation_whose_reasons_cannot_be_read_is_raised_too(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The fail direction of the one conclusion that reports success.
+
+        "Already applied" ends the record, so it needs positive evidence — the same
+        rule `CounterWrite.ROW_ABSENT` follows. A retry of an unapplied record is
+        correct and a retry of an applied one is refused by the claim it holds, so
+        being wrong in THIS direction costs nothing, while the other drops aggregates
+        for any response shape this could not parse.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        unreadable = ClientError(
+            {'Error': {'Code': 'TransactionCanceledException', 'Message': 'cancelled'}},
+            'TransactWriteItems',
+        )
+        with patch.object(aggregates.meta.client, 'transact_write_items',
+                          side_effect=unreadable):
+            with pytest.raises(ClientError):
+                record_handler(_record('INSERT', new=sample_feedback_item,
+                                       event_id=self.ID))
+
+    def test_an_unconfigured_dedupe_table_still_aggregates(
+        self, real_aggregates_table, sample_feedback_item
+    ):
+        """A missing table NAME degrades the protection; it must not stop the counting.
+
+        `IDEMPOTENCY_TABLE` unset is a CDK regression, and the right response to one
+        is the pre-#264 behaviour plus the warning this module logs at import — not a
+        Lambda that raises on every record and blocks its shard. `real_aggregates_table`
+        rather than `deduped_tables` IS the arrangement: that fixture is the one where
+        the name is not patched in.
+        """
+        from aggregator.handler import IDEMPOTENCY_TABLE, record_handler
+
+        assert not IDEMPOTENCY_TABLE, 'the arrangement requires an unset table name'
+
+        assert record_handler(_record('INSERT', new=sample_feedback_item,
+                                      event_id=self.ID)) == {"status": "success"}
+
+        assert _counts(real_aggregates_table)['METRIC#daily_total'] == Decimal(1)
+
+    def test_a_record_with_no_event_id_is_applied_rather_than_dropped(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The other fail-open direction, and the same judgement the module makes
+        elsewhere: aggregating a record twice is recoverable, never aggregating it is
+        not. `is_ttl_expiry` and `_day_has_aggregates` both fail in this direction.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, idempotency = deduped_tables
+
+        assert record_handler(
+            _record('INSERT', new=sample_feedback_item)
+        ) == {"status": "success"}
+
+        assert _counts(aggregates)['METRIC#daily_total'] == Decimal(1)
+        assert idempotency.scan()['Count'] == 0, 'nothing to claim without a record id'
+
+    def test_the_claim_expires_so_markers_do_not_accumulate_forever(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The marker carries the table's TTL attribute, or the table grows without end.
+
+        `lib/stacks/core-stack.ts` gives the idempotency table
+        `timeToLiveAttribute: 'expiration'`, and a marker written under any other name
+        is one DynamoDB will never delete — a leak no error and no other test reports.
+
+        The horizon is read off the item rather than restated, and what it is compared
+        against is the STREAM'S retention: a marker must outlive the window a
+        redelivery can arrive in, or the last possible redelivery finds it gone and is
+        applied twice. Asserting `> 24h` rather than `>= 24h` is the point — an
+        expiry equal to the horizon races the TTL deleting its own marker, and TTL
+        deletion is best-effort anyway. This is what caught the first version of the
+        constant, which was exactly 24 hours.
+        """
+        from datetime import timezone as tz
+
+        from aggregator.handler import record_handler
+        from shared.idempotency import (
+            IDEMPOTENCY_EXPIRY_ATTRIBUTE,
+            IDEMPOTENCY_KEY_ATTRIBUTE,
+        )
+
+        stream_retention_seconds = 24 * 60 * 60
+        _, idempotency = deduped_tables
+        record_handler(_record('INSERT', new=sample_feedback_item, event_id=self.ID))
+
+        marker = idempotency.scan()['Items'][0]
+        assert IDEMPOTENCY_KEY_ATTRIBUTE in marker
+        now = datetime.now(tz.utc).timestamp()
+        assert marker[IDEMPOTENCY_EXPIRY_ATTRIBUTE] > now + stream_retention_seconds, (
+            'the claim does not outlive the 24 hours a stream record survives, so a '
+            'late redelivery would find the marker gone and be applied again'
+        )
+
+    def test_the_claim_is_namespaced_away_from_the_processors_keys(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """One table, two writers: a stream `eventID` must not collide with a
+        `{source_platform}:{source_id}` the processor claims. A collision would make
+        one of the two silently skip real work, in whichever direction lost the race.
+        """
+        from aggregator.handler import record_handler
+        from shared.idempotency import IDEMPOTENCY_KEY_ATTRIBUTE
+
+        _, idempotency = deduped_tables
+        record_handler(_record('INSERT', new=sample_feedback_item, event_id=self.ID))
+
+        key = idempotency.scan()['Items'][0][IDEMPOTENCY_KEY_ATTRIBUTE]
+        assert key.startswith('aggregator#'), key
+        assert self.ID in key, key
 
 
 class TestAnUnrecognizedEventIsSkippedRatherThanFatal:

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -3668,8 +3668,9 @@ class TestTheTransactionIsAnArrivalAndOnlyAnArrival:
         Compared on the ROWS, not on the calls: `updated_at` and the TTL are stamped
         from the clock, so the comparison is over (pk, sk, count) and the average's
         (sum, count). Two separate fixtures would be cleaner but cannot share one moto
-        table; the same table is used twice with the day cleared between, which is why
-        the dates differ rather than the rows being deleted.
+        table, so ONE date is used for both passes and the rows are DELETED between
+        them — which is what makes the second pass' counts comparable to the first's
+        rather than double them.
         """
         from aggregator.handler import SENTIMENT_AVG_PK, record_handler
 
@@ -3719,6 +3720,14 @@ class TestAWriteConflictIsRetriedRatherThanReported:
     answer for a different reason (a voter who cannot resubmit); the aggregator's is
     that the stream would otherwise be the only retry budget. Both use three attempts.
 
+    THROTTLING IS THE SAME PROBLEM, and it is retried for the same reason. Botocore's
+    throttling policies match the TOP-LEVEL error code, which for a cancelled
+    transaction is always `TransactionCanceledException` — the throttle is one level
+    down, inside the reasons — so nothing absorbs it and an unretried throttle costs
+    the record exactly what an unretried conflict does. This module already calls
+    throttling transient for the day READ (`_TRANSIENT_READ_ERRORS`), so the write path
+    reaching the opposite conclusion about one condition was the defect, not a policy.
+
     REVERT MAP, each entry RUN:
       * Delete the `_conflicted` branch from `_claimed_transaction` — fails
         test_a_conflicted_transaction_is_re_attempted and
@@ -3727,6 +3736,21 @@ class TestAWriteConflictIsRetriedRatherThanReported:
         test_a_validation_failure_is_not_retried, whose subject is that a request
         which will fail identically must not be re-sent: it spends the invocation and
         delays the record.
+      * Narrow `_RETRYABLE_CANCELLATION_REASONS` back to the conflict alone — fails
+        test_a_throttled_transaction_is_re_attempted_like_a_conflict and
+        test_every_retryable_reason_is_transient_on_the_read_path_too. Measured: with
+        only `TransactionConflict` in the set, a throttled cancellation is attempted
+        ONCE and raised, so the record has only `retryAttempts: 3` left before it is
+        dropped with its aggregates lost permanently.
+      * Make `_conflicted` `any` rather than `all` — fails
+        test_a_conflict_alongside_a_permanent_reason_is_not_retried. Measured: reasons
+        `[None, TransactionConflict, ValidationError]` were re-attempted to the bound
+        (3 attempts, 2 sleeps) on a request that cannot succeed, which is the cost
+        test_a_validation_failure_is_not_retried exists to prevent.
+      * Treat `NO_CANCELLATION_REASON` as blocking — fails
+        test_a_conflicted_transaction_is_re_attempted, since a cancelled transaction
+        reports one reason per item and most items did not fail, so `'None'` is the
+        commonest entry in any real response.
       * Retry forever — fails test_the_attempts_are_bounded, which is what keeps a
         contended shard from holding Lambda concurrency in a tight loop.
       * Set TRANSACT_WRITE_ATTEMPTS to 0 — fails
@@ -3737,24 +3761,33 @@ class TestAWriteConflictIsRetriedRatherThanReported:
     ID = 'a-contended-record'
 
     @staticmethod
-    def _conflict() -> ClientError:
-        """The response shape DynamoDB sends for a contended item.
+    def _cancelled(*codes: str) -> ClientError:
+        """A cancellation naming `codes`, one reason per item, in that order.
 
-        Reasons are POSITIONAL and the claim is item 0, so the conflict is placed on a
-        counter — index 1 — which is where contention really happens: the claim's key
-        is unique per record and cannot be contended by another record at all.
+        Built as the response shape DynamoDB sends rather than by provoking a real
+        cancellation, which moto cannot produce on demand. Reasons are POSITIONAL and
+        complete — one entry per transaction item, `'None'` for every item that did not
+        fail — so the caller passes the codes in item order and the claim at index 0 is
+        normally `'None'`: its key is unique per record, so no other record can contend
+        or throttle it.
         """
         return ClientError(
             {
                 'Error': {'Code': 'TransactionCanceledException',
                           'Message': 'cancelled'},
-                'CancellationReasons': [
-                    {'Code': 'None'},
-                    {'Code': 'TransactionConflict', 'Message': 'conflict'},
-                ],
+                'CancellationReasons': [{'Code': code} for code in codes],
             },
             'TransactWriteItems',
         )
+
+    @classmethod
+    def _conflict(cls) -> ClientError:
+        """The response shape DynamoDB sends for a contended item.
+
+        The conflict sits at index 1 — a counter — which is where contention really
+        happens: the claim's key is unique per record and cannot be contended at all.
+        """
+        return cls._cancelled('None', 'TransactionConflict')
 
     def test_a_conflicted_transaction_is_re_attempted(
         self, deduped_tables, sample_feedback_item
@@ -3872,25 +3905,19 @@ class TestAWriteConflictIsRetriedRatherThanReported:
     def test_a_validation_failure_is_not_retried(
         self, deduped_tables, sample_feedback_item
     ):
-        """Only a CONFLICT is transient. A `ValidationException` will fail identically
-        on the next attempt, so re-sending it spends the invocation's time and delays
-        the record for nothing — the same reason `_write_ballot` does not retry a row
-        that has gone away.
+        """A `ValidationException` will fail identically on the next attempt, so
+        re-sending it spends the invocation's time and delays the record for nothing —
+        the same reason `_write_ballot` does not retry a row that has gone away.
+
+        The complement of the two transient reasons, and the reason
+        `_RETRYABLE_CANCELLATION_REASONS` is an allowlist rather than a denylist: a
+        reason code this module has never heard of is far more likely to be permanent
+        than transient, so an unknown one must not buy a retry.
         """
         from aggregator.handler import record_handler
 
         aggregates, _ = deduped_tables
-        permanent = ClientError(
-            {
-                'Error': {'Code': 'TransactionCanceledException',
-                          'Message': 'cancelled'},
-                'CancellationReasons': [
-                    {'Code': 'None'},
-                    {'Code': 'ValidationError', 'Message': 'not a number'},
-                ],
-            },
-            'TransactWriteItems',
-        )
+        permanent = self._cancelled('None', 'ValidationError')
         with patch.object(aggregates.meta.client, 'transact_write_items',
                           side_effect=permanent) as attempted:
             with pytest.raises(ClientError):
@@ -3901,6 +3928,144 @@ class TestAWriteConflictIsRetriedRatherThanReported:
             'a cancellation no contention caused was re-attempted; it will fail the '
             'same way and the record is delayed by every wait'
         )
+
+    @pytest.mark.parametrize('reason', ['ThrottlingError',
+                                        'ProvisionedThroughputExceeded'])
+    def test_a_throttled_transaction_is_re_attempted_like_a_conflict(
+        self, deduped_tables, sample_feedback_item, reason
+    ):
+        """🔑 A THROTTLE IS AS TRANSIENT AS A CONFLICT, AND NOTHING ELSE ABSORBS IT.
+
+        Botocore's throttling policies match the TOP-LEVEL `service_error_code`, and a
+        throttled transaction's is `TransactionCanceledException` — the throttle is one
+        level down, in the reasons — so `botocore/data/_retry.json` never matches it.
+        Unretried, a throttled arrival gets ONE attempt, then spends the event source's
+        `retryAttempts: 3`, and past that is dropped with its aggregates lost for good.
+
+        Both spellings, because `_TRANSIENT_READ_ERRORS` already calls both transient
+        for the day read (as `ThrottlingException` and
+        `ProvisionedThroughputExceededException`), and the write path reaching the
+        opposite conclusion about the same condition was the defect. Fails if
+        `_RETRYABLE_CANCELLATION_REASONS` is narrowed back to the conflict alone.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        real = aggregates.meta.client.transact_write_items
+        attempts = iter([self._cancelled('None', reason)])
+
+        def flaky(**kwargs):
+            failure = next(attempts, None)
+            if failure is not None:
+                raise failure
+            return real(**kwargs)
+
+        with patch.object(aggregates.meta.client, 'transact_write_items', flaky), \
+                patch('aggregator.handler.time.sleep') as slept:
+            assert record_handler(
+                _record('INSERT', new=sample_feedback_item, event_id=self.ID)
+            ) == {"status": "success"}
+
+        # The retry is what wrote the record, and it waited first.
+        assert _counts(aggregates)['METRIC#daily_total'] == Decimal(1)
+        assert slept.call_count == 1
+
+    def test_a_conflict_alongside_a_permanent_reason_is_not_retried(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """🔑 "TRANSIENT AND NOTHING ELSE", which is why `_conflicted` is `all`.
+
+        It was `any`, so one contended item licensed the retry no matter what the other
+        reasons said — and a cancellation carrying BOTH a conflict and a
+        `ValidationError` was then re-attempted to the full bound on a request that
+        cannot succeed. That is exactly the cost
+        test_a_validation_failure_is_not_retried exists to prevent, reached whenever the
+        two coincide, which the poison-row shape elsewhere in this file makes ordinary:
+        a `ValidationError` on one item, and a collision on `METRIC#daily_total` if
+        another record of the day arrives in the same batch.
+
+        Nothing is lost by refusing: the transaction wrote nothing either way, and the
+        permanent item refuses every re-attempt identically, so a retry could only add
+        delay before reporting the same failure.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        mixed = self._cancelled('None', 'TransactionConflict', 'ValidationError')
+        with patch.object(aggregates.meta.client, 'transact_write_items',
+                          side_effect=mixed) as attempted, \
+                patch('aggregator.handler.time.sleep') as slept:
+            with pytest.raises(ClientError):
+                record_handler(_record('INSERT', new=sample_feedback_item,
+                                       event_id=self.ID))
+
+        assert attempted.call_count == 1, (
+            'a cancellation carrying a permanent reason was re-attempted because '
+            'another item merely contended; every one of those attempts fails on the '
+            'permanent item, so the bound is spent to reach the same report'
+        )
+        assert slept.call_count == 0
+
+    def test_a_cancellation_naming_no_failure_at_all_is_not_retried(
+        self, deduped_tables, sample_feedback_item
+    ):
+        """The denominator for `NO_CANCELLATION_REASON` being treated as "says nothing".
+
+        `'None'` cannot veto a retry — a cancelled transaction reports one reason per
+        item and most items did not fail, so it is the commonest entry in any real
+        response — but it must not GRANT one either, or a cancellation this module
+        cannot explain would be retried to the bound on the strength of no evidence.
+        """
+        from aggregator.handler import record_handler
+
+        aggregates, _ = deduped_tables
+        with patch.object(aggregates.meta.client, 'transact_write_items',
+                          side_effect=self._cancelled('None', 'None')) as attempted:
+            with pytest.raises(ClientError):
+                record_handler(_record('INSERT', new=sample_feedback_item,
+                                       event_id=self.ID))
+
+        assert attempted.call_count == 1
+
+    def test_every_retryable_reason_is_transient_on_the_read_path_too(self):
+        """The two paths must not disagree about one condition.
+
+        `_TRANSIENT_READ_ERRORS` decides what a transient failure of the day READ is;
+        `_RETRYABLE_CANCELLATION_REASONS` decides the same for the transactional WRITE.
+        This is what fails if one grows a member the other lacks — the divergence that
+        produced the throttling gap, where the read called it transient and the write
+        did not.
+
+        🔑 THE PAIRING IS SPELLED OUT RATHER THAN DERIVED, and that is the finding.
+        Appending `Exception` works for two of the three and NOT for the throttle: the
+        reasons list says `ThrottlingError` where the exception is `ThrottlingException`,
+        so a suffix rule would have quietly passed on a mapping it got wrong. There is
+        no algorithm relating the two vocabularies, which is exactly why both sets are
+        named in full in the module and why this table is written out here.
+        """
+        from aggregator.handler import (
+            _RETRYABLE_CANCELLATION_REASONS,
+            _TRANSIENT_READ_ERRORS,
+        )
+
+        # reason code (in CancellationReasons) -> exception code (on a plain request)
+        same_condition = {
+            'TransactionConflict': 'TransactionConflictException',
+            'ThrottlingError': 'ThrottlingException',
+            'ProvisionedThroughputExceeded': 'ProvisionedThroughputExceededException',
+        }
+
+        assert set(same_condition) == set(_RETRYABLE_CANCELLATION_REASONS), (
+            'a retryable cancellation reason has no counterpart named here, so nothing '
+            'checks whether the read path agrees it is transient'
+        )
+        for reason, exception in same_condition.items():
+            assert exception in _TRANSIENT_READ_ERRORS, (
+                f'{reason!r} is retried as a cancelled transaction but {exception!r} '
+                f'is not transient for the day read, so the two paths disagree about '
+                f'one DynamoDB condition. Add it to _TRANSIENT_READ_ERRORS, or say at '
+                f'_RETRYABLE_CANCELLATION_REASONS why the write is special.'
+            )
 
     def test_a_redelivery_is_still_a_skip_and_not_a_retry(
         self, deduped_tables, sample_feedback_item

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -185,7 +185,7 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       auto-retry a cancelled transaction, so without the in-process retry a same-date
       collision spends the event source's `retryAttempts: 3` and the record is then
       DROPPED, its aggregates lost permanently — worse than the double-count. Deleting
-      the retry fails four; retrying ANY cancellation fails the one whose subject is
+      the retry fails two; retrying ANY cancellation fails the one whose subject is
       that a request which will fail identically must not be re-sent.
 
   TestRedeliveryMovesACounterTwice
@@ -3253,9 +3253,10 @@ class TestARedeliveredArrivalMovesNothing:
         This is the case that produces INTERNALLY INCONSISTENT metrics: with one
         independent `update_item` call per dimension, a record that dies partway has
         applied the ones before it, so the daily total no longer equals the sum of the
-        per-category counts — and the retry applies every one of them on top. A marker written before
-        the writes records the half-application as done; written after, it leaves it to
-        be re-applied. Only transacting them removes the partial state itself.
+        per-category counts — and the retry applies every one of them on top. A marker
+        written before the writes records the half-application as done; written after,
+        it leaves it to be re-applied. Only transacting them removes the partial state
+        itself.
 
         ⚠️ THE FAILURE IS INJECTED MID-WAY THROUGH THE WRITES, and that is what makes
         the arrangement honest. `_POISON_PK` sorts BETWEEN the per-category counter and
@@ -3731,7 +3732,7 @@ class TestAWriteConflictIsRetriedRatherThanReported:
     REVERT MAP, each entry RUN:
       * Delete the `_conflicted` branch from `_claimed_transaction` — fails
         test_a_conflicted_transaction_is_re_attempted and
-        test_a_conflict_that_clears_leaves_the_record_applied.
+        test_a_conflict_that_clears_leaves_the_record_applied_exactly_once.
       * Retry ANY cancellation (drop the reason check in `_conflicted`) — fails
         test_a_validation_failure_is_not_retried, whose subject is that a request
         which will fail identically must not be re-sent: it spends the invocation and
@@ -4028,7 +4029,7 @@ class TestAWriteConflictIsRetriedRatherThanReported:
         assert attempted.call_count == 1
 
     def test_every_retryable_reason_is_transient_on_the_read_path_too(self):
-        """The two paths must not disagree about one condition.
+        """The two paths must not disagree about one condition, in EITHER direction.
 
         `_TRANSIENT_READ_ERRORS` decides what a transient failure of the day READ is;
         `_RETRYABLE_CANCELLATION_REASONS` decides the same for the transactional WRITE.
@@ -4042,6 +4043,23 @@ class TestAWriteConflictIsRetriedRatherThanReported:
         so a suffix rule would have quietly passed on a mapping it got wrong. There is
         no algorithm relating the two vocabularies, which is exactly why both sets are
         named in full in the module and why this table is written out here.
+
+        🔑 BOTH DIRECTIONS, not just write-covers-read. A first version of this test
+        asserted `same_condition`'s keys EQUAL `_RETRYABLE_CANCELLATION_REASONS`, then
+        checked each mapped exception INTO `_TRANSIENT_READ_ERRORS` — which pins today's
+        three but would not fail if `_TRANSIENT_READ_ERRORS` grew a fourth transient
+        condition with a `CancellationReasons` counterpart nobody added to the write
+        side. That is the exact shape of the gap this test exists to prevent, just with
+        the two paths swapped: "the read calls it transient and the write does not." A
+        table that only checks read ⊇ write cannot catch write ⊇ read going missing.
+
+        A SECOND assert reusing `same_condition`'s own keys against
+        `_RETRYABLE_CANCELLATION_REASONS` would be a TAUTOLOGY, not a second direction:
+        the first assert already pins them equal, so it can never fail. Closing the
+        other direction means walking `_TRANSIENT_READ_ERRORS` itself, which is why
+        `HAS_CANCELLATION_COUNTERPART` below enumerates it in full — a member added
+        there with no `True`/`False` decision fails the completeness assert, and a
+        `True` with no reason code fails the containment assert.
         """
         from aggregator.handler import (
             _RETRYABLE_CANCELLATION_REASONS,
@@ -4065,6 +4083,47 @@ class TestAWriteConflictIsRetriedRatherThanReported:
                 f'is not transient for the day read, so the two paths disagree about '
                 f'one DynamoDB condition. Add it to _TRANSIENT_READ_ERRORS, or say at '
                 f'_RETRYABLE_CANCELLATION_REASONS why the write is special.'
+            )
+
+        # The other direction. Every `_TRANSIENT_READ_ERRORS` member, and whether it has
+        # a `CancellationReasons` counterpart at all — most do not, which is why this
+        # cannot be `set(_TRANSIENT_READ_ERRORS) == set(same_condition.values())`: five
+        # of the nine are read-only failure modes (a throttled or slow-server READ, not
+        # a cancelled transaction) with no transactional analogue. That is a fact about
+        # DynamoDB's error surface, not an oversight, so it is recorded per-member rather
+        # than derived — the same reasoning `same_condition` itself gives for being
+        # spelled out instead of computed.
+        exception_to_reason = {v: k for k, v in same_condition.items()}
+        has_cancellation_counterpart = {
+            'ProvisionedThroughputExceededException': True,
+            'ThrottlingException': True,
+            'TransactionConflictException': True,
+            'ThrottlingException.TooManyRequests': False,
+            'RequestLimitExceeded': False,
+            'InternalServerError': False,
+            'ServiceUnavailable': False,
+            'RequestTimeout': False,
+            'RequestTimeoutException': False,
+        }
+        assert set(has_cancellation_counterpart) == set(_TRANSIENT_READ_ERRORS), (
+            '_TRANSIENT_READ_ERRORS gained or lost a member with no matching entry '
+            'here, so nothing decided whether it needs a _RETRYABLE_CANCELLATION_'
+            'REASONS counterpart. Add it above with True or False.'
+        )
+        for exception, has_counterpart in has_cancellation_counterpart.items():
+            if not has_counterpart:
+                continue
+            assert exception in exception_to_reason, (
+                f'{exception!r} is marked as having a cancellation-reason counterpart '
+                f'but same_condition names none — add the pair above.'
+            )
+            reason = exception_to_reason[exception]
+            assert reason in _RETRYABLE_CANCELLATION_REASONS, (
+                f'{exception!r} is transient for the day read and is marked as having '
+                f'a cancellation-reason counterpart ({reason!r}), but that reason is '
+                f'not retried as a cancelled transaction — the reverse of the '
+                f'throttling gap this test exists to prevent. Add it to '
+                f'_RETRYABLE_CANCELLATION_REASONS.'
             )
 
     def test_a_redelivery_is_still_a_skip_and_not_a_retry(

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -4057,7 +4057,7 @@ class TestAWriteConflictIsRetriedRatherThanReported:
         `_RETRYABLE_CANCELLATION_REASONS` would be a TAUTOLOGY, not a second direction:
         the first assert already pins them equal, so it can never fail. Closing the
         other direction means walking `_TRANSIENT_READ_ERRORS` itself, which is why
-        `HAS_CANCELLATION_COUNTERPART` below enumerates it in full — a member added
+        `has_cancellation_counterpart` below enumerates it in full — a member added
         there with no `True`/`False` decision fails the completeness assert, and a
         `True` with no reason code fails the containment assert.
         """
@@ -4087,12 +4087,14 @@ class TestAWriteConflictIsRetriedRatherThanReported:
 
         # The other direction. Every `_TRANSIENT_READ_ERRORS` member, and whether it has
         # a `CancellationReasons` counterpart at all — most do not, which is why this
-        # cannot be `set(_TRANSIENT_READ_ERRORS) == set(same_condition.values())`: five
-        # of the nine are read-only failure modes (a throttled or slow-server READ, not
-        # a cancelled transaction) with no transactional analogue. That is a fact about
+        # cannot be `set(_TRANSIENT_READ_ERRORS) == set(same_condition.values())`: a
+        # majority are read-only failure modes (a throttled or slow-server READ, not a
+        # cancelled transaction) with no transactional analogue. That is a fact about
         # DynamoDB's error surface, not an oversight, so it is recorded per-member rather
         # than derived — the same reasoning `same_condition` itself gives for being
-        # spelled out instead of computed.
+        # spelled out instead of computed. Not counted here on purpose: the completeness
+        # assert below already enforces every member has a decision, so a stated count
+        # is one more thing to go stale for nothing it checks.
         exception_to_reason = {v: k for k, v in same_condition.items()}
         has_cancellation_counterpart = {
             'ProvisionedThroughputExceededException': True,

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -167,6 +167,27 @@ decisions inside it that a naive implementation gets wrong. The revert map:
       which mutation each citation was measured against and the one test there
       that passes in both states and why that is correct.
 
+  TestTheTransactionIsAnArrivalAndOnlyAnArrival
+    — what the transactional path may BUILD, asserted on the request rather than
+      through the handler, because none of these is reachable from a record. Giving
+      any builder a `sign` again fails one — the original defect: the sign reached the
+      counters while the average hardcoded `+1`, so `-1` decremented every counter and
+      INCREMENTED the average, atomically. A second dimension on an EXISTING pk fails
+      another, where production would answer `ValidationException` for every ingested
+      record. Bypassing `_counter_request` fails the `metric_type` one, where the GSI
+      that `/metrics/sources` and `/metrics/personas` read would silently empty while
+      every count stayed correct. Its parity test is the one to keep in mind when
+      adding a dimension test: `_record` omits `event_id` by default, so those tests
+      take the path production no longer takes for an INSERT.
+
+  TestAWriteConflictIsRetriedRatherThanReported
+    — contention on `METRIC#daily_total` must not cost a record. Botocore does not
+      auto-retry a cancelled transaction, so without the in-process retry a same-date
+      collision spends the event source's `retryAttempts: 3` and the record is then
+      DROPPED, its aggregates lost permanently — worse than the double-count. Deleting
+      the retry fails four; retrying ANY cancellation fails the one whose subject is
+      that a request which will fail identically must not be re-sent.
+
   TestRedeliveryMovesACounterTwice
     — the residual that REMAINS after that: a REVERSAL is not transacted, because
       every decrement is a conditional write whose refusal the code above it READS

--- a/voc-datalake/lambda/aggregator/test/test_handler.py
+++ b/voc-datalake/lambda/aggregator/test/test_handler.py
@@ -206,7 +206,7 @@ Each of those reverts was RUN, not predicted. Two more were run for the same
 reason:
 
   * having the reverse path skip one dimension — the shape an inverted
-    hand-written twin of the eight original `update_counter` calls would
+    hand-written twin of the original per-dimension `update_counter` calls would
     eventually take — fails
     `test_the_reversed_dimensions_are_exactly_the_incremented_ones`;
   * treating an absent `userIdentity` as TTL expiry fails
@@ -3076,7 +3076,7 @@ class TestARedeliveredArrivalMovesNothing:
     #
     # 🔑 THE PK IS CHOSEN FOR WHERE IT SORTS. Keys are applied in sorted order, so
     # `METRIC#daily_sentiment#negative` falls after `METRIC#daily_category#...` and
-    # before `METRIC#daily_total` — which against eight independent writes leaves the
+    # before `METRIC#daily_total` — which against independent writes leaves the
     # category count applied and the daily total not, the internally inconsistent
     # state the issue names. A poison row at either END of that order would let the
     # partial-application tests pass against the very defect they are written for.
@@ -3098,9 +3098,9 @@ class TestARedeliveredArrivalMovesNothing:
     ):
         """🔑 THE ACCEPTANCE CRITERION, over EVERY counter rather than one of them.
 
-        The urgent fixture, so all eight dimensions are present — the urgent row is
-        the one conditional dimension, and a claim that covered seven writes of eight
-        is the shape this asserts against by comparing the whole table.
+        The urgent fixture, so EVERY dimension is present — the urgent row is the one
+        conditional one — and a claim covering all of them but one is the shape this
+        asserts against by comparing the whole table rather than a count of rows.
         """
         from aggregator.handler import record_handler
 
@@ -3229,10 +3229,10 @@ class TestARedeliveredArrivalMovesNothing:
     ):
         """🔑 THE PARTIAL-APPLICATION CRITERION, which the claim alone does not meet.
 
-        This is the case that produces INTERNALLY INCONSISTENT metrics: with eight
-        independent `update_item` calls, a record that dies on its fifth has applied
-        four, so the daily total no longer equals the sum of the per-category counts —
-        and the retry applies all eight on top of those four. A marker written before
+        This is the case that produces INTERNALLY INCONSISTENT metrics: with one
+        independent `update_item` call per dimension, a record that dies partway has
+        applied the ones before it, so the daily total no longer equals the sum of the
+        per-category counts — and the retry applies every one of them on top. A marker written before
         the writes records the half-application as done; written after, it leaves it to
         be re-applied. Only transacting them removes the partial state itself.
 

--- a/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
@@ -57,10 +57,16 @@ _TTL_PARAMETER = 'ttl_days'
 #
 # FOUR since the arrival path became transactional (issue #264): an INSERT's counters
 # and average are built as `TransactWriteItems` entries, and each of those builders
-# computes its own `#ttl` from its own `ttl_days` default. That is a third and fourth
-# copy of the horizon — on the path EVERY ingested item takes — and a lockstep naming
-# only the two single-write functions would have left them free to drift while
-# reporting the constant as honoured.
+# takes its own `ttl_days` default. That is a third and fourth copy of the horizon — on
+# the path EVERY ingested item takes — and a lockstep naming only the two single-write
+# functions would have left them free to drift while reporting the constant as honoured.
+#
+# The `now + ttl_days * 24 * 60 * 60` ARITHMETIC is not in four places: `_counter_request`
+# and `_average_request` each do it once for both of their issuers, and both take
+# `ttl_days` as a REQUIRED parameter, so neither can carry a default that disagrees with
+# anything. What the four names below still own is the DEFAULT — the number a caller gets
+# when it does not say — which is the only thing a constant can describe and so the only
+# thing this file reads.
 _WRITERS = (
     'update_counter', 'update_average',
     '_counter_transaction_item', '_average_transaction_item',

--- a/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_aggregate_retention_lockstep.py
@@ -31,9 +31,11 @@ Which mutation makes each assertion fail: change `ttl_days`' default in
 `aggregator/handler.py`, or `AGGREGATE_RETENTION_DAYS` in `shared/api.py`,
 without changing the other, and
 `test_the_shared_constant_equals_the_aggregators_ttl_default` fails naming both
-numbers. `test_both_writers_stamp_the_same_horizon` fails if only one of the two
-aggregator functions is changed — half the rows would then outlive the other
-half and no single constant could describe the window.
+numbers. `test_every_writer_stamps_the_same_horizon` fails if only one of the
+aggregator's writers is changed — some rows would then outlive the others and no
+single constant could describe the window. It derives the writers from `_WRITERS`
+rather than naming two inline, which is what it did until the arrival path became
+transactional and added two more.
 `test_no_call_site_overrides_the_ttl` fails if a writer is called with an explicit
 `ttl_days`, which would make the default true and the rows' real horizon something
 else; `test_each_writer_applies_the_parameter_it_takes` fails if a writer accepts
@@ -49,9 +51,20 @@ _AGGREGATOR_SOURCE = (
     Path(__file__).resolve().parents[2] / 'aggregator' / 'handler.py'
 )
 _TTL_PARAMETER = 'ttl_days'
-# The two functions that write aggregate rows. Both, because one TTL per writer
-# would mean two horizons over partitions a single window read spans.
-_WRITERS = ('update_counter', 'update_average')
+# Every function that STAMPS an aggregate row's TTL. All of them, because one TTL per
+# writer would mean two horizons over partitions a single window read spans, and
+# `AGGREGATE_RETENTION_DAYS` could then describe none of them.
+#
+# FOUR since the arrival path became transactional (issue #264): an INSERT's counters
+# and average are built as `TransactWriteItems` entries, and each of those builders
+# computes its own `#ttl` from its own `ttl_days` default. That is a third and fourth
+# copy of the horizon — on the path EVERY ingested item takes — and a lockstep naming
+# only the two single-write functions would have left them free to drift while
+# reporting the constant as honoured.
+_WRITERS = (
+    'update_counter', 'update_average',
+    '_counter_transaction_item', '_average_transaction_item',
+)
 
 
 def _aggregator_tree() -> ast.Module:
@@ -181,15 +194,26 @@ class TestAggregateRetentionLockstep:
                 'stamps is not the horizon this lockstep is about'
             )
 
-    def test_both_writers_stamp_the_same_horizon(self):
-        """`update_counter` and `update_average` write into the SAME partitions
-        that one window read spans (`METRIC#daily_total` counts beside
-        `METRIC#daily_sentiment_avg` sums), so two TTLs would mean two horizons
-        and no single constant could describe the window."""
-        assert (
-            _aggregator_ttl_default('update_counter')
-            == _aggregator_ttl_default('update_average')
-            == AGGREGATE_RETENTION_DAYS
+    def test_every_writer_stamps_the_same_horizon(self):
+        """All of them write into the SAME partitions that one window read spans
+        (`METRIC#daily_total` counts beside `METRIC#daily_sentiment_avg` sums), so two
+        TTLs would mean two horizons and no single constant could describe the window.
+
+        DERIVED FROM `_WRITERS`, not from two names written out here. This assertion
+        used to name `update_counter` and `update_average` inline, and when the arrival
+        path became transactional it went half-blind: `_WRITERS` grew the two
+        transaction builders, `test_no_call_site_overrides_the_ttl` and
+        `test_each_writer_applies_the_parameter_it_takes` covered them because they
+        iterate the tuple, and this one kept comparing the same two — so dropping the
+        transactional counter's default to 30 days failed NOTHING. Measured, not
+        supposed: that mutation now fails here and passed before.
+        """
+        horizons = {name: _aggregator_ttl_default(name) for name in _WRITERS}
+        assert set(horizons.values()) == {AGGREGATE_RETENTION_DAYS}, (
+            f'{horizons}: the aggregator stamps more than one retention horizon (or '
+            f'one that is not AGGREGATE_RETENTION_DAYS={AGGREGATE_RETENTION_DAYS}), '
+            f'so no single constant describes how far back the metrics routes may '
+            f'report a window as complete.'
         )
 
     def test_the_retention_is_narrower_than_the_widest_requestable_window(self):

--- a/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_streaming_categories_lockstep.py
@@ -78,7 +78,21 @@ PYTHON_WRITER_PK_PATTERN = rf'^CATEGORIES_PK = {_Q}([^\'"]+){_Q}'
 PYTHON_WRITER_SK_PATTERN = rf'^CATEGORIES_SK = {_Q}([^\'"]+){_Q}'
 
 # The counter writers whose sort key the streaming window predicate depends on.
-AGGREGATOR_COUNTER_WRITERS = ('update_counter', 'update_average')
+#
+# FOUR, not two, since the arrival path became transactional (issue #264). An INSERT's
+# counters now go out as `TransactWriteItems` entries built by
+# `_counter_transaction_item` / `_average_transaction_item`, and those take the same
+# (pk, sk, ...) leading pair as the two single-write functions — so they are counter
+# writers in exactly the sense this file means, and leaving them out would have left
+# the sort keys of the MOST COMMON path (every ingested item) unpinned while every
+# assertion here stayed green. That is the partial-blindness failure
+# `_aggregator_counter_writes` was rewritten with `ast` to remove, arriving by a
+# different route: not a call shape the reader could not parse, but a call it was
+# never told to look for.
+AGGREGATOR_COUNTER_WRITERS = (
+    'update_counter', 'update_average',
+    '_counter_transaction_item', '_average_transaction_item',
+)
 
 # The one function that BUILDS a counter key, now that the call sites are generic
 # (`update_counter(pk, date, field)` serves both the increment and the reversal).

--- a/voc-datalake/lambda/shared/idempotency.py
+++ b/voc-datalake/lambda/shared/idempotency.py
@@ -160,8 +160,8 @@ def dedupe_claim_item(
     🔑 WHY NOT `idempotent_function`. That decorator is two writes around a call: an
     INPROGRESS record, the function, then a COMPLETED record carrying its result.
     The function's own writes therefore land between the two, unprotected — so a
-    record that dies partway through eight counter updates has applied some of them,
-    the marker is not COMPLETED, and the retry applies the whole eight again on top.
+    record that dies partway through a set of counter updates has applied some of them,
+    the marker is not COMPLETED, and the retry applies the whole set again on top.
     That partial-application case is the one that leaves aggregate rows disagreeing
     with each other (a daily total that does not equal the sum of its categories),
     and it is precisely what a transaction removes. The decorator also stores and

--- a/voc-datalake/lambda/shared/idempotency.py
+++ b/voc-datalake/lambda/shared/idempotency.py
@@ -27,7 +27,12 @@ names are declared here once (`IDEMPOTENCY_KEY_ATTRIBUTE`,
 `IDEMPOTENCY_EXPIRY_ATTRIBUTE`) rather than spelled again at either call site. The
 expiry attribute in particular has to agree with the table's
 `timeToLiveAttribute: 'expiration'` (`lib/stacks/core-stack.ts`) or markers
-accumulate forever, which no test and no error would report.
+accumulate forever — which no error and no runtime behaviour reports, so
+`test/test_idempotency_table_schema_lockstep.py` compares the constants below
+against that construct. It is a lockstep rather than a test of either side because
+every test that reads these names reads them THROUGH the constants: renaming one
+here moves the production write and its expectation together and stays green, while
+the table keeps expiring an attribute nothing writes.
 """
 
 import os
@@ -45,6 +50,7 @@ from aws_lambda_powertools.utilities.idempotency.exceptions import (
 # Re-export for convenience
 __all__ = [
     "dedupe_claim_item",
+    "DEDUPE_CLAIM_TTL_SECONDS",
     "get_idempotency_config",
     "get_persistence_layer",
     "idempotent",

--- a/voc-datalake/lambda/shared/idempotency.py
+++ b/voc-datalake/lambda/shared/idempotency.py
@@ -7,6 +7,27 @@ the same result and side effects only happen once - critical for:
 - SQS message retries
 - Lambda retries on failure
 - Concurrent executions of the same event
+
+Two shapes, one table
+---------------------
+Powertools' `idempotent_function` (used by `processor/handler.py`) is the shape for
+work whose RESULT is worth remembering: it writes an INPROGRESS record, runs the
+function, then stores the response so a replay can return it without re-running.
+
+`dedupe_claim_item` is the shape for work whose result is a set of DynamoDB writes
+that must happen exactly once — the aggregator's counter updates. It is a single
+conditional `Put` built for `TransactWriteItems`, so the claim and the writes it
+guards commit TOGETHER or not at all. Powertools' two-phase form cannot give that:
+between its INPROGRESS write and its COMPLETED write the counters are applied
+non-atomically, so a record that dies halfway leaves the aggregates internally
+inconsistent and the retry re-applies whatever already landed.
+
+Both write to the same table with the same attribute names, which is why those
+names are declared here once (`IDEMPOTENCY_KEY_ATTRIBUTE`,
+`IDEMPOTENCY_EXPIRY_ATTRIBUTE`) rather than spelled again at either call site. The
+expiry attribute in particular has to agree with the table's
+`timeToLiveAttribute: 'expiration'` (`lib/stacks/core-stack.ts`) or markers
+accumulate forever, which no test and no error would report.
 """
 
 import os
@@ -23,13 +44,25 @@ from aws_lambda_powertools.utilities.idempotency.exceptions import (
 
 # Re-export for convenience
 __all__ = [
+    "dedupe_claim_item",
     "get_idempotency_config",
     "get_persistence_layer",
     "idempotent",
     "idempotent_function",
+    "IDEMPOTENCY_EXPIRY_ATTRIBUTE",
+    "IDEMPOTENCY_KEY_ATTRIBUTE",
     "IdempotencyAlreadyInProgressError",
     "IdempotencyItemAlreadyExistsError",
 ]
+
+# The idempotency table's schema, as BOTH writers spend it. `id` is the partition
+# key declared in `lib/stacks/core-stack.ts`, and it is also Powertools'
+# `key_attr` default — so the two writers cannot collide on a key while disagreeing
+# about which attribute holds it. `expiration` is that table's
+# `timeToLiveAttribute`, which is what makes a marker self-deleting; spelled
+# differently, every marker would live forever and nothing would say so.
+IDEMPOTENCY_KEY_ATTRIBUTE = "id"
+IDEMPOTENCY_EXPIRY_ATTRIBUTE = "expiration"
 
 # Module-level cache for persistence layer
 _persistence_layer = None
@@ -92,3 +125,64 @@ def get_idempotency_config(
         local_cache_max_items=local_cache_max_items,
         raise_on_no_idempotency_key=raise_on_no_idempotency_key,
     )
+
+
+# How long a dedupe claim is kept. DynamoDB Streams retain a record for 24 hours, so
+# that is the longest a redelivery of one can arrive after the first — and the marker
+# has to OUTLIVE that window rather than match it: expiring at exactly the horizon
+# leaves the last possible redelivery racing the TTL that deletes its own marker, and
+# TTL deletion is best-effort besides (DynamoDB documents up to 48 hours of lag), so
+# the boundary is not even sharp. Double the window is the smallest horizon with
+# headroom on both sides; the only cost is storage for markers that can no longer be
+# claimed, and the table's TTL still collects them.
+DEDUPE_CLAIM_TTL_SECONDS = 2 * 24 * 60 * 60
+
+
+def dedupe_claim_item(
+    table_name: str, key: str, now: int,
+    expires_after_seconds: int = DEDUPE_CLAIM_TTL_SECONDS,
+) -> dict:
+    """One `TransactWriteItems` entry that claims `key`, or fails the transaction.
+
+    The dedupe primitive for work whose "result" is a set of DynamoDB writes rather
+    than a value: a conditional `Put` of a marker that can be handed to
+    `transact_write_items` ALONGSIDE those writes, so the claim and the work commit
+    together. The condition is `attribute_not_exists(<key attr>)`, so the SECOND
+    delivery of the same key cancels the whole transaction and not one item of it —
+    which is what makes a redelivery leave every guarded counter untouched.
+
+    🔑 WHY NOT `idempotent_function`. That decorator is two writes around a call: an
+    INPROGRESS record, the function, then a COMPLETED record carrying its result.
+    The function's own writes therefore land between the two, unprotected — so a
+    record that dies partway through eight counter updates has applied some of them,
+    the marker is not COMPLETED, and the retry applies the whole eight again on top.
+    That partial-application case is the one that leaves aggregate rows disagreeing
+    with each other (a daily total that does not equal the sum of its categories),
+    and it is precisely what a transaction removes. The decorator also stores and
+    replays a RESULT, which is the wrong thing to remember for a counter update, and
+    it caches in memory across invocations — a cache hit would skip writes that a
+    concurrent execution had rolled back.
+
+    `now` is passed in rather than read here, so a caller that already has an
+    invocation clock stamps its marker with the same instant it stamps everything
+    else, and so a test can freeze one clock rather than two.
+
+    The default horizon is `DEDUPE_CLAIM_TTL_SECONDS` — see that constant for why it
+    is longer than the stream's own retention rather than equal to it. The table's TTL
+    (`timeToLiveAttribute: 'expiration'`) is what collects the markers, which is why
+    the attribute name is a shared constant and not a literal here.
+
+    Returns the transaction item; issues nothing itself. Every AWS call this
+    participates in belongs to the caller, whose client and whose error handling the
+    transaction outcome has to reach.
+    """
+    return {
+        'Put': {
+            'TableName': table_name,
+            'Item': {
+                IDEMPOTENCY_KEY_ATTRIBUTE: key,
+                IDEMPOTENCY_EXPIRY_ATTRIBUTE: now + expires_after_seconds,
+            },
+            'ConditionExpression': f'attribute_not_exists({IDEMPOTENCY_KEY_ATTRIBUTE})',
+        },
+    }

--- a/voc-datalake/lambda/shared/test/test_idempotency.py
+++ b/voc-datalake/lambda/shared/test/test_idempotency.py
@@ -1,0 +1,173 @@
+"""`dedupe_claim_item`, tested where it is DECLARED rather than only where it is spent.
+
+It was covered transitively from the aggregator's suite, which is the right place for
+"does a redelivered stream record move a counter" but the wrong place for "what
+exactly does this shared helper put on the wire". Two consequences of that gap:
+
+* the aggregator's tests assert on the marker they can SEE — the one the transaction
+  wrote — so the condition expression, which only matters when the item is already
+  there, was pinned only by a redelivery happening to be refused. A condition
+  naming the wrong attribute would still refuse (an absent attribute is absent), so
+  that assertion could not distinguish it;
+* nothing exercised the helper for a SECOND caller. It is in `shared/` because the
+  next Lambda with at-least-once delivery should reuse it rather than write a second
+  copy, and a shared helper whose only test is one caller's integration test is one
+  the next caller has to re-derive the contract of.
+
+The attribute names themselves are pinned against `core-stack.ts` in
+`test_idempotency_table_schema_lockstep.py` — that is the drift no runtime error
+reports. These are about the REQUEST: the shape, the condition, and the horizon.
+"""
+from shared.idempotency import (
+    DEDUPE_CLAIM_TTL_SECONDS,
+    IDEMPOTENCY_EXPIRY_ATTRIBUTE,
+    IDEMPOTENCY_KEY_ATTRIBUTE,
+    dedupe_claim_item,
+)
+
+NOW = 1_700_000_000
+TABLE = 'some-idempotency-table'
+KEY = 'caller#some-unit-of-work'
+
+
+class TestDedupeClaimItem:
+    """What the claim puts on the wire, asserted directly.
+
+    REVERT MAP, each entry RUN:
+      * Drop the `ConditionExpression` — fails
+        test_the_claim_refuses_a_key_that_is_already_there, and NOTHING else here,
+        which is the point: a claim without it is a `Put` that overwrites, so every
+        redelivery would be applied and the helper would still look correct.
+      * Condition on `attribute_not_exists` of some other attribute — fails
+        test_the_condition_names_the_attribute_the_item_is_keyed_on. A condition on an
+        attribute the item does not carry is refused by nothing, so it reads as a
+        working claim right up to the first redelivery.
+      * Return the `Put` without the `{'Put': ...}` wrapper, or add a second operation
+        — fails test_the_item_is_one_transaction_entry.
+      * Stamp `now` rather than `now + expires_after_seconds` — fails
+        test_the_marker_expires_in_the_future.
+      * Shorten `DEDUPE_CLAIM_TTL_SECONDS` to the stream's own 24 hours — fails
+        test_the_default_horizon_outlives_a_streams_retention, which is the assertion
+        that caught the first version of that constant.
+    """
+
+    def _put(self, **kwargs) -> dict:
+        return dedupe_claim_item(TABLE, KEY, NOW, **kwargs)['Put']
+
+    def test_the_item_is_one_transaction_entry(self):
+        """One `Put`, and nothing else: `transact_write_items` takes exactly one
+        operation per entry and rejects an entry carrying two."""
+        entry = dedupe_claim_item(TABLE, KEY, NOW)
+
+        assert list(entry) == ['Put'], entry
+        assert entry['Put']['TableName'] == TABLE
+
+    def test_the_claim_refuses_a_key_that_is_already_there(self):
+        """🔑 THE WHOLE MECHANISM. Without the condition this is a `Put` that
+        OVERWRITES, so a second delivery of the same key succeeds and the writes it
+        guards are applied twice — while every other assertion in this file still
+        passes, because the item it produces is identical.
+        """
+        assert 'ConditionExpression' in self._put(), (
+            'the claim carries no condition, so it cannot refuse a key it has already '
+            'seen: it would overwrite the marker and let the guarded writes re-apply'
+        )
+
+    def test_the_condition_names_the_attribute_the_item_is_keyed_on(self):
+        """The condition and the key must be the SAME attribute, and this is the
+        failure mode nothing at runtime reports.
+
+        `attribute_not_exists(<anything the item does not carry>)` is true of every
+        item, so a condition on the wrong attribute is never refused — the claim looks
+        like it works until a redelivery arrives, and then it silently does not. Read
+        out of the two rather than compared against a literal, so this cannot become
+        the stale copy of the name.
+        """
+        put = self._put()
+
+        assert IDEMPOTENCY_KEY_ATTRIBUTE in put['Item']
+        assert put['ConditionExpression'] == (
+            f'attribute_not_exists({IDEMPOTENCY_KEY_ATTRIBUTE})'
+        ), (
+            f"the claim conditions on something other than {IDEMPOTENCY_KEY_ATTRIBUTE!r}, "
+            f'the attribute it keys the item on. attribute_not_exists of an attribute '
+            f'the item does not carry is true of every item, so the claim would never '
+            f'refuse anything and the redelivery it exists to catch would be applied.'
+        )
+
+    def test_the_key_is_the_one_the_caller_asked_for(self):
+        """A helper that derived its own key would deduplicate the wrong unit of work.
+
+        The aggregator's key is per stream RECORD (`eventID`), which is what makes it
+        a redelivery test rather than a de-duplication of the feedback itself — a
+        decision that belongs to the caller and cannot be made here.
+        """
+        assert self._put()['Item'][IDEMPOTENCY_KEY_ATTRIBUTE] == KEY
+
+    def test_the_marker_expires_in_the_future(self):
+        """The horizon is `now + expires_after_seconds`, stamped on the attribute the
+        table collects. A marker whose expiry is in the PAST is deleted at DynamoDB's
+        leisure and the key becomes claimable again — the leak's opposite, and equally
+        silent: it looks like a working claim that occasionally lets one through.
+        """
+        expiry = self._put()['Item'][IDEMPOTENCY_EXPIRY_ATTRIBUTE]
+
+        assert expiry == NOW + DEDUPE_CLAIM_TTL_SECONDS
+        assert expiry > NOW
+
+    def test_the_horizon_is_the_callers_to_shorten(self):
+        """`expires_after_seconds` is honoured, so a caller whose redelivery window is
+        not a DynamoDB stream's can say so. It defaults rather than being required
+        because the aggregator's window is the common case, but a default nothing can
+        override is a constant with extra steps.
+        """
+        assert self._put(expires_after_seconds=60)['Item'][
+            IDEMPOTENCY_EXPIRY_ATTRIBUTE
+        ] == NOW + 60
+
+    def test_the_default_horizon_outlives_a_streams_retention(self):
+        """A marker must outlive the window a redelivery can arrive IN.
+
+        DynamoDB Streams retain a record for 24 hours, so that is the latest a
+        redelivery of one can appear. Asserting `>` rather than `>=` is the point: an
+        expiry equal to the horizon leaves the last possible redelivery racing the TTL
+        that deletes its own marker, and TTL deletion is best-effort besides
+        (documented as up to 48 hours of lag). This is what caught the first version of
+        the constant, which was exactly 24 hours.
+        """
+        stream_retention_seconds = 24 * 60 * 60
+
+        assert DEDUPE_CLAIM_TTL_SECONDS > stream_retention_seconds, (
+            f'a claim lives {DEDUPE_CLAIM_TTL_SECONDS}s, which does not outlast the '
+            f'{stream_retention_seconds}s a stream record survives — so the last '
+            f'possible redelivery can find the marker gone and be applied twice'
+        )
+
+    def test_the_marker_carries_nothing_else(self):
+        """Two attributes, and no stored result.
+
+        This is the difference from Powertools' `idempotent_function`, which remembers
+        a RESPONSE so a replay can return it. The result of a claimed unit of work here
+        is a set of DynamoDB writes that either committed with the claim or did not
+        exist, so there is nothing to remember and a marker carrying a payload would be
+        storing state whose only use is to become stale.
+        """
+        assert set(self._put()['Item']) == {
+            IDEMPOTENCY_KEY_ATTRIBUTE, IDEMPOTENCY_EXPIRY_ATTRIBUTE,
+        }
+
+    def test_two_callers_get_two_different_claims(self):
+        """No shared mutable state between calls: it builds a request and issues
+        nothing, so the same helper can serve two tables in one invocation. The reason
+        it takes `now` rather than reading a clock is the same — one invocation stamps
+        one instant across everything it writes, and a test can freeze one clock.
+        """
+        first = dedupe_claim_item('table-a', 'key-a', NOW)
+        second = dedupe_claim_item('table-b', 'key-b', NOW + 5)
+
+        assert first['Put']['TableName'] == 'table-a'
+        assert second['Put']['TableName'] == 'table-b'
+        assert first['Put']['Item'][IDEMPOTENCY_KEY_ATTRIBUTE] == 'key-a'
+        assert second['Put']['Item'][IDEMPOTENCY_EXPIRY_ATTRIBUTE] == (
+            NOW + 5 + DEDUPE_CLAIM_TTL_SECONDS
+        )

--- a/voc-datalake/lambda/shared/test/test_idempotency_table_schema_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_idempotency_table_schema_lockstep.py
@@ -1,0 +1,175 @@
+"""The idempotency table's schema is declared twice, and one copy is unverifiable.
+
+`shared/idempotency.py` names the two attributes BOTH of that table's writers spend:
+`IDEMPOTENCY_KEY_ATTRIBUTE` (the partition key, which is also Powertools'
+`key_attr` default) and `IDEMPOTENCY_EXPIRY_ATTRIBUTE` (the TTL attribute that makes
+a dedupe marker self-deleting). `lib/stacks/core-stack.ts` declares the same two on
+the `IdempotencyTable` construct. Nothing linked them.
+
+🔑 WHY THIS ONE IS WORSE THAN A NORMAL DRIFT. The expiry attribute's whole job is to
+be READ BY DYNAMODB, and DynamoDB does not complain about an item that lacks the
+attribute its TTL names — it simply never deletes it. So a marker written under any
+other name leaks, forever, with no error, no log and nothing served wrongly. The
+module's own comment says exactly that ("spelled differently, every marker would
+live forever and nothing would say so"), and the fix was HALF applied: the test that
+checks a marker carries an expiry reads the attribute name THROUGH the constant, so
+renaming the constant changes the production write and the expectation together and
+that test stays green while the table's `timeToLiveAttribute` still says
+`expiration`. A lockstep is the only shape that fails on it.
+
+The key attribute is pinned for a smaller but real reason: two writers share this
+table (Powertools' `idempotent_function` in `processor/handler.py`, and
+`dedupe_claim_item` from the aggregator), and a claim written under one attribute
+while the table keys on another is a `ValidationException` at runtime rather than a
+leak — loud, but still worth catching in CI given it is free once this file exists.
+
+WHICH MUTATION FAILS WHICH ASSERTION. Change `timeToLiveAttribute: 'expiration'` in
+`core-stack.ts` (or `IDEMPOTENCY_EXPIRY_ATTRIBUTE` in `shared/idempotency.py`)
+without changing the other and `test_the_ttl_attribute_is_the_one_the_writers_stamp`
+fails naming both spellings. Do the same for the partition key and
+`test_the_partition_key_is_the_one_the_writers_claim` fails. Delete the
+`timeToLiveAttribute` line entirely and `test_the_table_has_a_ttl_at_all` fails —
+which is the other way this leaks, and the one a value comparison alone would report
+as a missing pattern rather than as the defect it is. Both were verified by making
+the change and watching the failure, then reverting.
+
+Read by PARSING the TypeScript, as `test_indexes.py` and
+`test_lookback_window_lockstep.py` do: there is no parser for it on this side, and
+the construct's properties are simple literals, so a scoped regular expression is
+the available tool. Scoped to the construct's own block, not the file — this stack
+declares a dozen tables and several of them have a `timeToLiveAttribute`, so an
+unscoped pattern would happily read the FEEDBACK table's `'ttl'` and report the
+idempotency table as correct (or as broken) on the strength of another table's line.
+"""
+import re
+from pathlib import Path
+
+from shared.idempotency import (
+    IDEMPOTENCY_EXPIRY_ATTRIBUTE,
+    IDEMPOTENCY_KEY_ATTRIBUTE,
+)
+
+# lambda/shared/test/ -> voc-datalake/
+_CORE_STACK = Path(__file__).resolve().parents[3] / 'lib' / 'stacks' / 'core-stack.ts'
+
+# The construct id CDK gives the table, which is also what its logical id is derived
+# from — so renaming it is a CloudFormation REPLACEMENT and a deliberate act, not the
+# kind of edit this file is guarding against.
+_CONSTRUCT = "new dynamodb.Table(this, 'IdempotencyTable'"
+
+# Quoting is not part of the contract: this file must not fail on a reformat.
+_Q = r"""['"]"""
+
+
+def _table_block() -> str:
+    """The `IdempotencyTable` construct's properties, and nothing else's.
+
+    The scope IS the assertion's soundness. `core-stack.ts` declares a dozen tables,
+    several with their own `timeToLiveAttribute` — the feedback table's is `'ttl'` —
+    so a pattern run over the whole file answers with whichever table happens to
+    match first. That would make this lockstep report on a table it is not about, in
+    both directions: green while the idempotency table's TTL was renamed, red when
+    another table's was.
+
+    The block ends at the closing `});` of the construct call, found as the first
+    such line at the construct's own indentation. Read from the source text rather
+    than from a synthesized template deliberately: a synth needs Docker and an
+    esbuild bundle in this repo, which would make an attribute-name lockstep fail for
+    reasons that have nothing to do with attribute names.
+    """
+    source = _CORE_STACK.read_text(encoding='utf-8')
+    start = source.find(_CONSTRUCT)
+    assert start != -1, (
+        f'{_CONSTRUCT} not found in {_CORE_STACK.name}. If the idempotency table was '
+        f'renamed or moved, follow it here — this file is the only thing that fails '
+        f'when its TTL attribute stops matching the name the writers stamp, and a '
+        f'wrong TTL attribute leaks every dedupe marker silently.'
+    )
+    rest = source[start:]
+    end = re.search(r'^\s*\}\);\s*$', rest, re.MULTILINE)
+    assert end, (
+        f'The {_CONSTRUCT} call in {_CORE_STACK.name} has no closing brace this '
+        f'helper can find, so it cannot tell where the construct ends and would '
+        f'scope every assertion below to the rest of the file — where another '
+        f"table's timeToLiveAttribute would satisfy them."
+    )
+    return rest[:end.end()]
+
+
+def _declared(property_name: str, pattern: str) -> str:
+    block = _table_block()
+    matches = re.findall(pattern, block)
+    assert len(matches) == 1, (
+        f'Expected exactly one {property_name} on the idempotency table in '
+        f'{_CORE_STACK.name}; found {len(matches)}. If the declaration was '
+        f'restructured, update the pattern in this file rather than deleting the '
+        f'assertion that depends on it.'
+    )
+    return matches[0]
+
+
+class TestIdempotencyTableSchemaLockstep:
+    def test_the_ttl_attribute_is_the_one_the_writers_stamp(self):
+        """🔑 THE ASSERTION THIS FILE EXISTS FOR.
+
+        A marker whose expiry attribute is not the table's `timeToLiveAttribute` is
+        one DynamoDB will never delete. Nothing reports it: not an error, not a log,
+        not a served value — the table simply grows without end. Every other test
+        that touches this name reads it through the constant, so the constant and the
+        stack are the two things that have to be compared.
+        """
+        declared = _declared(
+            'timeToLiveAttribute', rf'timeToLiveAttribute:\s*{_Q}([^\'"]+){_Q}',
+        )
+        assert declared == IDEMPOTENCY_EXPIRY_ATTRIBUTE, (
+            f'the idempotency table expires items on {declared!r} but both of its '
+            f'writers stamp {IDEMPOTENCY_EXPIRY_ATTRIBUTE!r} '
+            f'(IDEMPOTENCY_EXPIRY_ATTRIBUTE in shared/idempotency.py). Every dedupe '
+            f'marker would then live forever, and nothing would report it. Change '
+            f'both.'
+        )
+
+    def test_the_partition_key_is_the_one_the_writers_claim(self):
+        """The louder half, pinned because it is free once the block is scoped.
+
+        `dedupe_claim_item` puts an item keyed on IDEMPOTENCY_KEY_ATTRIBUTE and
+        conditions on `attribute_not_exists` of the same name; Powertools' default
+        `key_attr` is the same string. A table keyed on anything else answers a
+        `ValidationException` — which at least fails loudly, but on the aggregator's
+        hot path, for every ingested record.
+        """
+        declared = _declared(
+            'partitionKey', rf'partitionKey:\s*\{{\s*name:\s*{_Q}([^\'"]+){_Q}',
+        )
+        assert declared == IDEMPOTENCY_KEY_ATTRIBUTE, (
+            f'the idempotency table is keyed on {declared!r} but its writers claim '
+            f'{IDEMPOTENCY_KEY_ATTRIBUTE!r} (IDEMPOTENCY_KEY_ATTRIBUTE in '
+            f'shared/idempotency.py), so every claim would be a ValidationException. '
+            f'Change both.'
+        )
+
+    def test_the_table_has_a_ttl_at_all(self):
+        """The other way the markers leak, and it is not a value mismatch.
+
+        Deleting the `timeToLiveAttribute` line leaves nothing for the assertion
+        above to compare, and a lockstep that reported "pattern not found" would be
+        describing its own reader rather than the defect. Stated as its own
+        expectation so the failure says what is wrong: the table has no expiry, so
+        every marker either writer has ever written is permanent.
+        """
+        assert 'timeToLiveAttribute' in _table_block(), (
+            'the idempotency table no longer declares a timeToLiveAttribute, so no '
+            'dedupe marker is ever deleted — neither the processor\'s hourly keys '
+            'nor the aggregator\'s per-stream-record claims. The attribute both '
+            'writers stamp is IDEMPOTENCY_EXPIRY_ATTRIBUTE.'
+        )
+
+    def test_the_two_attributes_are_not_the_same_name(self):
+        """The premise of both assertions above, asserted rather than assumed.
+
+        If the key and the expiry were ever spelled the same, each comparison would
+        be satisfiable by the other's declaration and neither would be pinning
+        anything — a lockstep passing for the wrong reason. Also a real error: a TTL
+        on the partition key would make DynamoDB delete rows by their own id.
+        """
+        assert IDEMPOTENCY_KEY_ATTRIBUTE != IDEMPOTENCY_EXPIRY_ATTRIBUTE

--- a/voc-datalake/lambda/shared/test/test_idempotency_table_schema_lockstep.py
+++ b/voc-datalake/lambda/shared/test/test_idempotency_table_schema_lockstep.py
@@ -42,6 +42,7 @@ unscoped pattern would happily read the FEEDBACK table's `'ttl'` and report the
 idempotency table as correct (or as broken) on the strength of another table's line.
 """
 import re
+from functools import cache
 from pathlib import Path
 
 from shared.idempotency import (
@@ -61,6 +62,7 @@ _CONSTRUCT = "new dynamodb.Table(this, 'IdempotencyTable'"
 _Q = r"""['"]"""
 
 
+@cache
 def _table_block() -> str:
     """The `IdempotencyTable` construct's properties, and nothing else's.
 
@@ -71,11 +73,21 @@ def _table_block() -> str:
     both directions: green while the idempotency table's TTL was renamed, red when
     another table's was.
 
-    The block ends at the closing `});` of the construct call, found as the first
-    such line at the construct's own indentation. Read from the source text rather
-    than from a synthesized template deliberately: a synth needs Docker and an
-    esbuild bundle in this repo, which would make an attribute-name lockstep fail for
-    reasons that have nothing to do with attribute names.
+    🔑 THE BLOCK ENDS AT A `});` MATCHING THE CONSTRUCT'S OWN INDENTATION, and the
+    indentation is derived from the opening line rather than allowed to be anything.
+    An indentation-agnostic `^\\s*\\}\\);\\s*$` was the first implementation and it
+    ends at the first such line at ANY depth — so a nested call among the properties
+    would truncate the block before `timeToLiveAttribute` and fail
+    `test_the_table_has_a_ttl_at_all` while the attribute was present and correct. A
+    false red naming the wrong defect is the better direction to fail in, but this
+    file's whole value is that its reader cannot report on something it is not about,
+    and that has to include its own closing-brace match.
+
+    Read from the source text rather than from a synthesized template deliberately: a
+    synth needs Docker and an esbuild bundle in this repo, which would make an
+    attribute-name lockstep fail for reasons that have nothing to do with attribute
+    names. `@cache` because all four assertions ask for the block and `core-stack.ts`
+    is ~1200 lines; the file cannot change during a run.
     """
     source = _CORE_STACK.read_text(encoding='utf-8')
     start = source.find(_CONSTRUCT)
@@ -85,13 +97,22 @@ def _table_block() -> str:
         f'when its TTL attribute stops matching the name the writers stamp, and a '
         f'wrong TTL attribute leaks every dedupe marker silently.'
     )
+    # The construct call starts mid-line (`this.idempotencyTable = new ...`), so the
+    # indentation to match the closing brace against is the OPENING LINE's, not the
+    # column the construct name happens to sit at.
+    line_start = source.rfind('\n', 0, start) + 1
+    indent = source[line_start:start]
+    indent = indent[:len(indent) - len(indent.lstrip())]
+
     rest = source[start:]
-    end = re.search(r'^\s*\}\);\s*$', rest, re.MULTILINE)
+    end = re.search(rf'^{re.escape(indent)}\}}\);[ \t]*$', rest, re.MULTILINE)
     assert end, (
-        f'The {_CONSTRUCT} call in {_CORE_STACK.name} has no closing brace this '
-        f'helper can find, so it cannot tell where the construct ends and would '
-        f'scope every assertion below to the rest of the file — where another '
-        f"table's timeToLiveAttribute would satisfy them."
+        f'The {_CONSTRUCT} call in {_CORE_STACK.name} has no closing brace at its own '
+        f'indentation ({len(indent)} space(s)) that this helper can find, so it cannot '
+        f'tell where the construct ends and would scope every assertion below to the '
+        f"rest of the file — where another table's timeToLiveAttribute would satisfy "
+        f'them. If the construct was re-indented or reformatted, update this helper '
+        f'rather than deleting the assertions that depend on it.'
     )
     return rest[:end.end()]
 

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -276,20 +276,31 @@ describe('the aggregator can reach the dedupe table it is already allowed to (#2
   /** Every Lambda in this stack whose service name says it is the aggregator, found
    * by that name rather than by logical id: a CDK-generated id can change with a
    * construct-tree edit, and matching the function by what it IS keeps these tests
-   * pinned to the function rather than to a name. */
-  function aggregatorFunctions(): { Properties?: any }[] {
+   * pinned to the function rather than to a name.
+   *
+   * Returns the ENVIRONMENTS rather than the resources, so the narrowing that proves
+   * each one is an object happens once, here, where it is already being done — the
+   * caller then needs no cast and the helper needs no `any`. */
+  function aggregatorEnvironments(): Record<string, unknown>[] {
     return Object.values(template.findResources('AWS::Lambda::Function'))
-      .filter((fn) => {
-        const vars: unknown = fn.Properties?.Environment?.Variables;
-        return (
-          typeof vars === 'object' && vars !== null &&
-          (vars as Record<string, unknown>).POWERTOOLS_SERVICE_NAME === 'voc-aggregator'
-        );
-      });
+      .map((fn) => fn.Properties?.Environment?.Variables as unknown)
+      .filter((vars): vars is Record<string, unknown> => (
+        typeof vars === 'object' && vars !== null &&
+        (vars as Record<string, unknown>).POWERTOOLS_SERVICE_NAME === 'voc-aggregator'
+      ));
   }
 
   function aggregatorEnvironment(): Record<string, unknown> {
-    return aggregatorFunctions()[0].Properties.Environment.Variables as Record<string, unknown>;
+    const environments = aggregatorEnvironments();
+    // ASSERTED HERE TOO, rather than only in the test below that owns the diagnosis.
+    // Indexing [0] blind is what this replaced, and on zero matches that threw
+    // `Cannot read properties of undefined` from each of the four tests — a TypeError
+    // in a CDK assertion sends the reader looking for a template-shape problem when
+    // the subject is simply gone. The duplication is cheap and this is the readable
+    // failure; `finds exactly one aggregation Lambda` still reports it as its own
+    // distinct problem.
+    expect(environments).toHaveLength(1);
+    return environments[0];
   }
 
   it('finds exactly one aggregation Lambda to assert about', () => {
@@ -300,7 +311,7 @@ describe('the aggregator can reach the dedupe table it is already allowed to (#2
     // which reads as "the idempotency table name is missing" when what is really
     // wrong is that the subject is missing or ambiguous. Stated once, so the
     // diagnosis is one step shorter and names the real problem.
-    expect(aggregatorFunctions()).toHaveLength(1);
+    expect(aggregatorEnvironments()).toHaveLength(1);
   });
 
   it('passes the idempotency table name to the aggregation Lambda', () => {

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -254,3 +254,82 @@ describe('web-search wiring is skipped cleanly when the gateway is absent', () =
     expect(values.filter((v) => v.includes('undefined'))).toEqual([]);
   });
 });
+
+describe('the aggregator can reach the dedupe table it is already allowed to (#264)', () => {
+  /**
+   * DynamoDB Streams are at-least-once, and this Lambda's event source carries
+   * `retryAttempts: 3` with `reportBatchItemFailures: true` — so a batch that
+   * partially fails re-presents records whose counter updates already landed.
+   * The handler closes that by claiming each record's `eventID` in the idempotency
+   * table inside the same TransactWriteItems as the counters.
+   *
+   * The gap this pins was ENVIRONMENT ONLY: the shared `processingRole` has been
+   * granted `idempotencyTable.grantReadWriteData` all along for the processor, so
+   * the aggregator had the permission and not the NAME. That is exactly the shape
+   * that degrades silently — `handler.py` reads `IDEMPOTENCY_TABLE` with a default
+   * of empty and falls back to non-transactional writes with a warning, so a
+   * regression here does not fail a deploy, does not error at runtime, and shows up
+   * only as counters that drift under redelivery.
+   */
+  const template = synthProcessingTemplate();
+
+  /** The aggregation Lambda, found by its handler + description of the code asset
+   * rather than by logical id: a CDK-generated id can change with a construct-tree
+   * edit, and matching the function by what it IS keeps this test pinned to the
+   * function rather than to a name. */
+  function aggregatorEnvironment(): Record<string, unknown> {
+    const functions = Object.values(template.findResources('AWS::Lambda::Function'))
+      .filter((fn) => {
+        const vars: unknown = fn.Properties?.Environment?.Variables;
+        return (
+          typeof vars === 'object' && vars !== null &&
+          (vars as Record<string, unknown>).POWERTOOLS_SERVICE_NAME === 'voc-aggregator'
+        );
+      });
+    // The denominator: zero matches would make every assertion below vacuous, and a
+    // second match would mean this is no longer asserting about one function.
+    expect(functions).toHaveLength(1);
+    return functions[0].Properties.Environment.Variables as Record<string, unknown>;
+  }
+
+  it('passes the idempotency table name to the aggregation Lambda', () => {
+    expect(aggregatorEnvironment()).toHaveProperty('IDEMPOTENCY_TABLE');
+  });
+
+  it('names a real table rather than a literal, so the value resolves at deploy', () => {
+    // A hand-written string would synthesize as a plain value and point at a table
+    // that may not exist in this account. What a real table reference looks like is
+    // NOT pinned to one spelling: the table is created in the core stack, so it
+    // arrives here as an `Fn::ImportValue` today and would be a `Ref` if the two
+    // were ever merged into one stack — both are CloudFormation resolving the table
+    // this app created, and asserting the CloudFormation intrinsic rather than which
+    // one keeps a stack reorganisation from failing a test whose subject it is not.
+    const value = aggregatorEnvironment().IDEMPOTENCY_TABLE;
+    expect(typeof value).toBe('object');
+    expect(Object.keys(value as object).some((key) => key.startsWith('Fn::') || key === 'Ref'))
+      .toBe(true);
+  });
+
+  it('names the SAME table the processor claims into', () => {
+    // One table, two writers. Different tables would let a stream record and a
+    // feedback record be deduped against separate state, which is not wrong so much
+    // as unmeasurable — and it would silently double the tables an operator has to
+    // know about. The handler namespaces its keys (`aggregator#stream#...`) so the
+    // two cannot collide within it.
+    const processor = Object.values(template.findResources('AWS::Lambda::Function'))
+      .map((fn) => fn.Properties?.Environment?.Variables as Record<string, unknown> | undefined)
+      .find((vars) => vars?.POWERTOOLS_SERVICE_NAME === 'voc-processor');
+    expect(processor).toBeDefined();
+    expect(aggregatorEnvironment().IDEMPOTENCY_TABLE)
+      .toEqual(processor?.IDEMPOTENCY_TABLE);
+  });
+
+  it('keeps the aggregates table name too, so the transaction can name it', () => {
+    // The counters go out as transaction items, which name their table by STRING
+    // (`TableName`) rather than through the boto3 resource. So `AGGREGATES_TABLE`
+    // stopped being merely how the handler finds its table and became what the
+    // transaction is built from — losing it would break every write rather than
+    // only the dedupe.
+    expect(aggregatorEnvironment()).toHaveProperty('AGGREGATES_TABLE');
+  });
+});

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.test.ts
@@ -273,12 +273,12 @@ describe('the aggregator can reach the dedupe table it is already allowed to (#2
    */
   const template = synthProcessingTemplate();
 
-  /** The aggregation Lambda, found by its handler + description of the code asset
-   * rather than by logical id: a CDK-generated id can change with a construct-tree
-   * edit, and matching the function by what it IS keeps this test pinned to the
-   * function rather than to a name. */
-  function aggregatorEnvironment(): Record<string, unknown> {
-    const functions = Object.values(template.findResources('AWS::Lambda::Function'))
+  /** Every Lambda in this stack whose service name says it is the aggregator, found
+   * by that name rather than by logical id: a CDK-generated id can change with a
+   * construct-tree edit, and matching the function by what it IS keeps these tests
+   * pinned to the function rather than to a name. */
+  function aggregatorFunctions(): { Properties?: any }[] {
+    return Object.values(template.findResources('AWS::Lambda::Function'))
       .filter((fn) => {
         const vars: unknown = fn.Properties?.Environment?.Variables;
         return (
@@ -286,11 +286,22 @@ describe('the aggregator can reach the dedupe table it is already allowed to (#2
           (vars as Record<string, unknown>).POWERTOOLS_SERVICE_NAME === 'voc-aggregator'
         );
       });
-    // The denominator: zero matches would make every assertion below vacuous, and a
-    // second match would mean this is no longer asserting about one function.
-    expect(functions).toHaveLength(1);
-    return functions[0].Properties.Environment.Variables as Record<string, unknown>;
   }
+
+  function aggregatorEnvironment(): Record<string, unknown> {
+    return aggregatorFunctions()[0].Properties.Environment.Variables as Record<string, unknown>;
+  }
+
+  it('finds exactly one aggregation Lambda to assert about', () => {
+    // THE DENOMINATOR, and it is its own test rather than a line inside the helper.
+    // Zero matches would make every assertion below vacuously true and a second match
+    // would mean they are no longer about one function — but asserted per call, that
+    // showed up as a failure of whichever environment test happened to run first,
+    // which reads as "the idempotency table name is missing" when what is really
+    // wrong is that the subject is missing or ambiguous. Stated once, so the
+    // diagnosis is one step shorter and names the real problem.
+    expect(aggregatorFunctions()).toHaveLength(1);
+  });
 
   it('passes the idempotency table name to the aggregation Lambda', () => {
     expect(aggregatorEnvironment()).toHaveProperty('IDEMPOTENCY_TABLE');

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -183,8 +183,9 @@ export class VocProcessingStack extends VocStack {
         // The dedupe marker for one stream record (issue #264). Streams deliver
         // at-least-once and this event source sets `retryAttempts: 3` with
         // `reportBatchItemFailures: true`, so a batch that partially fails
-        // re-presents records whose eight counter updates already landed —
-        // permanently, since nothing recomputes a counter from source. The
+        // re-presents records whose counter updates (one per dimension, plus the
+        // running average) already landed — permanently, since nothing recomputes a
+        // counter from source. The
         // aggregator claims each record's `eventID` in this table INSIDE the same
         // TransactWriteItems as the counters, so the claim and the counters commit
         // together or not at all.

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -185,10 +185,9 @@ export class VocProcessingStack extends VocStack {
         // `reportBatchItemFailures: true`, so a batch that partially fails
         // re-presents records whose counter updates (one per dimension, plus the
         // running average) already landed — permanently, since nothing recomputes a
-        // counter from source. The
-        // aggregator claims each record's `eventID` in this table INSIDE the same
-        // TransactWriteItems as the counters, so the claim and the counters commit
-        // together or not at all.
+        // counter from source. The aggregator claims each record's `eventID` in this
+        // table INSIDE the same TransactWriteItems as the counters, so the claim and
+        // the counters commit together or not at all.
         //
         // The shared `processingRole` is already granted this table
         // (`idempotencyTable.grantReadWriteData` above, for the processor), so this

--- a/voc-datalake/lib/stacks/processing-stack-consolidated.ts
+++ b/voc-datalake/lib/stacks/processing-stack-consolidated.ts
@@ -180,6 +180,22 @@ export class VocProcessingStack extends VocStack {
       memorySize: 512,
       environment: {
         AGGREGATES_TABLE: aggregatesTable.tableName,
+        // The dedupe marker for one stream record (issue #264). Streams deliver
+        // at-least-once and this event source sets `retryAttempts: 3` with
+        // `reportBatchItemFailures: true`, so a batch that partially fails
+        // re-presents records whose eight counter updates already landed —
+        // permanently, since nothing recomputes a counter from source. The
+        // aggregator claims each record's `eventID` in this table INSIDE the same
+        // TransactWriteItems as the counters, so the claim and the counters commit
+        // together or not at all.
+        //
+        // The shared `processingRole` is already granted this table
+        // (`idempotencyTable.grantReadWriteData` above, for the processor), so this
+        // is an environment change alone: without the NAME the function cannot
+        // reach a table it already has permission on. Absent, the handler logs a
+        // warning and applies counters non-transactionally, which is the
+        // pre-#264 behaviour rather than an outage.
+        IDEMPOTENCY_TABLE: idempotencyTable.tableName,
         POWERTOOLS_SERVICE_NAME: 'voc-aggregator',
         LOG_LEVEL: 'INFO',
       },

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -186,7 +186,7 @@
       }
     },
     "VocProcessingStack": {
-      "templateSha256": "18fde97c1540237227e2e168b01da842c18d2f50fc95700445096ac83ad94a42",
+      "templateSha256": "be632c9d1172b3cd25eb6335447219884f0678b2885033a19ca791dc4970b9a8",
       "names": {
         "physicalNames": [
           "AWS::Lambda::Function FunctionName = voc-aggregation-processor-<AWS::AccountId>-<AWS::Region>",


### PR DESCRIPTION
Closes #264.

## Summary

`voc-datalake/lambda/aggregator/handler.py` applied eight independent counter updates plus a running average per feedback record. DynamoDB Streams are at-least-once and the event source carries `retryAttempts: 3` with `reportBatchItemFailures: true`, so a redelivered record re-applied every increment, and a record that failed on its fifth write was retried with writes one to four already applied. Because these counters are only ever incremented and nothing recomputes them from source, the divergence was **permanent**.

An `INSERT` now claims the stream record's `eventID` in the shared idempotency table **inside the same `TransactWriteItems` as its counters**.

## Which approach, and why

**Both of the two offered, because neither alone meets both acceptance criteria** — and the reason they combine is the interesting part.

- A **dedupe key alone** (approach 1) closes whole-record replay but *not* partial application. Powertools' `idempotent_function` is two writes around a call: INPROGRESS, the function, then COMPLETED. The eight counter updates land *between* them, unprotected. A record that dies partway has applied some of them, so a marker written before the writes **records a half-applied record as done**, and one written after **leaves the half-application to be re-applied on top**. The task explicitly asks that the partial-application case be addressed rather than only the replay, and a marker cannot do it.
- A **transaction alone** (approach 2) removes partial application but not replay.

Putting the claim *in* the transaction gets both from one request: on a first delivery everything commits at once, so there is no window where counters have moved and the record is not yet recorded; on a second, `attribute_not_exists(id)` refuses and **a refused item cancels the whole transaction**, leaving every counter untouched. It also reuses the machinery already here — the same table, the same key attribute, the shared `processingRole`'s existing grant.

`dedupe_claim_item` was added to `shared/idempotency.py` rather than built in the aggregator, per the house rule about extending a shared helper over adding a second copy.

## What was deliberately NOT changed

**Reversals (`REMOVE`, and the decrement half of `MODIFY`) stay non-transactional.** Every decrement is a conditional write whose refusal the code *above* it reads — `_reverse_a_pre_deploy_persona_row` triggers on `ROW_ABSENT`, `_rebucket_average` pairs on a refused reversal — and `TransactWriteItems` reports no per-item outcome; one refused item cancels everything. Transacting them would turn *"this decrement had nothing to correct, so carry on"* into *"the edit wrote nothing at all"*, silently disabling the aged-out-day protections that exist **by** observing a refusal.

So the decrement floor guard `attribute_exists(pk) AND #field >= :floor` is untouched and the REMOVE/MODIFY paths keep their existing behaviour, exactly as the task requires — idempotency is layered above it, on the path where it can be. The remaining residual is recorded in the module docstring and pinned by the existing `TestRedeliveryMovesACounterTwice`, whose docstring now says which half is closed. Closing it properly needs a claim that is not a transaction participant (write-then-compensate), which is new failure machinery rather than a wider transaction.

## Reconciliation: a documented procedure, not a job

`docs/processing-pipeline.md` gains *"Rebuilding aggregates for a window"*. **It writes absolute values via `put_item`, never replayed deltas** — precisely because `if_not_exists(#field, :zero) + :inc` against a row aged out of its 90-day TTL would recreate it holding a negative count under a fresh TTL, which `/metrics/summary` would then serve. A job would mean a new Lambda, role and schedule for a rare operator action; the procedure is proportionate, as the task allows.

## Red-before / green-after evidence

**This is the evidence the task asks for, and it was measured rather than asserted.**

Run against the pre-change handler, **13 of the 14** tests in `TestARedeliveredArrivalMovesNothing` fail **on their own assertions** — not on setup. The fixture patches only the module attributes that exist, deliberately, so each test reaches its subject instead of erroring on a missing name (the first version errored on arrangement, which is not evidence about behaviour).

The two acceptance criteria, stated in pre-change vocabulary:

```
FAILED test_a_redelivered_record_leaves_every_counter_where_the_first_delivery_left_it
  AssertionError: a redelivery moved a counter
FAILED test_a_record_that_fails_partway_leaves_no_counter_moved
  AssertionError: {'category_sentiment#...': 1, 'daily_category#customer_support': 1}:
  some counters moved while the record failed
```

After the change: **161 passed** in `lambda/aggregator`.

The 14th, `test_a_record_with_no_event_id_is_applied_rather_than_dropped`, **passes both ways and is documented as doing so** rather than dressed up: it is the fail-open control guarding against a future over-correction, and for such a test passing before the change is the correct outcome.

Two findings from my own arrangement, both recorded in the test docstrings:
- Poisoning the **last** write (the average) to force a partial failure **proved nothing** — every counter had already been applied, so the totals agreed and the test passed against the defect it was written for. The poison row now sorts *between* the per-category counter and `daily_total`, which is the shape the issue describes.
- The claim TTL was first exactly 24 hours, matching stream retention. `test_the_claim_expires_so_markers_do_not_accumulate_forever` failed it: expiring *at* the horizon races the TTL deleting its own marker. Now 48 hours.

## Two lockstep guards were half-blind and are now closed

Both found by reviewing my own diff, both verified by mutation:

1. **`test_streaming_categories_lockstep.py`** parses the aggregator's counter writers to prove every sort key is a bare `YYYY-MM-DD` (streaming chat sums with `sk BETWEEN`). It knew only `update_counter`/`update_average`, so my transaction builders' sort keys — on the path **every ingested item** takes — were unpinned while the file stayed green. Keying one by `f'{date}#x'` now fails it and did not before.
2. **`test_aggregate_retention_lockstep.py`** — I widened `_WRITERS`, and two of its three assertions picked the new writers up because they iterate the tuple, but the horizon comparison named two functions **inline** and stayed blind. Dropping the transactional counter's `ttl_days` to 30 **failed nothing**. Now derived from `_WRITERS`; that mutation fails naming all four horizons.

`lib/test-support/baseline.json` is regenerated. I diffed the synthesized template first to confirm the change is purely additive — exactly one added environment variable, no renames (a rename of a table would be a CloudFormation *replacement*, which is what that guard exists to catch):

```diff
                         "AGGREGATES_TABLE": { "Fn::ImportValue": "...AggregatesTable..." },
+                        "IDEMPOTENCY_TABLE": { "Fn::ImportValue": "...IdempotencyTable..." },
```

## Build and test results

Container had no installed deps, so I ran `npm ci`/`npm install` in all four workspaces and built the venv from `requirements-dev.txt` plus both layer requirement files.

| Gate | Before | After |
|---|---|---|
| `npm run test:backend` | 3897 passed | **3911 passed** (+14) |
| `npm run test:cdk` | 297 passed | **301 passed** (+4) |
| `npm run lint` | 4 errors | **4 errors — byte-identical** |
| `npm run typecheck:all` | — | **pass** |
| `npm run test` (frontend) | — | **3074 passed / 186 files** |
| `npm run test:stream` | — | **399 passed / 24 files** |
| `npm run build` | — | **pass** |

**On `npm run lint`:** it exits non-zero both before and after, with the *same* 4 pre-existing `E402` errors in `lambda/conftest.py` and `lambda/api/test/conftest.py` — two files this PR does not touch. I verified by stashing: the output is byte-identical, and my files are clean (`ruff check` on them: *All checks passed*). I did **not** fix that debt here, to keep the diff scoped; note it needs `ruff>=0.15` as `requirements-dev.txt` pins, since 0.16 reports 514 errors under the same config.

`mise run build` does not exist in this repo (no mise config); the setup notes flag build gating as inert. I ran the real gates above instead.

## Agent notes

**What went well.** The module docstring named the fix, the table already existed, and the role already had the grant — so the infrastructure change really was one additive line. The existing test suite is unusually good at defending itself: the baseline snapshot guard, the two locksteps and the persona revert maps each caught something real, and two of those catches were in *my* work.

**What was difficult, and the lesson.** Getting the *evidence* right was harder than the fix. My first partial-failure test passed against the defect because I poisoned the last write instead of a middle one, and my first red run errored on arrangement rather than failing on assertions. Both would have looked like credible evidence in a PR body. This repo's steering says a test that passes both ways is measuring something else — that applies to the new test as much as the old, and the only way to know is to actually run it against the unfixed code and read *why* each line fails.

**Conventions discovered.** `AGGREGATES_TABLE` was previously just how the handler found its table; a transaction names its table by *string*, so that env var became load-bearing for every write, which is why there is now a CDK test for it. Cross-stack table references synthesize as `Fn::ImportValue`, not `Ref` — my first CDK assertion pinned the wrong spelling and the test correctly rejected it; asserting "some CloudFormation intrinsic" keeps it from failing on a future stack reorganisation. Also: moto rejects two operations on one item in a transaction, matching DynamoDB, which is worth knowing before designing around symmetric differences.

**Suggestions for future tasks.** When adding a *second* way to do something the aggregator already does, grep the lockstep tests for the function names they parse — those files enumerate writers explicitly and go silently half-blind, which is the exact failure mode they exist to prevent. And `npm run check` chains with `&&`, so the pre-existing lint debt hides every later gate; run the individual scripts when triaging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

```abca-verify
no-ui
```