### PR TITLE
feat(prioritization): enlarge a row's prototype to fill the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   overlay's shape — so focus bounced between the dialog's own controls and every link inside the
   artifact was unreachable by keyboard. A frame the page cannot read into, or one with nothing
   focusable in it, keeps the old behaviour: there would be nothing inside it to bring focus back out.
+  This holds at any depth, so a prototype that embeds a frame of its own — a map, a video, a
+  documentation pane — is reachable too.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   never reached the dialog, so any modal embedding one (the prototype overlay above) could not be
   dismissed from the keyboard once a reader clicked into its content. A frame the page cannot read
   into — cross-origin, or sandboxed without `allow-same-origin` — still cannot be observed, so
-  dialogs embedding one must offer a visible dismiss control.
+  dialogs embedding one must offer a visible dismiss control. One further exception is known and
+  tracked as #386: a frame whose content rewrites itself with `document.open()` keeps the same
+  document object while a compliant browser erases the listeners on it, so the dialog believes it is
+  still listening there.
 - Tab can now reach the controls inside a dialog's nested `<iframe>`. Descending into a frame is the
   browser's default action for a Tab pressed while the frame itself has focus, and the focus trap
   cancelled that action whenever the frame was the dialog's last focusable — which is the prototype

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   dismissed from the keyboard once a reader clicked into its content. A frame the page cannot read
   into — cross-origin, or sandboxed without `allow-same-origin` — still cannot be observed, so
   dialogs embedding one must offer a visible dismiss control.
+- Tab can now reach the controls inside a dialog's nested `<iframe>`. Descending into a frame is the
+  browser's default action for a Tab pressed while the frame itself has focus, and the focus trap
+  cancelled that action whenever the frame was the dialog's last focusable — which is the prototype
+  overlay's shape — so focus bounced between the dialog's own controls and every link inside the
+  artifact was unreachable by keyboard. A frame the page cannot read into, or one with nothing
+  focusable in it, keeps the old behaviour: there would be nothing inside it to bring focus back out.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   artifact was unreachable by keyboard. A frame the page cannot read into, or one with nothing
   focusable in it, keeps the old behaviour: there would be nothing inside it to bring focus back out.
   This holds at any depth, so a prototype that embeds a frame of its own — a map, a video, a
-  documentation pane — is reachable too.
+  documentation pane — is reachable too, and leaving such a frame continues through the prototype's
+  own content rather than jumping out of the artifact to the dialog's controls.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   This holds at any depth, so a prototype that embeds a frame of its own — a map, a video, a
   documentation pane — is reachable too, and leaving such a frame continues through the prototype's
   own content rather than jumping out of the artifact to the dialog's controls.
+- Tabbing through a large prototype inside a dialog no longer slows down with the size of the
+  prototype. Each keypress measured the whole embedded document to decide whether the key was leaving
+  it — for a 400-control page, 2800 style resolutions per keystroke, nearly all of it to conclude that
+  the key was an ordinary one the dialog should ignore. The question is now answered from the first
+  control the key can still reach.
+- A dialog whose embedded content replaces a frame of its own no longer accumulates one DOM observer
+  per replacement. Each nested document is watched so that keyboard handling follows frames the
+  content inserts itself, and a watcher for a document that had been swapped away was held until the
+  dialog closed, keeping the discarded document alive with it. Watchers are now dropped as soon as
+  their document leaves the frame tree.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
 ## [Unreleased]
 
+### Added
+
+- An expanded prioritization row can enlarge the prototype it is showing to fill the viewport, in
+  place, so a pitch session can look at the artifact without leaving the sliders, the team's numbers
+  and the room vote behind on the page. Escape, the visible Close control and a click outside all
+  return to the row. Offered for every prototype the row renders, including a legacy inline one and a
+  JSON spec, neither of which has an address that "Open in new tab" could use.
+
+### Fixed
+
+- Shared modal dialogs now honour Escape and keep Tab inside themselves while focus is in a nested
+  same-origin `<iframe>`. Keys pressed inside a frame are raised in the frame's own document and
+  never reached the dialog, so any modal embedding one (the prototype overlay above) could not be
+  dismissed from the keyboard once a reader clicked into its content. A frame the page cannot read
+  into — cross-origin, or sandboxed without `allow-same-origin` — still cannot be observed, so
+  dialogs embedding one must offer a visible dismiss control.
+
 ### Security
 
 - `POST /projects/{project_id}/document` validates `doc_type` against an allowlist of `prd` and

--- a/voc-datalake/frontend/public/locales/de/prioritization.json
+++ b/voc-datalake/frontend/public/locales/de/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "Notizen zu dieser Priorisierungsentscheidung hinzufügen..."
   },
   "preview": {
+    "enlarge": "Vergrößern",
     "prototypeTitle": "Prototyp",
     "title": "Dokumentvorschau",
     "viewFull": "Vollständiges Dokument anzeigen",

--- a/voc-datalake/frontend/public/locales/en/prioritization.json
+++ b/voc-datalake/frontend/public/locales/en/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "Add notes about this prioritization decision..."
   },
   "preview": {
+    "enlarge": "Enlarge",
     "prototypeTitle": "Prototype",
     "title": "Document Preview",
     "viewFull": "View Full Document",

--- a/voc-datalake/frontend/public/locales/es/prioritization.json
+++ b/voc-datalake/frontend/public/locales/es/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "Agregar notas sobre esta decisión de priorización..."
   },
   "preview": {
+    "enlarge": "Ampliar",
     "prototypeTitle": "Prototipo",
     "title": "Vista previa del documento",
     "viewFull": "Ver documento completo",

--- a/voc-datalake/frontend/public/locales/fr/prioritization.json
+++ b/voc-datalake/frontend/public/locales/fr/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "Ajouter des notes sur cette décision de priorisation..."
   },
   "preview": {
+    "enlarge": "Agrandir",
     "prototypeTitle": "Prototype cliquable",
     "title": "Aperçu du document",
     "viewFull": "Voir le document complet",

--- a/voc-datalake/frontend/public/locales/ja/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ja/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "この優先順位付けの決定に関するメモを追加..."
   },
   "preview": {
+    "enlarge": "拡大",
     "prototypeTitle": "プロトタイプ",
     "title": "ドキュメントプレビュー",
     "viewFull": "完全なドキュメントを表示",

--- a/voc-datalake/frontend/public/locales/ko/prioritization.json
+++ b/voc-datalake/frontend/public/locales/ko/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "이 우선순위 지정 결정에 대한 메모를 추가하세요..."
   },
   "preview": {
+    "enlarge": "확대",
     "prototypeTitle": "프로토타입",
     "title": "문서 미리보기",
     "viewFull": "전체 문서 보기",

--- a/voc-datalake/frontend/public/locales/pt/prioritization.json
+++ b/voc-datalake/frontend/public/locales/pt/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "Adicione notas sobre esta decisão de priorização..."
   },
   "preview": {
+    "enlarge": "Ampliar",
     "prototypeTitle": "Protótipo",
     "title": "Visualização do Documento",
     "viewFull": "Visualizar Documento Completo",

--- a/voc-datalake/frontend/public/locales/zh/prioritization.json
+++ b/voc-datalake/frontend/public/locales/zh/prioritization.json
@@ -87,6 +87,7 @@
     "placeholder": "添加关于此优先级排序决策的备注..."
   },
   "preview": {
+    "enlarge": "放大",
     "prototypeTitle": "原型",
     "title": "文档预览",
     "viewFull": "查看完整文档",

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -481,7 +481,13 @@ describe('ModalShell with a nested frame', () => {
     } else {
       doc.body.insertAdjacentHTML('beforeend', '<iframe title="nested"></iframe>')
     }
-    const nested = doc.querySelector('iframe')
+    // The frame THIS call added — always the last one in the document, since both
+    // branches append. `doc.querySelector('iframe')` returns the FIRST, so a second call
+    // on the same document handed back the PREVIOUS frame and overwrote its content,
+    // leaving the one just added dead and every later assertion silently about the old
+    // element. Review found the swap test below in exactly that state: it ends its loop
+    // with one frame, then adds another without clearing first.
+    const nested = [...doc.querySelectorAll('iframe')].at(-1) ?? null
     const nestedDoc = nested?.contentDocument
     if (!nested || !nestedDoc?.body) throw new Error('no nested frame document')
     nestedDoc.body.innerHTML = inner
@@ -589,6 +595,32 @@ describe('ModalShell with a nested frame', () => {
     expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
   })
 
+  it('wraps Tab off a frame whose controls all exist but are hidden, pressed inside it', () => {
+    // The sibling above has ZERO raw candidates and presses in the PAGE, so it exercises
+    // `tabWouldEnterFrame`'s reachability gate. This one has TWO candidates that are all
+    // unreachable and presses INSIDE the frame, which is the only route to
+    // `tabWouldLeave`'s "focus is not on a candidate" branch — and that branch is where a
+    // refactor asking the RAW candidate count instead of the reachable one answers "there
+    // is somewhere to go here", declines to intervene, and lets the browser move focus
+    // past the frame into the page behind the dialog. Both reviewers found it; neither
+    // existing test could, because the zero-candidate fixture agrees with either reading.
+    //
+    // A `display:none` container is not a contrived fixture: it is what a generated
+    // prototype's unopened modal and inactive screens are.
+    const { doc, pressInFrame } = renderFramedShell({
+      inner: '<div style="display:none"><button>one</button><button>two</button></div>',
+    })
+    // Both halves of the state are asserted rather than arranged, so this cannot decay
+    // into the zero-candidate case it exists to be distinct from: the candidates are
+    // present, and focus sits on the frame's `<body>` rather than on one of them.
+    expect(doc.querySelectorAll('button')).toHaveLength(2)
+    expect(doc.activeElement).toBe(doc.body)
+
+    pressInFrame('Tab')
+
+    expect(screen.getByRole('button', { name: 'after' })).toHaveFocus()
+  })
+
   it('wraps Tab off a frame this page cannot read into', () => {
     // Cross-origin, or `sandbox` without `allow-same-origin` — how legacy `srcDoc`
     // prototypes render. There is no listener of ours inside such a frame to bring
@@ -661,6 +693,94 @@ describe('ModalShell with a nested frame', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('re-scans when a container holding a frame is removed from the prototype', async () => {
+    // The mutation filter has to look INSIDE a moved node, not only at the node itself: a
+    // prototype's own script works in containers, so `<div><iframe/></div>` reports the DIV
+    // and a filter asking "is this a frame" drops the batch. For an INSERTION that gap
+    // hides — the frame's own `load` re-scans a moment later, and a test asserting the end
+    // state passes either way (measured: it survived the mutation).
+    //
+    // A REMOVAL is the case with no second chance. Nothing loads, so if the batch is
+    // dropped the shell keeps a listener and an `isListened` entry for a document that has
+    // gone — which is precisely what `reap` exists to prevent, and what makes a dead
+    // document read as a safe place to send focus.
+    //
+    // `nestedDocuments` descends with `querySelectorAll('iframe')`, so a call with that
+    // selector on this document is a scan of it. The spy goes on AFTER the insertion has
+    // settled, so every call it sees belongs to the removal.
+    const { doc } = renderFramedShell()
+    const box = doc.createElement('div')
+    box.innerHTML = '<iframe title="wrapped"></iframe>'
+    doc.body.append(box)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const walk = vi.spyOn(doc.body, 'querySelectorAll')
+    const scans = () => walk.mock.calls.filter(([selector]) => selector === 'iframe').length
+    try {
+      box.remove()
+      await Promise.resolve()
+
+      expect(scans()).toBeGreaterThan(0)
+    } finally {
+      walk.mockRestore()
+    }
+  })
+
+  it('listens to a second frame added beside the first in one document', () => {
+    // Two sibling frames in one prototype document — an embedded map next to an embedded
+    // video — and the second must be listened in its own right.
+    //
+    // It also pins `addNestedFrame`'s contract, which review found broken: the helper used
+    // to hand back `doc.querySelector('iframe')`, the document's FIRST frame, so a second
+    // call returned the previous frame and overwrote its content. Every assertion after
+    // such a call was quietly about the wrong element.
+    const { doc } = renderFramedShell()
+    const first = addNestedFrame(doc, { inserted: true })
+    const second = addNestedFrame(doc, { inserted: true })
+
+    expect(doc.querySelectorAll('iframe')).toHaveLength(2)
+    expect(second.nested).not.toBe(first.nested)
+
+    second.nestedDoc.getElementById('deep')?.focus()
+    second.pressInNested('Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-scans for a frame\'s load but not for the prototype\'s own resource loads', () => {
+    // A capture-phase `load` on the prototype's document sees every image, script and
+    // stylesheet in it — hundreds for a generated page — and each one used to run the
+    // recursive `nestedDocuments(panel)` walk. The panel-level cheap negative cannot help
+    // here: this consumer's panel always holds a frame.
+    //
+    // Counting the walk rather than timing it, as the sibling below does for style
+    // resolutions: `nestedDocuments` descends with `querySelectorAll('iframe')`, so a call
+    // with that selector on this document IS a scan of it.
+    const { doc } = renderFramedShell({ inner: '<img id="asset" alt="" /><iframe title="nested"></iframe>' })
+    const walk = vi.spyOn(doc.body, 'querySelectorAll')
+    const scans = () => walk.mock.calls.filter(([selector]) => selector === 'iframe').length
+    try {
+      const asset = doc.getElementById('asset')
+      const nested = doc.querySelector('iframe')
+      if (!asset || !nested) throw new Error('fixture is missing the asset or the frame')
+      const before = scans()
+
+      // A resource load: ignored, or every asset in the prototype costs a tree walk.
+      asset.dispatchEvent(new (doc.defaultView ?? window).Event('load'))
+      const afterAsset = scans()
+
+      // A FRAME's load: acted on, because it can change which documents exist to listen
+      // to. Both directions in one test, so a filter that rejects everything — which would
+      // pass a negative-only assertion — fails here.
+      nested.dispatchEvent(new (doc.defaultView ?? window).Event('load'))
+
+      expect(afterAsset).toBe(before)
+      expect(scans()).toBeGreaterThan(afterAsset)
+    } finally {
+      walk.mockRestore()
+    }
+  })
+
   it('does not scan the whole prototype for a Tab that stays inside it', () => {
     // The common keypress, and the expensive one: a reviewer walking through a
     // prototype presses Tab repeatedly, and every one of those but the last is a Tab
@@ -716,29 +836,41 @@ describe('ModalShell with a nested frame', () => {
     // reviewer navigates it, so the count grows while the overlay is simply in use.
     const { doc } = renderFramedShell({ inner: '' })
     const spy = spyOnObservers()
+    // The frame that SURVIVES the swaps, kept so the assertion after the spy block is
+    // about that document rather than a freshly added one. A mutable binding is fine
+    // here: eslint ignores `*.test.tsx`, so `no-restricted-syntax` does not reach it.
+    let surviving: ReturnType<typeof addNestedFrame> | undefined
     try {
       const atRest = spy.live()
       for (const _ of Array.from({ length: 8 })) {
         doc.body.innerHTML = ''
-        addNestedFrame(doc, { inserted: true })
+        surviving = addNestedFrame(doc, { inserted: true })
         // MutationObserver callbacks are microtasks, so the scan (and the reap) runs
         // between swaps rather than all at the end.
         await Promise.resolve()
         await Promise.resolve()
       }
 
-      // One watcher for whichever nested document is current — not eight. `atRest` is
-      // the baseline because the outer frame's own watcher predates the spy.
-      expect(spy.live() - atRest).toBeLessThanOrEqual(1)
+      // EXACTLY one watcher for whichever nested document is current — not eight.
+      // `atRest` is the baseline because the outer frame's own watcher predates the spy.
+      //
+      // An equality, because review asked whether the previous `<= 1` was loose by
+      // necessity and it was not: two microtasks after the last swap the reap has already
+      // run, so the count is settled. The inequality also admitted the very failure this
+      // test is named for — one watcher leaked permanently reads as `<= 1` too.
+      expect(spy.live()).toBe(atRest + 1)
     } finally {
       spy.restore()
     }
 
-    // And the surviving frame still works, so the reaping did not take the live
-    // document's listener with it.
-    const { nestedDoc, pressInNested } = addNestedFrame(doc)
-    nestedDoc.getElementById('deep')?.focus()
-    pressInNested('Escape')
+    // And the SURVIVING frame still works, so the reaping did not take the live
+    // document's listener with it. On the loop's own last frame, deliberately: adding a
+    // fresh frame here would prove only that a new scan attaches a listener, a different
+    // and weaker claim. That is what this assertion silently did before `addNestedFrame`
+    // was fixed to hand back the frame it created rather than the document's first.
+    if (!surviving) throw new Error('the swap loop added no frame')
+    surviving.nestedDoc.getElementById('deep')?.focus()
+    surviving.pressInNested('Escape')
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })
@@ -791,6 +923,17 @@ describe('ModalShell with a nested frame', () => {
     const nestedDoc = el.contentDocument
     if (!nestedDoc?.body) throw new Error('no nested frame document')
     nestedDoc.body.innerHTML = '<button id="deep">deep</button>'
+    // THE PRECONDITION, ASSERTED. Review's point was that this test arranged the
+    // readable-but-unlistened state through getter surgery and then trusted it: the Tab
+    // assertion below also passes if the frame simply has nothing reachable inside it, so
+    // a fixture that stopped taking effect would keep the test green while testing nothing.
+    // Escape is the direct observable — with no listener inside that document it is dead —
+    // so if the shell ever does pick this frame up, it fails HERE, naming the reason.
+    nestedDoc.getElementById('deep')?.focus()
+    ;(nestedDoc.activeElement ?? nestedDoc.body).dispatchEvent(
+      new (nestedDoc.defaultView ?? window).KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+    expect(onClose).not.toHaveBeenCalled()
     el.focus()
 
     pressInFrame('Tab')

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -425,6 +425,43 @@ describe('ModalShell with a nested frame', () => {
     return { doc, frame, pressInFrame, pressInPage }
   }
 
+  /**
+   * A frame inside `doc` — the shape a generated prototype embedding a map, a video
+   * or a docs frame produces without anyone choosing it.
+   *
+   * `querySelector('iframe')` rather than `instanceof HTMLIFrameElement`: the element
+   * belongs to the OUTER FRAME's realm, whose `HTMLIFrameElement` is a different
+   * constructor object from this document's — the realm trap `asFrame` exists for, and
+   * it applies to the test too. The tag-name overload types it without an assertion,
+   * which this repo bans.
+   *
+   * @param inserted whether the frame is added AFTER `doc` was first scanned, which is
+   *   what a script inside the prototype does. `false` writes it in `doc`'s initial
+   *   markup, where a static parse means the outer `load` fires with the nested
+   *   document already present, so one scan of the panel happens to catch both.
+   */
+  function addNestedFrame(doc: Document, { inserted = false, inner = '<button id="deep">deep</button>' } = {}) {
+    if (inserted) {
+      const el = doc.createElement('iframe')
+      el.title = 'nested'
+      doc.body.append(el)
+    } else {
+      doc.body.insertAdjacentHTML('beforeend', '<iframe title="nested"></iframe>')
+    }
+    const nested = doc.querySelector('iframe')
+    const nestedDoc = nested?.contentDocument
+    if (!nested || !nestedDoc?.body) throw new Error('no nested frame document')
+    nestedDoc.body.innerHTML = inner
+    /** Raise a key in the NESTED frame's document. */
+    const pressInNested = (key: string, shiftKey = false) => {
+      const target = nestedDoc.activeElement ?? nestedDoc.body
+      target.dispatchEvent(
+        new (nestedDoc.defaultView ?? window).KeyboardEvent('keydown', { key, shiftKey, bubbles: true }),
+      )
+    }
+    return { nested, nestedDoc, pressInNested }
+  }
+
   it('closes on Escape pressed inside the frame', () => {
     // Without the frame listener this is silent: the reviewer is inside the
     // artifact, which is where the overlay is meant to be used, and the documented
@@ -558,24 +595,104 @@ describe('ModalShell with a nested frame', () => {
     // As above, jsdom performs no default Tab action, so the observable is that the
     // shell did not intervene: focus stays on the nested frame element for the browser
     // to descend from, and the panel's own controls are untouched.
-    const { doc, pressInFrame } = renderFramedShell({
-      inner: '<button id="inner-first">inner one</button><iframe id="nested" title="nested"></iframe>',
-    })
-    // `querySelector('iframe')` rather than `instanceof HTMLIFrameElement`: this
-    // element belongs to the FRAME's realm, whose `HTMLIFrameElement` is a different
-    // constructor from this one — the same realm trap `raisedIn` avoids in the shell.
-    // The tag-name overload types it without an assertion.
-    const nested = doc.querySelector('iframe')
-    const nestedDoc = nested?.contentDocument
-    if (!nestedDoc?.body) throw new Error('no nested frame document')
-    nestedDoc.body.innerHTML = '<button id="deep">deep</button>'
-    nested?.focus()
+    const { doc, pressInFrame } = renderFramedShell({ inner: '<button id="inner-first">inner one</button>' })
+    const { nested } = addNestedFrame(doc)
+    nested.focus()
 
     pressInFrame('Tab')
 
     expect(doc.activeElement).toBe(nested)
     expect(screen.getByRole('button', { name: 'after' })).not.toHaveFocus()
     expect(screen.getByRole('button', { name: 'close' })).not.toHaveFocus()
+  })
+
+  it('listens to a frame inserted inside the prototype\'s own document', () => {
+    // The guarantee the entry guard rests on. Both of this page's re-scan triggers are
+    // in the TOP document — the observer watches the panel's node subtree, and the
+    // capture-phase `load` is on the panel — and neither sees a frame inserted into
+    // another frame's document, because that document is not part of the panel's node
+    // tree and a `load` raised in it never reaches the panel. So a frame a script in the
+    // prototype adds after the outer document was scanned used to be readable and
+    // UNLISTENED, and the entry guard (which checked only readability) let a keyboard
+    // user descend into it: the exiting Tab was unobserved, so focus went on out of the
+    // dialog, and Escape was dead in there too.
+    //
+    // The static-markup case passes either way, which is why it cannot stand in for
+    // this: a parsed frame's `load` waits on its subframes, so one scan catches both.
+    const { doc } = renderFramedShell()
+    const { nestedDoc, pressInNested } = addNestedFrame(doc, { inserted: true })
+
+    nestedDoc.getElementById('deep')?.focus()
+    pressInNested('Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps Tab off a readable frame it is not listening to', async () => {
+    // The other half of the guarantee above, and the reason the guard asks whether a
+    // document is LISTENED to rather than merely readable. An exit this shell cannot see
+    // is not an exit, so descending would be a one-way trip out of the dialog — exactly
+    // the opaque-frame case, reached with a frame that IS readable by the time Tab is
+    // pressed. Without this, "readable" and "listened" could drift back together.
+    const { doc, pressInFrame } = renderFramedShell({ inner: '' })
+    // Unreadable while it is inserted, so the shell's scan of the outer document skips
+    // it exactly as it skips a cross-origin frame, then readable afterwards. That is a
+    // real ordering rather than listener surgery: whatever the reason a frame was missed,
+    // the guard must not treat it as an entry.
+    const el = doc.createElement('iframe')
+    el.title = 'nested'
+    const real = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentDocument')
+    if (!real?.get) throw new Error('no contentDocument getter to wrap')
+    Object.defineProperty(el, 'contentDocument', {
+      configurable: true,
+      get() {
+        throw new DOMException('not yet', 'SecurityError')
+      },
+    })
+    doc.body.append(el)
+    // Let the observer run and skip it — MutationObserver callbacks are microtasks.
+    await Promise.resolve()
+    Reflect.deleteProperty(el, 'contentDocument')
+    const nestedDoc = el.contentDocument
+    if (!nestedDoc?.body) throw new Error('no nested frame document')
+    nestedDoc.body.innerHTML = '<button id="deep">deep</button>'
+    el.focus()
+
+    pressInFrame('Tab')
+
+    expect(screen.getByRole('button', { name: 'after' })).toHaveFocus()
+  })
+
+  it('resumes after a nested frame in the prototype\'s own document, not in the panel', () => {
+    // `items` is the PANEL's focusables and the top document's activeElement is the
+    // OUTERMOST frame element whenever focus is anywhere inside it, so resolving the
+    // exit against those collapsed every depth to the panel's order: a Tab leaving a
+    // frame nested in the prototype jumped to the panel item after the OUTER frame,
+    // skipping whatever followed the nested frame inside the prototype. Focus left the
+    // artifact entirely rather than continuing through it.
+    const { doc } = renderFramedShell({ inner: '<button id="inner-first">inner one</button>' })
+    const { nestedDoc, pressInNested } = addNestedFrame(doc, { inserted: true })
+    doc.body.insertAdjacentHTML('beforeend', '<button id="o2">after the nested frame</button>')
+    nestedDoc.getElementById('deep')?.focus()
+
+    pressInNested('Tab')
+
+    expect(doc.activeElement).toBe(doc.getElementById('o2'))
+    expect(screen.getByRole('button', { name: 'after' })).not.toHaveFocus()
+  })
+
+  it('walks out to the panel when a nested frame is the prototype\'s last focusable', () => {
+    // The recursive leg of the walk: leaving the nested frame leaves the outer document
+    // too, because the nested frame is its last focusable. Only then does the panel's
+    // order apply — and it must, or focus would be left inside a document the Tab has
+    // already logically left.
+    const { doc } = renderFramedShell({ inner: '<button id="inner-first">inner one</button>' })
+    const { nestedDoc, pressInNested } = addNestedFrame(doc, { inserted: true })
+    nestedDoc.getElementById('deep')?.focus()
+
+    pressInNested('Tab')
+
+    expect(screen.getByRole('button', { name: 'after' })).toHaveFocus()
   })
 
   it('keeps the frame\'s listener attached across an unrelated re-render', async () => {
@@ -589,10 +706,12 @@ describe('ModalShell with a nested frame', () => {
     const added: EventListenerOrEventListenerObject[] = []
     const removed: EventListenerOrEventListenerObject[] = []
     // A fresh `onClose` identity per render, as every consumer of this shell writes it.
+    // Still the shared mock underneath, so the listener can be shown to WORK and not
+    // merely to be attached.
     function Rerendering() {
       const [n, setN] = React.useState(0)
       return (
-        <ModalShell isOpen onClose={() => undefined} ariaLabel="Re-rendering dialog">
+        <ModalShell isOpen onClose={() => onClose()} ariaLabel="Re-rendering dialog">
           <button onClick={() => setN(n + 1)}>bump {n}</button>
           <iframe title="prototype" />
         </ModalShell>
@@ -613,6 +732,19 @@ describe('ModalShell with a nested frame', () => {
     // detach, and would pass the assertion below.
     expect(added.length).toBeGreaterThan(0)
     expect(removed).toHaveLength(0)
+    // The bookkeeping above cannot tell a working listener from one that is merely
+    // still attached — a handler closed over a panel node the re-render replaced, or
+    // one that early-returns, keeps both counts identical while Escape silently stops
+    // closing the dialog. So the property a reader actually cares about is asserted
+    // directly: after the re-renders, a key raised inside the frame still works.
+    const frame = screen.getByTitle('prototype')
+    const doc = frame instanceof HTMLIFrameElement ? frame.contentDocument : null
+    if (!doc?.body) throw new Error('no frame document')
+    doc.body.dispatchEvent(
+      new (doc.defaultView ?? window).KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('listens to a frame that arrives after the dialog is already open', async () => {

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -308,6 +308,14 @@ describe('ModalShell', () => {
  * (`frameDocument()`), so wrapping the getter puts the spy in front of every attach
  * without changing which object anyone gets: the same document is returned, with its
  * own `addEventListener` / `removeEventListener` wrapped once.
+ *
+ * `restore()` undoes BOTH halves — the prototype getter and the listener methods on
+ * every document already wrapped. Restoring only the getter would stop new documents
+ * being wrapped while leaving live closures on the old ones still pushing into these
+ * arrays, so a later test that spied, restored and then rendered another framed shell
+ * would read contributions from the previous one. The helper is therefore reusable
+ * rather than single-use, which is what a reader of the rest of this comment would
+ * assume anyway.
  */
 function spyOnFrameDocumentListeners(
   added: EventListenerOrEventListenerObject[],
@@ -317,6 +325,7 @@ function spyOnFrameDocumentListeners(
   if (!real?.get) throw new Error('no contentDocument getter to wrap')
   const realGet = real.get
   const wrapped = new WeakSet<Document>()
+  const unwrap: (() => void)[] = []
   Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', {
     configurable: true,
     get(): Document | null {
@@ -325,6 +334,14 @@ function spyOnFrameDocumentListeners(
         wrapped.add(doc)
         const realAdd = doc.addEventListener.bind(doc)
         const realRemove = doc.removeEventListener.bind(doc)
+        // The own properties are deleted rather than reassigned, so the document is
+        // left reading these through its prototype exactly as it did before.
+        // `Reflect.deleteProperty` rather than `delete`, which TypeScript rejects for
+        // a non-optional property and which would otherwise need a type assertion.
+        unwrap.push(() => {
+          Reflect.deleteProperty(doc, 'addEventListener')
+          Reflect.deleteProperty(doc, 'removeEventListener')
+        })
         doc.addEventListener = (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
           if (type === 'keydown') added.push(listener)
           realAdd(type, listener, options)
@@ -337,7 +354,10 @@ function spyOnFrameDocumentListeners(
       return doc
     },
   })
-  return () => Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', real)
+  return () => {
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', real)
+    for (const undo of unwrap) undo()
+  }
 }
 
 describe('ModalShell with a nested frame', () => {
@@ -526,6 +546,73 @@ describe('ModalShell with a nested frame', () => {
     frame.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
 
     expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
+  })
+
+  it('lets Tab into a frame nested inside the frame\'s own content', () => {
+    // The same defect one level down. A prototype is generated HTML, so a page that
+    // embeds a map, a video or a docs frame produces this shape without anyone
+    // choosing it: the nested frame is the OUTER document's last focusable, so a Tab
+    // raised in the outer document reads as an exit, wraps into the panel and cancels
+    // the descent — exactly what the panel-level entry guard was added to stop.
+    //
+    // As above, jsdom performs no default Tab action, so the observable is that the
+    // shell did not intervene: focus stays on the nested frame element for the browser
+    // to descend from, and the panel's own controls are untouched.
+    const { doc, pressInFrame } = renderFramedShell({
+      inner: '<button id="inner-first">inner one</button><iframe id="nested" title="nested"></iframe>',
+    })
+    // `querySelector('iframe')` rather than `instanceof HTMLIFrameElement`: this
+    // element belongs to the FRAME's realm, whose `HTMLIFrameElement` is a different
+    // constructor from this one — the same realm trap `raisedIn` avoids in the shell.
+    // The tag-name overload types it without an assertion.
+    const nested = doc.querySelector('iframe')
+    const nestedDoc = nested?.contentDocument
+    if (!nestedDoc?.body) throw new Error('no nested frame document')
+    nestedDoc.body.innerHTML = '<button id="deep">deep</button>'
+    nested?.focus()
+
+    pressInFrame('Tab')
+
+    expect(doc.activeElement).toBe(nested)
+    expect(screen.getByRole('button', { name: 'after' })).not.toHaveFocus()
+    expect(screen.getByRole('button', { name: 'close' })).not.toHaveFocus()
+  })
+
+  it('keeps the frame\'s listener attached across an unrelated re-render', async () => {
+    // Consumers pass `onClose` as an inline arrow, so with it in the wiring effect's
+    // deps every re-render of the component holding the dialog detached and re-attached
+    // the listener on every frame document — a frame-tree walk per render, and a window
+    // in each one where a key pressed inside the prototype is unobserved. The page this
+    // overlay lives on re-renders while it is open (a refetch, a slider, the hourly
+    // re-signing), so that window recurs rather than being a one-off.
+    const user = userEvent.setup()
+    const added: EventListenerOrEventListenerObject[] = []
+    const removed: EventListenerOrEventListenerObject[] = []
+    // A fresh `onClose` identity per render, as every consumer of this shell writes it.
+    function Rerendering() {
+      const [n, setN] = React.useState(0)
+      return (
+        <ModalShell isOpen onClose={() => undefined} ariaLabel="Re-rendering dialog">
+          <button onClick={() => setN(n + 1)}>bump {n}</button>
+          <iframe title="prototype" />
+        </ModalShell>
+      )
+    }
+    const restore = spyOnFrameDocumentListeners(added, removed)
+    try {
+      render(<Rerendering />)
+      // Nothing about the dialog changes; only the consumer's own state does, which is
+      // what a refetch or a slider move looks like from here.
+      await user.click(screen.getByRole('button', { name: /bump/ }))
+      await user.click(screen.getByRole('button', { name: /bump/ }))
+    } finally {
+      restore()
+    }
+
+    // Anti-vacuous first: a shell that never attached to the frame would also never
+    // detach, and would pass the assertion below.
+    expect(added.length).toBeGreaterThan(0)
+    expect(removed).toHaveLength(0)
   })
 
   it('listens to a frame that arrives after the dialog is already open', async () => {

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -360,6 +360,39 @@ function spyOnFrameDocumentListeners(
   }
 }
 
+/**
+ * Count the `MutationObserver`s constructed, and how many have been disconnected,
+ * while the returned restore function has not been called.
+ *
+ * The observers the shell attaches to nested frame documents are not reachable from
+ * the test — they are effect-local — so the only way to see one being held is to
+ * count constructions against disconnections. `disconnect` is wrapped per instance
+ * rather than on the prototype so an observer constructed before the spy (there are
+ * none today, but a future `beforeEach` could) cannot be double-counted.
+ */
+function spyOnObservers(): { readonly live: () => number; readonly restore: () => void } {
+  const real = globalThis.MutationObserver
+  const state = { made: 0, gone: 0 }
+  class Counting extends real {
+    constructor(callback: MutationCallback) {
+      super(callback)
+      state.made += 1
+    }
+
+    override disconnect() {
+      state.gone += 1
+      super.disconnect()
+    }
+  }
+  globalThis.MutationObserver = Counting
+  return {
+    live: () => state.made - state.gone,
+    restore: () => {
+      globalThis.MutationObserver = real
+    },
+  }
+}
+
 describe('ModalShell with a nested frame', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -626,6 +659,108 @@ describe('ModalShell with a nested frame', () => {
     pressInNested('Escape')
 
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not scan the whole prototype for a Tab that stays inside it', () => {
+    // The common keypress, and the expensive one: a reviewer walking through a
+    // prototype presses Tab repeatedly, and every one of those but the last is a Tab
+    // this shell declines to act on. Deciding that by building the document's filtered
+    // focusable list resolved styles and ran three `closest()` walks for EVERY control
+    // in the frame — measured at 2800 style resolutions for the 400-control document
+    // below, per keystroke, all of it to answer "no".
+    //
+    // Counting `getComputedStyle` rather than timing: the count is the property (jsdom's
+    // style resolution is slower than a browser's, so the wall time is not a production
+    // number) and a threshold in milliseconds would be flaky on shared CI.
+    const { doc, pressInFrame } = renderFramedShell({ inner: '' })
+    const controls = 400
+    doc.body.innerHTML = Array.from(
+      { length: controls },
+      (_, i) => `<div><div><div><div><button id="c${i}">c${i}</button></div></div></div></div>`,
+    ).join('')
+    const view = doc.defaultView
+    if (!view) throw new Error('no view for the prototype document')
+    const real = view.getComputedStyle.bind(view)
+    const calls: Element[] = []
+    view.getComputedStyle = (el: Element, pseudo?: string | null) => {
+      calls.push(el)
+      return real(el, pseudo)
+    }
+    try {
+      // Mid-document, so the key has somewhere to go and the shell must not intervene.
+      doc.getElementById('c200')?.focus()
+
+      pressInFrame('Tab')
+
+      // Well under one per control: the answer comes from the first reachable control
+      // beyond the focused one, not from the whole document. The unfixed code called it
+      // 2800 times — seven times the control count — so any threshold near `controls`
+      // separates the two, and this one does not have to be re-tuned as the fixture grows.
+      expect(calls.length).toBeLessThan(controls)
+    } finally {
+      view.getComputedStyle = real
+    }
+
+    // Behaviour unchanged, which is the point: still no intervention.
+    expect(doc.activeElement).toBe(doc.getElementById('c200'))
+    expect(screen.getByRole('button', { name: 'after' })).not.toHaveFocus()
+  })
+
+  it('does not accumulate watchers for a frame the prototype keeps replacing', async () => {
+    // Each nested document is watched in its own right, and a frame that is REPLACED
+    // leaves its old document unreachable but still watched. Held to close, that was one
+    // live `MutationObserver` per swap, each keeping a detached body alive — bounded by
+    // the dialog's lifetime, but the wrong lifetime: the document is gone long before.
+    //
+    // A prototype swapping an embedded frame is what a generated page does when a
+    // reviewer navigates it, so the count grows while the overlay is simply in use.
+    const { doc } = renderFramedShell({ inner: '' })
+    const spy = spyOnObservers()
+    try {
+      const atRest = spy.live()
+      for (const _ of Array.from({ length: 8 })) {
+        doc.body.innerHTML = ''
+        addNestedFrame(doc, { inserted: true })
+        // MutationObserver callbacks are microtasks, so the scan (and the reap) runs
+        // between swaps rather than all at the end.
+        await Promise.resolve()
+        await Promise.resolve()
+      }
+
+      // One watcher for whichever nested document is current — not eight. `atRest` is
+      // the baseline because the outer frame's own watcher predates the spy.
+      expect(spy.live() - atRest).toBeLessThanOrEqual(1)
+    } finally {
+      spy.restore()
+    }
+
+    // And the surviving frame still works, so the reaping did not take the live
+    // document's listener with it.
+    const { nestedDoc, pressInNested } = addNestedFrame(doc)
+    nestedDoc.getElementById('deep')?.focus()
+    pressInNested('Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disconnects every watcher when the dialog closes', () => {
+    // The teardown half: whatever is still attached at close must go, including the
+    // per-nested-document watchers. Counted rather than inspected, because the
+    // observers are effect-local and unreachable from here.
+    const spy = spyOnObservers()
+    try {
+      const { doc } = renderFramedShell({ inner: '' })
+      addNestedFrame(doc, { inserted: true })
+      // Anti-vacuous: a shell that stopped watching frames would trivially satisfy the
+      // assertion below by never constructing one.
+      expect(spy.live()).toBeGreaterThan(0)
+
+      cleanup()
+
+      expect(spy.live()).toBe(0)
+    } finally {
+      spy.restore()
+    }
   })
 
   it('wraps Tab off a readable frame it is not listening to', async () => {

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -297,31 +297,94 @@ describe('ModalShell', () => {
  * browser does and what `user.keyboard` cannot do — it targets the top document,
  * i.e. the pre-iframe state only.
  */
+/**
+ * Record the keydown listeners added to, and removed from, every frame document any
+ * code reads while the returned restore function has not been called.
+ *
+ * Installed by patching `contentDocument` rather than the documents themselves,
+ * because a frame's document does not exist until the frame is inserted and the shell
+ * attaches during that same synchronous insertion — there is no moment in between for
+ * a test to hold. Reading `contentDocument` is how the shell finds a document at all
+ * (`frameDocument()`), so wrapping the getter puts the spy in front of every attach
+ * without changing which object anyone gets: the same document is returned, with its
+ * own `addEventListener` / `removeEventListener` wrapped once.
+ */
+function spyOnFrameDocumentListeners(
+  added: EventListenerOrEventListenerObject[],
+  removed: EventListenerOrEventListenerObject[],
+): () => void {
+  const real = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentDocument')
+  if (!real?.get) throw new Error('no contentDocument getter to wrap')
+  const realGet = real.get
+  const wrapped = new WeakSet<Document>()
+  Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', {
+    configurable: true,
+    get(): Document | null {
+      const doc: Document | null = realGet.call(this)
+      if (doc && !wrapped.has(doc)) {
+        wrapped.add(doc)
+        const realAdd = doc.addEventListener.bind(doc)
+        const realRemove = doc.removeEventListener.bind(doc)
+        doc.addEventListener = (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
+          if (type === 'keydown') added.push(listener)
+          realAdd(type, listener, options)
+        }
+        doc.removeEventListener = (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => {
+          if (type === 'keydown') removed.push(listener)
+          realRemove(type, listener, options)
+        }
+      }
+      return doc
+    },
+  })
+  return () => Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', real)
+}
+
 describe('ModalShell with a nested frame', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   /**
-   * The shell with an `<iframe>` between two panel controls, its document filled
-   * with `inner` controls.
+   * The shell with an `<iframe>` among its panel controls, its document filled with
+   * `inner` controls.
    *
    * No `src`: jsdom gives a src-less frame a real about:blank document with a body,
    * where one loading over the network has `contentDocument` but no `body` — the
    * frame is a stand-in for a LOADED prototype, which is the state under test.
+   *
+   * @param options.trailing whether a control FOLLOWS the frame in the panel.
+   *   `true` (the default) is the shape the frame-exit tests need: only a following
+   *   item can show that focus resumes AFTER the frame rather than at the panel's
+   *   edge. `false` is the shape the only real consumer actually has —
+   *   `PrototypeEnlargeButton`'s panel is `[Close, <iframe>]` — where the frame is
+   *   the panel's LAST focusable and the parent-document Tab path behaves
+   *   differently. Both geometries are covered because the easier one cannot fail on
+   *   the harder one's behaviour.
+   * @param options.leading whether a control PRECEDES the frame. `false` makes the
+   *   frame the panel's first focusable, which is where the backwards wrap is
+   *   observable.
+   * @param options.inner the frame's own content, so a test can give the frame
+   *   nothing focusable — the case where Tab must NOT be allowed to descend.
    */
-  function renderFramedShell() {
+  function renderFramedShell(
+    {
+      leading = true,
+      trailing = true,
+      inner = '<button id="inner-first">inner one</button><button id="inner-last">inner two</button>',
+    } = {},
+  ) {
     render(
       <ModalShell isOpen onClose={onClose} ariaLabel="Framed dialog">
-        <button>close</button>
+        {leading ? <button>close</button> : null}
         <iframe title="prototype" />
-        <button>after</button>
+        {trailing ? <button>after</button> : null}
       </ModalShell>,
     )
     const frame = screen.getByTitle('prototype')
     const doc = frame instanceof HTMLIFrameElement ? frame.contentDocument : null
     if (!doc?.body) throw new Error('no frame document to write the prototype into')
-    doc.body.innerHTML = '<button id="inner-first">inner one</button><button id="inner-last">inner two</button>'
+    doc.body.innerHTML = inner
     /** Raise a key in the FRAME's document, as a browser does for a key pressed inside it. */
     const pressInFrame = (key: string, shiftKey = false) => {
       const target = doc.activeElement ?? doc.body
@@ -329,7 +392,17 @@ describe('ModalShell with a nested frame', () => {
         new (doc.defaultView ?? window).KeyboardEvent('keydown', { key, shiftKey, bubbles: true }),
       )
     }
-    return { doc, frame, pressInFrame }
+    /**
+     * Raise a key in THIS page's document, with focus wherever the test put it.
+     * `user.keyboard` cannot be used for the frame-element case: it dispatches at
+     * `document.activeElement` only after its own focus bookkeeping, and the
+     * `<iframe>` element having focus is precisely the state under test.
+     */
+    const pressInPage = (key: string, shiftKey = false) => {
+      const target = document.activeElement ?? document.body
+      target.dispatchEvent(new KeyboardEvent('keydown', { key, shiftKey, bubbles: true }))
+    }
+    return { doc, frame, pressInFrame, pressInPage }
   }
 
   it('closes on Escape pressed inside the frame', () => {
@@ -375,6 +448,82 @@ describe('ModalShell with a nested frame', () => {
     doc.getElementById('inner-first')?.focus()
 
     pressInFrame('Tab', true)
+
+    expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
+  })
+
+  it('lets Tab into a frame that is the panel\'s last focusable', () => {
+    // The direction the trap gets wrong by default, and the geometry the tests above
+    // cannot see: with a control after the frame the frame is never `last`, so no wrap
+    // fires. `PrototypeEnlargeButton`'s panel is `[Close, <iframe>]`, where the wrap
+    // fires on the very keypress that would have descended into the artifact — and
+    // `preventDefault()` cancels exactly that default action. Close ⇄ frame element
+    // for ever, and every control inside the prototype is keyboard-unreachable in the
+    // dialog built for walking through it.
+    //
+    // jsdom performs no default Tab action, so what is asserted is that the shell did
+    // NOT intervene: focus is left on the frame element for the browser to descend
+    // from. Redirected-to-`close` is the defect.
+    const { frame, pressInPage } = renderFramedShell({ trailing: false })
+    frame.focus()
+
+    pressInPage('Tab')
+
+    expect(frame).toHaveFocus()
+    expect(screen.getByRole('button', { name: 'close' })).not.toHaveFocus()
+  })
+
+  it('wraps shift-Tab off a focused frame that is the panel\'s first focusable', () => {
+    // Backwards there is no descent to protect — shift-Tab off a focused frame element
+    // moves to whatever precedes the frame, never into it — so the trap must still act
+    // at the panel's leading edge. Pinning it stops the entry fix above from being
+    // widened into "never intervene while a frame has focus", which would let
+    // shift-Tab out of the dialog and into the page behind.
+    const { frame, pressInPage } = renderFramedShell({ leading: false })
+    frame.focus()
+
+    pressInPage('Tab', true)
+
+    expect(screen.getByRole('button', { name: 'after' })).toHaveFocus()
+  })
+
+  it('wraps Tab off a frame with nothing focusable inside it', () => {
+    // A frame the key cannot move focus within: the browser skips past it to whatever
+    // follows, which is the page behind the overlay. Declining the wrap here would
+    // strand a keyboard user outside the dialog, so an empty frame is not an entry.
+    const { frame, pressInPage } = renderFramedShell({ trailing: false, inner: '<p>no controls here</p>' })
+    frame.focus()
+
+    pressInPage('Tab')
+
+    expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
+  })
+
+  it('wraps Tab off a frame this page cannot read into', () => {
+    // Cross-origin, or `sandbox` without `allow-same-origin` — how legacy `srcDoc`
+    // prototypes render. There is no listener of ours inside such a frame to bring
+    // focus back out, so letting Tab descend would be a one-way trip out of the
+    // dialog. Today's wrap is the correct answer, and this pins that the entry fix
+    // guards on readability rather than on the element being an iframe.
+    render(
+      <ModalShell isOpen onClose={onClose} ariaLabel="Opaque dialog">
+        <button>close</button>
+        <iframe title="opaque" />
+      </ModalShell>,
+    )
+    const frame = screen.getByTitle('opaque')
+    // Stand in for the browser refusing access: `frameDocument` catches the throw for
+    // a cross-origin frame and returns null, which is the state under test. jsdom
+    // enforces neither origins nor `sandbox`, so the refusal has to be arranged.
+    Object.defineProperty(frame, 'contentDocument', {
+      configurable: true,
+      get() {
+        throw new DOMException('cross-origin', 'SecurityError')
+      },
+    })
+    frame.focus()
+
+    frame.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
 
     expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
   })
@@ -439,16 +588,34 @@ describe('ModalShell with a nested frame', () => {
     // caught by dispatching a key afterwards — the top-most guard makes a leaked
     // listener inert, so the only observable is the detach itself, and a page with
     // one of these per row would otherwise accumulate one per open.
-    const { doc } = renderFramedShell()
-    const removals: unknown[] = []
-    const realRemove = doc.removeEventListener.bind(doc)
-    doc.removeEventListener = (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => {
-      removals.push(type)
-      realRemove(type, listener, options)
+    //
+    // Listener IDENTITY, not just the event name: `expect(removals).toContain(
+    // 'keydown')` passed for any keydown removal on that document by anyone, so it
+    // stayed green if the shell detached the wrong handler, or only one of several —
+    // a test that could not fail on the regression it is the sole guard against. What
+    // is pinned here is that the exact function the shell ADDED is the one it removes.
+    const added: EventListenerOrEventListenerObject[] = []
+    const removed: EventListenerOrEventListenerObject[] = []
+    // The spy has to exist before the shell attaches, and there is no moment in
+    // between: jsdom creates a frame's document and fires its `load` synchronously
+    // during insertion, which is when the shell attaches. Nor can the frame realm's
+    // `EventTarget.prototype` be patched ahead of time — each frame has its own realm,
+    // reachable only once the frame exists. So the spy is installed on the way IN, by
+    // wrapping each frame document the first time anything reads it. `frameDocument()`
+    // is that read.
+    const restore = spyOnFrameDocumentListeners(added, removed)
+    try {
+      renderFramedShell()
+
+      cleanup()
+    } finally {
+      restore()
     }
 
-    cleanup()
-
-    expect(removals).toContain('keydown')
+    // Anti-vacuous: "every added listener was removed" is satisfied by adding none,
+    // which is also what a shell that stopped listening to frames at all would do —
+    // the defect the rest of this describe exists to catch.
+    expect(added.length).toBeGreaterThan(0)
+    for (const listener of added) expect(removed).toContain(listener)
   })
 })

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.test.tsx
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ModalShell from './ModalShell'
 
@@ -279,5 +279,176 @@ describe('ModalShell', () => {
     await user.tab()
 
     expect(first).toHaveFocus()
+  })
+})
+
+/**
+ * A dialog whose content is an `<iframe>` — the prototype enlarge overlay (#314).
+ *
+ * A keydown raised inside a frame's own document does NOT reach the embedder, so a
+ * listener on this page's document alone stops seeing keys the moment focus enters
+ * the frame. The frame is also in `focusable()`'s selector list, so a single Tab
+ * puts it there. For an overlay whose entire purpose is that a reviewer clicks into
+ * the artifact and navigates it, that is the DOMINANT state, not an edge case:
+ * without the per-frame listeners, Escape and the Tab trap are inert for almost all
+ * of the dialog's useful life.
+ *
+ * The keys below are dispatched on the frame's own document, which is what a
+ * browser does and what `user.keyboard` cannot do — it targets the top document,
+ * i.e. the pre-iframe state only.
+ */
+describe('ModalShell with a nested frame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /**
+   * The shell with an `<iframe>` between two panel controls, its document filled
+   * with `inner` controls.
+   *
+   * No `src`: jsdom gives a src-less frame a real about:blank document with a body,
+   * where one loading over the network has `contentDocument` but no `body` — the
+   * frame is a stand-in for a LOADED prototype, which is the state under test.
+   */
+  function renderFramedShell() {
+    render(
+      <ModalShell isOpen onClose={onClose} ariaLabel="Framed dialog">
+        <button>close</button>
+        <iframe title="prototype" />
+        <button>after</button>
+      </ModalShell>,
+    )
+    const frame = screen.getByTitle('prototype')
+    const doc = frame instanceof HTMLIFrameElement ? frame.contentDocument : null
+    if (!doc?.body) throw new Error('no frame document to write the prototype into')
+    doc.body.innerHTML = '<button id="inner-first">inner one</button><button id="inner-last">inner two</button>'
+    /** Raise a key in the FRAME's document, as a browser does for a key pressed inside it. */
+    const pressInFrame = (key: string, shiftKey = false) => {
+      const target = doc.activeElement ?? doc.body
+      target.dispatchEvent(
+        new (doc.defaultView ?? window).KeyboardEvent('keydown', { key, shiftKey, bubbles: true }),
+      )
+    }
+    return { doc, frame, pressInFrame }
+  }
+
+  it('closes on Escape pressed inside the frame', () => {
+    // Without the frame listener this is silent: the reviewer is inside the
+    // artifact, which is where the overlay is meant to be used, and the documented
+    // way out does nothing.
+    const { doc, pressInFrame } = renderFramedShell()
+    doc.getElementById('inner-first')?.focus()
+
+    pressInFrame('Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves Tab alone while it still has somewhere to go inside the frame', () => {
+    // The trap must not fire on every Tab: a prototype is a page of its own, and
+    // yanking a reviewer out of it at the first control would make the overlay
+    // unusable for the thing it exists for.
+    const { doc, pressInFrame } = renderFramedShell()
+    const innerFirst = doc.getElementById('inner-first')
+    innerFirst?.focus()
+
+    pressInFrame('Tab')
+
+    expect(doc.activeElement).toBe(innerFirst)
+    expect(screen.getByRole('button', { name: 'after' })).not.toHaveFocus()
+  })
+
+  it('brings Tab back into the panel from the frame\'s last control', () => {
+    // Where a browser would hand focus to whatever follows the frame — the page
+    // BEHIND the overlay, which for this consumer is a second copy of the same
+    // interactive prototype.
+    const { doc, pressInFrame } = renderFramedShell()
+    doc.getElementById('inner-last')?.focus()
+
+    pressInFrame('Tab')
+
+    expect(screen.getByRole('button', { name: 'after' })).toHaveFocus()
+  })
+
+  it('brings shift-Tab back into the panel from the frame\'s first control', () => {
+    const { doc, pressInFrame } = renderFramedShell()
+    doc.getElementById('inner-first')?.focus()
+
+    pressInFrame('Tab', true)
+
+    expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
+  })
+
+  it('listens to a frame that arrives after the dialog is already open', async () => {
+    // The overlay's frame does not exist on the shell's first commit in every
+    // consumer: content can arrive with a query. A one-shot scan at mount would
+    // cover the prototype overlay and quietly miss those.
+    const user = userEvent.setup()
+    function Late() {
+      const [shown, setShown] = React.useState(false)
+      return (
+        <ModalShell isOpen onClose={onClose} ariaLabel="Late dialog">
+          <button onClick={() => setShown(true)}>load</button>
+          {shown ? <iframe title="late" /> : null}
+        </ModalShell>
+      )
+    }
+    render(<Late />)
+    await user.click(screen.getByRole('button', { name: 'load' }))
+    const frame = screen.getByTitle('late')
+    const doc = frame instanceof HTMLIFrameElement ? frame.contentDocument : null
+    if (!doc?.body) throw new Error('no late frame document')
+
+    doc.body.dispatchEvent(
+      new (doc.defaultView ?? window).KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes only the top-most dialog for Escape raised inside a frame', () => {
+    // The stacking guard is document-position based and must keep working for a key
+    // that arrived through a frame: `ConfirmModal` opens over other modals, and one
+    // Escape closing both is the defect that guard exists for.
+    const onCloseOuter = vi.fn()
+    const onCloseInner = vi.fn()
+    render(
+      <>
+        <ModalShell isOpen onClose={onCloseOuter} ariaLabel="Outer">
+          <button>outer-button</button>
+        </ModalShell>
+        <ModalShell isOpen onClose={onCloseInner} ariaLabel="Inner">
+          <iframe title="inner-frame" />
+        </ModalShell>
+      </>,
+    )
+    const frame = screen.getByTitle('inner-frame')
+    const doc = frame instanceof HTMLIFrameElement ? frame.contentDocument : null
+    if (!doc?.body) throw new Error('no inner frame document')
+
+    doc.body.dispatchEvent(
+      new (doc.defaultView ?? window).KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+
+    expect(onCloseInner).toHaveBeenCalledTimes(1)
+    expect(onCloseOuter).not.toHaveBeenCalled()
+  })
+
+  it('detaches the frame\'s listener when the dialog closes', () => {
+    // The listener lives on a document this shell does not own. Leaking it is not
+    // caught by dispatching a key afterwards — the top-most guard makes a leaked
+    // listener inert, so the only observable is the detach itself, and a page with
+    // one of these per row would otherwise accumulate one per open.
+    const { doc } = renderFramedShell()
+    const removals: unknown[] = []
+    const realRemove = doc.removeEventListener.bind(doc)
+    doc.removeEventListener = (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => {
+      removals.push(type)
+      realRemove(type, listener, options)
+    }
+
+    cleanup()
+
+    expect(removals).toContain('keydown')
   })
 })

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -32,14 +32,22 @@
  * can put it there. That made Escape and the Tab trap inert for the whole useful
  * life of a panel whose content IS a frame (the prototype enlarge overlay, #314).
  * The keydown listener is therefore attached to every same-origin document nested
- * in the panel as well, and re-attached as frames load or arrive.
+ * in the panel as well, at any depth, and re-attached as frames load or arrive.
+ * Each nested document is watched in its own right, because a frame inserted or
+ * navigated INSIDE one is invisible to the panel's own observer — a frame's document
+ * is not part of its embedder's node tree.
  *
  * The trap also has to let Tab move INTO such a frame. Descending into a frame is
  * the browser's DEFAULT action for a Tab pressed while the frame element has focus,
  * so the wrap's `preventDefault()` cancels it — and when the frame is the panel's
  * last focusable, which is the prototype overlay's shape, the wrap fires on exactly
  * that keypress and the frame's content is unreachable by keyboard. See
- * `tabWouldEnterFrame`.
+ * `tabWouldEnterFrame`, which descends only into a frame this shell is actually
+ * listening to, so that the Tab which eventually leaves it is seen.
+ *
+ * Leaving a frame resumes at the item after it in the frame's OWN document, walking
+ * outward and wrapping only at the panel — see `tabOutOfFrame`. Resuming at the panel
+ * from any depth would skip whatever followed a nested frame inside the prototype.
  *
  * A frame the parent cannot reach into — cross-origin, or sandboxed without
  * `allow-same-origin` — keeps the old behaviour in both directions, because there is
@@ -158,6 +166,19 @@ function asFrame(el: Element | null): HTMLIFrameElement | null {
 }
 
 /**
+ * The frame element hosting `doc`, or null when `doc` is not in a frame this page
+ * can reach out of.
+ *
+ * `frameElement` is the only way back OUT of a document: a frame's own document has
+ * no other reference to the element embedding it, and the element belongs to the
+ * PARENT's realm, which is why it goes through `asFrame` rather than a bare
+ * `instanceof`.
+ */
+function hostFrame(doc: Document): HTMLIFrameElement | null {
+  return asFrame(doc.defaultView?.frameElement ?? null)
+}
+
+/**
  * Every same-origin document nested under `root`, at any depth — the documents a
  * keydown can be raised in while focus is somewhere inside this dialog.
  */
@@ -197,33 +218,68 @@ function tabWouldLeave(doc: Document, back: boolean): boolean {
 }
 
 /**
+ * The next focusable OUTSIDE `frame`, walking outward one document at a time.
+ *
+ * A frame is one stop in its own document's order, so leaving it resumes at the item
+ * after it THERE — not at the panel, which is only the right answer when the frame is
+ * a panel focusable. Reading the top document's activeElement instead (which is the
+ * outermost frame element whenever focus is anywhere inside it) collapsed every depth
+ * to the panel's order, so an exit from a frame nested inside the prototype skipped
+ * whatever followed it in the prototype's own document and jumped focus out of the
+ * artifact entirely.
+ *
+ * Recursive rather than a single step because the frame may be its document's last
+ * focusable, in which case leaving it leaves that document too, and so on outward.
+ * The walk terminates at the panel's document, where `items` applies and the edges
+ * wrap — that wrap is the trap, and is the only place one belongs.
+ */
+function tabOutOfFrame(
+  frame: HTMLIFrameElement, items: HTMLElement[], back: boolean,
+): HTMLElement | null {
+  const owner = frame.ownerDocument
+  if (owner === document) {
+    const at = items.indexOf(frame)
+    // A frame not in `items` at all (hidden, or the panel re-rendered under us):
+    // position 0 keeps focus inside the panel rather than guessing.
+    const from = at === -1 ? 0 : at
+    return items[(from + (back ? -1 : 1) + items.length) % items.length]
+  }
+  // See `nestedDocuments` on why `body` is checked despite its non-null type.
+  const siblings = owner.body ? focusable(owner.body) : []
+  const at = siblings.indexOf(frame)
+  // No wrap in an intermediate document: running off its edge means this Tab leaves
+  // that document too, which is the recursion below, not a jump to its other end.
+  const next = siblings[at + (back ? -1 : 1)]
+  if (at !== -1 && next) return next
+  // Nothing after it here either, so this Tab leaves the intermediate document too.
+  const outer = hostFrame(owner)
+  return outer ? tabOutOfFrame(outer, items, back) : items[0]
+}
+
+/**
  * Where Tab should go when the key came from inside a nested frame, or null to
  * leave it to that frame.
  *
  * Inside the frame it is the frame's business: intervening on every Tab would
  * yank a reviewer out of a prototype they are walking through. Only at the frame's
- * own last (or first) control does this take over, and then it steps to the panel
- * item after the frame rather than to the panel's edge — the frame is one stop in
- * the panel's order, not necessarily its final one. `active` is this document's
- * activeElement, which is the `<iframe>` ELEMENT while focus is inside it.
+ * own last (or first) control does this take over, and then it steps to whatever
+ * follows the frame in the frame's OWN document, walking outward to the panel only
+ * when the frame is that document's edge too — see `tabOutOfFrame`.
  */
 function tabAcrossFrame(
-  doc: Document, items: HTMLElement[], active: Element | null, back: boolean,
+  doc: Document, items: HTMLElement[], back: boolean, isListened: (doc: Document) => boolean,
 ): HTMLElement | null {
   // Entry is checked on THIS path too, against `doc`'s own activeElement: a frame
   // nested inside a frame (a generated prototype embedding a map, a video or a docs
   // frame) is that document's last focusable, so it would otherwise be read as an
   // exit and wrapped — cancelling the descent, which is the very defect
-  // `tabWouldEnterFrame` exists to prevent, one level down. Recursion makes the rest
-  // work: `nestedDocuments` attaches to frames at any depth, so the Tab that leaves
-  // the inner frame is seen here in turn.
-  if (tabWouldEnterFrame(doc.activeElement, back)) return null
+  // `tabWouldEnterFrame` exists to prevent, one level down.
+  if (tabWouldEnterFrame(doc.activeElement, back, isListened)) return null
   if (!tabWouldLeave(doc, back)) return null
-  const at = active instanceof HTMLElement ? items.indexOf(active) : -1
-  // A frame nested deeper than the panel's own children is not in `items`; treat
-  // it as position 0, which still keeps focus inside the panel.
-  const from = at === -1 ? 0 : at
-  return items[(from + (back ? -1 : 1) + items.length) % items.length]
+  const frame = hostFrame(doc)
+  // A document with no reachable host frame cannot be stepped out of by position, so
+  // fall back to the panel's first item rather than leaving focus where it is.
+  return frame ? tabOutOfFrame(frame, items, back) : items[0]
 }
 
 /**
@@ -240,16 +296,19 @@ function tabAcrossFrame(
  * inside the artifact keyboard-unreachable — in the dialog that exists to walk
  * through that artifact.
  *
- * Declining here is safe because the frame is not an exit: a Tab at the frame's own
- * last control is raised in the frame's document and `tabAcrossFrame` brings focus
- * back to the panel item after the frame. Focus is inside the dialog throughout.
+ * Declining here is safe only when a Tab inside the frame will come back to us: the
+ * exit is `tabAcrossFrame`, and it runs from a listener on the frame's OWN document.
+ * So the guard requires that document to be one this shell is currently LISTENING to,
+ * not merely one it can read. Readability is necessary but not sufficient — a frame
+ * inserted into another frame's document after that document was scanned is readable
+ * and unlistened, because both re-scan triggers (the MutationObserver on the panel's
+ * subtree, and the capture-phase `load` on the panel) live in the top document and see
+ * neither insertions into a nested document nor `load`s dispatched there. Declining for
+ * one of those let a keyboard user descend into a frame nothing could bring them out
+ * of, with Escape dead too — the trap silently ended at that frame.
  *
- * Only when the frame's content is REACHABLE, though. An opaque frame
- * (cross-origin, or sandboxed without `allow-same-origin`) has no listener of ours
- * inside it, so nothing would bring focus back out and declining would hand the
- * page behind the overlay a keyboard user; the same goes for a frame with nothing
- * focusable in it, where the browser skips straight past to whatever follows.
- * Both keep the wrap.
+ * A frame with nothing focusable in it also keeps the wrap: the browser skips straight
+ * past such a frame to whatever follows, so it is not an entry at all.
  *
  * Backwards is deliberately not included: shift-Tab from a focused frame element
  * moves to what precedes the frame rather than descending, so there is no default
@@ -264,18 +323,26 @@ function tabAcrossFrame(
  * A frame the parent cannot read into is opaque at every depth, so an opaque frame
  * inside a readable one keeps the wrap for the reason above: it would still be a
  * one-way trip.
+ *
+ * @param isListened whether this shell has a keydown listener on a given document —
+ *   i.e. whether an exiting Tab raised inside it would be seen.
  */
-function tabWouldEnterFrame(active: Element | null, back: boolean): boolean {
+function tabWouldEnterFrame(
+  active: Element | null, back: boolean, isListened: (doc: Document) => boolean,
+): boolean {
   const frame = back ? null : asFrame(active)
   if (frame === null) return false
   const doc = frameDocument(frame)
   // See `nestedDocuments` on why `body` is checked despite its non-null type.
-  return doc?.body ? focusable(doc.body).length > 0 : false
+  if (!doc?.body) return false
+  return isListened(doc) && focusable(doc.body).length > 0
 }
 
 /** Where Tab must go to stay in the panel, or null when the panel's own order suffices. */
-function tabWithinPanel(items: HTMLElement[], active: Element | null, back: boolean): HTMLElement | null {
-  if (tabWouldEnterFrame(active, back)) return null
+function tabWithinPanel(
+  items: HTMLElement[], active: Element | null, back: boolean, isListened: (doc: Document) => boolean,
+): HTMLElement | null {
+  if (tabWouldEnterFrame(active, back, isListened)) return null
   const first = items[0]
   const last = items[items.length - 1]
   if (back && active === first) return last
@@ -401,8 +468,8 @@ export default function ModalShell({
       const items = focusable(panel)
       if (items.length === 0) return
       const next = raisedIn === document
-        ? tabWithinPanel(items, document.activeElement, e.shiftKey)
-        : tabAcrossFrame(raisedIn, items, document.activeElement, e.shiftKey)
+        ? tabWithinPanel(items, document.activeElement, e.shiftKey, isListened)
+        : tabAcrossFrame(raisedIn, items, e.shiftKey, isListened)
       if (next === null) return
       e.preventDefault()
       next.focus()
@@ -411,21 +478,48 @@ export default function ModalShell({
     // this page's, plus each same-origin frame's. Without the frames, Escape and
     // the trap go quiet as soon as focus enters one — see NESTED FRAMES above.
     const listening = new Map<Document, (e: KeyboardEvent) => void>()
+    // Read by the Tab handlers: descending into a frame is only safe if a Tab raised
+    // inside it comes back to us, which requires a listener on ITS document.
+    const isListened = (doc: Document) => listening.has(doc)
     /**
      * Attach to any document not already covered. Idempotent, because it runs again
      * whenever the panel's contents change and a frame navigation REPLACES a
      * document rather than mutating it — the old entry is left in place, already
      * unreachable, and detached with the rest on close.
+     *
+     * Each nested document is watched in its OWN right, not just scanned once: a
+     * script in the prototype can insert or navigate a frame inside it, and neither
+     * the observer on the panel's subtree nor the panel's capture-phase `load` sees
+     * that — a frame's internal document is not part of its embedder's node tree, and
+     * a `load` dispatched inside one does not reach the panel. Without this, such a
+     * frame was readable but unlistened, and `tabWouldEnterFrame` would have let a
+     * keyboard user descend into it with nothing to bring them back out.
      */
+    const watching = new Map<Document, MutationObserver>()
+    /**
+     * One stable identity for every re-scan trigger, in this document and in each
+     * nested one, so all of them can be detached again. An arrow rather than a hoisted
+     * `function` because a hoisted declaration is analysed as if it could run before
+     * `panel` was narrowed, and this closes over the narrowed `panel`; it forwards to
+     * `listenToFrames` rather than being it, so the two can refer to each other.
+     */
+    const rescan = () => listenToFrames()
     const listen = (docs: readonly Document[]) => {
       for (const doc of docs) {
         if (listening.has(doc)) continue
         const handler = keyHandlerFor(doc)
         doc.addEventListener('keydown', handler)
         listening.set(doc, handler)
+        // Skipped for `document`, whose triggers are attached to the panel below —
+        // narrower than this whole page's tree, and already in place.
+        if (doc !== document && doc.body) {
+          doc.addEventListener('load', rescan, true)
+          const nested = new MutationObserver(rescan)
+          nested.observe(doc.body, { childList: true, subtree: true })
+          watching.set(doc, nested)
+        }
       }
     }
-    listen([document])
     // A frame's document may not exist yet on this commit — the prototype overlay's
     // frame mounts with the dialog, and other content arrives with a query — so the
     // scan is repeated when the panel's subtree changes and when a frame loads
@@ -437,14 +531,19 @@ export default function ModalShell({
       if (panel.querySelector('iframe') === null) return
       listen(nestedDocuments(panel))
     }
+    listen([document])
     listenToFrames()
-    panel.addEventListener('load', listenToFrames, true)
-    const frames = new MutationObserver(listenToFrames)
+    panel.addEventListener('load', rescan, true)
+    const frames = new MutationObserver(rescan)
     frames.observe(panel, { childList: true, subtree: true })
     return () => {
       frames.disconnect()
-      panel.removeEventListener('load', listenToFrames, true)
-      for (const [doc, handler] of listening) doc.removeEventListener('keydown', handler)
+      panel.removeEventListener('load', rescan, true)
+      for (const observer of watching.values()) observer.disconnect()
+      for (const [doc, handler] of listening) {
+        doc.removeEventListener('keydown', handler)
+        if (doc !== document) doc.removeEventListener('load', rescan, true)
+      }
     }
     // `isOpen` alone: `onClose` and `dismissable` are read through refs, so a
     // consumer's inline arrow does not rebuild the observer and every frame

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -34,10 +34,19 @@
  * The keydown listener is therefore attached to every same-origin document nested
  * in the panel as well, and re-attached as frames load or arrive.
  *
+ * The trap also has to let Tab move INTO such a frame. Descending into a frame is
+ * the browser's DEFAULT action for a Tab pressed while the frame element has focus,
+ * so the wrap's `preventDefault()` cancels it — and when the frame is the panel's
+ * last focusable, which is the prototype overlay's shape, the wrap fires on exactly
+ * that keypress and the frame's content is unreachable by keyboard. See
+ * `tabWouldEnterFrame`.
+ *
  * A frame the parent cannot reach into — cross-origin, or sandboxed without
- * `allow-same-origin` — keeps the old behaviour, because there is no way to
- * observe its keys at all. A consumer embedding one of those must render its own
- * visible dismiss control; nothing here can substitute for it.
+ * `allow-same-origin` — keeps the old behaviour in both directions, because there is
+ * no way to observe its keys at all: its keys are invisible, and letting Tab descend
+ * into it would strand a keyboard user with nothing to bring them back. A consumer
+ * embedding one of those must render its own visible dismiss control; nothing here
+ * can substitute for it.
  *
  * @module components/ModalShell
  */
@@ -181,8 +190,45 @@ function tabAcrossFrame(
   return items[(from + (back ? -1 : 1) + items.length) % items.length]
 }
 
+/**
+ * Whether a forward Tab is about to move focus INTO a frame's own content, and so
+ * must be left to the browser.
+ *
+ * This is the other half of `tabAcrossFrame`, and the one the trap gets wrong by
+ * default. While an `<iframe>` ELEMENT has focus the browser's next Tab descends
+ * into that frame's first control — a default action, so any `preventDefault()`
+ * cancels it. When the frame is the panel's LAST focusable (`[Close, <iframe>]`,
+ * which is exactly the prototype enlarge overlay's shape) the wrap fires on that
+ * very keypress: `active === last`, focus is sent back to the panel's first item,
+ * and the descent never happens. Close ⇄ frame element for ever, with every link
+ * inside the artifact keyboard-unreachable — in the dialog that exists to walk
+ * through that artifact.
+ *
+ * Declining here is safe because the frame is not an exit: a Tab at the frame's own
+ * last control is raised in the frame's document and `tabAcrossFrame` brings focus
+ * back to the panel item after the frame. Focus is inside the dialog throughout.
+ *
+ * Only when the frame's content is REACHABLE, though. An opaque frame
+ * (cross-origin, or sandboxed without `allow-same-origin`) has no listener of ours
+ * inside it, so nothing would bring focus back out and declining would hand the
+ * page behind the overlay a keyboard user; the same goes for a frame with nothing
+ * focusable in it, where the browser skips straight past to whatever follows.
+ * Both keep the wrap.
+ *
+ * Backwards is deliberately not included: shift-Tab from a focused frame element
+ * moves to what precedes the frame rather than descending, so there is no default
+ * action to protect.
+ */
+function tabWouldEnterFrame(active: Element | null, back: boolean): boolean {
+  if (back || !(active instanceof HTMLIFrameElement)) return false
+  const doc = frameDocument(active)
+  // See `nestedDocuments` on why `body` is checked despite its non-null type.
+  return doc?.body ? focusable(doc.body).length > 0 : false
+}
+
 /** Where Tab must go to stay in the panel, or null when the panel's own order suffices. */
 function tabWithinPanel(items: HTMLElement[], active: Element | null, back: boolean): HTMLElement | null {
+  if (tabWouldEnterFrame(active, back)) return null
   const first = items[0]
   const last = items[items.length - 1]
   if (back && active === first) return last

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -25,6 +25,20 @@
  * that is Cancel, deliberately the non-destructive choice). Introducing an
  * `initialFocusRef` would change that, so it is stated here rather than implied.
  *
+ * NESTED FRAMES: a keydown raised inside an `<iframe>`'s own document does NOT
+ * propagate to the embedder — different document, different event target tree — so
+ * a listener on this document alone stops seeing keys the moment focus enters a
+ * frame, and an `<iframe>` is itself in `focusable()`'s selector list, so one Tab
+ * can put it there. That made Escape and the Tab trap inert for the whole useful
+ * life of a panel whose content IS a frame (the prototype enlarge overlay, #314).
+ * The keydown listener is therefore attached to every same-origin document nested
+ * in the panel as well, and re-attached as frames load or arrive.
+ *
+ * A frame the parent cannot reach into — cross-origin, or sandboxed without
+ * `allow-same-origin` — keeps the old behaviour, because there is no way to
+ * observe its keys at all. A consumer embedding one of those must render its own
+ * visible dismiss control; nothing here can substitute for it.
+ *
  * @module components/ModalShell
  */
 import { useEffect, useRef, type ReactNode } from 'react'
@@ -77,6 +91,10 @@ function focusable(root: HTMLElement): HTMLElement[] {
   const candidates = root.querySelectorAll<HTMLElement>(
     'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), iframe, [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], [tabindex]:not([tabindex="-1"])',
   )
+  // Styles are resolved through the element's OWN view, because `root` can be a
+  // nested frame's body (see `tabWouldLeave`) and a document has no obligation to
+  // compute styles for elements it does not own.
+  const styleOf = (el: Element) => (el.ownerDocument.defaultView ?? window).getComputedStyle(el)
   // NB: deliberately not using offsetParent — jsdom does no layout and returns
   // null for every element, which would filter the list empty under test.
   /**
@@ -86,14 +104,90 @@ function focusable(root: HTMLElement): HTMLElement[] {
    * Tab keypress.
    */
   const hiddenByAncestor = (el: HTMLElement): boolean =>
-    getComputedStyle(el).display === 'none' ||
+    styleOf(el).display === 'none' ||
     (el !== root && el.parentElement !== null && hiddenByAncestor(el.parentElement))
   return [...candidates].filter((el) => {
     if (el.closest('[hidden]') !== null || el.closest('[aria-hidden="true"]') !== null) return false
     if (el.closest('details:not([open])') !== null) return false
-    if (getComputedStyle(el).visibility === 'hidden') return false
+    if (styleOf(el).visibility === 'hidden') return false
     return !hiddenByAncestor(el)
   })
+}
+
+/**
+ * The document inside a frame, or null when this page is not allowed to see it.
+ *
+ * Cross-origin frames throw on access, and a `sandbox` without `allow-same-origin`
+ * (how legacy `srcDoc` prototypes are rendered) makes an otherwise same-origin
+ * frame opaque too. Both are unobservable rather than merely awkward: nothing here
+ * can see keys pressed inside them, which is why the header tells consumers
+ * embedding one to render their own visible dismiss control.
+ */
+function frameDocument(frame: HTMLIFrameElement): Document | null {
+  try {
+    return frame.contentDocument
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Every same-origin document nested under `root`, at any depth — the documents a
+ * keydown can be raised in while focus is somewhere inside this dialog.
+ */
+function nestedDocuments(root: HTMLElement): Document[] {
+  return [...root.querySelectorAll('iframe')].flatMap((frame) => {
+    const doc = frameDocument(frame)
+    // Truthiness rather than a null check: `Document['body']` is typed non-null,
+    // but a frame that has not finished loading genuinely has none yet.
+    if (!doc?.body) return []
+    return [doc, ...nestedDocuments(doc.body)]
+  })
+}
+
+/**
+ * Whether a Tab pressed inside `doc` would leave it — i.e. focus is already on
+ * that document's last focusable (or its first, going backwards).
+ *
+ * A frame with nothing focusable counts as leaving: the key cannot move focus
+ * within it, so the browser would hand focus to whatever follows the frame.
+ */
+function tabWouldLeave(doc: Document, back: boolean): boolean {
+  // See `nestedDocuments` on why `body` is checked despite its non-null type.
+  const items = doc.body ? focusable(doc.body) : []
+  if (items.length === 0) return true
+  return doc.activeElement === (back ? items[0] : items[items.length - 1])
+}
+
+/**
+ * Where Tab should go when the key came from inside a nested frame, or null to
+ * leave it to that frame.
+ *
+ * Inside the frame it is the frame's business: intervening on every Tab would
+ * yank a reviewer out of a prototype they are walking through. Only at the frame's
+ * own last (or first) control does this take over, and then it steps to the panel
+ * item after the frame rather than to the panel's edge — the frame is one stop in
+ * the panel's order, not necessarily its final one. `active` is this document's
+ * activeElement, which is the `<iframe>` ELEMENT while focus is inside it.
+ */
+function tabAcrossFrame(
+  doc: Document, items: HTMLElement[], active: Element | null, back: boolean,
+): HTMLElement | null {
+  if (!tabWouldLeave(doc, back)) return null
+  const at = active instanceof HTMLElement ? items.indexOf(active) : -1
+  // A frame nested deeper than the panel's own children is not in `items`; treat
+  // it as position 0, which still keeps focus inside the panel.
+  const from = at === -1 ? 0 : at
+  return items[(from + (back ? -1 : 1) + items.length) % items.length]
+}
+
+/** Where Tab must go to stay in the panel, or null when the panel's own order suffices. */
+function tabWithinPanel(items: HTMLElement[], active: Element | null, back: boolean): HTMLElement | null {
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (back && active === first) return last
+  if (!back && active === last) return first
+  return null
 }
 
 /**
@@ -167,9 +261,17 @@ export default function ModalShell({
 
   useEffect(() => {
     if (!isOpen) return
-    const onKeyDown = (e: KeyboardEvent) => {
-      const panel = panelRef.current
-      if (!panel) return
+    const panel = panelRef.current
+    if (!panel) return
+    /**
+     * The handler as attached to ONE document.
+     *
+     * `raisedIn` is captured rather than read off `e.currentTarget`, because a
+     * frame's Document belongs to the frame's realm: `currentTarget instanceof
+     * Document` is false for it in a real browser, silently treating a frame's
+     * keys as the page's own.
+     */
+    const keyHandlerFor = (raisedIn: Document) => (e: KeyboardEvent) => {
       // Only the top-most open dialog reacts — independent of focus and of the
       // order the shells happened to mount in.
       if (topMostShell() !== panel) return
@@ -182,19 +284,52 @@ export default function ModalShell({
 
       const items = focusable(panel)
       if (items.length === 0) return
-      const first = items[0]
-      const last = items[items.length - 1]
-      const active = document.activeElement
-      if (e.shiftKey && active === first) {
-        e.preventDefault()
-        last.focus()
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault()
-        first.focus()
+      const next = raisedIn === document
+        ? tabWithinPanel(items, document.activeElement, e.shiftKey)
+        : tabAcrossFrame(raisedIn, items, document.activeElement, e.shiftKey)
+      if (next === null) return
+      e.preventDefault()
+      next.focus()
+    }
+    // Every document a key can be raised in while focus is inside this dialog:
+    // this page's, plus each same-origin frame's. Without the frames, Escape and
+    // the trap go quiet as soon as focus enters one — see NESTED FRAMES above.
+    const listening = new Map<Document, (e: KeyboardEvent) => void>()
+    /**
+     * Attach to any document not already covered. Idempotent, because it runs again
+     * whenever the panel's contents change and a frame navigation REPLACES a
+     * document rather than mutating it — the old entry is left in place, already
+     * unreachable, and detached with the rest on close.
+     */
+    const listen = (docs: readonly Document[]) => {
+      for (const doc of docs) {
+        if (listening.has(doc)) continue
+        const handler = keyHandlerFor(doc)
+        doc.addEventListener('keydown', handler)
+        listening.set(doc, handler)
       }
     }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
+    listen([document])
+    // A frame's document may not exist yet on this commit — the prototype overlay's
+    // frame mounts with the dialog, and other content arrives with a query — so the
+    // scan is repeated when the panel's subtree changes and when a frame loads
+    // (`load` does not bubble, but a capture-phase listener on the panel sees it).
+    const listenToFrames = () => {
+      // Cheap negative for the overwhelming majority of dialogs, which hold no frame
+      // at all: this runs on every mutation inside the panel, including the ones a
+      // form's own re-renders produce.
+      if (panel.querySelector('iframe') === null) return
+      listen(nestedDocuments(panel))
+    }
+    listenToFrames()
+    panel.addEventListener('load', listenToFrames, true)
+    const frames = new MutationObserver(listenToFrames)
+    frames.observe(panel, { childList: true, subtree: true })
+    return () => {
+      frames.disconnect()
+      panel.removeEventListener('load', listenToFrames, true)
+      for (const [doc, handler] of listening) doc.removeEventListener('keydown', handler)
+    }
   }, [isOpen, dismissable, onClose])
 
   if (!isOpen) return null

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -222,6 +222,14 @@ function asElement(node: Node): Element | null {
  * `Element` without the cross-realm `instanceof` this exists to avoid or a type
  * assertion the repo bans. `tagName` is realm-independent — `'IFRAME'` in every HTML
  * document — and `Reflect.get` reads it off an unknown without assuming a shape.
+ *
+ * DELIBERATELY STRUCTURAL, and NOT equivalent to `asFrame`, which is constructor-based:
+ * this answers a name, so it would also accept an element in an XML-ish document whose
+ * tag name happens to uppercase to `IFRAME`, and it says nothing about `<frame>` or
+ * `<object>`. That is the intended scope — only `<iframe>` is embedded by anything this
+ * shell renders, and both callers use the answer to decide whether to RE-SCAN, where a
+ * false positive costs one extra walk and `nestedDocuments` settles what is really there.
+ * Where the answer decides focus behaviour instead, `asFrame` is still the one to use.
  */
 function isFrameNode(node: unknown): boolean {
   return typeof node === 'object' && node !== null && Reflect.get(node, 'tagName') === 'IFRAME'
@@ -729,6 +737,27 @@ export default function ModalShell({
      * this consumer: the overlay's panel always holds a frame, so that guard is false
      * exactly when the cost is highest. Only a frame arriving, leaving or loading can
      * change which documents there are to listen to, so only those get a walk.
+     *
+     * ONE REPLACEMENT ROUTE IS SEEN BY NEITHER TRIGGER, unchanged by this filtering but
+     * worth naming here because the filter is where a reader will look for it: a prototype
+     * that rewrites itself through `document.open()`/`write()`/`close()` fires no `load` on
+     * the frame element and produces no childList record this observer can act on.
+     *
+     * Measured in jsdom, and the measurement is misleading in the SAFE direction, so read
+     * the spec rather than the test: `document.open()` REUSES the Document object, and
+     * jsdom leaves our keydown listener attached, so a rewritten prototype keeps working
+     * there. The HTML standard's "document open steps" say otherwise — they erase all
+     * event listeners on each shadow-including INCLUSIVE descendant of the document, the
+     * document itself included. In a compliant browser the object therefore stays in
+     * `listening` while its listener is gone, so `isListened` answers TRUE for a document
+     * nothing is listening to and the entry guard lets Tab descend into a frame that cannot
+     * hand focus back. That fails OPEN, which is the opposite of what it looks like.
+     *
+     * Not fixed here, deliberately: the fix is to stop treating `listening.has(doc)` as
+     * proof of an attached listener (re-assert the stored handler on each scan, and
+     * re-observe when `doc.body` is a different object), which changes this shell's
+     * idempotency contract for every dialog in the app — and jsdom cannot host a test for
+     * either the bug or the fix. Tracked separately rather than smuggled into this round.
      *
      * These three arrows and `listenToFrames` reference each other, so they are `const`
      * arrows read before the line that defines them — legal because nothing here runs

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -442,6 +442,20 @@ export default function ModalShell({
 
   useEffect(() => {
     if (!isOpen) return
+    /**
+     * Captured ONCE per open, and everything below is keyed on it: the top-most check
+     * compares against it, the `load` listener and the MutationObserver attach to it,
+     * and `listenToFrames` searches it.
+     *
+     * Valid for the lifetime of an open dialog because the panel is rendered
+     * unconditionally while open, so React keeps the same DOM node. That became
+     * load-bearing when this effect's deps narrowed to `[isOpen]`: an inline `onClose`
+     * used to re-run it on nearly every render, which refreshed the capture constantly
+     * and made a stale one impossible. What would break it now is unremarkable —
+     * wrapping `{children}` in a conditional, or giving the panel a `key` that changes —
+     * and it would break silently: the observer would watch a detached node and
+     * `topMostShell()` would never match, so Escape and the trap would simply stop.
+     */
     const panel = panelRef.current
     if (!panel) return
     /**

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -35,7 +35,9 @@
  * in the panel as well, at any depth, and re-attached as frames load or arrive.
  * Each nested document is watched in its own right, because a frame inserted or
  * navigated INSIDE one is invisible to the panel's own observer — a frame's document
- * is not part of its embedder's node tree.
+ * is not part of its embedder's node tree. A document that leaves the frame tree is
+ * dropped on the next scan rather than at close, so a prototype swapping an embedded
+ * frame does not accumulate a watcher per swap.
  *
  * The trap also has to let Tab move INTO such a frame. Descending into a frame is
  * the browser's DEFAULT action for a Tab pressed while the frame element has focus,
@@ -97,21 +99,40 @@ type ModalShellNameProps =
 type ModalShellProps = ModalShellBaseProps & ModalShellNameProps
 
 /**
- * Focusable descendants in DOM order, excluding anything not actually reachable.
+ * What can hold focus at all, before asking whether it is actually visible.
+ *
+ * A module constant because the cheap pre-checks in `tabWouldLeave` and
+ * `hasFocusable` need the same candidate set as `focusable` itself — two spellings
+ * of this list would let a control count as an edge in one place and not in the
+ * other.
+ */
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), iframe, [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], [tabindex]:not([tabindex="-1"])'
+
+/** Candidates under `root` in DOM order, unfiltered — visibility is `reachable`'s job. */
+function focusCandidates(root: HTMLElement): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)]
+}
+
+/**
+ * Whether a focus candidate under `root` is actually reachable by Tab.
  *
  * `display:none` must be checked up the ancestor chain: computed `display` of a
  * child inside a hidden container is the child's own value, so checking only the
  * element itself misses the motivating case — collapsible sections hide the
  * container, not each control. `visibility:hidden` inherits, so one check does.
+ *
+ * This is the expensive half — three `closest()` walks plus at least one style
+ * resolution per element, and `hiddenByAncestor` recurses to `root` — which is why
+ * callers that only need "is there one" or "is this an edge" short-circuit rather
+ * than building the whole filtered list. See `tabWouldLeave`.
  */
-function focusable(root: HTMLElement): HTMLElement[] {
-  const candidates = root.querySelectorAll<HTMLElement>(
-    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), iframe, [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], [tabindex]:not([tabindex="-1"])',
-  )
+function reachable(root: HTMLElement, el: HTMLElement): boolean {
   // Styles are resolved through the element's OWN view, because `root` can be a
   // nested frame's body (see `tabWouldLeave`) and a document has no obligation to
   // compute styles for elements it does not own.
-  const styleOf = (el: Element) => (el.ownerDocument.defaultView ?? window).getComputedStyle(el)
+  const styleOf = (target: Element) =>
+    (target.ownerDocument.defaultView ?? window).getComputedStyle(target)
   // NB: deliberately not using offsetParent — jsdom does no layout and returns
   // null for every element, which would filter the list empty under test.
   /**
@@ -120,15 +141,29 @@ function focusable(root: HTMLElement): HTMLElement[] {
    * and without building an intermediate array — this runs per candidate on every
    * Tab keypress.
    */
-  const hiddenByAncestor = (el: HTMLElement): boolean =>
-    styleOf(el).display === 'none' ||
-    (el !== root && el.parentElement !== null && hiddenByAncestor(el.parentElement))
-  return [...candidates].filter((el) => {
-    if (el.closest('[hidden]') !== null || el.closest('[aria-hidden="true"]') !== null) return false
-    if (el.closest('details:not([open])') !== null) return false
-    if (styleOf(el).visibility === 'hidden') return false
-    return !hiddenByAncestor(el)
-  })
+  const hiddenByAncestor = (target: HTMLElement): boolean =>
+    styleOf(target).display === 'none' ||
+    (target !== root && target.parentElement !== null && hiddenByAncestor(target.parentElement))
+  if (el.closest('[hidden]') !== null || el.closest('[aria-hidden="true"]') !== null) return false
+  if (el.closest('details:not([open])') !== null) return false
+  if (styleOf(el).visibility === 'hidden') return false
+  return !hiddenByAncestor(el)
+}
+
+/** Focusable descendants in DOM order, excluding anything not actually reachable. */
+function focusable(root: HTMLElement): HTMLElement[] {
+  return focusCandidates(root).filter((el) => reachable(root, el))
+}
+
+/**
+ * Whether `root` holds anything Tab can reach, without building the list.
+ *
+ * `focusable(root).length > 0` answers the same question, but pays for every
+ * candidate in a document that may be a whole generated prototype page. The first
+ * reachable one settles it.
+ */
+function hasFocusable(root: HTMLElement): boolean {
+  return focusCandidates(root).some((el) => reachable(root, el))
 }
 
 /**
@@ -209,12 +244,41 @@ function nestedDocuments(root: HTMLElement): Document[] {
  * (`nestedDocuments` returns nothing for a body-less document for the same reason).
  * If the two ever need to diverge, `body` alone cannot separate them —
  * `doc.readyState` is what distinguishes "loading" from "complete and empty".
+ *
+ * `doc` here is a whole page rather than a dialog panel, and this runs on EVERY Tab
+ * a reviewer presses while walking through a prototype — where the answer is "no"
+ * for all but the last one. So it is answered WITHOUT building the filtered list:
+ * the question is only whether any reachable control lies beyond the focused one, and
+ * the first one found settles it. Building the list instead resolved styles and ran
+ * three `closest()` walks for every control in the document on each keypress (2800
+ * style resolutions for a 400-control prototype), all of it to answer "no".
+ *
+ * Reachability is still what decides — checking raw DOM position instead would be
+ * wrong, not merely approximate: with the document's last candidate hidden, the last
+ * REACHABLE control is interior to the raw list, and a Tab there does leave.
  */
 function tabWouldLeave(doc: Document, back: boolean): boolean {
   // See `nestedDocuments` on why `body` is checked despite its non-null type.
-  const items = doc.body ? focusable(doc.body) : []
-  if (items.length === 0) return true
-  return doc.activeElement === (back ? items[0] : items[items.length - 1])
+  const body = doc.body
+  if (!body) return true
+  const candidates = focusCandidates(body)
+  const active = doc.activeElement
+  // `findIndex` on identity rather than `indexOf` after an `instanceof HTMLElement`
+  // narrowing: `active` belongs to THIS document's realm, whose `HTMLElement` is a
+  // different constructor object from the page's, so the narrowing is false for every
+  // element in a frame and every position would resolve to -1. Same trap as `asFrame`,
+  // and it failed silently — the trap simply never fired inside a frame.
+  const at = candidates.findIndex((el) => el === active)
+  // Focus is not on a candidate at all — `<body>` itself, or a control this selector
+  // does not cover. It is then not an edge in either direction, so the key remains this
+  // document's business unless there is nothing here to move between at all. That is
+  // what comparing `activeElement` against the edges directly used to say too.
+  if (at === -1) return candidates.length === 0
+  // Whatever the key could still reach inside `doc`, in the direction it is going. One
+  // reachable control among them settles the question, so `some` stops at the first
+  // rather than filtering every control in the document.
+  const ahead = back ? candidates.slice(0, at) : candidates.slice(at + 1)
+  return !ahead.some((el) => reachable(body, el))
 }
 
 /**
@@ -253,6 +317,9 @@ function tabOutOfFrame(
   if (at !== -1 && next) return next
   // Nothing after it here either, so this Tab leaves the intermediate document too.
   const outer = hostFrame(owner)
+  // `items[0]` when the walk runs out of enclosing frames without reaching this
+  // document — see `tabAcrossFrame`'s fallback for the route that produces it and why
+  // moving focus beats declining.
   return outer ? tabOutOfFrame(outer, items, back) : items[0]
 }
 
@@ -277,8 +344,17 @@ function tabAcrossFrame(
   if (tabWouldEnterFrame(doc.activeElement, back, isListened)) return null
   if (!tabWouldLeave(doc, back)) return null
   const frame = hostFrame(doc)
-  // A document with no reachable host frame cannot be stepped out of by position, so
-  // fall back to the panel's first item rather than leaving focus where it is.
+  // No host frame to step out of. Not a modelled state — every document listened to was
+  // found THROUGH a frame element — but it has one route: a frame detached (or navigated)
+  // between the listener being attached and this key being handled, which discards its
+  // browsing context and leaves `defaultView` null. `reap` closes that window on the next
+  // scan, so what remains is the key already in flight.
+  //
+  // The panel's first item rather than `null`, on the same fail-closed reasoning as the
+  // `at === -1` branch in `tabOutOfFrame`: the document this key came from no longer
+  // exists, so declining hands the Tab to a browser with nowhere sensible to put focus —
+  // which means outside the dialog. A wrong stop inside the panel is recoverable with
+  // another Tab; leaving the dialog is not.
   return frame ? tabOutOfFrame(frame, items, back) : items[0]
 }
 
@@ -335,7 +411,9 @@ function tabWouldEnterFrame(
   const doc = frameDocument(frame)
   // See `nestedDocuments` on why `body` is checked despite its non-null type.
   if (!doc?.body) return false
-  return isListened(doc) && focusable(doc.body).length > 0
+  // `hasFocusable` rather than `focusable(...).length`: this also runs per keypress
+  // over a whole prototype document, and one reachable control answers it.
+  return isListened(doc) && hasFocusable(doc.body)
 }
 
 /** Where Tab must go to stay in the panel, or null when the panel's own order suffices. */
@@ -497,9 +575,9 @@ export default function ModalShell({
     const isListened = (doc: Document) => listening.has(doc)
     /**
      * Attach to any document not already covered. Idempotent, because it runs again
-     * whenever the panel's contents change and a frame navigation REPLACES a
-     * document rather than mutating it — the old entry is left in place, already
-     * unreachable, and detached with the rest on close.
+     * whenever the panel's contents change; a frame navigation REPLACES a document
+     * rather than mutating it, so the new one is picked up here and the old one is
+     * dropped by `reap`.
      *
      * Each nested document is watched in its OWN right, not just scanned once: a
      * script in the prototype can insert or navigate a frame inside it, and neither
@@ -526,6 +604,31 @@ export default function ModalShell({
         }
       }
     }
+    /** Undo everything `listen` attached for one document. */
+    const forget = (doc: Document) => {
+      const handler = listening.get(doc)
+      if (handler) doc.removeEventListener('keydown', handler)
+      listening.delete(doc)
+      watching.get(doc)?.disconnect()
+      watching.delete(doc)
+      if (doc !== document) doc.removeEventListener('load', listenToFrames, true)
+    }
+    /**
+     * Drop the documents that are no longer in the panel's frame tree.
+     *
+     * A frame that is REPLACED or navigated leaves its old document unreachable but
+     * still attached to, and a `MutationObserver` is not something to leave for the
+     * dialog's whole open lifetime: it holds the detached body it watches alive, and a
+     * prototype that swaps an embedded frame accumulated one per swap. Reaping also
+     * keeps `isListened` honest, which the Tab guards depend on — a document that is
+     * gone must not read as a safe place to send focus.
+     */
+    const reap = (live: readonly Document[]) => {
+      const keep = new Set(live)
+      for (const doc of [...listening.keys()]) {
+        if (doc !== document && !keep.has(doc)) forget(doc)
+      }
+    }
     // A frame's document may not exist yet on this commit — the prototype overlay's
     // frame mounts with the dialog, and other content arrives with a query — so the
     // scan is repeated when the panel's subtree changes and when a frame loads
@@ -533,9 +636,12 @@ export default function ModalShell({
     const listenToFrames = () => {
       // Cheap negative for the overwhelming majority of dialogs, which hold no frame
       // at all: this runs on every mutation inside the panel, including the ones a
-      // form's own re-renders produce.
-      if (panel.querySelector('iframe') === null) return
-      listen(nestedDocuments(panel))
+      // form's own re-renders produce. Nothing to reap for those either — `listening`
+      // holds only `document` until a frame is found.
+      if (panel.querySelector('iframe') === null && listening.size <= 1) return
+      const live = nestedDocuments(panel)
+      reap(live)
+      listen(live)
     }
     listen([document])
     listenToFrames()
@@ -545,11 +651,9 @@ export default function ModalShell({
     return () => {
       frames.disconnect()
       panel.removeEventListener('load', listenToFrames, true)
-      for (const observer of watching.values()) observer.disconnect()
-      for (const [doc, handler] of listening) {
-        doc.removeEventListener('keydown', handler)
-        if (doc !== document) doc.removeEventListener('load', listenToFrames, true)
-      }
+      // Through `forget`, so a document detached here and one reaped mid-open are
+      // undone by the same code and cannot drift apart.
+      for (const doc of [...listening.keys()]) forget(doc)
     }
     // `isOpen` alone: `onClose` and `dismissable` are read through refs, so a
     // consumer's inline arrow does not rebuild the observer and every frame

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -201,6 +201,47 @@ function asFrame(el: Element | null): HTMLIFrameElement | null {
 }
 
 /**
+ * `node` as an element, resolved in the node's OWN realm — `asFrame` one type up.
+ *
+ * Needed because the mutation filter is handed `Node`s, and the nodes moved inside a
+ * prototype belong to its realm: a plain `node instanceof Element` is false for every
+ * one of them, so a filter built on it would quietly pass nothing through and the frame
+ * bookkeeping would stop happening. A `Document` has no `ownerDocument`, and is not an
+ * element either, so the page's constructor is a safe fallback that answers null.
+ */
+function asElement(node: Node): Element | null {
+  const ctor = node.ownerDocument?.defaultView?.Element ?? Element
+  return node instanceof ctor ? node : null
+}
+
+/**
+ * Whether a node is a frame element, decided without narrowing it first.
+ *
+ * `asFrame` needs an `Element`, and the two callers here hold an `EventTarget` (a
+ * `load`'s target) and a `Node` (a mutation record's), neither of which narrows to
+ * `Element` without the cross-realm `instanceof` this exists to avoid or a type
+ * assertion the repo bans. `tagName` is realm-independent — `'IFRAME'` in every HTML
+ * document — and `Reflect.get` reads it off an unknown without assuming a shape.
+ */
+function isFrameNode(node: unknown): boolean {
+  return typeof node === 'object' && node !== null && Reflect.get(node, 'tagName') === 'IFRAME'
+}
+
+/**
+ * Whether a moved node IS a frame or CONTAINS one.
+ *
+ * Both halves matter: `body.innerHTML = '<div><iframe/></div>'` reports the DIV as the
+ * added node, which is the shape a prototype's own script produces, so asking only about
+ * the node itself would miss the frame it brought with it and leave that document
+ * unlistened.
+ */
+function holdsFrame(node: Node): boolean {
+  if (isFrameNode(node)) return true
+  const el = asElement(node)
+  return el !== null && el.querySelector('iframe') !== null
+}
+
+/**
  * The frame element hosting `doc`, or null when `doc` is not in a frame this page
  * can reach out of.
  *
@@ -271,9 +312,24 @@ function tabWouldLeave(doc: Document, back: boolean): boolean {
   const at = candidates.findIndex((el) => el === active)
   // Focus is not on a candidate at all — `<body>` itself, or a control this selector
   // does not cover. It is then not an edge in either direction, so the key remains this
-  // document's business unless there is nothing here to move between at all. That is
-  // what comparing `activeElement` against the edges directly used to say too.
-  if (at === -1) return candidates.length === 0
+  // document's business unless there is nothing here Tab can REACH at all.
+  //
+  // REACHABLE, not raw, and that distinction is the whole of this branch. Both reviewers
+  // caught the refactor getting it wrong: a generated prototype's unopened modal or
+  // inactive screen lives in a `display:none` container, so its controls exist as
+  // candidates while none of them can be tabbed to. `candidates.length === 0` then
+  // answers "there is something here to move between", the shell declines to intervene,
+  // and the browser moves focus past the frame into the page behind the dialog — the
+  // very escape `tabWouldEnterFrame` prevents on the frame-element path via
+  // `hasFocusable`, reached instead through the in-frame keydown path once a click has
+  // put focus inside the prototype. Reproduced in jsdom before fixing: raw 2, reachable
+  // 0, where the pre-refactor `focusable(body).length === 0` correctly said "leaving".
+  //
+  // `some` over the list already built, rather than `hasFocusable(body)` — which is the
+  // same predicate and reads as the tidier call, but re-runs `querySelectorAll` over a
+  // whole prototype document that `candidates` has just walked. Keeping the short-circuit
+  // without paying for a second query is the point of this branch's shape.
+  if (at === -1) return !candidates.some((el) => reachable(body, el))
   // Whatever the key could still reach inside `doc`, in the direction it is going. One
   // reachable control among them settles the question, so `some` stops at the first
   // rather than filtering every control in the document.
@@ -529,10 +585,17 @@ export default function ModalShell({
      * unconditionally while open, so React keeps the same DOM node. That became
      * load-bearing when this effect's deps narrowed to `[isOpen]`: an inline `onClose`
      * used to re-run it on nearly every render, which refreshed the capture constantly
-     * and made a stale one impossible. What would break it now is unremarkable —
-     * wrapping `{children}` in a conditional, or giving the panel a `key` that changes —
-     * and it would break silently: the observer would watch a detached node and
-     * `topMostShell()` would never match, so Escape and the trap would simply stop.
+     * and made a stale one impossible. What would break it now is unremarkable — giving
+     * the panel a `key` that changes, or making the panel `<div>` itself conditional so
+     * React unmounts and remounts it — and it would break silently: the observer would
+     * watch a detached node and `topMostShell()` would never match, so Escape and the trap
+     * would simply stop.
+     *
+     * NOT `{children}` becoming conditional, which an earlier draft of this comment named:
+     * `panelRef` is on the panel `<div>` and `{children}` renders inside it, so emptying
+     * the children leaves the same element mounted and the capture stays valid. Review
+     * caught the wrong example, and a wrong example in a comment about an invariant is
+     * worse than none — it teaches the next reader to guard the wrong edit.
      */
     const panel = panelRef.current
     if (!panel) return
@@ -597,8 +660,8 @@ export default function ModalShell({
         // Skipped for `document`, whose triggers are attached to the panel below —
         // narrower than this whole page's tree, and already in place.
         if (doc !== document && doc.body) {
-          doc.addEventListener('load', listenToFrames, true)
-          const nested = new MutationObserver(listenToFrames)
+          doc.addEventListener('load', onFrameLoad, true)
+          const nested = new MutationObserver(onFrameMutation)
           nested.observe(doc.body, { childList: true, subtree: true })
           watching.set(doc, nested)
         }
@@ -611,7 +674,7 @@ export default function ModalShell({
       listening.delete(doc)
       watching.get(doc)?.disconnect()
       watching.delete(doc)
-      if (doc !== document) doc.removeEventListener('load', listenToFrames, true)
+      if (doc !== document) doc.removeEventListener('load', onFrameLoad, true)
     }
     /**
      * Drop the documents that are no longer in the panel's frame tree.
@@ -622,6 +685,16 @@ export default function ModalShell({
      * prototype that swaps an embedded frame accumulated one per swap. Reaping also
      * keeps `isListened` honest, which the Tab guards depend on — a document that is
      * gone must not read as a safe place to send focus.
+     *
+     * `live` is narrower than "still in the frame tree", and review was right to name it:
+     * it is what `nestedDocuments` could READ on this pass, which also excludes a frame
+     * that is merely mid-navigation or mid-`document.write` and has no `body` yet. Such a
+     * document is dropped here and re-listened on its next `load`, so there is a window
+     * where a LIVE frame reads as unlistened. That window fails closed — the entry guard
+     * declines to descend and Tab wraps into the panel instead — which is why this is
+     * recorded rather than fixed. Discriminating the two states would mean asking
+     * `doc.defaultView === null` for "really gone", and buying a narrower reap with a
+     * second notion of liveness is a worse trade than a wrap that is momentarily early.
      */
     const reap = (live: readonly Document[]) => {
       const keep = new Set(live)
@@ -643,14 +716,42 @@ export default function ModalShell({
       reap(live)
       listen(live)
     }
+    /**
+     * The two triggers, FILTERED. Review found both unfiltered, and both re-ran the
+     * recursive `nestedDocuments(panel)` walk for events that cannot change the answer:
+     *
+     *  - a capture-phase `load` on a prototype's own document fires for every image,
+     *    script and stylesheet in it, so a page with 200 assets paid 200 walks;
+     *  - the observer's callback took no arguments, so it ignored its records — any text
+     *    edit, class toggle or re-render anywhere inside the prototype re-walked the tree.
+     *
+     * The cheap `panel.querySelector('iframe')` negative in `listenToFrames` does not help
+     * this consumer: the overlay's panel always holds a frame, so that guard is false
+     * exactly when the cost is highest. Only a frame arriving, leaving or loading can
+     * change which documents there are to listen to, so only those get a walk.
+     *
+     * These three arrows and `listenToFrames` reference each other, so they are `const`
+     * arrows read before the line that defines them — legal because nothing here runs
+     * until an event fires, and kept mutually referential on purpose: making any of them
+     * a hoisted `function` would put the pair on two different declaration styles for no
+     * reason, and inlining them into the `addEventListener` calls would break `forget`,
+     * which needs the identical reference to detach.
+     */
+    const onFrameLoad = (e: Event) => {
+      if (isFrameNode(e.target)) listenToFrames()
+    }
+    const onFrameMutation = (records: readonly MutationRecord[]) => {
+      const moved = (nodes: NodeList) => [...nodes].some(holdsFrame)
+      if (records.some((r) => moved(r.addedNodes) || moved(r.removedNodes))) listenToFrames()
+    }
     listen([document])
     listenToFrames()
-    panel.addEventListener('load', listenToFrames, true)
-    const frames = new MutationObserver(listenToFrames)
+    panel.addEventListener('load', onFrameLoad, true)
+    const frames = new MutationObserver(onFrameMutation)
     frames.observe(panel, { childList: true, subtree: true })
     return () => {
       frames.disconnect()
-      panel.removeEventListener('load', listenToFrames, true)
+      panel.removeEventListener('load', onFrameLoad, true)
       // Through `forget`, so a document detached here and one reaped mid-open are
       // undone by the same code and cannot drift apart.
       for (const doc of [...listening.keys()]) forget(doc)

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -753,11 +753,12 @@ export default function ModalShell({
      * nothing is listening to and the entry guard lets Tab descend into a frame that cannot
      * hand focus back. That fails OPEN, which is the opposite of what it looks like.
      *
-     * Not fixed here, deliberately: the fix is to stop treating `listening.has(doc)` as
-     * proof of an attached listener (re-assert the stored handler on each scan, and
-     * re-observe when `doc.body` is a different object), which changes this shell's
-     * idempotency contract for every dialog in the app — and jsdom cannot host a test for
-     * either the bug or the fix. Tracked separately rather than smuggled into this round.
+     * Not fixed here, deliberately, and tracked as **issue #386**: the fix is to stop
+     * treating `listening.has(doc)` as proof of an attached listener (re-assert the stored
+     * handler on each scan, and re-observe when `doc.body` is a different object), which
+     * changes this shell's idempotency contract for every dialog in the app — and jsdom
+     * cannot host a test for either the bug or the fix, so it cannot ship with a guard that
+     * fails on revert. #386 carries the browser reproduction and the spec citation.
      *
      * These three arrows and `listenToFrames` reference each other, so they are `const`
      * arrows read before the line that defines them — legal because nothing here runs

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -141,6 +141,23 @@ function frameDocument(frame: HTMLIFrameElement): Document | null {
 }
 
 /**
+ * `el` as a frame, or null if it is not one.
+ *
+ * The realm-aware `instanceof`, and it has to be: an element inside a frame belongs
+ * to the FRAME's realm, whose `HTMLIFrameElement` is a different constructor object
+ * from this document's, so a plain `el instanceof HTMLIFrameElement` is false for a
+ * frame nested inside another frame. That is the same trap `raisedIn` avoids for
+ * `Document` in the keydown handler, and it fails in the direction that hurts: the
+ * frame is silently treated as an ordinary element, so `tabWouldEnterFrame` declines
+ * and the descent is cancelled.
+ */
+function asFrame(el: Element | null): HTMLIFrameElement | null {
+  if (el === null) return null
+  const ctor = el.ownerDocument.defaultView?.HTMLIFrameElement ?? HTMLIFrameElement
+  return el instanceof ctor ? el : null
+}
+
+/**
  * Every same-origin document nested under `root`, at any depth — the documents a
  * keydown can be raised in while focus is somewhere inside this dialog.
  */
@@ -160,6 +177,17 @@ function nestedDocuments(root: HTMLElement): Document[] {
  *
  * A frame with nothing focusable counts as leaving: the key cannot move focus
  * within it, so the browser would hand focus to whatever follows the frame.
+ *
+ * That covers two states the DOM cannot tell apart, deliberately treated alike.
+ * A frame LOADED with no controls in it is the case above. A frame still loading
+ * has no `body` yet, and so reaches the same answer by a different route — a Tab in
+ * those first moments is treated as an exit and wrapped back into the panel rather
+ * than allowed to descend into a document that does not exist. That is the safe
+ * reading of both: there is nothing to descend into either way, and it self-corrects
+ * on `load`, which is also when the frame's own listener is attached
+ * (`nestedDocuments` returns nothing for a body-less document for the same reason).
+ * If the two ever need to diverge, `body` alone cannot separate them —
+ * `doc.readyState` is what distinguishes "loading" from "complete and empty".
  */
 function tabWouldLeave(doc: Document, back: boolean): boolean {
   // See `nestedDocuments` on why `body` is checked despite its non-null type.
@@ -182,6 +210,14 @@ function tabWouldLeave(doc: Document, back: boolean): boolean {
 function tabAcrossFrame(
   doc: Document, items: HTMLElement[], active: Element | null, back: boolean,
 ): HTMLElement | null {
+  // Entry is checked on THIS path too, against `doc`'s own activeElement: a frame
+  // nested inside a frame (a generated prototype embedding a map, a video or a docs
+  // frame) is that document's last focusable, so it would otherwise be read as an
+  // exit and wrapped — cancelling the descent, which is the very defect
+  // `tabWouldEnterFrame` exists to prevent, one level down. Recursion makes the rest
+  // work: `nestedDocuments` attaches to frames at any depth, so the Tab that leaves
+  // the inner frame is seen here in turn.
+  if (tabWouldEnterFrame(doc.activeElement, back)) return null
   if (!tabWouldLeave(doc, back)) return null
   const at = active instanceof HTMLElement ? items.indexOf(active) : -1
   // A frame nested deeper than the panel's own children is not in `items`; treat
@@ -218,10 +254,21 @@ function tabAcrossFrame(
  * Backwards is deliberately not included: shift-Tab from a focused frame element
  * moves to what precedes the frame rather than descending, so there is no default
  * action to protect.
+ *
+ * Consulted on BOTH Tab paths, against whichever document raised the key: from
+ * `tabWithinPanel` for a frame that is a panel focusable, and from `tabAcrossFrame`
+ * for one nested inside another frame's document. The two are the same defect at
+ * different depths — a prototype is generated HTML and may embed a frame of its own
+ * without anyone choosing to — so the guard is not scoped to the panel's own level.
+ *
+ * A frame the parent cannot read into is opaque at every depth, so an opaque frame
+ * inside a readable one keeps the wrap for the reason above: it would still be a
+ * one-way trip.
  */
 function tabWouldEnterFrame(active: Element | null, back: boolean): boolean {
-  if (back || !(active instanceof HTMLIFrameElement)) return false
-  const doc = frameDocument(active)
+  const frame = back ? null : asFrame(active)
+  if (frame === null) return false
+  const doc = frameDocument(frame)
   // See `nestedDocuments` on why `body` is checked despite its non-null type.
   return doc?.body ? focusable(doc.body).length > 0 : false
 }
@@ -278,6 +325,27 @@ export default function ModalShell({
 }: ModalShellProps) {
   const panelRef = useRef<HTMLDivElement>(null)
 
+  /**
+   * The latest `onClose` and `dismissable`, read through a ref by the keydown
+   * handler so that the listener wiring below can depend on `isOpen` alone.
+   *
+   * Consumers pass `onClose` as an inline arrow — `PrototypeEnlargeButton` does, and
+   * so does most of this shell's usage — which is a fresh identity on every render.
+   * With those in the effect's deps, ONE re-render of the component holding an open
+   * dialog tore down and rebuilt everything the effect owns: the MutationObserver,
+   * the capture-phase `load` listener, and a keydown listener on every nested frame
+   * document. Symmetric, so nothing leaked, but it walked the frame tree per render
+   * and left a brief window with no listener attached — under a page that re-renders
+   * while an overlay is open (a query refetch, a slider move, the hourly re-signing
+   * this overlay exists to survive), that window recurs indefinitely.
+   */
+  const onCloseRef = useRef(onClose)
+  const dismissableRef = useRef(dismissable)
+  useEffect(() => {
+    onCloseRef.current = onClose
+    dismissableRef.current = dismissable
+  }, [onClose, dismissable])
+
   // Move focus into the dialog on open, and restore it to whatever opened the
   // dialog on close — otherwise keyboard users are dropped at the top of the page.
   useEffect(() => {
@@ -323,7 +391,9 @@ export default function ModalShell({
       if (topMostShell() !== panel) return
 
       if (e.key === 'Escape') {
-        if (dismissable) onClose()
+        // Through the refs, so this handler never has to be rebuilt to see a new
+        // `onClose` — see the refs' comment on what rebuilding it costs.
+        if (dismissableRef.current) onCloseRef.current()
         return
       }
       if (e.key !== 'Tab') return
@@ -376,7 +446,10 @@ export default function ModalShell({
       panel.removeEventListener('load', listenToFrames, true)
       for (const [doc, handler] of listening) doc.removeEventListener('keydown', handler)
     }
-  }, [isOpen, dismissable, onClose])
+    // `isOpen` alone: `onClose` and `dismissable` are read through refs, so a
+    // consumer's inline arrow does not rebuild the observer and every frame
+    // listener on each of its renders.
+  }, [isOpen])
 
   if (!isOpen) return null
 

--- a/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
+++ b/voc-datalake/frontend/src/components/ModalShell/ModalShell.tsx
@@ -510,14 +510,6 @@ export default function ModalShell({
      * keyboard user descend into it with nothing to bring them back out.
      */
     const watching = new Map<Document, MutationObserver>()
-    /**
-     * One stable identity for every re-scan trigger, in this document and in each
-     * nested one, so all of them can be detached again. An arrow rather than a hoisted
-     * `function` because a hoisted declaration is analysed as if it could run before
-     * `panel` was narrowed, and this closes over the narrowed `panel`; it forwards to
-     * `listenToFrames` rather than being it, so the two can refer to each other.
-     */
-    const rescan = () => listenToFrames()
     const listen = (docs: readonly Document[]) => {
       for (const doc of docs) {
         if (listening.has(doc)) continue
@@ -527,8 +519,8 @@ export default function ModalShell({
         // Skipped for `document`, whose triggers are attached to the panel below —
         // narrower than this whole page's tree, and already in place.
         if (doc !== document && doc.body) {
-          doc.addEventListener('load', rescan, true)
-          const nested = new MutationObserver(rescan)
+          doc.addEventListener('load', listenToFrames, true)
+          const nested = new MutationObserver(listenToFrames)
           nested.observe(doc.body, { childList: true, subtree: true })
           watching.set(doc, nested)
         }
@@ -547,16 +539,16 @@ export default function ModalShell({
     }
     listen([document])
     listenToFrames()
-    panel.addEventListener('load', rescan, true)
-    const frames = new MutationObserver(rescan)
+    panel.addEventListener('load', listenToFrames, true)
+    const frames = new MutationObserver(listenToFrames)
     frames.observe(panel, { childList: true, subtree: true })
     return () => {
       frames.disconnect()
-      panel.removeEventListener('load', rescan, true)
+      panel.removeEventListener('load', listenToFrames, true)
       for (const observer of watching.values()) observer.disconnect()
       for (const [doc, handler] of listening) {
         doc.removeEventListener('keydown', handler)
-        if (doc !== document) doc.removeEventListener('load', rescan, true)
+        if (doc !== document) doc.removeEventListener('load', listenToFrames, true)
       }
     }
     // `isOpen` alone: `onClose` and `dismissable` are read through refs, so a

--- a/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
+++ b/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
@@ -119,7 +119,29 @@ export function HtmlPrototypeFrame({
   )
 }
 
-export default function PrototypeRenderer({ spec }: { readonly spec: PrototypeSpec }) {
+/**
+ * The measure a spec prototype is laid out on when the caller does not say.
+ *
+ * A generated spec is prose, forms and lists — a document, not a canvas — so it is
+ * capped at a readable column and centred rather than stretched across whatever
+ * width it is given. Callers embedding it in a narrow pane never notice, because the
+ * pane is the tighter constraint; a caller that really does have the screen (the
+ * prioritization enlarge overlay) passes its own.
+ */
+const DEFAULT_SPEC_MEASURE = 'max-w-2xl mx-auto'
+
+/**
+ * @param className replaces the default measure (`max-w-2xl mx-auto`) — not added
+ *   to it, so a caller can widen the column rather than fight a cap it cannot see.
+ *   Omit it everywhere the artifact is embedded; the default is what the Documents
+ *   tab and the prioritization row's pane get, byte for byte.
+ */
+export default function PrototypeRenderer({
+  spec, className,
+}: {
+  readonly spec: PrototypeSpec
+  readonly className?: string
+}) {
   const screens = useMemo(
     () => spec.screens.filter((s) => s && typeof s.id === 'string'),
     [spec.screens],
@@ -137,7 +159,7 @@ export default function PrototypeRenderer({ spec }: { readonly spec: PrototypeSp
   const active = screens.find((s) => s.id === activeId) ?? screens[0]
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className={className ?? DEFAULT_SPEC_MEASURE}>
       {spec.banner ? (
         <div className="bg-amber-100 text-amber-900 text-xs text-center py-1.5 rounded-md mb-3 font-medium">
           {spec.banner}

--- a/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
+++ b/voc-datalake/frontend/src/components/PrototypeRenderer.tsx
@@ -131,16 +131,22 @@ export function HtmlPrototypeFrame({
 const DEFAULT_SPEC_MEASURE = 'max-w-2xl mx-auto'
 
 /**
- * @param className replaces the default measure (`max-w-2xl mx-auto`) — not added
- *   to it, so a caller can widen the column rather than fight a cap it cannot see.
- *   Omit it everywhere the artifact is embedded; the default is what the Documents
- *   tab and the prioritization row's pane get, byte for byte.
+ * @param measureClassName REPLACES the default measure (`max-w-2xl mx-auto`) rather
+ *   than being added to it, so a caller can widen the column instead of fighting a
+ *   cap it cannot reach — with both classes on the element, Tailwind's output order
+ *   and not the argument order would decide, and the cap would be unwidenable.
+ *
+ *   Named for the measure rather than called `className` because that name reads as
+ *   the conventional additive one, and a caller passing only spacing would silently
+ *   drop `mx-auto` and un-centre the artifact. Omit it everywhere the artifact is
+ *   embedded; the default is what the Documents tab and the prioritization row's pane
+ *   get, byte for byte.
  */
 export default function PrototypeRenderer({
-  spec, className,
+  spec, measureClassName,
 }: {
   readonly spec: PrototypeSpec
-  readonly className?: string
+  readonly measureClassName?: string
 }) {
   const screens = useMemo(
     () => spec.screens.filter((s) => s && typeof s.id === 'string'),
@@ -159,7 +165,7 @@ export default function PrototypeRenderer({
   const active = screens.find((s) => s.id === activeId) ?? screens[0]
 
   return (
-    <div className={className ?? DEFAULT_SPEC_MEASURE}>
+    <div className={measureClassName ?? DEFAULT_SPEC_MEASURE}>
       {spec.banner ? (
         <div className="bg-amber-100 text-amber-900 text-xs text-center py-1.5 rounded-md mb-3 font-medium">
           {spec.banner}

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -15,6 +15,7 @@ import PrototypeLinkActions, { PrototypeLinkLifetimeNote } from '../../component
 import PrototypeRenderer, { HtmlPrototypeFrame } from '../../components/PrototypeRenderer'
 import { parsePrototypeSpec, looksLikeHtmlDocument } from '../../components/prototypeSpec'
 import LinkedFormEvidence from './LinkedFormEvidence'
+import PrototypeEnlargeButton from './PrototypeEnlargeButton'
 import RoomVotePanel from './RoomVotePanel'
 import {
   getPriorityLabel, MAX_NOTE_LENGTH, reviewersDisagreed, SCORABLE_TYPE_META, teamScoreOf,
@@ -546,20 +547,70 @@ function resolvePrototypeMode(
 }
 
 /**
+ * The prototype panel's heading, and the two things a reader can do about a pane
+ * this size.
+ *
+ * Split out of `PrototypePanel` because that function's branch count is capped by
+ * eslint's `complexity` rule at 12 and adding the enlarge control put it at 13. A
+ * genuine seam rather than an appeasement: everything here is about the AFFORDANCES,
+ * and everything left there is about resolving which artifact to render.
+ *
+ * "Open in new tab" appears only with a `prototype_url` to open — a legacy
+ * prototype is inline HTML with no address, and the blob indirection the Documents
+ * tab uses for those is not worth carrying onto a page that lists every project.
+ * The deadline beneath it is stated rather than implied, because that URL is a
+ * signed session credential (see components/PrototypeLinkActions); the page
+ * schedules its own re-signing in `Prioritization.tsx`, without which the link
+ * would 403 for anyone who parks a pitch on screen for an hour.
+ *
+ * "Enlarge" appears for EVERY prototype the panel renders, url or not: it
+ * re-renders the pane the row is already showing and needs no address of its own,
+ * so a legacy inline prototype and a JSON spec enlarge exactly as well as a signed
+ * one. It sits beside the anchor because the two answer the same question — "I
+ * cannot see this properly" — and a reader comparing them should not have to find
+ * them in different places.
+ *
+ * @param enlarged the prototype as the overlay should render it: the row's own
+ *   pane element in a box that fills the dialog.
+ */
+function PrototypePanelHeader({
+  url, noteId, documentTitle, enlarged, t,
+}: {
+  readonly url?: string
+  readonly noteId: string
+  readonly documentTitle?: string
+  readonly enlarged: ReactElement
+  readonly t: TFunction
+}): ReactElement {
+  return (
+    <>
+      <div className="flex items-center justify-between mt-2 gap-3">
+        <h4 className="font-medium text-gray-900 flex items-center gap-1.5">
+          <Wand2 size={14} className="text-orange-500" />
+          {t('preview.prototypeTitle', { defaultValue: 'Prototype' })}
+        </h4>
+        <span className="flex items-center gap-3 text-xs flex-shrink-0">
+          {url ? <PrototypeLinkActions url={url} noteId={noteId} /> : null}
+          <PrototypeEnlargeButton documentTitle={documentTitle}>{enlarged}</PrototypeEnlargeButton>
+        </span>
+      </div>
+      {/* Under the link, not beside it: this column is half a row wide, and the
+          note wraps rather than truncates — the clipped end would be the warning. */}
+      {url ? <PrototypeLinkLifetimeNote url={url} noteId={noteId} className="mt-1 text-xs" /> : null}
+    </>
+  )
+}
+
+/**
  * Renders a project's latest prototype under the PR/FAQ preview. Chooses the
  * iframe (HTML format) or the native JSON-spec renderer, or renders nothing
  * when there's no usable prototype.
  *
  * The embedded frame is 384px tall inside half a row — enough to recognise the
- * prototype, not enough to walk a room through it — so this also offers it in a
- * new tab. Only when there is a `prototype_url` to open: a legacy prototype is
- * inline HTML with no address, and the blob indirection the Documents tab uses for
- * those is not worth carrying onto a page that lists every project.
- *
- * The deadline is stated next to the link rather than left implied, because that
- * URL is a signed session credential — see components/PrototypeLinkActions. The
- * page schedules its own re-signing (`Prioritization.tsx`); without that the link
- * below would 403 for anyone who parks a pitch on screen for an hour.
+ * prototype, not enough to walk a room through it — so the header above it offers
+ * the artifact bigger, two ways: out of the app in a new tab, and filling the
+ * viewport in place. See `PrototypePanelHeader` for which of those a given
+ * prototype gets and why.
  */
 function PrototypePanel({
   prototype, t,
@@ -580,29 +631,47 @@ function PrototypePanel({
     [url, content, protoFormat],
   )
   if (mode.kind === 'none') return null
+  /**
+   * The artifact itself, described once and rendered in two boxes: the row's
+   * 384px pane and the enlarge overlay's full-viewport one.
+   *
+   * One description rather than two, because the sizing lives on the CONTAINER —
+   * this frame is `w-full h-full` either way. A second `HtmlPrototypeFrame` call
+   * written for the overlay would be free to drift from this one, and the thing it
+   * would drift away from is `useLoadedUrl`: the handling that lets a re-signed URL
+   * through without reloading the frame under a reviewer, and lets an already-dead
+   * one be replaced. A React element is a description and not an instance, so using
+   * this in both places mounts a frame per box — and the overlay's box does not
+   * exist until somebody opens it, `ModalShell` rendering nothing while closed.
+   */
+  const pane = mode.kind === 'html' ? (
+    <HtmlPrototypeFrame url={url} html={content} title={prototype?.title} className="w-full h-full border-0" />
+  ) : (
+    <PrototypeRenderer spec={mode.spec} />
+  )
   return (
     <div>
-      <div className="flex items-center justify-between mt-2 gap-3">
-        <h4 className="font-medium text-gray-900 flex items-center gap-1.5">
-          <Wand2 size={14} className="text-orange-500" />
-          {t('preview.prototypeTitle', { defaultValue: 'Prototype' })}
-        </h4>
-        {url ? (
-          <span className="flex items-center gap-3 text-xs flex-shrink-0">
-            <PrototypeLinkActions url={url} noteId={lifetimeNoteId} />
-          </span>
-        ) : null}
-      </div>
-      {/* Under the link, not beside it: this column is half a row wide, and the
-          note wraps rather than truncates — the clipped end would be the warning. */}
-      {url ? <PrototypeLinkLifetimeNote url={url} noteId={lifetimeNoteId} className="mt-1 text-xs" /> : null}
+      <PrototypePanelHeader
+        url={url}
+        noteId={lifetimeNoteId}
+        documentTitle={prototype?.title}
+        enlarged={(
+          /* Full height inside the overlay's panel, and scrollable for the JSON
+             spec, which is a document rather than a frame and can be taller than
+             the screen. */
+          <div className={clsx('h-full', mode.kind === 'html' ? 'overflow-hidden' : 'overflow-y-auto p-4')}>
+            {pane}
+          </div>
+        )}
+        t={t}
+      />
       {mode.kind === 'html' ? (
         <div className="bg-white rounded-lg border overflow-hidden mt-2 h-96">
-          <HtmlPrototypeFrame url={url} html={content} title={prototype?.title} className="w-full h-full border-0" />
+          {pane}
         </div>
       ) : (
         <div className="bg-white rounded-lg border p-3 sm:p-4 max-h-96 overflow-y-auto mt-2">
-          <PrototypeRenderer spec={mode.spec} />
+          {pane}
         </div>
       )}
     </div>

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -547,6 +547,22 @@ function resolvePrototypeMode(
 }
 
 /**
+ * The measure a JSON-spec prototype is laid out on inside the enlarge overlay.
+ *
+ * `PrototypeRenderer`'s own default is `max-w-2xl` — a readable column, correct in
+ * the row's half-width pane and correct in the Documents tab, and invisible in both
+ * because the pane is the tighter constraint. In a viewport-wide dialog it is the
+ * only constraint, and the result is a 672px column in a mostly-empty panel: the
+ * reader asked for the screen and got a taller version of the same column.
+ *
+ * Wider, but still capped. A spec is prose, forms and lists, and a stats grid or a
+ * list stretched to a 2560px display is harder to read than the column was, not
+ * easier. `max-w-5xl` roughly doubles the measure on a laptop while keeping lines
+ * scannable; `mx-auto` keeps it centred, as it is in the row.
+ */
+const ENLARGED_SPEC_MEASURE = 'max-w-5xl mx-auto'
+
+/**
  * The prototype panel's heading, and the two things a reader can do about a pane
  * this size.
  *
@@ -565,10 +581,16 @@ function resolvePrototypeMode(
  *
  * "Enlarge" appears for EVERY prototype the panel renders, url or not: it
  * re-renders the pane the row is already showing and needs no address of its own,
- * so a legacy inline prototype and a JSON spec enlarge exactly as well as a signed
- * one. It sits beside the anchor because the two answer the same question — "I
- * cannot see this properly" — and a reader comparing them should not have to find
- * them in different places.
+ * so a legacy inline prototype and a JSON spec get it as much as a signed one does.
+ * It sits beside the anchor because the two answer the same question — "I cannot see
+ * this properly" — and a reader comparing them should not have to find them in
+ * different places.
+ *
+ * What each KIND gains differs, and the panel says so rather than implying they are
+ * equal: an HTML prototype is a page in a frame and simply gets the viewport, while
+ * a JSON spec is a document laid out on a readable measure, so it gains the height,
+ * the scroll and a wider column (`ENLARGED_SPEC_MEASURE`) but is still capped — a
+ * stats grid stretched across a 2560px display reads worse, not better.
  *
  * @param enlarged the prototype as the overlay should render it: the row's own
  *   pane element in a box that fills the dialog.
@@ -643,6 +665,21 @@ function PrototypePanel({
    * one be replaced. A React element is a description and not an instance, so using
    * this in both places mounts a frame per box — and the overlay's box does not
    * exist until somebody opens it, `ModalShell` rendering nothing while closed.
+   *
+   * The frame is the whole of what has to be shared. A JSON spec carries no signed
+   * URL and so nothing that can lapse under a reader, which is why the overlay is
+   * free to re-render it on a wider measure (`ENLARGED_SPEC_MEASURE`) while the row
+   * keeps the readable column its narrow pane needs.
+   *
+   * Mounting per box is also the cost of the reuse, and worth naming so nobody reads
+   * "the row's pane, bigger" too literally: each box performs its own load, so the
+   * enlarged frame starts at the prototype's FIRST screen regardless of where the
+   * row's pane had got to, and both frames are live and executing while the overlay
+   * is open. Accepted, not overlooked — `HtmlPrototypeFrame` exposes no navigation
+   * state to hand over, and a live iframe cannot be moved between parents without
+   * reloading. Compare `useLoadedUrl`: the reset it exists to prevent is the same
+   * one, minus the part that made it a defect, since this one happens because a
+   * reader asked rather than on a timer they cannot see.
    */
   const pane = mode.kind === 'html' ? (
     <HtmlPrototypeFrame url={url} html={content} title={prototype?.title} className="w-full h-full border-0" />
@@ -660,7 +697,7 @@ function PrototypePanel({
              spec, which is a document rather than a frame and can be taller than
              the screen. */
           <div className={clsx('h-full', mode.kind === 'html' ? 'overflow-hidden' : 'overflow-y-auto p-4')}>
-            {pane}
+            {mode.kind === 'html' ? pane : <PrototypeRenderer spec={mode.spec} className={ENLARGED_SPEC_MEASURE} />}
           </div>
         )}
         t={t}

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -677,7 +677,18 @@ function PrototypePanel({
    * "the row's pane, bigger" too literally: each box performs its own load, so the
    * enlarged frame starts at the prototype's FIRST screen regardless of where the
    * row's pane had got to, and both frames are live and executing while the overlay
-   * is open. Accepted, not overlooked — `HtmlPrototypeFrame` exposes no navigation
+   * is open.
+   *
+   * THE SPEC BRANCH LOSES ITS PLACE FOR A DIFFERENT REASON, and review noted the
+   * caveat above does not reach it: there is no frame and no load here, but the
+   * overlay mounts a SECOND `PrototypeRenderer`, and the active screen is that
+   * component's own `useState`. So a reader three screens into the row's spec
+   * prototype also opens at screen one. Same symptom, different mechanism, and the
+   * fix would be a different shape too — lifting `activeId` out of
+   * `PrototypeRenderer` so both copies share it, which is a change to a component
+   * the Documents tab also renders. Left as it is, deliberately, on the same
+   * reasoning as the html branch: the enlarge is an explicit act by the reader, not
+   * a reset sprung on them. Accepted, not overlooked — `HtmlPrototypeFrame` exposes no navigation
    * state to hand over, and a live iframe cannot be moved between parents without
    * reloading. Compare `useLoadedUrl`: the reset it exists to prevent is the same
    * one, minus the part that made it a defect, since this one happens because a

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -654,8 +654,9 @@ function PrototypePanel({
   )
   if (mode.kind === 'none') return null
   /**
-   * The artifact itself, described once and rendered in two boxes: the row's
-   * 384px pane and the enlarge overlay's full-viewport one.
+   * The artifact as the ROW shows it, and — for an HTML prototype — the very element
+   * the overlay shows too: one description rendered in two boxes, the row's 384px
+   * pane and the enlarge overlay's full-viewport one.
    *
    * One description rather than two, because the sizing lives on the CONTAINER —
    * this frame is `w-full h-full` either way. A second `HtmlPrototypeFrame` call
@@ -666,10 +667,11 @@ function PrototypePanel({
    * this in both places mounts a frame per box — and the overlay's box does not
    * exist until somebody opens it, `ModalShell` rendering nothing while closed.
    *
-   * The frame is the whole of what has to be shared. A JSON spec carries no signed
-   * URL and so nothing that can lapse under a reader, which is why the overlay is
-   * free to re-render it on a wider measure (`ENLARGED_SPEC_MEASURE`) while the row
-   * keeps the readable column its narrow pane needs.
+   * The FRAME is the whole of what has to be shared, and only the html branch has
+   * one. A JSON spec carries no signed URL, so nothing about it can lapse under a
+   * reader and nothing is at risk in rendering it twice — which is why the overlay
+   * renders its own on a wider measure (`ENLARGED_SPEC_MEASURE`) while this copy
+   * keeps the readable column the row's narrow pane needs.
    *
    * Mounting per box is also the cost of the reuse, and worth naming so nobody reads
    * "the row's pane, bigger" too literally: each box performs its own load, so the

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -677,22 +677,21 @@ function PrototypePanel({
    * "the row's pane, bigger" too literally: each box performs its own load, so the
    * enlarged frame starts at the prototype's FIRST screen regardless of where the
    * row's pane had got to, and both frames are live and executing while the overlay
-   * is open.
-   *
-   * THE SPEC BRANCH LOSES ITS PLACE FOR A DIFFERENT REASON, and review noted the
-   * caveat above does not reach it: there is no frame and no load here, but the
-   * overlay mounts a SECOND `PrototypeRenderer`, and the active screen is that
-   * component's own `useState`. So a reader three screens into the row's spec
-   * prototype also opens at screen one. Same symptom, different mechanism, and the
-   * fix would be a different shape too — lifting `activeId` out of
-   * `PrototypeRenderer` so both copies share it, which is a change to a component
-   * the Documents tab also renders. Left as it is, deliberately, on the same
-   * reasoning as the html branch: the enlarge is an explicit act by the reader, not
-   * a reset sprung on them. Accepted, not overlooked — `HtmlPrototypeFrame` exposes no navigation
+   * is open. Accepted, not overlooked — `HtmlPrototypeFrame` exposes no navigation
    * state to hand over, and a live iframe cannot be moved between parents without
    * reloading. Compare `useLoadedUrl`: the reset it exists to prevent is the same
    * one, minus the part that made it a defect, since this one happens because a
    * reader asked rather than on a timer they cannot see.
+   *
+   * THE SPEC BRANCH LOSES ITS PLACE FOR A DIFFERENT REASON, and the caveat above
+   * does not reach it: there is no frame and no load here, but the overlay mounts a
+   * SECOND `PrototypeRenderer`, and the active screen is that component's own
+   * `useState`. So a reader three screens into the row's spec prototype also opens
+   * at screen one. Same symptom, different mechanism, and the fix would be a
+   * different shape too — lifting `activeId` out of `PrototypeRenderer` so both
+   * copies share it, which is a change to a component the Documents tab also
+   * renders. Left as it is, deliberately, on the same reasoning as the html branch:
+   * the enlarge is an explicit act by the reader, not a reset sprung on them.
    */
   const pane = mode.kind === 'html' ? (
     <HtmlPrototypeFrame url={url} html={content} title={prototype?.title} className="w-full h-full border-0" />

--- a/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PRFAQRow.tsx
@@ -699,7 +699,7 @@ function PrototypePanel({
              spec, which is a document rather than a frame and can be taller than
              the screen. */
           <div className={clsx('h-full', mode.kind === 'html' ? 'overflow-hidden' : 'overflow-y-auto p-4')}>
-            {mode.kind === 'html' ? pane : <PrototypeRenderer spec={mode.spec} className={ENLARGED_SPEC_MEASURE} />}
+            {mode.kind === 'html' ? pane : <PrototypeRenderer spec={mode.spec} measureClassName={ENLARGED_SPEC_MEASURE} />}
           </div>
         )}
         t={t}

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
@@ -464,6 +464,34 @@ describe('getting back to the row', () => {
     expect(within(dialog).getByRole('button', { name: closeName })).toHaveFocus()
   })
 
+  it('lets Tab reach the prototype\'s own controls', async () => {
+    // The direction that has to work FIRST, and the one this overlay's geometry
+    // breaks: the panel is `[Close, <iframe>]`, so the frame is the panel's last
+    // focusable and a naive trap wraps on the very Tab that would have descended into
+    // the artifact — `preventDefault()` cancelling exactly that default action. The
+    // result is Close ⇄ frame element indefinitely, with every link and button inside
+    // the prototype unreachable by keyboard, in the dialog that exists to walk a room
+    // through it.
+    //
+    // jsdom performs no default Tab action, so the assertion is that the shell did NOT
+    // intervene: focus stays on the frame element for the browser to descend from.
+    // Focus landing back on Close is the defect.
+    const { dialog } = await openOverlay()
+    const frameDoc = prototypeDocumentIn(dialog)
+    frameDoc.body.innerHTML = '<button id="proto-next">Next screen</button>'
+    const frame = within(dialog).getByTitle(PROTOTYPE_TITLE)
+    frame.focus()
+
+    // Raised in THIS document, as a browser does for a Tab pressed while the frame
+    // ELEMENT (not its content) has focus. `user.tab()` cannot express that state.
+    act(() => {
+      frame.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    })
+
+    expect(frame).toHaveFocus()
+    expect(within(dialog).getByRole('button', { name: closeName })).not.toHaveFocus()
+  })
+
   it('leaves the row expanded underneath, so the ballot is still there on return', async () => {
     // The reason this is an overlay and not a new tab: the sliders, the team's
     // numbers and the room vote are on this page.

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
@@ -492,6 +492,31 @@ describe('getting back to the row', () => {
     expect(within(dialog).getByRole('button', { name: closeName })).not.toHaveFocus()
   })
 
+  it('keeps the trap and Escape working for a frame the prototype embeds itself', async () => {
+    // A prototype is Bedrock-generated HTML, so one embedding a map, a video or a docs
+    // frame produces a frame inside the frame without anyone choosing it. That is the
+    // shell's hardest case and this is its only real consumer, so it is pinned here as
+    // well as in the shell suite: a frame INSERTED into the prototype's document (what a
+    // script in the prototype does) is invisible to any observer watching only the
+    // panel's node tree, so it used to be readable but unlistened — and the entry guard
+    // let a keyboard user descend into it with no listener to bring them back and Escape
+    // dead inside it.
+    const { dialog, trigger } = await openOverlay()
+    const frameDoc = prototypeDocumentIn(dialog)
+    const embedded = frameDoc.createElement('iframe')
+    embedded.title = 'A map the prototype embeds'
+    frameDoc.body.append(embedded)
+    const embeddedDoc = embedded.contentDocument
+    if (!embeddedDoc?.body) throw new Error('the embedded frame has no document')
+    embeddedDoc.body.innerHTML = '<button id="pin">A pin on the map</button>'
+    embeddedDoc.getElementById('pin')?.focus()
+
+    pressInside(embeddedDoc, 'Escape')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
   it('leaves the row expanded underneath, so the ballot is still there on return', async () => {
     // The reason this is an overlay and not a new tab: the sliders, the team's
     // numbers and the room vote are on this page.

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
@@ -1,0 +1,320 @@
+/**
+ * Enlarging a row's prototype to the whole viewport, and getting back (issue #314).
+ *
+ * A pitch session looks at the prototype in a pane sized to a table row. The
+ * meeting exists to look at the artifact, so the row offers it at full size — and
+ * without leaving the page, because the team's numbers, the reader's own sliders
+ * and the room vote are all here and a new tab abandons them.
+ *
+ * Four properties are cheap to lose and invisible in review, so each is pinned by
+ * a test that fails when it is reverted:
+ *
+ * 1. **The overlay is a dialog with a name, and focus goes into it.** A
+ *    `fixed inset-0` div is the natural way to write this and the way 21 of the 23
+ *    overlays audited for #283 were written; it leaves a keyboard user stranded
+ *    behind the artifact.
+ * 2. **It comes back — by the close control AND by Escape — and focus returns to
+ *    the trigger.** An overlay that covers the row it was opened from is a trap if
+ *    only the mouse can leave it.
+ * 3. **It renders the ROW'S frame.** The overlay must show the same
+ *    `HtmlPrototypeFrame` the row does, because that frame carries the signed-URL
+ *    handling (`useLoadedUrl`) that turns a lapsed link into a readable message
+ *    rather than a broken pane. A second frame implementation is what this asserts
+ *    against, by pinning that the enlarged pane loads the row's signed address.
+ * 4. **No prototype, no control.** The affordance and the artifact appear
+ *    together; an enlarge button over an empty dialog is worse than no button.
+ *
+ * The open-in-a-new-tab anchor and the expiry note beside it are covered by
+ * Prioritization.prototypeLink.test.tsx and are only re-checked here for the one
+ * thing this change could plausibly have broken: that they are still there, still
+ * an anchor, now that a button sits next to them.
+ *
+ * No fake timers, for the reason that suite states: the scheduling half of this
+ * feature needs them and keeps them contained in
+ * Prioritization.prototypeRefresh.test.tsx.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import i18n from 'i18next'
+
+const mockGetProjects = vi.fn()
+const mockGetProject = vi.fn()
+const mockGetPrioritizationScores = vi.fn()
+const mockCreatePrioritizationRow = vi.fn()
+const mockGetFeedbackForms = vi.fn()
+
+vi.mock('../../api/projectsApi', () => ({
+  projectsApi: {
+    getProjects: () => mockGetProjects(),
+    getProject: (id: string) => mockGetProject(id),
+  },
+}))
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getPrioritizationScores: () => mockGetPrioritizationScores(),
+    createPrioritizationRow: (id: string) => mockCreatePrioritizationRow(id),
+    patchPrioritizationScores: () => Promise.resolve({ success: true }),
+    getFeedbackForms: () => mockGetFeedbackForms(),
+    getFeedbackFormStats: () => Promise.resolve({ success: true, stats: null }),
+  },
+}))
+
+vi.mock('../../store/configStore', () => ({
+  useConfigStore: () => ({ config: { apiEndpoint: 'https://api.example.com' } }),
+}))
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}))
+
+import Prioritization from './Prioritization'
+
+const { t } = i18n
+const HOUR_MS = 60 * 60_000
+const PROTOTYPE_PATH = 'https://d111.cloudfront.net/prototypes/p1/proto-1.html'
+const ROW_TITLE = 'Feature A PR/FAQ'
+const PROTOTYPE_TITLE = 'Feature A prototype'
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const signedUrl = (expiresAtMs: number, signature: string) =>
+  `${PROTOTYPE_PATH}?Expires=${Math.floor(expiresAtMs / 1000)}&Signature=${signature}&Key-Pair-Id=K1`
+
+const project = {
+  project_id: 'p1', name: 'Project 1', status: 'active',
+  created_at: '2025-01-01', updated_at: '2025-01-01', persona_count: 0, document_count: 2,
+}
+
+const prfaq = {
+  document_id: 'doc_prfaq', document_type: 'prfaq', title: ROW_TITLE,
+  content: '# Feature A', created_at: '2025-01-01',
+}
+
+/** The project's one row. `prototype_id` empty, so it falls back to the latest prototype. */
+const row = {
+  row_id: 'row_p1_default',
+  project_id: 'p1',
+  document_ids: ['doc_prfaq'],
+  prototype_id: '',
+  is_default: true,
+  created_at: '2025-01-01',
+}
+
+const prototypeDoc = (prototypeUrl?: string) => ({
+  document_id: 'proto-1',
+  document_type: 'prototype',
+  title: PROTOTYPE_TITLE,
+  content: '',
+  prototype_format: 'html',
+  prototype_url: prototypeUrl,
+  created_at: '2025-01-03',
+})
+
+function renderPrioritization() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createMemoryRouter([{ path: '/', element: <Prioritization /> }])
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+/** Render the page and open the row — the prototype panel is expand-only. */
+async function expandRow() {
+  const user = userEvent.setup()
+  renderPrioritization()
+  await waitFor(() => {
+    expect(screen.getByText(ROW_TITLE)).toBeInTheDocument()
+  })
+  await user.click(screen.getByText(ROW_TITLE))
+  return user
+}
+
+const enlargeName = new RegExp(escapeRegExp(t('prioritization:preview.enlarge')), 'i')
+const closeName = new RegExp(escapeRegExp(t('common:actions.close')), 'i')
+const openLinkName = new RegExp(escapeRegExp(t('components:prototypeLink.openNewTab')), 'i')
+
+/** Open the row, then the overlay, returning the trigger and the dialog. */
+async function openOverlay() {
+  const user = await expandRow()
+  const trigger = await screen.findByRole('button', { name: enlargeName })
+  await user.click(trigger)
+  return { user, trigger, dialog: screen.getByRole('dialog') }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetProjects.mockResolvedValue({ projects: [project] })
+  mockGetPrioritizationScores.mockResolvedValue({ scores: {}, rows: { [row.row_id]: row } })
+  mockCreatePrioritizationRow.mockResolvedValue({ success: true, created: false, row })
+  mockGetFeedbackForms.mockResolvedValue({ forms: [] })
+  mockGetProject.mockResolvedValue({
+    project_id: 'p1',
+    documents: [prfaq, prototypeDoc(signedUrl(Date.now() + HOUR_MS, 'sig-1'))],
+  })
+})
+
+describe('offering to enlarge a row\'s prototype', () => {
+  it('offers no enlarge control before the row is expanded', async () => {
+    // The whole panel is expand-only: a page listing every project must not mount a
+    // frame — or an affordance for one — per row at rest.
+    renderPrioritization()
+
+    await waitFor(() => {
+      expect(screen.getByText(ROW_TITLE)).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: enlargeName })).not.toBeInTheDocument()
+  })
+
+  it('offers no enlarge control for a row whose project has no prototype', async () => {
+    mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq] })
+
+    await expandRow()
+
+    // Wait for the expansion itself, so the absence below is an absence in a
+    // rendered panel rather than in a panel that has not arrived.
+    await waitFor(() => {
+      expect(screen.getByText(t('prioritization:scores.title'))).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: enlargeName })).not.toBeInTheDocument()
+    expect(screen.queryByText(enlargeName)).not.toBeInTheDocument()
+  })
+
+  it('offers the enlarge control for a legacy prototype, which has no address to open', async () => {
+    // A pre-migration prototype is inline HTML with no `prototype_url`, so there is
+    // nothing to open in a tab — but enlarging re-renders the pane the row already
+    // shows, which needs no address. The two affordances answer the same question
+    // and this is the row where only one of them can.
+    mockGetProject.mockResolvedValue({
+      project_id: 'p1',
+      documents: [prfaq, { ...prototypeDoc(undefined), content: '<html><body>legacy</body></html>' }],
+    })
+
+    await expandRow()
+
+    expect(await screen.findByRole('button', { name: enlargeName })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: openLinkName })).not.toBeInTheDocument()
+  })
+
+  it('leaves opening in a new tab a plain anchor beside the enlarge control', async () => {
+    // A button now sits next to the anchor, and the temptation is to make the pair
+    // consistent by turning the anchor into a button too. That trades a 403 for a
+    // popup blocker — see components/prototypeLinkLifetime.
+    const url = signedUrl(Date.now() + HOUR_MS, 'sig-1')
+    mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq, prototypeDoc(url)] })
+
+    await expandRow()
+
+    expect(await screen.findByRole('link', { name: openLinkName })).toHaveAttribute('href', url)
+    expect(screen.queryByRole('button', { name: openLinkName })).not.toBeInTheDocument()
+    // And the expiry stays visible beside it, rather than being displaced by the
+    // new control.
+    expect(screen.getByText(/tied to your session, not a share link/i)).toBeInTheDocument()
+  })
+
+  it('renders nothing enlarged until the control is used', async () => {
+    await expandRow()
+
+    await screen.findByRole('button', { name: enlargeName })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('the enlarged prototype', () => {
+  it('exposes itself as a modal dialog named after the prototype', async () => {
+    const { dialog } = await openOverlay()
+
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    // Non-empty and derived from the heading on screen, so the name cannot drift
+    // from what a sighted viewer reads.
+    expect(dialog).toHaveAccessibleName(
+      new RegExp(`${escapeRegExp(t('prioritization:preview.prototypeTitle'))}.*${escapeRegExp(PROTOTYPE_TITLE)}`),
+    )
+  })
+
+  it('moves focus into the dialog when it opens', async () => {
+    const { dialog } = await openOverlay()
+
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+  })
+
+  it('renders the row\'s own frame at the row\'s signed address', async () => {
+    // The property that says "not a second frame implementation": the enlarged pane
+    // is an iframe loading the same signed URL the row's pane does, and there are
+    // now two of them for the one document. A bespoke overlay renderer — a fetch, a
+    // blob, a rebuilt URL — fails this.
+    const url = signedUrl(Date.now() + HOUR_MS, 'sig-1')
+    mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq, prototypeDoc(url)] })
+
+    const { dialog } = await openOverlay()
+
+    const enlarged = within(dialog).getByTitle(PROTOTYPE_TITLE)
+    expect(enlarged.tagName).toBe('IFRAME')
+    expect(enlarged).toHaveAttribute('src', url)
+    expect(screen.getAllByTitle(PROTOTYPE_TITLE)).toHaveLength(2)
+  })
+
+  it('reports a lapsed link inside the overlay rather than showing a broken pane', async () => {
+    // Same degradation the row's pane gets, and the reason the overlay reuses the
+    // row's frame: an expired signature is announced by `HtmlPrototypeFrame`'s own
+    // handling, so the overlay inherits it instead of re-deciding it.
+    mockGetProject.mockResolvedValue({
+      project_id: 'p1', documents: [prfaq, prototypeDoc(signedUrl(Date.now() - HOUR_MS, 'sig-old'))],
+    })
+
+    const { dialog } = await openOverlay()
+
+    // The row says so, in the note beside the anchor…
+    expect(screen.getByText(/Link expired/)).toBeInTheDocument()
+    // …and the overlay still renders through the same frame, which is what carries
+    // that behaviour, rather than an empty box or a bespoke error of its own.
+    expect(within(dialog).getByTitle(PROTOTYPE_TITLE).tagName).toBe('IFRAME')
+  })
+})
+
+describe('getting back to the row', () => {
+  it('closes on the close control and returns focus to the enlarge control', async () => {
+    const { user, trigger, dialog } = await openOverlay()
+
+    await user.click(within(dialog).getByRole('button', { name: closeName }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // Focus back where it started: the overlay covered the row, so a keyboard user
+    // dropped at the top of the page has lost their place in a long list.
+    expect(trigger).toHaveFocus()
+  })
+
+  it('closes on Escape and returns focus to the enlarge control', async () => {
+    const { user, trigger } = await openOverlay()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('leaves the row expanded underneath, so the ballot is still there on return', async () => {
+    // The reason this is an overlay and not a new tab: the sliders, the team's
+    // numbers and the room vote are on this page.
+    const { user } = await openOverlay()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.getByText(t('prioritization:scores.title'))).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: enlargeName })).toBeInTheDocument()
+  })
+
+  it('can be reopened after closing', async () => {
+    const { user, trigger } = await openOverlay()
+
+    await user.keyboard('{Escape}')
+    await user.click(trigger)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})

--- a/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/Prioritization.prototypeEnlarge.test.tsx
@@ -6,7 +6,7 @@
  * without leaving the page, because the team's numbers, the reader's own sliders
  * and the room vote are all here and a new tab abandons them.
  *
- * Four properties are cheap to lose and invisible in review, so each is pinned by
+ * These properties are cheap to lose and invisible in review, so each is pinned by
  * a test that fails when it is reverted:
  *
  * 1. **The overlay is a dialog with a name, and focus goes into it.** A
@@ -15,7 +15,12 @@
  *    behind the artifact.
  * 2. **It comes back — by the close control AND by Escape — and focus returns to
  *    the trigger.** An overlay that covers the row it was opened from is a trap if
- *    only the mouse can leave it.
+ *    only the mouse can leave it. Escape is pinned twice, and the second one is the
+ *    load-bearing case: `user.keyboard` types into the TOP document, which is only
+ *    where focus is before anybody clicks into the artifact. A key pressed inside
+ *    the prototype is raised in the frame's own document, and a shell listening
+ *    only on `document` never sees it — so Escape and the Tab trap were inert for
+ *    exactly the state this overlay exists to be used in.
  * 3. **It renders the ROW'S frame.** The overlay must show the same
  *    `HtmlPrototypeFrame` the row does, because that frame carries the signed-URL
  *    handling (`useLoadedUrl`) that turns a lapsed link into a readable message
@@ -23,6 +28,10 @@
  *    against, by pinning that the enlarged pane loads the row's signed address.
  * 4. **No prototype, no control.** The affordance and the artifact appear
  *    together; an enlarge button over an empty dialog is worse than no button.
+ * 5. **A JSON spec is enlarged too, and gains WIDTH as well as height.** The other
+ *    prototype format, and the only branch where the container has a decision to
+ *    make: `PrototypeRenderer` caps itself at a readable column, invisible in the
+ *    row's narrow pane and the only constraint in a viewport-wide dialog.
  *
  * The open-in-a-new-tab anchor and the expiry note beside it are covered by
  * Prioritization.prototypeLink.test.tsx and are only re-checked here for the one
@@ -34,7 +43,7 @@
  * Prioritization.prototypeRefresh.test.tsx.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
@@ -114,6 +123,32 @@ const prototypeDoc = (prototypeUrl?: string) => ({
   created_at: '2025-01-03',
 })
 
+const SPEC_SCREEN_LABEL = 'Signup'
+const SPEC_HEADING = 'Create your account'
+
+/**
+ * A prototype in the OTHER format: a JSON spec, rendered natively by
+ * `PrototypeRenderer` rather than in a frame.
+ *
+ * `prototype_format` unset and no `prototype_url`, so `resolvePrototypeMode` takes
+ * the spec path — which is the half of the overlay's container the html cases never
+ * reach, and the half where the sizing question lives (a spec is laid out on a
+ * readable measure, so the row's cap has to be widened for the overlay rather than
+ * merely given more height).
+ */
+const specPrototypeDoc = () => ({
+  document_id: 'proto-1',
+  document_type: 'prototype',
+  title: PROTOTYPE_TITLE,
+  content: JSON.stringify({
+    screens: [
+      { id: 'signup', label: SPEC_SCREEN_LABEL, heading: SPEC_HEADING },
+      { id: 'done', label: 'Done', heading: 'All set' },
+    ],
+  }),
+  created_at: '2025-01-03',
+})
+
 function renderPrioritization() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const router = createMemoryRouter([{ path: '/', element: <Prioritization /> }])
@@ -138,6 +173,46 @@ async function expandRow() {
 const enlargeName = new RegExp(escapeRegExp(t('prioritization:preview.enlarge')), 'i')
 const closeName = new RegExp(escapeRegExp(t('common:actions.close')), 'i')
 const openLinkName = new RegExp(escapeRegExp(t('components:prototypeLink.openNewTab')), 'i')
+// Through `t`, like every other string here: the copy of the expiry note is not
+// this suite's to know, and the two catalogue keys drift independently of it.
+const lifetimeHint = new RegExp(escapeRegExp(t('components:prototypeLink.linkExpiryHint')), 'i')
+const lapsedNote = new RegExp(escapeRegExp(t('components:prototypeLink.linkExpired')), 'i')
+
+/**
+ * The prototype's OWN document inside the overlay, as it exists once the frame has
+ * loaded — the thing a reviewer is clicking around in.
+ *
+ * jsdom does not fetch a frame's `src`, so its document arrives empty and stays
+ * `readyState: 'loading'` forever. `write()` gives it the body a real load would,
+ * and the `load` event afterwards is the signal a browser raises at that moment and
+ * the one `ModalShell` re-scans on. Dispatching it is not a shortcut past the
+ * behaviour under test: without a `load` (or the mutation that added the frame) the
+ * shell has nothing to tell it a document now exists to listen to.
+ */
+function prototypeDocumentIn(dialog: HTMLElement): Document {
+  const frame = within(dialog).getByTitle(PROTOTYPE_TITLE)
+  const doc = frame instanceof HTMLIFrameElement ? frame.contentDocument : null
+  if (doc === null) throw new Error('the enlarged prototype is not a frame with a document')
+  doc.open()
+  doc.write('<html><body></body></html>')
+  doc.close()
+  frame.dispatchEvent(new Event('load'))
+  return doc
+}
+
+/**
+ * Raise a key in the prototype's own document, as a browser does for one pressed
+ * inside it. `act` because closing the overlay is a state update, and a dispatch
+ * React did not initiate leaves the re-render unflushed.
+ */
+function pressInside(doc: Document, key: string) {
+  act(() => {
+    const target = doc.activeElement ?? doc.body
+    target.dispatchEvent(
+      new (doc.defaultView ?? window).KeyboardEvent('keydown', { key, bubbles: true }),
+    )
+  })
+}
 
 /** Open the row, then the overlay, returning the trigger and the dialog. */
 async function openOverlay() {
@@ -214,7 +289,7 @@ describe('offering to enlarge a row\'s prototype', () => {
     expect(screen.queryByRole('button', { name: openLinkName })).not.toBeInTheDocument()
     // And the expiry stays visible beside it, rather than being displaced by the
     // new control.
-    expect(screen.getByText(/tied to your session, not a share link/i)).toBeInTheDocument()
+    expect(screen.getByText(lifetimeHint)).toBeInTheDocument()
   })
 
   it('renders nothing enlarged until the control is used', async () => {
@@ -240,7 +315,19 @@ describe('the enlarged prototype', () => {
   it('moves focus into the dialog when it opens', async () => {
     const { dialog } = await openOverlay()
 
-    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    // `contains` rather than `toContainElement(document.activeElement as …)`: the
+    // repo bans type assertions in source and this needs no widening anyway.
+    expect(dialog.contains(document.activeElement)).toBe(true)
+  })
+
+  it('announces itself as opening a dialog before focus moves there', async () => {
+    // `aria-haspopup="dialog"` is what lets a screen-reader user CHOOSE to open the
+    // overlay rather than discover they did once focus has moved. Comment-only
+    // otherwise, and the class of attribute that gets dropped in a restyle.
+    await expandRow()
+
+    expect(await screen.findByRole('button', { name: enlargeName }))
+      .toHaveAttribute('aria-haspopup', 'dialog')
   })
 
   it('renders the row\'s own frame at the row\'s signed address', async () => {
@@ -259,6 +346,46 @@ describe('the enlarged prototype', () => {
     expect(screen.getAllByTitle(PROTOTYPE_TITLE)).toHaveLength(2)
   })
 
+  it('renders a JSON spec inside the overlay, on a wider measure than the row\'s', async () => {
+    // The spec branch of the overlay's container, which no other prototype test
+    // reaches — every one of them sets `prototype_format: 'html'`, and the "legacy"
+    // case is legacy HTML, which still takes the html path.
+    //
+    // Both halves matter. That the spec RENDERS in the dialog is the claim that
+    // enlarge is offered without an address to open. That it renders on a measure
+    // the row does not use is the claim that enlarging a spec gains WIDTH:
+    // `PrototypeRenderer` caps itself at a readable column, so a viewport-wide
+    // dialog would otherwise be a 672px column in an empty panel — height gained,
+    // width not, contrary to what the panel's own comment promises.
+    mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq, specPrototypeDoc()] })
+
+    const { dialog } = await openOverlay()
+
+    const enlarged = within(dialog).getByRole('heading', { name: SPEC_HEADING })
+    expect(enlarged).toBeInTheDocument()
+    // Its own navigation too, i.e. the real renderer and not a static excerpt.
+    expect(within(dialog).getByRole('button', { name: SPEC_SCREEN_LABEL })).toBeInTheDocument()
+    // A class assertion because the measure is the whole point and nothing else
+    // observes it in jsdom, which does no layout. The row's own copy is the control:
+    // it must keep the narrow default while the overlay's does not.
+    const measureOf = (heading: HTMLElement) => heading.closest('div.mx-auto')?.className ?? ''
+    expect(measureOf(enlarged)).toContain('max-w-5xl')
+    const inRow = screen.getAllByRole('heading', { name: SPEC_HEADING }).filter((h) => !dialog.contains(h))
+    expect(inRow).toHaveLength(1)
+    expect(measureOf(inRow[0])).toContain('max-w-2xl')
+  })
+
+  it('offers the enlarge control for a JSON spec, which has no address to open', async () => {
+    // Same asymmetry the legacy-HTML case pins, on the other format: a spec has no
+    // signed URL, so "Open in new tab" cannot appear and "Enlarge" still must.
+    mockGetProject.mockResolvedValue({ project_id: 'p1', documents: [prfaq, specPrototypeDoc()] })
+
+    await expandRow()
+
+    expect(await screen.findByRole('button', { name: enlargeName })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: openLinkName })).not.toBeInTheDocument()
+  })
+
   it('reports a lapsed link inside the overlay rather than showing a broken pane', async () => {
     // Same degradation the row's pane gets, and the reason the overlay reuses the
     // row's frame: an expired signature is announced by `HtmlPrototypeFrame`'s own
@@ -270,7 +397,7 @@ describe('the enlarged prototype', () => {
     const { dialog } = await openOverlay()
 
     // The row says so, in the note beside the anchor…
-    expect(screen.getByText(/Link expired/)).toBeInTheDocument()
+    expect(screen.getByText(lapsedNote)).toBeInTheDocument()
     // …and the overlay still renders through the same frame, which is what carries
     // that behaviour, rather than an empty box or a bespoke error of its own.
     expect(within(dialog).getByTitle(PROTOTYPE_TITLE).tagName).toBe('IFRAME')
@@ -296,6 +423,45 @@ describe('getting back to the row', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(trigger).toHaveFocus()
+  })
+
+  it('closes on Escape pressed while focus is inside the prototype itself', async () => {
+    // THE state this overlay is used in, and the one the test above does not reach:
+    // `user.keyboard` types into the top document, which is only where focus is
+    // before anybody clicks into the artifact. A real key pressed inside the frame is
+    // raised in the FRAME's document and never reaches the embedder, so a shell
+    // listening only on `document` goes silent exactly when a reviewer is walking the
+    // room through the prototype — Escape inert, Tab untrapped, and the frame is
+    // itself focusable so one Tab from Close lands there.
+    const { dialog, trigger } = await openOverlay()
+    const frameDoc = prototypeDocumentIn(dialog)
+    // A control of the prototype's own, focused as a reviewer clicking into it would.
+    frameDoc.body.innerHTML = '<button id="proto-next">Next screen</button>'
+    frameDoc.getElementById('proto-next')?.focus()
+
+    pressInside(frameDoc, 'Escape')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('keeps Tab inside the dialog from the prototype\'s last control', async () => {
+    // Where a browser hands focus to whatever follows the frame — and what follows
+    // is the page behind the overlay, whose row is showing a SECOND live copy of the
+    // same interactive prototype. A keyboard user would be tabbing through content
+    // they cannot see.
+    const { dialog } = await openOverlay()
+    const frameDoc = prototypeDocumentIn(dialog)
+    frameDoc.body.innerHTML = '<button id="proto-last">Finish</button>'
+    frameDoc.getElementById('proto-last')?.focus()
+
+    pressInside(frameDoc, 'Tab')
+
+    // A named control rather than `dialog.contains(activeElement)`: while focus is
+    // inside the frame, this document's activeElement IS the <iframe> element, which
+    // is already inside the dialog — so the containment check passes even when
+    // nothing intervened and the browser is about to hand focus to the page behind.
+    expect(within(dialog).getByRole('button', { name: closeName })).toHaveFocus()
   })
 
   it('leaves the row expanded underneath, so the ballot is still there on return', async () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/PrototypeEnlargeButton.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PrototypeEnlargeButton.tsx
@@ -27,13 +27,30 @@
  * dialog opens, because `ModalShell` renders nothing while closed — so a row
  * showing a prototype pays for one frame, not two, until somebody asks.
  *
+ * What "the row's own frame, at a different size" does NOT mean is the same frame
+ * instance: each box mounts its own iframe, so opening this overlay performs a
+ * fresh load and the enlarged prototype starts at its FIRST screen no matter which
+ * screen the row's pane was showing, and both frames are live and executing while
+ * the overlay is open. Accepted rather than missed — `HtmlPrototypeFrame` exposes
+ * no navigation state to hand over, and a live iframe cannot be reparented without
+ * reloading. It is the same loss of place `useLoadedUrl` exists to prevent, minus
+ * the part that made that one a defect: this one happens because somebody asked,
+ * not on a timer they cannot see.
+ *
  * ## The dialog behaviour is `ModalShell`'s, deliberately
  *
- * Escape, the focus move in, the focus return to this trigger, `role="dialog"`
- * and `aria-modal` all come from the shared shell. The audit behind issue #283
- * found 21 of 23 overlays in this app missing dialog semantics precisely because
- * each one re-implemented them; a full-viewport overlay is not the place to start
- * that again.
+ * Escape, the focus move in, the focus return to this trigger, the Tab trap,
+ * `role="dialog"` and `aria-modal` all come from the shared shell. The audit behind
+ * issue #283 found 21 of 23 overlays in this app missing dialog semantics precisely
+ * because each one re-implemented them; a full-viewport overlay is not the place to
+ * start that again.
+ *
+ * A key pressed inside an iframe is raised in the FRAME's document and never
+ * reaches the embedder, which made both Escape and the trap inert for this overlay
+ * the moment a reviewer clicked into the prototype — i.e. for almost all of its
+ * useful life. That is fixed in the shell (see `ModalShell`'s NESTED FRAMES note)
+ * rather than here, because the next consumer to embed a frame would otherwise
+ * inherit the same silence.
  *
  * @module pages/Prioritization/PrototypeEnlargeButton
  */
@@ -59,7 +76,19 @@ export default function PrototypeEnlargeButton({
   readonly documentTitle?: string
   readonly children: ReactNode
 }): ReactElement {
-  const { t } = useTranslation('prioritization')
+  // Both namespaces this component reads, declared rather than left implicit: the
+  // dialog's dismiss control reuses `common:actions.close` instead of minting a
+  // ninth spelling of "Close", and that reach only resolves because `common` is
+  // loaded. Today every namespace is loaded at init (`i18n/options.ts`), so naming
+  // it changes nothing at runtime; it is what keeps this component correct if that
+  // ever becomes lazy, which no test would otherwise catch.
+  //
+  // EVERY key below is namespace-qualified, and must stay that way:
+  // `scripts/i18n-check.mjs` attributes an unqualified key to the single-string
+  // namespace it finds on this hook, and finds none in the array form — so an
+  // unqualified key here is filed under `common` and reported both missing-in-source
+  // and unused, i.e. as a deletion candidate.
+  const { t } = useTranslation(['prioritization', 'common'])
   const [isOpen, setIsOpen] = useState(false)
   // Names the dialog after the heading it already shows, so the accessible name
   // cannot drift from the visible one. `useId` because the page renders one of
@@ -72,15 +101,23 @@ export default function PrototypeEnlargeButton({
           without it the control announces as a plain button and a screen-reader
           user learns they are in a dialog only after focus has moved there.
           `aria-expanded` would be wrong — this is not a disclosure revealing
-          adjacent content, it is a modal that does not exist until asked for. */}
+          adjacent content, it is a modal that does not exist until asked for.
+
+          `hover:text-blue-700` and NOT the `hover:underline` of the anchor beside
+          it, following `FormQrButton`: underline on hover is what this app's links
+          do, and this control stays on the page. The two share the blue and sit
+          together because they answer the same question — "I cannot see this
+          properly" — but the hover is where a reader learns which of them is about
+          to take them somewhere. Stated because the neighbouring anchor's classes
+          are one line away and copying them looks like consistency. */}
       <button
         type="button"
         onClick={() => setIsOpen(true)}
         aria-haspopup="dialog"
-        className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+        className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-700"
       >
         <Maximize2 size={12} />
-        {t('preview.enlarge')}
+        {t('prioritization:preview.enlarge', { defaultValue: 'Enlarge' })}
       </button>
       <ModalShell
         isOpen={isOpen}
@@ -94,8 +131,13 @@ export default function PrototypeEnlargeButton({
         panelClassName="h-full flex flex-col overflow-hidden"
       >
         <div className="flex items-center justify-between gap-3 border-b px-4 py-2 flex-shrink-0">
-          <h3 id={headingId} className="font-medium text-gray-900 truncate">
-            {t('preview.prototypeTitle')}
+          {/* `min-w-0 flex-1` is what makes the `truncate` fire at all: a flex item's
+              default `min-width: auto` refuses to shrink below its content, so a long
+              document title would push this row wider and overflow the panel instead
+              of ellipsising. Same shape as the `min-h-0` below, on the other axis —
+              and the `flex-1 min-w-0 … truncate` pattern CategoriesManager uses. */}
+          <h3 id={headingId} className="font-medium text-gray-900 truncate min-w-0 flex-1">
+            {t('prioritization:preview.prototypeTitle', { defaultValue: 'Prototype' })}
             {/* The artifact's own name, inside the heading rather than beside it, so
                 it is part of the dialog's accessible name instead of a second label
                 a screen reader reaches only by exploring. Omitted when the document
@@ -107,14 +149,20 @@ export default function PrototypeEnlargeButton({
           {/* Visible, and the panel's first focusable so this is where the shell
               puts focus on open. The shell's own ways out — Escape and an overlay
               click — are both invisible, and this overlay covers the row a viewer
-              would otherwise click back to. */}
+              would otherwise click back to.
+              It is also the only exit that cannot be swallowed by the artifact: a
+              cross-origin or sandboxed prototype raises its keys in a document this
+              page is not allowed to read, so Escape genuinely does not reach the
+              shell from inside one (the shell listens through same-origin frames —
+              see its NESTED FRAMES note — which is all it can do). A prototype
+              served from another origin must still be dismissable, and this is how. */}
           <button
             type="button"
             onClick={() => setIsOpen(false)}
             className="inline-flex items-center gap-1 text-sm text-gray-700 hover:text-gray-900 flex-shrink-0"
           >
             <X size={16} />
-            {t('common:actions.close')}
+            {t('common:actions.close', { defaultValue: 'Close' })}
           </button>
         </div>
         {/* `min-h-0` beside `flex-1`: a flex child's default `min-height: auto`

--- a/voc-datalake/frontend/src/pages/Prioritization/PrototypeEnlargeButton.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PrototypeEnlargeButton.tsx
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Enlarging the prototype a prioritization row is showing, to the
+ * whole viewport and back again (issue #314).
+ *
+ * The row's embedded pane is 384px tall inside half a table row: enough to
+ * recognise a prototype, not enough for the thing a pitch session exists to do,
+ * which is look at the artifact together. "Open in new tab" already covers the
+ * reader who wants it out of the app entirely; this covers the meeting, where
+ * leaving the page loses the sliders, the team's numbers and the room vote that
+ * are the reason everyone is on this page.
+ *
+ * ## It renders the row's own frame, at a different size
+ *
+ * The prototype is handed in as `children` and the caller passes the very element
+ * it renders in the row — `HtmlPrototypeFrame` for an HTML prototype, the native
+ * `PrototypeRenderer` for a legacy JSON spec. Nothing about the artifact is
+ * re-implemented here, which matters more than it sounds: `HtmlPrototypeFrame`
+ * carries the signed-URL handling that makes a lapsed link degrade into a readable
+ * message instead of a broken pane (see components/PrototypeRenderer's
+ * `useLoadedUrl`), and a second frame written for the overlay would be the copy
+ * that loses it. This component owns the size and the dialog, and nothing else.
+ *
+ * `children` is a ReactNode rather than a render prop because the sizing
+ * difference is the CONTAINER, not the frame: the row wraps its frame in an
+ * `h-96` box and this wraps the same `w-full h-full` frame in a box that fills
+ * the viewport. An element passed here is created but not mounted until the
+ * dialog opens, because `ModalShell` renders nothing while closed — so a row
+ * showing a prototype pays for one frame, not two, until somebody asks.
+ *
+ * ## The dialog behaviour is `ModalShell`'s, deliberately
+ *
+ * Escape, the focus move in, the focus return to this trigger, `role="dialog"`
+ * and `aria-modal` all come from the shared shell. The audit behind issue #283
+ * found 21 of 23 overlays in this app missing dialog semantics precisely because
+ * each one re-implemented them; a full-viewport overlay is not the place to start
+ * that again.
+ *
+ * @module pages/Prioritization/PrototypeEnlargeButton
+ */
+import { Maximize2, X } from 'lucide-react'
+import { useId, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import ModalShell from '../../components/ModalShell'
+import type { ReactElement, ReactNode } from 'react'
+
+/**
+ * The trigger, and the full-viewport dialog it opens.
+ *
+ * @param documentTitle the prototype document's own title, shown beside the
+ *   heading so the dialog names the artifact on screen rather than only its kind.
+ *   Optional: a prototype is not required to carry one, and the heading alone
+ *   still gives the dialog a non-empty accessible name.
+ * @param children the prototype, as the caller already renders it in the row.
+ *   Sized by this component's container, so pass a frame that fills its box.
+ */
+export default function PrototypeEnlargeButton({
+  documentTitle, children,
+}: {
+  readonly documentTitle?: string
+  readonly children: ReactNode
+}): ReactElement {
+  const { t } = useTranslation('prioritization')
+  const [isOpen, setIsOpen] = useState(false)
+  // Names the dialog after the heading it already shows, so the accessible name
+  // cannot drift from the visible one. `useId` because the page renders one of
+  // these per expanded row, and a module constant would point every dialog at the
+  // first row's heading.
+  const headingId = useId()
+  return (
+    <>
+      {/* `aria-haspopup="dialog"` for the same reason `FormQrButton` carries it:
+          without it the control announces as a plain button and a screen-reader
+          user learns they are in a dialog only after focus has moved there.
+          `aria-expanded` would be wrong — this is not a disclosure revealing
+          adjacent content, it is a modal that does not exist until asked for. */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-haspopup="dialog"
+        className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+      >
+        <Maximize2 size={12} />
+        {t('preview.enlarge')}
+      </button>
+      <ModalShell
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        ariaLabelledBy={headingId}
+        // No max-width cap and a full-height panel: the point of this overlay is
+        // that the artifact gets the screen. `ModalShell`'s own container keeps a
+        // `p-4` gutter, so the panel's rounded corners and the overlay behind them
+        // stay visible — a viewer can still see they are in a dialog they can
+        // dismiss, which a literally edge-to-edge panel hides.
+        panelClassName="h-full flex flex-col overflow-hidden"
+      >
+        <div className="flex items-center justify-between gap-3 border-b px-4 py-2 flex-shrink-0">
+          <h3 id={headingId} className="font-medium text-gray-900 truncate">
+            {t('preview.prototypeTitle')}
+            {/* The artifact's own name, inside the heading rather than beside it, so
+                it is part of the dialog's accessible name instead of a second label
+                a screen reader reaches only by exploring. Omitted when the document
+                carries no title — an empty span would leave a stray separator. */}
+            {documentTitle ? (
+              <span className="ml-2 font-normal text-sm text-gray-500">{documentTitle}</span>
+            ) : null}
+          </h3>
+          {/* Visible, and the panel's first focusable so this is where the shell
+              puts focus on open. The shell's own ways out — Escape and an overlay
+              click — are both invisible, and this overlay covers the row a viewer
+              would otherwise click back to. */}
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            className="inline-flex items-center gap-1 text-sm text-gray-700 hover:text-gray-900 flex-shrink-0"
+          >
+            <X size={16} />
+            {t('common:actions.close')}
+          </button>
+        </div>
+        {/* `min-h-0` beside `flex-1`: a flex child's default `min-height: auto`
+            refuses to shrink below its content, and an iframe's content is not
+            something this box can measure — without it the frame pushes the panel
+            past the viewport and the header scrolls away. */}
+        <div className="flex-1 min-h-0">
+          {children}
+        </div>
+      </ModalShell>
+    </>
+  )
+}

--- a/voc-datalake/frontend/src/pages/Prioritization/PrototypeEnlargeButton.tsx
+++ b/voc-datalake/frontend/src/pages/Prioritization/PrototypeEnlargeButton.tsx
@@ -31,7 +31,10 @@
  * instance: each box mounts its own iframe, so opening this overlay performs a
  * fresh load and the enlarged prototype starts at its FIRST screen no matter which
  * screen the row's pane was showing, and both frames are live and executing while
- * the overlay is open. Accepted rather than missed — `HtmlPrototypeFrame` exposes
+ * the overlay is open. A JSON-spec prototype opens at its first screen too, for an
+ * unrelated reason — the overlay mounts a second `PrototypeRenderer` and the active
+ * screen is that component's own state; see `PRFAQRow`'s `pane` for why both are
+ * accepted. Accepted rather than missed — `HtmlPrototypeFrame` exposes
  * no navigation state to hand over, and a live iframe cannot be reparented without
  * reloading. It is the same loss of place `useLoadedUrl` exists to prevent, minus
  * the part that made that one a defect: this one happens because somebody asked,


### PR DESCRIPTION
## Summary

The remaining slice of issue #314. The QR halves (`FormQrCode/`, `SessionQrCode`) and the signed-URL
refresh scheduler have already shipped and are untouched here; this adds the one affordance that was
left: a way to enlarge the prototype a prioritization row is showing, and get back.

A pitch session looks at the prototype in a 384px pane inside half a table row. "Open in new tab"
already serves the reader who wants the artifact out of the app; it does not serve the *meeting*,
because the team's numbers, the reader's own sliders and the room-vote panel are all on this page and
a new tab abandons them. So the overlay is in-page.

**Three files, plus eight catalogues:**

- **`pages/Prioritization/PrototypeEnlargeButton.tsx`** (new) — the trigger and the full-viewport
  dialog it opens. It owns the *size* and nothing else: the prototype arrives as `children`, and the
  caller passes the very element it renders in the row.
- **`pages/Prioritization/PRFAQRow.tsx`** — `PrototypePanel` now describes its pane once and renders
  that description in two boxes (the row's `h-96` one and the overlay's full-height one). The control
  sits beside the existing open-in-a-new-tab anchor. A `PrototypePanelHeader` was split out; see
  *Decisions* for why.
- **`Prioritization.prototypeEnlarge.test.tsx`** (new, 13 tests) — one per behaviour, each shown red
  against the unfixed code (table below).
- `preview.enlarge` added to `prioritization.json` in all eight locales (en/es/fr/de/pt/ja/zh/ko).
  The dialog's close control reuses the existing `common:actions.close`, which is already present in
  all eight, so exactly one new string ships.

### Why it reuses `HtmlPrototypeFrame` rather than adding a second frame

`HtmlPrototypeFrame` carries `useLoadedUrl` — the handling that lets an hourly re-signing pass
*without* reloading the prototype under a reviewer who is several screens in, and that lets a URL
which was already dead on arrival be replaced. A frame written for the overlay would be free to drift
from that, and the drift would be invisible until somebody parked a pitch on screen for an hour. The
sizing difference is entirely the *container*, so `className` and a wrapper are the whole of it.

Dialog behaviour is `ModalShell`'s for the same reason: the audit behind #283 found 21 of 23 overlays
in this app missing dialog semantics precisely because each re-implemented them.

### Constraints honoured

- The open (and download) affordances remain **plain anchors**, per the reasoning in
  `prototypeLinkLifetime.ts`. A test asserts this explicitly, because a button now sits next to the
  anchor and "make the pair consistent" is exactly the tempting regression.
- The signed link's expiry note stays visible beside the anchor — also asserted.
- `FormQrCode/*`, `SessionQrCode` and the refresh scheduler are **read at most**; `git diff --stat`
  shows no change to any of them, and `Prioritization.prototypeRefresh.test.tsx` /
  `Prioritization.prototypeLink.test.tsx` still pass unmodified.
- No change to `prototypeLinkLifetime.ts`.
- Out of scope and not attempted: a QR over the prototype's (short-lived, signed) address, any change
  to how the links are built or triggered, a full present mode, and anything touching the public form
  routes, the widget or the authorization model.

## Each new test, shown red against the unfixed behaviour

Every revert below was applied to the working tree, the suite run, and the file restored. "Red"
means that named test failed; the count is how many of the 13 the revert took down.

| Revert applied | Red | Tests that failed |
|---|---|---|
| A. `ModalShell` replaced by a bare `fixed inset-0` div (the pre-#283 shape) | 8/13 | the whole dialog + return-to-row group |
| B. `dismissable={false}` on the shell — Escape stops closing | 1/13 | *closes on Escape and returns focus to the enlarge control* |
| C. the visible close control deleted, leaving only Escape | 1/13 | *closes on the close control and returns focus…* |
| D. `id={headingId}` dropped from the `<h3>`, so `aria-labelledby` dangles | 1/13 | *exposes itself as a modal dialog named after the prototype* |
| E. overlay given its own `<iframe srcDoc={content}>` instead of the row's pane | 1/13 | *renders the row's own frame at the row's signed address* |
| F. the `mode.kind === 'none'` guard dropped, so a prototype-less row still offers the control | 1/13 | *offers no enlarge control for a row whose project has no prototype* |
| G. `useState(true)` — the overlay mounted before anybody asks | 4/13 | *renders nothing enlarged until the control is used*, plus the focus/close trio |
| H. the control moved onto the resting row (one per row, before expansion) | 12/13 | *offers no enlarge control before the row is expanded*, and the rest |
| I. `PrototypeLinkActions`' anchor rewritten as a `window.open` button | 1/13 | *leaves opening in a new tab a plain anchor beside the enlarge control* |
| J. `PrototypeLinkLifetimeNote` removed from the panel | 2/13 | *…plain anchor beside the enlarge control*, *reports a lapsed link inside the overlay* |

Reverts I and J are the interesting pair: they are the two ways this change could plausibly damage
what already shipped, and both are caught.

## Build and test results

`npm run check` from the repository root. The container had no `node_modules` and no
`voc-datalake/.venv`, so both were created first (`npm install` in the three workspaces;
`ruff==0.15.0` per `requirements-dev.txt`'s floor, plus `requirements-dev.txt` and the runtime
imports the backend suite collects: `pydantic`, `tenacity`, `aws_xray_sdk`, `beautifulsoup4`,
`google-play-scraper`, `app-store-web-scraper`).

| Leg | Result |
|---|---|
| `lint:frontend` | **pass** — `eslint . --max-warnings 0`, clean |
| `lint:stream` | **pass** — 1 pre-existing warning in `indexes.test.ts` (`security/detect-non-literal-fs-filename`); that package's script has no `--max-warnings`, so it exits 0 |
| `lint:python` | **4 findings — identical on `development`.** All four are `E402` in conftest files (`lambda/conftest.py` ×3, `lambda/api/test/conftest.py` ×1). Verified by stashing this change and re-running: `Found 4 errors.` both ways. `npm run check` chains with `&&`, so it stops here — every leg below was therefore run individually |
| `typecheck:all` | **pass** (frontend + CDK + stream) |
| `npm run test` (frontend vitest) | **pass — 187 files, 3087 tests.** Before: **186 files, 3074 tests**. Delta is exactly this PR's 13 |
| `npm run test:cdk` | **pass** — 17 files. Needs `frontend/dist`, so `npm run build` was run first |
| `npm run test:stream` | **pass** — 24 files |
| `npm run test:backend` | **pass** — 3897 tests, 95% coverage |
| `npm run build` | **pass** — `tsc -b && vite build`, built in 8.7s |
| `scripts/i18n-check.mjs` | one finding **fewer** than `development`: `prioritization:preview.enlarge` was reported missing-in-source before the key existed and is now clean. Its other output (a long pre-existing unused-key list) is byte-identical |

Two notes on the environment rather than on the change: the first `vite build` died with `EMFILE:
too many open files` under a 1024-descriptor limit and succeeded unchanged on retry; and `lint:python`
under an *unpinned* ruff (0.16.4, which adds `I001` import sorting to the default set) reports 509
findings on `development` as well as here — the 4 above are ruff 0.15.0, the version
`requirements-dev.txt` pins the floor at.

## Decisions made

- **The enlarge control is offered for every prototype the panel renders, including one with no
  `prototype_url`.** Enlarging re-renders the pane the row already shows and needs no address of its
  own, whereas only a signed URL can be opened in a tab. So a legacy inline prototype and a JSON spec
  get "Enlarge" and not "Open in new tab" — pinned by a test, since the two controls sitting together
  makes it easy to later assume they share a condition.
- **`PrototypePanelHeader` was split out of `PrototypePanel`.** Adding the control pushed
  `PrototypePanel` to a cyclomatic complexity of 13 against eslint's cap of 12. The seam chosen is a
  real one (affordances vs. resolving which artifact to render) rather than a suppression, and the
  reason is recorded in the function's doc comment so a later reader does not "simplify" it back.
- **The panel keeps `ModalShell`'s `p-4` gutter** instead of going literally edge-to-edge, so the
  overlay behind the panel stays visible and a viewer can see they are in something dismissable.
- **`children: ReactNode`, not a render prop.** A React element is a description, so the same one
  used in both boxes mounts a frame per box — and the overlay's box does not exist until it is
  opened, `ModalShell` rendering nothing while closed. A row therefore still pays for one frame at
  rest.

## Agent notes

**What went well.** The brief named the reuse (`HtmlPrototypeFrame`) and the shape (dialog semantics,
row-with-no-prototype offers nothing), which made the design decisions mostly pre-made. `ModalShell`
already provided every accessibility guarantee the acceptance criteria ask for, so the overlay is
about thirty lines of actual behaviour. The per-behaviour revert discipline paid for itself twice:
revert G (`useState(true)`) and revert H (control on the resting row) each took down more tests than
expected, which is how I learned that "renders nothing enlarged until the control is used" and
"offers no enlarge control before the row is expanded" were each pulling their weight rather than
restating each other.

**What was difficult.** Mostly environment, not code. `npm run check` chains with `&&` and stops at
`lint:python`, which carries a long-standing 4-finding baseline — so the later legs had to be run
individually to learn anything, and the ruff *version* turned out to matter more than the code (0.16.4
adds `I001` and reports 509 on `development` too; the pinned floor is 0.15.0). `test:cdk` fails with
`CannotFindAsset` until `frontend/dist` exists, which is not obvious from the script name. `vite
build` hit `EMFILE` once under a 1024-descriptor limit.

**Conventions discovered.** They are unusually legible and worth stating for whoever picks up the
next slice:

- **Comments record which defect a line prevents**, and tests cite them back. `PrototypeLinkActions`'
  header explains why it must stay an anchor; `useLoadedUrl` explains why it freezes the URL. Code
  added without that reasoning reads as unfinished here, so this PR's new files carry it in the same
  register.
- **i18n keys must be statically visible to `scripts/i18n-check.mjs`.** A key assembled in a ternary
  is reported unused and becomes a deletion candidate — `PRFAQRow` has a comment saying this fired
  once already. Hence one literal `t('preview.enlarge')`.
- **`count` is reserved.** Several comments warn that passing it switches i18next into plural mode
  and renders a raw key path. Nothing here interpolates, but it is the trap to know about.
- **The locale set is exactly eight**, asserted anti-vacuously in `localeParity.test.ts`, and every
  namespace must have identical key sets across them.
- **Reuse an existing catalogue key when one exists** (`common:actions.close`) rather than minting a
  ninth spelling of "Close".
- eslint ignores `*.test.tsx`, so test files are not lint-gated — but `complexity`, `sonarjs` and
  `react-refresh/only-export-components` bite hard in source. `FormQrCode/index.tsx` documents a
  build failure caused by a second export in a barrel file; that is why the new component is imported
  deeply rather than barrelled.

**Suggestions for future tasks.**

1. `PrototypeEnlargeButton` is deliberately Prioritization-local, but the Documents tab renders the
   same prototype in a similarly cramped pane and would want the identical control. When a second
   caller appears, move it to `components/` — the same move `PrototypeRenderer` and
   `PrototypeLinkActions` already made, and each of their headers records the trigger.
2. `PrototypePanel` was one branch under the complexity cap before this change and needed a split to
   absorb one control. The next addition to it will need another. Resolving the mode (`html` / `spec`
   / `none`) into a small discriminated component per kind would give that function room.
3. The steering set is ~72k characters and the remote agent cannot see it, so the condensed house
   rules in the brief were load-bearing. Keeping that condensation in-repo (e.g. `CONTRIBUTING.md`)
   would let it be maintained alongside the rules rather than re-derived per task.
4. Four separate namespace lists exist (`i18n/options.ts`, `test/setup.ts`, `i18n-check.mjs`,
   `fix-i18n.mjs`), and `options.ts` already notes it. A single exported list would remove a
   four-way drift.

```abca-verify
no-ui
```

Everything this change puts on screen sits behind interaction, on data the preview does not have. The
enlarge control lives inside an *expanded* prioritization row whose project has a prototype document,
so with an empty database no row — and therefore no control — renders at load; the overlay itself
requires a click on top of that. A `selector` line here would fail for the absence of seeded data
rather than for a defect, which is worse than no line. The behaviour is pinned instead by the 13 tests
above, each demonstrated red against its own revert.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).