### PR TITLE
refactor(api): share one DocType union and retire the lockstep scanner

### DIFF
--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -1,3 +1,13 @@
+// ⚠️ This file is at the `max-lines` boundary: 599 counted lines against the limit of
+// 600 in eslint.config.js. ONE more line of code fails lint, and the error will name a
+// line number near the end of the file rather than whatever was added, so the next
+// person to add one learns it here instead of from a confusing failure.
+//
+// Comments and blank lines are FREE — the rule is configured `skipBlankLines: true,
+// skipComments: true` — so documentation costs nothing and only code counts. To
+// reclaim room, the `// Re-export all types for backward compatibility` block below is
+// the obvious candidate: this file is a thin wrapper whose methods mostly delegate via
+// `import('./projectsApi')`.
 import { authService } from '../services/auth'
 import { endExpiredSession } from '../services/sessionExpiry'
 import { getBaseUrl, getAuthHeaders, getDaysFromRange, getDateBasisBodyParams, ALL_TIME_DAYS } from './baseUrl'

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -1,13 +1,10 @@
 import { authService } from '../services/auth'
 import { endExpiredSession } from '../services/sessionExpiry'
 import { getBaseUrl, getAuthHeaders, getDaysFromRange, getDateBasisBodyParams, ALL_TIME_DAYS } from './baseUrl'
-// The generated-document union, imported rather than respelled: the route's
-// GENERATED_DOC_TYPES allowlist is pinned against this ONE declaration
-// (lambda/api/test/test_doc_type_lockstep.py), so an inline copy here could
-// disagree with the picker's type and with the route while the lockstep test
-// still passed. Type-only, so nothing about the module graph at runtime changes.
-import type { DocType } from '../pages/ProjectDetail/types'
 import type {
+  // The document-generation request body, shared with the `projectsApi` method
+  // this file's wrapper forwards to; see its declaration in `./types`.
+  GenerateDocumentBody,
   DateBasis,
   FeedbackItem,
   FeedbackListParams,
@@ -512,8 +509,12 @@ export const api = {
     import('./projectsApi').then(m => m.projectsApi.importPersona(projectId, data)),
   runResearch: (projectId: string, data: { question: string; title?: string; sources?: string[]; categories?: string[]; sentiments?: string[]; days?: number; selected_persona_ids?: string[]; selected_document_ids?: string[] }) =>
     import('./projectsApi').then(m => m.projectsApi.runResearch(projectId, data)),
-  generateDocument: (projectId: string, data: { doc_type: DocType; title: string; feature_idea: string; data_sources: { feedback: boolean; personas: boolean; documents: boolean; research: boolean }; selected_persona_ids: string[]; selected_document_ids: string[]; feedback_sources: string[]; feedback_categories: string[]; days: number; customer_questions?: string[] }) =>
+  generateDocument: (projectId: string, data: GenerateDocumentBody) =>
     import('./projectsApi').then(m => m.projectsApi.generateDocument(projectId, data)),
+  // `output_type` is a DIFFERENT contract from `DocType`, not a copy that was
+  // missed: POST .../documents/merge takes a third value (`custom`) and the merger
+  // reads it unchecked (`lambda/jobs/document_merger/handler.py`), so it is not
+  // bound to the document route's allowlist. Widening it is a separate change.
   mergeDocuments: (projectId: string, data: { output_type: 'prd' | 'prfaq' | 'custom'; title: string; instructions: string; selected_document_ids: string[]; selected_persona_ids?: string[]; use_feedback?: boolean; feedback_sources?: string[]; feedback_categories?: string[]; days?: number }) =>
     import('./projectsApi').then(m => m.projectsApi.mergeDocuments(projectId, data)),
   getJobStatus: (projectId: string, jobId: string) =>

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -1,6 +1,12 @@
 import { authService } from '../services/auth'
 import { endExpiredSession } from '../services/sessionExpiry'
 import { getBaseUrl, getAuthHeaders, getDaysFromRange, getDateBasisBodyParams, ALL_TIME_DAYS } from './baseUrl'
+// The generated-document union, imported rather than respelled: the route's
+// GENERATED_DOC_TYPES allowlist is pinned against this ONE declaration
+// (lambda/api/test/test_doc_type_lockstep.py), so an inline copy here could
+// disagree with the picker's type and with the route while the lockstep test
+// still passed. Type-only, so nothing about the module graph at runtime changes.
+import type { DocType } from '../pages/ProjectDetail/types'
 import type {
   DateBasis,
   FeedbackItem,
@@ -506,7 +512,7 @@ export const api = {
     import('./projectsApi').then(m => m.projectsApi.importPersona(projectId, data)),
   runResearch: (projectId: string, data: { question: string; title?: string; sources?: string[]; categories?: string[]; sentiments?: string[]; days?: number; selected_persona_ids?: string[]; selected_document_ids?: string[] }) =>
     import('./projectsApi').then(m => m.projectsApi.runResearch(projectId, data)),
-  generateDocument: (projectId: string, data: { doc_type: 'prd' | 'prfaq'; title: string; feature_idea: string; data_sources: { feedback: boolean; personas: boolean; documents: boolean; research: boolean }; selected_persona_ids: string[]; selected_document_ids: string[]; feedback_sources: string[]; feedback_categories: string[]; days: number; customer_questions?: string[] }) =>
+  generateDocument: (projectId: string, data: { doc_type: DocType; title: string; feature_idea: string; data_sources: { feedback: boolean; personas: boolean; documents: boolean; research: boolean }; selected_persona_ids: string[]; selected_document_ids: string[]; feedback_sources: string[]; feedback_categories: string[]; days: number; customer_questions?: string[] }) =>
     import('./projectsApi').then(m => m.projectsApi.generateDocument(projectId, data)),
   mergeDocuments: (projectId: string, data: { output_type: 'prd' | 'prfaq' | 'custom'; title: string; instructions: string; selected_document_ids: string[]; selected_persona_ids?: string[]; use_feedback?: boolean; feedback_sources?: string[]; feedback_categories?: string[]; days?: number }) =>
     import('./projectsApi').then(m => m.projectsApi.mergeDocuments(projectId, data)),

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -2,9 +2,6 @@ import { authService } from '../services/auth'
 import { endExpiredSession } from '../services/sessionExpiry'
 import { getBaseUrl, getAuthHeaders, getDaysFromRange, getDateBasisBodyParams, ALL_TIME_DAYS } from './baseUrl'
 import type {
-  // The document-generation request body, shared with the `projectsApi` method
-  // this file's wrapper forwards to; see its declaration in `./types`.
-  GenerateDocumentBody,
   DateBasis,
   FeedbackItem,
   FeedbackListParams,
@@ -34,6 +31,9 @@ import type {
   LogsSummary,
   ApiToken,
   CreateApiTokenResponse,
+  // The document-generation request body, shared with the `projectsApi` method
+  // this file's wrapper forwards to; see its declaration in `./types`.
+  GenerateDocumentBody,
 } from './types'
 
 // Re-export all types for backward compatibility

--- a/voc-datalake/frontend/src/api/client.ts
+++ b/voc-datalake/frontend/src/api/client.ts
@@ -509,6 +509,11 @@ export const api = {
     import('./projectsApi').then(m => m.projectsApi.importPersona(projectId, data)),
   runResearch: (projectId: string, data: { question: string; title?: string; sources?: string[]; categories?: string[]; sentiments?: string[]; days?: number; selected_persona_ids?: string[]; selected_document_ids?: string[] }) =>
     import('./projectsApi').then(m => m.projectsApi.runResearch(projectId, data)),
+  // Keep this signature on ONE line, and keep `data` taking the shared type by name:
+  // test_doc_type_lockstep.py matches it as exact text, and requires EVERY declaration
+  // of generateDocument to take `GenerateDocumentBody` (a ratio, because a mere
+  // substring search was satisfied by an unrelated occurrence while the real
+  // parameter was respelled inline — issue #381).
   generateDocument: (projectId: string, data: GenerateDocumentBody) =>
     import('./projectsApi').then(m => m.projectsApi.generateDocument(projectId, data)),
   // `output_type` is a DIFFERENT contract from `DocType`, not a copy that was

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -425,7 +425,16 @@ export type GenerateDocumentSignaturePinWouldSeeDrift = SignatureMustMatch<BothW
 // NARROWED side — refuses a `BothWays` collapsed to its ONE-WAY form, which the
 // control above cannot detect: a widened left side fails `[Left] extends [Right]`
 // under either form, so the two are indistinguishable to it (see the ⚠️ note on
-// `BothWays` in ./types). `never` is assignable to the body, so a one-way comparison
-// calls this `true`, the directive goes unused and the line becomes a TS2578.
-// @ts-expect-error `never` is narrower than the body, so it must NOT compare equal
-export type GenerateDocumentSignaturePinWouldSeeNarrowing = SignatureMustMatch<BothWays<never, GenerateDocumentBody>>
+// `BothWays` in ./types). The declared parameter is narrower than a body whose members
+// are all optional, so a one-way comparison calls this `true`, the directive goes
+// unused and the line becomes a TS2578; two-way, it is `false` as required.
+//
+// 🔑 Left side reads `Parameters<...>[1]`, the same operand as the pin, rather than the
+// `never` this once used. `never` discriminates the two forms just as well, but it
+// mentions nothing about this method — so it was a second detector of a collapse in the
+// SHARED `BothWays` (already caught once in ./types) rather than a control on THIS pin,
+// and deleting it left the collapse detected only by the other file. `Partial<...>` is
+// derived from the body, so it names no member and cannot go stale when the contract is
+// widened.
+// @ts-expect-error the declared parameter must NOT equal a body of optional members
+export type GenerateDocumentSignaturePinWouldSeeNarrowing = SignatureMustMatch<BothWays<Parameters<typeof projectsApi.generateDocument>[1], Partial<GenerateDocumentBody>>>

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -125,7 +125,19 @@ export const projectsApi = {
       message: string
     }>(`/projects/${projectId}/document`, {
       method: 'POST',
-      body: JSON.stringify({ ...getDateBasisBodyParams(), ...data }),
+      // 🔑 `satisfies` is load-bearing, not decoration. This method is the
+      // TERMINAL consumer of `data` — it is only spread into `JSON.stringify`, so
+      // the annotation above is compared against NOTHING and any widening of it
+      // type-checks. Naming the shared type is not enough either: an
+      // `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
+      // respelling still USES the name while widening the field. This clause is
+      // what makes either a TS1360 here, so widening has to happen in
+      // `GenerateDocumentBody` where the field is `DocType` and
+      // test_doc_type_lockstep.py compares it against the route (issue #381).
+      body: JSON.stringify({
+        ...getDateBasisBodyParams(),
+        ...(data satisfies GenerateDocumentBody),
+      }),
     }),
 
   mergeDocuments: (projectId: string, data: {

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -131,9 +131,18 @@ export const projectsApi = {
       // type-checks. Naming the shared type is not enough either: an
       // `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
       // respelling still USES the name while widening the field. This clause is
-      // what makes either a TS1360 here, so widening has to happen in
-      // `GenerateDocumentBody` where the field is `DocType` and
-      // test_doc_type_lockstep.py compares it against the route (issue #381).
+      // what makes either a TS1360 here.
+      //
+      // It has to be ON THIS METHOD, not merely somewhere in this file:
+      // `test_the_terminal_client_pins_the_body_structurally` searches only the
+      // `generateDocument` slice, because a whole-file check was measured to pass
+      // with the clause moved to an unrelated helper and this method widened.
+      //
+      // So widening means editing `DocType` and `GENERATED_DOC_TYPES` together.
+      // Editing `GenerateDocumentBody.doc_type` instead is NOT a way round that —
+      // `DocTypeFieldIsExactlyTheUnion` in `./types` makes it a TS2344 — and this
+      // clause alone would not have stopped it, since it checks the built object
+      // against that interface (issue #381).
       body: JSON.stringify({
         ...getDateBasisBodyParams(),
         ...(data satisfies GenerateDocumentBody),

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -383,29 +383,42 @@ export const projectsApi = {
 // the method's own type has no location to migrate to, so the text guard, its two
 // method-name markers and their ordering assumption all went with it.
 //
-// `Parameters<...>[1]` reads the parameter off the declaration rather than restating
-// it, so this cannot drift from the signature it pins. Equality in both directions
-// for the same reason as `DocTypeFieldIsExactlyTheUnion`: a one-way `extends` passes
-// on a NARROWED parameter, which is the "capability nobody can reach" half of this
-// contract's drift.
+// `Parameters<...>[1]` reads the parameter off the METHOD rather than restating it, so
+// the left side of this comparison is whatever the signature actually declares.
+// Applied INLINE below rather than through an intermediate alias: an alias is a second
+// place the left side can be respelled, and repointing one at `GenerateDocumentBody`
+// made the pin compare the interface to itself — trivially equal forever, with both
+// controls still green because they read through the same alias. Measured: `tsc` exit
+// 0, every lockstep test green, and a caller sending a value the route 400s.
+//
+// Equality in both directions for the same reason as `DocTypeFieldIsExactlyTheUnion`:
+// a one-way `extends` passes on a NARROWED parameter, which is the "capability nobody
+// can reach" half of this contract's drift.
 //
 // Each declaration below is on ONE line, with its comparison applied inline: the
-// lockstep test requires the source to spell `SignatureMustMatch<BothWays<`, and
-// wrapping puts a newline between the two so the substring goes absent.
+// lockstep test pins each as an EXACT string, so wrapping puts a newline inside what
+// it looks for. See TYPE_LEVEL_PINS in lambda/api/test/test_doc_type_lockstep.py.
+//
+// One verdict helper, no `SignatureMustDiffer` companion — see the 🔑 note on
+// `MustBeTrue` in ./types: the controls assert their verdict by expecting THIS helper's
+// error, so dropping `extends true` makes each `@ts-expect-error` unused (TS2578)
+// instead of silently disabling every control at once.
 type SignatureMustMatch<Verdict extends true> = Verdict
-// The parameter as DECLARED, read off the method so this cannot restate it.
-type DeclaredGenerateDocumentBody = Parameters<typeof projectsApi.generateDocument>[1]
-export type GenerateDocumentTakesTheSharedBody = SignatureMustMatch<BothWays<DeclaredGenerateDocumentBody, GenerateDocumentBody>>
-// The non-vacuity controls, in the convention the lockstep tests use for their own:
-// `SignatureMustMatch<BothWays<...>>` is also satisfied by a `BothWays` that
-// degenerates to `true`, which would report success while comparing nothing.
+export type GenerateDocumentTakesTheSharedBody = SignatureMustMatch<BothWays<Parameters<typeof projectsApi.generateDocument>[1], GenerateDocumentBody>>
+// The non-vacuity controls. `SignatureMustMatch<BothWays<...>>` is also satisfied by a
+// `BothWays` that degenerates to `true` or collapses to one-way, each of which reports
+// success while comparing less than it claims. Both are INVERTED assertions: the
+// comparison must NOT hold, so the helper must reject it and `@ts-expect-error`
+// consumes that error — self-checking, since a comparison that starts holding leaves
+// the directive unused.
 //
 // WIDENED side — a body with one extra member must NOT compare equal.
-type SignatureMustDiffer<Verdict extends false> = Verdict
-export type GenerateDocumentSignaturePinWouldSeeDrift = SignatureMustDiffer<BothWays<DeclaredGenerateDocumentBody, GenerateDocumentBody & { not_in_the_body: true }>>
+// @ts-expect-error the declared parameter must NOT equal a body with an extra member
+export type GenerateDocumentSignaturePinWouldSeeDrift = SignatureMustMatch<BothWays<Parameters<typeof projectsApi.generateDocument>[1], GenerateDocumentBody & { not_in_the_body: true }>>
 // NARROWED side — refuses a `BothWays` collapsed to its ONE-WAY form, which the
 // control above cannot detect: a widened left side fails `[Left] extends [Right]`
 // under either form, so the two are indistinguishable to it (see the ⚠️ note on
 // `BothWays` in ./types). `never` is assignable to the body, so a one-way comparison
-// calls this `true` and the line becomes a TS2344.
-export type GenerateDocumentSignaturePinWouldSeeNarrowing = SignatureMustDiffer<BothWays<never, GenerateDocumentBody>>
+// calls this `true`, the directive goes unused and the line becomes a TS2578.
+// @ts-expect-error `never` is narrower than the body, so it must NOT compare equal
+export type GenerateDocumentSignaturePinWouldSeeNarrowing = SignatureMustMatch<BothWays<never, GenerateDocumentBody>>

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -388,18 +388,24 @@ export const projectsApi = {
 // for the same reason as `DocTypeFieldIsExactlyTheUnion`: a one-way `extends` passes
 // on a NARROWED parameter, which is the "capability nobody can reach" half of this
 // contract's drift.
+//
+// Each declaration below is on ONE line, with its comparison applied inline: the
+// lockstep test requires the source to spell `SignatureMustMatch<BothWays<`, and
+// wrapping puts a newline between the two so the substring goes absent.
 type SignatureMustMatch<Verdict extends true> = Verdict
-export type GenerateDocumentTakesTheSharedBody = SignatureMustMatch<
-  BothWays<Parameters<typeof projectsApi.generateDocument>[1], GenerateDocumentBody>
->
-// The non-vacuity control, in the convention the lockstep tests use for their own:
+// The parameter as DECLARED, read off the method so this cannot restate it.
+type DeclaredGenerateDocumentBody = Parameters<typeof projectsApi.generateDocument>[1]
+export type GenerateDocumentTakesTheSharedBody = SignatureMustMatch<BothWays<DeclaredGenerateDocumentBody, GenerateDocumentBody>>
+// The non-vacuity controls, in the convention the lockstep tests use for their own:
 // `SignatureMustMatch<BothWays<...>>` is also satisfied by a `BothWays` that
-// degenerates to `true`, which would report success while comparing nothing. A body
-// with one extra member must therefore NOT compare equal.
+// degenerates to `true`, which would report success while comparing nothing.
+//
+// WIDENED side — a body with one extra member must NOT compare equal.
 type SignatureMustDiffer<Verdict extends false> = Verdict
-export type GenerateDocumentSignaturePinWouldSeeDrift = SignatureMustDiffer<
-  BothWays<
-    Parameters<typeof projectsApi.generateDocument>[1],
-    GenerateDocumentBody & { not_in_the_body: true }
-  >
->
+export type GenerateDocumentSignaturePinWouldSeeDrift = SignatureMustDiffer<BothWays<DeclaredGenerateDocumentBody, GenerateDocumentBody & { not_in_the_body: true }>>
+// NARROWED side — refuses a `BothWays` collapsed to its ONE-WAY form, which the
+// control above cannot detect: a widened left side fails `[Left] extends [Right]`
+// under either form, so the two are indistinguishable to it (see the ⚠️ note on
+// `BothWays` in ./types). `never` is assignable to the body, so a one-way comparison
+// calls this `true` and the line becomes a TS2344.
+export type GenerateDocumentSignaturePinWouldSeeNarrowing = SignatureMustDiffer<BothWays<never, GenerateDocumentBody>>

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -240,6 +240,14 @@ export const projectsApi = {
       },
     ),
 
+  // NOT `DocType`, and its agreement with that union today is coincidence rather
+  // than a floor: this is a DIFFERENT route (.../documents/suggest-brief) whose
+  // `doc_type` only picks a prompt label, with anything unrecognised falling back to
+  // 'PRD' (`projects.suggest_document_brief`). So it may legitimately fall behind a
+  // widening of the document route — the cost is one prompt labelled PRD instead of
+  // a new type's name, not a refused request. Binding it to `GENERATED_DOC_TYPES`
+  // would instead make widening THIS route fail a test named after the other one.
+  // If it is ever pinned it wants its own constant and its own rationale (#381).
   suggestDocumentBrief: (projectId: string, body: { doc_type?: 'prd' | 'prfaq'; response_language?: string } = {}) =>
     fetchApi<{ title: string; feature_idea: string }>(
       `/projects/${projectId}/documents/suggest-brief`,

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -118,6 +118,13 @@ export const projectsApi = {
       body: JSON.stringify({ ...getDateBasisBodyParams(), ...data }),
     }),
 
+  // Keep this signature on ONE line, and keep `data` taking the shared type by name:
+  // test_doc_type_lockstep.py matches it as exact text, and requires EVERY declaration
+  // of generateDocument to take `GenerateDocumentBody`. That is a ratio rather than a
+  // substring search because a substring was satisfied by an unrelated occurrence —
+  // and by a decoy copy of this signature — while the real parameter was respelled as
+  // a structurally identical inline literal. The pin at the foot of this file cannot
+  // see that one either: an identical shape compares EQUAL (issue #381).
   generateDocument: (projectId: string, data: GenerateDocumentBody) =>
     fetchApi<{
       success: boolean;

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -6,8 +6,9 @@ import type {
   Project, ProjectDetail, ProjectPersona, ProjectDocument, ProjectJob,
   ProductContext, ProductDoc, ProductInterviewTurnResponse,
   // The document-generation request body; see its declaration for why it is a
-  // named type rather than an object literal spelled out here.
-  GenerateDocumentBody,
+  // named type rather than an object literal spelled out here. `BothWays` comes with
+  // it for the signature pin at the foot of this file.
+  GenerateDocumentBody, BothWays,
 } from './types'
 
 export const projectsApi = {
@@ -125,28 +126,11 @@ export const projectsApi = {
       message: string
     }>(`/projects/${projectId}/document`, {
       method: 'POST',
-      // 🔑 `satisfies` is load-bearing, not decoration. This method is the
-      // TERMINAL consumer of `data` — it is only spread into `JSON.stringify`, so
-      // the annotation above is compared against NOTHING and any widening of it
-      // type-checks. Naming the shared type is not enough either: an
-      // `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
-      // respelling still USES the name while widening the field. This clause is
-      // what makes either a TS1360 here.
-      //
-      // It has to be ON THIS METHOD, not merely somewhere in this file:
-      // `test_the_terminal_client_pins_the_body_structurally` searches only the
-      // `generateDocument` slice, because a whole-file check was measured to pass
-      // with the clause moved to an unrelated helper and this method widened.
-      //
-      // So widening means editing `DocType` and `GENERATED_DOC_TYPES` together.
-      // Editing `GenerateDocumentBody.doc_type` instead is NOT a way round that —
-      // `DocTypeFieldIsExactlyTheUnion` in `./types` makes it a TS2344 — and this
-      // clause alone would not have stopped it, since it checks the built object
-      // against that interface (issue #381).
-      body: JSON.stringify({
-        ...getDateBasisBodyParams(),
-        ...(data satisfies GenerateDocumentBody),
-      }),
+      // `data` is only spread into the body — nothing here constrains its type. What
+      // stops the annotation above being widened is
+      // `GenerateDocumentTakesTheSharedBody` at the foot of this file; see there for
+      // why it is a type-level comparison and not a clause on this object (#381).
+      body: JSON.stringify({ ...getDateBasisBodyParams(), ...data }),
     }),
 
   mergeDocuments: (projectId: string, data: {
@@ -375,3 +359,47 @@ export const projectsApi = {
     return fetchApi<{ project: Record<string, unknown>; files: Array<{ path: string; content: string }> }>(path)
   },
 }
+
+// 🔑 The pin on `generateDocument`'s request-body parameter: it must admit EXACTLY
+// `GenerateDocumentBody`, in both directions. `test_doc_type_lockstep.py` keeps this
+// block present, since deleting it compiles cleanly.
+//
+// Needed because this method is the TERMINAL consumer of `data` — it is only spread
+// into `JSON.stringify`, so the annotation is compared against nothing and any
+// widening of it type-checks on its own. Measured, both spellings:
+//   * `data: { doc_type: 'prd' | 'prfaq' | 'onepager', ... }` — the plain respelling;
+//   * `data: Omit<GenerateDocumentBody, 'doc_type'>
+//        & { doc_type: GenerateDocumentBody['doc_type'] | 'onepager' }` — which USES
+//     the shared name, so neither `noUnusedLocals` nor a text check for the name sees
+//     it.
+// Both exited `tsc` 0 and sent a value the route 400s.
+//
+// ⚠️ This replaced a `satisfies GenerateDocumentBody` clause inside the method body,
+// which was equivalent for the compiler but had to be pinned BY LOCATION from
+// Python: a whole-file text check passed with the clause moved to an unrelated
+// helper, and narrowing the search to the slice before the next method still passed
+// with the clause in a NEW method inserted into that slice — measured, `tsc` exit 0
+// and every lockstep test green while the axis was reopened. A comparison against
+// the method's own type has no location to migrate to, so the text guard, its two
+// method-name markers and their ordering assumption all went with it.
+//
+// `Parameters<...>[1]` reads the parameter off the declaration rather than restating
+// it, so this cannot drift from the signature it pins. Equality in both directions
+// for the same reason as `DocTypeFieldIsExactlyTheUnion`: a one-way `extends` passes
+// on a NARROWED parameter, which is the "capability nobody can reach" half of this
+// contract's drift.
+type SignatureMustMatch<Verdict extends true> = Verdict
+export type GenerateDocumentTakesTheSharedBody = SignatureMustMatch<
+  BothWays<Parameters<typeof projectsApi.generateDocument>[1], GenerateDocumentBody>
+>
+// The non-vacuity control, in the convention the lockstep tests use for their own:
+// `SignatureMustMatch<BothWays<...>>` is also satisfied by a `BothWays` that
+// degenerates to `true`, which would report success while comparing nothing. A body
+// with one extra member must therefore NOT compare equal.
+type SignatureMustDiffer<Verdict extends false> = Verdict
+export type GenerateDocumentSignaturePinWouldSeeDrift = SignatureMustDiffer<
+  BothWays<
+    Parameters<typeof projectsApi.generateDocument>[1],
+    GenerateDocumentBody & { not_in_the_body: true }
+  >
+>

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -2,6 +2,12 @@
 // Uses shared fetchApi from client.ts for consistent 401 retry + token refresh
 import { fetchApi } from './client'
 import { getDateBasisBodyParams } from './baseUrl'
+// The generated-document union, imported rather than respelled: the route's
+// GENERATED_DOC_TYPES allowlist is pinned against this ONE declaration
+// (lambda/api/test/test_doc_type_lockstep.py), so an inline copy here could
+// disagree with the picker's type and with the route while the lockstep test
+// still passed. Type-only, so nothing about the module graph at runtime changes.
+import type { DocType } from '../pages/ProjectDetail/types'
 import type {
   Project, ProjectDetail, ProjectPersona, ProjectDocument, ProjectJob,
   ProductContext, ProductDoc, ProductInterviewTurnResponse,
@@ -115,7 +121,7 @@ export const projectsApi = {
     }),
 
   generateDocument: (projectId: string, data: {
-    doc_type: 'prd' | 'prfaq'
+    doc_type: DocType
     title: string
     feature_idea: string
     data_sources: {

--- a/voc-datalake/frontend/src/api/projectsApi.ts
+++ b/voc-datalake/frontend/src/api/projectsApi.ts
@@ -2,15 +2,12 @@
 // Uses shared fetchApi from client.ts for consistent 401 retry + token refresh
 import { fetchApi } from './client'
 import { getDateBasisBodyParams } from './baseUrl'
-// The generated-document union, imported rather than respelled: the route's
-// GENERATED_DOC_TYPES allowlist is pinned against this ONE declaration
-// (lambda/api/test/test_doc_type_lockstep.py), so an inline copy here could
-// disagree with the picker's type and with the route while the lockstep test
-// still passed. Type-only, so nothing about the module graph at runtime changes.
-import type { DocType } from '../pages/ProjectDetail/types'
 import type {
   Project, ProjectDetail, ProjectPersona, ProjectDocument, ProjectJob,
   ProductContext, ProductDoc, ProductInterviewTurnResponse,
+  // The document-generation request body; see its declaration for why it is a
+  // named type rather than an object literal spelled out here.
+  GenerateDocumentBody,
 } from './types'
 
 export const projectsApi = {
@@ -120,24 +117,7 @@ export const projectsApi = {
       body: JSON.stringify({ ...getDateBasisBodyParams(), ...data }),
     }),
 
-  generateDocument: (projectId: string, data: {
-    doc_type: DocType
-    title: string
-    feature_idea: string
-    data_sources: {
-      feedback: boolean;
-      personas: boolean;
-      documents: boolean;
-      research: boolean
-    }
-    selected_persona_ids: string[]
-    selected_document_ids: string[]
-    feedback_sources: string[]
-    feedback_categories: string[]
-    days: number
-    customer_questions?: string[]
-    response_language?: string
-  }) =>
+  generateDocument: (projectId: string, data: GenerateDocumentBody) =>
     fetchApi<{
       success: boolean;
       job_id: string;

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -401,6 +401,47 @@ export interface ProjectPersona {
   source_breakdown?: Record<string, number>
 }
 
+// 🔑 The ONE declaration of what POST /projects/{id}/document accepts in
+// `doc_type`. `projects_handler.GENERATED_DOC_TYPES` is pinned against THIS line by
+// lambda/api/test/test_doc_type_lockstep.py, so widen both together or that test
+// fails. Keep it a union of string LITERALS: the lockstep parser refuses a derived
+// spelling (`typeof GENERATED_DOC_TYPES[number]`) rather than resolving it.
+//
+// It lives here, beside the other wire types, rather than in
+// `pages/ProjectDetail/types.ts` where it was declared before: the route owns this
+// contract, and `api/` importing from `pages/` inverted the layering. The document
+// picker re-exports it from there (issue #381).
+export type DocType = 'prd' | 'prfaq'
+
+// The POST /projects/{id}/document request body, named so that BOTH
+// `generateDocument` signatures — `projectsApi.ts` and the `client.ts` wrapper that
+// forwards to it — reference one declaration instead of restating the shape.
+//
+// 🔑 Why a named type and not just `doc_type: DocType` in each signature: the
+// `projectsApi` one is the TERMINAL consumer (its `data` is only spread into
+// `JSON.stringify`), so widening its annotation inline is an assignability error
+// NOWHERE — `tsc` accepts it and the request goes out with a value the route 400s.
+// Only the shared name closes that, and `test_doc_type_lockstep.py` asserts both
+// signatures still spell it.
+export interface GenerateDocumentBody {
+  doc_type: DocType
+  title: string
+  feature_idea: string
+  data_sources: {
+    feedback: boolean;
+    personas: boolean;
+    documents: boolean;
+    research: boolean
+  }
+  selected_persona_ids: string[]
+  selected_document_ids: string[]
+  feedback_sources: string[]
+  feedback_categories: string[]
+  days: number
+  customer_questions?: string[]
+  response_language?: string
+}
+
 export interface ProjectDocument {
   document_id: string
   document_type: 'prd' | 'prfaq' | 'research' | 'custom' | 'product_report' | 'prototype'

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -448,17 +448,28 @@ export interface GenerateDocumentBody {
   response_language?: string
 }
 
-// 🔑 The pin that makes `GenerateDocumentBody.doc_type` REFERENCE `DocType` rather
-// than merely happen to list the same members today. Deleting this block compiles
-// cleanly, so `test_the_request_body_field_is_pinned_to_the_union` in
+// 🔑 The pin on `GenerateDocumentBody.doc_type`. What it guarantees, stated as the
+// property it actually checks: that field admits EXACTLY the members of `DocType`,
+// in both directions. Deleting this block compiles cleanly, so
+// `test_the_request_body_field_is_pinned_to_the_union` in
 // lambda/api/test/test_doc_type_lockstep.py keeps both declarations present.
 //
-// Why it is needed at all — measured, not assumed. Every other guard around this
-// contract stops one level further out:
+// ⚠️ It does NOT check that the field REFERENCES `DocType` — an earlier version of
+// this comment said it did, and that was measured to be the opposite of the truth.
+// `BothWays` is a structural comparison, so respelling the field `'prd' | 'prfaq'`
+// — the same members, no reference to the union at all — passes it (verified: `tsc`
+// exit 0, every lockstep test green). Set equality is the weaker property and it is
+// the SUFFICIENT one: a same-member respelling is harmless today, and if `DocType`
+// is later widened the stale field stops being equal to it and this line becomes a
+// TS2344. So the drift this contract cares about is still caught at the moment it
+// would be introduced; only the coincidence is tolerated, and never silently.
+//
+// Why the pin is needed at all — measured, not assumed. Every other guard around
+// this contract stops one level further out:
 //   * the lockstep test parses only the `export type DocType =` declaration above,
 //     so it cannot see this interface;
-//   * `satisfies GenerateDocumentBody` in `projectsApi.generateDocument` checks the
-//     built object against THIS interface, so a widened interface satisfies it by
+//   * `GenerateDocumentTakesTheSharedBody` in `projectsApi.ts` compares that
+//     method's PARAMETER to this interface, so a widened interface satisfies it by
 //     construction;
 //   * `noUnusedLocals` stays quiet, since `DocType` is still used by
 //     `ProjectDocument` below.
@@ -472,8 +483,8 @@ export interface GenerateDocumentBody {
 // drift this contract is about) would pass. Hence equality in both directions.
 // `[T] extends [U]` rather than `T extends U`: the bare form distributes over a
 // union, which would compare member-by-member and accept a subset.
-type BothWays<Field, Union> = [Field] extends [Union]
-  ? ([Union] extends [Field] ? true : false)
+export type BothWays<Left, Right> = [Left] extends [Right]
+  ? ([Right] extends [Left] ? true : false)
   : false
 type MustBeTrue<Verdict extends true> = Verdict
 type MustBeFalse<Verdict extends false> = Verdict

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -451,8 +451,8 @@ export interface GenerateDocumentBody {
 // 🔑 The pin on `GenerateDocumentBody.doc_type`. What it guarantees, stated as the
 // property it actually checks: that field admits EXACTLY the members of `DocType`,
 // in both directions. Deleting this block compiles cleanly, so
-// `test_the_request_body_field_is_pinned_to_the_union` in
-// lambda/api/test/test_doc_type_lockstep.py keeps both declarations present.
+// `test_the_type_level_pins_are_present` in
+// lambda/api/test/test_doc_type_lockstep.py keeps these declarations present.
 //
 // ⚠️ It does NOT check that the field REFERENCES `DocType` — an earlier version of
 // this comment said it did, and that was measured to be the opposite of the truth.
@@ -483,25 +483,51 @@ export interface GenerateDocumentBody {
 // drift this contract is about) would pass. Hence equality in both directions.
 // `[T] extends [U]` rather than `T extends U`: the bare form distributes over a
 // union, which would compare member-by-member and accept a subset.
+//
+// ⚠️ WHAT PINS THE SECOND DIRECTION. A WIDENED-side control does not: a superset
+// fails `[Left] extends [Right]` under the one-way form too, so the two forms are
+// INDISTINGUISHABLE to it, and collapsing this type to `[Left] extends [Right]`
+// was measured to leave `tsc` at exit 0 with every lockstep test green. Only a
+// NARROWED-side control separates them, which is why each pin below has one as well
+// (`...WouldSeeNarrowing`). Their left side is `never` — the maximally narrowed
+// type, assignable to everything — so it is `true` under a one-way comparison and
+// `false` under this one, with no member spelled out to go stale.
+//
+// `never` rather than the narrowed spellings that look more natural: measured,
+// `Omit<GenerateDocumentBody, 'doc_type'>` is NOT assignable to the interface (it
+// lacks a required property), so it is `false` under BOTH forms and detects
+// nothing. A narrowed-FIELD shape such as
+// `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: 'prd' }` does discriminate,
+// but it names a member and so goes stale the moment the contract is widened.
 export type BothWays<Left, Right> = [Left] extends [Right]
   ? ([Right] extends [Left] ? true : false)
   : false
 type MustBeTrue<Verdict extends true> = Verdict
 type MustBeFalse<Verdict extends false> = Verdict
+// Each pin below is written on ONE line, with its comparison applied inline. That is
+// load-bearing rather than a formatting choice: the lockstep test requires the source
+// to spell `MustBeTrue<BothWays<`, and a wrapped declaration puts a newline between
+// the two so the substring is absent. See TYPE_LEVEL_PINS in
+// lambda/api/test/test_doc_type_lockstep.py for why the check includes the
+// comparison and not just the helper's name.
+//
 // Exported only so `noUnusedLocals` cannot be what deletes them; nothing imports
-// either, and nothing should.
-export type DocTypeFieldIsExactlyTheUnion = MustBeTrue<
-  BothWays<GenerateDocumentBody['doc_type'], DocType>
->
-// The non-vacuity control for the line above, in the same convention the lockstep
+// any of them, and nothing should.
+export type DocTypeFieldIsExactlyTheUnion = MustBeTrue<BothWays<GenerateDocumentBody['doc_type'], DocType>>
+// The non-vacuity controls for the line above, in the same convention the lockstep
 // tests use: `MustBeTrue<BothWays<...>>` is also satisfied by a `BothWays` that
 // degenerates to `true`, which would be a pin reporting success while comparing
-// nothing. Adding a member the route cannot accept must therefore be `false`.
-// Derived from the field rather than listing members, so widening the contract
-// legitimately does not make this line the failure.
-export type DocTypeFieldPinWouldSeeDrift = MustBeFalse<
-  BothWays<GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>
->
+// nothing. Both are derived from the field rather than listing members, so widening
+// the contract legitimately does not make either one the failure.
+//
+// WIDENED side — refuses a `BothWays` that is always `true`. Adding a member the
+// route cannot accept must not compare equal.
+export type DocTypeFieldPinWouldSeeDrift = MustBeFalse<BothWays<GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>>
+// NARROWED side — refuses a `BothWays` collapsed to its ONE-WAY form, which the
+// control above cannot see (see the ⚠️ note on `BothWays`). `never` is assignable to
+// `DocType`, so a one-way comparison calls this `true` and this line becomes a
+// TS2344; two-way, it is `false` as required.
+export type DocTypeFieldPinWouldSeeNarrowing = MustBeFalse<BothWays<never, DocType>>
 
 export interface ProjectDocument {
   document_id: string

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -489,16 +489,23 @@ export interface GenerateDocumentBody {
 // INDISTINGUISHABLE to it, and collapsing this type to `[Left] extends [Right]`
 // was measured to leave `tsc` at exit 0 with every lockstep test green. Only a
 // NARROWED-side control separates them, which is why each pin below has one as well
-// (`...WouldSeeNarrowing`). Their left side is `never` — the maximally narrowed
-// type, assignable to everything — so it is `true` under a one-way comparison and
+// (`...WouldSeeNarrowing`). Each compares its OWN pin's left operand against a wider
+// type DERIVED from the right one, so it is `true` under a one-way comparison and
 // `false` under this one, with no member spelled out to go stale.
 //
-// `never` rather than the narrowed spellings that look more natural: measured,
-// `Omit<GenerateDocumentBody, 'doc_type'>` is NOT assignable to the interface (it
-// lacks a required property), so it is `false` under BOTH forms and detects
-// nothing. A narrowed-FIELD shape such as
-// `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: 'prd' }` does discriminate,
-// but it names a member and so goes stale the moment the contract is widened.
+// ⚠️ Not `Omit<...>`, which looks like the natural narrowing and detects nothing:
+// measured, `Omit<GenerateDocumentBody, 'doc_type'>` is NOT assignable to the
+// interface (it lacks a required property), so it is `false` under BOTH forms. A
+// narrowed-FIELD shape such as `Omit<GenerateDocumentBody, 'doc_type'> &
+// { doc_type: 'prd' }` does discriminate, but it names a member and so goes stale the
+// moment the contract is widened.
+//
+// ⚠️ Nor a bare `never` on the left, which the signature control used to have. It
+// discriminates the two forms perfectly well, but it mentions nothing about the thing
+// being pinned — so it was really a second detector of a collapse in THIS shared
+// helper (already reported once, here) rather than a control on that pin. Measured:
+// deleting it left a one-way collapse reported only by this file. Reading the pin's
+// own operand is what makes each control local to its pin.
 export type BothWays<Left, Right> = [Left] extends [Right]
   ? ([Right] extends [Left] ? true : false)
   : false
@@ -539,11 +546,15 @@ export type DocTypeFieldIsExactlyTheUnion = MustBeTrue<BothWays<GenerateDocument
 // @ts-expect-error the field plus a member DocType lacks must NOT compare equal
 export type DocTypeFieldPinWouldSeeDrift = MustBeTrue<BothWays<GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>>
 // NARROWED side — refuses a `BothWays` collapsed to its ONE-WAY form, which the
-// control above cannot see (see the ⚠️ note on `BothWays`). `never` is assignable to
-// `DocType`, so a one-way comparison calls this `true`, the directive goes unused and
-// the line becomes a TS2578; two-way, it is `false` as required.
-// @ts-expect-error `never` is narrower than DocType, so it must NOT compare equal
-export type DocTypeFieldPinWouldSeeNarrowing = MustBeTrue<BothWays<never, DocType>>
+// control above cannot see (see the ⚠️ note on `BothWays`). The field is narrower than
+// itself-plus-a-member, so a one-way comparison calls this `true`, the directive goes
+// unused and the line becomes a TS2578; two-way, it is `false` as required.
+//
+// Left side is the field — this pin's OWN operand — so this is a control on THIS pin
+// and not merely on the shared `BothWays`; right side is derived from it, so no member
+// is named that could go stale when the contract is widened.
+// @ts-expect-error the field is narrower than itself plus a member, so NOT equal
+export type DocTypeFieldPinWouldSeeNarrowing = MustBeTrue<BothWays<GenerateDocumentBody['doc_type'], DocType | 'not-a-doc-type'>>
 
 export interface ProjectDocument {
   document_id: string

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -502,32 +502,48 @@ export interface GenerateDocumentBody {
 export type BothWays<Left, Right> = [Left] extends [Right]
   ? ([Right] extends [Left] ? true : false)
   : false
+// The ONE verdict helper. `Verdict extends true` is the whole assertion: applied to a
+// comparison that came back `false`, the constraint is unsatisfied and the line is a
+// TS2344.
+//
+// 🔑 There is deliberately no `MustBeFalse` companion. The controls below assert their
+// verdict by applying THIS helper and expecting the error, via `@ts-expect-error`, so
+// that dropping `extends true` cannot go unnoticed: with the constraint gone the
+// controls stop erroring and each directive becomes an "unused '@ts-expect-error'"
+// TS2578. A separate `MustBeFalse<Verdict extends false>` could not do that — it was
+// measured that deleting BOTH constraints left `tsc` at exit 0 with every lockstep
+// test green while the field below was widened, because a text check on the helpers'
+// names is satisfied by their own declarations.
 type MustBeTrue<Verdict extends true> = Verdict
-type MustBeFalse<Verdict extends false> = Verdict
-// Each pin below is written on ONE line, with its comparison applied inline. That is
-// load-bearing rather than a formatting choice: the lockstep test requires the source
-// to spell `MustBeTrue<BothWays<`, and a wrapped declaration puts a newline between
-// the two so the substring is absent. See TYPE_LEVEL_PINS in
-// lambda/api/test/test_doc_type_lockstep.py for why the check includes the
-// comparison and not just the helper's name.
+// Each declaration below is written on ONE line. That is load-bearing rather than a
+// formatting choice: the lockstep test pins each one as an EXACT string, so a wrapped
+// declaration puts a newline inside what it is looking for. See TYPE_LEVEL_PINS in
+// lambda/api/test/test_doc_type_lockstep.py for why it pins the whole declaration
+// rather than a fragment of it.
 //
 // Exported only so `noUnusedLocals` cannot be what deletes them; nothing imports
 // any of them, and nothing should.
 export type DocTypeFieldIsExactlyTheUnion = MustBeTrue<BothWays<GenerateDocumentBody['doc_type'], DocType>>
-// The non-vacuity controls for the line above, in the same convention the lockstep
-// tests use: `MustBeTrue<BothWays<...>>` is also satisfied by a `BothWays` that
-// degenerates to `true`, which would be a pin reporting success while comparing
-// nothing. Both are derived from the field rather than listing members, so widening
-// the contract legitimately does not make either one the failure.
+// The non-vacuity controls for the line above. `MustBeTrue<BothWays<...>>` is also
+// satisfied by a `BothWays` that degenerates to `true` or collapses to a one-way
+// `extends`, either of which is a pin reporting success while comparing less than it
+// claims. Both controls are derived from the field rather than listing members, so
+// widening the contract legitimately does not make either one the failure.
 //
-// WIDENED side — refuses a `BothWays` that is always `true`. Adding a member the
-// route cannot accept must not compare equal.
-export type DocTypeFieldPinWouldSeeDrift = MustBeFalse<BothWays<GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>>
+// Each is an INVERTED assertion: the comparison must NOT hold, so `MustBeTrue` must
+// reject it and `@ts-expect-error` consumes that error. This is self-checking in both
+// directions — if the comparison starts holding the directive goes unused (TS2578),
+// and if the directive is deleted the genuine TS2344 surfaces.
+//
+// WIDENED side — adding a member the route cannot accept must not compare equal.
+// @ts-expect-error the field plus a member DocType lacks must NOT compare equal
+export type DocTypeFieldPinWouldSeeDrift = MustBeTrue<BothWays<GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>>
 // NARROWED side — refuses a `BothWays` collapsed to its ONE-WAY form, which the
 // control above cannot see (see the ⚠️ note on `BothWays`). `never` is assignable to
-// `DocType`, so a one-way comparison calls this `true` and this line becomes a
-// TS2344; two-way, it is `false` as required.
-export type DocTypeFieldPinWouldSeeNarrowing = MustBeFalse<BothWays<never, DocType>>
+// `DocType`, so a one-way comparison calls this `true`, the directive goes unused and
+// the line becomes a TS2578; two-way, it is `false` as required.
+// @ts-expect-error `never` is narrower than DocType, so it must NOT compare equal
+export type DocTypeFieldPinWouldSeeNarrowing = MustBeTrue<BothWays<never, DocType>>
 
 export interface ProjectDocument {
   document_id: string

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -558,6 +558,27 @@ export type DocTypeFieldPinWouldSeeNarrowing = MustBeTrue<BothWays<GenerateDocum
 
 export interface ProjectDocument {
   document_id: string
+  // ⚠️ A SUPERSET of `DocType`, RESTATED as literals rather than referencing it — which
+  // makes it a FIFTH edit a widening of `DocType` needs, stated here because no gate asks
+  // for it. The generator persists this field straight from `doc_type`
+  // (`'document_type': doc_type` at both save paths in
+  // `lambda/jobs/document_generator/handler.py`), so a widened `DocType` produces rows
+  // this union does not admit. Latent rather than absent: `tsc` is clean today only
+  // because nothing assigns a `DocType` into this field, and a one-line probe making the
+  // two meet is a TS2322 (measured).
+  //
+  // `DocType | 'research' | ...` would REMOVE the edit, and was tried. It is not
+  // available: `lambda/api/test/test_kiro_exportable_types_lockstep.py` parses THIS union
+  // as string literals to derive the full document-type set, and a referenced type makes
+  // it read zero members — loudly, but it fails. Teaching that parser to resolve
+  // `DocType` is a different contract's business (Kiro export inclusion, not this route's
+  // allowlist) and belongs beside it, so the ceiling is named here instead — the same
+  // call as the generator and picker ceilings in `lambda/api/test/test_doc_type_lockstep.py`.
+  //
+  // Superset deliberately: `research` and `custom` come from other routes,
+  // `product_report` and `prototype` from their own. So this is NOT a second copy of the
+  // route's contract and must not be pinned against `GENERATED_DOC_TYPES` — the same
+  // reason `suggestDocumentBrief` is left unbound.
   document_type: 'prd' | 'prfaq' | 'research' | 'custom' | 'product_report' | 'prototype'
   title: string
   // New (S3-only) HTML prototypes have NO `content` — the HTML lives at

--- a/voc-datalake/frontend/src/api/types.ts
+++ b/voc-datalake/frontend/src/api/types.ts
@@ -423,6 +423,12 @@ export type DocType = 'prd' | 'prfaq'
 // NOWHERE — `tsc` accepts it and the request goes out with a value the route 400s.
 // Only the shared name closes that, and `test_doc_type_lockstep.py` asserts both
 // signatures still spell it.
+//
+// `doc_type` below is pinned to `DocType` by `DocTypeFieldIsExactlyTheUnion`, a few
+// lines down. Referencing the union HERE is not self-enforcing: nothing had stopped
+// this one field being respelled back to `'prd' | 'prfaq' | 'onepager'`, which was
+// measured to leave `tsc`, `eslint` and the whole lockstep suite green while the
+// route 400s the third value.
 export interface GenerateDocumentBody {
   doc_type: DocType
   title: string
@@ -441,6 +447,50 @@ export interface GenerateDocumentBody {
   customer_questions?: string[]
   response_language?: string
 }
+
+// 🔑 The pin that makes `GenerateDocumentBody.doc_type` REFERENCE `DocType` rather
+// than merely happen to list the same members today. Deleting this block compiles
+// cleanly, so `test_the_request_body_field_is_pinned_to_the_union` in
+// lambda/api/test/test_doc_type_lockstep.py keeps both declarations present.
+//
+// Why it is needed at all — measured, not assumed. Every other guard around this
+// contract stops one level further out:
+//   * the lockstep test parses only the `export type DocType =` declaration above,
+//     so it cannot see this interface;
+//   * `satisfies GenerateDocumentBody` in `projectsApi.generateDocument` checks the
+//     built object against THIS interface, so a widened interface satisfies it by
+//     construction;
+//   * `noUnusedLocals` stays quiet, since `DocType` is still used by
+//     `ProjectDocument` below.
+// So respelling the field `'prd' | 'prfaq' | 'onepager'` was measured to exit `tsc`
+// 0, pass all lockstep tests and lint clean, while a caller could then send a value
+// the route 400s. That is the one edit the comments above direct a widener TO, which
+// is why it gets a compiler check and not a third text assertion.
+//
+// A one-way `extends` would not do: `'prd'` extends `DocType`, so a NARROWED field
+// (offering less than the route accepts — the "unreachable capability" half of the
+// drift this contract is about) would pass. Hence equality in both directions.
+// `[T] extends [U]` rather than `T extends U`: the bare form distributes over a
+// union, which would compare member-by-member and accept a subset.
+type BothWays<Field, Union> = [Field] extends [Union]
+  ? ([Union] extends [Field] ? true : false)
+  : false
+type MustBeTrue<Verdict extends true> = Verdict
+type MustBeFalse<Verdict extends false> = Verdict
+// Exported only so `noUnusedLocals` cannot be what deletes them; nothing imports
+// either, and nothing should.
+export type DocTypeFieldIsExactlyTheUnion = MustBeTrue<
+  BothWays<GenerateDocumentBody['doc_type'], DocType>
+>
+// The non-vacuity control for the line above, in the same convention the lockstep
+// tests use: `MustBeTrue<BothWays<...>>` is also satisfied by a `BothWays` that
+// degenerates to `true`, which would be a pin reporting success while comparing
+// nothing. Adding a member the route cannot accept must therefore be `false`.
+// Derived from the field rather than listing members, so widening the contract
+// legitimately does not make this line the failure.
+export type DocTypeFieldPinWouldSeeDrift = MustBeFalse<
+  BothWays<GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>
+>
 
 export interface ProjectDocument {
   document_id: string

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -253,9 +253,15 @@ export function DocWizard({
   // `tsc` is fine with a narrower argument to `includes`/`filter`, so the picker
   // silently keeps offering the old set — measured: adding a third member to both
   // leaves `tsc -b` clean and every lockstep test green with this file untouched.
-  // Adding a doc type therefore means editing this file too: `hasPrfaq`/`hasPrd`
-  // above and the two `toggleDocType('…')` buttons in `renderFinalStep` name their
-  // members as literals (issue #381).
+  // Adding a doc type therefore means editing this file too, in three places that name
+  // their members as literals: `hasPrfaq`/`hasPrd` above, the two `toggleDocType('…')`
+  // buttons in `renderFinalStep`, and the `bothSelected`/`singleTitle`/
+  // `singleSubmitLabel` copy, which is written as a PRD-or-PR-FAQ binary — a third
+  // member would fall into its PR-FAQ branch and be labelled as one.
+  //
+  // The lockstep test's module docstring carries the same list as the FOURTH edit a
+  // widening needs, so a widener reading either place learns it; keep the two
+  // consistent (issue #381).
   const toggleDocType = (type: DocType) => {
     const next = docTypes.includes(type)
       ? docTypes.filter((d) => d !== type)

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -244,9 +244,18 @@ export function DocWizard({
 
   // `DocType`, not a respelt `'prd' | 'prfaq'` — a convention here, not something a
   // test enforces: the lockstep test reads only the `DocType` declaration and the two
-  // api/ clients, never this file. A widening IS caught, but by the compiler at the
-  // `includes`/spread sites below, since `docConfig.docTypes` is `DocType[]` (issue
-  // #381).
+  // api/ clients, never this file. Widening THIS annotation past `DocType` is caught,
+  // by the compiler at the `includes`/spread sites below, since `docConfig.docTypes`
+  // is `DocType[]`.
+  //
+  // ⚠️ The REVERSE is not caught, and it is the direction that actually happens: if
+  // `DocType` and `GENERATED_DOC_TYPES` are widened together, nothing here fails.
+  // `tsc` is fine with a narrower argument to `includes`/`filter`, so the picker
+  // silently keeps offering the old set — measured: adding a third member to both
+  // leaves `tsc -b` clean and every lockstep test green with this file untouched.
+  // Adding a doc type therefore means editing this file too: `hasPrfaq`/`hasPrd`
+  // above and the two `toggleDocType('…')` buttons in `renderFinalStep` name their
+  // members as literals (issue #381).
   const toggleDocType = (type: DocType) => {
     const next = docTypes.includes(type)
       ? docTypes.filter((d) => d !== type)

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -253,11 +253,18 @@ export function DocWizard({
   // `tsc` is fine with a narrower argument to `includes`/`filter`, so the picker
   // silently keeps offering the old set — measured: adding a third member to both
   // leaves `tsc -b` clean and every lockstep test green with this file untouched.
-  // Adding a doc type therefore means editing this file too, in three places that name
+  // Adding a doc type therefore means editing this file too, in four places that name
   // their members as literals: `hasPrfaq`/`hasPrd` above, the two `toggleDocType('…')`
-  // buttons in `renderFinalStep`, and the `bothSelected`/`singleTitle`/
-  // `singleSubmitLabel` copy, which is written as a PRD-or-PR-FAQ binary — a third
-  // member would fall into its PR-FAQ branch and be labelled as one.
+  // buttons in `renderFinalStep`, the `bothSelected`/`singleTitle`/`singleSubmitLabel`
+  // copy, which is written as a PRD-or-PR-FAQ binary — a third member would fall into
+  // its PR-FAQ branch and be labelled as one — and `onSuggestBrief`'s
+  // `doc_type: … includes('prd') ? 'prd' : 'prfaq'`, the same binary against a
+  // DIFFERENT route: a third member selected alone asks `suggest-brief` for a PR-FAQ
+  // brief, so the AI-drafted title and description come back framed as a PR-FAQ for a
+  // document that is not one. That call is the only place the picker's set meets
+  // `suggestDocumentBrief`'s, which is deliberately left unbound to `DocType` (its
+  // signature and the reason sit at `api/projectsApi.ts`), so it needs naming rather
+  // than leaving implied by "unbound".
   //
   // The lockstep test's module docstring carries the same list as the FOURTH edit a
   // widening needs, so a widener reading either place learns it; keep the two

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -242,9 +242,11 @@ export function DocWizard({
   const hasPrfaq = docTypes.includes('prfaq')
   const hasPrd = docTypes.includes('prd')
 
-  // `DocType`, not a respelt `'prd' | 'prfaq'`: this toggles membership of
-  // `docConfig.docTypes`, which IS `DocType[]`, so an inline copy here could admit a
-  // value the picker cannot hold or refuse one it can (issue #381).
+  // `DocType`, not a respelt `'prd' | 'prfaq'` — a convention here, not something a
+  // test enforces: the lockstep test reads only the `DocType` declaration and the two
+  // api/ clients, never this file. A widening IS caught, but by the compiler at the
+  // `includes`/spread sites below, since `docConfig.docTypes` is `DocType[]` (issue
+  // #381).
   const toggleDocType = (type: DocType) => {
     const next = docTypes.includes(type)
       ? docTypes.filter((d) => d !== type)

--- a/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/Wizards.tsx
@@ -12,7 +12,7 @@ import DataSourceWizard from '../../components/DataSourceWizard'
 import ContextSummary from '../../components/DataSourceWizard/ContextSummary'
 import { isWebSearchAvailable } from '../../runtimeConfig'
 import type {
-  PersonaToolConfig, ResearchToolConfig, DocToolConfig, MergeToolConfig,
+  PersonaToolConfig, ResearchToolConfig, DocToolConfig, MergeToolConfig, DocType,
 } from './types'
 import type {
   ProjectPersona, ProjectDocument,
@@ -242,7 +242,10 @@ export function DocWizard({
   const hasPrfaq = docTypes.includes('prfaq')
   const hasPrd = docTypes.includes('prd')
 
-  const toggleDocType = (type: 'prd' | 'prfaq') => {
+  // `DocType`, not a respelt `'prd' | 'prfaq'`: this toggles membership of
+  // `docConfig.docTypes`, which IS `DocType[]`, so an inline copy here could admit a
+  // value the picker cannot hold or refuse one it can (issue #381).
+  const toggleDocType = (type: DocType) => {
     const next = docTypes.includes(type)
       ? docTypes.filter((d) => d !== type)
       : [...docTypes, type]

--- a/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
@@ -26,6 +26,15 @@ export interface ResearchToolConfig {
   useWebSearch: boolean
 }
 
+// 🔑 The ONE frontend declaration of what POST /projects/{id}/document accepts.
+// `client.ts` and `projectsApi.ts` import it rather than respelling
+// `'prd' | 'prfaq'` inline, which is what they used to do: three copies of the
+// contract meant the two client signatures could drift from this union and from
+// the route, and the guard that reads them (issue #381) had to locate a method by
+// name and delimit its parameter list by bracket balance to check. With one
+// declaration, `lambda/api/test/test_doc_type_lockstep.py` reads this line alone
+// and pins it against `projects_handler.GENERATED_DOC_TYPES`. Widen both together
+// or that test fails.
 export type DocType = 'prd' | 'prfaq'
 
 export interface DocToolConfig {

--- a/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
+++ b/voc-datalake/frontend/src/pages/ProjectDetail/types.ts
@@ -2,7 +2,7 @@
  * Shared types for ProjectDetail components
  */
 import type {
-  ProjectPersona, Project,
+  ProjectPersona, Project, DocType,
 } from '../../api/types'
 
 export type Tab = 'overview' | 'personas' | 'product' | 'documents' | 'chat' | 'mcp'
@@ -26,16 +26,12 @@ export interface ResearchToolConfig {
   useWebSearch: boolean
 }
 
-// 🔑 The ONE frontend declaration of what POST /projects/{id}/document accepts.
-// `client.ts` and `projectsApi.ts` import it rather than respelling
-// `'prd' | 'prfaq'` inline, which is what they used to do: three copies of the
-// contract meant the two client signatures could drift from this union and from
-// the route, and the guard that reads them (issue #381) had to locate a method by
-// name and delimit its parameter list by bracket balance to check. With one
-// declaration, `lambda/api/test/test_doc_type_lockstep.py` reads this line alone
-// and pins it against `projects_handler.GENERATED_DOC_TYPES`. Widen both together
-// or that test fails.
-export type DocType = 'prd' | 'prfaq'
+// What POST /projects/{id}/document accepts, RE-EXPORTED for the picker — the
+// declaration itself lives in `api/types.ts` beside the other wire types, because
+// that route owns the contract and the lockstep test pins it there. It was declared
+// here and imported by the two clients, which pointed `api/` at `pages/`; issue #381
+// turned it round. Do not respell `'prd' | 'prfaq'` from either side.
+export type { DocType } from '../../api/types'
 
 export interface DocToolConfig {
   // Which documents to generate. Both can be selected to generate PRD + PR-FAQ

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -312,6 +312,20 @@ DEFAULT_GENERATED_DOC_TYPE = 'prd'
 # What POST /projects/{id}/document accepts in `doc_type`. Mirrored in the
 # frontend's `DocType` union; `test_doc_type_lockstep.py` fails if the two drift.
 #
+# ⚠️ WIDENING THIS TUPLE TAKES A THIRD EDIT, and no gate asks for it. Adding a member
+# here and to `DocType` together leaves `tsc` at exit 0 and every lockstep test green
+# (measured) — but `lambda/jobs/document_generator/handler.py` dispatches `doc_type`
+# as a BINARY with PR-FAQ as the unconditional `else`, in three places: the
+# step-builder selection (`get_prd_generation_steps` vs `get_prfaq_generation_steps`),
+# the generation branch (`_generate_prd` vs `_generate_prfaq`) and the
+# assembly/result-indexing branch in `_assemble_and_save`. It never imports this
+# constant. So a new member is accepted here, routed into the chain by `is_chain`
+# below (true by construction once it is in this tuple), then generated and persisted
+# as a PR-FAQ — `document_type` and the `{DOC_TYPE}#` sort key say the new type while
+# the CONTENT is a PR-FAQ, after a Bedrock spend, with no error raised.
+# A third doc type therefore needs a step builder, a generation branch and an
+# assembly branch there, or it silently produces the wrong kind of document.
+#
 # ⚠️ NOT FOUR. The generator serves four doc types (`prd`, `prfaq`,
 # `build_prototype`, `product_report`) and this route's docstring names the
 # latter two, which reads like an argument for admitting them here. It isn't:

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -312,19 +312,31 @@ DEFAULT_GENERATED_DOC_TYPE = 'prd'
 # What POST /projects/{id}/document accepts in `doc_type`. Mirrored in the
 # frontend's `DocType` union; `test_doc_type_lockstep.py` fails if the two drift.
 #
-# ⚠️ WIDENING THIS TUPLE TAKES A THIRD EDIT, and no gate asks for it. Adding a member
-# here and to `DocType` together leaves `tsc` at exit 0 and every lockstep test green
-# (measured) — but `lambda/jobs/document_generator/handler.py` dispatches `doc_type`
-# as a BINARY with PR-FAQ as the unconditional `else`, in three places: the
-# step-builder selection (`get_prd_generation_steps` vs `get_prfaq_generation_steps`),
-# the generation branch (`_generate_prd` vs `_generate_prfaq`) and the
-# assembly/result-indexing branch in `_assemble_and_save`. It never imports this
-# constant. So a new member is accepted here, routed into the chain by `is_chain`
-# below (true by construction once it is in this tuple), then generated and persisted
-# as a PR-FAQ — `document_type` and the `{DOC_TYPE}#` sort key say the new type while
-# the CONTENT is a PR-FAQ, after a Bedrock spend, with no error raised.
-# A third doc type therefore needs a step builder, a generation branch and an
+# ⚠️ WIDENING THIS TUPLE TAKES TWO FURTHER EDITS, and no gate asks for either. Adding a
+# member here and to `DocType` together leaves `tsc` at exit 0 and every lockstep test
+# green (measured).
+#
+# THE GENERATOR is the one that matters: `lambda/jobs/document_generator/handler.py`
+# dispatches `doc_type` as a BINARY with PR-FAQ as the unconditional `else`, in three
+# places: the step-builder selection (`get_prd_generation_steps` vs
+# `get_prfaq_generation_steps`), the generation branch (`_generate_prd` vs
+# `_generate_prfaq`) and the assembly/result-indexing branch in `_assemble_and_save`.
+# It never imports this constant. So a new member is accepted here, routed into the
+# chain by `is_chain` below (true by construction once it is in this tuple), then
+# generated and persisted as a PR-FAQ — `document_type` and the `{DOC_TYPE}#` sort key
+# say the new type while the CONTENT is a PR-FAQ, after a Bedrock spend, with no error
+# raised. A new doc type therefore needs a step builder, a generation branch and an
 # assembly branch there, or it silently produces the wrong kind of document.
+#
+# THE PICKER is the other, and it is benign by comparison — dead capability rather than
+# wrong content, but still an edit the widening needs.
+# `frontend/src/pages/ProjectDetail/Wizards.tsx` names its members as LITERALS:
+# `hasPrfaq`/`hasPrd`, the two `toggleDocType('...')` buttons in `renderFinalStep`, and
+# the `bothSelected`/`singleTitle`/`singleSubmitLabel` copy, all written as a
+# PRD-or-PR-FAQ binary. `tsc` accepts a narrower argument to `includes`/`filter`, so the
+# widening compiles clean while the picker keeps offering the OLD set (measured): the new
+# type is accepted here but never offered to a user. That file documents this from its
+# own side, beside the literals.
 #
 # ⚠️ NOT FOUR. The generator serves four doc types (`prd`, `prfaq`,
 # `build_prototype`, `product_report`) and this route's docstring names the

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -312,7 +312,7 @@ DEFAULT_GENERATED_DOC_TYPE = 'prd'
 # What POST /projects/{id}/document accepts in `doc_type`. Mirrored in the
 # frontend's `DocType` union; `test_doc_type_lockstep.py` fails if the two drift.
 #
-# ⚠️ WIDENING THIS TUPLE TAKES TWO FURTHER EDITS, and no gate asks for either. Adding a
+# ⚠️ WIDENING THIS TUPLE TAKES THREE FURTHER EDITS, and no gate asks for any. Adding a
 # member here and to `DocType` together leaves `tsc` at exit 0 and every lockstep test
 # green (measured).
 #
@@ -331,12 +331,24 @@ DEFAULT_GENERATED_DOC_TYPE = 'prd'
 # THE PICKER is the other, and it is benign by comparison — dead capability rather than
 # wrong content, but still an edit the widening needs.
 # `frontend/src/pages/ProjectDetail/Wizards.tsx` names its members as LITERALS:
-# `hasPrfaq`/`hasPrd`, the two `toggleDocType('...')` buttons in `renderFinalStep`, and
-# the `bothSelected`/`singleTitle`/`singleSubmitLabel` copy, all written as a
-# PRD-or-PR-FAQ binary. `tsc` accepts a narrower argument to `includes`/`filter`, so the
+# `hasPrfaq`/`hasPrd`, the two `toggleDocType('...')` buttons in `renderFinalStep`, the
+# `bothSelected`/`singleTitle`/`singleSubmitLabel` copy, and `onSuggestBrief`'s
+# `doc_type` ternary — all written as a PRD-or-PR-FAQ binary, so a third member selected
+# alone falls into the PR-FAQ branch: labelled as one by the copy, and drafted as one by
+# `suggest-brief`. `tsc` accepts a narrower argument to `includes`/`filter`, so the
 # widening compiles clean while the picker keeps offering the OLD set (measured): the new
 # type is accepted here but never offered to a user. That file documents this from its
 # own side, beside the literals.
+#
+# THE WIRE TYPE is the third: `ProjectDocument.document_type` in
+# `frontend/src/api/types.ts` restates the doc types as literals and is a SUPERSET of
+# `DocType` (it also carries `research`, `custom`, `product_report`, `prototype`, which
+# this route never accepts). The generator writes that field straight from `doc_type`, so
+# a widened `DocType` produces rows the wire type does not admit — latent, since `tsc` is
+# clean until some code makes the two unions meet, at which point it is a TS2322.
+# Referencing `DocType` there would remove the edit but breaks
+# `test_kiro_exportable_types_lockstep.py`, which parses that union as literals; the
+# reason sits at the field.
 #
 # ⚠️ NOT FOUR. The generator serves four doc types (`prd`, `prfaq`,
 # `build_prototype`, `product_report`) and this route's docstring names the

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -321,10 +321,8 @@ DEFAULT_GENERATED_DOC_TYPE = 'prd'
 #     inputs before invoking the generator directly.
 #   * `api_generate_document` has no internal callers — the only occurrence of
 #     the symbol in `lambda/` is its own `def`.
-#   * The only frontend caller of this route types the field `doc_type: DocType`,
-#     the union declared once in `frontend/src/pages/ProjectDetail/types.ts` and
-#     imported by both client signatures (it used to be respelled inline in each;
-#     issue #381 collapsed the copies).
+#   * The only frontend caller types the field as `DocType`, declared once in
+#     `frontend/src/api/types.ts` (issue #381).
 # So narrowing this route cannot affect prototype building or product reports,
 # while widening it would re-open here the unvalidated entry those two
 # deliberately avoid. The docstring sentence is about which generator paths stay

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -321,8 +321,10 @@ DEFAULT_GENERATED_DOC_TYPE = 'prd'
 #     inputs before invoking the generator directly.
 #   * `api_generate_document` has no internal callers — the only occurrence of
 #     the symbol in `lambda/` is its own `def`.
-#   * The only frontend caller of this route types the field
-#     `doc_type: 'prd' | 'prfaq'`.
+#   * The only frontend caller of this route types the field `doc_type: DocType`,
+#     the union declared once in `frontend/src/pages/ProjectDetail/types.ts` and
+#     imported by both client signatures (it used to be respelled inline in each;
+#     issue #381 collapsed the copies).
 # So narrowing this route cannot affect prototype building or product reports,
 # while widening it would re-open here the unvalidated entry those two
 # deliberately avoid. The docstring sentence is about which generator paths stay

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -30,30 +30,29 @@ all of it, and an earlier version of this docstring claimed it did:
   * `DocType` -> the route's allowlist: THIS file, by parsing the declaration.
     Nothing in TypeScript knows what Python accepts.
   * `GenerateDocumentBody.doc_type` -> `DocType`: the compiler, but ONLY because
-    `DocTypeFieldIsExactlyTheUnion` in that file compares the two in both
-    directions. Referencing the union is not self-enforcing and this file cannot
-    see the field: it parses the `export type DocType =` declaration and nothing
-    else, so respelling the field `'prd' | 'prfaq' | 'onepager'` was measured to
-    exit `tsc` 0 and pass every test here. `satisfies` cannot help either — it
-    checks the built object AGAINST this interface, so a widened one satisfies it by
-    construction. `test_the_request_body_field_is_pinned_to_the_union` keeps that
-    type-level pin present, since deleting it compiles cleanly.
+    `DocTypeFieldIsExactlyTheUnion` in that file compares the two. Spelling the
+    union in the field is not self-enforcing and this file cannot see the field: it
+    parses the `export type DocType =` declaration and nothing else, so respelling
+    the field `'prd' | 'prfaq' | 'onepager'` was measured to exit `tsc` 0 and pass
+    every test here. The signature pin below cannot help either — it compares
+    against this interface, so a widened one satisfies it by construction.
+    ⚠️ What that pin checks is SET EQUALITY, not reference: the field must admit
+    exactly `DocType`'s members, and a same-member respelling (`'prd' | 'prfaq'`,
+    no reference at all) PASSES it. Measured — an earlier version of this file
+    claimed the opposite in four places. Equality is the sufficient property: the
+    coincidence is harmless today and becomes a TS2344 the moment `DocType` is
+    widened, so the drift is still caught where it would be introduced.
   * The two `generateDocument` signatures -> `GenerateDocumentBody`: the compiler
     for `client.ts`, which forwards its `data` into `projectsApi.generateDocument`
     and so gets a TS2345 if it widens. `projectsApi.generateDocument` is the
     TERMINAL consumer — its `data` is only spread into `JSON.stringify`, so its
     annotation is compared against nothing and by itself type-checks however wide it
-    is. Two things cover that one, and it took both:
-      - The body is a NAMED type, asserted by text in
-        `test_both_client_signatures_use_the_shared_request_body`. This stops the
-        plain inline respelling.
-      - `satisfies GenerateDocumentBody` on the object that method builds, pinned by
-        `test_the_terminal_client_pins_the_body_structurally`. NAMING the type is
-        not sufficient on its own: an
-        `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
-        annotation uses the name and still widens, and was measured to exit `tsc` 0
-        with every test here green. `noUnusedLocals` does NOT cover that — the name
-        is used — and an earlier version of this docstring wrongly said it did.
+    is. `GenerateDocumentTakesTheSharedBody` in that file is what closes it, by
+    comparing the parameter to the interface. NAMING the type is not sufficient on
+    its own — an `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ...
+    | 'onepager' }` annotation uses the name and still widens, and was measured to
+    exit `tsc` 0 with every test here green. `noUnusedLocals` does NOT cover that
+    either, since the name is used.
     So a widening has to edit `DocType` itself — the declaration this file parses —
     and `GENERATED_DOC_TYPES` with it. Editing `GenerateDocumentBody.doc_type` is
     not a way around that: the pin above makes it a compiler error.
@@ -61,13 +60,27 @@ all of it, and an earlier version of this docstring claimed it did:
 WHY EACH GUARD IS THE KIND IT IS. The rule this file has converged on over several
 rounds, each of which found the same hole one level further in: a link TypeScript can
 check gets a COMPILER check, and text assertions are reserved for the ones it cannot.
-`DocTypeFieldIsExactlyTheUnion` is a type-level comparison rather than a fourth
-`'... in source'` assertion for exactly that reason — a text check for one field
-would have to enumerate the spellings that widen it (enumerated members, an
-intersection, `Omit`, a widened alias), and enumerating legal TypeScript is what the
-deleted scanner did and why it was deleted. The text assertions that remain here pin
-the PRESENCE of things whose absence is silent (`satisfies`, the type-level pin
-itself) and the ONE link no compiler can see: `DocType` against a Python tuple.
+Both pins are type-level comparisons rather than `'... in source'` assertions for
+exactly that reason — a text check on a field or a parameter would have to enumerate
+the spellings that widen it (enumerated members, an intersection, `Omit`, a widened
+alias), and enumerating legal TypeScript is what the deleted scanner did and why it
+was deleted.
+
+A COMPARISON RATHER THAN A CLAUSE, for the same reason. The parameter link was first
+closed with `satisfies GenerateDocumentBody` inside the method body — equivalent for
+the compiler, but a clause has a LOCATION, so from Python it needed a text guard
+saying where it sat, and every bound tried was evadable: a whole-file check passed
+with the clause moved to an unrelated helper, and narrowing to the slice before the
+next named method passed with the clause in a NEW method inserted into that slice.
+Both measured, `tsc` exit 0 and every test here green while the axis was reopened.
+`GenerateDocumentTakesTheSharedBody` compares the method's own parameter type, which
+has nowhere to migrate to, so the guard, its two method-name markers and their
+ordering assumption all went.
+
+The text assertions that remain pin the PRESENCE of things whose absence is silent
+(the two type-level pins, and that each is still spelled as a comparison rather than
+stubbed to a constant) and the ONE link no compiler can see: `DocType` against a
+Python tuple.
 
 A `.test-d.ts`-style type test was considered for that job and REJECTED, so it does
 not get proposed again: `typecheck:tests` is not in the root `check` chain
@@ -114,21 +127,15 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     shared name appears, so it needs no model of TypeScript and cannot mis-read a
     restyling. A rename of `GenerateDocumentBody` fails it too, which is correct —
     the constant here is what the two files must agree on.
-  * `test_the_terminal_client_pins_the_body_structurally` — the `satisfies` clause
-    deleted from `projectsApi.generateDocument`, or MOVED off it. That deletion
-    compiles cleanly and is caught by nothing else, and without the clause an
-    intersection/`Omit` annotation widens `doc_type` while still naming the shared
-    type, so the test above stays green too. The slice is what catches the move: a
-    whole-file substring check was measured to pass with the clause relocated to an
-    unrelated helper and `generateDocument` widened.
-  * `test_the_request_body_field_is_pinned_to_the_union` —
-    `DocTypeFieldIsExactlyTheUnion` deleted from the frontend, which would let
-    `GenerateDocumentBody.doc_type` restate the members instead of referencing
-    `DocType`. Measured: that respelling exits `tsc` 0 and passes everything here,
-    because this file reads only the union declaration and `satisfies` compares
-    against the widened interface. Its non-vacuity control
-    (`DocTypeFieldPinWouldSeeDrift`) is pinned by the same test, since a comparison
-    that degenerates to `true` would satisfy the pin while measuring nothing.
+  * `test_the_type_level_pins_are_present` — either type-level pin deleted, or
+    STUBBED to a bare constant. Both are silent otherwise: deleting one compiles
+    cleanly, and stubbing both a pin and its control to `= true` / `= false` (with
+    the helper types removed so no unused-local fires) was measured to exit `tsc` 0
+    and pass every test here while the guarded field was widened. So the assertion
+    SPELLING is required, not just the name. Covers both links: the field-vs-union
+    pin, and the parameter-vs-body pin that replaced the `satisfies` clause and the
+    location guard it needed — see WHY EACH GUARD IS THE KIND IT IS for why a
+    comparison was the answer and a tighter text slice was not.
   * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
     union is edited, and its opposite, one that reports drift for a comment.
   * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
@@ -155,36 +162,52 @@ DOC_TYPE_UNION_SOURCE = 'frontend/src/api/types.ts'
 # see the docstring: the compiler catches that in one file and not the other.
 REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 
-# The type-level pin in `DOC_TYPE_UNION_SOURCE` that makes that body's `doc_type`
-# field REFERENCE the union above it rather than restate its members. Its own absence
-# is silent — delete it and the frontend still compiles — so
-# `test_the_request_body_field_is_pinned_to_the_union` keeps it present. See that
-# test for why nothing else in either language covers this one field.
-REQUEST_BODY_FIELD_PIN = 'DocTypeFieldIsExactlyTheUnion'
-# Its non-vacuity control, in the convention this file uses for its own: the pin is
-# also satisfiable by a comparison that degenerates to `true`, and this line is what
-# refuses that. Pinned alongside so deleting the control is a decision.
-REQUEST_BODY_FIELD_PIN_CONTROL = 'DocTypeFieldPinWouldSeeDrift'
-
-# The TERMINAL client — the one whose `data` is only spread into `JSON.stringify`,
-# so its annotation is checked against nothing and naming the body type is not
-# enough on its own (an `Omit<..> & { doc_type: .. | 'x' }` respelling names it and
-# still widens). The `satisfies` clause in it is what turns that into a compiler
-# error, and `test_the_terminal_client_pins_the_body_structurally` pins the clause:
-# removing it is invisible otherwise, since everything still type-checks and this
-# file's other assertions stay green.
+# The TERMINAL client — the one whose `data` is only spread into `JSON.stringify`, so
+# its annotation is checked against nothing and naming the body type is not enough on
+# its own (an `Omit<..> & { doc_type: .. | 'x' }` respelling names it and still
+# widens).
 TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
-STRUCTURAL_PIN = f'satisfies {REQUEST_BODY_TYPE}'
 
-# The clause has to be in the method it protects, not merely somewhere in a 400-line
-# file: a whole-file substring check was measured to stay GREEN when the clause was
-# moved to an unrelated helper and `generateDocument` was then widened, which is the
-# guard reporting success while the axis it exists for is reopened. These two literal
-# method names bound the slice searched. Deliberately NOT a parameter-list extent —
-# bracket balancing is what the deleted scanner did — so the slice is index arithmetic
-# on two names, and a rename of either fails loudly rather than silently widening it.
-GENERATE_DOCUMENT_MARKER = 'generateDocument:'
-NEXT_METHOD_MARKER = 'mergeDocuments:'
+# The two type-level pins that carry every link TypeScript can check, each with the
+# file it is declared in and its non-vacuity control. A pin's own absence is SILENT —
+# delete either block and the frontend still compiles — which is the only reason this
+# file mentions them at all: `test_the_type_level_pins_are_present` keeps them there.
+#
+# 🔑 A pin is spelled `<Guard><Name> = <Guard><Verdict><Comparison<...>>`, and the
+# CONSTANT INCLUDES THE COMPARISON'S OPENING BRACKET. That is deliberate and was
+# measured: with the names alone, both a pin and its control could be stubbed to bare
+# constants (`export type DocTypeFieldIsExactlyTheUnion = true`) and, with the helper
+# types deleted so no unused-local fired, `tsc` exited 0 and every test here passed
+# while the field it guards was widened past the route's allowlist. A name check is
+# satisfied by prose about the name; requiring `MustBeTrue<` means a stub has to keep
+# a real comparison to satisfy it.
+#
+# Keyed by relative path, since the two pins live in different files. Each value is
+# (pin, control, assertion-spelling, control-spelling).
+TYPE_LEVEL_PINS = {
+    # `GenerateDocumentBody.doc_type` admits exactly the members of `DocType`. Nothing
+    # else in either language sees this field: this file parses only the
+    # `export type DocType =` declaration, and the signature pin below compares
+    # against the interface, so a widened interface satisfies it by construction.
+    DOC_TYPE_UNION_SOURCE: (
+        'DocTypeFieldIsExactlyTheUnion',
+        'DocTypeFieldPinWouldSeeDrift',
+        'MustBeTrue<',
+        'MustBeFalse<',
+    ),
+    # `generateDocument`'s parameter admits exactly `GenerateDocumentBody`. This is the
+    # one that replaced a `satisfies` clause in the method body plus the text guard
+    # that pinned WHERE the clause sat — see the docstring's WHY EACH GUARD IS THE KIND
+    # IT IS: a clause has a location and could be migrated out of whatever slice was
+    # searched, and both slices tried were measured to be evadable. A comparison
+    # against the method's own type has nowhere to migrate to.
+    TERMINAL_CLIENT: (
+        'GenerateDocumentTakesTheSharedBody',
+        'GenerateDocumentSignaturePinWouldSeeDrift',
+        'SignatureMustMatch<',
+        'SignatureMustDiffer<',
+    ),
+}
 
 # Both clients, the terminal one included rather than respelled — a second copy of
 # that path here is the same duplication this whole issue was about.
@@ -684,11 +707,11 @@ class TestDocTypeLockstep:
         is false, and was measured to be: an
         `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
         annotation USES the imported name, so no unused-local fires and `tsc` exits
-        0. What closes it is the `satisfies GenerateDocumentBody` clause on the body
-        construction in `projectsApi.generateDocument`, which makes any widening of
-        that parameter a TS1360 at the point the object is built.
-        `test_the_terminal_client_pins_the_body_structurally` is what keeps that
-        clause present, since deleting it is silent otherwise.
+        0. What closes it is `GenerateDocumentTakesTheSharedBody`, a type-level
+        comparison of that method's parameter against the interface, which makes any
+        widening of it a TS2344 — whatever the spelling.
+        `test_the_type_level_pins_are_present` is what keeps it there, since deleting
+        it is silent otherwise.
         """
         for relative in GENERATE_DOCUMENT_CLIENTS:
             path = _repo_root() / relative
@@ -711,107 +734,65 @@ class TestDocTypeLockstep:
     @pytest.mark.skipif(
         not _frontend_tree_present(), reason='frontend tree absent from this checkout'
     )
-    def test_the_terminal_client_pins_the_body_structurally(self):
-        """The `satisfies` clause is what actually closes the widening axis.
+    @pytest.mark.parametrize('relative', TYPE_LEVEL_PINS, ids=lambda p: Path(p).name)
+    def test_the_type_level_pins_are_present(self, relative):
+        """Every link TypeScript CAN check has a compiler check, and each one's
+        absence is silent — so this keeps them present.
 
-        Naming `GenerateDocumentBody` (asserted above) is necessary but not
-        sufficient: measured, an
-        `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
-        annotation on this one method keeps the name in use, so `noUnusedLocals`
-        stays quiet, `tsc -p tsconfig.app.json --noEmit` exits 0 and the request goes
-        out with a value the route 400s. `satisfies GenerateDocumentBody` on the
-        object this method builds makes exactly that a TS1360.
+        The two links, and what each was measured to permit without its pin:
 
-        Pinned by text here because its ABSENCE is silent — remove the clause and the
-        frontend still compiles, so no other gate in either language notices. This
-        asserts only that the clause is SPELLED, and where; that it BITES is the
-        compiler's job, and `tsconfig.app.json` needs no flag for it (`satisfies` is
-        not optional behaviour).
+          * `GenerateDocumentBody.doc_type` vs `DocType` — respelling the field
+            `'prd' | 'prfaq' | 'onepager'` exited `tsc` 0, passed every test here and
+            linted clean, while a caller could then send a value the route 400s. This
+            file parses only the `export type DocType =` declaration, so the interface
+            field is invisible to it, and the signature pin below compares against the
+            interface, so a widened one satisfies it by construction.
+          * `generateDocument`'s parameter vs `GenerateDocumentBody` — that method is
+            the TERMINAL consumer, its `data` only spread into `JSON.stringify`, so
+            the annotation is compared against nothing. An
+            `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
+            respelling USES the shared name, so neither `noUnusedLocals` nor the name
+            assertion above sees it.
 
-        Scoped to the method rather than the file, because a whole-file substring
-        check was measured to permit exactly what it was added to stop: move the
-        clause to an unrelated helper, widen `generateDocument`, and `tsc` exits 0
-        with every test here green. The slice is bounded by two literal method names
-        (see GENERATE_DOCUMENT_MARKER) and both must be found, so a rename fails
-        loudly instead of widening the search back to the whole file.
+        Text, not a parse — but text with a lesson in it. Asserting the pin NAMES
+        alone was measured to be vacuous: stub both a pin and its control to bare
+        constants (`= true` / `= false`), delete the helper types so no unused-local
+        fires, and `tsc` exits 0 with every test here green while the guarded field is
+        widened. So the ASSERTION SPELLING is required too (`MustBeTrue<`), which a
+        bare constant cannot satisfy. That the comparisons BITE is the compiler's job;
+        this test says only that a real comparison is spelled.
+
+        Each pin's non-vacuity control is required alongside it, in the convention
+        this file uses for its own: `MustBeTrue<BothWays<...>>` is satisfied by a
+        `BothWays` that degenerates to `true`, and the control is what refuses that.
+        Verified by making it `[L, R] extends [L, R]` — both controls go red.
         """
-        path = _repo_root() / TERMINAL_CLIENT
-        assert path.is_file(), f'{TERMINAL_CLIENT} moved — update TERMINAL_CLIENT'
+        pin, control, assertion, control_assertion = TYPE_LEVEL_PINS[relative]
+        path = _repo_root() / relative
+        assert path.is_file(), f'{relative} moved — update TYPE_LEVEL_PINS'
         source = _without_comments(path.read_text(encoding='utf-8'))
-        start = source.find(GENERATE_DOCUMENT_MARKER)
-        assert start != -1, (
-            f'{TERMINAL_CLIENT} no longer spells `{GENERATE_DOCUMENT_MARKER}`, so the '
-            f'slice this test searches cannot be located. If the method was renamed, '
-            f'update GENERATE_DOCUMENT_MARKER.'
+        assert pin in source, (
+            f'{relative} no longer declares `{pin}`. That is the only check on its '
+            f'half of this contract — nothing else in either language covers it (see '
+            f'this test\'s docstring), so without it the doc_type it guards can be '
+            f'widened past the route\'s allowlist with tsc, eslint and this whole '
+            f'file green. Restore it, or widen DocType and GENERATED_DOC_TYPES '
+            f'together, which is the supported way to change the contract.'
         )
-        end = source.find(NEXT_METHOD_MARKER, start)
-        assert end != -1, (
-            f'{TERMINAL_CLIENT} no longer spells `{NEXT_METHOD_MARKER}` after '
-            f'`{GENERATE_DOCUMENT_MARKER}`, which is what bounds the slice. Without '
-            f'it this test would search to end-of-file and pass on a clause sitting '
-            f'in any other method — update NEXT_METHOD_MARKER to whatever now '
-            f'follows generateDocument.'
+        assert assertion in source, (
+            f'{relative} names `{pin}` but does not spell `{assertion}`, so the pin '
+            f'is no longer a comparison — a bare `= true` satisfies a name check '
+            f'while comparing nothing, which was measured to pass every gate with '
+            f'the guarded field widened. Restore the comparison.'
         )
-        assert STRUCTURAL_PIN in source[start:end], (
-            f'`{STRUCTURAL_PIN}` is not in {TERMINAL_CLIENT}\'s generateDocument. '
-            f'That clause is the only thing making a widened doc_type a compiler '
-            f'error in this file: its `data` is just spread into JSON.stringify, so '
-            f'the parameter annotation is compared against nothing and even one that '
-            f'NAMES {REQUEST_BODY_TYPE} can widen the field past what the route '
-            f'accepts. Restore it ON THAT METHOD — elsewhere in the file it protects '
-            f'nothing — or widen the contract in {DOC_TYPE_UNION_SOURCE}, where '
-            f'{REQUEST_BODY_FIELD_PIN} and this file\'s comparison both see it.'
-        )
-
-    @pytest.mark.skipif(
-        not _frontend_tree_present(), reason='frontend tree absent from this checkout'
-    )
-    def test_the_request_body_field_is_pinned_to_the_union(self):
-        """`GenerateDocumentBody.doc_type` must REFERENCE `DocType`, not restate it.
-
-        The innermost link in the chain, and it was the last one left open. Every
-        other guard around this contract stops one level further out, measured:
-
-          * this file parses only the `export type DocType =` declaration, so the
-            interface field is invisible to it;
-          * `satisfies GenerateDocumentBody` checks the built object against that
-            interface, so a WIDENED interface satisfies it by construction;
-          * `noUnusedLocals` stays quiet, since `DocType` is still used by
-            `ProjectDocument` in the same file.
-
-        So respelling the field `'prd' | 'prfaq' | 'onepager'` exited `tsc` 0, passed
-        every test here and linted clean, while a caller could then send a value the
-        route 400s. Worse than a generic residual axis: that line is where the
-        comments on both the union and the body DIRECT a widener, and it is what the
-        field looked like before this contract was collapsed — so reverting to it is a
-        plausible slip rather than a deliberate act.
-
-        What closes it is a compiler check in the frontend, not a fourth text
-        assertion here: `DocTypeFieldIsExactlyTheUnion` compares the field to the
-        union in BOTH directions, so any respelling — enumerated members, an
-        intersection, a widened alias, a narrowing — is a TS2344. A text check would
-        have to enumerate spellings, which is the road the deleted scanner went down.
-
-        This test pins that check's PRESENCE, since deleting it compiles cleanly, and
-        the presence of its non-vacuity control with it. Text, not a parse: two names
-        either appear in the file or they do not.
-        """
-        path = _repo_root() / DOC_TYPE_UNION_SOURCE
-        assert path.is_file(), f'{DOC_TYPE_UNION_SOURCE} moved'
-        source = _without_comments(path.read_text(encoding='utf-8'))
-        assert REQUEST_BODY_FIELD_PIN in source, (
-            f'{DOC_TYPE_UNION_SOURCE} no longer declares `{REQUEST_BODY_FIELD_PIN}`. '
-            f'That is the only check that {REQUEST_BODY_TYPE}.doc_type still '
-            f'references the DocType union rather than restating its members — '
-            f'nothing else in either language does (see this test\'s docstring), so '
-            f'without it the field can be widened past the route\'s allowlist with '
-            f'tsc, eslint and this whole file green. Restore it, or widen DocType '
-            f'itself and GENERATED_DOC_TYPES together.'
-        )
-        assert REQUEST_BODY_FIELD_PIN_CONTROL in source, (
-            f'{DOC_TYPE_UNION_SOURCE} declares `{REQUEST_BODY_FIELD_PIN}` but not its '
-            f'control `{REQUEST_BODY_FIELD_PIN_CONTROL}`. The pin is satisfied by a '
-            f'comparison that degenerates to `true`, which passes while comparing '
-            f'nothing; the control is what refuses that, the same way '
+        assert control in source, (
+            f'{relative} declares `{pin}` but not its control `{control}`. The pin is '
+            f'satisfied by a comparison that degenerates to `true`, which passes '
+            f'while measuring nothing; the control is what refuses that, the same way '
             f'TestContractDriftIsCaught does for the parser here.'
+        )
+        assert control_assertion in source, (
+            f'{relative} names `{control}` but does not spell `{control_assertion}`, '
+            f'so the control is no longer a comparison either — see the message '
+            f'above; a stubbed control is a non-vacuity guard that is itself vacuous.'
         )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -13,17 +13,55 @@ picker, and a client omitting one silently drops a feature the backend supports.
 Same pattern, and the same motivation, as `test_kiro_exportable_types_lockstep.py`
 and `lambda/shared/test/test_search_minimum_lockstep.py`.
 
-WHY THIS FILE IS SHORT NOW, and why it must not grow back (issue #381). It carried
-~300 lines of TypeScript scanner — `_parameter_list_end`,
-`GENERATE_DOCUMENT_ANCHOR`, `DOC_TYPE_ANNOTATION_ANCHOR`, `FINDABLE_SHAPES`,
-`WIDENED_SHAPES`, `NARROWED_SHAPES` — for one reason: `client.ts` and
-`projectsApi.ts` spelled `'prd' | 'prfaq'` INLINE inside their `generateDocument`
-signatures, so the contract existed in three places and checking the two inline
-copies meant locating a method by name inside an object literal and delimiting its
-parameter list by bracket balance. Every review round on that scanner found another
-shape of legal TypeScript it mis-read; none found a defect in the contract. Both
-signatures now take `GenerateDocumentBody`, which removes the drift axis rather
-than testing it.
+THE SCANNER IS GONE AND MUST NOT COME BACK (issue #381). This file used to carry
+~300 lines of TypeScript scanner — `_parameter_list_end`, `GENERATE_DOCUMENT_ANCHOR`,
+`DOC_TYPE_ANNOTATION_ANCHOR`, `FINDABLE_SHAPES`, `WIDENED_SHAPES`, `NARROWED_SHAPES`
+— for one reason: `client.ts` and `projectsApi.ts` spelled `'prd' | 'prfaq'` INLINE
+inside their `generateDocument` signatures, so the contract existed in three places
+and checking the two inline copies meant locating a method by name inside an object
+literal and delimiting its parameter list by bracket balance. Every review round on
+that scanner found another shape of legal TypeScript it mis-read; none found a defect
+in the contract. Both signatures now take `GenerateDocumentBody`, which removes that
+drift axis rather than testing it. Nothing here should ever again try to decide what
+an arbitrary TypeScript type expression MEANS.
+
+WHAT THIS FILE COSTS, stated plainly because a previous version of this heading read
+"WHY THIS FILE IS SHORT NOW" long after it had stopped being true. Measured:
+
+    944 lines   on `development`, the scanner version
+    455 lines   after the scanner was deleted
+  ~1030 lines   now
+
+So it is LONGER than the scanner it replaced, and the claim that it was short was
+false for two review rounds. What the growth is, in the current file: ~60% is prose
+(this docstring, ~190 lines; test docstrings, ~235; comments, ~190) and the rest is
+two type-level pins with two non-vacuity controls each, the text assertions that keep
+those present, and `_without_comments` plus `_doc_type_union` with their shape
+fixtures.
+
+Whether that is proportionate is a fair question and was asked in review. The honest
+answer: the PINS are cheap and they are what bite — every widening mutation tried is
+refused by the compiler, not by this file. The length is the SCAFFOLDING proving the
+pins are not vacuous, and it grew because six successive rounds each found a guard
+whose documented mechanism differed from its actual one.
+
+The scaffolding is not redundant, and that was measured rather than assumed. Each
+control was DELETED in turn and the degeneration it exists for reapplied; in both
+cases nothing else noticed:
+
+  * remove `...WouldSeeDrift` (widened side), then collapse `BothWays` to the reverse
+    one-way `[Right] extends [Left]` -> `tsc` reports NOTHING in that file.
+  * remove `...WouldSeeNarrowing` (narrowed side), then collapse it to the forward
+    one-way `[Left] extends [Right]` -> `tsc` reports NOTHING in that file.
+
+With both present, those two collapses are 2 errors each, and a `BothWays` degenerated
+to constant `true` is 4. So neither control covers the other's axis and there is no
+third one to add.
+
+THE RULE THAT REPLACES ADDING MORE: when a guard turns out to be evadable, move the
+check to the compiler or pin the whole construct. Do NOT add a longer text fragment —
+that was tried four times and defeated four times, because a fragment of the thing
+being pinned is always a substring something else can supply.
 
 WHAT ENFORCES WHICH HALF, measured rather than assumed — the compiler does NOT do
 all of it, and an earlier version of this docstring claimed it did:
@@ -54,10 +92,13 @@ all of it, and an earlier version of this docstring claimed it did:
     its own — an `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ...
     | 'onepager' }` annotation uses the name and still widens, and was measured to
     exit `tsc` 0 with every test here green. `noUnusedLocals` does NOT cover that
-    either, since the name is used. Nor does the name APPEARING in the file: the pin
-    block at its foot names the type nine times, so a structurally identical inline
-    literal passed that check with `tsc` at exit 0 — which is why the text guard pins
-    the annotation `data: GenerateDocumentBody` rather than the bare name.
+    either, since the name is used. Nor does any EXISTENCE check over the file: the
+    name APPEARING is satisfied by the pin block at its foot, the annotation
+    `data: GenerateDocumentBody` by any unrelated line spelling it, and the whole
+    signature by a decoy that copies it — all three measured, `tsc` exit 0 and every
+    test here green with the real parameter respelled as an inline literal. Which is
+    why the text guard asserts a RATIO: every declaration of the method takes the
+    shared body.
     So a widening has to edit `DocType` itself — the declaration this file parses —
     and `GENERATED_DOC_TYPES` with it. Editing `GenerateDocumentBody.doc_type` is
     not a way around that: the pin above makes it a compiler error.
@@ -143,15 +184,17 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     itself, in both directions.
   * `test_both_client_signatures_use_the_shared_request_body` — a signature
     respelling the body inline again, which is a compiler error in `client.ts` and
-    NOTHING in `projectsApi.ts` (see above). Text, not a parse: it asks whether the
-    parameter is ANNOTATED with the shared type (`data: GenerateDocumentBody`), so it
-    needs no model of TypeScript and cannot mis-read a restyling. ⚠️ It asked only
-    whether the NAME appeared anywhere in the file until the annotation was pinned,
-    and that was vacuous: the pin block at the foot of `projectsApi.ts` names the type
-    nine times, so a structurally identical inline literal — the exact edit #381
-    removed — passed with `tsc` at exit 0 and every test here green. A rename of
-    `GenerateDocumentBody` fails it too, which is correct — the constant here is what
-    the two files must agree on.
+    NOTHING in `projectsApi.ts` (see above). Text, not a parse: it requires EVERY
+    declaration of the method to take the shared body, so it needs no model of
+    TypeScript and cannot mis-read a restyling. ⚠️ THREE weaker spellings were each
+    measured to permit that respelling while claiming to forbid it — the bare NAME
+    (satisfied by the pin block at the foot of `projectsApi.ts`), the ANNOTATION
+    searched whole-file (satisfied by any unrelated `data: GenerateDocumentBody` line),
+    and the whole signature merely PRESENT or present once (satisfied by a decoy that
+    copies it). Each was `tsc` exit 0 with every test here green. Hence the RATIO,
+    which a decoy adds to both sides of. A rename of `GenerateDocumentBody` or of the
+    method fails it too, which is correct — the constants here are what the two files
+    must agree on.
   * `test_the_type_level_pins_are_present` — either type-level pin deleted, STUBBED
     to a bare constant, fed through an alias that compares a type to itself, left with
     only one of its two controls, or stripped of a control's `@ts-expect-error`. All
@@ -202,16 +245,55 @@ DOC_TYPE_UNION_SOURCE = 'frontend/src/api/types.ts'
 # see the docstring: the compiler catches that in one file and not the other.
 REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 
-# 🔑 The ANNOTATION, not just the name. Asserting `REQUEST_BODY_TYPE in source` was
-# measured to be vacuous in `projectsApi.ts`: the type-level pin block at the foot of
-# that file names `GenerateDocumentBody` nine times, so the name is present whatever
-# the signature says. Replacing the parameter with a structurally identical inline
-# object literal (every field spelled out, `doc_type: DocType`) left `tsc` at exit 0
-# — `BothWays` compares structurally, so an identical shape is equal — and every test
-# here green. That is the exact edit issue #381 set out to eliminate, so the guard
-# names the parameter's reference to the type rather than the type's appearance
-# anywhere in the file.
-REQUEST_BODY_ANNOTATION = f'data: {REQUEST_BODY_TYPE}'
+# 🔑 EVERY DECLARATION of `generateDocument` must be the whole pinned signature —
+# asserted as "the number of declaration openers equals the number of full
+# signatures", not as "the full signature appears somewhere". Both files spell the
+# signature identically, so one pair of constants covers them.
+#
+# Three successively weaker versions of this guard were each measured to permit the
+# very edit it names — a structurally identical inline object literal in place of the
+# shared type, which is precisely what issue #381 removed. None is hypothetical:
+#
+#   * `REQUEST_BODY_TYPE in source` — the bare NAME. Satisfied by the type-level pin
+#     block at the foot of `projectsApi.ts`, which names `GenerateDocumentBody` three
+#     times whatever the signature says. `tsc` exit 0, every test here green.
+#   * `f'data: {REQUEST_BODY_TYPE}'` — the ANNOTATION, but searched over the whole
+#     file, so ANY occurrence satisfies it. One unrelated line
+#     (`const _probe = (data: GenerateDocumentBody) => data`) plus the inline literal
+#     was again `tsc` exit 0 and all 29 tests green.
+#   * The whole signature, required merely to be PRESENT — or present exactly once.
+#     Still satisfied by a decoy, because a decoy may be a full COPY: a
+#     `const _decoy = { generateDocument: (projectId: string, data:
+#     GenerateDocumentBody) => ... }` above the real method makes the signature
+#     present (and, for the once-only form, makes the real one inline while the count
+#     still reaches its target). Measured: `tsc` exit 0, 29 passed.
+#
+# All three failed the same way, and it is the failure this file keeps rediscovering:
+# an EXISTENCE check over a whole file asks whether some construct supplies the
+# string, never whether the construct that matters does. A count of one is the same
+# check with one more way to satisfy it.
+#
+# So the property asserted is a RATIO, which no added text can satisfy: every place
+# the method is declared is a place the shared type is used. A decoy declaration adds
+# an opener and, unless it too takes `GenerateDocumentBody`, no signature — so it
+# fails. A decoy that DOES take the shared type adds one to both sides and is
+# harmless, which is correct: it is not a respelling of the contract. And the real
+# signature going inline removes a signature while leaving its opener, which fails.
+#
+# Not an enumeration of legal TypeScript — the thing this file refuses. There is one
+# string per side, and `generateDocument` is either declared here or it is not.
+#
+# The cost, as for the pins below: this signature must stay on ONE line in both files.
+GENERATE_DOCUMENT_SIGNATURE = (
+    f'generateDocument: (projectId: string, data: {REQUEST_BODY_TYPE}) =>'
+)
+
+# What a DECLARATION of the method looks like, independent of its parameter type. The
+# left side of the ratio above. `client.ts` also CALLS
+# `m.projectsApi.generateDocument(...)`, which this deliberately does not match: a
+# call site takes whatever the declaration admits and is not a place the contract can
+# be respelled.
+GENERATE_DOCUMENT_DECLARATION = 'generateDocument: ('
 
 # The TERMINAL client — the one whose `data` is only spread into `JSON.stringify`, so
 # its annotation is checked against nothing and naming the body type is not enough on
@@ -808,32 +890,50 @@ class TestDocTypeLockstep:
         and so is compared against nothing. `client.ts` is compiler-protected by
         forwarding into it; this test is what covers the other one.
 
-        Deliberately TEXT and not a parse. It asks whether each file mentions the
-        shared type at all — no method location, no parameter-list extent, no model
-        of TypeScript, so none of the ways the scanner mis-read legal code apply.
+        Deliberately TEXT and not a parse: it compares one fixed string against the
+        source. No method location, no parameter-list extent, no model of TypeScript,
+        so none of the ways the deleted scanner mis-read legal code apply here.
 
-        THE ANNOTATION, not merely the name — because the name alone was measured to
-        be vacuous here. An earlier version asserted `GenerateDocumentBody in source`,
-        which in `projectsApi.ts` is satisfied by the type-level pin block at the foot
-        of that file (it names the type nine times) whatever the signature says.
-        Replacing the parameter with a structurally identical inline object literal
-        left `tsc` at exit 0 — `BothWays` compares structurally, so an identical shape
-        is equal — and every test here green, i.e. the precise edit this file's own
-        issue set out to eliminate passed the guard named as forbidding it. Pinning
-        `data: GenerateDocumentBody` is the signature's REFERENCE to the shared type,
-        and there is one spelling of it, so this does not start an enumeration.
+        EVERY DECLARATION, not "the shared type appears somewhere" — because three
+        successively weaker spellings were each measured to permit the inline
+        respelling they were named as forbidding:
 
-        LIMIT: this cannot tell whether the referenced type is the right shape, only
-        that the parameter takes it by name. A signature that names the type and
-        widens `doc_type` in the SAME annotation
-        (`Omit<GenerateDocumentBody, 'doc_type'> & { ... }`) does not match this
-        string, but a widening that keeps the exact `data: GenerateDocumentBody`
-        prefix would; `noUnusedLocals` does not cover that either, since the name is
-        used. What closes it is `GenerateDocumentTakesTheSharedBody`, a type-level
-        comparison of that method's parameter against the interface, which makes any
-        widening a TS2344 whatever the spelling.
-        `test_the_type_level_pins_are_present` is what keeps it there, since deleting
-        it is silent otherwise.
+          * `GenerateDocumentBody in source`, the bare NAME. In `projectsApi.ts` the
+            type-level pin block at the foot of the file names the type three times, so
+            the assertion holds whatever the signature says. An inline literal left
+            `tsc` at exit 0 and every test here green.
+          * `data: GenerateDocumentBody`, the ANNOTATION — but searched over the whole
+            file, so ANY occurrence satisfies it. One unrelated line
+            (`const _probe = (data: GenerateDocumentBody) => data`) plus the inline
+            literal was again `tsc` exit 0 and 29 passed.
+          * The whole signature, required to be PRESENT, or present exactly ONCE. Still
+            evadable, because a decoy can be a full COPY: a `const _decoy = {
+            generateDocument: (projectId: string, data: GenerateDocumentBody) => ... }`
+            above the real method satisfies both forms while the real parameter is an
+            inline literal. Measured: `tsc` exit 0, 29 passed.
+
+        All three are one defect — an EXISTENCE check over a file asks whether SOME
+        construct supplies the string, never whether the one that matters does; a count
+        of one is the same check with one more way to be satisfied. So the property
+        asserted is a RATIO: the number of declarations of this method equals the number
+        that take the shared body. No added text can satisfy that, because a decoy
+        declaration adds to the left side too. A decoy that itself takes the shared type
+        adds to both and passes, which is correct — it is not a respelling of the
+        contract.
+
+        Not an enumeration of legal TypeScript, the thing this file refuses: there is
+        one string per side, and the method is either declared here or it is not.
+
+        LIMIT, and it is narrow: this pins the parameter's REFERENCE to the shared
+        type, not the type's shape. Widening `GenerateDocumentBody` itself does not
+        match a different string, and neither does a widening spelled INSIDE the
+        annotation (`Omit<GenerateDocumentBody, 'doc_type'> & { ... }`) — the latter
+        fails this test, but only incidentally, by no longer being this exact
+        signature. What positively refuses a widened parameter in ANY spelling is
+        `GenerateDocumentTakesTheSharedBody`, a type-level comparison of the method's
+        parameter against the interface, kept present by
+        `test_the_type_level_pins_are_present`. This test's job is the reference; the
+        pin's job is the shape.
         """
         for relative in GENERATE_DOCUMENT_CLIENTS:
             path = _repo_root() / relative
@@ -844,17 +944,33 @@ class TestDocTypeLockstep:
                 f'moved, point GENERATE_DOCUMENT_CLIENTS at its new home; if this '
                 f'client dropped it, drop the entry.'
             )
-            assert REQUEST_BODY_ANNOTATION in source, (
-                f'{relative} does not spell `{REQUEST_BODY_ANNOTATION}`, so its '
-                f'generateDocument body is not taken from the shared type — most '
-                f'likely restated as an inline object literal. In projectsApi.ts '
-                f'nothing else catches that: the name appearing SOMEWHERE in the file '
-                f'is satisfied by the pin block at its foot, and a structurally '
-                f'identical literal compares equal, so the request goes out with '
-                f'whatever the literal admits and the route 400s it. Take '
+            declared = source.count(GENERATE_DOCUMENT_DECLARATION)
+            shared = source.count(GENERATE_DOCUMENT_SIGNATURE)
+            assert declared >= 1, (
+                f'{relative} declares no `{GENERATE_DOCUMENT_DECLARATION}...`, so '
+                f'there is nothing here to pin. If the method changed shape, update '
+                f'GENERATE_DOCUMENT_DECLARATION; if this client dropped it, drop the '
+                f'entry from GENERATE_DOCUMENT_CLIENTS.'
+            )
+            assert shared == declared, (
+                f'{relative} declares generateDocument {declared} time(s) but only '
+                f'{shared} of those take the shared request body. Every declaration '
+                f'must be, exactly:\n'
+                f'    {GENERATE_DOCUMENT_SIGNATURE}\n'
+                f'A declaration that is not means its body is restated inline — the '
+                f'exact edit issue #381 removed — and in projectsApi.ts nothing else '
+                f'in either language catches it: a structurally identical literal '
+                f'compares EQUAL to the interface, so the parameter pin stays green '
+                f'too, and the request goes out with whatever the literal admits. Take '
                 f'{REQUEST_BODY_TYPE} (declared in {DOC_TYPE_UNION_SOURCE}) as the '
                 f'parameter type, and widen the contract there if that is what is '
-                f'wanted.'
+                f'wanted. Keep the signature on ONE line — it is matched as exact '
+                f'text.\n'
+                f'This is a RATIO rather than a presence check because presence was '
+                f'measured to be satisfiable by a decoy: an unrelated '
+                f'`data: GenerateDocumentBody` line, or a second copy of the whole '
+                f'signature, left this guard green while the real parameter was an '
+                f'inline literal.'
             )
 
     @pytest.mark.skipif(

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -120,6 +120,26 @@ a false FAILURE, bounded to the one line a regex body may occupy — while misre
 regex is this vacuity, a false PASS with no bound. The two mistakes are not symmetric,
 and `TestThePinMatcher` pins both directions.
 
+A NINTH defeat came from the same place one delimiter deeper, and it is why the lesson is
+better stated as a question about DELIMITERS than about any one construct: reading a regex
+is not enough if the scan is wrong about where the regex ENDS. A `/` inside a CHARACTER
+CLASS does not close one — `/[/`]/` is legal, and `node` confirms it compiles and matches
+a backtick — so a body scanned to the first `/` stopped at the class's own slash, leaving
+the backtick after it live to open a phantom template frame exactly as an unread regex
+had. Measured on the tree that shipped it, with the same resynchronising trailing regex:
+the field pin DELETED outright, a copy in such a decoy, the field widened to
+`DocType | 'onepager'` — `tsc` exit 0, eslint clean, every test here green, and again
+nothing for a lint rule to object to, since a character class needs no suppression. All
+four guards went with it, as in the seventh and eighth. The scan now tracks class state,
+and that fix has a wrong side of its own — treating every `[` as opening a class would
+swallow an indexed division — so both directions are pinned separately, because they are
+different mistakes.
+
+Rounds seven, eight and nine are ONE bug in ONE function surfacing in three constructs,
+each fixed in the shared helper rather than in any guard. That is the part worth keeping:
+the remaining surface is bounded by the ways JavaScript can open and close a string, not
+by the unbounded space of type expressions this file rightly refuses to model.
+
 THE GUARDS' OWN FIXES ARE PINNED TOO, which took its own finding. The two repairs made
 in the fifth round shipped with no test, and reverting either left all 30 tests here
 green — a green result meaning "did not check", applied to the machinery this file uses
@@ -373,6 +393,14 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         regex blanks real code (`test_a_division_is_not_read_as_a_regex`), and deciding
         from the last character alone misses `return /`/` and desynchronises exactly as
         before (`test_a_keyword_led_regex_is_still_read_as_one`).
+      - scanning a regex body to the first `/`, which a CHARACTER CLASS may contain
+        (`/[/`]/` is legal) — so the body ended early and the backtick after it
+        desynchronised the scan just as an unread regex did. The NINTH vacuity, the
+        eighth's root cause one delimiter deeper, and again in every guard at once. Two
+        cases here plus one in `TestTheUnionParser` are red when the class tracking is
+        reverted, and its wrong side is pinned separately too: treating every `[` as
+        opening a class swallows an indexed division
+        (`test_an_indexed_division_is_not_read_as_a_character_class`).
     Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
     assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
@@ -725,8 +753,9 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
 
     Blanked rather than deleted, newlines preserved, so indices still refer to the
     same place in the original. Quote state is tracked so a `//` inside a string is
-    not mistaken for a comment, and regex literals are read too — see the 🔑 note
-    below on the eighth vacuity, which is what that used to cost.
+    not mistaken for a comment, and regex literals are read too, character classes
+    included — see the 🔑 notes below on the eighth and ninth vacuities, which are what
+    each of those used to cost.
 
     🔑 `blank_strings` additionally blanks STRING and TEMPLATE bodies, and exists
     because "commentary is not a declaration" has a second half this file missed for
@@ -783,6 +812,16 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
     is deliberately CONSERVATIVE: misreading a division blanks real code, which is a false
     FAILURE bounded to one line, while misreading a regex is the vacuity above, a false
     PASS with no bound. Both directions are pinned, because the fix has a wrong side too.
+
+    🔑 And a regex body does not necessarily END at the next `/` — a CHARACTER CLASS may
+    hold one, `/[/`]/` being legal — which was the NINTH vacuity and the eighth's root
+    cause one delimiter deeper. The body stopped at the class's own slash, so the backtick
+    after it stayed live and opened a phantom template frame exactly as an unread regex
+    had; measured the same way, with the field pin deleted and every gate green. So the
+    scan tracks class state, and its wrong side is pinned too: taking every `[` to open a
+    class would swallow an indexed division (`x[i] / 2 + y[j] / 3`), the same false-FAILURE
+    direction as misreading a division. Rounds seven to nine were one bug in this function
+    surfacing in three constructs, which is why each fix belongs here and not in a guard.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -852,8 +891,22 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
         # commented-out predecessor and commented-out pin cases all fail.
         if char == '/' and _regex_allowed_here(out):
             stop = index + 1
-            while stop < len(source) and source[stop] not in '/\n':
-                stop += 2 if source[stop] == '\\' else 1
+            # A `/` inside a CHARACTER CLASS does not close the regex — `/[/`]/` is
+            # legal — and scanning to the first `/` regardless was the ninth vacuity.
+            # See the 🔑 note above; the class's own slash ended the body early, so the
+            # backtick after it opened a phantom template frame.
+            in_class = False
+            while stop < len(source) and source[stop] != '\n':
+                if source[stop] == '\\':
+                    stop += 2
+                    continue
+                if source[stop] == '[':
+                    in_class = True
+                elif source[stop] == ']':
+                    in_class = False
+                elif source[stop] == '/' and not in_class:
+                    break
+                stop += 1
             if stop < len(source) and source[stop] == '/':
                 out.append(char)
                 body = source[index + 1:stop]
@@ -1216,6 +1269,24 @@ class TestTheUnionParser:
         )
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
 
+    def test_a_union_inside_a_class_desynced_template_is_not_read(self):
+        """The same again where the regex's terminator is inside a CHARACTER CLASS — the
+        ninth vacuity.
+
+        `/[/`]/` is legal, so a body scanned to the first `/` stopped at the class's own
+        slash and left the backtick after it live, opening a phantom template frame. As in
+        the two cases above the live union carries the extra member deliberately: this must
+        read `onepager` rather than merely disagree with the decoy, or it would pass on a
+        parser that read nothing at all.
+        """
+        source = (
+            "const backtickMatcher = /[/`]/\n"
+            "const historical = `export type DocType = 'prd' | 'legacy'`\n"
+            "const secondMatcher = /[/`]/\n"
+            "export type DocType = 'prd' | 'prfaq' | 'onepager'\n"
+        )
+        assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
+
     # The refusals `_doc_type_union` must carry: no readable term at the anchor, a
     # matched non-literal, an unread term after the match.
     EXPECTED_REFUSALS = 3
@@ -1366,6 +1437,50 @@ class TestThePinMatcher:
         assert _pinned(self.PIN, f'{self.PIN}\n')
         assert _pinned(self.PIN, f'{self.REGEX_DESYNC}{self.PIN}\n')
 
+    # 🔑 A `/` inside a CHARACTER CLASS — the NINTH vacuity, and the eighth's root cause
+    # one delimiter deeper: `/[/`]/` is legal JavaScript (confirmed with `node`: it
+    # compiles and matches a backtick), but a body scanned to the first `/` ends at the
+    # class's own slash, so the backtick after it opened a phantom template frame exactly
+    # as an unread regex did. The trailing regex resynchronises the scan, as above.
+    CLASS_DESYNC = 'const backtickMatcher = /[/`]/\n'
+    CLASS_RESYNC = 'const secondMatcher = /[/`]/\n'
+
+    def test_a_declaration_inside_a_class_desynced_template_is_not_pinned(self):
+        """The ninth vacuity, again on the pin with no compiler backstop.
+
+        Measured on the tree that shipped it: `DocTypeFieldIsExactlyTheUnion` DELETED
+        outright, a copy left in a template literal opened by a class-borne backtick, and
+        the field it guards widened to `DocType | 'onepager'` — `tsc` exit 0, eslint
+        clean, and every test here green. A character class needs no lint suppression, so
+        nothing stood in the way of this one either.
+        """
+        decoy = (
+            f'{self.CLASS_DESYNC}export const historical = `\n{self.PIN}\n`\n'
+            f'{self.CLASS_RESYNC}'
+        )
+        assert not _pinned(self.PIN, decoy)
+        # The controls: a real declaration must still be found, and still be found with a
+        # genuine class-bearing regex above it — reading classes must not cost the live
+        # pin, which is the false-FAILURE direction of this fix.
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+        assert _pinned(self.PIN, f'{self.CLASS_DESYNC}{self.PIN}\n')
+
+    def test_an_indexed_division_is_not_read_as_a_character_class(self):
+        """The wrong side of the class fix, which is a different mistake from the wrong
+        side of the regex fix and so is pinned separately.
+
+        `x[i] / 2 + y[j] / 3` has brackets AND two divisions. If `[` were taken to open a
+        class wherever it appears, the first `/` would no longer close the body and the
+        code between the divisions would be blanked — a false FAILURE, the opposite error
+        from the vacuity above. The brackets here are an index, not a class, because
+        `_regex_allowed_here` never lets a `/` after `]` open a regex in the first place.
+        """
+        indexed = 'const a = x[i] / 2 + y[j] / 3\n'
+        assert _declarations(indexed) == indexed
+        # The control: a class-bearing regex body IS still blanked, so this cannot pass by
+        # never reading a regex at all — which is what would reopen the vacuity above.
+        assert _declarations('const m = /[/`]/\n') == 'const m = /    /\n'
+
     def test_a_division_is_not_read_as_a_regex(self):
         """The conservative direction of `_regex_allowed_here`, pinned from the other side.
 
@@ -1512,6 +1627,18 @@ class TestThePinMatcher:
         decoy = (
             f'{self.REGEX_DESYNC}export const historical = `\n'
             f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{self.REGEX_RESYNC}'
+        )
+        assert _generate_document_ratio(decoy) == (0, 0)
+        assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
+
+    def test_a_signature_inside_a_class_desynced_template_is_not_counted(self):
+        """The ratio's version of the ninth vacuity: the regex's terminator sat inside a
+        character class, so the body ended early and the backtick after it desynchronised
+        the scan just as an unread regex did.
+        """
+        decoy = (
+            f'{self.CLASS_DESYNC}export const historical = `\n'
+            f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{self.CLASS_RESYNC}'
         )
         assert _generate_document_ratio(decoy) == (0, 0)
         assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -30,16 +30,16 @@ WHAT THIS FILE COSTS, stated plainly because a previous version of this heading 
 
     944 lines   on `development`, the scanner version
     455 lines   after the scanner was deleted
-   1230 lines   now
+   1445 lines   now
 
 So it is LONGER than the scanner it replaced, and the claim that it was short was
-false for two review rounds. What the growth is: 64% of the file is PROSE (this
-docstring 266 lines, test docstrings 314, comments 212). The 372 lines of code are
-`_without_comments` and `_doc_type_union` with their shape fixtures, plus the text
-assertions keeping two type-level pins and their four controls present. If these
-counts and the file disagree, the file is right and this block is stale — recompute
-rather than trusting it, with `ast` rather than by eye (this block has been stale
-twice, both times because a figure was written while the file was still being edited).
+false for two review rounds. What the growth is: 65% of the file is PROSE (this
+docstring 308 lines, test docstrings 420, comments 213). The 346 lines of code are
+`_without_comments`, `_doc_type_union` and the pin matcher with their shape fixtures,
+plus the text assertions keeping two type-level pins and their four controls present.
+If these counts and the file disagree, the file is right and this block is stale —
+recompute rather than trusting it, with `ast` rather than by eye (this block has been
+stale twice, both times because a figure was written while the file was still edited).
 
 Whether that is proportionate is a fair question and was asked in review. The honest
 answer: the PINS are cheap and they are what bite — every widening mutation tried is
@@ -71,6 +71,24 @@ to come from. Pinning the whole declaration still passed on a copy inside a temp
 literal, so the pins match against `_declarations(...)` — comment AND string bodies
 blanked — rather than against comment-stripped text. "Commentary is not a declaration"
 was only half the rule; a string is not one either.
+
+And its second corollary, from a SIXTH defeat: blanking is not comparing. Matching both
+sides through `_declarations` made the quoted operands INSIDE a pin equal by LENGTH —
+`'not-a-doc-type'` and `'AAAAAAAAAAAAAA'` blank to the same fourteen spaces — so a
+control's member could be swapped for an arbitrary same-length string with `tsc` at exit
+0 and every test here green. `_declaration_offset` therefore locates a candidate in the
+blanked view and then requires the RAW text to match there: structure decides WHERE,
+exact text decides WHAT. The compiler backstops one shape of this (a pin repointed at a
+field that does not exist is a TS2339) but not the operand swap, since one arbitrary
+non-member is as good as another to `BothWays` and the control goes on working.
+
+THE GUARDS' OWN FIXES ARE PINNED TOO, which took its own finding. The two repairs made
+in the fifth round shipped with no test, and reverting either left all 30 tests here
+green — a green result meaning "did not check", applied to the machinery this file uses
+to refuse exactly that. `TestThePinMatcher` covers `_declaration_offset` and
+`_carries_expect_error` directly, so each repair is red when reverted. That the pin
+matcher then needed a SIXTH repair, in a step whose first version was untested, is the
+argument for having it.
 
 WHAT ENFORCES WHICH HALF, measured rather than assumed — the compiler does NOT do
 all of it, and an earlier version of this docstring claimed it did:
@@ -211,6 +229,22 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     `` const historical = `export type DocType = 'prd' | 'legacy'` `` above the live
     union returned the DECOY's members, so the equality test compared the wrong set.
     Same silent failure as the commented-out predecessor, one quote character away.
+  * `TestThePinMatcher` — the pin MATCHER itself degenerating, which is what every
+    round's finding about these guards has actually been. Each case is one revert of a
+    repair that shipped untested and was therefore silently revertible:
+      - matching against comment-stripped text rather than `_declarations(...)`, so a
+        copy in an exported template literal supplies a pin that was DELETED;
+      - locating the `@ts-expect-error` with an independent `raw.find`, which such a
+        decoy redirects onto its own line, so the live control needs no directive;
+      - accepting a preceding line that merely MENTIONS the directive, which the prose
+        in these files does;
+      - dropping the exact-text step, which compares a pin's quoted operands by LENGTH
+        and lets `'not-a-doc-type'` become any other fourteen characters;
+      - stopping at the FIRST candidate offset, which a decoy above the live
+        declaration occupies — a false FAILURE rather than a false pass, and the reason
+        the search continues.
+    Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
+    assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
     itself, in both directions.
   * `test_both_client_signatures_use_the_shared_request_body` — a signature
@@ -597,16 +631,87 @@ def _declarations(raw: str) -> str:
     return _without_comments(raw, blank_strings=True)
 
 
-def _pinned(expected: str, raw: str) -> bool:
-    """Whether `raw` DECLARES `expected`, comparing like with like.
+def _declaration_offset(expected: str, raw: str) -> int | None:
+    """Where `raw` DECLARES `expected`, or None — structurally located, exactly matched.
 
-    Both sides go through `_declarations`, which is the point: the expected text
-    contains quoted members (`'not-a-doc-type'`), so blanking string bodies on only
-    one side would never match. Blanking both leaves the declaration's structure —
-    which is what is being pinned — while denying a decoy the ability to supply it
-    from inside a string.
+    Two steps, and both are needed:
+
+      1. WHERE. The candidate offsets come from `_declarations(raw)` matched against
+         `_declarations(expected)`, so a copy of the declaration inside a comment or a
+         template literal is not a place this can match. Blanking is done on BOTH
+         sides because the expected text contains quoted members
+         (`'not-a-doc-type'`), which blanking one side only would never match.
+      2. WHAT. At each candidate offset the RAW text must equal `expected`. Blanking
+         preserves length, so the offset is valid in `raw`.
+
+    🔑 Step 2 exists because step 1 alone compares quoted operands by LENGTH, not
+    content — blanking maps `'not-a-doc-type'` and `'AAAAAAAAAAAAAA'` to the same
+    fourteen spaces. Measured on the shipped tree: swapping the widened control's
+    member for an arbitrary same-length string left `tsc` at exit 0 with every test
+    here green, and swapping `['doc_type']` for `['bogusKey']` in the pin was caught
+    only by the compiler (TS2339), not here. The second is backstopped; the first is
+    not, since one arbitrary non-member is as good as another to the compiler and the
+    control keeps working — so nothing but this comparison notices the literals
+    drifting. A guard that reads a pin's operands by length is the same vacuity class
+    as the four this file already records, one level in.
+
+    Several candidates are tried rather than just the first, so a commented-out or
+    quoted copy ABOVE the live declaration cannot mask it: that copy blanks to the
+    same shape and would otherwise be the only offset examined, fail step 2, and
+    report the live pin missing.
+
+    Returns the OFFSET rather than a bool because the `@ts-expect-error` lookup needs
+    the same location, and computing it twice by different means is how the two
+    drifted apart before: that lookup used its own `find` and a decoy redirected it.
     """
-    return _declarations(expected) in _declarations(raw)
+    needle = _declarations(expected)
+    haystack = _declarations(raw)
+    located = haystack.find(needle)
+    while located != -1:
+        if raw[located:located + len(expected)] == expected:
+            return located
+        located = haystack.find(needle, located + 1)
+    return None
+
+
+def _pinned(expected: str, raw: str) -> bool:
+    """Whether `raw` declares `expected`. See `_declaration_offset`."""
+    return _declaration_offset(expected, raw) is not None
+
+
+def _directive_above(declaration: str, raw: str) -> str | None:
+    """The line directly above where `raw` declares `declaration`, or None if it does
+    not declare it at all.
+
+    Located via `_declaration_offset`, so it is the LIVE declaration's line and not
+    that of a copy in a comment or a template literal — an independent `raw.find` here
+    was measured to land on such a decoy, which let both real `@ts-expect-error`
+    directives be deleted with every gate green.
+
+    Returned rather than asserted on so the caller's rule ("must BE the directive, not
+    merely mention it") is checkable from a test without a fixture file. Both halves of
+    this lookup were silently revertible before that was possible.
+    """
+    located = _declaration_offset(declaration, raw)
+    if located is None:
+        return None
+    return raw[:located].rstrip().rsplit('\n', 1)[-1]
+
+
+def _carries_expect_error(declaration: str, raw: str) -> bool:
+    """Whether `raw` declares `declaration` with an `@ts-expect-error` directly above.
+
+    🔑 The line must BE the directive, not merely contain it: several comments in these
+    two files DISCUSS `@ts-expect-error` in prose, and a substring test over the
+    preceding line was measured to be satisfied by one of them — so both real
+    directives could be deleted and `extends true` dropped from a verdict helper,
+    disabling both pins and all four controls, with `tsc` at exit 0 and every test here
+    green.
+    """
+    preceding = _directive_above(declaration, raw)
+    if preceding is None:
+        return False
+    return preceding.lstrip().startswith(f'// {EXPECT_ERROR_DIRECTIVE}')
 
 
 def _doc_type_union(source: str) -> frozenset[str]:
@@ -847,6 +952,117 @@ class TestTheUnionParser:
             f'_doc_type_union should carry exactly {self.EXPECTED_REFUSALS} refusals '
             f'(anchor, non-literal term, unread term); found {len(raises)}'
         )
+
+
+class TestThePinMatcher:
+    """`_declaration_offset` — what `test_the_type_level_pins_are_present` locates the
+    pins with, on synthetic sources.
+
+    Its own controls, for the same reason `TestTheUnionParser` has them: every defect
+    ever found in the pin guards was the matcher accepting something that did not
+    declare the pin, and each fix to it was silently revertible — reverting either of
+    the two made in the fifth round left all 30 tests here green, which is the "green
+    result meaning did not check" this file exists to refuse, applied to its own
+    machinery. A positive assertion sits beside every negative one so none of these
+    can pass by rejecting everything.
+    """
+
+    # A pin's shape, without depending on the live ones: those are pinned as exact text
+    # elsewhere, and a fixture that tracked them would fail for a legitimate edit to
+    # them rather than for a defect in the matcher.
+    PIN = "export type X = MustBeTrue<BothWays<Body['doc_type'], DocType>>"
+
+    def test_a_declaration_inside_a_template_literal_is_not_pinned(self):
+        """A string is not a declaration — the fifth vacuity, and the general form of
+        the four before it.
+
+        A copy in an exported template literal survives comment-stripping, survives
+        `noUnusedLocals`, and can carry newlines. Measured on the shipped tree: with
+        the pins matched against comment-stripped text only, the real pin could be
+        DELETED, a copy left in such a literal, and the field it guards widened, with
+        `tsc` at exit 0 and every test here green.
+        """
+        decoy = f'export const historical = `\n{self.PIN}\n`\n'
+        assert not _pinned(self.PIN, decoy)
+        # The control: the same text as real code must still be found, or this would
+        # pass by matching nothing.
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+
+    def test_a_declaration_inside_a_comment_is_not_pinned(self):
+        """The same for a commented-out copy, which is the shape a maintainer actually
+        produces — disabling a pin by commenting it out, rather than by building a
+        decoy."""
+        assert not _pinned(self.PIN, f'// {self.PIN}\n')
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+
+    def test_a_decoy_above_the_live_declaration_does_not_mask_it(self):
+        """Both copies blank to the same shape, so the FIRST candidate offset is the
+        decoy's. Examining only that one would fail the exact-text step and report the
+        live pin missing — a false failure, and the reason the search continues past a
+        candidate that does not match rather than stopping at it."""
+        source = f'export const historical = `\n{self.PIN}\n`\n{self.PIN}\n'
+        assert _pinned(self.PIN, source)
+
+    def test_a_pinned_literal_may_not_be_swapped_for_another_of_equal_length(self):
+        """🔑 Blanking string bodies compares quoted operands by LENGTH, so this is
+        what compares them by CONTENT.
+
+        Measured on the shipped tree before this existed: swapping the widened
+        control's `'not-a-doc-type'` for `'AAAAAAAAAAAAAA'` left `tsc` at exit 0 with
+        every test here green, because the two blank to the same fourteen spaces. The
+        compiler does not backstop it — one arbitrary non-member is as good as another
+        to `BothWays`, so the control keeps working and nothing else looks at the
+        literal. A pin whose operands are read by length is a guard reporting success
+        while comparing less than it names.
+        """
+        same_length = self.PIN.replace("'doc_type'", "'bogusKey'")
+        assert len(same_length) == len(self.PIN), 'fixture must differ only in content'
+        assert not _pinned(self.PIN, f'{same_length}\n')
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+
+    def test_a_line_that_merely_mentions_the_directive_is_not_one(self):
+        """`@ts-expect-error` in prose is not a directive.
+
+        Several comments in `types.ts` and `projectsApi.ts` discuss the mechanism by
+        name — this file's own docstrings do too — so a substring test over the
+        preceding line is satisfied by explanatory text. Measured before this existed:
+        with such a line above each control, both real directives could be deleted and
+        `extends true` dropped from a verdict helper, disabling both pins and all four
+        controls, with `tsc` at exit 0 and every test here green.
+        """
+        prose = f'// the control below relies on {EXPECT_ERROR_DIRECTIVE} to assert it\n'
+        assert not _carries_expect_error(self.PIN, f'{prose}{self.PIN}\n')
+        assert _carries_expect_error(
+            self.PIN, f'// {EXPECT_ERROR_DIRECTIVE} must not compare equal\n{self.PIN}\n'
+        )
+
+    def test_a_directive_above_a_quoted_copy_does_not_count_for_the_live_one(self):
+        """The other half of the same defect: the directive was found by an index into
+        the RAW source, so a decoy copy of the control carrying a directive was the
+        first match and its line was the one inspected. The live declaration could then
+        have no directive at all.
+
+        Both halves had to be reverted together to reopen it, which is why they are one
+        function now — and why this asserts on `_carries_expect_error` rather than on
+        the index.
+        """
+        decoy = (
+            f'export const historical = `\n'
+            f'// {EXPECT_ERROR_DIRECTIVE} historical\n{self.PIN}\n`\n'
+        )
+        assert not _carries_expect_error(self.PIN, f'{decoy}{self.PIN}\n')
+        # Same decoy, but the LIVE declaration keeps its directive: still true, so this
+        # rejects the decoy rather than anything that merely follows one.
+        assert _carries_expect_error(
+            self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
+        )
+
+    def test_a_quoted_member_inside_the_pin_still_matches(self):
+        """The reason both sides are blanked at all: the pins contain string literals,
+        so blanking only the source would never match one. The negative cases above
+        are only meaningful if this positive one holds — otherwise they would pass by
+        the matcher rejecting every pin, live ones included."""
+        assert _pinned(self.PIN, f'const before = 1\n{self.PIN}\nconst after = 2\n')
 
 
 def _rendered_union(members: tuple[str, ...], comment: str = '') -> str:
@@ -1178,11 +1394,12 @@ class TestDocTypeLockstep:
         path = _repo_root() / relative
         assert path.is_file(), f'{relative} moved — update TYPE_LEVEL_PINS'
         raw = path.read_text(encoding='utf-8')
-        # Comment AND string bodies blanked for the declarations, so neither a
-        # commented-out copy nor one inside a template literal can satisfy them; raw
-        # for the directives, which are themselves comments. Same length, so an index
-        # from `source` is valid against `raw`.
-        source = _declarations(raw)
+        # Both checks take the RAW source. `_pinned` and `_carries_expect_error` do the
+        # blanking themselves — a declaration is located in the comment-and-string-blanked
+        # view and then matched exactly against the raw text there, and a directive is a
+        # comment so it only exists raw. Kept inside those helpers rather than spelled
+        # here because `TestThePinMatcher` can then pin them, which is what two rounds of
+        # silently revertible repairs to this lookup argued for.
         assert _pinned(pin, raw), (
             f'{relative} no longer declares, exactly:\n'
             f'    {pin}\n'
@@ -1206,23 +1423,13 @@ class TestDocTypeLockstep:
                 f'here. A widened-side control cannot detect the one-way collapse, '
                 f'so the narrowed-side one is not redundant.'
             )
-            # The line immediately above the control, in the RAW source — the
-            # declarations are pinned against the stripped source, but a directive IS a
-            # comment, so it only exists here.
-            #
-            # 🔑 Indexed with `source`, not `raw`. `source` has comment and string
-            # bodies blanked at the same length, so this finds the DECLARATION and not a
-            # copy of it sitting in a comment or a template literal above. Measured:
-            # with `raw.find`, two decoys carrying a directive and a copy of each
-            # control made this inspect their lines instead, so both real directives
-            # could be deleted and `extends true` dropped — `tsc` exit 0, every test
-            # here green, and the field they guard widened past the route's allowlist.
-            located = source.find(_declarations(control))
-            preceding = raw[:located].rstrip().rsplit('\n', 1)[-1]
-            # Must BE the directive, not merely mention it: a preceding line that
-            # DISCUSSES `@ts-expect-error` (as several comments in these files do) was
-            # measured to satisfy a substring test.
-            assert preceding.lstrip().startswith(f'// {EXPECT_ERROR_DIRECTIVE}'), (
+            # The directive on the line directly above, read from the RAW source — the
+            # declarations are pinned against the blanked view, but a directive IS a
+            # comment, so it only exists here. Both the location and the "must BE the
+            # directive" rule live in `_carries_expect_error`, and are pinned by
+            # `TestThePinMatcher`: each half of this lookup was silently revertible
+            # while it was spelled inline here.
+            assert _carries_expect_error(control, raw), (
                 f'{relative} declares the control\n'
                 f'    {control}\n'
                 f'but the line above it is not a `{EXPECT_ERROR_DIRECTIVE}`. That '
@@ -1234,5 +1441,5 @@ class TestDocTypeLockstep:
                 f'instead. The line must BE the directive: merely MENTIONING it, and a '
                 f'decoy copy of the control in a comment or template literal that this '
                 f'lookup once landed on instead, were both measured to pass.\n'
-                f'Found instead: {preceding.strip()!r}'
+                f'Found instead: {(_directive_above(control, raw) or "").strip()!r}'
             )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -141,8 +141,10 @@ all of it, and an earlier version of this docstring claimed it did:
     not a way around that: the pin above makes it a compiler error.
 
 ⚠️ THOSE TWO EDITS ARE NOT THE WHOLE SUPPORTED CHANGE, and every round of this file
-claimed they were. A THIRD edit is required, in the generator, and nothing here or in
-the compiler asks for it: `lambda/jobs/document_generator/handler.py` dispatches on
+claimed they were. TWO MORE are required — in the generator and in the picker — and
+neither this file nor the compiler asks for either.
+
+THE THIRD EDIT: the generator. `lambda/jobs/document_generator/handler.py` dispatches on
 `doc_type` as a BINARY with PR-FAQ as the unconditional `else`, in three places —
 anchored on the symbols rather than line numbers, since a citation into a file this
 test does not read is exactly what goes stale (it has three times on this branch):
@@ -165,12 +167,28 @@ drift this file does catch: a refused value is a visible 400, this is a wrong-co
 success. Adding a member therefore also needs a step builder, a generation branch and
 an assembly branch there.
 
-Deliberately NOT guarded here. That is a different contract — the generator's dispatch
-against the route's allowlist — and it wants its own test near the generator rather
-than a second responsibility bolted onto this file. What is fixed is the RECIPE: the
-ceiling is stated, so a widener reads it instead of discovering it from a mislabelled
-document. Same reasoning as `suggestDocumentBrief` above: name the boundary, do not
-grow the guard across it.
+THE FOURTH EDIT: the picker. `frontend/src/pages/ProjectDetail/Wizards.tsx` names its
+members as LITERALS, so a widening leaves the new type accepted by this route but never
+OFFERED by the UI — dead capability rather than wrong content. Also symbol-anchored:
+
+    `hasPrfaq` / `hasPrd`                       — the two selection flags
+    the two `toggleDocType('...')` buttons      — in `renderFinalStep`
+    `bothSelected`, `singleTitle`,              — copy and layout, all written as
+      `singleSubmitLabel`                         a PRD-or-PR-FAQ binary
+
+Measured the same way: the two blessed edits alone leave `tsc -p tsconfig.app.json
+--noEmit` at exit 0 and every test here green, with the picker still rendering exactly
+two buttons — `tsc` is fine with a NARROWER argument to `includes`/`filter`, so nothing
+in that file has to change for it to compile. `Wizards.tsx` documents this direction
+from its own side, beside the literals; the two statements should stay consistent.
+
+Deliberately NOT guarded here, either of them. Those are different contracts — the
+generator's dispatch and the picker's offering, each against the route's allowlist —
+and each wants its own test next to the code it constrains rather than a second and
+third responsibility bolted onto this file. What is fixed is the RECIPE: the ceilings
+are stated, so a widener reads them instead of discovering one from a mislabelled
+document and the other from a button that never appears. Same reasoning as
+`suggestDocumentBrief` above: name the boundary, do not grow the guard across it.
 
 WHY EACH GUARD IS THE KIND IT IS. The rule this file has converged on over several
 rounds, each of which found the same hole one level further in: a link TypeScript can

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -4,12 +4,11 @@ frontend can SEND must not drift apart.
 `projects_handler.GENERATED_DOC_TYPES` is what POST /projects/{id}/document
 validates against — anything outside it is a 400 raised before `create_job`. The
 frontend declares the same set ONCE, as the `DocType` union in
-`frontend/src/pages/ProjectDetail/types.ts`: the picker is built from it and both
-`generateDocument` client signatures import it, so there is a single declaration to
-pin. Nothing tied the two languages together, and the failure is user-visible
-rather than loud: a client offering a value the route refuses turns a click into an
-HTTP 400 from a document picker, and a client omitting one silently drops a feature
-the backend supports.
+`frontend/src/api/types.ts`, and reaches this route through ONE named request body,
+`GenerateDocumentBody`, whose `doc_type` field is that union. Nothing tied the two
+languages together, and the failure is user-visible rather than loud: a client
+offering a value the route refuses turns a click into an HTTP 400 from a document
+picker, and a client omitting one silently drops a feature the backend supports.
 
 Same pattern, and the same motivation, as `test_kiro_exportable_types_lockstep.py`
 and `lambda/shared/test/test_search_minimum_lockstep.py`.
@@ -18,16 +17,40 @@ WHY THIS FILE IS SHORT NOW, and why it must not grow back (issue #381). It carri
 ~300 lines of TypeScript scanner — `_parameter_list_end`,
 `GENERATE_DOCUMENT_ANCHOR`, `DOC_TYPE_ANNOTATION_ANCHOR`, `FINDABLE_SHAPES`,
 `WIDENED_SHAPES`, `NARROWED_SHAPES` — for one reason: `client.ts` and
-`projectsApi.ts` spelled `'prd' | 'prfaq'` INLINE, so the contract existed in three
-places and checking the two inline copies meant locating a method by name inside an
-object literal and delimiting its parameter list by bracket balance. Successive
-review rounds on PR #377 each found a new way that mis-read legal TypeScript
-(nested callback, column-0 latch, nested namespace, `//` and `/* */` comments,
-unbalanced brackets, non-literal terms, an unreadable first term) — every one a
-defect in the scanner, not in the contract. Both signatures now say
-`doc_type: DocType`, which removes the drift axis instead of testing it: the copies
-can no longer disagree, and TypeScript, not a regex, enforces it. If a signature
-respells the union inline again, the fix is the import, not a parser.
+`projectsApi.ts` spelled `'prd' | 'prfaq'` INLINE inside their `generateDocument`
+signatures, so the contract existed in three places and checking the two inline
+copies meant locating a method by name inside an object literal and delimiting its
+parameter list by bracket balance. Every review round on that scanner found another
+shape of legal TypeScript it mis-read; none found a defect in the contract. Both
+signatures now take `GenerateDocumentBody`, which removes the drift axis rather
+than testing it.
+
+WHAT ENFORCES WHICH HALF, measured rather than assumed — the compiler does NOT do
+all of it, and an earlier version of this docstring claimed it did:
+  * `DocType` -> the route's allowlist: THIS file, by parsing the declaration.
+    Nothing in TypeScript knows what Python accepts.
+  * `GenerateDocumentBody.doc_type` -> `DocType`: the compiler, because the field
+    references the union by name.
+  * The two `generateDocument` signatures -> `GenerateDocumentBody`: the compiler
+    for `client.ts`, which forwards its `data` into `projectsApi.generateDocument`
+    and so gets a TS2345 if it widens; NOTHING for `projectsApi.generateDocument`,
+    which is the terminal consumer — its `data` is only spread into
+    `JSON.stringify`, so an inline object literal in that one signature type-checks
+    however wide it is. That is why the body is a NAMED type and why
+    `test_both_client_signatures_use_the_shared_request_body` asserts by text that
+    both signatures still name it. A widening now has to edit
+    `GenerateDocumentBody` itself, where the field is `DocType` and this file's
+    comparison sees it.
+
+A LITERAL UNION IS THE REQUIRED SHAPE for `DocType`. A derivation
+(`typeof GENERATED_DOC_TYPES[number]`, as `KIRO_EXPORTABLE_DOC_TYPES` uses one
+directory away) is refused by `_doc_type_union`, deliberately and permanently:
+resolving an alias means evaluating TypeScript, which is what the deleted scanner
+tried and is the whole reason it was deleted. If the frontend wants a runtime array
+of doc types, declare the array FROM the union (`const DOC_TYPES: DocType[] = [...]`)
+rather than the union from the array, so the pinned declaration stays a literal
+union. The same answer applies to `test_kiro_exportable_types_lockstep.py`, which
+therefore cannot share this parser.
 
 `suggestDocumentBrief` also takes a `doc_type` and is still NOT pinned here: it
 calls a different route which the comment above GENERATED_DOC_TYPES documents as
@@ -49,6 +72,12 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     moved, leaving the equality test comparing empty sets.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
     itself, in both directions.
+  * `test_both_client_signatures_use_the_shared_request_body` — a signature
+    respelling the body inline again, which is a compiler error in `client.ts` and
+    NOTHING in `projectsApi.ts` (see above). Text, not a parse: it asks whether the
+    shared name appears, so it needs no model of TypeScript and cannot mis-read a
+    restyling. A rename of `GenerateDocumentBody` fails it too, which is correct —
+    the constant here is what the two files must agree on.
   * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
     union is edited, and its opposite, one that reports drift for a comment.
   * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
@@ -67,7 +96,17 @@ import pytest
 # The TypeScript declaration that must agree with GENERATED_DOC_TYPES. Update this
 # path if the file moves; a stale path fails the findability test rather than
 # silently skipping.
-DOC_TYPE_UNION_SOURCE = 'frontend/src/pages/ProjectDetail/types.ts'
+DOC_TYPE_UNION_SOURCE = 'frontend/src/api/types.ts'
+
+# The named request body both `generateDocument` signatures must take, and the two
+# files that must take it. `client.ts` only wraps `projectsApi.ts`, so a body type
+# in one and an inline object literal in the other is the shape this pins against —
+# see the docstring: the compiler catches that in one file and not the other.
+REQUEST_BODY_TYPE = 'GenerateDocumentBody'
+GENERATE_DOCUMENT_CLIENTS = (
+    'frontend/src/api/projectsApi.ts',
+    'frontend/src/api/client.ts',
+)
 
 
 def _repo_root() -> Path:
@@ -262,10 +301,18 @@ UNION_SHAPES = {
     'commented_out_predecessor':
         "// export type DocType = 'prd' | 'prfaq' | 'legacy'\n"
         "export type DocType = 'prd' | 'prfaq'\n",
-    # The shape types.ts has today: a leading comment explaining why this is the
-    # only copy. It must not be read as the union.
+    # A DOCUMENTING comment — one whose subject IS this declaration — that quotes the
+    # declaration to say what not to do with it. Distinct from the case above, which
+    # is dead code: this one is prose a maintainer is invited to write, and the
+    # comment `types.ts` carries today already quotes the members
+    # (``respelling `'prd' | 'prfaq'` inline``). It becomes the first `re.search`
+    # match the moment someone quotes the whole `export type` line in it, which is a
+    # natural edit in a comment about that line. An earlier version of this fixture
+    # quoted NEITHER, so it parsed the same whether `_without_comments` ran or not
+    # and pinned nothing.
     'documented': (
-        '// 🔑 The ONE frontend declaration. Do not respell it inline; import it.\n'
+        '// 🔑 The ONE declaration. Not '
+        "`export type DocType = 'prd' | 'legacy'` — import this one.\n"
         "export type DocType = 'prd' | 'prfaq'\n"
     ),
 }
@@ -367,20 +414,51 @@ class TestTheUnionParser:
             f'these parser guards refuse via `assert`, which `python -O` removes '
             f'entirely: {asserts}. Use `raise AssertionError(...)`.'
         )
-        assert len(raises) >= self.EXPECTED_REFUSALS, (
-            f'_doc_type_union should carry {self.EXPECTED_REFUSALS} refusals '
+        # EXACTLY, now that one function carries all three: `>=` also passed on a
+        # guard duplicated rather than moved, and there is no reason for a fourth
+        # raise in a parser with three unreadable positions.
+        assert len(raises) == self.EXPECTED_REFUSALS, (
+            f'_doc_type_union should carry exactly {self.EXPECTED_REFUSALS} refusals '
             f'(anchor, non-literal term, unread term); found {len(raises)}'
         )
 
 
-# Edits to the exported union that MUST break the equality test below. One per
-# direction, because the two are user-visible in different ways: an added member is
-# a 400 from a picker, a removed one a backend capability nobody can reach.
-DRIFTED_UNIONS = {
-    'member_added': "export type DocType = 'prd' | 'prfaq' | 'onepager'\n",
-    'member_removed': "export type DocType = 'prd'\n",
-    'member_replaced': "export type DocType = 'prd' | 'onepager'\n",
-}
+def _rendered_union(members, comment: str = '') -> str:
+    """`export type DocType = ...` over `members`.
+
+    With a `comment`, one member per line and the comment after the FIRST — the
+    position where it truncates the union if it is not stripped.
+
+    Rendered from the members rather than written out because the controls below
+    compare against the LIVE allowlist: fixtures pinned to today's two values would
+    turn a legitimate widening of the contract into three extra failures in the one
+    file whose job is to point at the single real one.
+    """
+    quoted = [f"'{member}'" for member in members]
+    if not comment:
+        return f"export type DocType = {' | '.join(quoted)}\n"
+    terms = [f'  | {term}' for term in quoted]
+    terms[0] = f'{terms[0]} {comment}'
+    return 'export type DocType =\n' + '\n'.join(terms) + '\n'
+
+
+def _member_the_route_refuses(accepted: frozenset[str]) -> str:
+    """A doc_type value outside `accepted`, for the widening mutations.
+
+    Derived rather than hardcoded for the same reason: if `onepager` is ever added
+    to the allowlist, a mutation using it would compare EQUAL and the control would
+    pass while measuring nothing.
+    """
+    candidate = 'onepager'
+    while candidate in accepted:
+        candidate = f'{candidate}_unaccepted'
+    return candidate
+
+
+# The three ways the exported union can drift from the allowlist. Named, and turned
+# into sources inside the test, because deriving them needs the handler imported —
+# which the tests here do in their bodies, not at collection time.
+DRIFT_KINDS = ('member_added', 'member_removed', 'member_replaced')
 
 
 class TestContractDriftIsCaught:
@@ -392,25 +470,57 @@ class TestContractDriftIsCaught:
     satisfied by a parser that always agrees or always refuses.
     """
 
-    @pytest.mark.parametrize('source', DRIFTED_UNIONS.values(), ids=DRIFTED_UNIONS)
-    def test_a_changed_member_no_longer_matches_the_route(self, source):
+    @pytest.mark.parametrize('kind', DRIFT_KINDS)
+    def test_a_changed_member_no_longer_matches_the_route(self, kind):
+        """Each direction is user-visible in a different way: an added member is a
+        400 from a picker, a removed one a backend capability nobody can reach."""
         from projects_handler import GENERATED_DOC_TYPES
+
+        accepted = tuple(GENERATED_DOC_TYPES)
+        extra = _member_the_route_refuses(frozenset(accepted))
+        if kind != 'member_added' and len(accepted) < 2:
+            # Removing from a one-member allowlist leaves no union at all, which the
+            # parser REFUSES rather than returning a set to compare — a different
+            # test than this one. Skipped rather than silently reinterpreted.
+            pytest.skip('the route accepts one value; there is nothing to drop')
+        mutations = {
+            'member_added': (*accepted, extra),
+            'member_removed': accepted[:-1],
+            'member_replaced': (*accepted[:-1], extra),
+        }
+        source = _rendered_union(mutations[kind])
 
         assert _doc_type_union(source) != frozenset(GENERATED_DOC_TYPES), (
             f'this edit to DocType compares EQUAL to the route\'s allowlist, so '
             f'the lockstep test below cannot see it:\n{source}'
         )
 
-    @pytest.mark.parametrize('shape', ['commented', 'commented_out_predecessor'])
+    @pytest.mark.parametrize(
+        'shape', ['between_members', 'commented_out_predecessor', 'documented']
+    )
     def test_a_legal_comment_leaves_the_result_matching_the_route(self, shape):
-        """Restricted to the two comment shapes on purpose: the rest of
-        `UNION_SHAPES` is reformatting, already pinned above against the same two
-        members. A comment is the case where the parser reads the WRONG declaration
-        rather than none, so `_without_comments` is the only thing standing between
-        it and a report of drift the frontend does not have."""
+        """Restricted to the comment shapes on purpose: the rest of `UNION_SHAPES` is
+        reformatting, already pinned above against its own members. A comment is the
+        case where the parser reads the WRONG declaration rather than none, so
+        `_without_comments` is the only thing standing between it and a report of
+        drift the frontend does not have.
+
+        All three quote or carry a full declaration, so each goes red if
+        `_without_comments` is stubbed to a pass-through — which is how to check that
+        they measure what they claim.
+        """
         from projects_handler import GENERATED_DOC_TYPES
 
-        assert _doc_type_union(UNION_SHAPES[shape]) == frozenset(GENERATED_DOC_TYPES)
+        accepted = tuple(GENERATED_DOC_TYPES)
+        live = _rendered_union(accepted)
+        dead = _rendered_union((*accepted, _member_the_route_refuses(frozenset(accepted))))
+        shapes = {
+            'between_members': _rendered_union(accepted, '// the default'),
+            'commented_out_predecessor': f'// {dead}{live}',
+            'documented': f'// The ONE declaration. Not `{dead.strip()}`.\n{live}',
+        }
+
+        assert _doc_type_union(shapes[shape]) == frozenset(GENERATED_DOC_TYPES)
 
 
 class TestDocTypeLockstep:
@@ -438,9 +548,11 @@ class TestDocTypeLockstep:
         frontend never offers is a backend capability no user can reach. Both are
         drift, so neither direction is allowed.
 
-        This is the whole contract now that both `generateDocument` signatures import
-        `DocType` instead of respelling it: TypeScript rejects a request body outside
-        the union, and this test pins the union to the allowlist.
+        This half of the contract is only checkable HERE: TypeScript has no idea
+        what Python accepts. The compiler's half is that
+        `GenerateDocumentBody.doc_type` references this union by name, which
+        `test_both_client_signatures_use_the_shared_request_body` keeps true of both
+        signatures.
         """
         from projects_handler import GENERATED_DOC_TYPES
 
@@ -453,3 +565,41 @@ class TestDocTypeLockstep:
             f'  Accepted but never offered (unreachable): '
             f'{sorted(frozenset(GENERATED_DOC_TYPES) - declared)}'
         )
+
+    @pytest.mark.skipif(
+        not _frontend_tree_present(), reason='frontend tree absent from this checkout'
+    )
+    def test_both_client_signatures_use_the_shared_request_body(self):
+        """Neither `generateDocument` may respell the body inline again.
+
+        The axis the deleted scanner covered, at ~1/60th of its size, and it is
+        genuinely uncovered otherwise: widening `projectsApi.generateDocument`'s
+        annotation type-checks cleanly (measured — `tsc -p tsconfig.app.json
+        --noEmit` exits 0), because that `data` is only spread into `JSON.stringify`
+        and so is compared against nothing. `client.ts` is compiler-protected by
+        forwarding into it; this test is what covers the other one.
+
+        Deliberately TEXT and not a parse. It asks whether each file mentions the
+        shared type at all — no method location, no parameter-list extent, no model
+        of TypeScript, so none of the ways the scanner mis-read legal code apply. It
+        cannot tell WHERE the name is used, which is the trade: `GenerateDocumentBody`
+        imported but the signature widened anyway would pass here. `noUnusedLocals`
+        makes that combination a compiler error, so the two together close it.
+        """
+        for relative in GENERATE_DOCUMENT_CLIENTS:
+            path = _repo_root() / relative
+            assert path.is_file(), f'{relative} moved — update GENERATE_DOCUMENT_CLIENTS'
+            source = _without_comments(path.read_text(encoding='utf-8'))
+            assert 'generateDocument' in source, (
+                f'{relative} no longer mentions generateDocument. If the method '
+                f'moved, point GENERATE_DOCUMENT_CLIENTS at its new home; if this '
+                f'client dropped it, drop the entry.'
+            )
+            assert REQUEST_BODY_TYPE in source, (
+                f'{relative} does not name {REQUEST_BODY_TYPE}, so its '
+                f'generateDocument body is spelled inline. In projectsApi.ts nothing '
+                f'checks such an annotation — the request goes out with whatever it '
+                f'admits and the route 400s it. Take {REQUEST_BODY_TYPE} (declared '
+                f'in {DOC_TYPE_UNION_SOURCE}) instead, and widen the contract there '
+                f'if that is what is wanted.'
+            )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -30,11 +30,11 @@ WHAT THIS FILE COSTS, stated plainly because a previous version of this heading 
 
     944 lines   on `development`, the scanner version
     455 lines   after the scanner was deleted
-   1445 lines   now
+   1452 lines   now
 
 So it is LONGER than the scanner it replaced, and the claim that it was short was
 false for two review rounds. What the growth is: 65% of the file is PROSE (this
-docstring 308 lines, test docstrings 420, comments 213). The 346 lines of code are
+docstring 308 lines, test docstrings 427, comments 213). The 345 lines of code are
 `_without_comments`, `_doc_type_union` and the pin matcher with their shape fixtures,
 plus the text assertions keeping two type-level pins and their four controls present.
 If these counts and the file disagree, the file is right and this block is stale —
@@ -565,10 +565,12 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
     line must BE the directive" spelling that was the obvious fix for it.
 
     Off by default because `_doc_type_union` reads the union's members, which ARE
-    string literals — blanking them there would blank the contract itself. On for the
-    declaration pins, where BOTH the source and the expected text go through it (see
-    `_pinned`), so a quoted member inside a pinned declaration still matches while a
-    decoy that merely contains the same characters no longer supplies them.
+    string literals — blanking them there would blank the contract itself. On for
+    LOCATING the declaration pins, where both the source and the expected text go
+    through it (see `_declaration_offset`), so a decoy that merely contains the same
+    characters is not a place a pin can match. What the pin says is then read from the
+    raw text at that offset: blanking cannot tell two same-length literals apart, so it
+    answers where a declaration is and never what it declares.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -620,10 +622,15 @@ def _declarations(raw: str) -> str:
     """`raw` reduced to the text that can actually DECLARE something: comment bodies
     and string bodies both blanked, length preserved.
 
-    This is what every declaration pin below matches against, and the expected text is
-    put through it too (see `_pinned`) so the two are compared on equal terms — a
-    quoted member inside a pinned declaration still matches, while the same characters
-    sitting inside a template literal no longer supply them.
+    This is where a pin is LOCATED: `_declaration_offset` matches here, with the
+    expected text put through this too so the two are compared on equal terms, which is
+    what stops a copy inside a comment or a template literal from being a place a pin
+    can match.
+
+    ⚠️ Locating is all it does. Blanking makes two quoted operands of equal length
+    indistinguishable, so it cannot decide WHAT was declared — `_declaration_offset`
+    re-checks the raw text at each candidate for that, and the 🔑 note there carries
+    the measurement. Reading a pin's operands from this view alone was a vacuity.
 
     Length preserved, so an index found here is valid against `raw`. That is relied on
     for the `@ts-expect-error` lookup, which has to read a line this function blanks.

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -259,7 +259,13 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     copies it). Each was `tsc` exit 0 with every test here green. Hence the RATIO,
     which a decoy adds to both sides of. A rename of `GenerateDocumentBody` or of the
     method fails it too, which is correct — the constants here are what the two files
-    must agree on.
+    must agree on. ⚠️ A FOURTH spelling of this guard was also vacuous, and for the
+    VIEW rather than the pattern: counted over comment-stripped text, a decoy inside an
+    exported template literal added to both sides, and respelling the real colon
+    (`generateDocument:(`) removed the real declaration from the count entirely —
+    `tsc` exit 0, eslint clean, every test here green. Counted over `_declarations(...)`
+    now, so this guard and the pins read the same code-only view; the `declared >= 1`
+    floor is what refuses the respelled colon.
   * `test_the_type_level_pins_are_present` — either type-level pin deleted, STUBBED
     to a bare constant, fed through an alias that compares a type to itself, left with
     only one of its two controls, or stripped of a control's `@ts-expect-error`. All
@@ -359,6 +365,18 @@ REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 #
 # Not an enumeration of legal TypeScript — the thing this file refuses. There is one
 # string per side, and `generateDocument` is either declared here or it is not.
+#
+# ⚠️ A SIXTH vacuity, and it is the fourth one whose root cause was the VIEW rather
+# than the pattern: the ratio was counted over `_without_comments`, which blanks
+# comment bodies but leaves STRING bodies intact — so a copy of this signature inside
+# an exported template literal counted toward BOTH sides. Combined with respelling the
+# real method's colon `generateDocument:(` (legal TypeScript, lints clean, and NOT this
+# whitespace-exact opener), the real declaration went inline while the decoy supplied
+# one opener and one signature: measured `tsc` exit 0, eslint clean, every test here
+# green. The count is now taken over `_declarations(...)`, the same view the pins use,
+# so every text guard in this file reads code and only code. The `declared >= 1` floor
+# is what catches the colon half, and says so, because a method that is not SEEN is a
+# different failure from one seen and unpinned.
 #
 # The cost, as for the pins below: this signature must stay on ONE line in both files.
 GENERATE_DOCUMENT_SIGNATURE = (
@@ -684,6 +702,31 @@ def _declaration_offset(expected: str, raw: str) -> int | None:
 def _pinned(expected: str, raw: str) -> bool:
     """Whether `raw` declares `expected`. See `_declaration_offset`."""
     return _declaration_offset(expected, raw) is not None
+
+
+def _generate_document_ratio(raw: str) -> tuple[int, int]:
+    """How many times `raw` DECLARES `generateDocument`, and how many of those take the
+    shared request body — the two sides of the ratio
+    `test_both_client_signatures_use_the_shared_request_body` asserts.
+
+    🔑 Counted over `_declarations(...)`, not over comment-stripped text, and that was
+    a measured vacuity of its own: `_without_comments` leaves STRING bodies intact, so a
+    copy of the signature inside an exported template literal counted toward BOTH sides.
+    Paired with respelling the real method's colon (`generateDocument:(` — legal
+    TypeScript, lint-clean, and not the exact opener counted) the real declaration
+    vanished from the count while the decoy supplied one of each side, so the ratio held
+    with `tsc` at exit 0, eslint clean, and every test here green. Same root cause as
+    the pins' fourth vacuity, which is why both read one view now.
+
+    A function rather than two inline `str.count` calls so the property is reachable from
+    a test without a fixture file on disk — the fix above was silently revertible until
+    this existed, which is the failure mode this file's own controls exist to refuse.
+    """
+    source = _declarations(raw)
+    return (
+        source.count(GENERATE_DOCUMENT_DECLARATION),
+        source.count(GENERATE_DOCUMENT_SIGNATURE),
+    )
 
 
 def _directive_above(declaration: str, raw: str) -> str | None:
@@ -1064,6 +1107,48 @@ class TestThePinMatcher:
             self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
         )
 
+    # A `generateDocument` declaration taking the shared body, as the ratio counts it.
+    SIGNATURE = GENERATE_DOCUMENT_SIGNATURE
+
+    def test_a_signature_inside_a_template_literal_is_not_counted(self):
+        """The ratio guard's own version of the fifth vacuity — the same defect, in the
+        last text guard that still read comment-stripped text rather than
+        `_declarations(...)`.
+
+        A copy of the signature in an exported template literal counted toward BOTH
+        sides of the ratio, so pairing it with a respelled colon on the real method
+        (below) let the real parameter go inline with the ratio still holding. Measured
+        on the shipped tree: `tsc` exit 0, eslint clean, every test here green.
+        """
+        decoy = f'export const historical = `\n  {self.SIGNATURE}\n`\n'
+        assert _generate_document_ratio(decoy) == (0, 0)
+        # The control: the same text as real code must still be counted on both sides,
+        # or this would pass by counting nothing at all.
+        assert _generate_document_ratio(f'  {self.SIGNATURE}\n') == (1, 1)
+
+    def test_a_respelled_colon_is_not_counted_as_a_declaration(self):
+        """`generateDocument:(` — no space — is legal TypeScript and lints clean, but is
+        not the exact opener counted, so the real method disappears from the LEFT side.
+
+        Deliberately not tolerated by widening the pattern: the point is that the ratio
+        cannot be read as "the method is fine" when the method was never seen. The
+        `declared >= 1` floor is what refuses it, and its message says so, because
+        not-FOUND and found-and-unpinned want different fixes.
+        """
+        respelled = self.SIGNATURE.replace('generateDocument: (', 'generateDocument:(')
+        assert _generate_document_ratio(f'  {respelled}\n') == (0, 0)
+        assert _generate_document_ratio(f'  {self.SIGNATURE}\n') == (1, 1)
+
+    def test_an_inline_literal_leaves_its_opener_counted_but_unpinned(self):
+        """The respelling this guard exists to refuse: the declaration stays visible on
+        the left while the right loses its signature, so the ratio breaks.
+
+        This is the positive direction of the guard — without it the two tests above
+        could pass by the counter never counting anything.
+        """
+        inline = 'generateDocument: (projectId: string, data: { doc_type: DocType }) =>'
+        assert _generate_document_ratio(f'  {inline}\n') == (1, 0)
+
     def test_a_quoted_member_inside_the_pin_still_matches(self):
         """The reason both sides are blanked at all: the pins contain string literals,
         so blanking only the source would never match one. The negative cases above
@@ -1273,6 +1358,17 @@ class TestDocTypeLockstep:
         adds to both and passes, which is correct — it is not a respelling of the
         contract.
 
+        🔑 The ratio is counted over `_declarations(...)`, not over comment-stripped
+        text, and that WAS the fourth measured defect of this guard: `_without_comments`
+        leaves string bodies intact, so a copy of the signature inside an exported
+        template literal counted toward BOTH sides. Paired with respelling the real
+        method's colon (`generateDocument:(` — legal, lint-clean, and not the exact
+        opener counted), the real declaration went inline while the decoy supplied one of
+        each: `tsc` exit 0, eslint clean, every test here green. Same root cause as the
+        pins' own fourth vacuity, which is why both now read one view. The `declared >= 1`
+        floor catches the colon half and its message distinguishes not-FOUND from
+        found-and-unpinned, since those want different fixes.
+
         Not an enumeration of legal TypeScript, the thing this file refuses: there is
         one string per side, and the method is either declared here or it is not.
 
@@ -1290,19 +1386,27 @@ class TestDocTypeLockstep:
         for relative in GENERATE_DOCUMENT_CLIENTS:
             path = _repo_root() / relative
             assert path.is_file(), f'{relative} moved — update GENERATE_DOCUMENT_CLIENTS'
-            source = _without_comments(path.read_text(encoding='utf-8'))
-            assert 'generateDocument' in source, (
+            raw = path.read_text(encoding='utf-8')
+            assert 'generateDocument' in _declarations(raw), (
                 f'{relative} no longer mentions generateDocument. If the method '
                 f'moved, point GENERATE_DOCUMENT_CLIENTS at its new home; if this '
                 f'client dropped it, drop the entry.'
             )
-            declared = source.count(GENERATE_DOCUMENT_DECLARATION)
-            shared = source.count(GENERATE_DOCUMENT_SIGNATURE)
+            declared, shared = _generate_document_ratio(raw)
             assert declared >= 1, (
                 f'{relative} declares no `{GENERATE_DOCUMENT_DECLARATION}...`, so '
-                f'there is nothing here to pin. If the method changed shape, update '
-                f'GENERATE_DOCUMENT_DECLARATION; if this client dropped it, drop the '
-                f'entry from GENERATE_DOCUMENT_CLIENTS.'
+                f'there is nothing here to pin — the method was not FOUND, which is a '
+                f'different failure from found-and-unpinned below.\n'
+                f'The opener is matched as exact text, so a respelled colon '
+                f'(`generateDocument:(`, no space) is legal TypeScript that lints '
+                f'clean and is not counted at all. That was measured to combine with a '
+                f'decoy to defeat the ratio: with the real declaration invisible, a '
+                f'copy of the signature elsewhere supplied one of each side and the '
+                f'ratio held. This assertion is the floor that catches it.\n'
+                f'So: if the colon was respelled, restore `'
+                f'{GENERATE_DOCUMENT_DECLARATION}`; if the method genuinely changed '
+                f'shape, update GENERATE_DOCUMENT_DECLARATION; if this client dropped '
+                f'it, drop the entry from GENERATE_DOCUMENT_CLIENTS.'
             )
             assert shared == declared, (
                 f'{relative} declares generateDocument {declared} time(s) but only '

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -29,8 +29,15 @@ WHAT ENFORCES WHICH HALF, measured rather than assumed — the compiler does NOT
 all of it, and an earlier version of this docstring claimed it did:
   * `DocType` -> the route's allowlist: THIS file, by parsing the declaration.
     Nothing in TypeScript knows what Python accepts.
-  * `GenerateDocumentBody.doc_type` -> `DocType`: the compiler, because the field
-    references the union by name.
+  * `GenerateDocumentBody.doc_type` -> `DocType`: the compiler, but ONLY because
+    `DocTypeFieldIsExactlyTheUnion` in that file compares the two in both
+    directions. Referencing the union is not self-enforcing and this file cannot
+    see the field: it parses the `export type DocType =` declaration and nothing
+    else, so respelling the field `'prd' | 'prfaq' | 'onepager'` was measured to
+    exit `tsc` 0 and pass every test here. `satisfies` cannot help either — it
+    checks the built object AGAINST this interface, so a widened one satisfies it by
+    construction. `test_the_request_body_field_is_pinned_to_the_union` keeps that
+    type-level pin present, since deleting it compiles cleanly.
   * The two `generateDocument` signatures -> `GenerateDocumentBody`: the compiler
     for `client.ts`, which forwards its `data` into `projectsApi.generateDocument`
     and so gets a TS2345 if it widens. `projectsApi.generateDocument` is the
@@ -47,8 +54,29 @@ all of it, and an earlier version of this docstring claimed it did:
         annotation uses the name and still widens, and was measured to exit `tsc` 0
         with every test here green. `noUnusedLocals` does NOT cover that — the name
         is used — and an earlier version of this docstring wrongly said it did.
-    So a widening has to edit `GenerateDocumentBody` itself, where the field is
-    `DocType` and this file's comparison sees it.
+    So a widening has to edit `DocType` itself — the declaration this file parses —
+    and `GENERATED_DOC_TYPES` with it. Editing `GenerateDocumentBody.doc_type` is
+    not a way around that: the pin above makes it a compiler error.
+
+WHY EACH GUARD IS THE KIND IT IS. The rule this file has converged on over several
+rounds, each of which found the same hole one level further in: a link TypeScript can
+check gets a COMPILER check, and text assertions are reserved for the ones it cannot.
+`DocTypeFieldIsExactlyTheUnion` is a type-level comparison rather than a fourth
+`'... in source'` assertion for exactly that reason — a text check for one field
+would have to enumerate the spellings that widen it (enumerated members, an
+intersection, `Omit`, a widened alias), and enumerating legal TypeScript is what the
+deleted scanner did and why it was deleted. The text assertions that remain here pin
+the PRESENCE of things whose absence is silent (`satisfies`, the type-level pin
+itself) and the ONE link no compiler can see: `DocType` against a Python tuple.
+
+A `.test-d.ts`-style type test was considered for that job and REJECTED, so it does
+not get proposed again: `typecheck:tests` is not in the root `check` chain
+(`typecheck:all` is `typecheck && typecheck:cdk && typecheck:stream`), so a type
+assertion living under a test tsconfig would be checked by no gate. The pin lives in
+`api/types.ts` — production source that `npm run typecheck` already compiles — which
+is why it needs no new wiring. If `typecheck:tests` is ever added to that chain, a
+type test becomes a reasonable home for it; until then it would be a control nothing
+runs.
 
 A LITERAL UNION IS THE REQUIRED SHAPE for `DocType`. A derivation
 (`typeof GENERATED_DOC_TYPES[number]`, as `KIRO_EXPORTABLE_DOC_TYPES` uses one
@@ -87,10 +115,20 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     restyling. A rename of `GenerateDocumentBody` fails it too, which is correct —
     the constant here is what the two files must agree on.
   * `test_the_terminal_client_pins_the_body_structurally` — the `satisfies` clause
-    deleted from `projectsApi.generateDocument`. That deletion compiles cleanly and
-    is caught by nothing else, and without the clause an intersection/`Omit`
-    annotation widens `doc_type` while still naming the shared type, so the test
-    above stays green too.
+    deleted from `projectsApi.generateDocument`, or MOVED off it. That deletion
+    compiles cleanly and is caught by nothing else, and without the clause an
+    intersection/`Omit` annotation widens `doc_type` while still naming the shared
+    type, so the test above stays green too. The slice is what catches the move: a
+    whole-file substring check was measured to pass with the clause relocated to an
+    unrelated helper and `generateDocument` widened.
+  * `test_the_request_body_field_is_pinned_to_the_union` —
+    `DocTypeFieldIsExactlyTheUnion` deleted from the frontend, which would let
+    `GenerateDocumentBody.doc_type` restate the members instead of referencing
+    `DocType`. Measured: that respelling exits `tsc` 0 and passes everything here,
+    because this file reads only the union declaration and `satisfies` compares
+    against the widened interface. Its non-vacuity control
+    (`DocTypeFieldPinWouldSeeDrift`) is pinned by the same test, since a comparison
+    that degenerates to `true` would satisfy the pin while measuring nothing.
   * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
     union is edited, and its opposite, one that reports drift for a comment.
   * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
@@ -117,6 +155,17 @@ DOC_TYPE_UNION_SOURCE = 'frontend/src/api/types.ts'
 # see the docstring: the compiler catches that in one file and not the other.
 REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 
+# The type-level pin in `DOC_TYPE_UNION_SOURCE` that makes that body's `doc_type`
+# field REFERENCE the union above it rather than restate its members. Its own absence
+# is silent — delete it and the frontend still compiles — so
+# `test_the_request_body_field_is_pinned_to_the_union` keeps it present. See that
+# test for why nothing else in either language covers this one field.
+REQUEST_BODY_FIELD_PIN = 'DocTypeFieldIsExactlyTheUnion'
+# Its non-vacuity control, in the convention this file uses for its own: the pin is
+# also satisfiable by a comparison that degenerates to `true`, and this line is what
+# refuses that. Pinned alongside so deleting the control is a decision.
+REQUEST_BODY_FIELD_PIN_CONTROL = 'DocTypeFieldPinWouldSeeDrift'
+
 # The TERMINAL client — the one whose `data` is only spread into `JSON.stringify`,
 # so its annotation is checked against nothing and naming the body type is not
 # enough on its own (an `Omit<..> & { doc_type: .. | 'x' }` respelling names it and
@@ -126,6 +175,16 @@ REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 # file's other assertions stay green.
 TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
 STRUCTURAL_PIN = f'satisfies {REQUEST_BODY_TYPE}'
+
+# The clause has to be in the method it protects, not merely somewhere in a 400-line
+# file: a whole-file substring check was measured to stay GREEN when the clause was
+# moved to an unrelated helper and `generateDocument` was then widened, which is the
+# guard reporting success while the axis it exists for is reopened. These two literal
+# method names bound the slice searched. Deliberately NOT a parameter-list extent —
+# bracket balancing is what the deleted scanner did — so the slice is index arithmetic
+# on two names, and a rename of either fails loudly rather than silently widening it.
+GENERATE_DOCUMENT_MARKER = 'generateDocument:'
+NEXT_METHOD_MARKER = 'mergeDocuments:'
 
 # Both clients, the terminal one included rather than respelled — a second copy of
 # that path here is the same duplication this whole issue was about.
@@ -665,19 +724,94 @@ class TestDocTypeLockstep:
 
         Pinned by text here because its ABSENCE is silent — remove the clause and the
         frontend still compiles, so no other gate in either language notices. This
-        asserts only that the clause is spelled; that it BITES is the compiler's job,
-        and `tsconfig.app.json` needs no flag for it (`satisfies` is not optional
-        behaviour).
+        asserts only that the clause is SPELLED, and where; that it BITES is the
+        compiler's job, and `tsconfig.app.json` needs no flag for it (`satisfies` is
+        not optional behaviour).
+
+        Scoped to the method rather than the file, because a whole-file substring
+        check was measured to permit exactly what it was added to stop: move the
+        clause to an unrelated helper, widen `generateDocument`, and `tsc` exits 0
+        with every test here green. The slice is bounded by two literal method names
+        (see GENERATE_DOCUMENT_MARKER) and both must be found, so a rename fails
+        loudly instead of widening the search back to the whole file.
         """
         path = _repo_root() / TERMINAL_CLIENT
         assert path.is_file(), f'{TERMINAL_CLIENT} moved — update TERMINAL_CLIENT'
         source = _without_comments(path.read_text(encoding='utf-8'))
-        assert STRUCTURAL_PIN in source, (
-            f'{TERMINAL_CLIENT} no longer spells `{STRUCTURAL_PIN}`. That clause is '
-            f'the only thing making a widened doc_type a compiler error in this '
-            f'file: its `data` is just spread into JSON.stringify, so the parameter '
-            f'annotation is compared against nothing and even one that NAMES '
-            f'{REQUEST_BODY_TYPE} can widen the field past what the route accepts. '
-            f'Restore it, or widen the contract in {DOC_TYPE_UNION_SOURCE} where '
-            f'this file can see it.'
+        start = source.find(GENERATE_DOCUMENT_MARKER)
+        assert start != -1, (
+            f'{TERMINAL_CLIENT} no longer spells `{GENERATE_DOCUMENT_MARKER}`, so the '
+            f'slice this test searches cannot be located. If the method was renamed, '
+            f'update GENERATE_DOCUMENT_MARKER.'
+        )
+        end = source.find(NEXT_METHOD_MARKER, start)
+        assert end != -1, (
+            f'{TERMINAL_CLIENT} no longer spells `{NEXT_METHOD_MARKER}` after '
+            f'`{GENERATE_DOCUMENT_MARKER}`, which is what bounds the slice. Without '
+            f'it this test would search to end-of-file and pass on a clause sitting '
+            f'in any other method — update NEXT_METHOD_MARKER to whatever now '
+            f'follows generateDocument.'
+        )
+        assert STRUCTURAL_PIN in source[start:end], (
+            f'`{STRUCTURAL_PIN}` is not in {TERMINAL_CLIENT}\'s generateDocument. '
+            f'That clause is the only thing making a widened doc_type a compiler '
+            f'error in this file: its `data` is just spread into JSON.stringify, so '
+            f'the parameter annotation is compared against nothing and even one that '
+            f'NAMES {REQUEST_BODY_TYPE} can widen the field past what the route '
+            f'accepts. Restore it ON THAT METHOD — elsewhere in the file it protects '
+            f'nothing — or widen the contract in {DOC_TYPE_UNION_SOURCE}, where '
+            f'{REQUEST_BODY_FIELD_PIN} and this file\'s comparison both see it.'
+        )
+
+    @pytest.mark.skipif(
+        not _frontend_tree_present(), reason='frontend tree absent from this checkout'
+    )
+    def test_the_request_body_field_is_pinned_to_the_union(self):
+        """`GenerateDocumentBody.doc_type` must REFERENCE `DocType`, not restate it.
+
+        The innermost link in the chain, and it was the last one left open. Every
+        other guard around this contract stops one level further out, measured:
+
+          * this file parses only the `export type DocType =` declaration, so the
+            interface field is invisible to it;
+          * `satisfies GenerateDocumentBody` checks the built object against that
+            interface, so a WIDENED interface satisfies it by construction;
+          * `noUnusedLocals` stays quiet, since `DocType` is still used by
+            `ProjectDocument` in the same file.
+
+        So respelling the field `'prd' | 'prfaq' | 'onepager'` exited `tsc` 0, passed
+        every test here and linted clean, while a caller could then send a value the
+        route 400s. Worse than a generic residual axis: that line is where the
+        comments on both the union and the body DIRECT a widener, and it is what the
+        field looked like before this contract was collapsed — so reverting to it is a
+        plausible slip rather than a deliberate act.
+
+        What closes it is a compiler check in the frontend, not a fourth text
+        assertion here: `DocTypeFieldIsExactlyTheUnion` compares the field to the
+        union in BOTH directions, so any respelling — enumerated members, an
+        intersection, a widened alias, a narrowing — is a TS2344. A text check would
+        have to enumerate spellings, which is the road the deleted scanner went down.
+
+        This test pins that check's PRESENCE, since deleting it compiles cleanly, and
+        the presence of its non-vacuity control with it. Text, not a parse: two names
+        either appear in the file or they do not.
+        """
+        path = _repo_root() / DOC_TYPE_UNION_SOURCE
+        assert path.is_file(), f'{DOC_TYPE_UNION_SOURCE} moved'
+        source = _without_comments(path.read_text(encoding='utf-8'))
+        assert REQUEST_BODY_FIELD_PIN in source, (
+            f'{DOC_TYPE_UNION_SOURCE} no longer declares `{REQUEST_BODY_FIELD_PIN}`. '
+            f'That is the only check that {REQUEST_BODY_TYPE}.doc_type still '
+            f'references the DocType union rather than restating its members — '
+            f'nothing else in either language does (see this test\'s docstring), so '
+            f'without it the field can be widened past the route\'s allowlist with '
+            f'tsc, eslint and this whole file green. Restore it, or widen DocType '
+            f'itself and GENERATED_DOC_TYPES together.'
+        )
+        assert REQUEST_BODY_FIELD_PIN_CONTROL in source, (
+            f'{DOC_TYPE_UNION_SOURCE} declares `{REQUEST_BODY_FIELD_PIN}` but not its '
+            f'control `{REQUEST_BODY_FIELD_PIN_CONTROL}`. The pin is satisfied by a '
+            f'comparison that degenerates to `true`, which passes while comparing '
+            f'nothing; the control is what refuses that, the same way '
+            f'TestContractDriftIsCaught does for the parser here.'
         )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -26,20 +26,30 @@ drift axis rather than testing it. Nothing here should ever again try to decide 
 an arbitrary TypeScript type expression MEANS.
 
 WHAT THIS FILE COSTS, stated plainly because a previous version of this heading read
-"WHY THIS FILE IS SHORT NOW" long after it had stopped being true. Measured:
+"WHY THIS FILE IS SHORT NOW" long after it had stopped being true. Two fixed points,
+both in OTHER commits and so both stable:
 
     944 lines   on `development`, the scanner version
     455 lines   after the scanner was deleted
-   1452 lines   now
 
-So it is LONGER than the scanner it replaced, and the claim that it was short was
-false for two review rounds. What the growth is: 65% of the file is PROSE (this
-docstring 308 lines, test docstrings 427, comments 213). The 345 lines of code are
-`_without_comments`, `_doc_type_union` and the pin matcher with their shape fixtures,
-plus the text assertions keeping two type-level pins and their four controls present.
-If these counts and the file disagree, the file is right and this block is stale —
-recompute rather than trusting it, with `ast` rather than by eye (this block has been
-stale twice, both times because a figure was written while the file was still edited).
+This file is now WELL OVER 1.5x the scanner it replaced, and about TWO THIRDS of it is
+prose — this docstring, the test docstrings and the comments — against a body of code
+that is `_without_comments`, `_doc_type_union` and the pin matcher with their shape
+fixtures, plus the text assertions keeping two type-level pins and their four controls
+present. So the claim that the file was short was false for two review rounds, and it
+is not becoming true.
+
+NO EXACT "NOW" FIGURE IS GIVEN HERE, and that is the fix rather than an omission. Three
+successive rounds shipped one wrong, each time for the same unavoidable reason: the
+count lives INSIDE the thing it counts, so any later edit — including an edit to this
+very block — falsifies it, and the last edit of a round is never the one that wrote the
+number. A self-referential exact count cannot be kept true by being more careful; the
+third recurrence landed in the same commit that added the instruction not to let it go
+wrong. The approximations above survive a hundred lines in either direction, which is
+the precision this argument actually needs. If a precise figure is wanted, MEASURE it
+rather than reading it here — parse the file with `ast`, take the module docstring's
+span, sum the docstring spans of every class and function, count lines whose stripped
+form starts with `#`, and derive code as total minus prose minus blank.
 
 Whether that is proportionate is a fair question and was asked in review. The honest
 answer: the PINS are cheap and they are what bite — every widening mutation tried is
@@ -129,6 +139,38 @@ all of it, and an earlier version of this docstring claimed it did:
     So a widening has to edit `DocType` itself — the declaration this file parses —
     and `GENERATED_DOC_TYPES` with it. Editing `GenerateDocumentBody.doc_type` is
     not a way around that: the pin above makes it a compiler error.
+
+⚠️ THOSE TWO EDITS ARE NOT THE WHOLE SUPPORTED CHANGE, and every round of this file
+claimed they were. A THIRD edit is required, in the generator, and nothing here or in
+the compiler asks for it: `lambda/jobs/document_generator/handler.py` dispatches on
+`doc_type` as a BINARY with PR-FAQ as the unconditional `else`, in three places —
+anchored on the symbols rather than line numbers, since a citation into a file this
+test does not read is exactly what goes stale (it has three times on this branch):
+
+    `_generate_prd` vs `_generate_prfaq`                — the generation branch
+    `get_prd_generation_steps` vs `get_prfaq_...`       — the step-builder selection
+    `_assemble_and_save`'s `if doc_type == 'prd'`       — assembly, result indexing
+
+— and it never imports `GENERATED_DOC_TYPES` (zero references). So a third member
+added the blessed way passes `_validated_doc_type`, is routed into the Step Functions
+chain by `is_chain = doc_type in GENERATED_DOC_TYPES` (true BY CONSTRUCTION for the
+new member), and is then generated as a PR-FAQ, persisted with `sk = '{DOC_TYPE}#...'`
+and `document_type = doc_type`. The user gets a document of the WRONG KIND under the
+right label, after a Bedrock spend, with no error anywhere.
+
+Measured: `DocType` and `GENERATED_DOC_TYPES` widened together leaves `tsc` at exit 0
+and every test here green — the correct false-positive result for THESE guards, and
+exactly why the incompleteness was invisible for seven rounds. That is worse than the
+drift this file does catch: a refused value is a visible 400, this is a wrong-content
+success. Adding a member therefore also needs a step builder, a generation branch and
+an assembly branch there.
+
+Deliberately NOT guarded here. That is a different contract — the generator's dispatch
+against the route's allowlist — and it wants its own test near the generator rather
+than a second responsibility bolted onto this file. What is fixed is the RECIPE: the
+ceiling is stated, so a widener reads it instead of discovering it from a mislabelled
+document. Same reasoning as `suggestDocumentBrief` above: name the boundary, do not
+grow the guard across it.
 
 WHY EACH GUARD IS THE KIND IT IS. The rule this file has converged on over several
 rounds, each of which found the same hole one level further in: a link TypeScript can

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -103,6 +103,23 @@ the union parser read the decoy's members instead of the live union's; the ratio
 satisfied by a decoy alone. Fixed in `_without_comments` with a frame stack, which is
 the one mechanism all four guards share, rather than in any of them.
 
+An EIGHTH defeat then made the same point about a different construct, which is why that
+corollary is phrased about where a string ENDS rather than about `${`: the scan had no
+notion of a REGEX literal, so a backtick inside one opened a phantom template frame that
+the decoy's own opening backtick then closed — and everything after it was code again,
+exactly as before. A second regex after the decoy resynchronises the scan, so only the
+decoy is affected and the evasion is clean rather than noisy (a bare desync runs to EOF
+and incidentally swallows whatever follows). Measured on the tree that shipped it: the
+field pin DELETED, a copy left in such a decoy, and the field widened — `tsc` exit 0,
+eslint clean, every test here green, and no lint rule in the way this time since nothing
+is nested. `_regex_allowed_here` now decides whether a `/` opens a regex or divides, and
+its branch sits AFTER the two comment branches: placed before them it consumes `//` as an
+empty regex, which is measured to break the commented-out predecessor and commented-out
+pin cases. It errs toward reading LESS, because misreading a division blanks real code —
+a false FAILURE, bounded to the one line a regex body may occupy — while misreading a
+regex is this vacuity, a false PASS with no bound. The two mistakes are not symmetric,
+and `TestThePinMatcher` pins both directions.
+
 THE GUARDS' OWN FIXES ARE PINNED TOO, which took its own finding. The two repairs made
 in the fifth round shipped with no test, and reverting either left all 30 tests here
 green — a green result meaning "did not check", applied to the machinery this file uses
@@ -348,6 +365,14 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         the union parser its own members, and satisfy both sides of the ratio alone.
         Three cases cover it here plus one in `TestTheUnionParser`, because the bug was
         in `_without_comments` and therefore in every guard that reads it.
+      - having no notion of a REGEX literal, so a backtick inside one desynchronised the
+        scan the same way — the EIGHTH vacuity, same root cause one construct over, and
+        again in every guard at once. Two cases here plus one in `TestTheUnionParser` are
+        red when the regex branch is reverted. Its two failure directions are pinned
+        separately, since the fix has a wrong side of its own: reading a DIVISION as a
+        regex blanks real code (`test_a_division_is_not_read_as_a_regex`), and deciding
+        from the last character alone misses `return /`/` and desynchronises exactly as
+        before (`test_a_keyword_led_regex_is_still_read_as_one`).
     Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
     assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
@@ -656,6 +681,35 @@ UNION_TERMS = re.compile(rf'{UNION_TERM}(?:\s*\|\s*{UNION_TERM})*')
 # read at all.
 DOC_TYPE_UNION_ANCHOR = re.compile(r'export\s+type\s+DocType\s*=\s*\|?\s*')
 
+# A `/` opens a REGEX rather than dividing when the last significant thing before it
+# cannot end an expression. Deliberately CONSERVATIVE: mistaking a division for a regex
+# would blank real code, while mistaking a regex for a division is what the eighth
+# vacuity was — so the two errors are not symmetric, and this errs toward reading less.
+_REGEX_MAY_FOLLOW = '=(,:[!&|?{};+-*%~^<>'
+# The keywords a regex may directly follow, where the preceding CHARACTER is a word
+# character and so says nothing on its own (`return /`/.test(x)`).
+_REGEX_MAY_FOLLOW_KEYWORD = frozenset({
+    'return', 'typeof', 'case', 'in', 'of', 'do', 'else', 'yield', 'await', 'delete',
+    'void', 'instanceof', 'new',
+})
+_TRAILING_WORD = re.compile(r'[A-Za-z_$][\w$]*$')
+
+
+def _regex_allowed_here(emitted: list[str]) -> bool:
+    """Whether a `/` at this point starts a REGEX rather than being a division operator.
+
+    Decided from what has already been emitted, since that is the only context a
+    single-pass scan has. See `_REGEX_MAY_FOLLOW` for why the conservative direction is
+    the safe one.
+    """
+    text = ''.join(emitted).rstrip()
+    if not text:
+        return True
+    if text[-1] in _REGEX_MAY_FOLLOW:
+        return True
+    trailing = _TRAILING_WORD.search(text)
+    return trailing is not None and trailing.group(0) in _REGEX_MAY_FOLLOW_KEYWORD
+
 
 def _without_comments(source: str, blank_strings: bool = False) -> str:
     """`source` with `//` and `/* */` comment BODIES blanked, same length.
@@ -671,9 +725,8 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
 
     Blanked rather than deleted, newlines preserved, so indices still refer to the
     same place in the original. Quote state is tracked so a `//` inside a string is
-    not mistaken for a comment; a regex literal containing `//` would be, but this
-    is a type declaration and the shapes that occur are pinned in
-    `TestTheUnionParser`.
+    not mistaken for a comment, and regex literals are read too — see the 🔑 note
+    below on the eighth vacuity, which is what that used to cost.
 
     🔑 `blank_strings` additionally blanks STRING and TEMPLATE bodies, and exists
     because "commentary is not a declaration" has a second half this file missed for
@@ -715,6 +768,21 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
     strings) applying in between. `TestThePinMatcher` and `TestTheUnionParser` pin all
     four consequences, since the previous round's finding was that repairs to these
     helpers ship silently revertible.
+
+    🔑 A REGEX literal is not code either, and having no notion of one was the EIGHTH
+    measured vacuity — the same root cause as the seventh, one construct over, and the
+    reason the module docstring's corollary is about where a string ENDS rather than about
+    `${`. A backtick inside a regex (`/`/`) opened a phantom template frame, which the
+    decoy's own opening backtick then CLOSED, so the decoy body was emitted as code; a
+    second regex after it resynchronises the scan, making the evasion clean rather than
+    running to EOF and swallowing whatever follows. Measured on the tree that shipped it:
+    the field pin deleted, a copy in such a decoy, the field widened — `tsc` exit 0,
+    eslint clean, every test here green, and this time no lint rule in the way.
+
+    `_regex_allowed_here` decides regex-versus-division from what has been emitted, and it
+    is deliberately CONSERVATIVE: misreading a division blanks real code, which is a false
+    FAILURE bounded to one line, while misreading a regex is the vacuity above, a false
+    PASS with no bound. Both directions are pinned, because the fix has a wrong side too.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -778,6 +846,21 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
             out.append(blanked(source[index:stop]))
             index = stop
             continue
+        # ⚠️ AFTER the two comment branches, never before: a `/` that opens `//` or `/*`
+        # would otherwise be consumed as an empty regex, and reading a comment as code is
+        # the defect `_without_comments` exists for. Measured — placed first, the
+        # commented-out predecessor and commented-out pin cases all fail.
+        if char == '/' and _regex_allowed_here(out):
+            stop = index + 1
+            while stop < len(source) and source[stop] not in '/\n':
+                stop += 2 if source[stop] == '\\' else 1
+            if stop < len(source) and source[stop] == '/':
+                out.append(char)
+                body = source[index + 1:stop]
+                out.append(blanked(body) if blank_strings else body)
+                out.append('/')
+                index = stop + 1
+                continue
         out.append(char)
         index += 1
     return ''.join(out)
@@ -1116,6 +1199,23 @@ class TestTheUnionParser:
         )
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
 
+    def test_a_union_inside_a_regex_desynced_template_is_not_read(self):
+        """The same again for a REGEX-borne backtick — the eighth vacuity.
+
+        The regex's backtick opened a phantom template frame which the decoy's own opening
+        backtick closed, so the decoy was anchored as if it were code and its members were
+        compared against the route. As above, the live union carries the extra member
+        deliberately: this must read `onepager` rather than merely disagree with the decoy,
+        or it would pass on a parser that read nothing at all.
+        """
+        source = (
+            "const backtickMatcher = /`/\n"
+            "const historical = `export type DocType = 'prd' | 'legacy'`\n"
+            "const secondMatcher = /`/\n"
+            "export type DocType = 'prd' | 'prfaq' | 'onepager'\n"
+        )
+        assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
+
     # The refusals `_doc_type_union` must carry: no readable term at the anchor, a
     # matched non-literal, an unread term after the match.
     EXPECTED_REFUSALS = 3
@@ -1237,6 +1337,62 @@ class TestThePinMatcher:
             self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
         )
 
+    # 🔑 A REGEX literal containing a backtick — the EIGHTH vacuity, and the same root
+    # cause as the seventh one construct over: the scan had no notion of a regex, so this
+    # backtick opened a phantom template frame that the DECOY's opening backtick then
+    # closed, and the pin body was emitted as code. The trailing regex resynchronises the
+    # scan, which is what makes it a clean evasion rather than a noisy one: a bare desync
+    # runs to EOF and incidentally swallows whatever follows, so the first attempt at this
+    # shape went red by accident rather than by design.
+    REGEX_DESYNC = 'const backtickMatcher = /`/\n'
+    REGEX_RESYNC = 'const secondMatcher = /`/\n'
+
+    def test_a_declaration_inside_a_regex_desynced_template_is_not_pinned(self):
+        """The eighth vacuity, on the pin with no compiler backstop.
+
+        Measured on the tree that shipped it: `DocTypeFieldIsExactlyTheUnion` DELETED
+        outright, a copy left in a template literal that a regex-borne backtick had
+        desynchronised, and the field it guards widened — `tsc` exit 0, eslint clean, and
+        every test here green. Unlike the nested-template shape no lint rule stands in the
+        way, since nothing here is nested.
+        """
+        decoy = (
+            f'{self.REGEX_DESYNC}export const historical = `\n{self.PIN}\n`\n'
+            f'{self.REGEX_RESYNC}'
+        )
+        assert not _pinned(self.PIN, decoy)
+        # The controls: a real declaration must still be found, and must still be found
+        # with a genuine regex above it — reading regexes must not cost the live pin.
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+        assert _pinned(self.PIN, f'{self.REGEX_DESYNC}{self.PIN}\n')
+
+    def test_a_division_is_not_read_as_a_regex(self):
+        """The conservative direction of `_regex_allowed_here`, pinned from the other side.
+
+        TWO divisions on one line are what discriminates: read as a regex, the first `/`
+        swallows through to the second and the code BETWEEN them is blanked. That is a
+        false FAILURE rather than a false pass — the opposite error from the eighth
+        vacuity — and it is bounded to the one line a regex body may occupy, which is why
+        the two mistakes are not symmetric and this scan errs toward reading less.
+        """
+        divided = 'const mid = width / 2 + height / 2\n'
+        assert _declarations(divided) == divided
+        # The control: a genuine regex body IS blanked, so this cannot pass by never
+        # reading a regex at all — which would reopen the vacuity above.
+        assert _declarations('const m = /`/\n') == 'const m = / /\n'
+
+    def test_a_keyword_led_regex_is_still_read_as_one(self):
+        """Why the check consults the trailing WORD and not just the last character:
+        `return /`/` ends in `n`, so a character-only rule would read it as a division,
+        leave its backtick live, and desynchronise the scan exactly as the eighth vacuity
+        did."""
+        assert not _pinned(
+            self.PIN,
+            f'const t = () => {{ return /`/.test(x) }}\nexport const h = `\n'
+            f'{self.PIN}\n`\n{self.REGEX_RESYNC}',
+        )
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+
     def test_blanking_preserves_length_through_a_nested_template(self):
         """The frame stack must not change how much it emits: every offset this module
         computes is found in the blanked view and read back from the raw text, so a
@@ -1345,6 +1501,17 @@ class TestThePinMatcher:
         decoy = (
             f'{self.NESTED_DECOY_OPEN}  {GENERATE_DOCUMENT_SIGNATURE}\n'
             f'{self.NESTED_DECOY_CLOSE}'
+        )
+        assert _generate_document_ratio(decoy) == (0, 0)
+        assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
+
+    def test_a_signature_inside_a_regex_desynced_template_is_not_counted(self):
+        """The ratio's version of the eighth vacuity, which the desync reopened along with
+        every other text guard here — the decoy supplied one of each side on its own.
+        """
+        decoy = (
+            f'{self.REGEX_DESYNC}export const historical = `\n'
+            f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{self.REGEX_RESYNC}'
         )
         assert _generate_document_ratio(decoy) == (0, 0)
         assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -137,6 +137,23 @@ That is not an enumeration of legal TypeScript, which is the thing this file ref
 there is one string per declaration, and any edit to it is either the same declaration
 or a different one. The cost is that these declarations must stay on ONE line.
 
+MATCHED AGAINST CODE, NOT AGAINST TEXT THAT MERELY LOOKS LIKE IT. Every pin above is
+compared against `_declarations(...)`, which blanks comment bodies AND string bodies.
+Blanking only comments — which is all this file did for seven rounds — left every one
+of these guards satisfiable by a decoy inside a template literal: it survives
+stripping, survives `noUnusedLocals` once exported, and can contain newlines, so it
+also redirects any index computed with `find`. Measured on the shipped tree: deleting
+`DocTypeFieldIsExactlyTheUnion` outright, putting a copy of it in an exported template
+literal and widening the field it guards left `tsc` at exit 0 with every test here
+green. The same decoy defeated the `@ts-expect-error` lookup, and would have defeated
+the narrower "the preceding line must BE the directive" spelling that was the obvious
+fix for that. This is the FOURTH shape of "some other construct supplies the string",
+after the three fragment defeats above, and it is the general form of them: the earlier
+three were about pinning too little of the declaration, this one about not caring where
+the declaration was. `_doc_type_union` had the same hole — a quoted union above the
+live one was read INSTEAD of it — and anchors in the same view now, while still reading
+its members from the comments-only view because those members ARE string literals.
+
 WHAT IS SELF-CHECKING, and therefore needs no text pin at all: the verdict helpers'
 `extends true`. Each control applies the same helper as its pin and expects to be
 rejected, via `@ts-expect-error`, so dropping the constraint — one edit that would
@@ -181,6 +198,11 @@ comparing nothing.
 REVERT MAP — which mutation each part catches, so a deletion is a decision:
   * `test_the_frontend_declaration_is_findable` — `DocType` renamed or the file
     moved, leaving the equality test comparing empty sets.
+  * `test_a_union_inside_a_string_is_not_read_as_the_declaration` — the union parser
+    anchoring on a quoted copy of the declaration instead of the live one. Measured: a
+    `` const historical = `export type DocType = 'prd' | 'legacy'` `` above the live
+    union returned the DECOY's members, so the equality test compared the wrong set.
+    Same silent failure as the commented-out predecessor, one quote character away.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
     itself, in both directions.
   * `test_both_client_signatures_use_the_shared_request_body` — a signature
@@ -215,11 +237,23 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     constraint turns every directive into a TS2578, so the constraint is
     self-checking rather than a further thing this file has to spell. `@ts-ignore`
     cannot be swapped in — `@typescript-eslint/ban-ts-comment` refuses it.
+    ⚠️ The directive is required to BE the line above the control, and is located by
+    an index into the comment-and-string-blanked view. Two weaker spellings were
+    measured to pass while both pins were fully disabled: a preceding line that merely
+    MENTIONS the directive (several comments in these files do), and an index taken
+    from the RAW source, which a decoy copy of a control in a comment or template
+    literal redirects onto its own line.
   * The `...WouldSeeNarrowing` controls — `BothWays` collapsed to a one-way
     `extends`, which admits a NARROWED field or parameter: the "capability nobody
     can reach" half of this contract's drift. The widened-side controls cannot see
     that collapse (a superset fails the one-way test too), and it was measured to
-    leave `tsc` at exit 0 with every test here green.
+    leave `tsc` at exit 0 with every test here green. Each reads the SAME operand as
+    the pin it controls: the signature one used `never`, which discriminates the two
+    forms but mentions nothing about the method, so it was a second detector of a
+    collapse in the shared `BothWays` — measured, deleting it left that collapse
+    reported only by `types.ts` — rather than a control on its own pin. Both right
+    sides are DERIVED (`Partial<...>`, the field itself) so neither names a member
+    that would go stale when the contract is legitimately widened.
   * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
     union is edited, and its opposite, one that reports drift for a comment.
   * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
@@ -342,11 +376,19 @@ TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
 # than a fourth thing this file has to spell. `@ts-ignore` cannot be swapped in: it is
 # a lint error under `@typescript-eslint/ban-ts-comment`.
 #
+# A FOURTH vacuity, and the general form of the three above: WHERE the string comes
+# from was never checked. Matching against the comment-stripped source stopped a
+# commented-out copy, but not one inside a template literal — which survives stripping,
+# survives `noUnusedLocals` once exported, and can carry newlines. Measured: delete
+# `DocTypeFieldIsExactlyTheUnion`, put a copy in an exported template literal and widen
+# the field it guards — `tsc` exit 0, every test here green. So these are matched
+# against `_declarations(...)`, which blanks string bodies as well; the expected text
+# goes through it too, so a quoted member inside a pinned declaration still matches.
+#
 # Keyed by relative path, since the pins live in two files. Each value is
 # (pin-declaration, control-declarations) — the controls are a tuple because each pin
 # needs TWO of them (widened and narrowed; see below). Every entry is the EXACT text of
-# a declaration, matched against the comment-stripped source so a commented-out copy
-# cannot satisfy it.
+# a declaration.
 TYPE_LEVEL_PINS = {
     # `GenerateDocumentBody.doc_type` admits exactly the members of `DocType`. Nothing
     # else in either language sees this field: this file parses only the
@@ -363,8 +405,8 @@ TYPE_LEVEL_PINS = {
                 "GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>>"
             ),
             (
-                'export type DocTypeFieldPinWouldSeeNarrowing = '
-                'MustBeTrue<BothWays<never, DocType>>'
+                'export type DocTypeFieldPinWouldSeeNarrowing = MustBeTrue<BothWays<'
+                "GenerateDocumentBody['doc_type'], DocType | 'not-a-doc-type'>>"
             ),
         ),
     ),
@@ -389,7 +431,8 @@ TYPE_LEVEL_PINS = {
             ),
             (
                 'export type GenerateDocumentSignaturePinWouldSeeNarrowing = '
-                'SignatureMustMatch<BothWays<never, GenerateDocumentBody>>'
+                'SignatureMustMatch<BothWays<Parameters<typeof '
+                'projectsApi.generateDocument>[1], Partial<GenerateDocumentBody>>>'
             ),
         ),
     ),
@@ -449,7 +492,7 @@ UNION_TERMS = re.compile(rf'{UNION_TERM}(?:\s*\|\s*{UNION_TERM})*')
 DOC_TYPE_UNION_ANCHOR = re.compile(r'export\s+type\s+DocType\s*=\s*\|?\s*')
 
 
-def _without_comments(source: str) -> str:
+def _without_comments(source: str, blank_strings: bool = False) -> str:
     """`source` with `//` and `/* */` comment BODIES blanked, same length.
 
     🔑 Kept when the scanner around it went (issue #381), because `_doc_type_union`
@@ -466,6 +509,24 @@ def _without_comments(source: str) -> str:
     not mistaken for a comment; a regex literal containing `//` would be, but this
     is a type declaration and the shapes that occur are pinned in
     `TestTheUnionParser`.
+
+    🔑 `blank_strings` additionally blanks STRING and TEMPLATE bodies, and exists
+    because "commentary is not a declaration" has a second half this file missed for
+    seven review rounds: a STRING is not a declaration either. Comments were the only
+    thing blanked, so every text guard here could be satisfied by a decoy inside a
+    template literal — which survives stripping, survives `noUnusedLocals` once
+    exported, and can carry newlines, so it also redirects an index computed with
+    `find`. Measured on the shipped tree: deleting `DocTypeFieldIsExactlyTheUnion`
+    outright, putting a copy in an exported template literal and widening the field it
+    guards left `tsc` at exit 0 with every test here green. The same decoy defeated
+    the `@ts-expect-error` check, and would have defeated the narrower "the preceding
+    line must BE the directive" spelling that was the obvious fix for it.
+
+    Off by default because `_doc_type_union` reads the union's members, which ARE
+    string literals — blanking them there would blank the contract itself. On for the
+    declaration pins, where BOTH the source and the expected text go through it (see
+    `_pinned`), so a quoted member inside a pinned declaration still matches while a
+    decoy that merely contains the same characters no longer supplies them.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -476,13 +537,19 @@ def _without_comments(source: str) -> str:
     while index < len(source):
         char = source[index]
         if quote is not None:
-            out.append(char)
             if char == '\\':
-                out.append(source[index + 1:index + 2])
+                # Blank the escape as a unit, so a trailing `\` cannot swallow the
+                # closing quote and blank the rest of the file.
+                out.append(blanked(source[index:index + 2]) if blank_strings
+                           else source[index:index + 2])
                 index += 2
                 continue
             if char == quote:
+                out.append(char)
                 quote = None
+                index += 1
+                continue
+            out.append(blanked(char) if blank_strings else char)
             index += 1
             continue
         if char in '\'"`':
@@ -505,6 +572,33 @@ def _without_comments(source: str) -> str:
         out.append(char)
         index += 1
     return ''.join(out)
+
+
+def _declarations(raw: str) -> str:
+    """`raw` reduced to the text that can actually DECLARE something: comment bodies
+    and string bodies both blanked, length preserved.
+
+    This is what every declaration pin below matches against, and the expected text is
+    put through it too (see `_pinned`) so the two are compared on equal terms — a
+    quoted member inside a pinned declaration still matches, while the same characters
+    sitting inside a template literal no longer supply them.
+
+    Length preserved, so an index found here is valid against `raw`. That is relied on
+    for the `@ts-expect-error` lookup, which has to read a line this function blanks.
+    """
+    return _without_comments(raw, blank_strings=True)
+
+
+def _pinned(expected: str, raw: str) -> bool:
+    """Whether `raw` DECLARES `expected`, comparing like with like.
+
+    Both sides go through `_declarations`, which is the point: the expected text
+    contains quoted members (`'not-a-doc-type'`), so blanking string bodies on only
+    one side would never match. Blanking both leaves the declaration's structure —
+    which is what is being pinned — while denying a decoy the ability to supply it
+    from inside a string.
+    """
+    return _declarations(expected) in _declarations(raw)
 
 
 def _doc_type_union(source: str) -> frozenset[str]:
@@ -535,9 +629,20 @@ def _doc_type_union(source: str) -> frozenset[str]:
     `raise AssertionError` rather than `assert`: `python -O` strips `assert`, and a
     guard whose whole purpose is to not be the quiet option must not have a mode
     where it silently is. `pytest.raises(AssertionError)` is unaffected.
+
+    🔑 The ANCHOR is located in `_declarations(source)` — comment AND string bodies
+    blanked — while the MEMBERS are read from `code`, which blanks comments only. Both
+    are needed and neither alone will do: the members are string literals, so reading
+    them from the strings-blanked view would return a set of empty strings, but
+    anchoring there means a declaration quoted inside a template literal is not the
+    first `re.search` match. Measured: without this, a decoy
+    `` const historical = `export type DocType = 'prd' | 'legacy'` `` above the live
+    declaration was read INSTEAD of it, returning the decoy's members — the same
+    silent failure as the commented-out predecessor, one quote character away. The two
+    views are the same length, so an index from one is valid in the other.
     """
     code = _without_comments(source)
-    anchor = DOC_TYPE_UNION_ANCHOR.search(code)
+    anchor = DOC_TYPE_UNION_ANCHOR.search(_declarations(source))
     if anchor is None:
         return frozenset()
     terms_match = UNION_TERMS.match(code, anchor.end())
@@ -670,6 +775,21 @@ class TestTheUnionParser:
         parametrised rather than each pinned as its own grammar."""
         with pytest.raises(AssertionError, match='continues past the terms'):
             _doc_type_union(f"export type DocType = 'prd' | 'prfaq' | {member}\n")
+
+    def test_a_union_inside_a_string_is_not_read_as_the_declaration(self):
+        """The parser reads the LIVE union, not a copy of one in a template literal.
+
+        `_doc_type_union` deliberately does NOT blank string bodies — the members it
+        reads are string literals — so this pins that the anchor still has to match
+        real code. A decoy above the live declaration would otherwise be the first
+        `re.search` match, which is the same silent failure as the commented-out
+        predecessor `_without_comments` exists for.
+        """
+        source = (
+            "const historical = `export type DocType = 'prd' | 'legacy'`\n"
+            "export type DocType = 'prd' | 'prfaq'\n"
+        )
+        assert _doc_type_union(source) == frozenset({'prd', 'prfaq'})
 
     # The refusals `_doc_type_union` must carry: no readable term at the anchor, a
     # matched non-literal, an unread term after the match.
@@ -997,9 +1117,10 @@ class TestDocTypeLockstep:
             respelling USES the shared name, so neither `noUnusedLocals` nor the name
             assertion above sees it.
 
-        Text, not a parse — but text with three lessons in it, one per review round,
-        which is why what it requires is now each WHOLE DECLARATION rather than a
-        fragment of one. Each fragment tried was satisfiable while the pin did nothing:
+        Text, not a parse — but text with four lessons in it, one per review round,
+        which is why what it requires is now each WHOLE DECLARATION, matched against
+        code rather than against anything that merely contains the same characters.
+        Each weaker version was satisfiable while the pin did nothing:
 
           * The pin NAMES alone. Stub both a pin and its control to bare constants
             (`= true` / `= false`), delete the helper types so no unused-local fires,
@@ -1014,8 +1135,16 @@ class TestDocTypeLockstep:
             same alias. `tsc` exit 0, every test here green, and a caller able to send
             a value the route 400s.
 
-        So the operands are part of what is pinned, and the alias is gone. That the
-        comparisons BITE is still the compiler's job; this says a real one is spelled.
+          * All of the above, matched against COMMENT-stripped source only. A copy
+            inside an exported template literal satisfied any of them — it survives
+            stripping and `noUnusedLocals`, and its newlines redirect a `find` index —
+            so the real pin could be DELETED outright and the field widened, with `tsc`
+            at exit 0 and every test here green. That is why the match is now against
+            `_declarations(...)`, which blanks string bodies too.
+
+        So the operands are part of what is pinned, the alias is gone, and the match is
+        against code. That the comparisons BITE is still the compiler's job; this says a
+        real one is spelled, in a place that can actually declare something.
 
         TWO controls per pin, both required. `MustBeTrue<BothWays<...>>` is satisfied
         by a `BothWays` that degenerates to `true`, and by one collapsed to its
@@ -1023,8 +1152,11 @@ class TestDocTypeLockstep:
         control cannot see the second: a superset fails `[Left] extends [Right]` under
         either form, so both forms look identical to it. Measured — collapsing
         `BothWays` to `[Left] extends [Right]` left `tsc` at exit 0 with every test
-        here green. The narrowed-side controls (`...WouldSeeNarrowing`) are what
-        refuse that, using `never` as the left side.
+        here green. The narrowed-side controls (`...WouldSeeNarrowing`) are what refuse
+        that. Each compares the SAME operand as its own pin against a DERIVED wider
+        type, so it is a control on that pin rather than a second detector of a collapse
+        in the shared `BothWays`: the signature one used `never`, and deleting it was
+        measured to leave the collapse reported only by the other file.
 
         AND each control's `@ts-expect-error`, which is what makes the verdict helper's
         `extends true` self-checking. A control applies the same helper as the pin and
@@ -1038,10 +1170,12 @@ class TestDocTypeLockstep:
         path = _repo_root() / relative
         assert path.is_file(), f'{relative} moved — update TYPE_LEVEL_PINS'
         raw = path.read_text(encoding='utf-8')
-        # Comment-stripped for the declarations, so a commented-out copy cannot satisfy
-        # them; raw for the directives, which are themselves comments.
-        source = _without_comments(raw)
-        assert pin in source, (
+        # Comment AND string bodies blanked for the declarations, so neither a
+        # commented-out copy nor one inside a template literal can satisfy them; raw
+        # for the directives, which are themselves comments. Same length, so an index
+        # from `source` is valid against `raw`.
+        source = _declarations(raw)
+        assert _pinned(pin, raw), (
             f'{relative} no longer declares, exactly:\n'
             f'    {pin}\n'
             f'That is the only check on its half of this contract — nothing else in '
@@ -1054,7 +1188,7 @@ class TestDocTypeLockstep:
             f'together, which is the supported way to change the contract.'
         )
         for control in controls:
-            assert control in source, (
+            assert _pinned(control, raw), (
                 f'{relative} declares its pin but not this control, exactly:\n'
                 f'    {control}\n'
                 f'The pin is satisfied both by a comparison that degenerates to `true` '
@@ -1067,8 +1201,20 @@ class TestDocTypeLockstep:
             # The line immediately above the control, in the RAW source — the
             # declarations are pinned against the stripped source, but a directive IS a
             # comment, so it only exists here.
-            preceding = raw[:raw.find(control)].rstrip().rsplit('\n', 1)[-1]
-            assert EXPECT_ERROR_DIRECTIVE in preceding, (
+            #
+            # 🔑 Indexed with `source`, not `raw`. `source` has comment and string
+            # bodies blanked at the same length, so this finds the DECLARATION and not a
+            # copy of it sitting in a comment or a template literal above. Measured:
+            # with `raw.find`, two decoys carrying a directive and a copy of each
+            # control made this inspect their lines instead, so both real directives
+            # could be deleted and `extends true` dropped — `tsc` exit 0, every test
+            # here green, and the field they guard widened past the route's allowlist.
+            located = source.find(_declarations(control))
+            preceding = raw[:located].rstrip().rsplit('\n', 1)[-1]
+            # Must BE the directive, not merely mention it: a preceding line that
+            # DISCUSSES `@ts-expect-error` (as several comments in these files do) was
+            # measured to satisfy a substring test.
+            assert preceding.lstrip().startswith(f'// {EXPECT_ERROR_DIRECTIVE}'), (
                 f'{relative} declares the control\n'
                 f'    {control}\n'
                 f'but the line above it is not a `{EXPECT_ERROR_DIRECTIVE}`. That '
@@ -1077,5 +1223,8 @@ class TestDocTypeLockstep:
                 f'drop that constraint — one edit that disables the pin and every '
                 f'control at once, measured to leave tsc at exit 0 with every test '
                 f'here green — and each directive becomes an unused-directive error '
-                f'instead. Found instead: {preceding.strip()!r}'
+                f'instead. The line must BE the directive: merely MENTIONING it, and a '
+                f'decoy copy of the control in a comment or template literal that this '
+                f'lookup once landed on instead, were both measured to pass.\n'
+                f'Found instead: {preceding.strip()!r}'
             )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -456,8 +456,8 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         (`test_an_awaited_group_is_not_a_control_head`), and that control is the ONLY thing
         red under the one-word fix — measured, with both older wrong-side controls green.
         ⚠️ The mapping has TWO halves and its `in admitted_by` membership test was itself
-        unpinned for a round: weakened to `keyword is not None`, all 65 tests passed while
-        `return await (w + h) / 2` was blanked. The `const a = …` fixture cannot see that —
+        unpinned for a round: weakened to `keyword is not None`, EVERY test here passed
+        while `return await (w + h) / 2` was blanked. The `const a = …` fixture cannot see that —
         its token before `await` is `=`, so no word precedes the modifier — so the same
         control now carries a KEYWORD-led fixture, which is what makes the membership half
         red. The mapping's other half needs no control: falling back to the head set for an

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -135,10 +135,28 @@ and that fix has a wrong side of its own — treating every `[` as opening a cla
 swallow an indexed division — so both directions are pinned separately, because they are
 different mistakes.
 
-Rounds seven, eight and nine are ONE bug in ONE function surfacing in three constructs,
-each fixed in the shared helper rather than in any guard. That is the part worth keeping:
-the remaining surface is bounded by the ways JavaScript can open and close a string, not
-by the unbounded space of type expressions this file rightly refuses to model.
+A TENTH defeat came from the third way a scan can be wrong about a regex: not whether it
+reads one, nor where one ends, but WHERE ONE MAY BEGIN. `_REGEX_MAY_FOLLOW` excludes `)`,
+which is right for an expression — `(a + b) / 2` divides — and wrong for the `)` that
+closes an `if`/`for`/`while`/`switch` HEAD, after which a statement follows and a statement
+cannot begin with a division. So `for (const _c of []) /`/…` was read as a division, its
+backtick stayed live, and a decoy's own backtick closed the phantom frame it opened, with
+the same resynchronising trailing statement as the eighth and ninth. Measured on the tree
+that shipped it: the field pin DELETED outright, a copy in such a decoy, the field widened
+to `DocType | 'onepager'` — `tsc` exit 0, eslint clean, every test here green, and nothing
+for a lint rule to object to (assigning `.lastIndex` rather than calling `.test(...)`
+raises no `sonarjs/no-ignored-return` and no TS2774). All four guards went with it again.
+`_closes_control_head` walks back to the matching `(` and reads the word before it, which
+is the only thing distinguishing the two `)`s. That fix has TWO wrong sides rather than
+one, and both are pinned, because a single over-broad rule produces only one of them:
+admitting a regex after every `)` blanks a grouped division, and accepting any word before
+the matching `(` blanks a CALL's.
+
+Rounds seven through ten are ONE bug in ONE function surfacing in four constructs, each
+fixed in the shared helper rather than in any guard. That is the part worth keeping: the
+remaining surface is bounded by the ways JavaScript delimits a string — whether one is
+read, where it ends, and where it may begin — not by the unbounded space of type
+expressions this file rightly refuses to model.
 
 THE GUARDS' OWN FIXES ARE PINNED TOO, which took its own finding. The two repairs made
 in the fifth round shipped with no test, and reverting either left all 30 tests here
@@ -401,6 +419,16 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         reverted, and its wrong side is pinned separately too: treating every `[` as
         opening a class swallows an indexed division
         (`test_an_indexed_division_is_not_read_as_a_character_class`).
+      - reading a `/` after a control-flow head's `)` as a DIVISION, which it cannot be —
+        a statement cannot begin with one. The TENTH vacuity, the same root cause a fourth
+        time, and again in every guard at once: `for (const _c of []) /`/…` left its
+        backtick live to open a phantom template frame. Three cases here plus one in
+        `TestTheUnionParser` are red when `_closes_control_head` is no longer consulted.
+        This fix has TWO wrong sides, pinned separately because a single over-broad rule
+        would produce only one of them: admitting a regex after every `)` blanks a grouped
+        division (`test_an_expression_division_is_not_read_as_a_regex`), and accepting any
+        word before the matching `(` blanks a CALL's
+        (`test_a_call_expression_is_not_a_control_head`).
     Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
     assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
@@ -713,6 +741,12 @@ DOC_TYPE_UNION_ANCHOR = re.compile(r'export\s+type\s+DocType\s*=\s*\|?\s*')
 # cannot end an expression. Deliberately CONSERVATIVE: mistaking a division for a regex
 # would blank real code, while mistaking a regex for a division is what the eighth
 # vacuity was — so the two errors are not symmetric, and this errs toward reading less.
+#
+# ⚠️ `)` is NOT here, and must not be: `(a + b) / 2` is a division, and taking every `)`
+# to admit a regex would blank the rest of that line. The one `)` that cannot be
+# followed by a division is the one closing an `if`/`for`/`while`/`switch` HEAD, which
+# `_closes_control_head` decides separately — leaving it out of both readings was the
+# TENTH vacuity.
 _REGEX_MAY_FOLLOW = '=(,:[!&|?{};+-*%~^<>'
 # The keywords a regex may directly follow, where the preceding CHARACTER is a word
 # character and so says nothing on its own (`return /`/.test(x)`).
@@ -720,7 +754,48 @@ _REGEX_MAY_FOLLOW_KEYWORD = frozenset({
     'return', 'typeof', 'case', 'in', 'of', 'do', 'else', 'yield', 'await', 'delete',
     'void', 'instanceof', 'new',
 })
+# The heads whose closing `)` ends a STATEMENT position, so a `/` after it can only open
+# a regex. `catch` is absent deliberately: `catch (e) /`/` is not reachable code, and the
+# conservative direction costs nothing here.
+_REGEX_MAY_FOLLOW_HEAD = frozenset({'if', 'for', 'while', 'switch'})
 _TRAILING_WORD = re.compile(r'[A-Za-z_$][\w$]*$')
+
+# 🔑 The TENTH vacuity's decoy opener, shared by every guard's fixture for it because the
+# defect was one — a regex in STATEMENT position, whose backtick opened a phantom template
+# frame that a decoy's own backtick then closed. Two of these bracket the decoy: the second
+# resynchronises the scan, which is what made the evasion clean rather than one that ran to
+# EOF and noisily swallowed whatever followed. Assigning `.lastIndex` rather than calling
+# `.test(...)` keeps it lint-clean, so nothing stood in the way of this one either.
+CONTROL_HEAD_DESYNC = 'for (const _c of []) /`/.lastIndex = Number(_c)\n'
+
+
+def _closes_control_head(text: str) -> bool:
+    """Whether `text` ends with the `)` that closed an `if`/`for`/`while`/`switch` head.
+
+    🔑 The TENTH vacuity, and the same root cause as the seventh through ninth: a `/`
+    after such a `)` can only open a regex, since a control-flow head is followed by a
+    STATEMENT and a statement cannot begin with a division. `_REGEX_MAY_FOLLOW` excludes
+    `)` — correctly, for an expression `)` — so `for (const _c of []) /`/…` was read as
+    a division, its backtick stayed live, and the phantom template frame it opened was
+    closed by a decoy's own backtick. Everything after that was code again.
+
+    Walks back to the matching `(` and reads the word before it, which is the only way to
+    tell the two `)`s apart: `(w + h) / 2` and `for (x of y) /re/` differ solely in what
+    precedes the group. Errs toward returning False for the reason `_REGEX_MAY_FOLLOW`
+    gives — an unmatched `(` or an unknown word leaves the `/` read as a division, which
+    is a false FAILURE bounded to one line.
+    """
+    depth = 0
+    for index in range(len(text) - 1, -1, -1):
+        char = text[index]
+        if char == ')':
+            depth += 1
+        elif char == '(':
+            depth -= 1
+            if depth == 0:
+                head = _TRAILING_WORD.search(text[:index].rstrip())
+                return head is not None and head.group(0) in _REGEX_MAY_FOLLOW_HEAD
+    return False
 
 
 def _regex_allowed_here(emitted: list[str]) -> bool:
@@ -728,13 +803,15 @@ def _regex_allowed_here(emitted: list[str]) -> bool:
 
     Decided from what has already been emitted, since that is the only context a
     single-pass scan has. See `_REGEX_MAY_FOLLOW` for why the conservative direction is
-    the safe one.
+    the safe one, and `_closes_control_head` for the one `)` that admits a regex.
     """
     text = ''.join(emitted).rstrip()
     if not text:
         return True
     if text[-1] in _REGEX_MAY_FOLLOW:
         return True
+    if text[-1] == ')':
+        return _closes_control_head(text)
     trailing = _TRAILING_WORD.search(text)
     return trailing is not None and trailing.group(0) in _REGEX_MAY_FOLLOW_KEYWORD
 
@@ -820,8 +897,18 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
     had; measured the same way, with the field pin deleted and every gate green. So the
     scan tracks class state, and its wrong side is pinned too: taking every `[` to open a
     class would swallow an indexed division (`x[i] / 2 + y[j] / 3`), the same false-FAILURE
-    direction as misreading a division. Rounds seven to nine were one bug in this function
-    surfacing in three constructs, which is why each fix belongs here and not in a guard.
+    direction as misreading a division.
+
+    🔑 And a regex does not only END where the scan must be right — it also BEGINS there,
+    which was the TENTH vacuity. A `/` after the `)` closing an `if`/`for`/`while`/`switch`
+    head can only open a regex, since what follows such a head is a statement; but `)` is
+    absent from `_REGEX_MAY_FOLLOW` (correctly, for a grouped `(a + b) / 2`), so
+    `for (const _c of []) /`/…` was read as a division and its backtick desynchronised the
+    scan exactly as an unread regex had. Measured the same way, with the field pin deleted
+    and every gate green including eslint. `_closes_control_head` decides it, and both of
+    its wrong sides are pinned — see there. Rounds seven to ten were one bug in this
+    function surfacing in four constructs, which is why each fix belongs here and not in a
+    guard.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -1287,6 +1374,23 @@ class TestTheUnionParser:
         )
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
 
+    def test_a_union_inside_a_control_head_desynced_template_is_not_read(self):
+        """The same again for a regex in STATEMENT position — the tenth vacuity.
+
+        `_REGEX_MAY_FOLLOW` excludes `)` because `(a + b) / 2` divides, so a regex after a
+        `for`/`if`/`while` head's `)` was read as a division and its backtick stayed live
+        to open a phantom template frame. As in the three cases above the live union
+        carries the extra member deliberately: this must read `onepager` rather than merely
+        disagree with the decoy, or it would pass on a parser that read nothing at all.
+        """
+        source = (
+            f'{CONTROL_HEAD_DESYNC}'
+            "const historical = `export type DocType = 'prd' | 'legacy'`\n"
+            f'{CONTROL_HEAD_DESYNC}'
+            "export type DocType = 'prd' | 'prfaq' | 'onepager'\n"
+        )
+        assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
+
     # The refusals `_doc_type_union` must carry: no readable term at the anchor, a
     # matched non-literal, an unread term after the match.
     EXPECTED_REFUSALS = 3
@@ -1465,6 +1569,59 @@ class TestThePinMatcher:
         assert _pinned(self.PIN, f'{self.PIN}\n')
         assert _pinned(self.PIN, f'{self.CLASS_DESYNC}{self.PIN}\n')
 
+    def test_a_declaration_inside_a_control_head_desynced_template_is_not_pinned(self):
+        """The tenth vacuity, again on the pin with no compiler backstop.
+
+        Measured on the tree that shipped it: `DocTypeFieldIsExactlyTheUnion` DELETED
+        outright, a copy left in a template literal opened by the backtick of a regex in
+        STATEMENT position, and the field it guards widened to `DocType | 'onepager'` —
+        `tsc` exit 0, eslint clean, and every test here green. Nothing for a lint rule to
+        object to either: unlike `if (x) /`/`, a `for` head assigning `.lastIndex` raises
+        no `sonarjs/no-ignored-return` and no TS2774.
+        """
+        decoy = (
+            f'{CONTROL_HEAD_DESYNC}export const historical = `\n{self.PIN}\n`\n'
+            f'{CONTROL_HEAD_DESYNC}'
+        )
+        assert not _pinned(self.PIN, decoy)
+        # The controls: a real declaration must still be found, and still be found with a
+        # genuine statement-position regex above it — reading those must not cost the live
+        # pin, which is the false-FAILURE direction of this fix.
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+        assert _pinned(self.PIN, f'{CONTROL_HEAD_DESYNC}{self.PIN}\n')
+
+    def test_an_expression_division_is_not_read_as_a_regex(self):
+        """The wrong side of the control-head fix, which is a different mistake from the
+        wrong side of the class fix and so is pinned separately.
+
+        `(w + h) / 2 + (i + j) / 3` closes two GROUPS, not two control heads, and both
+        `/`s divide. Admitting a regex after every `)` — the obvious over-broad fix — would
+        make the first `/` swallow through to the second and blank the code between them: a
+        false FAILURE, the opposite error from the vacuity above. `_closes_control_head`
+        reads the word before the matching `(` for exactly this reason.
+        """
+        divided = 'const a = (w + h) / 2 + (i + j) / 3\n'
+        assert _declarations(divided) == divided
+        # The control: a statement-position regex body IS still blanked, so this cannot
+        # pass by never reading a regex after `)` at all — which is the vacuity above.
+        assert _declarations('for (const c of []) /`/.test(c)\n') == (
+            'for (const c of []) / /.test(c)\n'
+        )
+
+    def test_a_call_expression_is_not_a_control_head(self):
+        """A function whose NAME happens to be a control keyword's neighbour must not open
+        a regex: `foo(bar) / 2` divides, and so does `matchAll(re) / n`.
+
+        Pinned separately from the group case above because the two reach
+        `_closes_control_head` by different routes — a group's `(` is preceded by an
+        operator, a call's by an identifier — and only the second could be admitted by a
+        rule that looked at the preceding word without checking it against a fixed set.
+        """
+        divided = 'const a = foo(bar) / 2 + baz(qux) / 3\n'
+        assert _declarations(divided) == divided
+        # The control, as above: a real control head must still admit one.
+        assert _declarations('if (x) /`/.test(y)\n') == 'if (x) / /.test(y)\n'
+
     def test_an_indexed_division_is_not_read_as_a_character_class(self):
         """The wrong side of the class fix, which is a different mistake from the wrong
         side of the regex fix and so is pinned separately.
@@ -1587,6 +1744,21 @@ class TestThePinMatcher:
             self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
         )
 
+    def test_a_directive_inside_a_control_head_desynced_template_is_not_the_live_one(self):
+        """The directive lookup's version of the tenth vacuity: the desynced decoy carried
+        both the control's text and a directive above it, so it was the offset inspected
+        and the live control could have no directive at all.
+        """
+        decoy = (
+            f'{CONTROL_HEAD_DESYNC}export const historical = `\n'
+            f'// {EXPECT_ERROR_DIRECTIVE} historical\n{self.PIN}\n`\n'
+            f'{CONTROL_HEAD_DESYNC}'
+        )
+        assert not _carries_expect_error(self.PIN, f'{decoy}{self.PIN}\n')
+        assert _carries_expect_error(
+            self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
+        )
+
     # ⚠️ The ratio cases below use the LIVE `GENERATE_DOCUMENT_SIGNATURE`, unlike `PIN`
     # above, and that is not an inconsistency: `_generate_document_ratio` counts by the
     # module constants rather than taking the text as an argument, so a synthetic
@@ -1639,6 +1811,18 @@ class TestThePinMatcher:
         decoy = (
             f'{self.CLASS_DESYNC}export const historical = `\n'
             f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{self.CLASS_RESYNC}'
+        )
+        assert _generate_document_ratio(decoy) == (0, 0)
+        assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
+
+    def test_a_signature_inside_a_control_head_desynced_template_is_not_counted(self):
+        """The ratio's version of the tenth vacuity: a regex in statement position was read
+        as a division, so its backtick stayed live and the decoy supplied one of each side
+        on its own — the same shape as the three cases above, one delimiter over.
+        """
+        decoy = (
+            f'{CONTROL_HEAD_DESYNC}export const historical = `\n'
+            f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{CONTROL_HEAD_DESYNC}'
         )
         assert _generate_document_ratio(decoy) == (0, 0)
         assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -152,11 +152,28 @@ one, and both are pinned, because a single over-broad rule produces only one of 
 admitting a regex after every `)` blanks a grouped division, and accepting any word before
 the matching `(` blanks a CALL's.
 
-Rounds seven through ten are ONE bug in ONE function surfacing in four constructs, each
+An ELEVENTH defeat then showed that fix had read the wrong word: the head KEYWORD is not
+always the word before the `(`, because one MODIFIER may sit between them. `for await (…)`
+ends in `await`, so `_closes_control_head` said False and `for await (const _c of []) /`/…`
+reopened all four guards exactly as the tenth had — measured on the tree that shipped it,
+with the field pin DELETED outright, a copy in such a decoy and the field widened: `tsc`
+exit 0, eslint clean, every test here green. `for await` is the ONLY modified head form in
+the language, so the surface here is one grammatical form rather than a construct; `catch`
+stays out because `catch (e) /`/` is TS1005 under `tsc` and a SyntaxError in `node`.
+
+⚠️ The one-word fix — adding `await` to `_REGEX_MAY_FOLLOW_HEAD` — is WRONG, and neither
+existing wrong-side control catches it (measured: both green under it). `await` also leads
+an EXPRESSION, so `await (w + h) / 2` is a legal division that a bare set membership blanks.
+`_REGEX_MAY_FOLLOW_HEAD_MODIFIER` maps each modifier to the heads admitting it, so the word
+before the modifier must be one of those, and `test_an_awaited_group_is_not_a_control_head`
+pins the direction the simpler fix would have broken.
+
+Rounds seven through eleven are ONE bug in ONE function surfacing in five constructs, each
 fixed in the shared helper rather than in any guard. That is the part worth keeping: the
 remaining surface is bounded by the ways JavaScript delimits a string — whether one is
 read, where it ends, and where it may begin — not by the unbounded space of type
-expressions this file rightly refuses to model.
+expressions this file rightly refuses to model. The eleventh is the narrowest of the five,
+being one grammatical form rather than a construct, which is what convergence looks like.
 
 THE GUARDS' OWN FIXES ARE PINNED TOO, which took its own finding. The two repairs made
 in the fifth round shipped with no test, and reverting either left all 30 tests here
@@ -429,6 +446,15 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         division (`test_an_expression_division_is_not_read_as_a_regex`), and accepting any
         word before the matching `(` blanks a CALL's
         (`test_a_call_expression_is_not_a_control_head`).
+      - reading only the word before that `(` as the head KEYWORD, which misses the one
+        modified form the language has: `for await (…)` ends in `await`. The ELEVENTH
+        vacuity, the same root cause a fifth time and again in every guard at once, so the
+        four cases for the tenth are PARAMETRISED over both openers rather than duplicated
+        — the `for_await` id of each is red when the modifier retry is reverted. Its wrong
+        side is the reason the fix is a mapping and not one more set member: `await` leads
+        an expression too, so `await (w + h) / 2` divides
+        (`test_an_awaited_group_is_not_a_control_head`), and that control is the ONLY thing
+        red under the one-word fix — measured, with both older wrong-side controls green.
     Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
     assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
@@ -755,9 +781,21 @@ _REGEX_MAY_FOLLOW_KEYWORD = frozenset({
     'void', 'instanceof', 'new',
 })
 # The heads whose closing `)` ends a STATEMENT position, so a `/` after it can only open
-# a regex. `catch` is absent deliberately: `catch (e) /`/` is not reachable code, and the
-# conservative direction costs nothing here.
+# a regex. `catch` is absent deliberately: `catch (e) /`/` is not reachable code — `tsc`
+# reports TS1005 and `node` a SyntaxError — and the conservative direction costs nothing.
 _REGEX_MAY_FOLLOW_HEAD = frozenset({'if', 'for', 'while', 'switch'})
+# 🔑 The modifiers a head may carry between the keyword and its `(`, mapped to the heads
+# that admit them. `for await (…)` is the only such form in the language, and reading only
+# the word immediately before the `(` — which is `await`, not `for` — was the ELEVENTH
+# vacuity: `_closes_control_head` said False, the regex after that `)` was read as a
+# division, and every guard here reopened.
+#
+# ⚠️ Mapped rather than folded into `_REGEX_MAY_FOLLOW_HEAD`, which is the one-word fix and
+# is WRONG: `await` also leads an expression, so `await (w + h) / 2` is a legal DIVISION
+# (`node` confirms it evaluates) that a bare set membership blanks. Requiring the word
+# BEFORE the modifier to be a head that admits it keeps the expression form dividing, so
+# this closes the vacuity without opening a false FAILURE beside it.
+_REGEX_MAY_FOLLOW_HEAD_MODIFIER = {'await': frozenset({'for'})}
 _TRAILING_WORD = re.compile(r'[A-Za-z_$][\w$]*$')
 
 # 🔑 The TENTH vacuity's decoy opener, shared by every guard's fixture for it because the
@@ -767,6 +805,14 @@ _TRAILING_WORD = re.compile(r'[A-Za-z_$][\w$]*$')
 # EOF and noisily swallowed whatever followed. Assigning `.lastIndex` rather than calling
 # `.test(...)` keeps it lint-clean, so nothing stood in the way of this one either.
 CONTROL_HEAD_DESYNC = 'for (const _c of []) /`/.lastIndex = Number(_c)\n'
+# 🔑 The ELEVENTH vacuity's opener: the same statement one MODIFIER wider. Every guard's
+# fixture for the tenth is parametrised over BOTH rather than duplicated, because the two
+# are one defect — the head keyword is not the word before the `(` — and four more test
+# bodies would have been four more places for the next round's fix to go untested.
+CONTROL_HEAD_DESYNCS = {
+    'for': CONTROL_HEAD_DESYNC,
+    'for_await': 'for await (const _c of []) /`/.lastIndex = Number(_c)\n',
+}
 
 
 def _closes_control_head(text: str) -> bool:
@@ -784,6 +830,13 @@ def _closes_control_head(text: str) -> bool:
     precedes the group. Errs toward returning False for the reason `_REGEX_MAY_FOLLOW`
     gives — an unmatched `(` or an unknown word leaves the `/` read as a division, which
     is a false FAILURE bounded to one line.
+
+    🔑 The word before the `(` is not always the HEAD KEYWORD, and assuming it was for one
+    round was the ELEVENTH vacuity: `for await (…)` ends in `await`, so this returned False
+    and the eleventh reopened all four guards exactly as the tenth had. One MODIFIER may sit
+    between the keyword and its `(`, so an unrecognised word is retried as one — see
+    `_REGEX_MAY_FOLLOW_HEAD_MODIFIER` for why that indirection is not the simpler set
+    addition, which would blank a legal `await (w + h) / 2`.
     """
     depth = 0
     for index in range(len(text) - 1, -1, -1):
@@ -794,7 +847,17 @@ def _closes_control_head(text: str) -> bool:
             depth -= 1
             if depth == 0:
                 head = _TRAILING_WORD.search(text[:index].rstrip())
-                return head is not None and head.group(0) in _REGEX_MAY_FOLLOW_HEAD
+                if head is None:
+                    return False
+                if head.group(0) in _REGEX_MAY_FOLLOW_HEAD:
+                    return True
+                # Not a head, so try it as a modifier: the head is then the word before it,
+                # and must be one this modifier is legal on.
+                admitted_by = _REGEX_MAY_FOLLOW_HEAD_MODIFIER.get(head.group(0))
+                if admitted_by is None:
+                    return False
+                keyword = _TRAILING_WORD.search(text[:head.start()].rstrip())
+                return keyword is not None and keyword.group(0) in admitted_by
     return False
 
 
@@ -906,9 +969,15 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
     `for (const _c of []) /`/…` was read as a division and its backtick desynchronised the
     scan exactly as an unread regex had. Measured the same way, with the field pin deleted
     and every gate green including eslint. `_closes_control_head` decides it, and both of
-    its wrong sides are pinned — see there. Rounds seven to ten were one bug in this
-    function surfacing in four constructs, which is why each fix belongs here and not in a
-    guard.
+    its wrong sides are pinned — see there.
+
+    🔑 And WHERE it begins is decided from a word, which must be the right one: reading the
+    word before that `)`'s matching `(` misses `for await (…)`, whose is `await`. The
+    ELEVENTH vacuity, measured the same way — field pin deleted, every gate green — and the
+    reason `_closes_control_head` retries an unrecognised word as a MODIFIER rather than
+    taking `await` as a head, which would blank a legal `await (w + h) / 2`. Rounds seven to
+    eleven were one bug in this function surfacing in five constructs, which is why each fix
+    belongs here and not in a guard.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -1374,19 +1443,27 @@ class TestTheUnionParser:
         )
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
 
-    def test_a_union_inside_a_control_head_desynced_template_is_not_read(self):
-        """The same again for a regex in STATEMENT position — the tenth vacuity.
+    @pytest.mark.parametrize(
+        'desync', CONTROL_HEAD_DESYNCS.values(), ids=CONTROL_HEAD_DESYNCS
+    )
+    def test_a_union_inside_a_control_head_desynced_template_is_not_read(self, desync):
+        """The same again for a regex in STATEMENT position — the tenth vacuity, and the
+        ELEVENTH in the `for_await` case.
 
         `_REGEX_MAY_FOLLOW` excludes `)` because `(a + b) / 2` divides, so a regex after a
         `for`/`if`/`while` head's `)` was read as a division and its backtick stayed live
         to open a phantom template frame. As in the three cases above the live union
         carries the extra member deliberately: this must read `onepager` rather than merely
         disagree with the decoy, or it would pass on a parser that read nothing at all.
+
+        Parametrised over both openers rather than duplicated, because they are one defect
+        read at two depths: `for await` ends in `await`, so a check reading only the word
+        before the `(` reopened this exactly as the tenth had.
         """
         source = (
-            f'{CONTROL_HEAD_DESYNC}'
+            f'{desync}'
             "const historical = `export type DocType = 'prd' | 'legacy'`\n"
-            f'{CONTROL_HEAD_DESYNC}'
+            f'{desync}'
             "export type DocType = 'prd' | 'prfaq' | 'onepager'\n"
         )
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
@@ -1569,26 +1646,35 @@ class TestThePinMatcher:
         assert _pinned(self.PIN, f'{self.PIN}\n')
         assert _pinned(self.PIN, f'{self.CLASS_DESYNC}{self.PIN}\n')
 
-    def test_a_declaration_inside_a_control_head_desynced_template_is_not_pinned(self):
-        """The tenth vacuity, again on the pin with no compiler backstop.
+    @pytest.mark.parametrize(
+        'desync', CONTROL_HEAD_DESYNCS.values(), ids=CONTROL_HEAD_DESYNCS
+    )
+    def test_a_declaration_inside_a_control_head_desynced_template_is_not_pinned(
+        self, desync
+    ):
+        """The tenth vacuity, again on the pin with no compiler backstop — and the ELEVENTH
+        in the `for_await` case, which is why this is parametrised rather than duplicated.
 
-        Measured on the tree that shipped it: `DocTypeFieldIsExactlyTheUnion` DELETED
+        Both measured on the tree that shipped each: `DocTypeFieldIsExactlyTheUnion` DELETED
         outright, a copy left in a template literal opened by the backtick of a regex in
         STATEMENT position, and the field it guards widened to `DocType | 'onepager'` —
         `tsc` exit 0, eslint clean, and every test here green. Nothing for a lint rule to
         object to either: unlike `if (x) /`/`, a `for` head assigning `.lastIndex` raises
         no `sonarjs/no-ignored-return` and no TS2774.
+
+        The `for_await` case is the same defect one word further out — the head keyword is
+        not the word before the `(` — so it needs no separate body, only the other opener.
         """
         decoy = (
-            f'{CONTROL_HEAD_DESYNC}export const historical = `\n{self.PIN}\n`\n'
-            f'{CONTROL_HEAD_DESYNC}'
+            f'{desync}export const historical = `\n{self.PIN}\n`\n'
+            f'{desync}'
         )
         assert not _pinned(self.PIN, decoy)
         # The controls: a real declaration must still be found, and still be found with a
         # genuine statement-position regex above it — reading those must not cost the live
         # pin, which is the false-FAILURE direction of this fix.
         assert _pinned(self.PIN, f'{self.PIN}\n')
-        assert _pinned(self.PIN, f'{CONTROL_HEAD_DESYNC}{self.PIN}\n')
+        assert _pinned(self.PIN, f'{desync}{self.PIN}\n')
 
     def test_an_expression_division_is_not_read_as_a_regex(self):
         """The wrong side of the control-head fix, which is a different mistake from the
@@ -1621,6 +1707,29 @@ class TestThePinMatcher:
         assert _declarations(divided) == divided
         # The control, as above: a real control head must still admit one.
         assert _declarations('if (x) /`/.test(y)\n') == 'if (x) / /.test(y)\n'
+
+    def test_an_awaited_group_is_not_a_control_head(self):
+        """The wrong side of the ELEVENTH fix, and the reason it is a MAPPING rather than
+        one more member of `_REGEX_MAY_FOLLOW_HEAD`.
+
+        `await` leads an expression as well as modifying a `for` head, so
+        `await (w + h) / 2` is a legal DIVISION — `node` evaluates it — while
+        `for await (…) /re/` is a regex. The one-word fix cannot tell them apart: adding
+        `await` to the head set blanks the code after the first `/` here, which is the same
+        false FAILURE `test_an_expression_division_is_not_read_as_a_regex` pins for the
+        grouped case, reached by a different route. Requiring the word BEFORE the modifier
+        to be a head that admits it is what discriminates.
+
+        Neither existing wrong-side control catches this: both are green under the one-word
+        fix, measured, because neither fixture contains an awaited group.
+        """
+        divided = 'const a = await (w + h) / 2 + await (i + j) / 3\n'
+        assert _declarations(divided) == divided
+        # The control: the MODIFIED head must still admit a regex, so this cannot pass on a
+        # rule that refuses `await` everywhere and reopens the eleventh vacuity.
+        assert _declarations('for await (const c of []) /`/.test(c)\n') == (
+            'for await (const c of []) / /.test(c)\n'
+        )
 
     def test_an_indexed_division_is_not_read_as_a_character_class(self):
         """The wrong side of the class fix, which is a different mistake from the wrong
@@ -1744,15 +1853,21 @@ class TestThePinMatcher:
             self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
         )
 
-    def test_a_directive_inside_a_control_head_desynced_template_is_not_the_live_one(self):
-        """The directive lookup's version of the tenth vacuity: the desynced decoy carried
-        both the control's text and a directive above it, so it was the offset inspected
-        and the live control could have no directive at all.
+    @pytest.mark.parametrize(
+        'desync', CONTROL_HEAD_DESYNCS.values(), ids=CONTROL_HEAD_DESYNCS
+    )
+    def test_a_directive_inside_a_control_head_desynced_template_is_not_the_live_one(
+        self, desync
+    ):
+        """The directive lookup's version of the tenth vacuity, and of the ELEVENTH in the
+        `for_await` case: the desynced decoy carried both the control's text and a directive
+        above it, so it was the offset inspected and the live control could have no
+        directive at all.
         """
         decoy = (
-            f'{CONTROL_HEAD_DESYNC}export const historical = `\n'
+            f'{desync}export const historical = `\n'
             f'// {EXPECT_ERROR_DIRECTIVE} historical\n{self.PIN}\n`\n'
-            f'{CONTROL_HEAD_DESYNC}'
+            f'{desync}'
         )
         assert not _carries_expect_error(self.PIN, f'{decoy}{self.PIN}\n')
         assert _carries_expect_error(
@@ -1815,14 +1930,20 @@ class TestThePinMatcher:
         assert _generate_document_ratio(decoy) == (0, 0)
         assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
 
-    def test_a_signature_inside_a_control_head_desynced_template_is_not_counted(self):
-        """The ratio's version of the tenth vacuity: a regex in statement position was read
-        as a division, so its backtick stayed live and the decoy supplied one of each side
-        on its own — the same shape as the three cases above, one delimiter over.
+    @pytest.mark.parametrize(
+        'desync', CONTROL_HEAD_DESYNCS.values(), ids=CONTROL_HEAD_DESYNCS
+    )
+    def test_a_signature_inside_a_control_head_desynced_template_is_not_counted(
+        self, desync
+    ):
+        """The ratio's version of the tenth vacuity, and of the ELEVENTH in the `for_await`
+        case: a regex in statement position was read as a division, so its backtick stayed
+        live and the decoy supplied one of each side on its own — the same shape as the three
+        cases above, one delimiter over.
         """
         decoy = (
-            f'{CONTROL_HEAD_DESYNC}export const historical = `\n'
-            f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{CONTROL_HEAD_DESYNC}'
+            f'{desync}export const historical = `\n'
+            f'  {GENERATE_DOCUMENT_SIGNATURE}\n`\n{desync}'
         )
         assert _generate_document_ratio(decoy) == (0, 0)
         assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -30,15 +30,16 @@ WHAT THIS FILE COSTS, stated plainly because a previous version of this heading 
 
     944 lines   on `development`, the scanner version
     455 lines   after the scanner was deleted
-  ~1080 lines   now
+   1230 lines   now
 
 So it is LONGER than the scanner it replaced, and the claim that it was short was
-false for two review rounds. What the growth is: ~60% of the file is PROSE (this
-docstring ~230 lines, test docstrings ~245, comments ~190). The ~415 lines of code are
+false for two review rounds. What the growth is: 64% of the file is PROSE (this
+docstring 266 lines, test docstrings 314, comments 212). The 372 lines of code are
 `_without_comments` and `_doc_type_union` with their shape fixtures, plus the text
 assertions keeping two type-level pins and their four controls present. If these
 counts and the file disagree, the file is right and this block is stale — recompute
-rather than trusting it.
+rather than trusting it, with `ast` rather than by eye (this block has been stale
+twice, both times because a figure was written while the file was still being edited).
 
 Whether that is proportionate is a fair question and was asked in review. The honest
 answer: the PINS are cheap and they are what bite — every widening mutation tried is
@@ -55,14 +56,21 @@ cases nothing else noticed:
   * remove `...WouldSeeNarrowing` (narrowed side), then collapse it to the forward
     one-way `[Left] extends [Right]` -> `tsc` reports NOTHING in that file.
 
-With both present, those two collapses are 2 errors each, and a `BothWays` degenerated
-to constant `true` is 4. So neither control covers the other's axis and there is no
-third one to add.
+With both present, those two collapses are 2 errors each — one per pin, since each
+control now compares its OWN pin's operand — and a `BothWays` degenerated to constant
+`true` is 5. So neither control covers the other's axis and there is no third one to
+add.
 
 THE RULE THAT REPLACES ADDING MORE: when a guard turns out to be evadable, move the
 check to the compiler or pin the whole construct. Do NOT add a longer text fragment —
 that was tried four times and defeated four times, because a fragment of the thing
 being pinned is always a substring something else can supply.
+
+Its corollary, which took a fifth defeat to see: also ask WHERE the string is allowed
+to come from. Pinning the whole declaration still passed on a copy inside a template
+literal, so the pins match against `_declarations(...)` — comment AND string bodies
+blanked — rather than against comment-stripped text. "Commentary is not a declaration"
+was only half the rule; a string is not one either.
 
 WHAT ENFORCES WHICH HALF, measured rather than assumed — the compiler does NOT do
 all of it, and an earlier version of this docstring claimed it did:

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -1107,9 +1107,11 @@ class TestThePinMatcher:
             self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
         )
 
-    # A `generateDocument` declaration taking the shared body, as the ratio counts it.
-    SIGNATURE = GENERATE_DOCUMENT_SIGNATURE
-
+    # ⚠️ The ratio cases below use the LIVE `GENERATE_DOCUMENT_SIGNATURE`, unlike `PIN`
+    # above, and that is not an inconsistency: `_generate_document_ratio` counts by the
+    # module constants rather than taking the text as an argument, so a synthetic
+    # fixture would exercise nothing. Accepted knowingly — a legitimate rename of that
+    # constant also edits these fixtures, where for `PIN` it would not.
     def test_a_signature_inside_a_template_literal_is_not_counted(self):
         """The ratio guard's own version of the fifth vacuity — the same defect, in the
         last text guard that still read comment-stripped text rather than
@@ -1120,11 +1122,11 @@ class TestThePinMatcher:
         (below) let the real parameter go inline with the ratio still holding. Measured
         on the shipped tree: `tsc` exit 0, eslint clean, every test here green.
         """
-        decoy = f'export const historical = `\n  {self.SIGNATURE}\n`\n'
+        decoy = f'export const historical = `\n  {GENERATE_DOCUMENT_SIGNATURE}\n`\n'
         assert _generate_document_ratio(decoy) == (0, 0)
         # The control: the same text as real code must still be counted on both sides,
         # or this would pass by counting nothing at all.
-        assert _generate_document_ratio(f'  {self.SIGNATURE}\n') == (1, 1)
+        assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
 
     def test_a_respelled_colon_is_not_counted_as_a_declaration(self):
         """`generateDocument:(` — no space — is legal TypeScript and lints clean, but is
@@ -1135,9 +1137,11 @@ class TestThePinMatcher:
         `declared >= 1` floor is what refuses it, and its message says so, because
         not-FOUND and found-and-unpinned want different fixes.
         """
-        respelled = self.SIGNATURE.replace('generateDocument: (', 'generateDocument:(')
+        respelled = GENERATE_DOCUMENT_SIGNATURE.replace(
+            'generateDocument: (', 'generateDocument:('
+        )
         assert _generate_document_ratio(f'  {respelled}\n') == (0, 0)
-        assert _generate_document_ratio(f'  {self.SIGNATURE}\n') == (1, 1)
+        assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
 
     def test_an_inline_literal_leaves_its_opener_counted_but_unpinned(self):
         """The respelling this guard exists to refuse: the declaration stays visible on

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -455,6 +455,14 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         an expression too, so `await (w + h) / 2` divides
         (`test_an_awaited_group_is_not_a_control_head`), and that control is the ONLY thing
         red under the one-word fix — measured, with both older wrong-side controls green.
+        ⚠️ The mapping has TWO halves and its `in admitted_by` membership test was itself
+        unpinned for a round: weakened to `keyword is not None`, all 65 tests passed while
+        `return await (w + h) / 2` was blanked. The `const a = …` fixture cannot see that —
+        its token before `await` is `=`, so no word precedes the modifier — so the same
+        control now carries a KEYWORD-led fixture, which is what makes the membership half
+        red. The mapping's other half needs no control: falling back to the head set for an
+        unrecognised word differs only for `for each (` / `if foo (`, and `node` rejects
+        every such shape as a SyntaxError, so that mutation is a noop rather than a vacuity.
     Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
     assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
@@ -1725,8 +1733,17 @@ class TestThePinMatcher:
         """
         divided = 'const a = await (w + h) / 2 + await (i + j) / 3\n'
         assert _declarations(divided) == divided
-        # The control: the MODIFIED head must still admit a regex, so this cannot pass on a
-        # rule that refuses `await` everywhere and reopens the eleventh vacuity.
+        # 🔑 The MAPPING's second half, which the fixture above structurally cannot see: its
+        # token before `await` is `=`, so `_TRAILING_WORD` finds no word and a check weakened
+        # to `keyword is not None` still answers False. Here the preceding word is `return` —
+        # a keyword `await` may follow, but NOT a head that admits it as a modifier — so only
+        # the `in admitted_by` membership test keeps this line dividing. `node` evaluates it
+        # (to 5 for 2, 2, 6, 3), and `await` is already in `_REGEX_MAY_FOLLOW_KEYWORD`, so a
+        # keyword-led awaited group is a shape this module models rather than a contrivance.
+        keyword_led = 'return await (w + h) / 2 + await (i + j) / 3\n'
+        assert _declarations(keyword_led) == keyword_led
+        # The control: the MODIFIED head must still admit a regex, so neither assertion above
+        # can pass on a rule that refuses `await` everywhere and reopens the eleventh vacuity.
         assert _declarations('for await (const c of []) /`/.test(c)\n') == (
             'for await (const c of []) / /.test(c)\n'
         )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -54,7 +54,10 @@ all of it, and an earlier version of this docstring claimed it did:
     its own — an `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ...
     | 'onepager' }` annotation uses the name and still widens, and was measured to
     exit `tsc` 0 with every test here green. `noUnusedLocals` does NOT cover that
-    either, since the name is used.
+    either, since the name is used. Nor does the name APPEARING in the file: the pin
+    block at its foot names the type nine times, so a structurally identical inline
+    literal passed that check with `tsc` at exit 0 — which is why the text guard pins
+    the annotation `data: GenerateDocumentBody` rather than the bare name.
     So a widening has to edit `DocType` itself — the declaration this file parses —
     and `GENERATED_DOC_TYPES` with it. Editing `GenerateDocumentBody.doc_type` is
     not a way around that: the pin above makes it a compiler error.
@@ -80,9 +83,24 @@ has nowhere to migrate to, so the guard, its two method-name markers and their
 ordering assumption all went.
 
 The text assertions that remain pin the PRESENCE of things whose absence is silent
-(the two type-level pins, and that each is still spelled as a comparison rather than
-stubbed to a constant) and the ONE link no compiler can see: `DocType` against a
-Python tuple.
+(the two type-level pins, spelled out in full so neither a stub nor a self-comparing
+alias satisfies them, plus each control's `@ts-expect-error`) and the ONE link no
+compiler can see: `DocType` against a Python tuple.
+
+A DECLARATION RATHER THAN A FRAGMENT is the rule those pins converged on. Requiring
+part of a declaration was defeated three rounds running — by the helper's own
+declaration containing the fragment, and by the fragment saying nothing about the
+operands — so what is pinned is the exact text of each declaration, operands included.
+That is not an enumeration of legal TypeScript, which is the thing this file refuses:
+there is one string per declaration, and any edit to it is either the same declaration
+or a different one. The cost is that these declarations must stay on ONE line.
+
+WHAT IS SELF-CHECKING, and therefore needs no text pin at all: the verdict helpers'
+`extends true`. Each control applies the same helper as its pin and expects to be
+rejected, via `@ts-expect-error`, so dropping the constraint — one edit that would
+otherwise disable a pin and every control at once — makes those directives unused and
+`tsc` reports TS2578. Preferring that to a fifth spelling is the same rule as above:
+a link TypeScript can check gets a compiler check.
 
 A `.test-d.ts`-style type test was considered for that job and REJECTED, so it does
 not get proposed again: `typecheck:tests` is not in the root `check` chain
@@ -126,21 +144,33 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
   * `test_both_client_signatures_use_the_shared_request_body` — a signature
     respelling the body inline again, which is a compiler error in `client.ts` and
     NOTHING in `projectsApi.ts` (see above). Text, not a parse: it asks whether the
-    shared name appears, so it needs no model of TypeScript and cannot mis-read a
-    restyling. A rename of `GenerateDocumentBody` fails it too, which is correct —
-    the constant here is what the two files must agree on.
+    parameter is ANNOTATED with the shared type (`data: GenerateDocumentBody`), so it
+    needs no model of TypeScript and cannot mis-read a restyling. ⚠️ It asked only
+    whether the NAME appeared anywhere in the file until the annotation was pinned,
+    and that was vacuous: the pin block at the foot of `projectsApi.ts` names the type
+    nine times, so a structurally identical inline literal — the exact edit #381
+    removed — passed with `tsc` at exit 0 and every test here green. A rename of
+    `GenerateDocumentBody` fails it too, which is correct — the constant here is what
+    the two files must agree on.
   * `test_the_type_level_pins_are_present` — either type-level pin deleted, STUBBED
-    to a bare constant, or left with only one of its two controls. All are silent
-    otherwise: deleting a pin compiles cleanly, and stubbing both a pin and its
-    control to `= true` / `= false` was measured to exit `tsc` 0 and pass every test
-    here while the guarded field was widened. So the assertion SPELLING is required,
-    and it names the pin's USE of the verdict helper (`MustBeTrue<BothWays<`) — an
-    earlier version required only `MustBeTrue<`, which the helper's OWN declaration
-    contains, so exporting the helpers and stubbing the pins passed every gate.
-    Covers both links: the field-vs-union pin, and the parameter-vs-body pin that
-    replaced the `satisfies` clause and the location guard it needed — see WHY EACH
-    GUARD IS THE KIND IT IS for why a comparison was the answer and a tighter text
-    slice was not.
+    to a bare constant, fed through an alias that compares a type to itself, left with
+    only one of its two controls, or stripped of a control's `@ts-expect-error`. All
+    are silent otherwise, and each was measured to exit `tsc` 0 and pass every test
+    here while the guarded field or parameter was widened. So what is required is each
+    WHOLE DECLARATION, operands included — three successive fragments (the names,
+    `MustBeTrue<`, then `MustBeTrue<BothWays<`) each turned out to be satisfiable
+    without the pin doing anything: the second is in the helper's own declaration, and
+    the third says nothing about what is being compared. Covers both links: the
+    field-vs-union pin, and the parameter-vs-body pin that replaced the `satisfies`
+    clause and the location guard it needed — see WHY EACH GUARD IS THE KIND IT IS for
+    why a comparison was the answer and a tighter text slice was not.
+  * Each control's `@ts-expect-error` — `extends true` dropped from a verdict helper,
+    ONE edit that disables a pin and all its controls at once and was measured to
+    leave `tsc` at exit 0 with every test here green. Because a control asserts its
+    verdict by applying the SAME helper and expecting rejection, losing that
+    constraint turns every directive into a TS2578, so the constraint is
+    self-checking rather than a further thing this file has to spell. `@ts-ignore`
+    cannot be swapped in — `@typescript-eslint/ban-ts-comment` refuses it.
   * The `...WouldSeeNarrowing` controls — `BothWays` collapsed to a one-way
     `extends`, which admits a NARROWED field or parameter: the "capability nobody
     can reach" half of this contract's drift. The widened-side controls cannot see
@@ -172,6 +202,17 @@ DOC_TYPE_UNION_SOURCE = 'frontend/src/api/types.ts'
 # see the docstring: the compiler catches that in one file and not the other.
 REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 
+# 🔑 The ANNOTATION, not just the name. Asserting `REQUEST_BODY_TYPE in source` was
+# measured to be vacuous in `projectsApi.ts`: the type-level pin block at the foot of
+# that file names `GenerateDocumentBody` nine times, so the name is present whatever
+# the signature says. Replacing the parameter with a structurally identical inline
+# object literal (every field spelled out, `doc_type: DocType`) left `tsc` at exit 0
+# — `BothWays` compares structurally, so an identical shape is equal — and every test
+# here green. That is the exact edit issue #381 set out to eliminate, so the guard
+# names the parameter's reference to the type rather than the type's appearance
+# anywhere in the file.
+REQUEST_BODY_ANNOTATION = f'data: {REQUEST_BODY_TYPE}'
+
 # The TERMINAL client — the one whose `data` is only spread into `JSON.stringify`, so
 # its annotation is checked against nothing and naming the body type is not enough on
 # its own (an `Omit<..> & { doc_type: .. | 'x' }` respelling names it and still
@@ -179,13 +220,14 @@ REQUEST_BODY_TYPE = 'GenerateDocumentBody'
 TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
 
 # The two type-level pins that carry every link TypeScript can check, each with the
-# file it is declared in and its non-vacuity control. A pin's own absence is SILENT —
-# delete either block and the frontend still compiles — which is the only reason this
-# file mentions them at all: `test_the_type_level_pins_are_present` keeps them there.
+# file it is declared in. A pin's own absence is SILENT — delete either block and the
+# frontend still compiles — which is the only reason this file mentions them at all:
+# `test_the_type_level_pins_are_present` keeps them there.
 #
-# 🔑 A pin is spelled `<Name> = <Verdict><Comparison<...>>`, and the SPELLINGS BELOW
-# INCLUDE THE COMPARISON, not just the verdict helper. Both halves of that were
-# measured, one review round apart:
+# 🔑 WHOLE DECLARATIONS, not fragments. Three rounds each found the fragment being
+# required was satisfiable without the pin doing anything, so the rule this converged
+# on is: pin the entire right-hand side, because any fragment of it is a substring some
+# other construct can contain.
 #
 #   * Requiring only the NAMES was vacuous. Stub a pin and its control to bare
 #     constants (`export type DocTypeFieldIsExactlyTheUnion = true`), delete the helper
@@ -194,25 +236,54 @@ TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
 #   * Requiring `MustBeTrue<` was ALSO vacuous, for a subtler reason: that substring
 #     occurs in the helper's OWN declaration (`type MustBeTrue<Verdict ...>`), so it is
 #     satisfied by the helper merely existing. The stub only has to keep the helpers
-#     and `export` them — measured, `tsc` exit 0 and every test here green with the
-#     field widened. So the spelling must name the pin's USE of the helper, which
-#     `MustBeTrue<BothWays<` does and a declaration cannot accidentally contain.
+#     and `export` them — measured, `tsc` exit 0 and every test here green.
+#   * Requiring `MustBeTrue<BothWays<` was vacuous a THIRD way, and this is why the
+#     rule is now the whole declaration rather than a longer fragment: the fragment
+#     says nothing about what the comparison's OPERANDS are. Repointing the
+#     intermediate alias the left side was read through (`Parameters<...>[1]` ->
+#     `GenerateDocumentBody`) made the pin compare the interface to itself — still
+#     spelled `SignatureMustMatch<BothWays<`, still with both controls present and
+#     green because they read the same alias, `tsc` exit 0, every test here green, and
+#     a caller able to send a value the route 400s. The alias is now inlined and the
+#     operands are part of what is pinned.
 #
-# This is why the pins in both files are written on ONE line: the substring spans the
-# helper and the comparison, so a wrapped declaration puts a newline between them.
+# This is why every pinned declaration in both files is written on ONE line: what is
+# required is the exact text, so a wrapped declaration puts newlines inside it.
+#
+# The `@ts-expect-error` above each CONTROL is load-bearing, and pinned separately
+# below. A control asserts its comparison must NOT hold by applying the SAME verdict
+# helper as the pin and expecting the error — so if `extends true` is dropped from that
+# helper (which would silently disable the pin and every control at once) the expected
+# errors stop arriving and each directive becomes a TS2578 "unused
+# '@ts-expect-error'". That is what makes the helper's constraint self-checking rather
+# than a fourth thing this file has to spell. `@ts-ignore` cannot be swapped in: it is
+# a lint error under `@typescript-eslint/ban-ts-comment`.
 #
 # Keyed by relative path, since the pins live in two files. Each value is
-# (pin, controls, assertion-spellings) — the controls and spellings are tuples because
-# each pin needs TWO controls (widened and narrowed; see below).
+# (pin-declaration, control-declarations) — the controls are a tuple because each pin
+# needs TWO of them (widened and narrowed; see below). Every entry is the EXACT text of
+# a declaration, matched against the comment-stripped source so a commented-out copy
+# cannot satisfy it.
 TYPE_LEVEL_PINS = {
     # `GenerateDocumentBody.doc_type` admits exactly the members of `DocType`. Nothing
     # else in either language sees this field: this file parses only the
     # `export type DocType =` declaration, and the signature pin below compares
     # against the interface, so a widened interface satisfies it by construction.
     DOC_TYPE_UNION_SOURCE: (
-        'DocTypeFieldIsExactlyTheUnion',
-        ('DocTypeFieldPinWouldSeeDrift', 'DocTypeFieldPinWouldSeeNarrowing'),
-        ('MustBeTrue<BothWays<', 'MustBeFalse<BothWays<'),
+        (
+            "export type DocTypeFieldIsExactlyTheUnion = "
+            "MustBeTrue<BothWays<GenerateDocumentBody['doc_type'], DocType>>"
+        ),
+        (
+            (
+                "export type DocTypeFieldPinWouldSeeDrift = MustBeTrue<BothWays<"
+                "GenerateDocumentBody['doc_type'] | 'not-a-doc-type', DocType>>"
+            ),
+            (
+                'export type DocTypeFieldPinWouldSeeNarrowing = '
+                'MustBeTrue<BothWays<never, DocType>>'
+            ),
+        ),
     ),
     # `generateDocument`'s parameter admits exactly `GenerateDocumentBody`. This is the
     # one that replaced a `satisfies` clause in the method body plus the text guard
@@ -221,14 +292,29 @@ TYPE_LEVEL_PINS = {
     # searched, and both slices tried were measured to be evadable. A comparison
     # against the method's own type has nowhere to migrate to.
     TERMINAL_CLIENT: (
-        'GenerateDocumentTakesTheSharedBody',
         (
-            'GenerateDocumentSignaturePinWouldSeeDrift',
-            'GenerateDocumentSignaturePinWouldSeeNarrowing',
+            'export type GenerateDocumentTakesTheSharedBody = '
+            'SignatureMustMatch<BothWays<Parameters<typeof '
+            'projectsApi.generateDocument>[1], GenerateDocumentBody>>'
         ),
-        ('SignatureMustMatch<BothWays<', 'SignatureMustDiffer<BothWays<'),
+        (
+            (
+                'export type GenerateDocumentSignaturePinWouldSeeDrift = '
+                'SignatureMustMatch<BothWays<Parameters<typeof '
+                'projectsApi.generateDocument>[1], GenerateDocumentBody & '
+                '{ not_in_the_body: true }>>'
+            ),
+            (
+                'export type GenerateDocumentSignaturePinWouldSeeNarrowing = '
+                'SignatureMustMatch<BothWays<never, GenerateDocumentBody>>'
+            ),
+        ),
     ),
 }
+
+# The directive each control must carry, on the line immediately above it. Checked
+# against the RAW source, since `_without_comments` blanks exactly this.
+EXPECT_ERROR_DIRECTIVE = '@ts-expect-error'
 
 # Both clients, the terminal one included rather than respelled — a second copy of
 # that path here is the same duplication this whole issue was about.
@@ -726,16 +812,26 @@ class TestDocTypeLockstep:
         shared type at all — no method location, no parameter-list extent, no model
         of TypeScript, so none of the ways the scanner mis-read legal code apply.
 
-        LIMIT, stated precisely because an earlier version of this docstring
-        overstated it: this test cannot tell WHERE the name is used, so a signature
-        that names `GenerateDocumentBody` and widens `doc_type` anyway passes HERE.
-        That residue is not closed by `noUnusedLocals` — an earlier claim that it was
-        is false, and was measured to be: an
-        `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
-        annotation USES the imported name, so no unused-local fires and `tsc` exits
-        0. What closes it is `GenerateDocumentTakesTheSharedBody`, a type-level
+        THE ANNOTATION, not merely the name — because the name alone was measured to
+        be vacuous here. An earlier version asserted `GenerateDocumentBody in source`,
+        which in `projectsApi.ts` is satisfied by the type-level pin block at the foot
+        of that file (it names the type nine times) whatever the signature says.
+        Replacing the parameter with a structurally identical inline object literal
+        left `tsc` at exit 0 — `BothWays` compares structurally, so an identical shape
+        is equal — and every test here green, i.e. the precise edit this file's own
+        issue set out to eliminate passed the guard named as forbidding it. Pinning
+        `data: GenerateDocumentBody` is the signature's REFERENCE to the shared type,
+        and there is one spelling of it, so this does not start an enumeration.
+
+        LIMIT: this cannot tell whether the referenced type is the right shape, only
+        that the parameter takes it by name. A signature that names the type and
+        widens `doc_type` in the SAME annotation
+        (`Omit<GenerateDocumentBody, 'doc_type'> & { ... }`) does not match this
+        string, but a widening that keeps the exact `data: GenerateDocumentBody`
+        prefix would; `noUnusedLocals` does not cover that either, since the name is
+        used. What closes it is `GenerateDocumentTakesTheSharedBody`, a type-level
         comparison of that method's parameter against the interface, which makes any
-        widening of it a TS2344 — whatever the spelling.
+        widening a TS2344 whatever the spelling.
         `test_the_type_level_pins_are_present` is what keeps it there, since deleting
         it is silent otherwise.
         """
@@ -748,13 +844,17 @@ class TestDocTypeLockstep:
                 f'moved, point GENERATE_DOCUMENT_CLIENTS at its new home; if this '
                 f'client dropped it, drop the entry.'
             )
-            assert REQUEST_BODY_TYPE in source, (
-                f'{relative} does not name {REQUEST_BODY_TYPE}, so its '
-                f'generateDocument body is spelled inline. In projectsApi.ts nothing '
-                f'checks such an annotation — the request goes out with whatever it '
-                f'admits and the route 400s it. Take {REQUEST_BODY_TYPE} (declared '
-                f'in {DOC_TYPE_UNION_SOURCE}) instead, and widen the contract there '
-                f'if that is what is wanted.'
+            assert REQUEST_BODY_ANNOTATION in source, (
+                f'{relative} does not spell `{REQUEST_BODY_ANNOTATION}`, so its '
+                f'generateDocument body is not taken from the shared type — most '
+                f'likely restated as an inline object literal. In projectsApi.ts '
+                f'nothing else catches that: the name appearing SOMEWHERE in the file '
+                f'is satisfied by the pin block at its foot, and a structurally '
+                f'identical literal compares equal, so the request goes out with '
+                f'whatever the literal admits and the route 400s it. Take '
+                f'{REQUEST_BODY_TYPE} (declared in {DOC_TYPE_UNION_SOURCE}) as the '
+                f'parameter type, and widen the contract there if that is what is '
+                f'wanted.'
             )
 
     @pytest.mark.skipif(
@@ -780,16 +880,25 @@ class TestDocTypeLockstep:
             respelling USES the shared name, so neither `noUnusedLocals` nor the name
             assertion above sees it.
 
-        Text, not a parse — but text with two lessons in it, one per review round.
-        Asserting the pin NAMES alone was measured to be vacuous: stub both a pin and
-        its control to bare constants (`= true` / `= false`), delete the helper types
-        so no unused-local fires, and `tsc` exits 0 with every test here green while
-        the guarded field is widened. Requiring `MustBeTrue<` did not fix it, because
-        that substring is in the HELPER'S OWN DECLARATION — so the stub just keeps the
-        helpers and exports them, and every gate is green again. The spelling required
-        is therefore the pin's USE of the helper (`MustBeTrue<BothWays<`). That the
-        comparisons BITE is the compiler's job; this test says only that a real
-        comparison is spelled.
+        Text, not a parse — but text with three lessons in it, one per review round,
+        which is why what it requires is now each WHOLE DECLARATION rather than a
+        fragment of one. Each fragment tried was satisfiable while the pin did nothing:
+
+          * The pin NAMES alone. Stub both a pin and its control to bare constants
+            (`= true` / `= false`), delete the helper types so no unused-local fires,
+            and `tsc` exits 0 with every test here green while the guarded field is
+            widened.
+          * `MustBeTrue<`. That substring is in the HELPER'S OWN DECLARATION, so the
+            stub just keeps the helpers and exports them — every gate green again.
+          * `MustBeTrue<BothWays<`. Says nothing about the comparison's OPERANDS:
+            repointing the alias the left side was read through at the interface made
+            the pin compare that interface to itself, trivially equal forever, with the
+            fragment still present and both controls still green because they read the
+            same alias. `tsc` exit 0, every test here green, and a caller able to send
+            a value the route 400s.
+
+        So the operands are part of what is pinned, and the alias is gone. That the
+        comparisons BITE is still the compiler's job; this says a real one is spelled.
 
         TWO controls per pin, both required. `MustBeTrue<BothWays<...>>` is satisfied
         by a `BothWays` that degenerates to `true`, and by one collapsed to its
@@ -799,36 +908,57 @@ class TestDocTypeLockstep:
         `BothWays` to `[Left] extends [Right]` left `tsc` at exit 0 with every test
         here green. The narrowed-side controls (`...WouldSeeNarrowing`) are what
         refuse that, using `never` as the left side.
+
+        AND each control's `@ts-expect-error`, which is what makes the verdict helper's
+        `extends true` self-checking. A control applies the same helper as the pin and
+        expects to be rejected, so dropping that constraint — one edit that disables
+        the pin and all four controls at once, measured to leave `tsc` at exit 0 with
+        every test here green — turns each directive into a TS2578. Without the
+        directive pinned, that edit could be paired with deleting the directives and
+        nothing would notice.
         """
-        pin, controls, assertions = TYPE_LEVEL_PINS[relative]
+        pin, controls = TYPE_LEVEL_PINS[relative]
         path = _repo_root() / relative
         assert path.is_file(), f'{relative} moved — update TYPE_LEVEL_PINS'
-        source = _without_comments(path.read_text(encoding='utf-8'))
+        raw = path.read_text(encoding='utf-8')
+        # Comment-stripped for the declarations, so a commented-out copy cannot satisfy
+        # them; raw for the directives, which are themselves comments.
+        source = _without_comments(raw)
         assert pin in source, (
-            f'{relative} no longer declares `{pin}`. That is the only check on its '
-            f'half of this contract — nothing else in either language covers it (see '
-            f'this test\'s docstring), so without it the doc_type it guards can be '
-            f'widened past the route\'s allowlist with tsc, eslint and this whole '
-            f'file green. Restore it, or widen DocType and GENERATED_DOC_TYPES '
+            f'{relative} no longer declares, exactly:\n'
+            f'    {pin}\n'
+            f'That is the only check on its half of this contract — nothing else in '
+            f'either language covers it (see this test\'s docstring), so without it '
+            f'the doc_type it guards can be widened past the route\'s allowlist with '
+            f'tsc, eslint and this whole file green. The OPERANDS are part of what is '
+            f'pinned: reading the left side through an alias was measured to let the '
+            f'pin compare a type to itself while every gate stayed green. Keep it on '
+            f'ONE line. Restore it, or widen DocType and GENERATED_DOC_TYPES '
             f'together, which is the supported way to change the contract.'
         )
         for control in controls:
             assert control in source, (
-                f'{relative} declares `{pin}` but not its control `{control}`. The '
-                f'pin is satisfied both by a comparison that degenerates to `true` '
+                f'{relative} declares its pin but not this control, exactly:\n'
+                f'    {control}\n'
+                f'The pin is satisfied both by a comparison that degenerates to `true` '
                 f'and by one collapsed to a one-way `extends`, each of which passes '
                 f'while measuring less than it claims; the controls are what refuse '
                 f'those, the same way TestContractDriftIsCaught does for the parser '
                 f'here. A widened-side control cannot detect the one-way collapse, '
                 f'so the narrowed-side one is not redundant.'
             )
-        for assertion in assertions:
-            assert assertion in source, (
-                f'{relative} does not spell `{assertion}`, so a pin or a control is '
-                f'no longer applied to a comparison. A bare `= true` satisfies a '
-                f'name check while comparing nothing, and naming the helper alone is '
-                f'satisfied by the helper\'s own declaration — both were measured to '
-                f'pass every gate with the guarded field widened. Note these pins are '
-                f'written on ONE line deliberately: wrapping the declaration puts a '
-                f'newline inside this substring.'
+            # The line immediately above the control, in the RAW source — the
+            # declarations are pinned against the stripped source, but a directive IS a
+            # comment, so it only exists here.
+            preceding = raw[:raw.find(control)].rstrip().rsplit('\n', 1)[-1]
+            assert EXPECT_ERROR_DIRECTIVE in preceding, (
+                f'{relative} declares the control\n'
+                f'    {control}\n'
+                f'but the line above it is not a `{EXPECT_ERROR_DIRECTIVE}`. That '
+                f'directive is what asserts the control\'s comparison FAILS, and it is '
+                f'also what makes the verdict helper\'s `extends true` self-checking: '
+                f'drop that constraint — one edit that disables the pin and every '
+                f'control at once, measured to leave tsc at exit 0 with every test '
+                f'here green — and each directive becomes an unused-directive error '
+                f'instead. Found instead: {preceding.strip()!r}'
             )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -33,14 +33,22 @@ all of it, and an earlier version of this docstring claimed it did:
     references the union by name.
   * The two `generateDocument` signatures -> `GenerateDocumentBody`: the compiler
     for `client.ts`, which forwards its `data` into `projectsApi.generateDocument`
-    and so gets a TS2345 if it widens; NOTHING for `projectsApi.generateDocument`,
-    which is the terminal consumer — its `data` is only spread into
-    `JSON.stringify`, so an inline object literal in that one signature type-checks
-    however wide it is. That is why the body is a NAMED type and why
-    `test_both_client_signatures_use_the_shared_request_body` asserts by text that
-    both signatures still name it. A widening now has to edit
-    `GenerateDocumentBody` itself, where the field is `DocType` and this file's
-    comparison sees it.
+    and so gets a TS2345 if it widens. `projectsApi.generateDocument` is the
+    TERMINAL consumer — its `data` is only spread into `JSON.stringify`, so its
+    annotation is compared against nothing and by itself type-checks however wide it
+    is. Two things cover that one, and it took both:
+      - The body is a NAMED type, asserted by text in
+        `test_both_client_signatures_use_the_shared_request_body`. This stops the
+        plain inline respelling.
+      - `satisfies GenerateDocumentBody` on the object that method builds, pinned by
+        `test_the_terminal_client_pins_the_body_structurally`. NAMING the type is
+        not sufficient on its own: an
+        `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
+        annotation uses the name and still widens, and was measured to exit `tsc` 0
+        with every test here green. `noUnusedLocals` does NOT cover that — the name
+        is used — and an earlier version of this docstring wrongly said it did.
+    So a widening has to edit `GenerateDocumentBody` itself, where the field is
+    `DocType` and this file's comparison sees it.
 
 A LITERAL UNION IS THE REQUIRED SHAPE for `DocType`. A derivation
 (`typeof GENERATED_DOC_TYPES[number]`, as `KIRO_EXPORTABLE_DOC_TYPES` uses one
@@ -78,6 +86,11 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     shared name appears, so it needs no model of TypeScript and cannot mis-read a
     restyling. A rename of `GenerateDocumentBody` fails it too, which is correct —
     the constant here is what the two files must agree on.
+  * `test_the_terminal_client_pins_the_body_structurally` — the `satisfies` clause
+    deleted from `projectsApi.generateDocument`. That deletion compiles cleanly and
+    is caught by nothing else, and without the clause an intersection/`Omit`
+    annotation widens `doc_type` while still naming the shared type, so the test
+    above stays green too.
   * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
     union is edited, and its opposite, one that reports drift for a comment.
   * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
@@ -103,8 +116,21 @@ DOC_TYPE_UNION_SOURCE = 'frontend/src/api/types.ts'
 # in one and an inline object literal in the other is the shape this pins against —
 # see the docstring: the compiler catches that in one file and not the other.
 REQUEST_BODY_TYPE = 'GenerateDocumentBody'
+
+# The TERMINAL client — the one whose `data` is only spread into `JSON.stringify`,
+# so its annotation is checked against nothing and naming the body type is not
+# enough on its own (an `Omit<..> & { doc_type: .. | 'x' }` respelling names it and
+# still widens). The `satisfies` clause in it is what turns that into a compiler
+# error, and `test_the_terminal_client_pins_the_body_structurally` pins the clause:
+# removing it is invisible otherwise, since everything still type-checks and this
+# file's other assertions stay green.
+TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
+STRUCTURAL_PIN = f'satisfies {REQUEST_BODY_TYPE}'
+
+# Both clients, the terminal one included rather than respelled — a second copy of
+# that path here is the same duplication this whole issue was about.
 GENERATE_DOCUMENT_CLIENTS = (
-    'frontend/src/api/projectsApi.ts',
+    TERMINAL_CLIENT,
     'frontend/src/api/client.ts',
 )
 
@@ -423,7 +449,7 @@ class TestTheUnionParser:
         )
 
 
-def _rendered_union(members, comment: str = '') -> str:
+def _rendered_union(members: tuple[str, ...], comment: str = '') -> str:
     """`export type DocType = ...` over `members`.
 
     With a `comment`, one member per line and the comment after the FIRST — the
@@ -478,11 +504,20 @@ class TestContractDriftIsCaught:
 
         accepted = tuple(GENERATED_DOC_TYPES)
         extra = _member_the_route_refuses(frozenset(accepted))
-        if kind != 'member_added' and len(accepted) < 2:
-            # Removing from a one-member allowlist leaves no union at all, which the
-            # parser REFUSES rather than returning a set to compare — a different
-            # test than this one. Skipped rather than silently reinterpreted.
-            pytest.skip('the route accepts one value; there is nothing to drop')
+        if kind == 'member_removed' and len(accepted) < 2:
+            # REMOVAL only. Dropping the last member leaves `export type DocType =`
+            # with no union at all, which the parser REFUSES rather than returning a
+            # set to compare — a different test than this one. Skipped rather than
+            # silently reinterpreted.
+            #
+            # `member_replaced` is deliberately NOT skipped here: on a one-member
+            # allowlist `(*accepted[:-1], extra)` is `(extra,)`, a valid
+            # single-member union the parser reads cleanly and which compares
+            # unequal, so the control still works. Widening the skip to cover it
+            # would drop a working control the moment the contract narrowed to one
+            # value — a green result meaning "did not check", which is the failure
+            # this class exists to prevent.
+            pytest.skip('the route accepts one value; removal leaves no union to parse')
         mutations = {
             'member_added': (*accepted, extra),
             'member_removed': accepted[:-1],
@@ -581,10 +616,20 @@ class TestDocTypeLockstep:
 
         Deliberately TEXT and not a parse. It asks whether each file mentions the
         shared type at all — no method location, no parameter-list extent, no model
-        of TypeScript, so none of the ways the scanner mis-read legal code apply. It
-        cannot tell WHERE the name is used, which is the trade: `GenerateDocumentBody`
-        imported but the signature widened anyway would pass here. `noUnusedLocals`
-        makes that combination a compiler error, so the two together close it.
+        of TypeScript, so none of the ways the scanner mis-read legal code apply.
+
+        LIMIT, stated precisely because an earlier version of this docstring
+        overstated it: this test cannot tell WHERE the name is used, so a signature
+        that names `GenerateDocumentBody` and widens `doc_type` anyway passes HERE.
+        That residue is not closed by `noUnusedLocals` — an earlier claim that it was
+        is false, and was measured to be: an
+        `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
+        annotation USES the imported name, so no unused-local fires and `tsc` exits
+        0. What closes it is the `satisfies GenerateDocumentBody` clause on the body
+        construction in `projectsApi.generateDocument`, which makes any widening of
+        that parameter a TS1360 at the point the object is built.
+        `test_the_terminal_client_pins_the_body_structurally` is what keeps that
+        clause present, since deleting it is silent otherwise.
         """
         for relative in GENERATE_DOCUMENT_CLIENTS:
             path = _repo_root() / relative
@@ -603,3 +648,36 @@ class TestDocTypeLockstep:
                 f'in {DOC_TYPE_UNION_SOURCE}) instead, and widen the contract there '
                 f'if that is what is wanted.'
             )
+
+    @pytest.mark.skipif(
+        not _frontend_tree_present(), reason='frontend tree absent from this checkout'
+    )
+    def test_the_terminal_client_pins_the_body_structurally(self):
+        """The `satisfies` clause is what actually closes the widening axis.
+
+        Naming `GenerateDocumentBody` (asserted above) is necessary but not
+        sufficient: measured, an
+        `Omit<GenerateDocumentBody, 'doc_type'> & { doc_type: ... | 'onepager' }`
+        annotation on this one method keeps the name in use, so `noUnusedLocals`
+        stays quiet, `tsc -p tsconfig.app.json --noEmit` exits 0 and the request goes
+        out with a value the route 400s. `satisfies GenerateDocumentBody` on the
+        object this method builds makes exactly that a TS1360.
+
+        Pinned by text here because its ABSENCE is silent — remove the clause and the
+        frontend still compiles, so no other gate in either language notices. This
+        asserts only that the clause is spelled; that it BITES is the compiler's job,
+        and `tsconfig.app.json` needs no flag for it (`satisfies` is not optional
+        behaviour).
+        """
+        path = _repo_root() / TERMINAL_CLIENT
+        assert path.is_file(), f'{TERMINAL_CLIENT} moved — update TERMINAL_CLIENT'
+        source = _without_comments(path.read_text(encoding='utf-8'))
+        assert STRUCTURAL_PIN in source, (
+            f'{TERMINAL_CLIENT} no longer spells `{STRUCTURAL_PIN}`. That clause is '
+            f'the only thing making a widened doc_type a compiler error in this '
+            f'file: its `data` is just spread into JSON.stringify, so the parameter '
+            f'annotation is compared against nothing and even one that NAMES '
+            f'{REQUEST_BODY_TYPE} can widen the field past what the route accepts. '
+            f'Restore it, or widen the contract in {DOC_TYPE_UNION_SOURCE} where '
+            f'this file can see it.'
+        )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -30,14 +30,15 @@ WHAT THIS FILE COSTS, stated plainly because a previous version of this heading 
 
     944 lines   on `development`, the scanner version
     455 lines   after the scanner was deleted
-  ~1030 lines   now
+  ~1080 lines   now
 
 So it is LONGER than the scanner it replaced, and the claim that it was short was
-false for two review rounds. What the growth is, in the current file: ~60% is prose
-(this docstring, ~190 lines; test docstrings, ~235; comments, ~190) and the rest is
-two type-level pins with two non-vacuity controls each, the text assertions that keep
-those present, and `_without_comments` plus `_doc_type_union` with their shape
-fixtures.
+false for two review rounds. What the growth is: ~60% of the file is PROSE (this
+docstring ~230 lines, test docstrings ~245, comments ~190). The ~415 lines of code are
+`_without_comments` and `_doc_type_union` with their shape fixtures, plus the text
+assertions keeping two type-level pins and their four controls present. If these
+counts and the file disagree, the file is right and this block is stale — recompute
+rather than trusting it.
 
 Whether that is proportionate is a fair question and was asked in review. The honest
 answer: the PINS are cheap and they are what bite — every widening mutation tried is

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -92,6 +92,17 @@ exact text decides WHAT. The compiler backstops one shape of this (a pin repoint
 field that does not exist is a TS2339) but not the operand swap, since one arbitrary
 non-member is as good as another to `BothWays` and the control goes on working.
 
+And its THIRD corollary, from a seventh defeat: asking where a string may come from is
+only answered if the answer knows where a string ENDS. `${...}` inside a template
+literal is code again, so a scan that ran to the next backtick had the inner template's
+opening backtick close the OUTER one — and a decoy in a nested template was in the
+blanked view as if it were real source. That one bug reopened every text guard here at
+once: the field pin could be DELETED with a copy in such a decoy and the field widened
+(`tsc` exit 0, eslint clean, all tests green, and NO compiler backstop for that pin);
+the union parser read the decoy's members instead of the live union's; the ratio was
+satisfied by a decoy alone. Fixed in `_without_comments` with a frame stack, which is
+the one mechanism all four guards share, rather than in any of them.
+
 THE GUARDS' OWN FIXES ARE PINNED TOO, which took its own finding. The two repairs made
 in the fifth round shipped with no test, and reverting either left all 30 tests here
 green — a green result meaning "did not check", applied to the machinery this file uses
@@ -175,6 +186,14 @@ OFFERED by the UI — dead capability rather than wrong content. Also symbol-anc
     the two `toggleDocType('...')` buttons      — in `renderFinalStep`
     `bothSelected`, `singleTitle`,              — copy and layout, all written as
       `singleSubmitLabel`                         a PRD-or-PR-FAQ binary
+    `onSuggestBrief`'s `doc_type` ternary       — the same binary against a DIFFERENT
+      (`...includes('prd') ? 'prd' : 'prfaq'`)    route: a third member selected alone
+                                                  asks `suggest-brief` for a PR-FAQ
+                                                  brief, so the AI-drafted title and
+                                                  description come back framed as one.
+                                                  The only place the picker's set meets
+                                                  `suggestDocumentBrief`'s, which is
+                                                  deliberately unbound (see above)
 
 Measured the same way: the two blessed edits alone leave `tsc -p tsconfig.app.json
 --noEmit` at exit 0 and every test here green, with the picker still rendering exactly
@@ -182,13 +201,28 @@ two buttons — `tsc` is fine with a NARROWER argument to `includes`/`filter`, s
 in that file has to change for it to compile. `Wizards.tsx` documents this direction
 from its own side, beside the literals; the two statements should stay consistent.
 
-Deliberately NOT guarded here, either of them. Those are different contracts — the
-generator's dispatch and the picker's offering, each against the route's allowlist —
-and each wants its own test next to the code it constrains rather than a second and
-third responsibility bolted onto this file. What is fixed is the RECIPE: the ceilings
-are stated, so a widener reads them instead of discovering one from a mislabelled
-document and the other from a button that never appears. Same reasoning as
-`suggestDocumentBrief` above: name the boundary, do not grow the guard across it.
+THE FIFTH EDIT: the wire type the generator writes. `ProjectDocument.document_type` in
+`frontend/src/api/types.ts` restates the doc types as LITERALS and is a SUPERSET of
+`DocType` — it also carries `research`, `custom`, `product_report` and `prototype`, which
+this route never accepts. The generator persists that field straight from `doc_type`, so
+a widened `DocType` produces rows the wire type does not admit: latent rather than
+absent, since `tsc` is clean until something assigns a `DocType` into the field, and a
+probe that makes the two meet is a TS2322 (measured).
+
+Referencing `DocType` there would remove the edit, and was tried — it is NOT available.
+`test_kiro_exportable_types_lockstep.py` parses that union as string literals to derive
+the full document-type set, and a referenced type makes it read zero members; it fails
+loudly, but it fails. That parser answers a different contract (Kiro export inclusion),
+so the ceiling is named at the field instead, beside the literals.
+
+Deliberately NOT guarded here, any of the three. Those are different contracts — the
+generator's dispatch, the picker's offering, and the wire type's superset, each against
+the route's allowlist — and each wants its own test next to the code it constrains rather
+than three further responsibilities bolted onto this file. What is fixed is the RECIPE:
+the ceilings are stated, so a widener reads them instead of discovering one from a
+mislabelled document, one from a button that never appears, and one from a type error in
+whatever code first makes the two unions meet. Same reasoning as `suggestDocumentBrief`
+above: name the boundary, do not grow the guard across it.
 
 WHY EACH GUARD IS THE KIND IT IS. The rule this file has converged on over several
 rounds, each of which found the same hole one level further in: a link TypeScript can
@@ -289,6 +323,12 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     `` const historical = `export type DocType = 'prd' | 'legacy'` `` above the live
     union returned the DECOY's members, so the equality test compared the wrong set.
     Same silent failure as the commented-out predecessor, one quote character away.
+  * `test_a_union_inside_a_nested_template_is_not_read_as_the_declaration` — the same,
+    one interpolation deeper, which is the SEVENTH vacuity: `${` re-enters code, so a
+    scan running to the next backtick let the inner template's backtick close the outer
+    one and the decoy became code again. Red when `_without_comments`'s frame stack is
+    reverted to a single quote character, as are the three nested-template cases in
+    `TestThePinMatcher` — one bug, four guards, so all four are pinned.
   * `TestThePinMatcher` — the pin MATCHER itself degenerating, which is what every
     round's finding about these guards has actually been. Each case is one revert of a
     repair that shipped untested and was therefore silently revertible:
@@ -302,7 +342,12 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
         and lets `'not-a-doc-type'` become any other fourteen characters;
       - stopping at the FIRST candidate offset, which a decoy above the live
         declaration occupies — a false FAILURE rather than a false pass, and the reason
-        the search continues.
+        the search continues;
+      - scanning a template body to the next backtick, so a decoy in a NESTED template
+        (`` `${`...`}` ``) was code again and could supply a pin that was DELETED, feed
+        the union parser its own members, and satisfy both sides of the ratio alone.
+        Three cases cover it here plus one in `TestTheUnionParser`, because the bug was
+        in `_without_comments` and therefore in every guard that reads it.
     Each was measured against the live tree, `tsc` at exit 0 in every case. Positive
     assertions sit beside the negative ones so none can pass by rejecting everything.
   * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
@@ -649,16 +694,42 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
     characters is not a place a pin can match. What the pin says is then read from the
     raw text at that offset: blanking cannot tell two same-length literals apart, so it
     answers where a declaration is and never what it declares.
+
+    🔑 A template body is NOT opaque to its closing backtick, and scanning as if it
+    were was the seventh measured vacuity — a bug in this one function that reopened
+    every text guard in the file. `${...}` is CODE again, so the first backtick inside
+    an interpolation CLOSED the outer template under a single-quote-character scan and
+    everything after it was code once more. A decoy in a NESTED template was therefore
+    in the blanked view exactly as if it were real source. Measured on the tree that
+    shipped it, with `sonarjs/no-nested-template-literals` suppressed on one line
+    (legal, and lint-clean): `DocTypeFieldIsExactlyTheUnion` deleted outright, a copy
+    left in a nested template, and the field it guards widened left `tsc` at exit 0,
+    eslint clean, and every test here green — and that pin has NO compiler backstop,
+    since nothing else in either language compares the field to the union. The same
+    decoy also fed `_doc_type_union` the decoy's members instead of the live union's,
+    and supplied both sides of `_generate_document_ratio` on its own.
+
+    So the state is a STACK of frames rather than one quote character: inside a
+    template, `${` pushes an interpolation frame; inside that frame braces track depth
+    and the depth-0 `}` pops back into the template, with code rules (comments, new
+    strings) applying in between. `TestThePinMatcher` and `TestTheUnionParser` pin all
+    four consequences, since the previous round's finding was that repairs to these
+    helpers ship silently revertible.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
 
     out: list[str] = []
-    quote = None
+    # A STACK, not a single quote character, because `${...}` inside a template
+    # literal is CODE again — see the 🔑 note above on the seventh vacuity. Frames are
+    # `('str', quote_char)` for a string or template body and `('interp', depth)` for
+    # an interpolation, whose brace depth says which `}` closes it.
+    frames: list[tuple[str, object]] = []
     index = 0
     while index < len(source):
         char = source[index]
-        if quote is not None:
+        if frames and frames[-1][0] == 'str':
+            quote = frames[-1][1]
             if char == '\\':
                 # Blank the escape as a unit, so a trailing `\` cannot swallow the
                 # closing quote and blank the rest of the file.
@@ -666,17 +737,33 @@ def _without_comments(source: str, blank_strings: bool = False) -> str:
                            else source[index:index + 2])
                 index += 2
                 continue
+            if quote == '`' and source.startswith('${', index):
+                frames.append(('interp', 0))
+                out.append(blanked('${') if blank_strings else '${')
+                index += 2
+                continue
             if char == quote:
                 out.append(char)
-                quote = None
+                frames.pop()
                 index += 1
                 continue
             out.append(blanked(char) if blank_strings else char)
             index += 1
             continue
         if char in '\'"`':
-            quote = char
+            frames.append(('str', char))
             out.append(char)
+            index += 1
+            continue
+        if frames and frames[-1][0] == 'interp' and char in '{}':
+            depth = frames[-1][1]
+            assert isinstance(depth, int)
+            if char == '}' and depth == 0:
+                # Back into the enclosing template body.
+                frames.pop()
+            else:
+                frames[-1] = ('interp', depth + (1 if char == '{' else -1))
+            out.append(blanked(char) if blank_strings else char)
             index += 1
             continue
         if source.startswith('//', index):
@@ -1014,6 +1101,21 @@ class TestTheUnionParser:
         )
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq'})
 
+    def test_a_union_inside_a_nested_template_is_not_read_as_the_declaration(self):
+        """The same, one interpolation deeper — the seventh vacuity.
+
+        `${` re-enters code, so under a scan that ran to the next backtick the inner
+        template's opening backtick closed the outer one and the decoy became code. The
+        union read was then the DECOY's, so a live union that had DRIFTED compared equal
+        to the route and reported no drift. The live union here carries the extra member
+        deliberately: this must read `onepager`, not agree with a stale copy.
+        """
+        source = (
+            "const historical = `kept: ${`export type DocType = 'prd' | 'legacy'`}`\n"
+            "export type DocType = 'prd' | 'prfaq' | 'onepager'\n"
+        )
+        assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
+
     # The refusals `_doc_type_union` must carry: no readable term at the anchor, a
     # matched non-literal, an unread term after the match.
     EXPECTED_REFUSALS = 3
@@ -1097,6 +1199,53 @@ class TestThePinMatcher:
         # The control: the same text as real code must still be found, or this would
         # pass by matching nothing.
         assert _pinned(self.PIN, f'{self.PIN}\n')
+
+    # 🔑 A NESTED template literal — the seventh vacuity. `${` re-enters code, so the
+    # backtick that opens the inner template used to CLOSE the outer one, and everything
+    # after it was code again: this decoy sat in the blanked view as if it were real
+    # source. Every case below is red when `_without_comments`'s frame stack is reverted
+    # to a single quote character.
+    NESTED_DECOY_OPEN = 'export const historical = `kept: ${`\n'
+    NESTED_DECOY_CLOSE = '`}`\n'
+
+    def test_a_declaration_inside_a_nested_template_literal_is_not_pinned(self):
+        """The seventh vacuity, and the one with no compiler backstop.
+
+        Measured on the tree that shipped it: the real pin DELETED, a copy left in a
+        nested template literal (one `// eslint-disable-next-line
+        sonarjs/no-nested-template-literals` away from lint-clean), and the field it
+        guards widened — `tsc` exit 0, eslint clean, every test here green. Unlike the
+        inline-literal cases the parameter pin backstops, nothing else in either language
+        compares `GenerateDocumentBody.doc_type` to `DocType`, so this one was the whole
+        guard.
+        """
+        decoy = f'{self.NESTED_DECOY_OPEN}{self.PIN}\n{self.NESTED_DECOY_CLOSE}'
+        assert not _pinned(self.PIN, decoy)
+        # The control, as everywhere here: real code must still be found.
+        assert _pinned(self.PIN, f'{self.PIN}\n')
+
+    def test_a_directive_inside_a_nested_template_literal_is_not_the_live_one(self):
+        """The same decoy against the `@ts-expect-error` lookup: it carried both the
+        control's text and a directive above it, so the live control could have neither.
+        """
+        decoy = (
+            f'{self.NESTED_DECOY_OPEN}// {EXPECT_ERROR_DIRECTIVE} historical\n'
+            f'{self.PIN}\n{self.NESTED_DECOY_CLOSE}'
+        )
+        assert not _carries_expect_error(self.PIN, f'{decoy}{self.PIN}\n')
+        assert _carries_expect_error(
+            self.PIN, f'{decoy}// {EXPECT_ERROR_DIRECTIVE} live\n{self.PIN}\n'
+        )
+
+    def test_blanking_preserves_length_through_a_nested_template(self):
+        """The frame stack must not change how much it emits: every offset this module
+        computes is found in the blanked view and read back from the raw text, so a
+        length change would silently misread the pin at that offset rather than fail."""
+        source = (
+            f'{self.NESTED_DECOY_OPEN}{self.PIN}\n{self.NESTED_DECOY_CLOSE}{self.PIN}\n'
+        )
+        assert len(_declarations(source)) == len(source)
+        assert len(_without_comments(source)) == len(source)
 
     def test_a_declaration_inside_a_comment_is_not_pinned(self):
         """The same for a commented-out copy, which is the shape a maintainer actually
@@ -1186,6 +1335,18 @@ class TestThePinMatcher:
         assert _generate_document_ratio(decoy) == (0, 0)
         # The control: the same text as real code must still be counted on both sides,
         # or this would pass by counting nothing at all.
+        assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
+
+    def test_a_signature_inside_a_nested_template_literal_is_not_counted(self):
+        """The ratio's version of the seventh vacuity: paired with the respelled colon
+        below, the real method vanished from the left side while this decoy supplied one
+        of each, so the ratio held with `tsc` exit 0, eslint clean and every test green.
+        """
+        decoy = (
+            f'{self.NESTED_DECOY_OPEN}  {GENERATE_DOCUMENT_SIGNATURE}\n'
+            f'{self.NESTED_DECOY_CLOSE}'
+        )
+        assert _generate_document_ratio(decoy) == (0, 0)
         assert _generate_document_ratio(f'  {GENERATE_DOCUMENT_SIGNATURE}\n') == (1, 1)
 
     def test_a_respelled_colon_is_not_counted_as_a_declaration(self):

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -38,9 +38,11 @@ all of it, and an earlier version of this docstring claimed it did:
     against this interface, so a widened one satisfies it by construction.
     ⚠️ What that pin checks is SET EQUALITY, not reference: the field must admit
     exactly `DocType`'s members, and a same-member respelling (`'prd' | 'prfaq'`,
-    no reference at all) PASSES it. Measured — an earlier version of this file
-    claimed the opposite in four places. Equality is the sufficient property: the
-    coincidence is harmless today and becomes a TS2344 the moment `DocType` is
+    no reference at all) PASSES it. Measured — earlier versions of this file claimed
+    the opposite in five places, the last of them surviving a round that was
+    supposed to have corrected all of them, so treat "reference" phrasing about
+    either pin as a bug wherever it turns up. Equality is the sufficient property:
+    the coincidence is harmless today and becomes a TS2344 the moment `DocType` is
     widened, so the drift is still caught where it would be introduced.
   * The two `generateDocument` signatures -> `GenerateDocumentBody`: the compiler
     for `client.ts`, which forwards its `data` into `projectsApi.generateDocument`
@@ -127,15 +129,23 @@ REVERT MAP — which mutation each part catches, so a deletion is a decision:
     shared name appears, so it needs no model of TypeScript and cannot mis-read a
     restyling. A rename of `GenerateDocumentBody` fails it too, which is correct —
     the constant here is what the two files must agree on.
-  * `test_the_type_level_pins_are_present` — either type-level pin deleted, or
-    STUBBED to a bare constant. Both are silent otherwise: deleting one compiles
-    cleanly, and stubbing both a pin and its control to `= true` / `= false` (with
-    the helper types removed so no unused-local fires) was measured to exit `tsc` 0
-    and pass every test here while the guarded field was widened. So the assertion
-    SPELLING is required, not just the name. Covers both links: the field-vs-union
-    pin, and the parameter-vs-body pin that replaced the `satisfies` clause and the
-    location guard it needed — see WHY EACH GUARD IS THE KIND IT IS for why a
-    comparison was the answer and a tighter text slice was not.
+  * `test_the_type_level_pins_are_present` — either type-level pin deleted, STUBBED
+    to a bare constant, or left with only one of its two controls. All are silent
+    otherwise: deleting a pin compiles cleanly, and stubbing both a pin and its
+    control to `= true` / `= false` was measured to exit `tsc` 0 and pass every test
+    here while the guarded field was widened. So the assertion SPELLING is required,
+    and it names the pin's USE of the verdict helper (`MustBeTrue<BothWays<`) — an
+    earlier version required only `MustBeTrue<`, which the helper's OWN declaration
+    contains, so exporting the helpers and stubbing the pins passed every gate.
+    Covers both links: the field-vs-union pin, and the parameter-vs-body pin that
+    replaced the `satisfies` clause and the location guard it needed — see WHY EACH
+    GUARD IS THE KIND IT IS for why a comparison was the answer and a tighter text
+    slice was not.
+  * The `...WouldSeeNarrowing` controls — `BothWays` collapsed to a one-way
+    `extends`, which admits a NARROWED field or parameter: the "capability nobody
+    can reach" half of this contract's drift. The widened-side controls cannot see
+    that collapse (a superset fails the one-way test too), and it was measured to
+    leave `tsc` at exit 0 with every test here green.
   * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
     union is edited, and its opposite, one that reports drift for a comment.
   * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
@@ -173,17 +183,27 @@ TERMINAL_CLIENT = 'frontend/src/api/projectsApi.ts'
 # delete either block and the frontend still compiles — which is the only reason this
 # file mentions them at all: `test_the_type_level_pins_are_present` keeps them there.
 #
-# 🔑 A pin is spelled `<Guard><Name> = <Guard><Verdict><Comparison<...>>`, and the
-# CONSTANT INCLUDES THE COMPARISON'S OPENING BRACKET. That is deliberate and was
-# measured: with the names alone, both a pin and its control could be stubbed to bare
-# constants (`export type DocTypeFieldIsExactlyTheUnion = true`) and, with the helper
-# types deleted so no unused-local fired, `tsc` exited 0 and every test here passed
-# while the field it guards was widened past the route's allowlist. A name check is
-# satisfied by prose about the name; requiring `MustBeTrue<` means a stub has to keep
-# a real comparison to satisfy it.
+# 🔑 A pin is spelled `<Name> = <Verdict><Comparison<...>>`, and the SPELLINGS BELOW
+# INCLUDE THE COMPARISON, not just the verdict helper. Both halves of that were
+# measured, one review round apart:
 #
-# Keyed by relative path, since the two pins live in different files. Each value is
-# (pin, control, assertion-spelling, control-spelling).
+#   * Requiring only the NAMES was vacuous. Stub a pin and its control to bare
+#     constants (`export type DocTypeFieldIsExactlyTheUnion = true`), delete the helper
+#     types so no unused-local fires, and `tsc` exits 0 with every test here green
+#     while the field they guard is widened past the route's allowlist.
+#   * Requiring `MustBeTrue<` was ALSO vacuous, for a subtler reason: that substring
+#     occurs in the helper's OWN declaration (`type MustBeTrue<Verdict ...>`), so it is
+#     satisfied by the helper merely existing. The stub only has to keep the helpers
+#     and `export` them — measured, `tsc` exit 0 and every test here green with the
+#     field widened. So the spelling must name the pin's USE of the helper, which
+#     `MustBeTrue<BothWays<` does and a declaration cannot accidentally contain.
+#
+# This is why the pins in both files are written on ONE line: the substring spans the
+# helper and the comparison, so a wrapped declaration puts a newline between them.
+#
+# Keyed by relative path, since the pins live in two files. Each value is
+# (pin, controls, assertion-spellings) — the controls and spellings are tuples because
+# each pin needs TWO controls (widened and narrowed; see below).
 TYPE_LEVEL_PINS = {
     # `GenerateDocumentBody.doc_type` admits exactly the members of `DocType`. Nothing
     # else in either language sees this field: this file parses only the
@@ -191,9 +211,8 @@ TYPE_LEVEL_PINS = {
     # against the interface, so a widened interface satisfies it by construction.
     DOC_TYPE_UNION_SOURCE: (
         'DocTypeFieldIsExactlyTheUnion',
-        'DocTypeFieldPinWouldSeeDrift',
-        'MustBeTrue<',
-        'MustBeFalse<',
+        ('DocTypeFieldPinWouldSeeDrift', 'DocTypeFieldPinWouldSeeNarrowing'),
+        ('MustBeTrue<BothWays<', 'MustBeFalse<BothWays<'),
     ),
     # `generateDocument`'s parameter admits exactly `GenerateDocumentBody`. This is the
     # one that replaced a `satisfies` clause in the method body plus the text guard
@@ -203,9 +222,11 @@ TYPE_LEVEL_PINS = {
     # against the method's own type has nowhere to migrate to.
     TERMINAL_CLIENT: (
         'GenerateDocumentTakesTheSharedBody',
-        'GenerateDocumentSignaturePinWouldSeeDrift',
-        'SignatureMustMatch<',
-        'SignatureMustDiffer<',
+        (
+            'GenerateDocumentSignaturePinWouldSeeDrift',
+            'GenerateDocumentSignaturePinWouldSeeNarrowing',
+        ),
+        ('SignatureMustMatch<BothWays<', 'SignatureMustDiffer<BothWays<'),
     ),
 }
 
@@ -665,11 +686,16 @@ class TestDocTypeLockstep:
         frontend never offers is a backend capability no user can reach. Both are
         drift, so neither direction is allowed.
 
-        This half of the contract is only checkable HERE: TypeScript has no idea
-        what Python accepts. The compiler's half is that
-        `GenerateDocumentBody.doc_type` references this union by name, which
-        `test_both_client_signatures_use_the_shared_request_body` keeps true of both
-        signatures.
+        This half of the contract is only checkable HERE: TypeScript has no idea what
+        Python accepts. The compiler's half is that `GenerateDocumentBody.doc_type`
+        admits EXACTLY this union's members, in both directions — set equality, NOT
+        reference: a same-member respelling of the field passes, and is harmless for
+        the reason given on `BothWays`. That is enforced by
+        `DocTypeFieldIsExactlyTheUnion` in `frontend/src/api/types.ts` and kept present
+        by `test_the_type_level_pins_are_present`. Not by
+        `test_both_client_signatures_use_the_shared_request_body`, which an earlier
+        version of this docstring credited: that one asserts the two client FILES name
+        the shared body type, and says nothing about the interface field.
         """
         from projects_handler import GENERATED_DOC_TYPES
 
@@ -754,20 +780,27 @@ class TestDocTypeLockstep:
             respelling USES the shared name, so neither `noUnusedLocals` nor the name
             assertion above sees it.
 
-        Text, not a parse — but text with a lesson in it. Asserting the pin NAMES
-        alone was measured to be vacuous: stub both a pin and its control to bare
-        constants (`= true` / `= false`), delete the helper types so no unused-local
-        fires, and `tsc` exits 0 with every test here green while the guarded field is
-        widened. So the ASSERTION SPELLING is required too (`MustBeTrue<`), which a
-        bare constant cannot satisfy. That the comparisons BITE is the compiler's job;
-        this test says only that a real comparison is spelled.
+        Text, not a parse — but text with two lessons in it, one per review round.
+        Asserting the pin NAMES alone was measured to be vacuous: stub both a pin and
+        its control to bare constants (`= true` / `= false`), delete the helper types
+        so no unused-local fires, and `tsc` exits 0 with every test here green while
+        the guarded field is widened. Requiring `MustBeTrue<` did not fix it, because
+        that substring is in the HELPER'S OWN DECLARATION — so the stub just keeps the
+        helpers and exports them, and every gate is green again. The spelling required
+        is therefore the pin's USE of the helper (`MustBeTrue<BothWays<`). That the
+        comparisons BITE is the compiler's job; this test says only that a real
+        comparison is spelled.
 
-        Each pin's non-vacuity control is required alongside it, in the convention
-        this file uses for its own: `MustBeTrue<BothWays<...>>` is satisfied by a
-        `BothWays` that degenerates to `true`, and the control is what refuses that.
-        Verified by making it `[L, R] extends [L, R]` — both controls go red.
+        TWO controls per pin, both required. `MustBeTrue<BothWays<...>>` is satisfied
+        by a `BothWays` that degenerates to `true`, and by one collapsed to its
+        ONE-WAY form — and those need different controls, because a widened-side
+        control cannot see the second: a superset fails `[Left] extends [Right]` under
+        either form, so both forms look identical to it. Measured — collapsing
+        `BothWays` to `[Left] extends [Right]` left `tsc` at exit 0 with every test
+        here green. The narrowed-side controls (`...WouldSeeNarrowing`) are what
+        refuse that, using `never` as the left side.
         """
-        pin, control, assertion, control_assertion = TYPE_LEVEL_PINS[relative]
+        pin, controls, assertions = TYPE_LEVEL_PINS[relative]
         path = _repo_root() / relative
         assert path.is_file(), f'{relative} moved — update TYPE_LEVEL_PINS'
         source = _without_comments(path.read_text(encoding='utf-8'))
@@ -779,20 +812,23 @@ class TestDocTypeLockstep:
             f'file green. Restore it, or widen DocType and GENERATED_DOC_TYPES '
             f'together, which is the supported way to change the contract.'
         )
-        assert assertion in source, (
-            f'{relative} names `{pin}` but does not spell `{assertion}`, so the pin '
-            f'is no longer a comparison — a bare `= true` satisfies a name check '
-            f'while comparing nothing, which was measured to pass every gate with '
-            f'the guarded field widened. Restore the comparison.'
-        )
-        assert control in source, (
-            f'{relative} declares `{pin}` but not its control `{control}`. The pin is '
-            f'satisfied by a comparison that degenerates to `true`, which passes '
-            f'while measuring nothing; the control is what refuses that, the same way '
-            f'TestContractDriftIsCaught does for the parser here.'
-        )
-        assert control_assertion in source, (
-            f'{relative} names `{control}` but does not spell `{control_assertion}`, '
-            f'so the control is no longer a comparison either — see the message '
-            f'above; a stubbed control is a non-vacuity guard that is itself vacuous.'
-        )
+        for control in controls:
+            assert control in source, (
+                f'{relative} declares `{pin}` but not its control `{control}`. The '
+                f'pin is satisfied both by a comparison that degenerates to `true` '
+                f'and by one collapsed to a one-way `extends`, each of which passes '
+                f'while measuring less than it claims; the controls are what refuse '
+                f'those, the same way TestContractDriftIsCaught does for the parser '
+                f'here. A widened-side control cannot detect the one-way collapse, '
+                f'so the narrowed-side one is not redundant.'
+            )
+        for assertion in assertions:
+            assert assertion in source, (
+                f'{relative} does not spell `{assertion}`, so a pin or a control is '
+                f'no longer applied to a comparison. A bare `= true` satisfies a '
+                f'name check while comparing nothing, and naming the helper alone is '
+                f'satisfied by the helper\'s own declaration — both were measured to '
+                f'pass every gate with the guarded field widened. Note these pins are '
+                f'written on ONE line deliberately: wrapping the declaration puts a '
+                f'newline inside this substring.'
+            )

--- a/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_doc_type_lockstep.py
@@ -3,63 +3,71 @@ frontend can SEND must not drift apart.
 
 `projects_handler.GENERATED_DOC_TYPES` is what POST /projects/{id}/document
 validates against — anything outside it is a 400 raised before `create_job`. The
-frontend independently declares the same set: the `DocType` union it builds its
-picker from, and the `doc_type` field of the two `generateDocument` client
-signatures that call this route.
-
-Only THIS route's declarations are pinned. `suggestDocumentBrief` also takes a
-`doc_type`, but it calls a different route which the comment above
-GENERATED_DOC_TYPES documents as deliberately not sharing this allowlist (there
-the value picks a prompt label and never reaches a key, a job type or a routing
-decision). Binding it here would turn widening that route — a change the same
-comment invites — into a failure attributed to this one.
-
-Nothing tied them together. The failure is user-visible rather than loud: a client
-that offers a value the route refuses turns a click into an HTTP 400 from a
-document picker, and a client that omits one silently drops a feature the backend
-supports. Parsing the other language's source and asserting equality moves that
-into CI.
+frontend declares the same set ONCE, as the `DocType` union in
+`frontend/src/pages/ProjectDetail/types.ts`: the picker is built from it and both
+`generateDocument` client signatures import it, so there is a single declaration to
+pin. Nothing tied the two languages together, and the failure is user-visible
+rather than loud: a client offering a value the route refuses turns a click into an
+HTTP 400 from a document picker, and a client omitting one silently drops a feature
+the backend supports.
 
 Same pattern, and the same motivation, as `test_kiro_exportable_types_lockstep.py`
-and `lambda/shared/test/test_search_minimum_lockstep.py` in this repo.
+and `lambda/shared/test/test_search_minimum_lockstep.py`.
 
-MOST OF THIS FILE WANTS DELETING, and issue #381 carries the argument. In short:
-the scanner exists only because `client.ts` and `projectsApi.ts` spell
-`'prd' | 'prfaq'` INLINE rather than referencing the `DocType` union, so there are
-three copies of the contract instead of one. Point both signatures at `DocType` and
-`_doc_type_union` alone suffices. Read that issue before extending the parser
-again — several review rounds have each found a new way it mis-reads legal
-TypeScript, so a further round should be a choice, not a default.
+WHY THIS FILE IS SHORT NOW, and why it must not grow back (issue #381). It carried
+~300 lines of TypeScript scanner — `_parameter_list_end`,
+`GENERATE_DOCUMENT_ANCHOR`, `DOC_TYPE_ANNOTATION_ANCHOR`, `FINDABLE_SHAPES`,
+`WIDENED_SHAPES`, `NARROWED_SHAPES` — for one reason: `client.ts` and
+`projectsApi.ts` spelled `'prd' | 'prfaq'` INLINE, so the contract existed in three
+places and checking the two inline copies meant locating a method by name inside an
+object literal and delimiting its parameter list by bracket balance. Successive
+review rounds on PR #377 each found a new way that mis-read legal TypeScript
+(nested callback, column-0 latch, nested namespace, `//` and `/* */` comments,
+unbalanced brackets, non-literal terms, an unreadable first term) — every one a
+defect in the scanner, not in the contract. Both signatures now say
+`doc_type: DocType`, which removes the drift axis instead of testing it: the copies
+can no longer disagree, and TypeScript, not a regex, enforces it. If a signature
+respells the union inline again, the fix is the import, not a parser.
 
-The comparisons SKIP when the frontend tree is absent (a backend-only sparse
+`suggestDocumentBrief` also takes a `doc_type` and is still NOT pinned here: it
+calls a different route which the comment above GENERATED_DOC_TYPES documents as
+deliberately not sharing this allowlist (there the value picks a prompt label and
+never reaches a key, a job type or a routing decision). Binding it here would turn
+widening that route — a change the same comment invites — into a failure attributed
+to this one. Reading only the `DocType` DECLARATION, rather than every `doc_type`
+annotation in the client, keeps that separation with no scoping code at all.
+
+The comparison SKIPS when the frontend tree is absent (a backend-only sparse
 checkout should not report a mismatch it never measured), but
-`test_the_frontend_declarations_are_findable` carries NO skip marker: it asserts
-the sources exist and parse, which is the check that must run — without it a
-rename would make every parser return an empty set and the equality tests would
-pass while comparing nothing.
+`test_the_frontend_declaration_is_findable` carries NO skip marker: it asserts the
+source exists and parses, which is the check that must run — without it a rename
+would make the parser return an empty set and the equality test would pass while
+comparing nothing.
 
-Both parsers are pure functions of the text (`_doc_type_union`,
-`_doc_type_annotations`) and both have their own class of synthetic shapes
-(`TestTheUnionParser`, `TestTheParser`). That is deliberate and it is the half the
-findability control cannot cover: the control can report that a parser found
-nothing in the sources as they are TODAY, never that a plausible restyling — a
-Prettier-wrapped union, a double-quoted member, a commented-out predecessor — would
-make it find nothing tomorrow. Every shape pinned there is one an earlier version
-of this file read wrongly or not at all.
+REVERT MAP — which mutation each part catches, so a deletion is a decision:
+  * `test_the_frontend_declaration_is_findable` — `DocType` renamed or the file
+    moved, leaving the equality test comparing empty sets.
+  * `test_the_route_accepts_exactly_what_the_doc_type_union_offers` — the contract
+    itself, in both directions.
+  * `TestContractDriftIsCaught` — a parser that returns the allowlist however the
+    union is edited, and its opposite, one that reports drift for a comment.
+  * `TestTheUnionParser` — a legal restyling the parser reads wrongly or silently
+    truncates. The findability control cannot cover this half: it reports that the
+    parser found nothing in the source as it is TODAY, never that a Prettier-wrapped
+    union or a commented-out predecessor would make it find nothing tomorrow. Every
+    shape there is one an earlier version of this file read wrongly or not at all.
+  * `test_the_guards_refuse_in_a_form_python_dash_o_keeps` — a refusal respelled as
+    `assert`, which `-O` strips entirely.
 """
 import re
 from pathlib import Path
 
 import pytest
 
-# The TypeScript declarations that must agree with GENERATED_DOC_TYPES. Update
-# these paths if the files move; a stale path fails the findability test rather
-# than silently skipping.
+# The TypeScript declaration that must agree with GENERATED_DOC_TYPES. Update this
+# path if the file moves; a stale path fails the findability test rather than
+# silently skipping.
 DOC_TYPE_UNION_SOURCE = 'frontend/src/pages/ProjectDetail/types.ts'
-API_CLIENT_SOURCES = (
-    'frontend/src/api/client.ts',
-    'frontend/src/api/projectsApi.ts',
-)
 
 
 def _repo_root() -> Path:
@@ -71,97 +79,56 @@ def _frontend_tree_present() -> bool:
     return (_repo_root() / DOC_TYPE_UNION_SOURCE).is_file()
 
 
-# A quoted string-literal union member, in either quote style. TypeScript accepts
-# both and Prettier's `singleQuote` setting decides which a file uses, so reading
-# only one of them makes a formatter setting the difference between a parser that
-# works and one that silently returns nothing.
+# A quoted string-literal member, in either quote style: TypeScript accepts both and
+# Prettier's `singleQuote` setting decides which a file uses, so reading only one
+# makes a formatter setting the difference between a parser that works and one that
+# silently returns nothing.
 QUOTED_MEMBER = r"""(?:'[^']+'|"[^"]+")"""
 # A union TERM is a quoted literal OR a bare identifier. Identifiers are matched
-# deliberately, not tolerated: a union that refers to another type
-# (`'prd' | 'prfaq' | ExtraDocType`) cannot be compared against the route's
-# allowlist, and matching only the literals beside it would truncate the union and
-# PASS while the frontend can send whatever the identifier admits. Captured here
-# so `_union_members` can refuse it by name instead.
-#
-# Widening this grammar further would be the wrong answer to the shapes it still
-# does not match — `(string & {})`, `` `${string}-draft` ``, `{ custom: string }`.
-# TypeScript admits unboundedly many type expressions, so no term pattern is
-# exhaustive, and each addition only moves where the silence starts. That is why
-# `_union_members` also checks POSITIONALLY for a term the pattern could not
-# read at all; see its docstring.
+# deliberately, not tolerated: `'prd' | 'prfaq' | ExtraDocType` cannot be compared
+# against the allowlist, and reading the literals beside the identifier would
+# truncate the union and PASS while the frontend can send whatever it admits — so it
+# matches, and `_doc_type_union` refuses it by name. Widening this grammar further
+# would be the wrong answer to the shapes it still misses (`(string & {})`,
+# `` `${string}-draft` ``, `{ custom: string }`): TypeScript admits unboundedly many
+# type expressions, so each addition only moves where the silence starts. The
+# POSITIONAL check in `_doc_type_union` is what closes it instead.
 UNION_TERM = rf"""(?:{QUOTED_MEMBER}|[A-Za-z_$][\w$]*)"""
 MEMBER_LITERAL = re.compile(rf'^{QUOTED_MEMBER}$')
 QUOTED_TEXT = re.compile(r"""['"]([^'"]+)['"]""")
 
-# The `DocType` union. The optional leading `|` matters: it is what Prettier
-# produces once a union exceeds the print width, so adding a third member — the
-# very drift this file exists to catch — is a realistic route into a shape the
-# previous pattern could not read at all.
-# The TERMS of a union, matched only once an anchor below has said where the
-# right-hand side starts. Split from the anchors deliberately: while the terms and
-# the declaration were one pattern, a declaration whose FIRST term is unreadable
-# (`= (string & {}) | 'prd' | 'prfaq'`) matched NOTHING, so the parser returned an
-# empty set, the equality test passed, and only the findability control fired —
-# asking whether the type had been renamed while the declaration sat there,
-# widened. Anchoring first turns that into a refusal at the declaration.
+# The TERMS, matched only once the anchor has said where the right-hand side starts.
+# Split from the anchor deliberately: while they were one pattern, a declaration
+# whose FIRST term is unreadable (`= (string & {}) | 'prd'`) matched NOTHING, so the
+# parser returned an empty set, the equality test passed, and only the findability
+# control fired — asking whether the type had been renamed while the declaration sat
+# there, widened.
 UNION_TERMS = re.compile(rf'{UNION_TERM}(?:\s*\|\s*{UNION_TERM})*')
 
+# The optional trailing `|` matters: Prettier emits a leading pipe once a union
+# exceeds the print width, so adding a third member — the very drift this file
+# exists to catch — is a realistic route into a shape a pattern without it cannot
+# read at all.
 DOC_TYPE_UNION_ANCHOR = re.compile(r'export\s+type\s+DocType\s*=\s*\|?\s*')
-
-# The client method whose parameters type THIS route's request body, anchored by
-# NAME rather than by tracking whichever `name: (` was seen most recently. An
-# indentation heuristic was tried first and had to be abandoned: a nested
-# function-typed field (`onProgress: (pct: number) => void`) matches `name: (`
-# too, and any rule for deciding which match ENDS the enclosing method got the
-# answer wrong for some real shape — scoping to the shallowest column seen
-# latched onto the first column-0 declaration in the file and skipped
-# `generateDocument` forever, silently. Anchoring on the name and delimiting by
-# bracket balance asks the question directly and has no such state.
-GENERATE_DOCUMENT_ANCHOR = re.compile(r'\bgenerateDocument\s*:\s*(?:async\s*)?\(')
-# The union is OPTIONAL, so a NARROWED signature (`doc_type: 'prd'`, dropping
-# PR-FAQ from the client while the route still accepts it) is read and reported as
-# drift against the route. Requiring a `|` made that edit unparseable instead, and
-# the two failures send a maintainer to different places: "the client and the route
-# disagree" is the finding, "was the method renamed?" is a wrong turn.
-#
-# Built from UNION_TERM, not from QUOTED_MEMBER, for the reason recorded there and
-# because THIS is the parser that reads the declaration typing the request body.
-# With quoted literals only, a signature widened to
-# `doc_type: 'prd' | 'prfaq' | LegacyDocType` matched just the first two terms and
-# was reported as agreeing with the route — the same silent pass the union parser
-# was hardened against, on the more load-bearing of the two declarations. The union
-# is the picker's type; the signature is the wire contract.
-#
-# `\|?\s*` matches the union anchor's, and closes a gap this parser had from the
-# start: Prettier emits a LEADING PIPE once a union outgrows the print width, so
-# `doc_type:\n  | 'prd'\n  | 'prfaq'` read as nothing at all — widened or not. That
-# is also the likeliest route into a first-position widening, since a maintainer
-# reformatting to that shape and then adding a member lands in it.
-DOC_TYPE_ANNOTATION_ANCHOR = re.compile(r'doc_type\??\s*:\s*\|?\s*')
 
 
 def _without_comments(source: str) -> str:
     """`source` with `//` and `/* */` comment BODIES blanked, same length.
 
-    Comments are removed before anything else looks at the text, because both
-    parsers below were reading declarations out of them. A commented-out older
-    signature above the live one was collected as a second declaration and failed
-    the equality test while the client was correct; worse, a renamed method with a
-    commented-out reference left behind was collected as though it were live, so
-    the findability control passed while nothing live was pinned — the "green
-    result meaning did not check" this file exists to prevent, arriving through the
-    parser instead of the code under test. Same defect class as counting brackets
-    on `line.split('#')[0]` in `test_the_routing_predicate_reads_the_allowlist_constant`:
-    commentary is not a declaration.
+    🔑 Kept when the scanner around it went (issue #381), because `_doc_type_union`
+    needs it just as much: `re.search` takes the FIRST match, so a commented-out
+    older union above the live one is what gets read — reporting the dead
+    declaration's members, or agreeing with the route while the live union has
+    drifted. A comment BETWEEN members (`| 'prd' // the default`) truncates the
+    union at the comment instead. Stubbing this out turns `commented_out_predecessor`
+    and `commented` red. Same defect class as counting brackets on
+    `line.split('#')[0]`: commentary is not a declaration.
 
-    Blanked rather than deleted, and newlines inside comments preserved, so every
-    index and every line number in the result still refers to the same place in the
-    original file — the annotation line numbers are what a failure report names.
-
-    Quote state is tracked so a `//` inside a string is not mistaken for a comment.
-    A regex literal containing `//` or `/*` would be, but an empty regex is not
-    legal TypeScript and these are API-client type signatures; the shapes that do
-    occur are pinned in `TestTheParser`.
+    Blanked rather than deleted, newlines preserved, so indices still refer to the
+    same place in the original. Quote state is tracked so a `//` inside a string is
+    not mistaken for a comment; a regex literal containing `//` would be, but this
+    is a type declaration and the shapes that occur are pinned in
+    `TestTheUnionParser`.
     """
     def blanked(text: str) -> str:
         return ''.join('\n' if char == '\n' else ' ' for char in text)
@@ -203,48 +170,43 @@ def _without_comments(source: str) -> str:
     return ''.join(out)
 
 
-def _union_members(code: str, anchor: re.Match, what: str) -> frozenset[str]:
-    """The quoted members of the union at `anchor`, or a LOUD failure.
+def _doc_type_union(source: str) -> frozenset[str]:
+    """The `DocType` members, an empty set if the declaration is gone, or a LOUD
+    failure if the union cannot be compared against the route's allowlist.
 
-    Shared by both parsers because both had the same hole, and a guard written twice
-    is how the earlier rounds' defects happened. A union can be unreadable in three
-    positions and all three must be loud, because the quiet version of any of them
-    is the same thing: a PASS reporting agreement with the route while the frontend
-    admits values it refuses.
+    Reads `export type DocType = 'prd' | 'prfaq'` and its wrapped, leading-pipe,
+    double-quoted and commented restylings; `UNION_SHAPES` is the list.
 
-    FIRST — nothing matches at the anchor. `= (string & {}) | 'prd' | 'prfaq'`.
-    Before the anchors were split out this returned an empty set, which the equality
-    test reads as "no drift" and the findability control reports as a possible
-    rename. The worst of the three, because the message sent the maintainer looking
-    for something that had not happened.
+    A union can be unreadable in three positions and all three must be loud, because
+    the quiet version of any of them is the same thing: a PASS reporting agreement
+    with the route while the frontend admits values it refuses.
 
-    MIDDLE or LAST — a term is not a string literal. Two sub-cases, and the split
-    matters because only one of them can be spelled as a pattern:
+      * AT THE ANCHOR — nothing matches, because the first term is unreadable. An
+        empty set is what a RENAMED type returns, so this used to report "no drift"
+        and send the maintainer looking for a rename that had not happened.
+      * A MATCHED NON-LITERAL — an identifier. It matches deliberately (see
+        UNION_TERM) so the refusal can name it, rather than tightening the pattern
+        until it stops matching and yields an empty set again.
+      * AN UNREAD TERM — no pattern matched it, so the terms before it look like the
+        whole union. Caught POSITIONALLY: a `|` after the match means something was
+        left unread, whatever its shape. This is the only one of the three that does
+        not depend on anyone having enumerated TypeScript's type expressions.
 
-      * it MATCHED and is an identifier (`ExtraDocType`, `string`, `DocType`).
-        UNION_TERM matches identifiers deliberately so they arrive here to be named,
-        rather than tightening the pattern until they stop matching — which yields
-        an empty set and, again, a rename message.
-      * it did not match, so the terms before it look like the whole union.
-        `(string & {})` — "any string, but keep autocomplete", precisely what one
-        reaches for to widen a picker — plus template-literal and inline object
-        types. No grammar is exhaustive over TypeScript's type expressions, so this
-        one is caught POSITIONALLY: a `|` after the match means a term was left
-        unread, whatever its shape.
-
-    Between the anchor check and the positional check, a value comes back only when
-    every `|`-separated term in the declaration was read AND was a literal. That is
-    the property worth having; it does not depend on anyone having enumerated the
-    shapes TypeScript admits.
+    Between them, a value comes back only when every `|`-separated term was read AND
+    was a literal.
 
     `raise AssertionError` rather than `assert`: `python -O` strips `assert`, and a
-    guard whose entire purpose is to not be the quiet option must not have a mode
+    guard whose whole purpose is to not be the quiet option must not have a mode
     where it silently is. `pytest.raises(AssertionError)` is unaffected.
     """
+    code = _without_comments(source)
+    anchor = DOC_TYPE_UNION_ANCHOR.search(code)
+    if anchor is None:
+        return frozenset()
     terms_match = UNION_TERMS.match(code, anchor.end())
     if terms_match is None:
         raise AssertionError(
-            f'{what} begins with a term this parser cannot read: '
+            f'the DocType union begins with a term this parser cannot read: '
             f'{code[anchor.end():anchor.end() + 60]!r}. Returning nothing here '
             f'would report no drift and blame a rename.'
         )
@@ -253,49 +215,22 @@ def _union_members(code: str, anchor: re.Match, what: str) -> frozenset[str]:
     non_literal = [term for term in terms if not MEMBER_LITERAL.match(term)]
     if non_literal:
         raise AssertionError(
-            f'{what} has members that are not string literals: {non_literal}. '
-            f'This parser cannot compare those against the route\'s allowlist, and '
-            f'silently reading only the literals beside them would PASS while the '
-            f'frontend can send whatever they admit. If the declaration now '
-            f'references the shared DocType union, this parser wants retiring '
-            f'rather than teaching to resolve it — see '
-            f'test_the_frontend_declarations_are_findable.'
+            f'the DocType union has members that are not string literals: '
+            f'{non_literal}. Those cannot be compared against the route\'s '
+            f'allowlist, and reading only the literals beside them would PASS '
+            f'while the frontend can send whatever they admit.'
         )
     unread = code[terms_match.end():].lstrip()
     if unread.startswith('|'):
         raise AssertionError(
-            f'{what} continues past the terms this parser could read, with '
-            f'{unread[:60]!r}. Reading only the members before it would report '
+            f'the DocType union continues past the terms this parser could read, '
+            f'with {unread[:60]!r}. Reading only the members before it would report '
             f'agreement with the route while the frontend admits more. This says '
             f'only that the term could not be READ — a parenthesised or '
-            f'backtick-quoted literal would land here too, and is still drift the '
+            f'backtick-quoted literal lands here too, and is still drift the '
             f'comparison cannot make.'
         )
     return frozenset(QUOTED_TEXT.findall(matched))
-
-
-def _doc_type_union(source: str) -> frozenset[str]:
-    """The `DocType` union members, or an empty set if the declaration is gone.
-
-    A pure function of the text, for the same reason `_doc_type_annotations` is:
-    the findability control can report that this parser found nothing, never that
-    a plausible restyling of the declaration would make it find nothing.
-    `TestTheUnionParser` is that second half.
-
-    Reads, among others:
-        export type DocType = 'prd' | 'prfaq'
-        export type DocType =
-          | 'prd'
-          | 'prfaq'
-
-    Raises rather than truncating when a member is not a string literal — see
-    UNION_TERM.
-    """
-    code = _without_comments(source)
-    anchor = DOC_TYPE_UNION_ANCHOR.search(code)
-    if anchor is None:
-        return frozenset()
-    return _union_members(code, anchor, 'the DocType union')
 
 
 def _declared_doc_type_union() -> frozenset[str]:
@@ -305,421 +240,46 @@ def _declared_doc_type_union() -> frozenset[str]:
     )
 
 
-def _parameter_list_end(source: str, open_paren: int) -> int | None:
-    """The index just past the `)` closing the parameter list at `open_paren`.
-
-    None when the brackets never balance, which means the extent of the method
-    could not be determined. Returning the rest of the file instead would be
-    worse than returning nothing: in `projectsApi.ts` the next `doc_type` below
-    `generateDocument` belongs to `suggestDocumentBrief`, which this file
-    deliberately does not pin, so an over-long extent would quietly reintroduce
-    the coupling. Nothing found fails the findability control loudly instead.
-
-    Quoted strings are skipped so a bracket inside one cannot unbalance the count.
-    Comments need no handling here because `_doc_type_annotations` blanks them
-    before calling this — which is also what stops a bracket or an apostrophe
-    inside a `/* */` comment from unbalancing the count or opening a quote state
-    that swallows the rest of the parameter list.
-    """
-    depth = 0
-    quote = None
-    index = open_paren
-    while index < len(source):
-        char = source[index]
-        if quote is not None:
-            if char == '\\':
-                index += 2
-                continue
-            if char == quote:
-                quote = None
-        elif char in '\'"`':
-            quote = char
-        elif char == '(':
-            depth += 1
-        elif char == ')':
-            depth -= 1
-            if depth == 0:
-                return index + 1
-        index += 1
-    return None
-
-
-def _doc_type_annotations(source: str) -> dict[int, frozenset[str]]:
-    """The `doc_type: 'a' | 'b'` annotations inside `generateDocument`'s signature.
-
-    Keyed by 1-based line number. A pure function of the text so the parser
-    itself is testable — `TestTheParser` below feeds it the awkward shapes that
-    broke earlier attempts, because a lockstep test whose parser silently returns
-    nothing is a green result meaning "did not check".
-
-    Both the anchor and the annotations are matched against the COMMENT-FREE text,
-    so a commented-out signature is neither collected as a declaration nor allowed
-    to stand in for the live one. See `_without_comments`.
-
-    Scoped to that ONE client method on purpose. Matching every `doc_type`
-    annotation in these files also picks up `suggestDocumentBrief`, which calls a
-    DIFFERENT route (POST .../documents/suggest-brief) that the comment above
-    GENERATED_DOC_TYPES documents as deliberately NOT sharing this allowlist —
-    there the value only picks a prompt label and never reaches a key, a job type
-    or a routing decision. Asserting it against this constant would make widening
-    suggest-brief, the change that comment invites, fail a test named after the
-    document route, and narrowing the test back would look like weakening a
-    security check. If suggest-brief is ever worth pinning it wants its own
-    constant and its own rationale.
-    """
-    code = _without_comments(source)
-    found: dict[int, frozenset[str]] = {}
-    for anchor in GENERATE_DOCUMENT_ANCHOR.finditer(code):
-        open_paren = anchor.end() - 1
-        end = _parameter_list_end(code, open_paren)
-        if end is None:
-            continue
-        signature = code[open_paren:end]
-        first_line = code.count('\n', 0, open_paren) + 1
-        for match in DOC_TYPE_ANNOTATION_ANCHOR.finditer(signature):
-            line_number = first_line + signature.count('\n', 0, match.start())
-            # The line number is in the message because a refusal has to point at
-            # the declaration, not just report that one exists somewhere.
-            found[line_number] = _union_members(
-                signature,
-                match,
-                f'the generateDocument doc_type annotation on line {line_number}',
-            )
-    return found
-
-
-def _api_client_doc_type_sets() -> dict[str, frozenset[str]]:
-    """`_doc_type_annotations` over each client source.
-
-    Keyed by "file:line" so a mismatch report names the declaration that drifted
-    rather than only the file.
-    """
-    found: dict[str, frozenset[str]] = {}
-    for relative in API_CLIENT_SOURCES:
-        path = _repo_root() / relative
-        if not path.is_file():
-            continue
-        source = path.read_text(encoding='utf-8')
-        for line_number, declared in _doc_type_annotations(source).items():
-            found[f'{relative}:{line_number}'] = declared
-    return found
-
-
-# Each value is a client source the parser must find the annotation in. Named
-# rather than inlined so the reason a shape is here sits with the shape.
-FINDABLE_SHAPES = {
-    # The shape in projectsApi.ts today: the annotation a line below the
-    # method, inside a multi-line request-body type.
-    'multi_line': """generateDocument: (projectId: string, data: {
-  doc_type: 'prd' | 'prfaq'
-}) => q,
-""",
-    # The shape in client.ts today: the whole signature on one line.
-    'single_line':
-        "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,\n",
-    # A function-typed field NESTED in the request body. It matches `name: (`
-    # as much as the method does, so a parser tracking "the most recent
-    # `name: (`" reassigns to it and skips the annotation below.
-    'nested_callback': """generateDocument: (projectId: string, data: {
-  onProgress: (pct: number) => void
-  doc_type: 'prd' | 'prfaq'
-}) => q,
-""",
-    # A column-0 function-typed declaration ABOVE the object literal. The
-    # column heuristic this parser replaced latched its threshold to 0 here and
-    # could never accept the indented `generateDocument` again, for the rest of
-    # the file — silently, which is why this case is pinned.
-    'column_zero_preamble': """label: (x: string) => void
-export const api = {
-  generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,
-}
-""",
-    # The method nested one level deeper than a sibling above it, which the
-    # same latch also refused.
-    'nested_namespace': """export const api = {
-  helper: (x: string) => x,
-  projects: {
-generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,
-  },
-}
-""",
-    # Brackets inside a string and inside a `//` comment, neither of which may
-    # unbalance the search for the end of the parameter list.
-    'bracket_in_string': """generateDocument: (p: string, d: {
-  label: ')('
-  doc_type: 'prd' | 'prfaq'
-}) => q,
-""",
-    'bracket_in_comment': """generateDocument: (p: string, d: {
-  // see runResearch( for the twin
-  doc_type: 'prd' | 'prfaq'
-}) => q,
-""",
-    # `async` between the name and the parameter list.
-    'async':
-        "generateDocument: async (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,\n",
-    # A BLOCK comment carrying a bracket, which unbalanced the end-of-signature
-    # search and lost the annotation entirely.
-    'bracket_in_block_comment': """generateDocument: (p: string, d: {
-  /* see runResearch( for the twin */
-  doc_type: 'prd' | 'prfaq'
-}) => q,
-""",
-    # A block comment carrying an apostrophe, which opened a quote state that
-    # swallowed the rest of the parameter list.
-    'apostrophe_in_block_comment': """generateDocument: (p: string, d: {
-  /* don't widen this */
-  doc_type: 'prd' | 'prfaq'
-}) => q,
-""",
-    # A commented-out OLDER signature above the live one — what a maintainer
-    # plausibly leaves behind when narrowing it. Only the live annotation may be
-    # collected: reading the comment too reported drift (`legacy`) against a
-    # client that was entirely correct.
-    'commented_out_predecessor':
-        """  // was: generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' | 'legacy' }) => q,
-  generateDocument: (projectId: string, data: {
-    doc_type: 'prd' | 'prfaq'
-  }) => q,
-""",
-    # Double-quoted members. Which quote style a file uses is a Prettier setting,
-    # not a fact about the contract.
-    'double_quoted':
-        'generateDocument: (p: string, d: { doc_type: "prd" | "prfaq" }) => q,\n',
-}
-
-# Shapes where the annotation is present but does NOT declare both members, so
-# `_doc_type_annotations` must report what it read rather than nothing. A narrowed
-# signature is real drift in the "accepted but never offered" direction, and it has
-# to surface from the comparison test that names that — not as an unparseable file
-# from the findability control, which would send a maintainer looking for a rename
-# that never happened.
-NARROWED_SHAPES = {
-    'single_value':
-        "generateDocument: (p: string, d: { doc_type: 'prd' }) => q,\n",
-    'optional_single_value':
-        "generateDocument: (p: string, d: { doc_type?: 'prd' }) => q,\n",
-}
-
-# Shapes where the signature admits MORE than the two literals, by a term this
-# parser cannot compare against the allowlist. Separate from NARROWED_SHAPES
-# because the required behaviour is the opposite: narrowing must be READ and
-# reported as drift, widening past a literal must REFUSE — reading the literals
-# beside such a term reports agreement with the route while the client can send
-# whatever it admits.
-#
-# Each maps to the message fragment its refusal must carry, so the test pins WHICH
-# of the three guards fired rather than only that something did. That matters here:
-# with a single either-message assertion, dropping the identifier alternation from
-# UNION_TERM left every one of these green, because one of the OTHER two guards
-# picked each of them up — measured under that mutation, 5 fall to the positional
-# guard and 3 (`single_named_type` and the two `unreadable_term_first*`) to the
-# anchor. So the grammar change the fix rests on was unpinned.
-WIDENED_SHAPES = {
-    # Caught BY NAME: an identifier matches UNION_TERM, so it reaches the
-    # not-a-literal check and the failure can say what it is.
-    # What a maintainer writes to add values without touching this signature —
-    # and so the realistic route to a client offering a value the route 400s.
-    'named_type': (
-        "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' | LegacyDocType }) => q,\n",
-        'not string literals',
-    ),
-    'bare_string': (
-        "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' | string }) => q,\n",
-        'not string literals',
-    ),
-    # The shape the grammar change ALONE catches: one non-literal term, no pipe, so
-    # the positional guard has nothing to see. With quoted literals only this
-    # parsed to {} and reported no drift. It is also `doc_type: DocType`, the end
-    # state the module docstring recommends — which must fail loudly here rather
-    # than quietly, so whoever makes that frontend change is told to retire this
-    # parser instead of finding a green suite that checks nothing.
-    'single_named_type': (
-        'generateDocument: (p: string, d: { doc_type: DocType }) => q,\n',
-        'not string literals',
-    ),
-    # Caught POSITIONALLY: no term pattern matches these, so the guard sees only
-    # that a `|` follows what it could read.
-    # "Any string, but keep autocomplete on the known members" — the idiom for
-    # exactly this widening.
-    'string_and_empty_object': (
-        "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' | (string & {}) }) => q,\n",
-        'continues past',
-    ),
-    'template_literal': (
-        'generateDocument: (p: string, d: { doc_type: \'prd\' | \'prfaq\' | `${string}-draft` }) => q,\n',
-        'continues past',
-    ),
-    'inline_object': (
-        "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' | { custom: string } }) => q,\n",
-        'continues past',
-    ),
-    # Caught at the ANCHOR: the unreadable term comes FIRST, so nothing matches at
-    # all. This is the position the earlier fix missed entirely — it returned {},
-    # the comparison test passed, and only the findability control fired, blaming a
-    # rename that had not happened.
-    'unreadable_term_first': (
-        "generateDocument: (p: string, d: { doc_type: (string & {}) | 'prd' | 'prfaq' }) => q,\n",
-        'begins with a term',
-    ),
-    # The same, in Prettier's leading-pipe form — the likeliest route here, since
-    # reformatting to it and then adding a member lands in this class.
-    'unreadable_term_first_leading_pipe': (
-        (
-            "generateDocument: (projectId: string, data: {\n"
-            "  doc_type:\n"
-            "    | (string & {})\n"
-            "    | 'prd'\n"
-            "}) => q,\n"
-        ),
-        'begins with a term',
-    ),
-}
-
-
-class TestTheParser:
-    """The parser itself, on synthetic sources.
-
-    A lockstep test is only worth its positive control, and the control can only
-    report that the parser found nothing — never that a plausible restyling of the
-    client would make it find nothing. These cases are that second half: each is a
-    shape an earlier version of this parser silently returned `{}` for, which
-    would have left the equality tests below comparing empty sets.
-    """
-
-    @pytest.mark.parametrize('shape', FINDABLE_SHAPES.values(), ids=FINDABLE_SHAPES)
-    def test_the_annotation_is_found_however_the_signature_is_shaped(self, shape):
-        assert list(_doc_type_annotations(shape).values()) == [
-            frozenset({'prd', 'prfaq'})
-        ], f'parsed nothing from:\n{shape}'
-
-    def test_the_line_number_points_at_the_annotation(self):
-        """The keys are what a failure report names, so they must be right —
-        pointing a maintainer at the method's line instead of the annotation's
-        would send them to the wrong declaration in a file with several."""
-        source = (
-            'export const api = {\n'
-            '  generateDocument: (p: string, d: {\n'
-            "    doc_type: 'prd' | 'prfaq'\n"
-            '  }) => q,\n'
-            '}\n'
-        )
-        assert list(_doc_type_annotations(source)) == [3]
-
-    def test_a_sibling_methods_doc_type_is_not_collected(self):
-        """`suggestDocumentBrief` calls a different route which the handler comment
-        documents as deliberately not sharing this allowlist. Widening it must not
-        fail a test named after the document route — see this module's docstring.
-        """
-        source = (
-            "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,\n"
-            "suggestDocumentBrief: (p: string, b: "
-            "{ doc_type?: 'prd' | 'prfaq' | 'brief_only' }) => q,\n"
-        )
-        assert list(_doc_type_annotations(source).values()) == [
-            frozenset({'prd', 'prfaq'})
-        ]
-
-    def test_an_unbalanced_signature_yields_nothing_rather_than_overreaching(self):
-        """Failing to find the end of the parameter list must find NOTHING.
-
-        Falling back to "the rest of the file" would sweep in the next method's
-        `doc_type` — which in projectsApi.ts is `suggestDocumentBrief`'s, the one
-        annotation this file must not pin. An empty result is caught loudly by the
-        findability control instead.
-        """
-        source = "generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq'\n"
-        assert _doc_type_annotations(source) == {}
-
-    def test_a_renamed_method_yields_nothing(self):
-        """The negative control for the anchor: if this returned annotations for
-        any method name, scoping to `generateDocument` would be doing nothing and
-        the suggest-brief exclusion above would be accidental."""
-        source = "createDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,\n"
-        assert _doc_type_annotations(source) == {}
-
-    def test_a_renamed_method_yields_nothing_despite_a_commented_out_reference(self):
-        """The worst of the comment cases, because it is SILENT.
-
-        A rename that leaves the old call commented out used to satisfy the
-        findability control — one annotation parsed per source — while the live
-        signature was pinned by nothing. That is the "green result meaning did not
-        check" this file exists to prevent, arriving through the parser rather than
-        through the code under test, so the comment must not stand in for the
-        declaration it is a copy of.
-        """
-        source = (
-            "  // generateDocument: (p: string, d: { doc_type: 'prd' | 'prfaq' }) => q,\n"
-            '  createDocument: (projectId: string, data: {\n'
-            "    doc_type: 'prd' | 'prfaq'\n"
-            '  }) => q,\n'
-        )
-        assert _doc_type_annotations(source) == {}
-
-    @pytest.mark.parametrize(
-        ('shape', 'expected'), WIDENED_SHAPES.values(), ids=WIDENED_SHAPES
-    )
-    def test_a_widened_signature_refuses_rather_than_truncating(self, shape, expected):
-        """The signature is what types the request body, so this is the direction
-        that matters: every one of these returned `{'prd','prfaq'}` or `{}` and
-        reported agreement with the route while the client admitted more.
-
-        Asserting the refusal rather than the parsed value on purpose — a test
-        expecting `{'prd','prfaq','LegacyDocType'}` would pass on a parser that
-        merely widened its grammar, and the point is that the two declarations can
-        no longer be compared by equality at all.
-
-        The expected MESSAGE is asserted per shape, not just "some refusal": the
-        three guards are independent, and a shared either-message assertion let a
-        revert of one of them stay green.
-        """
-        with pytest.raises(AssertionError, match=expected):
-            _doc_type_annotations(shape)
-
-    @pytest.mark.parametrize('shape', NARROWED_SHAPES.values(), ids=NARROWED_SHAPES)
-    def test_a_narrowed_signature_is_read_rather_than_missed(self, shape):
-        """Drift must be reported as drift, not as an unparseable file.
-
-        Dropping PR-FAQ from the client while the route still accepts it is exactly
-        the "accepted but never offered (unreachable)" direction the comparison test
-        names. Requiring a `|` in the annotation made that edit invisible to this
-        parser, so it surfaced from the findability control as "was the method
-        renamed?" — a wrong turn for a maintainer who had just narrowed a union.
-        """
-        assert list(_doc_type_annotations(shape).values()) == [frozenset({'prd'})]
-
-
-# Each value declares `prd` and `prfaq`, however it is styled.
+# Each value declares `prd` and `prfaq`, however it is styled. The reason a shape is
+# here sits with the shape.
 UNION_SHAPES = {
     # The declaration in types.ts today.
     'single_line': "export type DocType = 'prd' | 'prfaq'\n",
     # What Prettier produces once the union exceeds the print width — so adding a
     # third member, the drift this file exists to catch, is a realistic route into
-    # this shape. The previous pattern required a quoted literal immediately after
-    # `=` and read nothing here.
+    # this shape. An earlier pattern required a quoted literal straight after `=`.
     'leading_pipe': "export type DocType =\n  | 'prd'\n  | 'prfaq'\n",
     'wrapped_without_leading_pipe': "export type DocType =\n  'prd'\n  | 'prfaq'\n",
     # Quote style is a formatter setting, not a fact about the contract.
     'double_quoted': 'export type DocType = "prd" | "prfaq"\n',
-    # A comment between the members, which must not end the union.
+    # A comment between the members, which must not end the union — in both
+    # spellings, since `_without_comments` handles them by separate branches.
     'commented': "export type DocType =\n  | 'prd' // the default\n  | 'prfaq'\n",
-    # A commented-out predecessor above the live declaration. `re.search` takes the
-    # first match, so without comment stripping the DEAD union is what gets read.
+    'block_commented':
+        "export type DocType =\n  | 'prd' /* the default */\n  | 'prfaq'\n",
+    # A commented-out predecessor above the live declaration: without comment
+    # stripping the DEAD union is the first match, so it is what gets read.
     'commented_out_predecessor':
         "// export type DocType = 'prd' | 'prfaq' | 'legacy'\n"
         "export type DocType = 'prd' | 'prfaq'\n",
+    # The shape types.ts has today: a leading comment explaining why this is the
+    # only copy. It must not be read as the union.
+    'documented': (
+        '// 🔑 The ONE frontend declaration. Do not respell it inline; import it.\n'
+        "export type DocType = 'prd' | 'prfaq'\n"
+    ),
 }
 
 
-class TestTheUnionParser:
-    """`_doc_type_union` on synthetic declarations.
+# Legal TypeScript that UNION_TERM does not match. In FIRST position nothing matches
+# at all; in LAST position the pattern stops before it and the union looks complete.
+# Both returned a value that compared equal to the allowlist, so both positions are
+# parametrised over the same three members.
+UNMATCHABLE_MEMBERS = ('(string & {})', '`${string}-draft`', '{ custom: string }')
 
-    The same reasoning as `TestTheParser`, applied to the other parser in this
-    file: the findability control can only report that this one found nothing, and
-    a maintainer who reads its message ("was the type renamed, or reformatted
-    across lines?") is sent looking for a rename when the real answer may be that
-    their union is legal TypeScript this parser could not read.
-    """
+
+class TestTheUnionParser:
+    """`_doc_type_union` on synthetic declarations."""
 
     @pytest.mark.parametrize('shape', UNION_SHAPES.values(), ids=UNION_SHAPES)
     def test_the_members_are_found_however_the_union_is_styled(self, shape):
@@ -728,176 +288,144 @@ class TestTheUnionParser:
         )
 
     def test_a_three_member_union_is_read_whole(self):
-        """The drift this file exists to catch is a member being ADDED, so the
-        parser must read the added one — truncating to the first two would report
-        agreement with the route while the picker offers a third value."""
+        """The drift this file exists to catch is a member being ADDED, so the added
+        one must be read — truncating to the first two reports agreement with the
+        route while the picker offers a third value."""
         source = "export type DocType =\n  | 'prd'\n  | 'prfaq'\n  | 'onepager'\n"
         assert _doc_type_union(source) == frozenset({'prd', 'prfaq', 'onepager'})
 
     def test_a_renamed_type_yields_nothing(self):
-        """The negative control: the findability check below is only meaningful if
-        an empty set really means the declaration was not found."""
+        """The negative control: the findability check is only meaningful if an empty
+        set really means the declaration was not found."""
         assert _doc_type_union("export type DocKind = 'prd' | 'prfaq'\n") == frozenset()
 
     def test_a_non_literal_member_fails_rather_than_truncating(self):
-        """A union referring to another type cannot be compared with the route's
-        allowlist. Reading only the literals beside it returned {'prd','prfaq'} and
-        PASSED, while the frontend could send whatever the identifier admits — a
-        silent pass, which is the direction that matters here.
-        """
+        """Reading only the literals beside an identifier returned {'prd','prfaq'}
+        and PASSED, while the frontend could send whatever the identifier admits — a
+        silent pass, which is the direction that matters here."""
         with pytest.raises(AssertionError, match='not string literals'):
             _doc_type_union("export type DocType = 'prd' | 'prfaq' | ExtraDocType\n")
 
-    @pytest.mark.parametrize('member', [
-        '(string & {})',
-        '`${string}-draft`',
-        '{ custom: string }',
-    ])
+    @pytest.mark.parametrize('member', UNMATCHABLE_MEMBERS)
     def test_an_unreadable_member_in_FIRST_position_refuses_at_the_anchor(self, member):
-        """The position the positional guard cannot see.
-
-        `= (string & {}) | 'prd' | 'prfaq'` matched nothing at all, because the
-        pattern required a readable term immediately after `=`. An empty set is what
-        a renamed type returns, so the equality test read "no drift" and the
-        findability control asked whether `DocType` had been renamed — while the
-        declaration sat there, widened. Splitting the anchor from the terms is what
-        turns this into a refusal; these three pin the direction the earlier fix
-        missed.
-        """
+        """The position the positional guard cannot see: `= (string & {}) | 'prd'`
+        matched nothing, and an empty set is what a renamed type returns — so the
+        equality test read "no drift" and the control asked about a rename while the
+        declaration sat there, widened."""
         with pytest.raises(AssertionError, match='begins with a term'):
             _doc_type_union(f"export type DocType = {member} | 'prd' | 'prfaq'\n")
 
-    @pytest.mark.parametrize('member', [
-        # Each is legal TypeScript that UNION_TERM does not match, so the pattern
-        # stopped at it and `{'prd','prfaq'}` was returned as though complete.
-        '(string & {})',
-        '`${string}-draft`',
-        '{ custom: string }',
-    ])
+    @pytest.mark.parametrize('member', UNMATCHABLE_MEMBERS)
     def test_a_member_the_grammar_cannot_read_fails_rather_than_ending_the_match(
         self, member
     ):
-        """The second half of the guard, and the one no term pattern can supply.
-
-        `UNION_TERM` covers quoted literals and identifiers, so a member that is
-        neither did not MATCH — and because the union pattern stops at the first
-        unmatched term, it was dropped before the not-a-literal check could see it.
-        These three all returned {'prd','prfaq'} and passed the equality test.
-
-        Fixing this by adding alternations would have been endless: TypeScript
-        admits arbitrarily many type expressions. The positional check in
-        `_union_members` closes it for shapes nobody enumerated, which is why
-        these three are parametrised rather than each pinned as its own grammar.
-        """
+        """The half no term pattern can supply. Adding alternations would be endless
+        — TypeScript admits arbitrarily many type expressions — so the positional
+        check closes it for shapes nobody enumerated, which is why these are
+        parametrised rather than each pinned as its own grammar."""
         with pytest.raises(AssertionError, match='continues past the terms'):
             _doc_type_union(f"export type DocType = 'prd' | 'prfaq' | {member}\n")
 
+    # The refusals `_doc_type_union` must carry: no readable term at the anchor, a
+    # matched non-literal, an unread term after the match.
+    EXPECTED_REFUSALS = 3
 
-class TestTheParserGuardsAreLoud:
-    """That the refusals in every parser here are `raise`, not `assert`.
-
-    Its own class because it is scoped to all three parser functions, where
-    `TestTheParser` and `TestTheUnionParser` are each scoped to one.
-    """
-
-    # The refusals `_union_members` is required to carry: no readable term at the
-    # anchor, a matched non-literal term, an unread term after the match.
-    UNION_MEMBERS_REFUSALS = 3
-
-    def test_no_parser_refuses_via_a_statement_python_dash_o_would_strip(self):
-        """`assert` is stripped under `python -O`, and these guards' whole purpose is
-        to be the loud option — so none of them may have a mode where it is not.
+    def test_the_guards_refuse_in_a_form_python_dash_o_keeps(self):
+        """`assert` is stripped under `python -O`, and these guards exist to be the
+        loud option — so none may have a mode where it is not.
 
         Read from the source rather than run under a second interpreter, because an
-        `assert` compiles to nothing under `-O`: no runtime observation distinguishes
-        "the guard passed" from "the guard was removed", which is the whole problem.
-        The property is syntactic, so the source is the only place it is visible.
+        `assert` compiles to nothing under `-O`: no runtime observation
+        distinguishes "the guard passed" from "the guard was removed", which is the
+        whole problem. Walked as an AST rather than matched as text, which two
+        earlier versions got wrong in opposite directions — searching for `raise
+        AssertionError` passed on a body with no raise at all, because this
+        docstring names the phrase, and stripping the docstring line-by-line deleted
+        code lines that equalled a short docstring line. A docstring is an `Expr`,
+        never an `Assert`.
 
-        Walked as an AST rather than by string matching, which two earlier versions
-        of this test got wrong in opposite directions. Matching `raise AssertionError`
-        in the source text passed on a body containing no raise at all, because the
-        docstring discusses the phrase by name — a test satisfied by prose about
-        itself. Stripping the docstring line-by-line then deleted any code line that
-        happened to equal a short docstring line. `ast` has neither problem: a
-        docstring is an `Expr`, never an `Assert`.
-
-        The `assert` scan covers all three parsers, since `_doc_type_union` and
-        `_doc_type_annotations` are where a future guard would naturally be added.
-        The refusal COUNT is per-function, and only `_union_members` is required to
-        carry any: a total across the three would stay green if a guard moved out of
-        the helper and any unrelated `raise` appeared elsewhere. Verified by making
-        exactly that edit.
-
-        LIMIT worth knowing: this counts `raise` statements SYNTACTICALLY, so it
-        cannot tell a reachable refusal from one behind an `if False:`. Reachability
-        is what the behavioural cases in `TestTheParser` and `TestTheUnionParser`
-        cover — each guard has fixtures that fail when it stops firing. This test
-        answers only "are the refusals spelled in a form `-O` keeps".
+        The COUNT is the complement: the `assert` scan alone is also satisfied by
+        there being no guard at all. LIMIT: `raise` is counted SYNTACTICALLY, so this
+        cannot tell a reachable refusal from one behind an `if False:` —
+        reachability is what the behavioural cases above cover.
         """
         import ast
         import inspect
         import textwrap
 
-        asserts: list[str] = []
-        raises: dict[str, int] = {}
-        for function in (_union_members, _doc_type_union, _doc_type_annotations):
-            # `getsource` starts at the def, so ast line numbers are offsets within
-            # it. Rebase onto the file so a failure names a line you can open.
-            first_line = function.__code__.co_firstlineno - 1
-            tree = ast.parse(textwrap.dedent(inspect.getsource(function)))
-            raises[function.__name__] = 0
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Assert):
-                    asserts.append(f'{function.__name__} at line {first_line + node.lineno}')
-                elif isinstance(node, ast.Raise):
-                    raises[function.__name__] += 1
+        # `getsource` starts at the def, so ast line numbers are offsets within it.
+        # Rebase onto the file so a failure names a line you can open.
+        first_line = _doc_type_union.__code__.co_firstlineno - 1
+        tree = ast.parse(textwrap.dedent(inspect.getsource(_doc_type_union)))
+        asserts = [
+            f'line {first_line + node.lineno}'
+            for node in ast.walk(tree) if isinstance(node, ast.Assert)
+        ]
+        raises = [node for node in ast.walk(tree) if isinstance(node, ast.Raise)]
 
         assert not asserts, (
             f'these parser guards refuse via `assert`, which `python -O` removes '
             f'entirely: {asserts}. Use `raise AssertionError(...)`.'
         )
-        # The complement: the scan above is also satisfied by there being no guard at
-        # all, so require the refusals to still be where they belong.
-        assert raises['_union_members'] >= self.UNION_MEMBERS_REFUSALS, (
-            f'_union_members should carry {self.UNION_MEMBERS_REFUSALS} refusals '
-            f'(anchor, non-literal term, unread term); found '
-            f'{raises["_union_members"]}. Counts per function: {raises}'
+        assert len(raises) >= self.EXPECTED_REFUSALS, (
+            f'_doc_type_union should carry {self.EXPECTED_REFUSALS} refusals '
+            f'(anchor, non-literal term, unread term); found {len(raises)}'
         )
+
+
+# Edits to the exported union that MUST break the equality test below. One per
+# direction, because the two are user-visible in different ways: an added member is
+# a 400 from a picker, a removed one a backend capability nobody can reach.
+DRIFTED_UNIONS = {
+    'member_added': "export type DocType = 'prd' | 'prfaq' | 'onepager'\n",
+    'member_removed': "export type DocType = 'prd'\n",
+    'member_replaced': "export type DocType = 'prd' | 'onepager'\n",
+}
+
+
+class TestContractDriftIsCaught:
+    """The complement of the equality test: that it is equality doing the work.
+
+    Without these it could be green because the parser returns the allowlist however
+    the union is edited — the "green result meaning did not check" this file exists
+    to prevent, applied to itself. Both directions are here so neither can be
+    satisfied by a parser that always agrees or always refuses.
+    """
+
+    @pytest.mark.parametrize('source', DRIFTED_UNIONS.values(), ids=DRIFTED_UNIONS)
+    def test_a_changed_member_no_longer_matches_the_route(self, source):
+        from projects_handler import GENERATED_DOC_TYPES
+
+        assert _doc_type_union(source) != frozenset(GENERATED_DOC_TYPES), (
+            f'this edit to DocType compares EQUAL to the route\'s allowlist, so '
+            f'the lockstep test below cannot see it:\n{source}'
+        )
+
+    @pytest.mark.parametrize('shape', ['commented', 'commented_out_predecessor'])
+    def test_a_legal_comment_leaves_the_result_matching_the_route(self, shape):
+        """Restricted to the two comment shapes on purpose: the rest of
+        `UNION_SHAPES` is reformatting, already pinned above against the same two
+        members. A comment is the case where the parser reads the WRONG declaration
+        rather than none, so `_without_comments` is the only thing standing between
+        it and a report of drift the frontend does not have."""
+        from projects_handler import GENERATED_DOC_TYPES
+
+        assert _doc_type_union(UNION_SHAPES[shape]) == frozenset(GENERATED_DOC_TYPES)
 
 
 class TestDocTypeLockstep:
     """The route refuses what the client cannot send, so the two must agree."""
 
-    def test_the_frontend_declarations_are_findable(self):
-        """The positive control.
-
-        Renaming `DocType`, or restyling the client signatures, would make the
-        parsers above return nothing and leave the equality tests passing while
-        comparing empty sets — a green result meaning "did not check", which is
-        the failure mode this file exists to prevent, applied to itself.
-        """
+    def test_the_frontend_declaration_is_findable(self):
+        """The positive control. Renaming `DocType` would make the parser return
+        nothing and leave the equality test passing while comparing empty sets — the
+        failure mode this file exists to prevent, applied to itself."""
         union_path = _repo_root() / DOC_TYPE_UNION_SOURCE
         assert union_path.is_file(), f'DocType source moved: {DOC_TYPE_UNION_SOURCE}'
         assert _declared_doc_type_union(), (
             f'parsed no DocType union members from {DOC_TYPE_UNION_SOURCE} — '
-            f'was the type renamed? (Restylings of the union itself are covered by '
-            f'TestTheUnionParser, so a legal reformatting should not land here.)'
-        )
-        client_sets = _api_client_doc_type_sets()
-        # PER FILE, not a total. `found` is keyed "file:line", so a bare
-        # `len(client_sets) == 2` is satisfied by two annotations parsed from one
-        # source while the other is entirely unparsed — which is precisely the mode
-        # this control exists to exclude, so counting the total lets through the
-        # only thing it is for.
-        parsed_sources = sorted({where.split(':')[0] for where in client_sets})
-        assert parsed_sources == sorted(API_CLIENT_SOURCES), (
-            f'expected a generateDocument doc_type annotation in EACH of '
-            f'{sorted(API_CLIENT_SOURCES)}, parsed only {parsed_sources} '
-            f'(declarations found: {sorted(client_sets)}) — was the method renamed, '
-            f'or the request-body signature extracted into a named type? '
-            f'If a named type: pointing this parser at it is ONE option, and '
-            f'retiring most of this parser is the other — see the module docstring '
-            f'on collapsing the duplicated declarations.'
+            f'was the type renamed? (Legal restylings of the union are covered by '
+            f'TestTheUnionParser, so a reformatting should not land here.)'
         )
 
     @pytest.mark.skipif(
@@ -906,9 +434,13 @@ class TestDocTypeLockstep:
     def test_the_route_accepts_exactly_what_the_doc_type_union_offers(self):
         """Equality, not containment.
 
-        A frontend value the route refuses is a 400 from a picker; a route value
-        the frontend never offers is a backend capability no user can reach. Both
-        are drift, so neither direction is allowed.
+        A frontend value the route refuses is a 400 from a picker; a route value the
+        frontend never offers is a backend capability no user can reach. Both are
+        drift, so neither direction is allowed.
+
+        This is the whole contract now that both `generateDocument` signatures import
+        `DocType` instead of respelling it: TypeScript rejects a request body outside
+        the union, and this test pins the union to the allowlist.
         """
         from projects_handler import GENERATED_DOC_TYPES
 
@@ -920,25 +452,4 @@ class TestDocTypeLockstep:
             f'{sorted(declared - frozenset(GENERATED_DOC_TYPES))}\n'
             f'  Accepted but never offered (unreachable): '
             f'{sorted(frozenset(GENERATED_DOC_TYPES) - declared)}'
-        )
-
-    @pytest.mark.skipif(
-        not _frontend_tree_present(), reason='frontend tree absent from this checkout'
-    )
-    def test_every_generate_document_signature_agrees_with_the_route(self):
-        """The `generateDocument` signatures are what actually types this route's
-        request body, so a widened signature is the change that would let a
-        refused value be sent. Sibling routes' `doc_type` fields are out of scope
-        — see this module's docstring for why suggest-brief is excluded."""
-        from projects_handler import GENERATED_DOC_TYPES
-
-        expected = frozenset(GENERATED_DOC_TYPES)
-        drifted = {
-            where: sorted(declared)
-            for where, declared in _api_client_doc_type_sets().items()
-            if declared != expected
-        }
-        assert not drifted, (
-            f'generateDocument doc_type signatures disagree with the route, '
-            f'which accepts {sorted(expected)}: {drifted}'
         )


### PR DESCRIPTION
Resolves #381.

## Summary

The generated-document contract was spelled **three** times in the frontend — the `DocType` union the picker is built from, plus `'prd' | 'prfaq'` **inline** in each of the two `generateDocument` client signatures. There is now one declaration, both clients take one shared request-body type, and the ~300 lines of TypeScript scanner that existed only to compare the inline copies are deleted.

Seven review rounds then went into making the remaining guards non-vacuous. That work is most of the diff, and the section below is honest about its cost.

| File | Change |
| --- | --- |
| `frontend/src/api/types.ts` | **`DocType` is declared here**, beside the other wire types (moved from `pages/`, which had `api/` importing from `pages/`). Plus `GenerateDocumentBody`, and the type-level pins with their controls. |
| `frontend/src/api/projectsApi.ts` | `generateDocument` takes `GenerateDocumentBody`; the pin on its parameter lives at the foot of the file. `suggestDocumentBrief` deliberately left unbound — documented at the line. |
| `frontend/src/api/client.ts` | Wrapper takes the same shared type. Also records that the file is one line from its `max-lines` cap. |
| `frontend/src/pages/ProjectDetail/types.ts` | Re-exports `DocType` for the picker. |
| `frontend/src/pages/ProjectDetail/Wizards.tsx` | `DocType` in the toggle, and a note on the three literals a widener must also edit here. |
| `lambda/api/projects_handler.py` | Comment only. `GENERATED_DOC_TYPES` untouched. |
| `lambda/api/test/test_doc_type_lockstep.py` | 944 → **~2380 lines**, 65 tests. See below. |

**No wire-shape or runtime change.** `GENERATED_DOC_TYPES` and `DocType`'s members are identical to `development`.

## What enforces what

The rule the file converged on: **a link TypeScript can check gets a compiler check; text assertions are reserved for the ones it cannot.**

| link | enforced by |
| --- | --- |
| `GenerateDocumentBody.doc_type` ≡ `DocType` | compiler — `DocTypeFieldIsExactlyTheUnion` |
| `generateDocument`'s parameter ≡ the body | compiler — `GenerateDocumentTakesTheSharedBody` |
| verdict helpers still constrain | compiler — each control's `@ts-expect-error` becomes TS2578 |
| both signatures reference the shared type | text — a *ratio*, not a substring |
| `DocType` ≡ `GENERATED_DOC_TYPES` | **this test** — no compiler sees a Python tuple |
| the generator's dispatch ≡ the allowlist | **nothing** — stated as a ceiling in the widening recipe, deliberately not guarded here |

Set equality in both directions, deliberately: a one-way `extends` passes on a *narrowed* field, which is the "capability nobody can reach" half of the drift.

## The widening recipe was incomplete (this round's blocking fix)

Seven rounds treated "widen `DocType` and `GENERATED_DOC_TYPES` together" as the whole supported change. It is not. `lambda/jobs/document_generator/handler.py` dispatches `doc_type` as a **binary** with PR-FAQ as the unconditional `else` — at the step-builder selection, the generation branch and `_assemble_and_save` — and never imports `GENERATED_DOC_TYPES` (zero references).

So a third member added the blessed way is accepted by `_validated_doc_type`, routed into the Step Functions chain by `is_chain` (true *by construction* once it is in the tuple), and then generated as a PR-FAQ. Driving the real constants:

```
accepted='onepager'  is_chain=True  generated=PRFAQ  sk=ONEPAGER#<id>  document_type='onepager'
```

The row is labelled the new type while the **content** is a PR-FAQ — wrong kind under the right label, after a Bedrock spend, with no error raised. That is worse than the drift these guards do catch: a refused value is a visible 400, this is a wrong-content *success*.

It was invisible because the guards are working correctly — the blessed widening is `tsc` exit 0 and every test here passing, which is the right false-positive result for a contract test that compares a TypeScript union to a Python tuple. Nothing in either language looks at the generator.

**Fixed as a stated ceiling, not a new guard.** The third edit is now named in both places a widener reads (the module docstring's recipe and the `GENERATED_DOC_TYPES` comment), anchored on **symbols** rather than line numbers — line-number citations into a file the test does not read are exactly what went stale three times on this branch. The generator's dispatch versus the route's allowlist is a different contract and wants its own test near the generator; bolting a second responsibility onto this file is the growth this PR argues against.

## On the size of the test file

It is **longer** than the scanner it replaced, and an earlier version of its own docstring claimed the opposite for two rounds. Measured with `ast` at the head of this branch: **2380 lines**, **66% prose** (module docstring 526, test docstrings 724, comments 318) against 566 lines of code — **2.52x** the 944-line scanner.

⚠️ Those exact figures are a snapshot and a *previous* set of them in this section was stale for a round, for the same structural reason the docstring's were: they describe a file that later commits keep editing. The durable claims are the shape — **well over 1.5x** the scanner, **about two thirds** prose — and the `ast` recipe in the module docstring, which is how these were measured. If a figure here and the file disagree, **the file is right**.

The docstring itself no longer restates an exact "now" count. That figure shipped wrong three rounds running, for a structural reason rather than carelessness: the count lives inside the thing it counts, so any later edit falsifies it and the last edit of a round is never the one that wrote the number — the third recurrence landed in the commit that added the instruction not to let it go wrong. It now claims the shape ("well over 1.5x the scanner", "about two thirds prose") and gives the `ast` recipe to measure precisely. The figures in this paragraph are the measured ones and carry the same caveat: if they and the file disagree, the file is right.

The pins are ~6 declarations and are what actually bite. The length is the scaffolding proving they are not vacuous, and it grew because each review round found a guard whose documented mechanism differed from its real one. Five successive text spellings were each measured to pass while the pin did nothing — so the rule is now: **when a guard is evadable, move the check to the compiler or pin the whole construct; do not add a longer fragment.** A fragment of the thing being pinned is always a substring something else can supply.

## Build and test results

Run from the repo root. `.venv`, `node_modules` and the root/`voc-datalake` npm trees were absent in this container and were created (`python -m venv`, `npm install`); none are committed. `mise run build` reports **no tasks defined** (this repo has no `mise.toml`), so the gates below are the ones `package.json` defines.

| Command | Result |
| --- | --- |
| `pytest lambda/api/test/test_doc_type_lockstep.py` | ✅ **65 passed** |
| `pytest lambda/api/test` | ✅ **2438 passed** |
| `npm run typecheck` (frontend `tsc -b`) | ✅ 0 errors |
| `npm run typecheck:cdk` | ✅ pass |
| `npm run lint:frontend` (eslint `--max-warnings 0`) | ✅ pass |
| `npx vitest run` (frontend) | ✅ **3191 passed / 189 files** |
| `npx vitest run src/api src/pages/ProjectDetail` | ✅ **927 passed / 65 files** |
| `ruff check` (both touched Python files) | ✅ new test file clean; 3 findings in `projects_handler.py` **identical to the `development` baseline** |
| `npm run build` | ✅ `✓ built in 8.76s` |
| `npm run typecheck:stream` | ⚠️ pre-existing env gap — see below |

⚠️ `npm run build` also failed intermittently in this container with `Rollup failed to resolve import` naming a *different* installed package each run (`date-fns`, `amazon-cognito-identity-js`, `recharts` — all present in `node_modules`). It is memory pressure on a 2-core container, not a code fault: `NODE_OPTIONS=--max-old-space-size=4096 npm run build` is a clean `✓ built in 8.76s`, and `npx vite build` alone succeeds unmodified. No file this PR touches is involved.

**`typecheck:stream`**: 62 errors, all in `voc-datalake/lambda/stream/src/`, rooted in `TS2307: Cannot find module '@aws-sdk/…'` because `lambda/stream/node_modules` is not installed here (the rest are `TS7006` cascades from the missing types). **No file under `lambda/stream/` is touched by this PR.** Install with `npm install --prefix voc-datalake/lambda/stream` before running `typecheck:all`.

### Mutation matrix

Every mutation applied to a throwaway worktree, one at a time. The `tsc` column is what the compiler reports; the `pytest` column is this file. A guard is only worth having if something goes red.

| mutation | tsc | pytest |
| --- | --- | --- |
| **intact** | exit 0 | **65 passed** |
| pin deleted, copy in a template literal, field widened | exit 0 | **1 failed** |
| pin deleted, copy in a **nested** template, field widened | exit 0 | **1 failed** |
| pin deleted, copy in a **regex-desynced** template, field widened | exit 0 | **1 failed** |
| pin deleted, copy in a **character-class-desynced** template, field widened | exit 0 | **1 failed** |
| pin deleted, copy in a **`for await`-desynced** template, field widened | exit 0 | **1 failed** |
| block-comment decoy + verdict constraint dropped | exit 0 | **1 failed** |
| directive line only *mentions* `@ts-expect-error` | 1 error | **1 failed** |
| `BothWays` collapsed one-way (forward / reverse) | **2 errors** | 65 passed |
| verdict constraints stripped in both files | **4 errors** | 65 passed |
| `BothWays` degenerated to constant `true` | **5 errors** | 65 passed |
| `DocType` widened alone | exit 0 | **1 failed** (`Offered but refused: ['onepager']`) |
| parameter widened via `Omit`/intersection | **1 error** | 1 failed |
| **supported change**: union + allowlist widened together | exit 0 | **65 passed** |

The last row is the one that matters as a false-positive check: the intended way to change the contract stays green.

The five "pin deleted" rows are the same defect in five constructs, and all five were fixed in the ONE helper the guards share rather than in any guard: `_without_comments` has to know where a string **ends** and where one may **begin**. A plain template literal was the fifth vacuity, `${...}` re-entering code was the seventh, a backtick inside a **regex literal** — which opened a phantom template frame that the decoy's own backtick then closed — was the eighth, a `/` inside a **character class**, which does not close the regex, was the ninth, a regex after a control-flow head's `)` was the tenth, and **`for await`** — whose head keyword is not the word before the `(` — was the eleventh. Each is red when its fix is reverted and nothing else is, so none of the repairs is silently revertible.

Rounds seven to eleven are one bug in one function surfacing in five constructs, which is why the lesson is now stated as a question about **delimiters** rather than about any one of them: the remaining surface is bounded by the ways JavaScript can open and close a string — whether one is read, where it ends, and where it may begin — not by the unbounded space of type expressions this file refuses to model. Each fix also has a wrong side, pinned separately — misreading a *division* as a regex, an indexed `[` as a character class, or an **awaited group** (`await (w + h) / 2` is a legal division) as a control head, is a false FAILURE bounded to one line, against a false PASS with no bound. The eleventh is the narrowest of the five, being one grammatical form rather than a construct: `for await` is the only modified head the language has, and the obvious one-word fix for it is caught by its own new wrong-side control and by nothing else.

Each control is also load-bearing individually — deleted in turn, with the degeneration it exists for reapplied, `tsc` reports **nothing in that file**.

## Verification

```abca-verify
no-ui
```

Type-only: `import type` is erased, `DocType`'s members are unchanged, and the pins are type declarations that emit nothing. The picker renders exactly as before. The only reachable surface is the document-generation wizard, behind a project selection and a tab click, so it is not observable on page load against an empty database.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).




