### PR TITLE
fix(feedback-forms): validate and serialize the public iframe route's form id (#379)

### DIFF
--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -263,7 +263,7 @@ embeddable widget calls from the customer's own site.
 > | Route | Rate / burst | Why |
 > |---|---|---|
 > | `POST /submit` | **20 rps / 40** | Each submission enqueues a record that drives Comprehend, Translate and a Bedrock invocation in the processor — a per-request model call against a shared quota |
-> | `GET /config`, `GET /iframe` | **100 rps / 200** | Fetched on every page load of every embed; cheap (one `get_item`, and a static HTML render, respectively) |
+> | `GET /config`, `GET /iframe` | **100 rps / 200** | Fetched on every page load of every embed; cheap (one `get_item` each — `iframe` reads the same record to confirm the form exists (#379) — plus a static HTML render for `iframe`) |
 >
 > The method-setting keys spell the variable `{form_id}` — the resource is created
 > as `addResource('{form_id}')`, so that is the path to look for in the template,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a
   model call.
+- The public embeddable feedback form page, `GET /feedback-forms/{form_id}/iframe`, no longer
+  reflects its form id into the page it returns. The id was interpolated into a `<script>` block
+  inside handwritten quotes, so a path the route's own pattern accepts —
+  `a');alert(document.domain);x=('` — came back as executable script on the API's own origin, to any
+  visitor who could be sent the link (#379). The id is now format-checked before the page is built,
+  every value the page inlines is serialized rather than quoted by hand, and the response carries a
+  Content-Security-Policy. The page also confirms the form exists first, so an attacker-chosen id no
+  longer produces a page at all. Embedding is unaffected: no `frame-ancestors` and no
+  `X-Frame-Options` are set, deliberately.
+- Every route that takes a form id out of the URL now checks its format before reading or writing,
+  so a probe or an unbounded path segment costs no DynamoDB call on the unauthenticated ones.
+- `PUT /feedback-forms/{form_id}` no longer creates a record. The write was an unconditional
+  `UpdateItem`, which is an upsert, so a request naming an id the table did not hold created a row
+  with no `form_id` of its own — one that read back with an empty id and could not afterwards be
+  addressed or deleted by id. It is now conditional on the form existing.
 
 ### Upgrade notes
 
@@ -75,6 +90,19 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   previously started a default `prd` generation. Unparseable JSON is a 400 too, where it was
   previously a 500. A body that is absent altogether, a literal JSON `null`, or zero-length
   (`Content-Length: 0`), still means "generate a PRD with the defaults" and is unchanged.
+- **A feedback form id that this service could not have issued now answers 404 on every route that
+  takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`
+  and `-`; surrounding whitespace is no longer trimmed, so ` abc123` is a 404 rather than another way
+  of writing `abc123`. Forms created through this platform are unaffected — the ids it mints are
+  8 hex characters — and a hand-seeded id like `website-form` still works.
+- **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
+  request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
+  answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route
+  had to refuse before enqueueing anything. A well-formed id with an empty `text` still answers 400.
+- **`PUT /feedback-forms/{form_id}` answers 404 for a form that does not exist**, instead of creating
+  one. Create through `POST /feedback-forms`, which mints the id. Any phantom rows an earlier version
+  created are visible in `GET /feedback-forms` as entries with an empty `form_id`; they have to be
+  removed directly from the aggregates table, since no route can address them by id.
 
 ## [0.2.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `UpdateItem`, which is an upsert, so a request naming an id the table did not hold created a row
   with no `form_id` of its own — one that read back with an empty id and could not afterwards be
   addressed or deleted by id. It is now conditional on the form existing.
+- `POST /feedback-forms` can no longer overwrite an existing form. The write was an unconditional
+  `PutItem`, which replaces whatever is stored at the same key, so a minted id that collided with a
+  form already there would have replaced it — that form's `enabled` flag, theme and document link
+  gone, reported as a successful create. Unreachable by a caller, since the id is minted rather than
+  taken from the request, so it required a collision between two draws; the write is now conditional
+  on the id being free and a collision answers 500 instead of losing the form.
 
 ### Upgrade notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,9 +92,11 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   (`Content-Length: 0`), still means "generate a PRD with the defaults" and is unchanged.
 - **A feedback form id that this service could not have issued now answers 404 on every route that
   takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`
-  and `-`; surrounding whitespace is no longer trimmed, so ` abc123` is a 404 rather than another way
-  of writing `abc123`. Forms created through this platform are unaffected — the ids it mints are
-  8 hex characters — and a hand-seeded id like `website-form` still works.
+  and `-`, so an id containing anything else — a space, for instance — answers 404: ` abc123` is
+  refused on its format. Note that no route ever resolved ` abc123` to `abc123`; the space was always
+  part of the key, so there is no stored data to migrate. Forms created through this platform are
+  unaffected — the ids it mints are 8 hex characters — and a hand-seeded id like `website-form` still
+  works.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/docs/SYSTEM_DOCUMENTATION.md
+++ b/docs/SYSTEM_DOCUMENTATION.md
@@ -596,6 +596,22 @@ is no separate script to load:
 <iframe src="https://your-api/v1/feedback-forms/{form_id}/iframe" width="100%" height="500" frameborder="0"></iframe>
 ```
 
+Two things about that page to know before debugging a blank or error frame:
+
+- It answers **404 for a form id the table does not hold**, and for one this
+  service could not have issued — the route confirms the form exists before
+  rendering, where it previously served a page having read nothing. A deleted form
+  or a typo in `{form_id}` is therefore an error frame rather than an empty
+  widget. See
+  [how a form id is checked](feedback-forms.md#how-a-form-id-is-checked-on-every-one-of-those-routes).
+- It sets a **Content-Security-Policy**, and that one fails silently: the frame
+  goes blank with nothing to see but a violation in the browser console. It
+  deliberately sets no `frame-ancestors` and no `X-Frame-Options`, so a proxy or
+  CDN in front of the API that adds either will break every embed. See
+  [Embedding Forms](feedback-forms.md#embedding-forms), which is where both are
+  described — this page links rather than repeating them so there is one copy to
+  keep correct.
+
 The only public per-form routes are `config`, `submit` and `iframe`; there is no
 `widget.js` route, and requesting one returns `403 Missing Authentication Token`.
 See [Feedback Forms](feedback-forms.md#embedding-forms).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -791,6 +791,16 @@ inlines it into the HTML page returned by `/feedback-forms/{form_id}/iframe`
 embed path — see [Feedback Forms](feedback-forms.md) for the snippet to hand to
 customers.
 
+Operationally, that route now reads the aggregates table to confirm the form
+exists before rendering (#379), so it has a dependency it did not have: a
+DynamoDB failure answers `500`, which arrives as a raw API Gateway error page
+**inside the customer's frame** with no widget message and no retry, where the
+route previously served a working page having read nothing. It also answers 404
+for a form the table does not hold. Both are triaged from
+[Feedback Forms](feedback-forms.md#embedding-forms), which lists what makes an
+embed that used to work start showing an error frame; the read failure is
+counted by the `FeedbackFormReadFailed` metric.
+
 A second, stale copy used to be published to the CDN from
 `frontend/public/feedback-widget.js`. It called the retired `/feedback-form/*`
 (singular) routes and had no callers, so it was deleted. If an old integration

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -71,8 +71,10 @@ needs loading.
 
 It answers **404 both for a form id the service could not have issued and for one
 that is not in the table** — the same answer for either, so the response tells an
-anonymous caller nothing about which. All three public routes format-check the id
-before they read anything, so a malformed one is refused rather than looked up.
+anonymous caller nothing about which. Every route that takes a form id out of the
+URL format-checks it before reading anything, so a malformed one is refused rather
+than looked up; see
+[how a form id is checked](#how-a-form-id-is-checked-on-every-one-of-those-routes).
 
 The iframe route carries one extra concern, because it is the only route in the
 API that returns HTML, on the API's own origin, and its page is framed on
@@ -147,6 +149,30 @@ Customize the form appearance:
 | GET | `/feedback-forms/{id}/config` | Public config endpoint. **Unauthenticated** and fetched cross-origin by the embedded widget, so it returns only the widget-rendering fields, via a separate allowlist (`item_to_widget_config` in `lambda/api/feedback_form_handler.py`) rather than the projection the authenticated routes use. It never returns internal identifiers such as `project_id` / `document_id`. |
 | POST | `/feedback-forms/{id}/submit` | Submit feedback |
 | GET | `/feedback-forms/{id}/iframe` | Embeddable HTML page |
+
+### How a form id is checked, on every one of those routes
+
+Every route above that takes an id out of the URL checks its **format** before it
+reads or writes anything: an id that this service could not have issued answers
+`404 Form not found` without a lookup. Ids are up to 64 characters of letters,
+digits, `_` and `-`, with no surrounding whitespace — so ` abc123` is not a way of
+addressing `abc123`, it is a 404.
+
+Two consequences are worth knowing if you integrate against these routes, both new
+in the change that closed #379:
+
+- **`POST /{id}/submit` reports a bad id ahead of a bad body.** A request carrying
+  both a malformed id and an invalid body — an empty `text`, say — now answers
+  `404 Form not found` where it previously answered
+  `400 Feedback text is required`. This is deliberate: the id is wrong regardless
+  of what the body contains, and the check has to come first because this is the
+  one public route that enqueues work. A well-formed id with an empty `text` still
+  answers 400, unchanged.
+- **`PUT /{id}` no longer creates a form.** It updates an existing one and answers
+  `404 Form not found` for an id the table does not hold. Previously the underlying
+  write was an upsert, so a `PUT` to an unknown id silently created a record with
+  no `form_id` of its own — an unaddressable row in the list. Use
+  `POST /feedback-forms` to create a form; it mints the id.
 
 ### Rate limits on the three public routes
 

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -155,8 +155,9 @@ Customize the form appearance:
 Every route above that takes an id out of the URL checks its **format** before it
 reads or writes anything: an id that this service could not have issued answers
 `404 Form not found` without a lookup. Ids are up to 64 characters of letters,
-digits, `_` and `-`, with no surrounding whitespace — so ` abc123` is not a way of
-addressing `abc123`, it is a 404.
+digits, `_` and `-`. Anything else is refused on its format, so ` abc123` is a 404
+— and it never addressed `abc123` in the first place: the space was always part of
+the key, so nothing that used to resolve has stopped resolving.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -69,6 +69,16 @@ The iframe route returns a self-contained HTML page: the Lambda inlines
 with the form's `config` and `submit` endpoints already wired, so nothing else
 needs loading.
 
+It answers **404 both for a form id the service could not have issued and for one
+that is not in the table** — the same answer for either, so the response tells an
+anonymous caller nothing about which. This is the only route in the API that
+returns HTML, on the API's own origin, and its page is framed on third-party
+sites, so the id is format-checked before any read and every value written into
+the page's script is serialized with `json.dumps` rather than quoted by hand
+(issue #379). If an embed that used to work starts showing an error frame, check
+that the form still exists before suspecting the
+[rate limits](#rate-limits-on-the-three-public-routes).
+
 There is no standalone `widget.js` script to load. That path is registered
 nowhere — not by the handler and not by the API — so a
 `<script src=".../widget.js">` tag never reaches the application at all and gets
@@ -143,8 +153,9 @@ knowing before you embed the widget, because they are observable from your page:
 
 `submit` is the tighter one because each submission enqueues a record that drives
 Comprehend, Translate and a Bedrock model invocation downstream. The two reads are
-cheap — one `get_item`, and a static HTML render — so they are held at the higher
-pair, sized for widget page-view traffic rather than for submissions.
+cheap — one `get_item` each, and for `iframe` a static HTML render on top of it —
+so they are held at the higher pair, sized for widget page-view traffic rather
+than for submissions.
 
 These figures are **pinned against the synthesized template** by a lockstep case in
 `voc-datalake/lib/stacks/api-stack.test.ts`, so tuning the numbers in `api-stack.ts`

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -71,13 +71,36 @@ needs loading.
 
 It answers **404 both for a form id the service could not have issued and for one
 that is not in the table** — the same answer for either, so the response tells an
-anonymous caller nothing about which. This is the only route in the API that
-returns HTML, on the API's own origin, and its page is framed on third-party
-sites, so the id is format-checked before any read and every value written into
-the page's script is serialized with `json.dumps` rather than quoted by hand
-(issue #379). If an embed that used to work starts showing an error frame, check
-that the form still exists before suspecting the
-[rate limits](#rate-limits-on-the-three-public-routes).
+anonymous caller nothing about which. All three public routes format-check the id
+before they read anything, so a malformed one is refused rather than looked up.
+
+The iframe route carries one extra concern, because it is the only route in the
+API that returns HTML, on the API's own origin, and its page is framed on
+third-party sites: every value written into that page's script is serialized with
+`json.dumps` rather than quoted by hand, **and** the characters the HTML parser
+acts on (`<`, `>`, `&`) are escaped on top of that — a `</script>` sequence ends
+the script element even inside a JavaScript string, which serializing alone does
+not prevent (issue #379). If you are extending the page, reaching for
+`json.dumps` is half the mechanism; `_js_value` in
+`voc-datalake/lambda/api/feedback_form_handler.py` is the one place to emit a
+value from, and its docstring says why.
+
+If an embed that used to work starts showing an error frame, check that the form
+still exists before suspecting the
+[rate limits](#rate-limits-on-the-three-public-routes). Two other causes to know
+about:
+
+- **The page now depends on a table read.** It confirms the form exists before
+  rendering, so a DynamoDB failure answers `500` — a raw API Gateway error page
+  inside the frame — where the route previously served a working page having read
+  nothing.
+- **The page sets a Content-Security-Policy.** It permits inline script and
+  style, and network access to the API's own origin, which is everything the
+  widget uses; it names no `img-src`, `font-src` or `frame-src`, so an asset added
+  to the widget later would be blocked until the policy names it. It deliberately
+  sets **no `frame-ancestors` and no `X-Frame-Options`**, because either would
+  refuse the embed this route exists for — if a proxy or CDN in front of the API
+  adds one, the frame will be blank on every customer site.
 
 There is no standalone `widget.js` script to load. That path is registered
 nowhere — not by the handler and not by the API — so a

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -515,16 +515,53 @@ def list_forms():
 @app.post("/feedback-forms")
 @tracer.capture_method
 def create_form():
-    """Create a new feedback form."""
+    """Create a new feedback form.
+
+    The other half of `update_form`'s condition, and here for the mirror-image
+    reason: PutItem OVERWRITES an item at the same key as silently as UpdateItem
+    creates one. `attribute_not_exists(sk)` makes this write a create only, so a
+    minted id that collides with a form already stored is refused instead of
+    replacing it — a customer's live form, its `enabled` flag, its theme and its
+    link to a prioritization document, gone with a 200 and a response echoing the
+    NEW record. The idiom is `projects_handler`'s, at its own two creates.
+
+    Reachable only through a collision, which is why this is a guard rather than a
+    fix for something observed: the id is never taken from the caller
+    (`build_form_item` mints it), so two `_minted_form_id()` draws would have to
+    agree — a birthday problem over `FORM_ID_LENGTH` hex characters, 32 bits at
+    the current 8. Small at a few thousand forms, and not zero. The constant's
+    comment says it is safe to RAISE, and this condition is what keeps that a free
+    choice rather than something eventually forced: it makes the collision a
+    refused request instead of a silent loss, whatever the width.
+
+    A collision is the SERVER's fault, not the caller's, so it answers 500 with
+    the generic message rather than a 4xx — the client did nothing wrong and
+    retrying is the right move, since the retry mints a different id.
+    `test_a_create_that_would_overwrite_a_stored_form_is_refused` pins it.
+    """
     body = app.current_event.json_body or {}
     # Link fields are validated inside build_form_item, structurally.
     item = build_form_item(body)
-    
+
     try:
-        aggregates_table.put_item(Item=item)
+        aggregates_table.put_item(
+            Item=item,
+            # See the docstring: this is what makes the route a create rather than
+            # a blind overwrite of whatever the minted id happens to name.
+            ConditionExpression='attribute_not_exists(sk)',
+        )
         logger.info(f"Created feedback form: {item['form_id']}")
         return {'success': True, 'form': item_to_form(item)}
     except Exception as e:
+        if _is_conditional_check_failure(e):
+            # A minted id that is already taken. Logged distinctly because it is
+            # the one failure here that says something about FORM_ID_LENGTH rather
+            # than about DynamoDB, and it would otherwise be invisible.
+            logger.error(
+                f"Refused to overwrite existing form {item['form_id']}: "
+                'the minted id collided with a stored one'
+            )
+            raise ServiceError('Failed to create form') from e
         logger.error(f"Error creating form: {e}")
         raise ServiceError('Failed to create form')
 

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -129,9 +129,16 @@ LINK_FIELDS = ('project_id', 'document_id')
 # Form identifier
 # ============================================
 #
-# A form id is MINTED by this module and never taken from a request body — see
-# `_minted_form_id`, the one place the format is decided. Everything below is
-# derived from that one place so the two cannot drift.
+# Two SEPARATE decisions, and they are deliberately not derived from each other:
+# `_minted_form_id` is the one place the format this service ISSUES is decided,
+# and `_FORM_ID_PATTERN` is a deliberately WIDER bound on what a caller may hand
+# back. Narrowing the mint therefore does not tighten the validator, and is not
+# meant to — the width is argued below and pinned in both directions by tests
+# (`test_a_hand_seeded_form_id_is_still_embeddable` for the width,
+# `test_an_over_long_id_is_refused_without_a_read` for the bound). The ONE
+# coupling that must hold — the service can always serve a page for an id it
+# issued — is checked by `test_a_minted_id_always_satisfies_the_validator`
+# rather than assumed here.
 FORM_ID_LENGTH = 8
 
 # The shape a caller-supplied form id has to have before it reaches a read or a
@@ -147,6 +154,9 @@ FORM_ID_LENGTH = 8
 # the parenthesis, the semicolon, '<', '>', '&', the backslash — is outside it.
 # Powertools' dynamic-route capture group admits all of those (issue #379), so
 # this pattern, not the route, is what bounds them.
+#
+# No whitespace either, and that is a choice rather than an oversight: see
+# `_validated_form_id`.
 FORM_ID_MAX_LENGTH = 64
 _FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
 
@@ -154,22 +164,34 @@ _FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
 def _minted_form_id() -> str:
     """A new form's id: the first `FORM_ID_LENGTH` hex characters of a uuid4.
 
-    The only place a form id is created. Named so the validator below can be
-    described against one definition rather than against a literal repeated at
-    the two sites that used to spell it out.
+    The only place a form id is created — it is never taken from a request body.
+
+    `.hex` rather than `str(uuid4())[:n]`, so the constant above is safe to
+    RAISE: the dashed form puts a '-' at offset 8, so slicing 9 characters of it
+    would mint an id ending in a separator, and slicing 14 would mint one holding
+    a '-' that the reader has no reason to expect. `.hex` is 32 hex characters
+    with no separators, so every length from 1 to 32 yields the format this
+    docstring claims.
     """
-    return str(uuid.uuid4())[:FORM_ID_LENGTH]
+    return uuid.uuid4().hex[:FORM_ID_LENGTH]
 
 
 def _validated_form_id(raw: Any) -> str | None:
     """The form id from the URL, or None if it cannot be one of ours.
+
+    THE authoritative statement of why this exists; the call sites point here
+    rather than restating it.
 
     Modelled on `ballots_handler._validated_session_id`, for the same two
     reasons: a format check before any read means a probe for
     `/feedback-forms/admin` or a 1 MB path segment costs no DynamoDB call, and
     None rather than a raise because every caller answers the same 404 — telling
     an anonymous caller "malformed" apart from "absent" only helps someone
-    probing.
+    probing. Like that sibling, it is applied at EVERY route that takes a form id
+    out of the URL and turns it into a key: `/config`, `/submit`, `/iframe`,
+    `/submissions` and `/stats` (the last two through `_load_form_for_query`), so
+    the cost argument above holds everywhere it is stated rather than on one route
+    only.
 
     The defect this closes (#379) is narrower than "unvalidated input", and worth
     stating so nobody relaxes the pattern on the grounds that the render escapes
@@ -177,13 +199,25 @@ def _validated_form_id(raw: Any) -> str | None:
     pattern Powertools compiles accepts `'`, `)` and `;`, so
     `a');alert(document.domain);x=('` matched the route and used to be rendered
     into a `<script>` block verbatim. Validation bounds what reaches the handler;
-    the structural serialization at the render site bounds what a value can do
-    once there. Both, because either alone leaves the other's failure fatal.
+    the structural serialization at the render site (`_js_value`) bounds what a
+    value can do once there. Both, because either alone leaves the other's
+    failure fatal.
+
+    NOT `.strip()`ed, which is where this parts company with the sibling it is
+    modelled on. There a session id is a 128-bit token and the leniency is
+    inconsequential; here it would make `' deadbeef'` an alias for `'deadbeef'`,
+    so every whitespace variant of an id would be a distinct URL serving
+    byte-identical HTML. That is a cache-key multiplier for the `Cache-Control`
+    follow-up recorded in `lib/stacks/api-stack.ts`, whose whole premise is that
+    the response is a pure function of the id and the host — with a strip it
+    would be a pure function of the STRIPPED id while the cache keys on the raw
+    path. An exact id keeps the URL-to-content mapping one-to-one, and no id this
+    service mints has whitespace to forgive
+    (`test_an_id_padded_with_whitespace_is_not_an_alias_for_the_id`).
     """
     if not isinstance(raw, str):
         return None
-    form_id = raw.strip()
-    return form_id if _FORM_ID_PATTERN.match(form_id) else None
+    return raw if _FORM_ID_PATTERN.match(raw) else None
 
 
 def validate_link_fields(body: dict) -> None:
@@ -554,10 +588,20 @@ def delete_form(form_id: str):
 @app.get("/feedback-forms/<form_id>/config")
 @tracer.capture_method
 def get_form_config_by_id(form_id: str):
-    """Get form config for widget (public endpoint)."""
+    """Get form config for widget (public endpoint).
+
+    The id is format-checked before the read, for the reason `_validated_form_id`
+    gives: this route is unauthenticated and its path segment is unbounded, so a
+    probe for `/feedback-forms/admin` or a megabyte of path must not buy a
+    DynamoDB call. Same 404 either way, so the refusal says no more than "no such
+    form" does.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
         item = response.get('Item')
         
@@ -576,17 +620,28 @@ def get_form_config_by_id(form_id: str):
 @app.post("/feedback-forms/<form_id>/submit")
 @tracer.capture_method
 def submit_form_feedback(form_id: str):
-    """Submit feedback to a specific form."""
+    """Submit feedback to a specific form.
+
+    The id is format-checked before the read (`_validated_form_id`), and BEFORE
+    the body is looked at: the write side of the public trio is the one route here
+    that also enqueues, so a form id that cannot be one of ours must not reach
+    either the table or the queue. The validated value is used everywhere below —
+    the key, `source_channel`, the metadata and `_anchor_form_brand` — so what is
+    stored is what was checked.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     body = app.current_event.json_body or {}
-    
+
     text = body.get('text', '').strip()
     if not text:
         raise ValidationError('Feedback text is required')
-    
+
     # Get form config
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
         form = response.get('Item')
         
@@ -618,14 +673,14 @@ def submit_form_feedback(form_id: str):
     if not form.get('brand_name') and effective_brand:
         # Store it, so this form stops depending on the environment variable —
         # see _anchor_form_brand.
-        _anchor_form_brand(form_id, effective_brand)
+        _anchor_form_brand(validated, effective_brand)
 
     now = datetime.now(timezone.utc)
     feedback_id = str(uuid.uuid4())
 
     # Build normalized record with category routing
     metadata = {
-        'form_id': form_id,
+        'form_id': validated,
         'form_name': form.get('name', ''),
         'form_version': '2.0',
     }
@@ -639,7 +694,7 @@ def submit_form_feedback(form_id: str):
     normalized_record = {
         'id': feedback_id,
         'source_platform': 'feedback_form',
-        'source_channel': f'form_{form_id}',
+        'source_channel': f'form_{validated}',
         'text': text,
         'rating': body.get('rating'),
         'created_at': now.isoformat(),
@@ -659,7 +714,7 @@ def submit_form_feedback(form_id: str):
             QueueUrl=PROCESSING_QUEUE_URL,
             MessageBody=json.dumps(normalized_record, default=str)
         )
-        logger.info(f"Submitted feedback to form {form_id}: {feedback_id}")
+        logger.info(f"Submitted feedback to form {validated}: {feedback_id}")
         return {
             'success': True,
             'feedback_id': feedback_id,
@@ -693,11 +748,16 @@ def _js_value(value: Any) -> str:
     while making it inert to the parser above it.
 
     U+2028 and U+2029 need the same treatment (they terminate a JavaScript line
-    but not a JSON string) and get it for free: `json.dumps` defaults to
-    `ensure_ascii=True`, which escapes every non-ASCII character.
+    but not a JSON string) and get it from `ensure_ascii=True`, which escapes
+    every non-ASCII character. That is `json.dumps`'s default and is passed
+    EXPLICITLY anyway: it is load-bearing here rather than cosmetic, and
+    `ensure_ascii=False` is an inviting edit (it makes a non-ASCII value readable
+    in a debug dump) that would put those two characters back into the script
+    raw. `test_a_line_separator_cannot_end_the_statement` is what fails if it is
+    removed.
     """
     return (
-        json.dumps(value)
+        json.dumps(value, ensure_ascii=True)
         .replace('<', '\\u003c')
         .replace('>', '\\u003e')
         .replace('&', '\\u0026')
@@ -716,9 +776,26 @@ def _js_value(value: Any) -> str:
 # serializer above has nowhere to send anything.
 #
 # `style-src 'unsafe-inline'` is required by the page's own <style> block and by
-# the widget's `style="..."` attributes; `connect-src 'self'` is the widget's
+# the widget's `style.cssText` assignments; `connect-src 'self'` is the widget's
 # fetch of /config and /submit, which are on this origin by construction
 # (api_endpoint is built from this request's own host).
+#
+# Those three are what makes the page WORK, and `default-src 'none'` is the
+# fallback for everything not named — so deleting any one of them is a total,
+# silent failure of the product on a customer's site rather than a degraded page.
+# That is why the whole policy is pinned as a directive-to-sources mapping by
+# `test_the_policy_names_every_directive_the_page_needs_and_no_wildcard`, which
+# fails on a removal AND on a widening.
+#
+# There is deliberately NO `img-src`, `font-src` or `frame-src`: the widget
+# builds its UI from DOM elements, text and CSS only — no <img>, no `url(...)`,
+# no `data:` URI, no webfont — so `default-src 'none'` blocks nothing it asks
+# for. `form-action 'none'` is correct for the same kind of reason: the widget
+# submits through `fetch`, never through a <form>. Those are claims about
+# feedback-widget.js rather than about this dict, so they are derived from that
+# file by `test_the_widget_asks_for_no_asset_the_policy_would_block` instead of
+# being trusted here — the day the widget grows an icon, that test fails and
+# names the directive to add.
 #
 # `frame-ancestors` is deliberately absent, and that is the decision this route
 # turns on: it EXISTS to be framed on customers' sites (docs/feedback-forms.md),
@@ -745,23 +822,33 @@ def get_form_iframe(form_id: str):
     """Serve the HTML page a customer's site frames for one form.
 
     The only route in this API that answers with a document rather than JSON, on
-    the API's own origin, unauthenticated — which is why the two gates below come
-    before a single character of HTML is produced (#379):
+    the API's own origin, unauthenticated — which is why two gates come before a
+    single character of HTML is produced. `_validated_form_id` carries the
+    argument for the FORMAT gate and is not restated here; what is specific to
+    this route is the EXISTENCE gate below and the availability consequence of
+    having one (#379).
 
-    - The id must have the SHAPE of one of ours (`_validated_form_id`). Powertools'
-      dynamic-route capture group accepts `'`, `)` and `;`, so the route pattern
-      is no bound at all; without this, `a');alert(document.domain);x=('` matched
-      and was rendered into the script block below.
-    - The form must EXIST. This route used to read nothing, so any string matching
-      the capture group got a 200 and a page — unlike /config and /submit, which
-      404 an id the table does not have. Existence is checked through
-      `_load_form_for_query`, the same one-get_item lookup those routes' siblings
-      use, so a caller cannot mint an attacker-chosen page on this origin at all,
-      and a deleted form stops serving an embed that can only fail.
+    The form must EXIST. This route used to read nothing, so any string matching
+    the capture group got a 200 and a page — unlike /config and /submit, which
+    404 an id the table does not have. That is what let a caller mint an
+    attacker-chosen page on this origin without even needing a malformed id, and
+    it is why the check is here rather than left to the widget's own /config
+    fetch. `_load_form_for_query` is the same one-get_item lookup /stats and
+    /submissions make, so both gates answer the same 404 as every sibling.
 
-    Both answer the same 404, deliberately: a malformed id and an absent one are
-    indistinguishable to an anonymous caller, which is `_validated_form_id`'s
-    reasoning and `ballots_handler._validated_session_id`'s before it.
+    THE TRADE, because it is a new coupling and a reader hunting "why did every
+    embed go blank" needs to find it: reading anything means the route can now
+    fail. `_load_form_for_query` raises `ServiceError` if the get_item raises, so
+    an aggregates-table blip answers 500 here where this route previously served
+    a working page having read nothing — and a 500 on this route is a raw API
+    Gateway error page inside the customer's iframe, with no widget string and no
+    retry (the throttle comment in `lib/stacks/api-stack.ts` traces the same
+    symptom for a 429). Accepted rather than overlooked: a page served for a form
+    that may not exist is the defect being closed, and a page whose /config fetch
+    is about to fail against the same table has nothing to render anyway, so
+    failing at the frame is more honest than failing inside it. It is also
+    observable — `_load_form_for_query` emits `FeedbackFormReadFailed` — which is
+    what makes it a trade rather than a silent regression.
 
     Neither gate is trusted alone. Every value that reaches the script is built by
     `_js_value`, so the render is safe even if the pattern is later widened or the
@@ -865,7 +952,18 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
 
     Both failure modes previously produced HTTP 200 with total_submissions: 0 on
     the stats route, which is the exact defect issue #312 is about.
+
+    The FORMAT check is here rather than at each caller because this function is
+    the one read those routes make, so one call covers `/stats`, `/submissions`
+    and the iframe page's existence gate — `_validated_form_id`'s cost argument
+    then holds at every route that states it rather than at one. Callers keep
+    using their own `form_id` for anything else they build (`source_channel`,
+    the response's echo) with no risk of a split-brain, because the validator is
+    EXACT: it returns the string it was given or None, never a normalized
+    variant of it.
     """
+    if not _validated_form_id(form_id):
+        raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
             Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -4,6 +4,7 @@ Handles: /feedback-forms/* - multiple forms management
 """
 import json
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -124,6 +125,67 @@ LINK_FIELD_MAX_LENGTH = 128
 LINK_FIELDS = ('project_id', 'document_id')
 
 
+# ============================================
+# Form identifier
+# ============================================
+#
+# A form id is MINTED by this module and never taken from a request body — see
+# `_minted_form_id`, the one place the format is decided. Everything below is
+# derived from that one place so the two cannot drift.
+FORM_ID_LENGTH = 8
+
+# The shape a caller-supplied form id has to have before it reaches a read or a
+# rendered page (`_validated_form_id`).
+#
+# WIDER than the mint on purpose, and that width is the whole decision worth
+# arguing: the mint is `[0-9a-f]{8}`, but records seeded by hand or by an import
+# carry ids like 'website-form', and their embeddable page must keep working — a
+# validator narrowed to the mint would 404 the iframe for a form whose /config
+# and /submit still answer, which reads as "the product broke" rather than as a
+# refusal. So the bound is on the CHARACTER SET and the LENGTH instead, and every
+# character that could end a JavaScript string or open an HTML tag — the quote,
+# the parenthesis, the semicolon, '<', '>', '&', the backslash — is outside it.
+# Powertools' dynamic-route capture group admits all of those (issue #379), so
+# this pattern, not the route, is what bounds them.
+FORM_ID_MAX_LENGTH = 64
+_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
+
+
+def _minted_form_id() -> str:
+    """A new form's id: the first `FORM_ID_LENGTH` hex characters of a uuid4.
+
+    The only place a form id is created. Named so the validator below can be
+    described against one definition rather than against a literal repeated at
+    the two sites that used to spell it out.
+    """
+    return str(uuid.uuid4())[:FORM_ID_LENGTH]
+
+
+def _validated_form_id(raw: Any) -> str | None:
+    """The form id from the URL, or None if it cannot be one of ours.
+
+    Modelled on `ballots_handler._validated_session_id`, for the same two
+    reasons: a format check before any read means a probe for
+    `/feedback-forms/admin` or a 1 MB path segment costs no DynamoDB call, and
+    None rather than a raise because every caller answers the same 404 — telling
+    an anonymous caller "malformed" apart from "absent" only helps someone
+    probing.
+
+    The defect this closes (#379) is narrower than "unvalidated input", and worth
+    stating so nobody relaxes the pattern on the grounds that the render escapes
+    anyway: `get_form_iframe` returns HTML on the API's own origin, and the route
+    pattern Powertools compiles accepts `'`, `)` and `;`, so
+    `a');alert(document.domain);x=('` matched the route and used to be rendered
+    into a `<script>` block verbatim. Validation bounds what reaches the handler;
+    the structural serialization at the render site bounds what a value can do
+    once there. Both, because either alone leaves the other's failure fatal.
+    """
+    if not isinstance(raw, str):
+        return None
+    form_id = raw.strip()
+    return form_id if _FORM_ID_PATTERN.match(form_id) else None
+
+
 def validate_link_fields(body: dict) -> None:
     """Reject a malformed project_id / document_id before it is persisted.
 
@@ -241,7 +303,7 @@ def build_form_item(body: dict, form_id: str | None = None) -> dict:
     """
     validate_link_fields(body)
     now = datetime.now(timezone.utc).isoformat()
-    fid = form_id or str(uuid.uuid4())[:8]
+    fid = form_id or _minted_form_id()
     
     item = {
         'pk': 'FEEDBACK_FORM',
@@ -608,14 +670,134 @@ def submit_form_feedback(form_id: str):
         raise ServiceError('Failed to submit feedback. Please try again.')
 
 
+def _js_value(value: Any) -> str:
+    """A trusted Python value as a JavaScript expression to inline in a script.
+
+    `json.dumps` and nothing hand-written: JSON is a subset of JavaScript
+    expression syntax, so the serializer — not the template — decides where the
+    quotes go and how a quote inside the value is escaped. The spelling this
+    replaced was `'{value}'`, a handwritten quote pair around raw text, and every
+    reflected-XSS variant on this route came from a value that closed it (#379).
+    Wrapping `json.dumps(...)` in quotes of our own would reintroduce exactly
+    that: the result already carries its own, and a second pair round it makes the
+    inner ones data again.
+
+    The three replacements are for the HTML parser, which sees this text before
+    any JavaScript engine does: inside a `<script>` element `</script>` ends the
+    element wherever it appears — string literal or not — so `<` and `>` cannot be
+    left as themselves. `&` goes with them because it is the other character an
+    HTML parser gives meaning to. `html.escape` is deliberately NOT used here and
+    could not be: it produces `&#x27;` and `&lt;`, which are entities the script
+    context does not decode, so it would corrupt the value rather than protect it.
+    Escaping to `\\uXXXX` keeps the string byte-identical to the JavaScript engine
+    while making it inert to the parser above it.
+
+    U+2028 and U+2029 need the same treatment (they terminate a JavaScript line
+    but not a JSON string) and get it for free: `json.dumps` defaults to
+    `ensure_ascii=True`, which escapes every non-ASCII character.
+    """
+    return (
+        json.dumps(value)
+        .replace('<', '\\u003c')
+        .replace('>', '\\u003e')
+        .replace('&', '\\u0026')
+    )
+
+
+# Sent with the one response in this API that is HTML rather than JSON, so it is
+# the one response a browser will parse as a document on the API's own origin.
+#
+# `script-src 'unsafe-inline'` is there because the widget is INLINED into the
+# page (get_widget_js) and this is the deployment's only script host; removing it
+# means a nonce and a widget that loads from a URL, which is a bigger change than
+# this one. What the policy still buys with that in place is worth having: no
+# EXTERNAL script can load, no image, font or frame can be fetched, and the only
+# network destination is this same origin — so a value that did escape the
+# serializer above has nowhere to send anything.
+#
+# `style-src 'unsafe-inline'` is required by the page's own <style> block and by
+# the widget's `style="..."` attributes; `connect-src 'self'` is the widget's
+# fetch of /config and /submit, which are on this origin by construction
+# (api_endpoint is built from this request's own host).
+#
+# `frame-ancestors` is deliberately absent, and that is the decision this route
+# turns on: it EXISTS to be framed on customers' sites (docs/feedback-forms.md),
+# and the directive has no fallback to `default-src`, so leaving it out is how
+# "any site may embed this" is spelled. Adding it, or an X-Frame-Options header,
+# would break every embed.
+_IFRAME_SECURITY_HEADERS = {
+    'Content-Security-Policy': (
+        "default-src 'none'; "
+        "script-src 'unsafe-inline'; "
+        "style-src 'unsafe-inline'; "
+        "connect-src 'self'; "
+        "base-uri 'none'; "
+        "form-action 'none'"
+    ),
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+}
+
+
 @app.get("/feedback-forms/<form_id>/iframe")
 @tracer.capture_method
 def get_form_iframe(form_id: str):
-    """Serve HTML page for form-specific iframe embedding."""
+    """Serve the HTML page a customer's site frames for one form.
+
+    The only route in this API that answers with a document rather than JSON, on
+    the API's own origin, unauthenticated — which is why the two gates below come
+    before a single character of HTML is produced (#379):
+
+    - The id must have the SHAPE of one of ours (`_validated_form_id`). Powertools'
+      dynamic-route capture group accepts `'`, `)` and `;`, so the route pattern
+      is no bound at all; without this, `a');alert(document.domain);x=('` matched
+      and was rendered into the script block below.
+    - The form must EXIST. This route used to read nothing, so any string matching
+      the capture group got a 200 and a page — unlike /config and /submit, which
+      404 an id the table does not have. Existence is checked through
+      `_load_form_for_query`, the same one-get_item lookup those routes' siblings
+      use, so a caller cannot mint an attacker-chosen page on this origin at all,
+      and a deleted form stops serving an embed that can only fail.
+
+    Both answer the same 404, deliberately: a malformed id and an absent one are
+    indistinguishable to an anonymous caller, which is `_validated_form_id`'s
+    reasoning and `ballots_handler._validated_session_id`'s before it.
+
+    Neither gate is trusted alone. Every value that reaches the script is built by
+    `_js_value`, so the render is safe even if the pattern is later widened or the
+    route's own regex changes underneath it.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
+    # Return value unused: this is the existence gate, not a projection. The
+    # page's content is a function of the id and the host, nothing stored.
+    _load_form_for_query(validated, 'Failed to load form')
+
     host = app.current_event.request_context.get('domainName', '')
     stage = app.current_event.request_context.get('stage', 'v1')
     api_endpoint = f"https://{host}/{stage}" if host else ''
-    
+
+    # ONE serialized object rather than five interpolated fields: the options
+    # object is a JSON object literal, so json.dumps writes every quote, brace and
+    # comma in it and the template writes none. `api_endpoint` goes through it too
+    # — it is derived from a request header (domainName), so it is not ours either.
+    #
+    # This is the page's ONLY reflected value, and it is in SCRIPT context, which
+    # is why `html.escape` appears nowhere below: the <title>, the container id and
+    # the <style> block are fixed text, so no request value reaches an HTML
+    # context. `html.escape(..., quote=True)` is the right tool for a value
+    # rendered as MARKUP and the wrong one inside a script, where its entities are
+    # never decoded — so if a later change puts the form id in the title or an
+    # attribute, that value needs it and NOT this function.
+    init_options = _js_value({
+        'container': '#voc-feedback-form',
+        'apiEndpoint': api_endpoint,
+        'formId': validated,
+        'configEndpoint': f'/feedback-forms/{validated}/config',
+        'submitEndpoint': f'/feedback-forms/{validated}/submit',
+    })
+
     html = f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -632,18 +814,17 @@ def get_form_iframe(form_id: str):
   <div id="voc-feedback-form"></div>
   <script>
   {get_widget_js()}
-  VoCFeedbackForm.init({{
-    container: '#voc-feedback-form',
-    apiEndpoint: '{api_endpoint}',
-    formId: '{form_id}',
-    configEndpoint: '/feedback-forms/{form_id}/config',
-    submitEndpoint: '/feedback-forms/{form_id}/submit'
-  }});
+  VoCFeedbackForm.init({init_options});
   </script>
 </body>
 </html>'''
-    
-    return Response(status_code=200, content_type="text/html", body=html)
+
+    return Response(
+        status_code=200,
+        content_type="text/html",
+        body=html,
+        headers=dict(_IFRAME_SECURITY_HEADERS),
+    )
 
 
 # ============================================

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -938,6 +938,16 @@ def get_form_iframe(form_id: str):
         raise NotFoundError('Form not found')
     # Return value unused: this is the existence gate, not a projection. The
     # page's content is a function of the id and the host, nothing stored.
+    #
+    # EXISTENCE ONLY — `enabled` is deliberately NOT consulted, which the unused
+    # return value makes look like an oversight rather than a decision. A disabled
+    # form still gets its page, matching `GET /config`, which publishes `enabled`
+    # in its projection and leaves the decision to the widget; `submit_form_feedback`
+    # is where it is enforced. The reason to keep the asymmetry is that the widget
+    # has to RUN in order to show its own disabled state — gate the page on
+    # `enabled` and the visitor gets a raw API Gateway 404 frame instead, which is
+    # a worse answer for the customer who turned the form off on purpose.
+    # `test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so` pins it.
     _load_form_for_query(validated, 'Failed to load form')
 
     host = app.current_event.request_context.get('domainName', '')

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -187,11 +187,24 @@ def _validated_form_id(raw: Any) -> str | None:
     `/feedback-forms/admin` or a 1 MB path segment costs no DynamoDB call, and
     None rather than a raise because every caller answers the same 404 — telling
     an anonymous caller "malformed" apart from "absent" only helps someone
-    probing. Like that sibling, it is applied at EVERY route that takes a form id
-    out of the URL and turns it into a key: `/config`, `/submit`, `/iframe`,
-    `/submissions` and `/stats` (the last two through `_load_form_for_query`), so
-    the cost argument above holds everywhere it is stated rather than on one route
-    only.
+    probing.
+
+    Like that sibling, it is applied at EVERY route that takes a form id out of
+    the URL and turns it into a key. All eight, so the claim can be read as
+    written and a reader does not have to hold a list of exceptions:
+
+    - unauthenticated: `/config`, `/submit`, `/iframe`
+    - authenticated reads: `/submissions`, `/stats` (both through
+      `_load_form_for_query`, the single read they make)
+    - authenticated CRUD: `GET`, `PUT` and `DELETE /feedback-forms/<form_id>`
+
+    The cost argument only earns its keep on the first three — the others are
+    behind Cognito, so nobody is probing them for free. They are covered anyway
+    because a universal claim is worth more than the three lines it saves: the
+    next reader of this function should not have to check which routes meant it.
+    `test_no_route_keys_on_a_form_id_without_validating_it_first` derives the list
+    from the module's own routing table rather than from this docstring, so a
+    route added later is a failure here instead of a quiet omission.
 
     The defect this closes (#379) is narrower than "unvalidated input", and worth
     stating so nobody relaxes the pattern on the grounds that the render escapes
@@ -509,10 +522,19 @@ def create_form():
 @app.get("/feedback-forms/<form_id>")
 @tracer.capture_method
 def get_form(form_id: str):
-    """Get a specific feedback form."""
+    """Get a specific feedback form.
+
+    Authenticated, so `_validated_form_id` is not buying a bound against an
+    anonymous prober here — it is buying the SAME bound at every route that turns
+    this URL segment into a key, so the claim in that function's docstring is true
+    of the module rather than of the public trio only.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
         item = response.get('Item')
         
@@ -530,7 +552,28 @@ def get_form(form_id: str):
 @app.put("/feedback-forms/<form_id>")
 @tracer.capture_method
 def update_form(form_id: str):
-    """Update a feedback form."""
+    """Update a feedback form.
+
+    UpdateItem is an UPSERT, which is the whole reason the two guards below are
+    here rather than only on the public routes:
+
+    - The id is format-checked first (`_validated_form_id`), so a segment that
+      could not be one of ours never becomes a key.
+    - `attribute_exists(sk)` makes this an UPDATE rather than a create. Without it
+      a PUT to an id the table does not hold WROTE one: a bare
+      {pk, sk, <updated fields>} row with no `form_id` attribute, which
+      `item_to_form` reads back as `form_id: ''` — a nameless entry in
+      `list_forms` that nothing can address or delete by id. That is the same
+      phantom-stub shape `_anchor_form_brand` already refuses for the same reason;
+      this route simply had no condition at all.
+
+    Creation is `POST /feedback-forms`, which mints the id, so nothing legitimate
+    reaches this route with an id that does not exist yet — a PUT to an absent id
+    is a client bug or a probe, and 404 is the answer both want.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     body = app.current_event.json_body or {}
     validate_link_fields(body)
     now = datetime.now(timezone.utc).isoformat()
@@ -553,15 +596,24 @@ def update_form(form_id: str):
     
     try:
         response = aggregates_table.update_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'},
             UpdateExpression='SET ' + ', '.join(update_parts),
             ExpressionAttributeNames=expr_names,
             ExpressionAttributeValues=expr_values,
+            # See the docstring: this is what makes the route an update instead of
+            # a create. One round trip, and no read-then-write race — a form
+            # deleted between a check and this write would still be refused.
+            ConditionExpression='attribute_exists(sk)',
             ReturnValues='ALL_NEW'
         )
-        
+
         return {'success': True, 'form': item_to_form(response.get('Attributes', {}))}
     except Exception as e:
+        # The condition failing is not a server error: it means the form is not
+        # there, which is the same 404 `get_form` gives for the same id. Reported
+        # before the generic branch so it cannot be logged as a failure to update.
+        if _is_conditional_check_failure(e):
+            raise NotFoundError('Form not found') from e
         logger.error(f"Error updating form: {e}")
         raise ServiceError('Failed to update form')
 
@@ -569,12 +621,21 @@ def update_form(form_id: str):
 @app.delete("/feedback-forms/<form_id>")
 @tracer.capture_method
 def delete_form(form_id: str):
-    """Delete a feedback form."""
+    """Delete a feedback form.
+
+    Format-checked for the same module-wide reason as `get_form`. No
+    `attribute_exists` condition, unlike `update_form`: DeleteItem on a key that
+    is not there is a no-op rather than a write, so the idempotent 200 this
+    already returns is the honest answer and there is no phantom row to prevent.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     try:
         aggregates_table.delete_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
-        logger.info(f"Deleted feedback form: {form_id}")
+        logger.info(f"Deleted feedback form: {validated}")
         return {'success': True}
     except Exception as e:
         logger.error(f"Error deleting form: {e}")
@@ -780,6 +841,24 @@ def _js_value(value: Any) -> str:
 # fetch of /config and /submit, which are on this origin by construction
 # (api_endpoint is built from this request's own host).
 #
+# That construction is what `'self'` depends on, and it holds for the ONE
+# deployment topology this stack builds: API Gateway invoked directly, so
+# `requestContext.domainName` — the host the document was served from — is also
+# the host the widget fetches. `lib/stacks/api-stack.ts` takes a
+# `frontendDistribution`, but that CloudFront distribution fronts the website
+# bucket only; no behaviour points at the API, and no custom domain or base-path
+# mapping is declared for it.
+#
+# If a deployment ever puts this API behind a distribution or a custom domain that
+# rewrites Host, `'self'` and `api_endpoint` stop agreeing — `domainName` would be
+# the ORIGIN's host while the document came from the EDGE's — and the widget's own
+# fetch is refused, with nothing to see but a CSP violation in a console nobody is
+# watching. The fix then is to derive both from the same forwarded host rather
+# than to widen the directive: `connect-src` naming an explicit API host is still
+# a bound, `'self' *` is not. Out of scope here because the topology does not
+# exist yet, and recorded because this comment is where the reader of that
+# deployment's blank frame will end up.
+#
 # Those three are what makes the page WORK, and `default-src 'none'` is the
 # fallback for everything not named — so deleting any one of them is a total,
 # silent failure of the product on a customer's site rather than a degraded page.
@@ -956,17 +1035,26 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
     The FORMAT check is here rather than at each caller because this function is
     the one read those routes make, so one call covers `/stats`, `/submissions`
     and the iframe page's existence gate — `_validated_form_id`'s cost argument
-    then holds at every route that states it rather than at one. Callers keep
-    using their own `form_id` for anything else they build (`source_channel`,
-    the response's echo) with no risk of a split-brain, because the validator is
-    EXACT: it returns the string it was given or None, never a normalized
-    variant of it.
+    then holds at every route that states it rather than at one.
+
+    The key is built from the VALIDATED value, like every other call site, rather
+    than from the parameter. Those are the same string today, and relying on that
+    was a latent split rather than a saving: a validator that normalized — a
+    plausible "form ids are case-insensitive" change — would have this function
+    read `FORM#DEADBEEF` while `/config` read `FORM#deadbeef` for the same URL,
+    and `/submissions` would then filter on a `source_channel` built by its caller
+    from the raw id, which no write ever used. A silent zero, which is the exact
+    defect class this function exists to prevent (#312). Keying on the validated
+    value removes the dependency instead of documenting it;
+    `test_the_validator_returns_its_input_unchanged` pins the exactness the
+    callers' own use of `form_id` still relies on.
     """
-    if not _validated_form_id(form_id):
+    validated = _validated_form_id(form_id)
+    if not validated:
         raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
     except Exception as e:
         # Surfaced as a metric because this failure used to be invisible: it was

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -980,6 +980,10 @@ def get_form_iframe(form_id: str):
     # `enabled` and the visitor gets a raw API Gateway 404 frame instead, which is
     # a worse answer for the customer who turned the form off on purpose.
     # `test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so` pins it.
+    #
+    # Both halves of the pair are discarded, including the validated id it hands
+    # back for `/stats` and `/submissions` to build their filter from: this route
+    # already holds that string, having passed it in.
     _load_form_for_query(validated, 'Failed to load form')
 
     host = app.current_event.request_context.get('domainName', '')
@@ -1058,7 +1062,9 @@ def _form_source_pk(form: dict) -> str:
     return f"SOURCE#{effective_brand}" if effective_brand else 'SOURCE#feedback_form'
 
 
-def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
+def _load_form_for_query(
+    form_id: str, read_failure_message: str
+) -> tuple[str, dict]:
     """Load a form record for a stats/submissions query, failing loudly.
 
     One get_item answers both questions those routes need, so neither has to be
@@ -1079,17 +1085,24 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
     and the iframe page's existence gate — `_validated_form_id`'s cost argument
     then holds at every route that states it rather than at one.
 
-    The key is built from the VALIDATED value, like every other call site, rather
-    than from the parameter. Those are the same string today, and relying on that
-    was a latent split rather than a saving: a validator that normalized — a
-    plausible "form ids are case-insensitive" change — would have this function
-    read `FORM#DEADBEEF` while `/config` read `FORM#deadbeef` for the same URL,
-    and `/submissions` would then filter on a `source_channel` built by its caller
-    from the raw id, which no write ever used. A silent zero, which is the exact
-    defect class this function exists to prevent (#312). Keying on the validated
-    value removes the dependency instead of documenting it;
-    `test_the_validator_returns_its_input_unchanged` pins the exactness the
-    callers' own use of `form_id` still relies on.
+    Returns the VALIDATED id alongside the record, and that is the whole reason
+    this signature is a pair rather than a dict. The key here is built from the
+    validated value, but a caller's `source_channel` — the filter that selects
+    which submissions belong to this form — used to be built from the raw
+    parameter, so the read and the filter came from two different strings. They
+    are the same string today, and relying on that was a latent split rather than
+    a saving: a validator that normalized (a plausible "form ids are
+    case-insensitive" change) would have this function read `FORM#DEADBEEF` while
+    `/config` read `FORM#deadbeef` for the same URL, and the caller would filter
+    on `form_DEADBEEF` while every write used `form_deadbeef` — zero submissions
+    for a form that has them, reported as a 200. That is the exact defect class
+    this function exists to prevent (#312), arriving through the door the format
+    check installed. Handing the validated id back removes the dependency instead
+    of documenting it, so `submit_form_feedback`'s write (`f'form_{validated}'`)
+    and both read routes' filter are built from one string.
+    `test_the_validator_returns_its_input_unchanged` still pins the exactness, and
+    `test_the_key_a_query_route_reads_is_the_id_in_its_url` pins the pair
+    end to end.
     """
     validated = _validated_form_id(form_id)
     if not validated:
@@ -1108,7 +1121,7 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
     form = response.get('Item')
     if not form:
         raise NotFoundError('Form not found')
-    return form
+    return validated, form
 
 
 @app.get("/feedback-forms/<form_id>/submissions")
@@ -1124,9 +1137,14 @@ def get_form_submissions(form_id: str):
     # One read answers both the 404 and the partition, where this route used to
     # do its own existence check and then have _get_form_source_pk re-read the
     # same record (and swallow a failure of it).
-    form = _load_form_for_query(form_id, 'Failed to fetch form')
+    validated, form = _load_form_for_query(form_id, 'Failed to fetch form')
 
-    source_channel = f'form_{form_id}'
+    # From the VALIDATED id, so this filter and the write that produced the rows
+    # it selects (`submit_form_feedback`, `'source_channel': f'form_{validated}'`)
+    # are built from one string. See _load_form_for_query: a validator that
+    # normalized would otherwise have this route filter on a channel no write ever
+    # used, and the symptom is zero rows rather than an error.
+    source_channel = f'form_{validated}'
     source_pk = _form_source_pk(form)
 
     try:
@@ -1220,9 +1238,12 @@ def get_form_stats(form_id: str):
 
     # 404 for a deleted form, and the partition its submissions are in, from the
     # one read — never a partition guessed from a read that failed.
-    form = _load_form_for_query(form_id, 'Failed to fetch form stats')
+    validated, form = _load_form_for_query(form_id, 'Failed to fetch form stats')
 
-    source_channel = f'form_{form_id}'
+    # From the VALIDATED id, for the same reason as get_form_submissions above:
+    # this filter has to be the string `submit_form_feedback` wrote
+    # (`'source_channel': f'form_{validated}'`), or the count is a false zero.
+    source_channel = f'form_{validated}'
     source_pk = _form_source_pk(form)
 
     try:

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -157,8 +157,18 @@ FORM_ID_LENGTH = 8
 #
 # No whitespace either, and that is a choice rather than an oversight: see
 # `_validated_form_id`.
+#
+# `\Z` rather than `$`, and that ONE character is load-bearing: Python's `$` also
+# matches immediately before a trailing newline, so `$` with `.match` accepted
+# `'deadbeef\n'` — the single whitespace character this pattern is supposed to
+# exclude, arriving by the one route the character class does not police. It also
+# made the length cap bound the MATCHED PREFIX rather than the id, so
+# `'a' * FORM_ID_MAX_LENGTH + '\n'` was admitted at 65 characters. `\Z` matches
+# only at the very end of the string, so the cap and the character class both mean
+# what they say. `test_a_trailing_newline_is_not_a_valid_form_id` is what fails if
+# it goes back.
 FORM_ID_MAX_LENGTH = 64
-_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
+_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}\Z')
 
 
 def _minted_form_id() -> str:
@@ -881,6 +891,28 @@ def _js_value(value: Any) -> str:
 # and the directive has no fallback to `default-src`, so leaving it out is how
 # "any site may embed this" is spelled. Adding it, or an X-Frame-Options header,
 # would break every embed.
+#
+# The other two headers are conventional, but each is here for a reason specific to
+# THIS response rather than as boilerplate:
+#
+# `nosniff` matters more here than it would anywhere else in this API, because this
+# is the only `text/html` it serves. Everything else is JSON, so this is the one
+# response whose whole purpose is to be parsed as a document on the API's own
+# origin — exactly the case where letting a browser decide the type for itself has
+# something to get wrong.
+#
+# `no-referrer` is the one with a PRODUCT consequence, and it is the one worth
+# recording so a future reader does not read it as data the product wanted and lost.
+# The page is framed on a customer's site, so without it the `Referer` on the
+# widget's own two fetches would carry the customer's page URL into this API's
+# access logs. Note the widget already sends `page_url: window.location.href` in
+# the submit body ON PURPOSE — so this is not withholding the URL from the product,
+# which receives it as a field it chose. It keeps it out of a log nobody asked to
+# collect it in.
+#
+# Both are pinned by `test_the_response_carries_the_two_headers_the_csp_does_not`:
+# `test_the_policy_names_every_directive_the_page_needs_and_no_wildcard` reads the
+# policy BY KEY and so would not notice either being removed or renamed.
 _IFRAME_SECURITY_HEADERS = {
     'Content-Security-Policy': (
         "default-src 'none'; "

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -1,8 +1,12 @@
 """
 Tests for feedback_form_handler.py - /feedback-forms/* endpoints.
 """
+import ast
+import inspect
 import json
+import os
 import re
+import textwrap
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2143,4 +2147,472 @@ class TestTheAnchorCanOnlyEverUpdateAFormThatExists:
             'covering the pre-anchor partition means recording the prior brand '
             'and doubling the reads on a route that already pages a whole '
             'partition. If that changed, this expectation changes with it.'
+        )
+
+
+# ============================================
+# The public iframe page (issue #379)
+# ============================================
+#
+# `GET /feedback-forms/<form_id>/iframe` is the ONE route in this API that answers
+# with a document instead of JSON, unauthenticated, on the API's own origin, and
+# it is designed to be framed on customers' sites. Before this change it
+# interpolated the caller-supplied path segment straight into a `<script>` block
+# and returned 200 without reading the table at all, so
+# `a');alert(document.domain);x=('` — which the route's own pattern accepts — was
+# rendered as executable script.
+
+# The payload from the issue, kept as one constant because three separate tests
+# assert three different things about the same string: that the ROUTE admits it,
+# that the HANDLER refuses it, and that the SERIALIZER would have made it inert
+# even if it arrived. Its three dangerous characters are the quote that closes the
+# string literal, the `)` that closes the init call and the `;` that starts a
+# second statement.
+_INJECTION_PAYLOAD = "a');alert(document.domain);x=('"
+
+
+def _iframe_event(api_gateway_event, form_id: str) -> dict:
+    """A GET of the public iframe page for `form_id`.
+
+    `resource` is spelled the way API Gateway sends it for the deployed route
+    (`/feedback-forms/{form_id}/iframe`) rather than left to the fixture's
+    path-derived default, which would embed the id itself and stop Powertools
+    matching the dynamic route for an id containing a `/`.
+
+    `domainName` is set because the page's apiEndpoint is built from it, and it is
+    a REQUEST-supplied value like the id — asserted below to be serialized too.
+    """
+    event = api_gateway_event(
+        method='GET',
+        path=f'/feedback-forms/{form_id}/iframe',
+        path_params={'form_id': form_id},
+        resource='/feedback-forms/{form_id}/iframe',
+    )
+    event['requestContext']['domainName'] = 'api.example.com'
+    return event
+
+
+def _route_pattern_for_iframe(handler) -> re.Pattern:
+    """The regex Powertools compiled for the iframe route, off the live resolver.
+
+    Read from the app rather than restated: the point of the positive control
+    below is that the FRAMEWORK accepts the payload, so a copy of powertools'
+    capture group pasted here would prove nothing about the version installed.
+    """
+    routes = [
+        route for route in handler.app._dynamic_routes
+        if route.rule.pattern.endswith('/iframe/*$')
+    ]
+    assert len(routes) == 1, (
+        f'expected exactly one dynamic /iframe route on the resolver, found '
+        f'{len(routes)} — this helper needs updating, it is not a finding about '
+        'validation.'
+    )
+    return routes[0].rule
+
+
+def _init_call_argument(page: str) -> str:
+    """The text between `VoCFeedbackForm.init(` and the end of the page.
+
+    Everything the handler wrote AFTER the opening parenthesis of the init call,
+    deliberately unparsed: the assertions below decide where the argument ends by
+    handing this to a JSON decoder, which is the whole question. Slicing at a
+    matching `)` here would answer it in the helper.
+
+    `rfind`, because the inlined widget's own docblock contains a
+    `VoCFeedbackForm.init({` usage example; the call the handler emits is the last
+    one on the page.
+    """
+    marker = 'VoCFeedbackForm.init('
+    start = page.rfind(marker)
+    assert start != -1, (
+        'the rendered page contains no VoCFeedbackForm.init( call — the embed '
+        'contract changed; this is a broken helper, not an injection finding.'
+    )
+    return page[start + len(marker):]
+
+
+def _quoted_interpolations(source: str, function_name: str) -> list[str]:
+    """Interpolations inside `function_name` that a handwritten quote pair wraps.
+
+    Derived from the handler's SOURCE with `ast`, scoped to one function, because
+    the defect being pinned is a spelling rather than an output: `'{form_id}'` in
+    an f-string is a JavaScript string literal whose quotes the template chose, so
+    the value can close them. `json.dumps` brings its own quotes; wrapping its
+    result in another pair puts the value back outside them.
+
+    Returns the offending source snippets so a failure names them. An interpolated
+    expression that is followed by a quote but not preceded by one (or the reverse)
+    is reported too: an unbalanced quote around a value is not a safe spelling
+    either, it is a broken one.
+    """
+    tree = ast.parse(source)
+    functions = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    ]
+    assert len(functions) == 1, (
+        f'expected exactly one def {function_name} in the source given, found '
+        f'{len(functions)} — a rename would otherwise make this derivation '
+        'silently scan nothing.'
+    )
+    function = functions[0]
+    offenders = []
+    for joined in (n for n in ast.walk(function) if isinstance(n, ast.JoinedStr)):
+        parts = joined.values
+        for index, part in enumerate(parts):
+            if not isinstance(part, ast.FormattedValue):
+                continue
+            before = parts[index - 1] if index else None
+            after = parts[index + 1] if index + 1 < len(parts) else None
+            preceded = (
+                isinstance(before, ast.Constant)
+                and isinstance(before.value, str)
+                and before.value.endswith(('"', "'"))
+            )
+            followed = (
+                isinstance(after, ast.Constant)
+                and isinstance(after.value, str)
+                and after.value.startswith(('"', "'"))
+            )
+            if preceded or followed:
+                # The EXPRESSION, not the `{...}` around it: the name is what a
+                # failure has to report, since it is the value whose quoting is
+                # wrong and the thing the reader has to go and fix.
+                offenders.append(ast.unparse(part.value))
+    return offenders
+
+
+class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
+    """Both gates in front of the iframe page, and the page they gate (#379).
+
+    A malformed id and an id for a form that does not exist answer the same 404,
+    and both answer it BEFORE any HTML exists — the route used to render a page
+    for any string its pattern matched, having read nothing.
+    """
+
+    def test_the_route_pattern_admits_the_payload_this_class_refuses(
+        self, feedback_form_handler
+    ):
+        """The positive control, without which every 404 below is meaningless.
+
+        If powertools' capture group refused this string, the refusals asserted
+        below would be the FRAMEWORK's and the tests would pass with
+        `_validated_form_id` deleted. Read off the compiled route on the live
+        resolver, so it tracks the installed version.
+        """
+        rule = _route_pattern_for_iframe(feedback_form_handler)
+
+        assert rule.match(f'/feedback-forms/{_INJECTION_PAYLOAD}/iframe'), (
+            f'the route pattern {rule.pattern} no longer matches '
+            f'{_INJECTION_PAYLOAD!r}, so the 404s in this class prove nothing '
+            'about the handler. If powertools narrowed its capture group, this '
+            'class needs a payload that still reaches the handler.'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_quote_paren_semicolon_id_is_refused_before_any_html(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The defect itself: this used to be 200 text/html with the payload in a
+        script block. It must be a 404, produced without touching the table —
+        format is decided before a read is paid for."""
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, _INJECTION_PAYLOAD), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        assert 'html' not in response['body'].lower()
+        assert 'alert(' not in response['body']
+        # Not echoed back in any form, either: the refusal names the resource,
+        # never the caller's string.
+        assert 'document.domain' not in response['body']
+        mock_table.get_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_an_over_long_id_is_refused_without_a_read(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """Length is bounded as well as character set, so a megabyte path segment
+        costs no DynamoDB call. Derived from the cap rather than hardcoded: a
+        literal would silently become a VALID length the day the cap is raised."""
+        too_long = 'a' * (feedback_form_handler.FORM_ID_MAX_LENGTH + 1)
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, too_long), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_well_formed_id_for_an_absent_form_is_refused(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The gate the route did not have at all: /config and /submit 404 an id
+        the table does not hold, and this route rendered a page for it. An
+        attacker-chosen page on this origin is the thing that mattered, and it did
+        not need a malformed id."""
+        mock_table.get_item.return_value = {}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        assert 'html' not in response['body'].lower()
+        # The read HAPPENED — this is the existence gate, not the format one, and
+        # a 404 that skipped the lookup would be the format check refusing a
+        # legitimate id instead.
+        mock_table.get_item.assert_called_once()
+        assert (
+            mock_table.get_item.call_args.kwargs['Key']['sk'] == 'FORM#deadbeef'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_server_minted_id_still_serves_the_embeddable_page(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The contract that must survive the two gates: a real form's page still
+        renders, inlines the widget and points it at that form's config and submit
+        endpoints on this request's own host.
+
+        The id comes from the mint (`_minted_form_id`) rather than from a literal,
+        so a validator narrowed past the format this service actually issues fails
+        here instead of in a customer's iframe.
+        """
+        form_id = feedback_form_handler._minted_form_id()
+        mock_table.get_item.return_value = {'Item': {'form_id': form_id}}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, form_id), lambda_context
+        )
+        page = response['body']
+
+        assert response['statusCode'] == 200
+        assert response['multiValueHeaders']['Content-Type'] == ['text/html']
+        assert '<div id="voc-feedback-form"></div>' in page
+        # The widget is inlined, not linked: the page has no second request to
+        # make for its own code (get_widget_js).
+        assert 'window.VoCFeedbackForm' in page
+
+        options = json.loads(_json_prefix(_init_call_argument(page)))
+        assert options['formId'] == form_id
+        assert options['configEndpoint'] == f'/feedback-forms/{form_id}/config'
+        assert options['submitEndpoint'] == f'/feedback-forms/{form_id}/submit'
+        assert options['apiEndpoint'] == 'https://api.example.com/test'
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_hand_seeded_form_id_is_still_embeddable(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The bound is wider than the mint deliberately, and this is why.
+
+        Records seeded by hand or by an import carry readable ids
+        ('website-form'), and their /config and /submit routes answer, so an
+        iframe narrowed to `[0-9a-f]{8}` would 404 a form that otherwise works —
+        which reads as the product breaking rather than as a refusal. Pinned so
+        the width is a decision rather than an accident of the pattern.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'website-form_2'}}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'website-form_2'), lambda_context
+        )
+
+        assert response['statusCode'] == 200
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_page_carries_a_policy_that_still_lets_a_customer_frame_it(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """A CSP on the only HTML response in the API — with the ONE directive it
+        must not carry.
+
+        `frame-ancestors` (and X-Frame-Options) would refuse the embed this route
+        exists for, and `frame-ancestors` has no fallback to `default-src`, so its
+        absence is the deliberate half of the header rather than an omission. The
+        asserted half is `default-src 'none'`: no external script, image or frame
+        can load, so a value that somehow escaped the serializer has nowhere to
+        send anything.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'deadbeef'}}
+        event = _iframe_event(api_gateway_event, 'deadbeef')
+        # The resolver only emits a CORS header for a request that carries an
+        # Origin it is configured to allow, so the last assertion below needs one
+        # sent. In this suite that is conftest's ALLOWED_ORIGIN; the deployed
+        # Lambda is given '*' (api-stack.ts) because the embed's origin is a
+        # customer's own domain.
+        event['headers']['Origin'] = os.environ['ALLOWED_ORIGIN']
+
+        headers = feedback_form_handler.lambda_handler(event, lambda_context)[
+            'multiValueHeaders'
+        ]
+
+        policy = headers['Content-Security-Policy'][0]
+        assert "default-src 'none'" in policy
+        assert 'frame-ancestors' not in policy, (
+            'frame-ancestors refuses the embed this route exists for — see '
+            'docs/feedback-forms.md, which publishes the iframe snippet'
+        )
+        assert 'X-Frame-Options' not in headers
+        # And the CORS header is still there: adding response headers of our own
+        # must not have replaced the ones the resolver contributes.
+        assert headers['Access-Control-Allow-Origin'] == [
+            os.environ['ALLOWED_ORIGIN']
+        ]
+
+
+def _json_prefix(text: str) -> str:
+    """The longest leading substring of `text` that is one JSON value.
+
+    `raw_decode` is the point rather than a convenience: it reports where the
+    value ENDS, so the caller can assert what follows it. That is how "the input
+    could not create a second statement" is checked without a JavaScript engine —
+    if a payload had closed the argument, the decoder would stop early and the
+    remainder would carry the caller's code instead of just `);`.
+    """
+    value, end = json.JSONDecoder().raw_decode(text)
+    assert value is not None
+    return text[:end]
+
+
+class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
+    """Escaping, asserted independently of the validation in front of it.
+
+    The two are not alternatives: `_validated_form_id` bounds what reaches the
+    handler, and this bounds what a value can DO once there — so widening the
+    pattern later, or a change in the route regex underneath it, cannot turn into
+    executable script. Which means these cases have to reach the serializer
+    directly, since the route now refuses the payload before rendering.
+    """
+
+    def test_the_injection_payload_serializes_to_one_inert_string(
+        self, feedback_form_handler
+    ):
+        """Quote, `)` and `;` become data: one JSON string, nothing after it.
+
+        The failing spelling — `'{form_id}'` — produced
+        `formId: 'a');alert(document.domain);x=('',` i.e. a closed string, a
+        closed call and a second statement. The assertion is therefore about the
+        REMAINDER: a serialized value that consumed the whole text cannot have
+        ended early enough to start anything.
+        """
+        serialized = feedback_form_handler._js_value(_INJECTION_PAYLOAD)
+
+        value, end = json.JSONDecoder().raw_decode(serialized)
+        assert value == _INJECTION_PAYLOAD, (
+            'the value did not survive as itself — the widget would receive a '
+            'different form id than the caller asked for'
+        )
+        assert end == len(serialized), (
+            f'the JSON value ends at {end} of {len(serialized)}; '
+            f'{serialized[end:]!r} is trailing text a JavaScript engine would '
+            'read as further code'
+        )
+        # The serializer chose the delimiters, which is why the payload's
+        # apostrophe is harmless while still being emitted as itself: the literal
+        # is double-quoted, so `'` is an ordinary character inside it and the `)`
+        # and `;` after it never leave it. Asserted this way rather than as "`'`
+        # does not appear", which would be a claim about JSON's escaping style
+        # rather than about what the value can do.
+        assert serialized.startswith('"') and serialized.endswith('"')
+        assert '"' not in serialized[1:-1], (
+            'an unescaped double quote inside the literal would close the '
+            'delimiter the serializer chose, which is the same defect one '
+            'delimiter along'
+        )
+
+    def test_a_script_closing_tag_cannot_end_the_element(
+        self, feedback_form_handler
+    ):
+        """`</script>` ends a script element wherever it appears, INCLUDING inside
+        a JavaScript string literal — the HTML parser gets there first and knows
+        nothing about quoting. So `json.dumps` alone is not enough for this
+        position, and `html.escape` would be wrong (its `&lt;` is an entity the
+        script context never decodes, corrupting the value).
+        """
+        serialized = feedback_form_handler._js_value('</script><img src=x>')
+
+        assert '<' not in serialized
+        assert '>' not in serialized
+        # Still the same string to the JavaScript engine, which is the half a
+        # naive strip-the-characters fix would lose.
+        assert json.loads(serialized) == '</script><img src=x>'
+
+    def test_no_javascript_value_is_wrapped_in_a_handwritten_quote_pair(
+        self, feedback_form_handler
+    ):
+        """The spelling, not just this render's output.
+
+        Read off `get_form_iframe`'s source with `ast`: an interpolation with a
+        quote character on either side is a template deciding where a JavaScript
+        string begins and ends, which is the defect. A serializer's output brings
+        its own quotes, so it needs none around it — and quotes around it would
+        make the ones it wrote into data.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+        offenders = _quoted_interpolations(source, 'get_form_iframe')
+
+        assert offenders == [], (
+            f'{offenders} are interpolated inside handwritten quotes in '
+            'get_form_iframe. A JS value must be emitted through _js_value, '
+            'which quotes it itself.'
+        )
+
+    def test_the_quoted_interpolation_check_can_fail(self):
+        """Positive control for the derivation above.
+
+        Without it, an `ast` walk that found no JoinedStr at all — a template
+        moved into a helper, a parse that quietly matched nothing — would report
+        an empty list and the test above would pass while pinning nothing. The
+        input is the exact spelling this change removed.
+        """
+        source = textwrap.dedent('''
+            def get_form_iframe(form_id):
+                return f"""
+                  formId: '{form_id}',
+                  options: {init_options}
+                """
+        ''')
+
+        offenders = _quoted_interpolations(source, 'get_form_iframe')
+
+        assert offenders == ['form_id'], (
+            'the derivation did not flag the exact spelling this change removed, '
+            f'it reported {offenders} — so a green result above means nothing.'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_rendered_init_call_carries_exactly_one_statement(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """End to end, on a page that really renders: the init argument is one
+        JSON value and what follows it is only the call's own punctuation.
+
+        This is the property the route-level 404s cannot show, because they never
+        get as far as HTML — and it is the property that survives someone
+        widening the id pattern.
+        """
+        form_id = feedback_form_handler._minted_form_id()
+        mock_table.get_item.return_value = {'Item': {'form_id': form_id}}
+
+        page = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, form_id), lambda_context
+        )['body']
+
+        argument = _init_call_argument(page)
+        _value, end = json.JSONDecoder().raw_decode(argument)
+        remainder = argument[end:]
+
+        assert remainder.startswith(');'), (
+            f'the init argument is followed by {remainder[:40]!r} rather than '
+            'the call being closed immediately — anything between the value and '
+            "the `)` is code the page's own template put there"
+        )
+        # Nothing but the closing of the script and the document after it.
+        assert remainder.split(');', 1)[1].strip() == (
+            '</script>\n</body>\n</html>'
         )

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3466,31 +3466,73 @@ _FORM_ID_SINKS = frozenset({
     'aggregates_table', 'feedback_table', 'sqs', 'dynamodb',
 })
 
+# The OPERATION names, which is the property that is closed over spellings where
+# the receiver names above are not.
+#
+# A receiver allowlist cannot be complete for "reaches a form id into a sink",
+# because the handle can be produced by anything: this repo alone reads the same
+# table as `aggregates_table.get_item(...)`, as
+# `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` (module scope, line ~40), as
+# `table = get_aggregates_table()` then `table.get_item(...)` (the PREVAILING
+# style — `ballots_handler.py:379`, `projects_handler.py:1347`/`:2283`/`:2402`,
+# `integrations_handler.py:545`, `scrapers_handler.py:228`, twelve sites), and
+# `lambda/shared/tables.py` routes that factory through
+# `get_dynamodb_resource().Table(...)`. Every one of those names a different
+# receiver and the same METHOD, and it is the method that makes the call a read or
+# a write. `ballots_handler` is the sibling `_validated_form_id`'s docstring names
+# as this design's model, so the shape the receiver allowlist could not see was the
+# one a new form-id route was most likely to be written in.
+#
+# Adding a name to the frozenset above closes one spelling; matching the operation
+# closes the class. Both are kept: the receiver match still catches a call whose
+# method this set does not name (a `meta.client` call, a paginator), and the
+# operation match catches a named method through any handle at all.
+#
+# Erring toward calling something a sink is the right side of this: a false
+# positive costs a route author an explanation, while a false negative is a read
+# NOBODY reports — an empty `sink_positions` makes `_validates_its_form_id`'s
+# `all(...)` vacuously True, so the instrument answers "bounded" when it understood
+# nothing.
+_SINK_OPERATIONS = frozenset({
+    'get_item', 'put_item', 'update_item', 'delete_item', 'query', 'scan',
+    'batch_get_item', 'batch_write_item', 'send_message', 'send_message_batch',
+})
+
 
 def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
     """Positions of every call in `function` that reaches a form id into a sink.
 
-    Matched on the CALLEE CHAIN rather than on `<sink>.<method>` alone, which is
-    what an earlier version of this derivation did — and it recognised a read only
-    when spelled `aggregates_table.get_item(...)` literally. Two shapes therefore
-    reported as bounded while reading before validating, and the failure mode was
+    A call counts as a sink two ways, and either is enough:
+
+    - its METHOD is one of `_SINK_OPERATIONS`, whatever handle it arrives through.
+      That is the one that is closed over spellings; the constant's comment carries
+      the argument and the in-repo lines it is derived from.
+    - a sink NAME appears anywhere in the callee chain — including a local alias of
+      one — which still catches a call whose method that set does not name.
+
+    Both exist because an earlier version had only the second, spelled as
+    `<sink>.<method>` on the immediate owner, and every shape it could not see
+    reported as bounded while reading before validating. The failure mode is
     SILENCE rather than a wrong answer: no sink found makes `sink_positions` empty,
-    and `all(...)` over an empty list is vacuously True.
+    and `all(...)` over an empty list is vacuously True. Each shape below is a
+    control in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`:
 
-    - `table = aggregates_table` then `table.get_item(...)`. Locally bound sinks
-      are tracked below for this one.
-    - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)`, where the sink name sits
-      further down the chain than `call.func.value`. Walking the whole callee
-      subtree is what catches it, and it is the more plausible of the two because
-      the module itself demonstrates that spelling.
+    - `table = aggregates_table` then `table.get_item(...)` — alias tracking.
+    - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` — the sink name sits deeper
+      in the chain than `call.func.value`.
+    - `table = get_aggregates_table()` then `table.get_item(...)`, and
+      `get_dynamodb_resource().Table(T).get_item(...)` — no sink name anywhere, so
+      only the operation match sees them.
 
-    Both are controls in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`.
-
-    Aliases are collected from the function's TOP LEVEL, in source order, and only
-    from a plain `name = <expression mentioning a sink>`. A conditionally bound
-    alias is not tracked, deliberately: this derivation errs toward calling
-    something a sink, and the cost of a false positive is a route author being made
-    to say why — whereas a false negative is a read nobody reports.
+    Aliases are collected in source order and from NESTED bodies as well as the top
+    level (`try`, `with`, `if`, `for`), because every table read in this handler
+    sits inside a `try:` — so the plausible spelling of an alias is an indented
+    one, and three of the twelve in-repo `table = get_aggregates_table()` sites are
+    themselves inside one. An untracked alias is a FALSE NEGATIVE, not a cautious
+    false positive: the call drops out of `sink_positions` and the shorter list
+    makes the `all()` MORE likely to pass. That is the same vacuous pass the
+    controls exist to prevent, which is why alias collection is generous while the
+    REFUSAL's top-level requirement — a separate axis — stays strict.
     """
     aliases: set[str] = set()
 
@@ -3501,22 +3543,31 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
             for child in ast.walk(node)
         )
 
-    for statement in function.body:
-        if not isinstance(statement, ast.Assign):
-            continue
-        if not _mentions_a_sink(statement.value):
-            continue
-        aliases |= {
-            target.id for target in statement.targets
-            if isinstance(target, ast.Name)
-        }
+    def _collect_aliases(body: list[ast.stmt]) -> None:
+        for statement in body:
+            if isinstance(statement, ast.Assign) and _mentions_a_sink(
+                statement.value
+            ):
+                aliases.update(
+                    target.id for target in statement.targets
+                    if isinstance(target, ast.Name)
+                )
+            # A sink handle bound inside a `try:`/`with`/`if`/`for` is still bound.
+            for field in ('body', 'orelse', 'finalbody'):
+                nested = getattr(statement, field, None)
+                if isinstance(nested, list):
+                    _collect_aliases(nested)
+            for handler in getattr(statement, 'handlers', []):
+                _collect_aliases(handler.body)
+
+    _collect_aliases(function.body)
 
     return [
         (call.lineno, call.col_offset)
         for call in ast.walk(function)
         if isinstance(call, ast.Call)
         and isinstance(call.func, ast.Attribute)
-        and _mentions_a_sink(call.func)
+        and (call.func.attr in _SINK_OPERATIONS or _mentions_a_sink(call.func))
     ]
 
 
@@ -3546,7 +3597,43 @@ def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
     one, so hoisting just the assignment out of the dead block escaped the
     top-level requirement while nothing was ever refused
     (`test_the_derivation_refuses_a_refusal_that_only_runs_sometimes`).
+
+    A NEGATIVE test of the name — `if not <name>:` or `if <name> is None:` — and
+    not any `if` mentioning it. An earlier version accepted whatever the test
+    asserted, so an `if` returning on the SUCCESS path was credited as the
+    refusal: `if validated: return render(validated)` and
+    `if validated in _PAGE_CACHE: return _PAGE_CACHE[validated]` both reported a
+    bound while refusing nothing at all — the malformed id falls THROUGH the
+    condition with None bound and reaches the read. The second is the natural
+    spelling of the in-Lambda half of the `Cache-Control` follow-up recorded in
+    `lib/stacks/api-stack.ts`, so the gap sat in front of the next planned change
+    (`test_the_derivation_refuses_a_success_path_return`,
+    `test_the_derivation_refuses_a_cache_hit_return`).
+
+    Those two spellings are the only ones the module uses, so narrowing to them
+    changed no verdict. If a third legitimate one appears (`if validated is None
+    or ...`), widen this deliberately and add the control; do not go back to
+    accepting any test that names the value, because "the name is mentioned in a
+    condition" was never the claim.
     """
+    def _negatively_tested(test: ast.expr) -> list[str]:
+        # `if not <name>:`
+        if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+            if isinstance(test.operand, ast.Name):
+                return [test.operand.id]
+            return []
+        # `if <name> is None:`
+        if (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.Is)
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value is None
+        ):
+            return [test.left.id]
+        return []
+
     refused: dict[str, tuple[int, int]] = {}
     for node in function.body:
         if not isinstance(node, ast.If):
@@ -3558,11 +3645,9 @@ def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
         ):
             continue
         position = (node.lineno, node.col_offset)
-        for name in ast.walk(node.test):
-            if not isinstance(name, ast.Name):
-                continue
-            known = refused.get(name.id)
-            refused[name.id] = position if known is None else min(known, position)
+        for name in _negatively_tested(node.test):
+            known = refused.get(name)
+            refused[name] = position if known is None else min(known, position)
     return refused
 
 
@@ -3578,7 +3663,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     and each has a control below — the second one mattering most, since a route
     with no bound at all looked identical to a correct one.
 
-    A validating statement is one of two spellings, both required to sit at the
+    A validating statement is one of three spellings, all required to sit at the
     function's TOP LEVEL:
 
     - `<name> = _validated_form_id(...)` where `<name>` is later tested in an `if`
@@ -3587,6 +3672,16 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
       REFUSAL's, not the assignment's: an assignment that binds None costs nothing,
       so a read between it and the raise is a read of `FORM#None` that the check
       was supposed to prevent.
+    - `if not (<name> := _validated_form_id(...)):` — the walrus form, ACCEPTED
+      rather than tolerated. It is strictly safer than the two-statement one: there
+      is no statement boundary between the binding and the refusal, so the
+      `FORM#None` window the bullet above has to measure cannot exist in it at all.
+      An earlier version of this helper recognised only the two-statement spelling
+      and would therefore have reported a correctly guarded route as unbounded —
+      pushing whoever wrote the safer form back to the weaker one to get green,
+      which runs the cost of a false positive the wrong way
+      (`test_the_derivation_accepts_the_walrus_spelling`). The `if`'s own position
+      is the refusal's, because they are the same statement.
     - a call to `_load_form_for_query(...)`, which needs no result check because it
       RAISES for itself — so for that spelling the call's own position IS the
       refusal's. Following the delegation rather than demanding the direct call is
@@ -3598,7 +3693,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     validation together — a check that only runs on some paths is not a bound, and
     `if False:` is just the extreme of that. If a legitimate spelling ever needs to
     nest (validation inside a `with`, say), widen this deliberately and add the
-    control alongside the three below; do not relax it to get green.
+    control alongside the ones below; do not relax it to get green.
     """
     tree = ast.parse(source)
     functions = [
@@ -3617,8 +3712,37 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     def _named(call: ast.Call, name: str) -> bool:
         return isinstance(call.func, ast.Name) and call.func.id == name
 
+    def _walrus_refusal(statement) -> tuple[int, int] | None:
+        """`if not (<name> := _validated_form_id(...)):` — bind and refuse in one.
+
+        The `if`'s own position, because for this spelling the binding and the
+        refusal are the same statement — there is no gap between them to measure.
+        """
+        if not isinstance(statement, ast.If):
+            return None
+        test = statement.test
+        if not (isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)):
+            return None
+        bound = test.operand
+        if not (
+            isinstance(bound, ast.NamedExpr)
+            and isinstance(bound.value, ast.Call)
+            and _named(bound.value, '_validated_form_id')
+        ):
+            return None
+        if not any(
+            isinstance(child, (ast.Raise, ast.Return))
+            for node in statement.body
+            for child in ast.walk(node)
+        ):
+            return None
+        return (statement.lineno, statement.col_offset)
+
     validated_at = None
     for statement in function.body:
+        walrus = _walrus_refusal(statement)
+        if walrus is not None:
+            validated_at = min(validated_at or walrus, walrus)
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
                 # This one raises for itself, so the call is the refusal.
@@ -3935,6 +4059,226 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'this is the spelling the module demonstrates at module scope'
         )
 
+    def test_the_derivation_refuses_a_read_through_a_table_factory(self):
+        """The sink-side gap in the spelling this PACKAGE actually prefers.
+
+        `table = get_aggregates_table()` is not a hypothetical: it is how the
+        aggregates table is read at twelve sites here — `ballots_handler.py:379`
+        (the sibling `_validated_form_id`'s docstring names as this design's model),
+        `projects_handler.py:1347`/`:2283`/`:2402`, `integrations_handler.py:545`,
+        `scrapers_handler.py:228` among them — and `lambda/shared/tables.py:17`
+        routes that factory through `get_dynamodb_resource().Table(...)`, which
+        `feedback_form_handler.py:31` is itself a caller of.
+
+        So the single most likely way the NEXT form-id route gets written in this
+        repo was the one shape a receiver-name allowlist could not see: no sink name
+        appears anywhere in the callee chain, `sink_positions` comes back empty, and
+        `all(...)` over an empty list is vacuously True. Matching the OPERATION
+        (`_SINK_OPERATIONS`) rather than the receiver is what closes the class
+        instead of one more spelling — the method is what makes a call a read.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/factory-read")
+            def get_factory_read(form_id: str):
+                table = get_aggregates_table()
+                item = table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_factory_read'), (
+            'a read through get_aggregates_table() was not recognised as a read — '
+            'no sink NAME appears in the chain, so only matching the operation '
+            'sees it, and this is the prevailing read idiom in this package'
+        )
+
+        # And the factory one level further out, which `shared/tables.py` itself
+        # composes and this module calls at line ~31 to obtain `dynamodb`.
+        resource_factory = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/resource-read")
+            def get_resource_read(form_id: str):
+                item = get_dynamodb_resource().Table(AGGREGATES_TABLE).get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(resource_factory, 'get_resource_read'), (
+            'a read through get_dynamodb_resource().Table(...) was not recognised '
+            'as a read — the receiver is produced by a call, so no name in the '
+            'chain is a sink and the verdict came from an EMPTY sink list'
+        )
+
+    def test_the_derivation_refuses_a_read_through_an_alias_bound_in_a_try(self):
+        """The alias one indentation level in, which is where the real ones are.
+
+        Aliases used to be collected from `function.body` only, so an alias bound
+        inside a `try:` was untracked — and EVERY table read in this handler sits
+        inside a `try:`, as do three of the twelve in-repo
+        `table = get_aggregates_table()` sites. The existing alias control passes
+        only because its own alias happens to be at the top level, which is the
+        less likely of the two placements.
+
+        Worth being precise about the direction, because the helper's own docstring
+        used to have it backwards: an untracked alias is a FALSE NEGATIVE. The call
+        drops out of `sink_positions`, and `all(...)` over the shorter list is MORE
+        likely to pass — so the read is not reported at all. That is the vacuous
+        pass these controls exist for, not a cautious over-report.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/nested-alias")
+            def get_nested_alias(form_id: str):
+                try:
+                    table = aggregates_table
+                    table.get_item(
+                        Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                    )
+                except Exception:
+                    pass
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_nested_alias'), (
+            'a read through an alias bound inside a try: was not recognised as a '
+            'read — alias collection has to descend into nested bodies, because '
+            'every read in this handler is inside one'
+        )
+
+    def test_the_derivation_refuses_a_success_path_return(self):
+        """An `if` that returns on the SUCCESS path is not a refusal.
+
+        `_refused_names` used to accept any top-level `if` whose body contained a
+        `Raise` or a `Return`, without looking at what the test asserted. So
+        `if validated: return render(validated)` was credited as the refusal while
+        refusing nothing at all: a malformed id falls THROUGH the condition with
+        `validated` bound to None and reaches the read below it, which is the
+        `Key={'sk': 'FORM#None'}` call the whole cost argument exists to avoid.
+
+        This is why the refusal is now recognised only as a NEGATIVE test of the
+        name — `if not <name>:` or `if <name> is None:`, the two spellings the
+        module uses. "An `if` mentions the value" was never the claim.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/success-return")
+            def get_success_return(form_id: str):
+                validated = _validated_form_id(form_id)
+                if validated:
+                    return render(validated)
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_success_return'), (
+            'a success-path return was counted as the refusal — nothing in this '
+            'function refuses anything, and the malformed id falls through to the '
+            'read with None bound'
+        )
+
+    def test_the_derivation_refuses_a_cache_hit_return(self):
+        """The same shape in the spelling the NEXT planned change would produce.
+
+        `lib/stacks/api-stack.ts` records a `Cache-Control` follow-up as unblocked
+        by #379. If it lands as an in-Lambda cache rather than at the edge, this is
+        what the route looks like — `if validated in _PAGE_CACHE: return ...` — and
+        under the old derivation it was credited as the refusal because the test
+        mentions the name and the body returns.
+
+        So the gap sat directly in front of the one change this PR declares next,
+        which is what makes it worth a case of its own rather than being covered by
+        the success-path one: they fail for the same reason, but only this one is
+        already on somebody's list.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/cached")
+            def get_cached(form_id: str):
+                validated = _validated_form_id(form_id)
+                if validated in _PAGE_CACHE:
+                    return _PAGE_CACHE[validated]
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_cached'), (
+            'a cache-hit return was counted as the refusal — a cache MISS for a '
+            'malformed id falls through to the read with None bound, so this '
+            'function has no bound at all'
+        )
+
+    def test_the_derivation_accepts_the_walrus_spelling(self):
+        """The one spelling that CANNOT exhibit the window the others are measured
+        against — accepted, not merely tolerated.
+
+        `if not (validated := _validated_form_id(form_id)):` binds and refuses in a
+        single statement, so there is no boundary between the two for a read to be
+        inserted into. Every other control in this class is about that gap: the
+        assignment binds None for free, so it is the refusal's position that has to
+        beat the first sink.
+
+        The derivation used to reject it, which is the wrong direction for the cost
+        of a false positive to run: the explanation offered to whoever wrote it
+        would have been "rewrite your safe code into the shape with the window in
+        it" to get green. Reported here as the accepting side so a future narrowing
+        of the helper cannot quietly reintroduce that.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/walrus")
+            def get_walrus(form_id: str):
+                if not (validated := _validated_form_id(form_id)):
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert _validates_its_form_id(source, 'get_walrus'), (
+            'the walrus guard was reported as unbounded — it is strictly safer '
+            'than the two-statement form it models, so rejecting it pushes an '
+            'author toward the weaker spelling'
+        )
+
+        # And the same spelling with the read moved AHEAD of it, so acceptance is
+        # not simply "a walrus anywhere passes": the position still has to win.
+        read_first = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/walrus-late")
+            def get_walrus_late(form_id: str):
+                item = aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                if not (validated := _validated_form_id(form_id)):
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(read_first, 'get_walrus_late'), (
+            'a walrus guard AFTER the read was reported as a bound — recognising '
+            'the spelling must not cost the ordering that is the actual claim'
+        )
+
     def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):
         """The shape that has NO bound while looking exactly like one.
 
@@ -4067,22 +4411,29 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
     """`_validated_form_id` returns what it was given, and that is load-bearing.
 
-    Callers use their own `form_id` for things that are not the key —
-    `source_channel` in `/submissions`, the id echoed in a response — so the
+    Callers use their own `form_id` for the id echoed in a response, so the
     validated value and the parameter have to be the same string. `.strip()` was
     removed for a related reason, but exactness is the broader property and it was
     carried entirely by a sentence in a docstring.
+
+    The `source_channel` those routes filter on no longer depends on it — it is
+    built from the id `_load_form_for_query` hands back, which is the same string
+    the write side used — but the identity below is what keeps the echoed id and
+    the key describing the same form, and it is the assertion a future "form ids
+    are case-insensitive" change has to come and argue with.
     """
 
     def test_the_validator_returns_its_input_unchanged(self, feedback_form_handler):
         """Identity, not merely truthiness.
 
         A normalizing validator — lower-casing, say, for a plausible "form ids are
-        case-insensitive" change — would pass every existing test while splitting
-        the module: `/stats` would read the record its key names and then filter
-        submissions on a `source_channel` its CALLER built from the raw id, which
-        no write ever used. Zero submissions for a form that has them, which is
-        the false zero `_load_form_for_query` exists to prevent (#312).
+        case-insensitive" change — would pass every existing test while making the
+        record a route reads and the id it echoes describe two different forms: the
+        caller answers with its own `form_id` while the key names the normalized
+        one, so a client that stores what it was told would then address something
+        else. The `source_channel` half of that split is closed structurally
+        (`_load_form_for_query` hands the validated id to both read routes), which
+        is why this identity is the assertion that remains.
 
         So the invariant gets a test instead of a sentence. If ids ever should be
         case-insensitive, the normalization belongs at the mint and at every read
@@ -4157,11 +4508,17 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
     ):
         """The consequence, end to end on the route where it would surface.
 
-        `_load_form_for_query` keys on the VALIDATED value while its callers build
-        `source_channel` from the parameter. Both are asserted here against the id
-        in the URL, so the two halves cannot drift apart without a failure — which
-        is the only way this defect would ever have been noticed, since it produces
-        a plausible-looking zero rather than an error.
+        The `sk` read and the `source_channel` filtered on are asserted TOGETHER
+        against the id in the URL, because it is their agreement rather than either
+        one that decides whether the route reports the submissions a form has. Both
+        now come from the same string — `_load_form_for_query` returns the validated
+        id and its caller builds the channel from that — where the filter used to
+        be built from the raw parameter beside a key built from the validated one.
+
+        This is the only way the defect would ever have been noticed: a filter that
+        names a channel no write used produces a plausible-looking zero, not an
+        error. So the case has to be the composite one; asserting the key alone
+        passes while the filter is wrong.
         """
         mock_table.get_item.return_value = {
             'Item': {'form_id': 'DeadBeef', 'brand_name': 'acme'}
@@ -4184,6 +4541,66 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'ExpressionAttributeValues'
             ][':sc']
             == 'form_DeadBeef'
+        )
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_query_route_filters_on_the_id_it_read_even_if_the_validator_normalizes(
+        self,
+        mock_table,
+        mock_feedback_table,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The case above cannot fail while the two strings are equal; this one can.
+
+        `test_the_key_a_query_route_reads_is_the_id_in_its_url` asserts the key and
+        the filter against the URL's id, which they both match whether the route
+        builds them from the validated value or from the raw parameter — so it
+        pins the OUTCOME today without pinning the DERIVATION. That leaves the very
+        coupling this test class exists for resting on the identity next door, and
+        a "form ids are case-insensitive" change would edit that identity rather
+        than discover this.
+
+        So the validator is made to normalize FOR THIS CASE ONLY, and the two are
+        asserted to still agree with each other. That is the property: whatever the
+        validator returns, the channel a read route filters on is the id its read
+        was keyed on, which is the id `submit_form_feedback` wrote
+        (`f'form_{validated}'`). A route that rebuilt the channel from its raw
+        parameter would filter on `form_DeadBeef` beside a key of `FORM#deadbeef`
+        and select nothing — zero submissions for a form that has them, answered
+        as a 200, which is #312's false zero.
+        """
+        exact = feedback_form_handler._validated_form_id
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'deadbeef', 'brand_name': 'acme'}
+        }
+        mock_feedback_table.query.return_value = {'Items': []}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/DeadBeef/submissions',
+            path_params={'form_id': 'DeadBeef'},
+            resource='/feedback-forms/{form_id}/submissions',
+        )
+
+        with patch.object(
+            feedback_form_handler,
+            '_validated_form_id',
+            lambda raw: (exact(raw) or '').lower() or None,
+        ):
+            response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        key = mock_table.get_item.call_args.kwargs['Key']['sk']
+        channel = mock_feedback_table.query.call_args.kwargs[
+            'ExpressionAttributeValues'
+        ][':sc']
+        assert (key, channel) == ('FORM#deadbeef', 'form_deadbeef'), (
+            f'the route read {key} and filtered on {channel} — the two are built '
+            'from different strings, so the filter names a source_channel no write '
+            'produced and the route reports zero for a form that has submissions'
         )
 
 

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2596,11 +2596,25 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
             (r'<iframe\b', 'frame-src'),
             (r'<form\b', "form-action — currently 'none'"),
         ):
-            assert not re.search(pattern, widget), (
-                f'feedback-widget.js now matches {pattern!r}, so the page needs '
-                f'{directive} in _IFRAME_SECURITY_HEADERS. Without it the asset '
-                'is blocked in every embed and nothing else reports it — '
-                "default-src 'none' fails closed and silently."
+            match = re.search(pattern, widget)
+            # The MATCHED TEXT and its line, not just the pattern that fired.
+            # Several of these patterns are broad on purpose — `data:` matches a
+            # Content-Type literal or the word in a comment as readily as a real
+            # URI — so a failure has to hand the reader the thing to look at.
+            # Otherwise the message points at CSP for what may be a false
+            # positive, and the derivation gets deleted rather than narrowed.
+            context = ''
+            if match:
+                line_number = widget.count('\n', 0, match.start()) + 1
+                line = widget.splitlines()[line_number - 1].strip()
+                context = f' at line {line_number}: {line[:120]!r}'
+            assert not match, (
+                f'feedback-widget.js now matches {pattern!r}{context}, so the '
+                f'page needs {directive} in _IFRAME_SECURITY_HEADERS. Without it '
+                'the asset is blocked in every embed and nothing else reports '
+                "it — default-src 'none' fails closed and silently. If the match "
+                'is not a real asset request, narrow the pattern rather than '
+                'dropping the case.'
             )
 
     def test_a_minted_id_always_satisfies_the_validator(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3884,12 +3884,18 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         assert unbounded == [], (
             f'{unbounded} take a form id out of the URL without establishing the '
-            'bound before their first read or send. Three shapes report here, and '
-            'the message cannot tell them apart: no validator call at all; a call '
-            'whose None result is never refused (which is no bound — see '
-            '_refused_names); or a call that comes AFTER the table or the queue is '
-            "touched. Add the check rather than narrowing the claim: the value of a "
-            'universal bound is that a reader does not have to hold the exceptions.'
+            'bound before their first read or send. Several shapes report here and '
+            'the message cannot tell them apart, so check each in turn: no '
+            'validator call at all; a result that is never refused, or refused by '
+            'something that is not a NEGATIVE test of it — a success-path or '
+            'cache-hit `return` is not a refusal (see `_refused_names`); a refusal '
+            'that is nested, so it runs on some paths only; or a REFUSAL that comes '
+            'after the table or the queue is touched. Add the check rather than '
+            'narrowing the claim: the value of a universal bound is that a reader '
+            'does not have to hold the exceptions. And if the route is genuinely '
+            'bounded in a spelling this derivation does not know, widen the '
+            'derivation and add a control for it — '
+            '`test_the_derivation_accepts_the_walrus_spelling` is the precedent.'
         )
 
     def test_the_derivation_sees_the_routes_this_module_actually_has(
@@ -4519,8 +4525,8 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
             assert feedback_form_handler._validated_form_id(valid) == valid, (
                 f'{valid!r} came back as '
                 f'{feedback_form_handler._validated_form_id(valid)!r} — a '
-                'normalized return splits the key a route reads from the '
-                'source_channel it filters on'
+                'normalized return makes the record a route reads and the id it '
+                'echoes back describe two different forms'
             )
 
     def test_a_trailing_newline_is_not_a_valid_form_id(
@@ -4539,9 +4545,9 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
 
         Two consequences, both asserted:
 
-        - It reached `f'FORM#{validated}'`, `source_channel = f'form_{form_id}'` and
-          the log line in `_load_form_for_query`, where an embedded newline in a
-          structured log record is its own small problem.
+        - It reached `f'FORM#{validated}'`, the `source_channel` the query routes
+          filter on, and the log line in `_load_form_for_query`, where an embedded
+          newline in a structured log record is its own small problem.
         - The length cap bounded the matched PREFIX rather than the id, so
           `'a' * FORM_ID_MAX_LENGTH + '\\n'` was admitted at 65 characters while
           `'a' * (FORM_ID_MAX_LENGTH + 1)` was refused. Derived from the constant

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3576,16 +3576,23 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
     that hands an unvalidated id to a helper writes it to the table with no sink
     call of its own anywhere in its body. `_sink_calls` matched only an
     `ast.Attribute` callee, so a plain `helper(form_id)` was not a sink at all, the
-    list came back empty, and the vacuous `all(...)` reported the route as bounded.
-    Silence again, this time through the call SHAPE rather than the receiver name.
+    list came back empty, and a route with nothing to answer for was reported
+    bounded. Silence again, through the call SHAPE rather than the receiver name.
 
-    Excluded: any function that calls `_validated_form_id` itself. That is what
-    makes `_load_form_for_query` — which reads, and is called by three routes — not
-    a hole: it establishes the bound on the id it was handed before its own read,
-    which is the delegating spelling `_validates_its_form_id` already accepts as a
-    refusal. Counting it as an unguarded sink would report `/iframe`, `/stats` and
-    `/submissions` as unbounded, which is the false-positive direction. The same
-    rule excludes the route handlers, each of which validates.
+    Two exclusions, both in the false-positive direction, because this set only
+    ever ADDS sinks to a caller:
+
+    - A function that calls `_validated_form_id` itself. That is what keeps
+      `_load_form_for_query` — which reads, and which three routes delegate to —
+      a refusal rather than an unguarded sink: it bounds the id it was handed
+      before its own read, which `_validates_its_form_id` already accepts as the
+      delegating spelling. Counting it would report `/iframe`, `/stats` and
+      `/submissions` as unbounded.
+    - A ROUTE handler, since a route is entered by the resolver rather than called
+      by another function here. Without this the set names `list_forms`,
+      `create_form`, `get_form_stats` and `get_form_submissions` — true of them
+      (they do read) and useless, because nothing calls them; and the day something
+      did, the caller would be accused for a read the route bounds for itself.
 
     A fixpoint rather than one level, because a helper calling a helper is the same
     hole one step further out and the loop costs four lines. It resolves NAMES in
@@ -3593,15 +3600,25 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
     which is the remaining ceiling — worth stating rather than implying, since the
     failure mode is the vacuous pass this whole helper exists to close.
     """
-    candidates = {
-        node.name: node for node in tree.body
-        if isinstance(node, ast.FunctionDef)
-        and not any(
+    def _eligible(node: ast.FunctionDef) -> bool:
+        validates = any(
             isinstance(call, ast.Call)
             and isinstance(call.func, ast.Name)
             and call.func.id == '_validated_form_id'
             for call in ast.walk(node)
         )
+        routed = any(
+            isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and isinstance(decorator.func.value, ast.Name)
+            and decorator.func.value.id == 'app'
+            for decorator in node.decorator_list
+        )
+        return not validates and not routed
+
+    candidates = {
+        node.name: node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and _eligible(node)
     }
     helpers: set[str] = set()
     growing = True
@@ -4179,6 +4196,37 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'answer when the call really does reach an id into a table, and both '
             'are a false positive otherwise — the earliest sink is what decides '
             'the verdict, so one spurious early entry accuses a correct route.'
+        )
+
+    def test_the_only_helper_that_writes_what_it_is_handed_is_the_brand_anchor(
+        self, feedback_form_handler
+    ):
+        """The helper set is exactly one function, and the two exclusions earn it.
+
+        `_sink_bearing_helpers` only ever ADDS sinks to a caller, so its
+        over-reporting direction is the one that accuses a correct route. Both
+        exclusions were needed to get here and neither is cosmetic: without the
+        `_validated_form_id` one, `_load_form_for_query` becomes an unguarded sink
+        and `/iframe`, `/stats` and `/submissions` are all reported unbounded;
+        without the route-decorator one, the set names `list_forms`, `create_form`,
+        `get_form_stats` and `get_form_submissions` — each of which does read, and
+        none of which is CALLED by anything here, so naming them buys nothing and
+        would accuse whatever first called one.
+
+        Pinned as a set rather than a count so the failure says which function
+        arrived. A helper that starts writing SHOULD appear here — that is the
+        finding, not the breakage — and then every route calling it has to bound its
+        id first.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+
+        assert _sink_bearing_helpers(ast.parse(source)) == {'_anchor_form_brand'}, (
+            'the set of module-level helpers that write what they are handed '
+            'changed. If a new helper appears, check every route that calls it '
+            'validates first; if one disappeared, check the exclusions have not '
+            'started swallowing a real write.'
         )
 
     def test_the_derivation_can_fail(self):

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2198,15 +2198,27 @@ def _route_pattern_for_iframe(handler) -> re.Pattern:
     Read from the app rather than restated: the point of the positive control
     below is that the FRAMEWORK accepts the payload, so a copy of powertools'
     capture group pasted here would prove nothing about the version installed.
+
+    `app._dynamic_routes` is PRIVATE powertools API, used deliberately and for
+    that same reason — the installed version's compiled regex is the only thing
+    that answers the question, and it is not exposed publicly. So an upgrade that
+    renames the attribute should fail HERE, in a helper whose docstring says why
+    it reaches in, rather than anywhere else.
+
+    Selected on the full route path rather than on the `/iframe` suffix alone: a
+    second `<something>/iframe` route added later would otherwise be a candidate,
+    and this helper would either pick it or trip its own count assertion for a
+    reason that has nothing to do with the form id.
     """
     routes = [
         route for route in handler.app._dynamic_routes
         if route.rule.pattern.endswith('/iframe/*$')
+        and '/feedback-forms/' in route.rule.pattern
     ]
     assert len(routes) == 1, (
-        f'expected exactly one dynamic /iframe route on the resolver, found '
-        f'{len(routes)} — this helper needs updating, it is not a finding about '
-        'validation.'
+        f'expected exactly one dynamic /feedback-forms/<id>/iframe route on the '
+        f'resolver, found {len(routes)} — this helper needs updating, it is not '
+        'a finding about validation.'
     )
     return routes[0].rule
 
@@ -2245,6 +2257,14 @@ def _quoted_interpolations(source: str, function_name: str) -> list[str]:
     expression that is followed by a quote but not preceded by one (or the reverse)
     is reported too: an unbalanced quote around a value is not a safe spelling
     either, it is a broken one.
+
+    NOTE for whoever this fails on: an interpolation adjacent to a quote is not
+    universally wrong — `id="{html.escape(x, quote=True)}"` is the CORRECT spelling
+    for a value rendered as MARKUP, and `_js_value`'s docstring says so. This check
+    is about the page as it stands, where the only reflected value is in SCRIPT
+    context and none is in an attribute. If a legitimate HTML-context value is
+    added here, widen this derivation to allow it — do NOT remove the escaping to
+    get green.
     """
     tree = ast.parse(source)
     functions = [
@@ -2257,8 +2277,23 @@ def _quoted_interpolations(source: str, function_name: str) -> list[str]:
         'silently scan nothing.'
     )
     function = functions[0]
+    joined_strings = [
+        n for n in ast.walk(function) if isinstance(n, ast.JoinedStr)
+    ]
+    # THE VACUITY GUARD, and the reason it is an assert rather than an early
+    # return: "no offenders" and "nothing to judge" are the same empty list to the
+    # caller, and only one of them is a pass. `get_form_iframe` renders the page
+    # from an f-string, so finding none means the template moved — most plausibly
+    # into a private helper, since the function is long — and the caller's green
+    # result would be about a function that no longer renders anything.
+    assert joined_strings, (
+        f'{function_name} contains no f-string, so this derivation has nothing '
+        'to judge and a green result from it would mean nothing. If the HTML '
+        'template moved into a helper, point the caller at that helper (or scan '
+        'both) rather than deleting this guard.'
+    )
     offenders = []
-    for joined in (n for n in ast.walk(function) if isinstance(n, ast.JoinedStr)):
+    for joined in joined_strings:
         parts = joined.values
         for index, part in enumerate(parts):
             if not isinstance(part, ast.FormattedValue):
@@ -2322,7 +2357,12 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
         assert response['statusCode'] == 404
-        assert 'html' not in response['body'].lower()
+        # "This response is not a document" — stated as the response's own
+        # content type, which is the positive assertion
+        # test_a_server_minted_id_still_serves_the_embeddable_page makes. Asserted
+        # this way rather than as "the letters h-t-m-l are absent from the body",
+        # which is a property of an unrelated JSON error message.
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
         assert 'alert(' not in response['body']
         # Not echoed back in any form, either: the refusal names the resource,
         # never the caller's string.
@@ -2360,7 +2400,8 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
         assert response['statusCode'] == 404
-        assert 'html' not in response['body'].lower()
+        # Not a document — see the note on the same assertion above.
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
         # The read HAPPENED — this is the existence gate, not the format one, and
         # a 404 that skipped the lookup would be the format check refusing a
         # legitimate id instead.
@@ -2462,6 +2503,170 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
             os.environ['ALLOWED_ORIGIN']
         ]
 
+    def test_the_policy_names_every_directive_the_page_needs_and_no_wildcard(
+        self, feedback_form_handler
+    ):
+        """The FUNCTIONAL half of the policy, pinned in both directions.
+
+        The case above pins the two deliberate OMISSIONS. This one pins what the
+        page needs in order to work at all, because `default-src 'none'` is the
+        fallback for anything not named: delete `script-src 'unsafe-inline'` and
+        the inlined widget never executes, delete `style-src 'unsafe-inline'` and
+        the <style> block plus every `style.cssText` assignment is dropped, delete
+        `connect-src 'self'` and the widget's /config fetch and submit POST are
+        blocked. Each is a TOTAL, SILENT failure of the product on every customer
+        site — the frame renders an empty div, and no assertion about `default-src`
+        alone notices.
+
+        Compared as a whole mapping rather than directive by directive, so the
+        other direction fails too: widening `script-src` to `'unsafe-inline' *`, or
+        adding `img-src *`, undoes the containment argument on
+        `_IFRAME_SECURITY_HEADERS` — that a value which escaped the serializer has
+        nowhere to send anything — and an `in`-style assertion would stay green
+        through it.
+        """
+        policy = feedback_form_handler._IFRAME_SECURITY_HEADERS[
+            'Content-Security-Policy'
+        ]
+
+        directives = {}
+        for directive in policy.split(';'):
+            name, _, sources = directive.strip().partition(' ')
+            assert name not in directives, (
+                f'{name} is stated twice in the policy; a browser honours the '
+                'FIRST occurrence, so the second is silently dead'
+            )
+            directives[name] = sources.split()
+
+        assert directives == {
+            'default-src': ["'none'"],
+            'script-src': ["'unsafe-inline'"],
+            'style-src': ["'unsafe-inline'"],
+            'connect-src': ["'self'"],
+            'base-uri': ["'none'"],
+            'form-action': ["'none'"],
+        }, (
+            f'the policy is now {directives}. A REMOVAL from script-src, '
+            'style-src or connect-src breaks every embed silently (default-src '
+            "'none' is the fallback); an ADDITION or a widening undoes the "
+            'containment argument on _IFRAME_SECURITY_HEADERS. Either way this '
+            'expectation and that comment change together.'
+        )
+        # Restated as its own assertion because it is the failure worth naming:
+        # a wildcard anywhere is what turns the policy from a bound into a
+        # formality, and the mapping above would report it as a diff of quoted
+        # strings rather than as "this is now open".
+        assert not any(
+            '*' in source for sources in directives.values() for source in sources
+        ), f'a wildcard source makes the policy no bound at all: {directives}'
+
+    def test_the_widget_asks_for_no_asset_the_policy_would_block(
+        self, feedback_form_handler
+    ):
+        """`default-src 'none'` also blocks images, fonts and frames — and that is
+        only safe because the widget asks for none of them.
+
+        The policy deliberately carries no `img-src`, `font-src` or `frame-src`,
+        on the grounds that feedback-widget.js builds its UI from DOM elements,
+        text and CSS alone. That is a claim about ANOTHER file, so it is derived
+        from that file rather than trusted: the day the widget grows an icon, a
+        `url(...)` background or a webfont, this fails and names the directive the
+        policy needs — instead of the asset silently not loading in every
+        customer's iframe.
+
+        `form-action 'none'` rides on the same derivation: the widget submits
+        through `fetch`, and a real <form> would need that directive relaxed.
+
+        Read through `get_widget_js` rather than off the path, so this judges the
+        script the page actually inlines — including the fallback, if the static
+        file is ever missing.
+        """
+        widget = feedback_form_handler.get_widget_js()
+
+        # `data:` is included because it is a source EXPRESSION, not just a URL
+        # scheme: `default-src 'none'` blocks a `data:` image or font as surely as
+        # a remote one, and a `data:` URI is the shape an inlined icon takes.
+        for pattern, directive in (
+            (r'<img\b', 'img-src'),
+            (r'\.src\s*=', 'img-src (or script-src for a loaded script)'),
+            (r'url\(', 'img-src / font-src, for a CSS-referenced asset'),
+            (r'data:', 'img-src / font-src, for an inlined asset'),
+            (r'@font-face', 'font-src'),
+            (r'<iframe\b', 'frame-src'),
+            (r'<form\b', "form-action — currently 'none'"),
+        ):
+            assert not re.search(pattern, widget), (
+                f'feedback-widget.js now matches {pattern!r}, so the page needs '
+                f'{directive} in _IFRAME_SECURITY_HEADERS. Without it the asset '
+                'is blocked in every embed and nothing else reports it — '
+                "default-src 'none' fails closed and silently."
+            )
+
+    def test_a_minted_id_always_satisfies_the_validator(
+        self, feedback_form_handler
+    ):
+        """The ONE coupling between the mint and the validator that must hold.
+
+        The two are deliberately independent — the validator is wider, for the
+        reason `test_a_hand_seeded_form_id_is_still_embeddable` pins — so nothing
+        else ties `FORM_ID_LENGTH` to `_FORM_ID_PATTERN`. But an id this service
+        ISSUES must always be one it will serve a page for, or `create_form`
+        would hand back an id whose iframe 404s.
+
+        Asserted over many mints rather than one, because the failure mode is
+        value-dependent: a mint that emitted a separator, or a length raised past
+        what the pattern admits, would only show up for some draws.
+
+        Also pins the format the mint's docstring CLAIMS — hex, no separator —
+        which the pattern alone would not, since it admits `-`. That assertion is
+        what makes `FORM_ID_LENGTH` safe to RAISE: the dashed spelling of a uuid4
+        puts a '-' at offset 8, so slicing 9 or more characters of it mints an id
+        holding a separator the docstring does not describe. With this here,
+        raising the constant is a one-line change rather than a trap.
+        """
+        for _ in range(200):
+            minted = feedback_form_handler._minted_form_id()
+
+            assert feedback_form_handler._FORM_ID_PATTERN.match(minted), (
+                f'_minted_form_id() produced {minted!r}, which _validated_form_id '
+                'refuses — every public route would 404 an id this service just '
+                'issued. The mint and the pattern are independent by design, but '
+                'not in this direction.'
+            )
+            assert len(minted) == feedback_form_handler.FORM_ID_LENGTH
+            assert re.fullmatch(r'[0-9a-f]+', minted), (
+                f'_minted_form_id() produced {minted!r}, which is not the "hex '
+                'characters" its docstring describes. This is what fails if the '
+                'slice goes back to `str(uuid.uuid4())` — harmless at length 8, '
+                'a separator in the id at 9 or more.'
+            )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_an_id_padded_with_whitespace_is_not_an_alias_for_the_id(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """A form id is EXACT: `' deadbeef'` is not `'deadbeef'`.
+
+        `ballots_handler._validated_session_id`, the sibling this is modelled on,
+        `.strip()`s — harmlessly, since a session id is a 128-bit token. Inheriting
+        that here would make every whitespace variant of an id a distinct URL
+        serving byte-identical HTML, which is a cache-key multiplier for the
+        `Cache-Control` follow-up recorded in `lib/stacks/api-stack.ts` — whose
+        premise is that this response is a pure function of the id and the host.
+        With a strip it is a pure function of the STRIPPED id while the cache keys
+        on the raw path.
+
+        So the leniency is dropped rather than inherited, and pinned here so
+        re-adding it is a decision. No id this service mints has whitespace to
+        forgive (`test_a_minted_id_always_satisfies_the_validator`).
+        """
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, ' deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+
 
 def _json_prefix(text: str) -> str:
     """The longest leading substring of `text` that is one JSON value.
@@ -2540,6 +2745,53 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         # naive strip-the-characters fix would lose.
         assert json.loads(serialized) == '</script><img src=x>'
 
+    def test_an_ampersand_cannot_reach_the_html_parser(
+        self, feedback_form_handler
+    ):
+        """`&` is the other character the HTML parser gives meaning to, and it is
+        escaped by the implementation — asserted here because it was the one of the
+        three replacements nothing covered.
+
+        It matters for the same reason `<` does and for one more: an entity the
+        parser decodes could reconstitute a character the escaping above removed,
+        so leaving `&` as itself would make the `<`/`>` handling conditional on
+        the parser's behaviour rather than absolute.
+        """
+        serialized = feedback_form_handler._js_value('a &lt; b &amp; c')
+
+        assert '&' not in serialized, (
+            'an unescaped & lets the HTML parser decode an entity inside the '
+            'script, which is how a removed character comes back'
+        )
+        assert json.loads(serialized) == 'a &lt; b &amp; c'
+
+    def test_a_line_separator_cannot_end_the_statement(
+        self, feedback_form_handler
+    ):
+        """U+2028 and U+2029 terminate a JavaScript LINE but are legal, raw, inside
+        a JSON string — so a serializer that emitted them as themselves would end
+        the statement from inside the literal, which is the same defect as an
+        unescaped quote arriving by a route JSON considers valid.
+
+        They are handled by `ensure_ascii=True`, which is `json.dumps`'s default
+        AND is now passed explicitly — this case is what fails if someone writes
+        `ensure_ascii=False` to make a non-ASCII value readable in a debug dump.
+        Before this test, the safety of the two most JavaScript-specific
+        characters on the page rested on an implicit default that nothing checked.
+        """
+        # Spelled as escapes, deliberately: a literal U+2028 in this file is
+        # invisible to a reader and is exactly the character some tools
+        # normalise away, which would make the case pass by having no subject.
+        value = 'before\u2028after\u2029end'
+
+        serialized = feedback_form_handler._js_value(value)
+
+        assert '\u2028' not in serialized and '\u2029' not in serialized, (
+            'a raw U+2028/U+2029 ends the JavaScript line inside the string '
+            'literal — check that _js_value still passes ensure_ascii=True'
+        )
+        assert json.loads(serialized) == value
+
     def test_no_javascript_value_is_wrapped_in_a_handwritten_quote_pair(
         self, feedback_form_handler
     ):
@@ -2563,12 +2815,11 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         )
 
     def test_the_quoted_interpolation_check_can_fail(self):
-        """Positive control for the derivation above.
+        """Positive control for the derivation above: it flags the real defect.
 
-        Without it, an `ast` walk that found no JoinedStr at all — a template
-        moved into a helper, a parse that quietly matched nothing — would report
-        an empty list and the test above would pass while pinning nothing. The
-        input is the exact spelling this change removed.
+        Without it, a parse that quietly matched nothing would report an empty
+        list and the test above would pass while pinning nothing. The input is the
+        exact spelling this change removed.
         """
         source = textwrap.dedent('''
             def get_form_iframe(form_id):
@@ -2584,6 +2835,35 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
             'the derivation did not flag the exact spelling this change removed, '
             f'it reported {offenders} — so a green result above means nothing.'
         )
+
+    def test_the_quoted_interpolation_check_refuses_to_pass_vacuously(self):
+        """The OTHER way the derivation could be meaningless: nothing to judge.
+
+        The control above proves the walk flags the defect when the template is
+        inline. It does not cover the case where `get_form_iframe` contains no
+        f-string at all — which is what happens if the ~90-line HTML template is
+        ever refactored into a private helper, a very plausible change. The walk
+        would then find no `JoinedStr`, return `[]`, and
+        `test_no_javascript_value_is_wrapped_in_a_handwritten_quote_pair` would
+        pass while checking nothing.
+
+        So that case must RAISE rather than return `[]`. The input is the
+        moved-to-helper shape, with the offending spelling sitting in the helper
+        where the derivation cannot see it: the guard has to fire on the absence
+        of a subject, not on the absence of offenders.
+        """
+        source = textwrap.dedent('''
+            def _iframe_page(form_id):
+                return f"""
+                  formId: '{form_id}'
+                """
+
+            def get_form_iframe(form_id):
+                return _iframe_page(form_id)
+        ''')
+
+        with pytest.raises(AssertionError, match='no f-string'):
+            _quoted_interpolations(source, 'get_form_iframe')
 
     @patch('feedback_form_handler.aggregates_table')
     def test_the_rendered_init_call_carries_exactly_one_statement(
@@ -2616,3 +2896,152 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         assert remainder.split(');', 1)[1].strip() == (
             '</script>\n</body>\n</html>'
         )
+
+
+class TestEveryRouteThatKeysOnAFormIdChecksItsFormatFirst:
+    """`_validated_form_id` at every route that turns a URL segment into a key.
+
+    Its docstring makes a general argument — "a format check before any read
+    means a probe for `/feedback-forms/admin` or a 1 MB path segment costs no
+    DynamoDB call" — and that argument is only true where it is applied. It was
+    applied on `/iframe` alone, so the two sibling PUBLIC routes (`/config`,
+    `/submit`) took the raw capture group straight into a `get_item`, which is the
+    cost basis the throttle pair in `lib/stacks/api-stack.ts` is argued from. The
+    two authenticated read routes reach the same check through
+    `_load_form_for_query`.
+
+    Not an injection finding on any of them — those four answer JSON through
+    `json.dumps` — but the gap is what would make the next reader of
+    `_validated_form_id` assume a protection that was not there.
+    `ballots_handler` applies its equivalent at all five of its routes; this
+    mirrors that.
+
+    Asserted as "no read happened", route by route, because that is the property
+    the comment claims and the only one a 404 alone would not distinguish from a
+    lookup that merely found nothing.
+    """
+
+    # (route path suffix, method, whether the route needs a JSON body). The
+    # malformed id must be refused BEFORE the body is considered too, which is why
+    # `/submit` is exercised with a valid one: a 404 that only happened because
+    # the body failed validation would prove nothing about the id.
+    ROUTES = (
+        ('config', 'GET', None),
+        ('submit', 'POST', {'text': 'a real submission'}),
+        ('stats', 'GET', None),
+        ('submissions', 'GET', None),
+    )
+
+    @staticmethod
+    def _malformed_ids(handler) -> tuple[str, ...]:
+        """The two shapes the pattern refuses, derived rather than restated.
+
+        The over-length one comes off `FORM_ID_MAX_LENGTH` so that raising the cap
+        does not silently turn this case into a VALID id — the same reason
+        `test_an_over_long_id_is_refused_without_a_read` derives its own.
+        """
+        return (_INJECTION_PAYLOAD, 'a' * (handler.FORM_ID_MAX_LENGTH + 1))
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_malformed_id_never_reaches_dynamodb_on_any_of_them(
+        self,
+        mock_table,
+        _mock_feedback_table,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The cost argument, checked where it is stated.
+
+        A 4000-character path segment or the #379 payload must cost zero
+        `get_item` calls on every route that keys on a form id — not just on the
+        one whose rendering made it a security defect.
+        """
+        for suffix, method, body in self.ROUTES:
+            for malformed in self._malformed_ids(feedback_form_handler):
+                mock_table.reset_mock()
+                event = api_gateway_event(
+                    method=method,
+                    path=f'/feedback-forms/{malformed}/{suffix}',
+                    path_params={'form_id': malformed},
+                    body=body,
+                    resource=f'/feedback-forms/{{form_id}}/{suffix}',
+                )
+
+                response = feedback_form_handler.lambda_handler(
+                    event, lambda_context
+                )
+
+                assert response['statusCode'] == 404, (
+                    f'{method} /{suffix} answered {response["statusCode"]} for a '
+                    f'malformed id ({malformed[:20]!r}...) rather than the same '
+                    '404 every sibling gives'
+                )
+                mock_table.get_item.assert_not_called()
+                # Nor echoed: none of these four renders HTML, but a message that
+                # quotes an unbounded path segment back is its own problem.
+                assert malformed not in response['body']
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_well_formed_id_is_still_read_and_answered(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The other direction: the format gate must not have become the answer.
+
+        `/config` with a real form still reads the table and serves its
+        projection — so the 404s above are the validator refusing a shape, not a
+        route that stopped working. The id is the hand-seeded style the pattern is
+        deliberately wide enough for.
+        """
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'website-form', 'enabled': True}
+        }
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/website-form/config',
+            path_params={'form_id': 'website-form'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['config']['enabled'] is True
+        assert (
+            mock_table.get_item.call_args.kwargs['Key']['sk']
+            == 'FORM#website-form'
+        )
+
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_malformed_id_never_reaches_the_queue_either(
+        self,
+        mock_table,
+        mock_sqs,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """`/submit` is the one public route that also WRITES, so its refusal has a
+        second thing to prove.
+
+        A record enqueued for a form id that cannot be one of ours would be
+        processed downstream — a Comprehend, Translate and Bedrock invocation
+        each — and would land in the feedback partition under a `source_channel`
+        no form can ever be read back through. So the refusal has to come before
+        the send, not just before the read.
+        """
+        event = api_gateway_event(
+            method='POST',
+            path=f'/feedback-forms/{_INJECTION_PAYLOAD}/submit',
+            path_params={'form_id': _INJECTION_PAYLOAD},
+            body={'text': 'a real submission'},
+            resource='/feedback-forms/{form_id}/submit',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+        mock_sqs.send_message.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2515,6 +2515,44 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         assert response['statusCode'] == 200
 
     @patch('feedback_form_handler.aggregates_table')
+    def test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The gate checks EXISTENCE, not `enabled` — and that is a decision.
+
+        It reads like an oversight, especially since the returned record is
+        discarded: someone arriving via "the iframe route now checks the form
+        exists" has a standing invitation to add `if not form.get('enabled')` here,
+        and it would look like tightening.
+
+        It would be a regression. The widget has to RUN in order to render its own
+        disabled state, so refusing the page replaces that with a raw API Gateway
+        404 frame on the customer's site — a broken embed for a customer who merely
+        turned the form off. The division of labour is `GET /config` publishing
+        `enabled` in its projection and `submit_form_feedback` enforcing it, and
+        this route matches /config rather than /submit.
+
+        Asserted on the PAGE, not just the status, because a 200 alone would not
+        show that the widget is present to do the saying.
+        """
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'deadbeef', 'enabled': False}
+        }
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 200, (
+            'a disabled form was refused its page — the visitor now sees a raw '
+            'API Gateway error frame instead of the widget saying the form is '
+            'unavailable. `enabled` belongs to /config and /submit, not to this '
+            'existence gate.'
+        )
+        assert response['multiValueHeaders']['Content-Type'] == ['text/html']
+        assert 'window.VoCFeedbackForm' in response['body']
+
+    @patch('feedback_form_handler.aggregates_table')
     def test_the_page_carries_a_policy_that_still_lets_a_customer_frame_it(
         self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
@@ -3371,17 +3409,35 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
 _FORM_ID_SINKS = frozenset({'aggregates_table', 'feedback_table', 'sqs'})
 
 
-def _refused_names(function: ast.FunctionDef) -> set[str]:
-    """Names this function tests in an `if` that then raises or returns.
+def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
+    """Name -> position of the earliest top-level `if` refusing it.
 
     `_validated_form_id` returns None rather than raising — deliberately, since
     every caller answers the same 404 — so the CALL is not the bound; the refusal
     after it is. A function that calls the validator and ignores what comes back
     has no bound at all, which is the natural mistake for someone copying the call
     and dropping the two lines that follow it at every current site.
+
+    A POSITION rather than a bare name, because WHERE the refusal sits is half the
+    claim and an earlier version of this helper answered only WHETHER one existed.
+    That let the refusal sit AFTER the read: the assignment binds None for a
+    malformed id, `get_item` runs with `Key={'sk': 'FORM#None'}` — the call the
+    whole cost argument exists to avoid — and the raise happens once it has been
+    paid for. Reported as a bound, because only the assignment's position was ever
+    compared against the sinks.
+    `test_the_derivation_refuses_a_refusal_that_happens_after_the_read` is the
+    control.
+
+    `function.body` rather than `ast.walk`, for the same reason
+    `_validates_its_form_id` requires the assignment at the top level: a refusal
+    nested under a condition refuses on some paths only, and `if False:` is the
+    extreme of that. Walking the whole function counted a dead refusal as a real
+    one, so hoisting just the assignment out of the dead block escaped the
+    top-level requirement while nothing was ever refused
+    (`test_the_derivation_refuses_a_refusal_that_only_runs_sometimes`).
     """
-    refused = set()
-    for node in ast.walk(function):
+    refused: dict[str, tuple[int, int]] = {}
+    for node in function.body:
         if not isinstance(node, ast.If):
             continue
         if not any(
@@ -3390,9 +3446,12 @@ def _refused_names(function: ast.FunctionDef) -> set[str]:
             for child in ast.walk(statement)
         ):
             continue
-        refused |= {
-            name.id for name in ast.walk(node.test) if isinstance(name, ast.Name)
-        }
+        position = (node.lineno, node.col_offset)
+        for name in ast.walk(node.test):
+            if not isinstance(name, ast.Name):
+                continue
+            known = refused.get(name.id)
+            refused[name.id] = position if known is None else min(known, position)
     return refused
 
 
@@ -3413,12 +3472,16 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
 
     - `<name> = _validated_form_id(...)` where `<name>` is later tested in an `if`
       whose body raises or returns. The assignment alone is not enough (see
-      `_refused_names`).
+      `_refused_names`), and the position that has to beat the sinks is the
+      REFUSAL's, not the assignment's: an assignment that binds None costs nothing,
+      so a read between it and the raise is a read of `FORM#None` that the check
+      was supposed to prevent.
     - a call to `_load_form_for_query(...)`, which needs no result check because it
-      RAISES for itself. Following the delegation rather than demanding the direct
-      call is deliberate: `/stats` and `/submissions` validate through it, and a
-      derivation that named only `_validated_form_id` would push someone into
-      adding a redundant second call to each.
+      RAISES for itself — so for that spelling the call's own position IS the
+      refusal's. Following the delegation rather than demanding the direct call is
+      deliberate: `/stats` and `/submissions` validate through it, and a derivation
+      that named only `_validated_form_id` would push someone into adding a
+      redundant second call to each.
 
     Top level rather than anywhere is what excludes dead code and conditional
     validation together — a check that only runs on some paths is not a bound, and
@@ -3447,6 +3510,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     for statement in function.body:
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
+                # This one raises for itself, so the call is the refusal.
                 position = (statement.lineno, statement.col_offset)
                 validated_at = min(validated_at or position, position)
             if not _named(call, '_validated_form_id'):
@@ -3458,11 +3522,16 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
                 else [statement.target] if isinstance(statement, ast.AnnAssign)
                 else []
             )
-            if any(
-                isinstance(target, ast.Name) and target.id in refused
-                for target in targets
-            ):
-                position = (statement.lineno, statement.col_offset)
+            # The REFUSAL's position, not the assignment's: binding None is free,
+            # and anything between the two runs with it. Taking the earliest over
+            # the targets keeps `min` below meaningful when a function validates
+            # more than one id.
+            refusals = [
+                refused[target.id] for target in targets
+                if isinstance(target, ast.Name) and target.id in refused
+            ]
+            if refusals:
+                position = min(refusals)
                 validated_at = min(validated_at or position, position)
 
     if validated_at is None:
@@ -3615,6 +3684,80 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'a get_item before the validator was reported as validated — the '
             'derivation is order-insensitive again, and the cost argument it '
             'checks is about order'
+        )
+
+    def test_the_derivation_refuses_a_refusal_that_happens_after_the_read(self):
+        """The order defect one step along: the CALL beats the read, the RAISE
+        does not.
+
+        `test_the_derivation_refuses_a_read_that_happens_before_the_check` moves
+        the whole validating statement after the sink. This moves only the two
+        lines that do the refusing — which is both subtler to read and the shape a
+        reorder produces naturally, since the assignment looks like the check.
+
+        It is unsafe for exactly the reason that test's shape is: `validated` binds
+        None for an id the pattern refuses, so `get_item` runs with
+        `Key={'sk': 'FORM#None'}` before the raise. The DynamoDB call the bound
+        exists to prevent is paid for, and the 404 the caller sees is
+        indistinguishable from the correct one — which is why nothing but this
+        derivation would report it.
+
+        So the position compared against the sinks has to be the refusal's, not the
+        assignment's (`_refused_names` returns it for that reason). This is what
+        fails if it goes back to reporting a bare set of names.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/late-refusal")
+            def get_late_refusal(form_id: str):
+                validated = _validated_form_id(form_id)
+                item = aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_late_refusal'), (
+            'a refusal placed after the read was reported as a bound — the '
+            'assignment binds None for free, so it is the RAISE that has to beat '
+            "the first sink. `Key={'sk': 'FORM#None'}` is still a get_item."
+        )
+
+    def test_the_derivation_refuses_a_refusal_that_only_runs_sometimes(self):
+        """The dead-code defect one step along: the ASSIGNMENT is hoisted, the
+        refusal is not.
+
+        `test_the_derivation_refuses_validation_that_only_runs_sometimes` nests the
+        whole block, so the top-level requirement on the assignment catches it.
+        Hoisting just the assignment out satisfies that requirement while the
+        refusal stays unreachable — no request is ever refused, and the read runs
+        with None bound exactly as in the case above.
+
+        This is why `_refused_names` iterates `function.body` rather than walking:
+        a refusal found anywhere in the tree includes ones that never execute, and
+        "the check is somewhere in the source" was never the claim.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/dead-refusal")
+            def get_dead_refusal(form_id: str):
+                validated = _validated_form_id(form_id)
+                if False:
+                    if not validated:
+                        raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_dead_refusal'), (
+            'a refusal inside dead code was reported as a bound — the assignment '
+            'being at the top level is not the property that matters, the refusal '
+            'running on every path is'
         )
 
     def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2592,6 +2592,55 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
             os.environ['ALLOWED_ORIGIN']
         ]
 
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_response_carries_the_two_headers_the_csp_does_not(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """`nosniff` and `no-referrer`, which nothing else in this suite reads.
+
+        The CSP is pinned in both directions by the case below, but that case reads
+        `_IFRAME_SECURITY_HEADERS['Content-Security-Policy']` BY KEY — so it sees no
+        other entry in the dict, and deleting either of the other two headers left
+        the whole suite green.
+
+        Asserted as the WHOLE key set rather than as two `in` checks, so a header
+        added later has to be argued for here and in the comment above the dict
+        together — which is the convention the CSP already follows.
+
+        Read off the rendered response rather than off the constant, because the
+        constant being right is only half of it: `get_form_iframe` passes
+        `headers=dict(_IFRAME_SECURITY_HEADERS)`, and a `Response` that dropped them
+        or a resolver that overwrote them would leave the dict itself untouched.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'deadbeef'}}
+
+        headers = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )['multiValueHeaders']
+
+        assert set(feedback_form_handler._IFRAME_SECURITY_HEADERS) == {
+            'Content-Security-Policy',
+            'X-Content-Type-Options',
+            'Referrer-Policy',
+        }, (
+            'a header was added to or removed from _IFRAME_SECURITY_HEADERS. A '
+            'REMOVAL of X-Content-Type-Options or Referrer-Policy is otherwise '
+            'silent — the CSP case reads the policy by key and sees no other '
+            'entry — and an ADDITION needs its reason recorded in the comment '
+            'above the dict, as the CSP and these two both are.'
+        )
+
+        # nosniff, because this is the only text/html in an otherwise all-JSON API:
+        # the one response a browser would otherwise be free to type for itself,
+        # and the one whose point is to be parsed as a document on this origin.
+        assert headers['X-Content-Type-Options'] == ['nosniff']
+        # no-referrer, because the page is framed on a customer's site, so the
+        # Referer on the widget's own fetches would put the customer's page URL in
+        # this API's access logs. The submit body carries `page_url` deliberately,
+        # so the product is not losing the URL — a log is just not where it was
+        # asked for.
+        assert headers['Referrer-Policy'] == ['no-referrer']
+
     def test_the_policy_names_every_directive_the_page_needs_and_no_wildcard(
         self, feedback_form_handler
     ):
@@ -3406,7 +3455,69 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
 # cannot be one of ours costs a Comprehend, Translate and Bedrock invocation
 # downstream. A call on any of these is what "keys on it" means below, and the
 # first one is the deadline the validation has to beat.
-_FORM_ID_SINKS = frozenset({'aggregates_table', 'feedback_table', 'sqs'})
+#
+# `dynamodb` is here for a different reason than the other three: no route calls
+# it today, but `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` is the spelling
+# the module DEMONSTRATES at module scope (line ~40), so it is the one a route
+# needing a different table would copy — and a resource handle obtained inline is
+# a read just as much as one bound at import. Only module-level uses exist now,
+# which is why adding it costs nothing and closes the shape before it appears.
+_FORM_ID_SINKS = frozenset({
+    'aggregates_table', 'feedback_table', 'sqs', 'dynamodb',
+})
+
+
+def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
+    """Positions of every call in `function` that reaches a form id into a sink.
+
+    Matched on the CALLEE CHAIN rather than on `<sink>.<method>` alone, which is
+    what an earlier version of this derivation did — and it recognised a read only
+    when spelled `aggregates_table.get_item(...)` literally. Two shapes therefore
+    reported as bounded while reading before validating, and the failure mode was
+    SILENCE rather than a wrong answer: no sink found makes `sink_positions` empty,
+    and `all(...)` over an empty list is vacuously True.
+
+    - `table = aggregates_table` then `table.get_item(...)`. Locally bound sinks
+      are tracked below for this one.
+    - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)`, where the sink name sits
+      further down the chain than `call.func.value`. Walking the whole callee
+      subtree is what catches it, and it is the more plausible of the two because
+      the module itself demonstrates that spelling.
+
+    Both are controls in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`.
+
+    Aliases are collected from the function's TOP LEVEL, in source order, and only
+    from a plain `name = <expression mentioning a sink>`. A conditionally bound
+    alias is not tracked, deliberately: this derivation errs toward calling
+    something a sink, and the cost of a false positive is a route author being made
+    to say why — whereas a false negative is a read nobody reports.
+    """
+    aliases: set[str] = set()
+
+    def _mentions_a_sink(node: ast.AST) -> bool:
+        return any(
+            isinstance(child, ast.Name)
+            and (child.id in _FORM_ID_SINKS or child.id in aliases)
+            for child in ast.walk(node)
+        )
+
+    for statement in function.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if not _mentions_a_sink(statement.value):
+            continue
+        aliases |= {
+            target.id for target in statement.targets
+            if isinstance(target, ast.Name)
+        }
+
+    return [
+        (call.lineno, call.col_offset)
+        for call in ast.walk(function)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and _mentions_a_sink(call.func)
+    ]
 
 
 def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
@@ -3537,14 +3648,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     if validated_at is None:
         return False
 
-    sink_positions = [
-        (call.lineno, call.col_offset)
-        for call in ast.walk(function)
-        if isinstance(call, ast.Call)
-        and isinstance(call.func, ast.Attribute)
-        and isinstance(call.func.value, ast.Name)
-        and call.func.value.id in _FORM_ID_SINKS
-    ]
+    sink_positions = _sink_call_positions(function)
     # No sink is not a pass by default: #379 was a route that touched no AWS
     # service at all and still put the id in its response, so a route that keys on
     # nothing yet takes an id out of the URL still has to establish the bound.
@@ -3760,6 +3864,77 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'running on every path is'
         )
 
+    def test_the_derivation_refuses_a_read_through_a_local_alias(self):
+        """The SINK side of the derivation, where the previous rounds' fixes did
+        not reach.
+
+        Every control above moves the validation relative to a sink spelled
+        `aggregates_table.get_item(...)`. This leaves the validation alone and
+        changes how the READ is spelled: bind the table to a local name first, and a
+        selector matching only `<sink>.<method>` stops recognising it.
+
+        The failure mode is what makes this worth a case rather than a note — it is
+        SILENCE, not a wrong answer. `sink_positions` comes back empty, and
+        `all(validated_at < sink for sink in [])` is vacuously True, so a route
+        reading before validating is reported as bounded. A derivation that reports
+        "fine" when it understood nothing is worse than no derivation, because the
+        docstring above it is then trusted.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/aliased-read")
+            def get_aliased_read(form_id: str):
+                table = aggregates_table
+                item = table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_aliased_read'), (
+            'a read through a local alias of a sink was not recognised as a read, '
+            'so the route was reported as bounded on an EMPTY sink list — '
+            'vacuously, which is the silent failure this control exists for'
+        )
+
+    def test_the_derivation_refuses_a_read_through_a_freshly_built_table(self):
+        """The same sink-side gap, in the spelling the module itself demonstrates.
+
+        `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` puts the sink name deeper
+        in the callee chain than `call.func.value`, so a selector looking only at
+        the attribute's immediate owner sees no sink and `sink_positions` is empty —
+        vacuously True again.
+
+        This is the more plausible of the two shapes, and that is the whole argument
+        for the case: the module binds its tables exactly this way at module scope,
+        so a route that needs a different table has a working example of the
+        spelling in front of it. Nothing in the module does it inside a function
+        today, which is precisely when to close the shape — before the first one.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/fresh-table")
+            def get_fresh_table(form_id: str):
+                item = dynamodb.Table(AGGREGATES_TABLE).get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_fresh_table'), (
+            'a read through dynamodb.Table(...) built inline was not recognised '
+            'as a read — the sink name sits further down the callee chain, and '
+            'this is the spelling the module demonstrates at module scope'
+        )
+
     def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):
         """The shape that has NO bound while looking exactly like one.
 
@@ -3927,6 +4102,48 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'normalized return splits the key a route reads from the '
                 'source_channel it filters on'
             )
+
+    def test_a_trailing_newline_is_not_a_valid_form_id(
+        self, feedback_form_handler
+    ):
+        """`$` matches before a final newline; `\\Z` is why this now refuses.
+
+        The one whitespace character the character class did not actually exclude.
+        `re`'s `$` also matches immediately BEFORE a trailing newline, so
+        `_FORM_ID_PATTERN.match('deadbeef\\n')` succeeded and the validator returned
+        the newline-bearing string — while the pattern's own comment says "No
+        whitespace either, and that is a choice rather than an oversight" and
+        `test_an_id_padded_with_whitespace_is_not_an_alias_for_the_id` pins only the
+        LEADING-space case. So the single character that got through was precisely
+        the one nothing checked.
+
+        Two consequences, both asserted:
+
+        - It reached `f'FORM#{validated}'`, `source_channel = f'form_{form_id}'` and
+          the log line in `_load_form_for_query`, where an embedded newline in a
+          structured log record is its own small problem.
+        - The length cap bounded the matched PREFIX rather than the id, so
+          `'a' * FORM_ID_MAX_LENGTH + '\\n'` was admitted at 65 characters while
+          `'a' * (FORM_ID_MAX_LENGTH + 1)` was refused. Derived from the constant
+          rather than spelled as a literal, for the same reason every other
+          over-length case here is.
+
+        Unreachable through the deployed route today — powertools' capture group
+        excludes `\\n`, and `%0A` arrives as the three literal characters `%0A`,
+        which `%` already refuses — and that is exactly the argument for fixing it
+        HERE: the pattern is documented as the bound that does not depend on the
+        route regex, so it has to hold on its own terms.
+        """
+        assert feedback_form_handler._validated_form_id('deadbeef\n') is None, (
+            "a trailing newline was accepted — check that _FORM_ID_PATTERN ends "
+            'in \\Z rather than $, which also matches before a final newline'
+        )
+        over_long = 'a' * feedback_form_handler.FORM_ID_MAX_LENGTH + '\n'
+        assert feedback_form_handler._validated_form_id(over_long) is None, (
+            f'{len(over_long)} characters were accepted against a cap of '
+            f'{feedback_form_handler.FORM_ID_MAX_LENGTH} — with `$` the cap bounds '
+            'the matched prefix, not the id'
+        )
 
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2412,6 +2412,56 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
     @patch('feedback_form_handler.aggregates_table')
+    def test_a_read_that_fails_refuses_the_page_rather_than_rendering_it(
+        self, mock_table, capsys, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The availability trade `get_form_iframe`'s docstring argues, pinned.
+
+        Having an existence gate means this route can now FAIL: before it, a page
+        was served having read nothing, so a table blip could not affect it. That
+        paragraph calls the 500 acceptable rather than a regression on two grounds,
+        and both of them are assertions here rather than prose:
+
+        - The page must NOT render for a form whose existence could not be
+          confirmed. A future `except` that swallowed the read failure and rendered
+          anyway — the obvious "keep the embed working" fix — restores exactly
+          #379's hole, a page on this origin for a form that may not exist, and
+          nothing else in the suite would notice.
+        - It must be OBSERVABLE. `FeedbackFormReadFailed` is the whole basis for
+          calling this a trade: a 500 the customer sees and operations does not is
+          the silent half of the defect `_load_form_for_query` was introduced for
+          (#312). Asserted all the way out through the EMF flush, like the /stats
+          case, so a metric that is buffered and never published still fails.
+        """
+        mock_table.get_item.side_effect = Exception(
+            'ProvisionedThroughputExceededException'
+        )
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 500
+        assert json.loads(response['body'])['success'] is False
+        # No document, which is the security half: the 500 has to be INSTEAD of
+        # the page, not alongside a rendered one.
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
+        assert 'VoCFeedbackForm' not in response['body']
+
+        emitted = _emitted_metrics(capsys, 'FeedbackFormReadFailed')
+        assert emitted, (
+            'the iframe read failed and emitted no CloudWatch metric — the '
+            'customer sees a broken frame and operations sees nothing, which is '
+            'what would make this existence check a regression rather than the '
+            'trade the docstring argues'
+        )
+        assert _namespaces_of(emitted) == {feedback_form_handler.metrics.namespace}, (
+            f'metric emitted under {_namespaces_of(emitted)}, not the namespace '
+            'shared/logging sets on the Metrics singleton'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
     def test_a_server_minted_id_still_serves_the_embeddable_page(
         self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
@@ -3084,9 +3134,10 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
       keyed on whatever the caller put in the path.
     """
 
-    # The three shapes, and what each must not do. Kept as data so a route added
-    # to the trio is a one-line addition rather than a fourth near-copy.
-    MALFORMED_BODY = {'name': 'pwn'}
+    # A VALID `PUT` body, and it has to be: `update_form` 400s on an empty update
+    # (`No fields to update`), so a body with nothing in it would produce a refusal
+    # that says nothing about the id. What is malformed in these cases is the ID.
+    A_VALID_UPDATE_BODY = {'name': 'pwn'}
 
     @patch('feedback_form_handler.aggregates_table')
     def test_no_crud_route_turns_a_malformed_id_into_a_key(
@@ -3101,7 +3152,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
         """
         for method, body in (
             ('GET', None),
-            ('PUT', self.MALFORMED_BODY),
+            ('PUT', self.A_VALID_UPDATE_BODY),
             ('DELETE', None),
         ):
             for malformed in (
@@ -3150,7 +3201,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
             method='PUT',
             path=f'/feedback-forms/{_INJECTION_PAYLOAD}',
             path_params={'form_id': _INJECTION_PAYLOAD},
-            body=self.MALFORMED_BODY,
+            body=self.A_VALID_UPDATE_BODY,
             resource='/feedback-forms/{form_id}',
         )
 
@@ -3257,7 +3308,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
 
 
 def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
-    """Every `@app.<method>` route whose path captures `<form_id>`, from source.
+    """Every `@app.<method>` route under `/feedback-forms/` that captures anything.
 
     Returns route path -> handler function name, read off the module with `ast`
     rather than listed here. The two classes above name their routes explicitly,
@@ -3265,8 +3316,20 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
     lists is what the module is measured against. A route added later appears here
     for free, and if it does not validate its id the test below fails naming it.
 
-    Only `<form_id>` counts: `/feedback-forms` and `POST /feedback-forms` take no
-    id out of the URL and have nothing to check.
+    Selected on the PATH PREFIX plus the presence of a `<...>` capture, and
+    deliberately NOT on the literal `<form_id>`: the capture's NAME is the route
+    author's choice, so `<id>`, `<formId>` or `<form>` are all plausible spellings
+    for a route added later — and every one of them would have escaped a
+    `'<form_id>' in path` filter while keying on the same partition. A universal
+    claim whose universe is chosen by a name nobody has to use is not a universal
+    claim; `test_a_route_that_captures_the_id_under_another_name_is_still_judged`
+    is the control.
+
+    Still excludes `/feedback-forms` and `POST /feedback-forms`: those carry no
+    capture, so they take no id out of the URL and have nothing to check. A route
+    under this prefix that captures something OTHER than a form id (a submission
+    id, say) would be included and would have to establish the bound or say why —
+    which is the right side to err on, since the alternative is silence.
     """
     tree = ast.parse(source)
     routes = {}
@@ -3289,25 +3352,79 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
             path = decorator.args[0]
             if not (isinstance(path, ast.Constant) and isinstance(path.value, str)):
                 continue
-            if '<form_id>' in path.value:
+            if path.value.startswith('/feedback-forms/') and '<' in path.value:
                 routes[f'{target.attr.upper()} {path.value}'] = node.name
     assert routes, (
-        'no @app route capturing <form_id> was found in the handler source — the '
-        'derivation found nothing to judge, so a green result below would be '
-        'meaningless. If the routes moved or the decorator spelling changed, fix '
-        'this helper; do not delete the assertion.'
+        'no @app route under /feedback-forms/ with a <...> capture was found in '
+        'the handler source — the derivation found nothing to judge, so a green '
+        'result below would be meaningless. If the routes moved or the decorator '
+        'spelling changed, fix this helper; do not delete the assertion.'
     )
     return routes
 
 
-def _validates_its_form_id(source: str, function_name: str) -> bool:
-    """Does `function_name` reach `_validated_form_id` before it keys on anything?
+# The objects a route reaches a form id INTO: the two DynamoDB tables, and the
+# queue because `/submit` writes there and an enqueued record for an id that
+# cannot be one of ours costs a Comprehend, Translate and Bedrock invocation
+# downstream. A call on any of these is what "keys on it" means below, and the
+# first one is the deadline the validation has to beat.
+_FORM_ID_SINKS = frozenset({'aggregates_table', 'feedback_table', 'sqs'})
 
-    True if the function calls it directly, or calls `_load_form_for_query` — the
-    one read `/stats` and `/submissions` make, which validates on their behalf.
-    Following the delegation rather than requiring the direct call is the point:
-    the alternative is a test that demands a particular spelling and fails on a
-    legitimate refactor.
+
+def _refused_names(function: ast.FunctionDef) -> set[str]:
+    """Names this function tests in an `if` that then raises or returns.
+
+    `_validated_form_id` returns None rather than raising — deliberately, since
+    every caller answers the same 404 — so the CALL is not the bound; the refusal
+    after it is. A function that calls the validator and ignores what comes back
+    has no bound at all, which is the natural mistake for someone copying the call
+    and dropping the two lines that follow it at every current site.
+    """
+    refused = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.If):
+            continue
+        if not any(
+            isinstance(child, (ast.Raise, ast.Return))
+            for statement in node.body
+            for child in ast.walk(statement)
+        ):
+            continue
+        refused |= {
+            name.id for name in ast.walk(node.test) if isinstance(name, ast.Name)
+        }
+    return refused
+
+
+def _validates_its_form_id(source: str, function_name: str) -> bool:
+    """Does `function_name` reach the validator, and REFUSE, before keying on
+    anything?
+
+    Positional and result-aware, because the order and the refusal are the whole
+    claim. An earlier version of this helper was an order-insensitive set-membership
+    test over every call name in the body, which three unsafe shapes satisfied: a
+    `get_item` before the validator, a validator whose return value was discarded,
+    and a validator mentioned only inside `if False:`. Each is reported False now,
+    and each has a control below — the second one mattering most, since a route
+    with no bound at all looked identical to a correct one.
+
+    A validating statement is one of two spellings, both required to sit at the
+    function's TOP LEVEL:
+
+    - `<name> = _validated_form_id(...)` where `<name>` is later tested in an `if`
+      whose body raises or returns. The assignment alone is not enough (see
+      `_refused_names`).
+    - a call to `_load_form_for_query(...)`, which needs no result check because it
+      RAISES for itself. Following the delegation rather than demanding the direct
+      call is deliberate: `/stats` and `/submissions` validate through it, and a
+      derivation that named only `_validated_form_id` would push someone into
+      adding a redundant second call to each.
+
+    Top level rather than anywhere is what excludes dead code and conditional
+    validation together — a check that only runs on some paths is not a bound, and
+    `if False:` is just the extreme of that. If a legitimate spelling ever needs to
+    nest (validation inside a `with`, say), widen this deliberately and add the
+    control alongside the three below; do not relax it to get green.
     """
     tree = ast.parse(source)
     functions = [
@@ -3317,12 +3434,52 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     assert len(functions) == 1, (
         f'expected exactly one def {function_name}, found {len(functions)}'
     )
-    called = {
-        node.func.id
-        for node in ast.walk(functions[0])
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-    }
-    return bool(called & {'_validated_form_id', '_load_form_for_query'})
+    function = functions[0]
+    refused = _refused_names(function)
+
+    def _calls(statement) -> list[ast.Call]:
+        return [n for n in ast.walk(statement) if isinstance(n, ast.Call)]
+
+    def _named(call: ast.Call, name: str) -> bool:
+        return isinstance(call.func, ast.Name) and call.func.id == name
+
+    validated_at = None
+    for statement in function.body:
+        for call in _calls(statement):
+            if _named(call, '_load_form_for_query'):
+                position = (statement.lineno, statement.col_offset)
+                validated_at = min(validated_at or position, position)
+            if not _named(call, '_validated_form_id'):
+                continue
+            # The result has to be BOUND and then refused. An `Expr` statement, or
+            # an assignment to a name nothing tests, is the shape that has no bound.
+            targets = (
+                statement.targets if isinstance(statement, ast.Assign)
+                else [statement.target] if isinstance(statement, ast.AnnAssign)
+                else []
+            )
+            if any(
+                isinstance(target, ast.Name) and target.id in refused
+                for target in targets
+            ):
+                position = (statement.lineno, statement.col_offset)
+                validated_at = min(validated_at or position, position)
+
+    if validated_at is None:
+        return False
+
+    sink_positions = [
+        (call.lineno, call.col_offset)
+        for call in ast.walk(function)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id in _FORM_ID_SINKS
+    ]
+    # No sink is not a pass by default: #379 was a route that touched no AWS
+    # service at all and still put the id in its response, so a route that keys on
+    # nothing yet takes an id out of the URL still has to establish the bound.
+    return all(validated_at < sink for sink in sink_positions)
 
 
 class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
@@ -3340,13 +3497,13 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
     def test_no_route_keys_on_a_form_id_without_validating_it_first(
         self, feedback_form_handler
     ):
-        """Every `<form_id>` route validates, or the failure names the ones that do
-        not.
+        """Every route under `/feedback-forms/<...>` validates and refuses first, or
+        the failure names the ones that do not.
 
         This is the test that makes the docstring's "EVERY" audit itself. A route
-        added later is included automatically, so the next person to write
-        `@app.get("/feedback-forms/<form_id>/something")` finds out here rather
-        than in a review.
+        added later is included automatically — whatever it calls its capture — so
+        the next person to write `@app.get("/feedback-forms/<id>/something")` finds
+        out here rather than in a review.
         """
         source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
             encoding='utf-8'
@@ -3360,11 +3517,13 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         )
 
         assert unbounded == [], (
-            f'{unbounded} take a form id out of the URL without reaching '
-            '_validated_form_id (directly or through _load_form_for_query), so '
-            "that function's docstring no longer describes the module. Add the "
-            'check rather than narrowing the claim: the value of a universal '
-            'bound is that a reader does not have to hold the exceptions.'
+            f'{unbounded} take a form id out of the URL without establishing the '
+            'bound before their first read or send. Three shapes report here, and '
+            'the message cannot tell them apart: no validator call at all; a call '
+            'whose None result is never refused (which is no bound — see '
+            '_refused_names); or a call that comes AFTER the table or the queue is '
+            "touched. Add the check rather than narrowing the claim: the value of a "
+            'universal bound is that a reader does not have to hold the exceptions.'
         )
 
     def test_the_derivation_sees_the_routes_this_module_actually_has(
@@ -3412,6 +3571,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             @app.get("/feedback-forms/<form_id>/checked")
             def get_checked(form_id: str):
                 validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
                 return validated
             '''
         )
@@ -3422,9 +3583,148 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'GET /feedback-forms/<form_id>/checked': 'get_checked',
         }
         assert not _validates_its_form_id(source, 'get_new_thing')
-        # And the delegating spelling is accepted, so the check is about reaching
-        # the validator rather than about naming it.
+        # And the accepting side, so the check is not simply always False: the
+        # module's own spelling — validate, refuse on None, then proceed.
         assert _validates_its_form_id(source, 'get_checked')
+
+    def test_the_derivation_refuses_a_read_that_happens_before_the_check(self):
+        """ORDER is part of the claim, and the old derivation ignored it.
+
+        A route that reads first and validates afterwards satisfies "calls the
+        validator" while paying for the DynamoDB call the check exists to avoid —
+        which is the entire cost argument `_validated_form_id`'s docstring makes and
+        the basis for the throttle pair in `lib/stacks/api-stack.ts`. So the
+        validation has to beat the first sink, not merely appear somewhere in the
+        body.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/backwards")
+            def get_backwards(form_id: str):
+                item = aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_backwards'), (
+            'a get_item before the validator was reported as validated — the '
+            'derivation is order-insensitive again, and the cost argument it '
+            'checks is about order'
+        )
+
+    def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):
+        """The shape that has NO bound while looking exactly like one.
+
+        `_validated_form_id` returns None rather than raising — deliberately, since
+        every caller answers the same 404 — so the call is not the bound; the
+        refusal after it is. A route that calls it and drops the result reads a
+        malformed id straight into the table, and under the old set-membership
+        derivation it was indistinguishable from a correct route.
+
+        It is also the likeliest mistake in practice: the two-line
+        `if not validated: raise` is separable from the call, and every one of the
+        module's current sites spells it out by hand.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/discarded")
+            def get_discarded(form_id: str):
+                _validated_form_id(form_id)
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_discarded'), (
+            'a discarded validator result was reported as a bound — the value the '
+            'derivation is checking for is the REFUSAL, not the call'
+        )
+
+        # And the same thing one step subtler: the result is bound to a name, but
+        # nothing ever tests it. An assignment is not a refusal either.
+        assigned_but_unchecked = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/assigned")
+            def get_assigned(form_id: str):
+                validated = _validated_form_id(form_id)
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(assigned_but_unchecked, 'get_assigned'), (
+            'a validated value used as a key without being refused first was '
+            "reported as bounded — `f'FORM#None'` is still a read"
+        )
+
+    def test_the_derivation_refuses_validation_that_only_runs_sometimes(self):
+        """Dead or conditional validation is not validation.
+
+        `if False:` is the extreme of a check that does not run on every path, and
+        it passed the old derivation because the call was lexically present. The
+        general property is what matters: validation nested under a condition
+        bounds some requests and not others, so the derivation requires it at the
+        function's top level.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/dead")
+            def get_dead(form_id: str):
+                if False:
+                    validated = _validated_form_id(form_id)
+                    if not validated:
+                        raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_dead'), (
+            'validation inside dead code was reported as a bound — the check has '
+            'to be on every path, not merely in the source'
+        )
+
+    def test_a_route_that_captures_the_id_under_another_name_is_still_judged(self):
+        """The universe is chosen by the PATH, not by the capture's name.
+
+        This is the hole a `'<form_id>' in path` filter left: a route capturing the
+        same id as `<id>` keyed on the same partition while being invisible to the
+        claim, so `test_no_route_keys_on_a_form_id_without_validating_it_first`
+        passed with it unvalidated — silence, which is the failure mode this
+        derivation replaced a prose list to avoid. `<id>` is not a hypothetical
+        spelling; it is the shorter and more natural one for someone adding a
+        route.
+
+        Both directions, because only the pair makes the selector meaningful: the
+        renamed route must be REPORTED as part of the universe, and then reported
+        as UNVALIDATED. A selector that included it but a check that waved it
+        through would be the same hole one step along.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<id>/export")
+            def export_form(id: str):
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{id}'}
+                )
+            '''
+        )
+
+        routes = _routes_keying_on_a_form_id(source)
+
+        assert routes == {'GET /feedback-forms/<id>/export': 'export_form'}, (
+            f'the derivation reported {routes} — a route capturing the form id '
+            'under a name other than form_id escapes the universal claim entirely'
+        )
+        assert not _validates_its_form_id(source, 'export_form')
 
     def test_the_derivation_accepts_the_delegating_spelling(self):
         """`/stats` and `/submissions` validate through `_load_form_for_query`.

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3393,6 +3393,75 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
         )
         assert 'ConditionExpression' not in mock_table.delete_item.call_args.kwargs
 
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_create_that_would_overwrite_a_stored_form_is_refused(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The mirror image of `PUT`'s condition, on the write that OVERWRITES.
+
+        `update_form` needed `attribute_exists(sk)` because UpdateItem creates
+        silently. PutItem replaces just as silently, so `create_form` is the other
+        half: with no condition, a minted id that collides with a stored form
+        REPLACES it — that customer's `enabled` flag, theme and prioritization link
+        gone, answered 200, the response echoing the NEW record so nothing anywhere
+        says a form was lost.
+
+        Not reachable by a caller, since the id is minted and never taken from the
+        body, so it takes a collision: two `_minted_form_id()` draws agreeing, a
+        birthday problem over 32 bits at `FORM_ID_LENGTH = 8`. Small, not zero —
+        and the constant's comment says it is safe to RAISE, which this condition
+        is what keeps a free choice rather than one eventually forced by the loss.
+
+        500 rather than a 4xx is the deliberate part: a collision is the server's
+        problem, the caller did nothing wrong, and a retry mints a different id.
+        """
+        mock_table.put_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException',
+                       'Message': 'The conditional request failed'}},
+            'PutItem',
+        )
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'a form whose minted id is already taken'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 500
+        assert json.loads(response['body'])['success'] is False
+        # The condition is on the REQUEST rather than only in the docstring —
+        # without it this write succeeds and the stored form is gone.
+        assert (
+            mock_table.put_item.call_args.kwargs['ConditionExpression']
+            == 'attribute_not_exists(sk)'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_create_of_a_new_form_still_succeeds(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The contract the condition must not have broken.
+
+        Every create in practice is of an id nothing holds, so the condition has to
+        be invisible on the path that matters. Without this, the case above would
+        pass just as well with `create_form` broken outright.
+        """
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'A brand new form'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        form = json.loads(response['body'])['form']
+        assert form['name'] == 'A brand new form'
+        # And a real minted id came back, so the caller can address what it made.
+        assert feedback_form_handler._validated_form_id(form['form_id'])
+
 
 def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
     """Every `@app.<method>` route under `/feedback-forms/` that captures anything.

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3559,32 +3559,88 @@ _FORM_ID_SINKS = frozenset({
 #
 # Erring toward calling something a sink is the right side of this: a false
 # positive costs a route author an explanation, while a false negative is a read
-# NOBODY reports — an empty `sink_positions` makes `_validates_its_form_id`'s
-# `all(...)` vacuously True, so the instrument answers "bounded" when it understood
-# nothing.
+# NOBODY reports — a sink the derivation cannot see is a sink it asks no question
+# about, so `_validates_its_form_id` answers "bounded" having understood nothing.
 _SINK_OPERATIONS = frozenset({
     'get_item', 'put_item', 'update_item', 'delete_item', 'query', 'scan',
     'batch_get_item', 'batch_write_item', 'send_message', 'send_message_batch',
 })
 
 
-def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
-    """Positions of every call in `function` that reaches a form id into a sink.
+def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
+    """Module-level functions that reach what they are handed into a sink.
 
-    A call counts as a sink two ways, and either is enough:
+    A sink does not have to be spelled in the route. `_anchor_form_brand`
+    (`feedback_form_handler.py:269`) performs an `update_item` on a key built from
+    the id it is passed, and `submit_form_feedback` already calls it — so a route
+    that hands an unvalidated id to a helper writes it to the table with no sink
+    call of its own anywhere in its body. `_sink_calls` matched only an
+    `ast.Attribute` callee, so a plain `helper(form_id)` was not a sink at all, the
+    list came back empty, and the vacuous `all(...)` reported the route as bounded.
+    Silence again, this time through the call SHAPE rather than the receiver name.
+
+    Excluded: any function that calls `_validated_form_id` itself. That is what
+    makes `_load_form_for_query` — which reads, and is called by three routes — not
+    a hole: it establishes the bound on the id it was handed before its own read,
+    which is the delegating spelling `_validates_its_form_id` already accepts as a
+    refusal. Counting it as an unguarded sink would report `/iframe`, `/stats` and
+    `/submissions` as unbounded, which is the false-positive direction. The same
+    rule excludes the route handlers, each of which validates.
+
+    A fixpoint rather than one level, because a helper calling a helper is the same
+    hole one step further out and the loop costs four lines. It resolves NAMES in
+    this module only: a sink reached through an imported function is still invisible,
+    which is the remaining ceiling — worth stating rather than implying, since the
+    failure mode is the vacuous pass this whole helper exists to close.
+    """
+    candidates = {
+        node.name: node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and not any(
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == '_validated_form_id'
+            for call in ast.walk(node)
+        )
+    }
+    helpers: set[str] = set()
+    growing = True
+    while growing:
+        growing = False
+        for name, node in candidates.items():
+            if name not in helpers and _sink_calls(node, frozenset(helpers)):
+                helpers.add(name)
+                growing = True
+    return frozenset(helpers)
+
+
+def _sink_calls(
+    function: ast.FunctionDef, helpers: frozenset[str] = frozenset()
+) -> list[tuple[tuple[int, int], frozenset[str]]]:
+    """Every call in `function` that reaches a form id into a sink.
+
+    `(position, the names mentioned in the call's arguments)` per sink — the names
+    because a position alone answers "was something validated before this read",
+    and the claim is that the id THIS read keys on was. See
+    `_validates_its_form_id`.
+
+    A call counts as a sink three ways, and any one is enough:
 
     - its METHOD is one of `_SINK_OPERATIONS`, whatever handle it arrives through.
       That is the one that is closed over spellings; the constant's comment carries
       the argument and the in-repo lines it is derived from.
     - a sink NAME appears anywhere in the callee chain — including a local alias of
       one — which still catches a call whose method that set does not name.
+    - it calls a module-level function that reaches its own argument into a sink
+      (`_sink_bearing_helpers`), so an indirect write is a write.
 
-    Both exist because an earlier version had only the second, spelled as
+    All three exist because an earlier version had only the second, spelled as
     `<sink>.<method>` on the immediate owner, and every shape it could not see
     reported as bounded while reading before validating. The failure mode is
-    SILENCE rather than a wrong answer: no sink found makes `sink_positions` empty,
-    and `all(...)` over an empty list is vacuously True. Each shape below is a
-    control in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`:
+    SILENCE rather than a wrong answer: a sink missing from this list is one
+    `_validates_its_form_id` asks neither of its questions about, so an empty list
+    passes both vacuously. Each shape below is a control in
+    `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`:
 
     - `table = aggregates_table` then `table.get_item(...)` — alias tracking.
     - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` — the sink name sits deeper
@@ -3592,14 +3648,16 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
     - `table = get_aggregates_table()` then `table.get_item(...)`, and
       `get_dynamodb_resource().Table(T).get_item(...)` — no sink name anywhere, so
       only the operation match sees them.
+    - `_anchor_form_brand(form_id, ...)` — no attribute callee at all, so only the
+      helper match sees it.
 
     Aliases are collected in source order and from NESTED bodies as well as the top
     level (`try`, `with`, `if`, `for`), because every table read in this handler
     sits inside a `try:` — so the plausible spelling of an alias is an indented
     one, and three of the twelve in-repo `table = get_aggregates_table()` sites are
     themselves inside one. An untracked alias is a FALSE NEGATIVE, not a cautious
-    false positive: the call drops out of `sink_positions` and the shorter list
-    makes the `all()` MORE likely to pass. That is the same vacuous pass the
+    false positive: the call drops out of this list, so nothing is asked about it
+    and the shorter list is MORE likely to pass. That is the same vacuous pass the
     controls exist to prevent, which is why alias collection is generous while the
     REFUSAL's top-level requirement — a separate axis — stays strict.
 
@@ -3651,12 +3709,34 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
 
     _collect_aliases(function.body)
 
+    def _is_sink(call: ast.Call) -> bool:
+        if isinstance(call.func, ast.Attribute):
+            return (
+                call.func.attr in _SINK_OPERATIONS or _mentions_a_sink(call.func)
+            )
+        # A module-level helper that writes what it is handed. See
+        # `_sink_bearing_helpers`.
+        return isinstance(call.func, ast.Name) and call.func.id in helpers
+
+    def _names_in_arguments(call: ast.Call) -> frozenset[str]:
+        """Every identifier the call's arguments mention.
+
+        Includes names inside an f-string, since `f'FORM#{form_id}'` is how every
+        key in this module is built — `ast.walk` reaches into `JoinedStr` for free.
+        The callee is deliberately excluded: `table.get_item(...)`'s receiver is not
+        an id that needed validating.
+        """
+        return frozenset(
+            child.id
+            for argument in [*call.args, *(kw.value for kw in call.keywords)]
+            for child in ast.walk(argument)
+            if isinstance(child, ast.Name)
+        )
+
     return [
-        (call.lineno, call.col_offset)
+        ((call.lineno, call.col_offset), _names_in_arguments(call))
         for call in ast.walk(function)
-        if isinstance(call, ast.Call)
-        and isinstance(call.func, ast.Attribute)
-        and (call.func.attr in _SINK_OPERATIONS or _mentions_a_sink(call.func))
+        if isinstance(call, ast.Call) and _is_sink(call)
     ]
 
 
@@ -3783,6 +3863,32 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     `if False:` is just the extreme of that. If a legitimate spelling ever needs to
     nest (validation inside a `with`, say), widen this deliberately and add the
     control alongside the ones below; do not relax it to get green.
+
+    Two questions are asked of every sink, not one:
+
+    - ORDER: no sink may precede the earliest refusal. That is the cost argument —
+      a read paid for before the check is a read the check existed to avoid — and
+      it holds even for a sink that mentions no id at all.
+    - LINKAGE: the id the sink keys on has to be one that WAS bounded. Position
+      alone answered "was something validated first", and a route that validated a
+      DIFFERENT capture satisfied that while keying on a raw one:
+      `validated = _validated_form_id(submission_id)` refused, then
+      `get_item(Key={'sk': f'FORM#{form_id}'})`. Reported bounded, with `form_id`
+      reaching the key unchecked. Not remote — the route selector is deliberately
+      capture-name-agnostic, so a two-capture route like
+      `/feedback-forms/<form_id>/submissions/<submission_id>` is already in the
+      universe, and it could satisfy the derivation by bounding whichever capture
+      was easier (`test_the_derivation_refuses_validating_the_wrong_capture`).
+
+    Linkage is asked of the PARAMETERS, because they are the untrusted values: a
+    parameter is bounded once it has been handed to `_validated_form_id` (or
+    `_load_form_for_query`) in a statement whose refusal precedes the sink, and so
+    is anything the validator handed back. Every other local is judged by what it
+    was built from, so `key = f'FORM#{form_id}'` before the check is a tainted key
+    rather than an unremarkable string. The ceiling: propagation follows `Assign`
+    and `AnnAssign` only, so an id smuggled through a `for` target or a mutated
+    container is not traced — a deliberate stopping point, since the shapes that
+    exist here build keys and filters by assignment.
     """
     tree = ast.parse(source)
     functions = [
@@ -3801,7 +3907,27 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     def _named(call: ast.Call, name: str) -> bool:
         return isinstance(call.func, ast.Name) and call.func.id == name
 
-    def _walrus_refusal(statement) -> tuple[int, int] | None:
+    def _mentioned(node: ast.AST) -> set[str]:
+        return {
+            child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+        }
+
+    def _target_names(statement) -> set[str]:
+        targets = (
+            statement.targets if isinstance(statement, ast.Assign)
+            else [statement.target] if isinstance(statement, ast.AnnAssign)
+            else []
+        )
+        # A tuple target too: `validated, form = _load_form_for_query(...)` binds
+        # both, and the validated id is the one the caller keys and filters on.
+        return {
+            name.id
+            for target in targets
+            for name in ast.walk(target)
+            if isinstance(name, ast.Name)
+        }
+
+    def _walrus_refusal(statement) -> tuple[tuple[int, int], ast.Call] | None:
         """`if not (<name> := _validated_form_id(...)):` — bind and refuse in one.
 
         The `if`'s own position, because for this spelling the binding and the
@@ -3825,47 +3951,87 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
             for child in ast.walk(node)
         ):
             return None
-        return (statement.lineno, statement.col_offset)
+        return (statement.lineno, statement.col_offset), bound.value
 
-    validated_at = None
+    # name -> the earliest position from which it is known to be bounded. Both the
+    # id handed TO the validator and the value handed BACK are bounded from the
+    # refusal, since the refusal is what makes the one a well-formed id and the
+    # other not None.
+    bounded_at: dict[str, tuple[int, int]] = {}
+
+    def _bind(names, position: tuple[int, int]) -> None:
+        for name in names:
+            known = bounded_at.get(name)
+            bounded_at[name] = position if known is None else min(known, position)
+
     for statement in function.body:
         walrus = _walrus_refusal(statement)
         if walrus is not None:
-            validated_at = min(validated_at or walrus, walrus)
+            position, call = walrus
+            _bind(_mentioned(call) | _mentioned(statement.test), position)
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
                 # This one raises for itself, so the call is the refusal.
                 position = (statement.lineno, statement.col_offset)
-                validated_at = min(validated_at or position, position)
+                _bind(_mentioned(call) | _target_names(statement), position)
             if not _named(call, '_validated_form_id'):
                 continue
             # The result has to be BOUND and then refused. An `Expr` statement, or
             # an assignment to a name nothing tests, is the shape that has no bound.
-            targets = (
-                statement.targets if isinstance(statement, ast.Assign)
-                else [statement.target] if isinstance(statement, ast.AnnAssign)
-                else []
-            )
+            targets = _target_names(statement)
             # The REFUSAL's position, not the assignment's: binding None is free,
-            # and anything between the two runs with it. Taking the earliest over
-            # the targets keeps `min` below meaningful when a function validates
-            # more than one id.
-            refusals = [
-                refused[target.id] for target in targets
-                if isinstance(target, ast.Name) and target.id in refused
-            ]
+            # and anything between the two runs with it.
+            refusals = [refused[target] for target in targets if target in refused]
             if refusals:
-                position = min(refusals)
-                validated_at = min(validated_at or position, position)
+                _bind(targets | _mentioned(call), min(refusals))
 
-    if validated_at is None:
+    if not bounded_at:
         return False
+    validated_at = min(bounded_at.values())
 
-    sink_positions = _sink_call_positions(function)
+    sinks = _sink_calls(function, _sink_bearing_helpers(tree))
     # No sink is not a pass by default: #379 was a route that touched no AWS
     # service at all and still put the id in its response, so a route that keys on
     # nothing yet takes an id out of the URL still has to establish the bound.
-    return all(validated_at < sink for sink in sink_positions)
+    if any(position <= validated_at for position, _ in sinks):
+        return False
+
+    parameters = {
+        argument.arg for argument in (
+            *function.args.posonlyargs, *function.args.args,
+            *function.args.kwonlyargs,
+        )
+    }
+    assignments = [
+        ((node.lineno, node.col_offset), _target_names(node), _mentioned(node.value))
+        for node in ast.walk(function)
+        if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.value is not None
+    ]
+
+    def _unbounded_at(position: tuple[int, int]) -> set[str]:
+        """Names holding a value no refusal before `position` has vouched for."""
+        tainted = {
+            name for name in parameters
+            if name not in bounded_at or bounded_at[name] >= position
+        }
+        growing = True
+        while growing:
+            growing = False
+            for at, targets, mentioned in assignments:
+                if at >= position or not (mentioned & tainted):
+                    continue
+                spreading = {
+                    target for target in targets - tainted
+                    if bounded_at.get(target, position) >= position
+                }
+                if spreading:
+                    tainted |= spreading
+                    growing = True
+        return tainted
+
+    return not any(
+        mentioned & _unbounded_at(position) for position, mentioned in sinks
+    )
 
 
 class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
@@ -3909,9 +4075,12 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'validator call at all; a result that is never refused, or refused by '
             'something that is not a NEGATIVE test of it — a success-path or '
             'cache-hit `return` is not a refusal (see `_refused_names`); a refusal '
-            'that is nested, so it runs on some paths only; or a REFUSAL that comes '
-            'after the table or the queue is touched. Add the check rather than '
-            'narrowing the claim: the value of a universal bound is that a reader '
+            'that is nested, so it runs on some paths only; a REFUSAL that comes '
+            'after the table or the queue is touched; or a bound established on a '
+            'DIFFERENT value than the one the read keys on — validating '
+            '`submission_id` and keying on a raw `form_id` reports here, as does a '
+            'key built from the raw id before the refusal. Add the check rather '
+            'than narrowing the claim: the value of a universal bound is that a reader '
             'does not have to hold the exceptions. And if the route is genuinely '
             'bounded in a spelling this derivation does not know, widen the '
             'derivation and add a control for it — '
@@ -3966,12 +4135,15 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         So the count is pinned per route, against what each one actually does. The
         numbers are small enough to read: one read each, `submit_form_feedback`
-        alone having a read AND the send that makes its cost argument different.
+        alone having a read AND the send that makes its cost argument different —
+        plus the `_anchor_form_brand` call, which is a sink because that helper
+        writes what it is handed (`_sink_bearing_helpers`).
         """
         source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
             encoding='utf-8'
         )
         tree = ast.parse(source)
+        helpers = _sink_bearing_helpers(tree)
 
         counted = {}
         for route, function_name in _routes_keying_on_a_form_id(source).items():
@@ -3979,15 +4151,18 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
                 node for node in ast.walk(tree)
                 if isinstance(node, ast.FunctionDef) and node.name == function_name
             )
-            counted[route] = len(_sink_call_positions(function))
+            counted[route] = len(_sink_calls(function, helpers))
 
         assert counted == {
             'GET /feedback-forms/<form_id>': 1,
             'PUT /feedback-forms/<form_id>': 1,
             'DELETE /feedback-forms/<form_id>': 1,
             'GET /feedback-forms/<form_id>/config': 1,
-            # The read for the enabled check, and the enqueue.
-            'POST /feedback-forms/<form_id>/submit': 2,
+            # The read for the enabled check, the enqueue, and the
+            # `_anchor_form_brand` call — that helper's own `update_item` writes a
+            # key built from the id it is handed, so the call site is a write
+            # whatever it is spelled like.
+            'POST /feedback-forms/<form_id>/submit': 3,
             # The existence gate is inside `_load_form_for_query`, so this route
             # touches no sink of its own — which is why "no sink" is deliberately
             # not a pass by default in `_validates_its_form_id`.
@@ -3997,9 +4172,13 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         }, (
             f'{counted} — a route gained or lost a read, or the derivation started '
             'counting something that is not one. If a count went UP without the '
-            'route changing, suspect `aliases`: binding the RESULT of a read makes '
-            'every subsequent `.get(...)` on it look like a sink, and the earliest '
-            'of those decides the verdict.'
+            'route changing, suspect two things: `aliases`, since binding the '
+            'RESULT of a read makes every subsequent `.get(...)` on it look like a '
+            'sink; and `_sink_bearing_helpers`, since a module-level function that '
+            'starts writing makes every call to it a sink. Both are the right '
+            'answer when the call really does reach an id into a table, and both '
+            'are a false positive otherwise — the earliest sink is what decides '
+            'the verdict, so one spurious early entry accuses a correct route.'
         )
 
     def test_the_derivation_can_fail(self):
@@ -4151,8 +4330,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         selector matching only `<sink>.<method>` stops recognising it.
 
         The failure mode is what makes this worth a case rather than a note — it is
-        SILENCE, not a wrong answer. `sink_positions` comes back empty, and
-        `all(validated_at < sink for sink in [])` is vacuously True, so a route
+        SILENCE, not a wrong answer. `_sink_calls` comes back empty, so neither the
+        order question nor the linkage one is asked of anything, and a route
         reading before validating is reported as bounded. A derivation that reports
         "fine" when it understood nothing is worse than no derivation, because the
         docstring above it is then trusted.
@@ -4183,8 +4362,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` puts the sink name deeper
         in the callee chain than `call.func.value`, so a selector looking only at
-        the attribute's immediate owner sees no sink and `sink_positions` is empty —
-        vacuously True again.
+        the attribute's immediate owner sees no sink and `_sink_calls` is empty —
+        nothing to ask a question about, vacuously bounded again.
 
         This is the more plausible of the two shapes, and that is the whole argument
         for the case: the module binds its tables exactly this way at module scope,
@@ -4225,8 +4404,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         So the single most likely way the NEXT form-id route gets written in this
         repo was the one shape a receiver-name allowlist could not see: no sink name
-        appears anywhere in the callee chain, `sink_positions` comes back empty, and
-        `all(...)` over an empty list is vacuously True. Matching the OPERATION
+        appears anywhere in the callee chain, `_sink_calls` comes back empty, and a
+        read nothing was asked about is a read that passed. Matching the OPERATION
         (`_SINK_OPERATIONS`) rather than the receiver is what closes the class
         instead of one more spelling — the method is what makes a call a read.
         """
@@ -4273,6 +4452,169 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'chain is a sink and the verdict came from an EMPTY sink list'
         )
 
+    def test_the_derivation_refuses_a_write_through_an_in_module_helper(self):
+        """The sink-side gap that is not about the RECEIVER but about the call SHAPE.
+
+        Every control above spells the sink as a method on something. This one has
+        no attribute callee at all: `_anchor_form_brand(form_id, ...)` is a plain
+        call, and the `update_item` is inside the helper — on a key built from the
+        id it was handed (`feedback_form_handler.py:269`). So a route can write an
+        unvalidated id to the table with no sink call anywhere in its own body.
+
+        Not a spelling nobody would reach for: `submit_form_feedback` already calls
+        that helper, so it is the in-module example of writing through a function.
+        And it is the same silence as the receiver cases — matching only
+        `ast.Attribute` callees left the list EMPTY, and `all(...)` over an empty
+        list is vacuously True, so the instrument answered "bounded" having seen
+        nothing.
+
+        `_sink_bearing_helpers` derives the set of such helpers from the module
+        rather than naming them, and excludes any that validates for itself — which
+        is what keeps `_load_form_for_query` a refusal rather than an unguarded
+        sink.
+        """
+        source = textwrap.dedent(
+            '''
+            def _anchor_form_brand(form_id, effective_brand):
+                aggregates_table.update_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+                    UpdateExpression='SET brand_name = :brand',
+                )
+
+            @app.post("/feedback-forms/<form_id>/helper-write")
+            def post_helper_write(form_id: str):
+                _anchor_form_brand(form_id, 'Acme')
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'post_helper_write'), (
+            'a write reached through an in-module helper was not recognised as a '
+            'write — the helper call has no attribute callee, so the sink list came '
+            'back EMPTY and the route was reported bounded vacuously'
+        )
+
+        # The accepting side, because a helper call must not become a blanket
+        # accusation: the same helper AFTER the refusal is what `submit_form_feedback`
+        # does, and it has to stay green.
+        after = textwrap.dedent(
+            '''
+            def _anchor_form_brand(form_id, effective_brand):
+                aggregates_table.update_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+                    UpdateExpression='SET brand_name = :brand',
+                )
+
+            @app.post("/feedback-forms/<form_id>/helper-write")
+            def post_helper_write(form_id: str):
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                _anchor_form_brand(validated, 'Acme')
+            '''
+        )
+
+        assert _validates_its_form_id(after, 'post_helper_write'), (
+            'a helper write AFTER the refusal was reported as unbounded — the '
+            'helper match is meant to see an indirect write, not to accuse every '
+            'route that delegates one'
+        )
+
+    def test_the_derivation_refuses_validating_the_wrong_capture(self):
+        """Validating SOMETHING is not validating the id the read keys on.
+
+        The derivation used to compare positions only, which answers "was a refusal
+        reached before the first sink" — not "was the value this sink keys on the
+        one that was refused". So a route could bound one capture and key on
+        another: `_validated_form_id(submission_id)` refused, then
+        `Key={'sk': f'FORM#{form_id}'}` with `form_id` never checked at all.
+
+        This is the residual half of making the route selector capture-name-agnostic
+        rather than a hypothetical: a two-capture route under this prefix is already
+        in the derived universe, and
+        `/feedback-forms/<form_id>/submissions/<submission_id>` is the natural next
+        one for this module. Bounding whichever capture is easier would satisfy the
+        old check while the other one — the one that becomes the key — arrived raw.
+
+        Both directions, because only the pair means anything: validating the KEYED
+        capture passes, validating the other does not. Without the accepting case a
+        derivation that simply rejected every two-capture route would look correct
+        here.
+        """
+        wrong = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/submissions/<submission_id>")
+            def get_one_wrong(form_id: str, submission_id: str):
+                validated = _validated_form_id(submission_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(wrong, 'get_one_wrong'), (
+            'a route that validated one capture and keyed on another was reported '
+            'as bounded — the position of a refusal says nothing about WHICH value '
+            'it vouched for, and the raw one is what reached the key'
+        )
+
+        right = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/submissions/<submission_id>")
+            def get_one_right(form_id: str, submission_id: str):
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert _validates_its_form_id(right, 'get_one_right'), (
+            'a two-capture route that validated the id it keys on was reported as '
+            'unbounded — the linkage check must judge WHICH value was bounded, not '
+            'refuse every route with more than one capture'
+        )
+
+    def test_the_derivation_refuses_a_key_built_before_the_check(self):
+        """The linkage check has to follow the value, not just the parameter name.
+
+        A route can put the raw id into a local first and hand THAT to the read:
+        `key = {'sk': f'FORM#{form_id}'}` above the refusal, `get_item(Key=key)`
+        below it. The sink then mentions no parameter at all, so a linkage check
+        that looked only for parameter names in the arguments would see nothing to
+        object to — while the key it reads was built from a value nothing had
+        vouched for at the time.
+
+        Ordering is what makes this the interesting case rather than a duplicate of
+        the read-before-check control: the READ is correctly placed after the
+        refusal. It is the key's CONSTRUCTION that is not, and the string does not
+        become well-formed later because the id it was built from was checked
+        afterwards.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/prebuilt-key")
+            def get_prebuilt_key(form_id: str, raw: str):
+                key = {'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{raw}'}
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(Key=key)
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_prebuilt_key'), (
+            'a key built from an unvalidated value before the refusal was reported '
+            'as bounded — the read mentions only the local, so the derivation has '
+            'to follow what that local was built from'
+        )
+
     def test_the_derivation_refuses_a_read_through_an_alias_bound_in_a_try(self):
         """The alias one indentation level in, which is where the real ones are.
 
@@ -4285,9 +4627,9 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         Worth being precise about the direction, because the helper's own docstring
         used to have it backwards: an untracked alias is a FALSE NEGATIVE. The call
-        drops out of `sink_positions`, and `all(...)` over the shorter list is MORE
-        likely to pass — so the read is not reported at all. That is the vacuous
-        pass these controls exist for, not a cautious over-report.
+        drops out of `_sink_calls`, so neither question is asked of it and the
+        shorter list is MORE likely to pass — the read is not reported at all. That
+        is the vacuous pass these controls exist for, not a cautious over-report.
         """
         source = textwrap.dedent(
             '''

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 WIDGET_SOURCE = Path(__file__).resolve().parents[1] / 'static' / 'feedback-widget.js'
@@ -2916,6 +2917,14 @@ class TestEveryRouteThatKeysOnAFormIdChecksItsFormatFirst:
     `ballots_handler` applies its equivalent at all five of its routes; this
     mirrors that.
 
+    These four are the routes an UNAUTHENTICATED caller can reach plus the two
+    authenticated reads. The authenticated CRUD trio is covered separately, by
+    `TestTheAuthenticatedCrudRoutesAreBoundedToo`, because what is at stake there
+    is a write rather than a read cost — and the whole set is derived from the
+    module's routing table by
+    `test_no_route_keys_on_a_form_id_without_validating_it_first`, so neither class
+    is the list of record.
+
     Asserted as "no read happened", route by route, because that is the property
     the comment claims and the only one a 404 alone would not distinguish from a
     lookup that merely found nothing.
@@ -3043,5 +3052,540 @@ class TestEveryRouteThatKeysOnAFormIdChecksItsFormatFirst:
         response = feedback_form_handler.lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+        mock_sqs.send_message.assert_not_called()
+
+
+class TestTheAuthenticatedCrudRoutesAreBoundedToo:
+    """`GET`/`PUT`/`DELETE /feedback-forms/<form_id>`, and the write PUT used to do.
+
+    These three are behind Cognito (`authMethodOptions` in
+    `lib/stacks/api-stack.ts`), so none of this is the #379 vulnerability and the
+    cost argument for a public probe does not apply. Two other things do:
+
+    - `_validated_form_id`'s docstring claims the check is at EVERY route that
+      turns a URL segment into a key. These were the three that disproved it.
+    - `update_form` called `update_item` with no condition, and UpdateItem is an
+      UPSERT. A `PUT` to an id the table did not hold therefore CREATED a row,
+      keyed on whatever the caller put in the path.
+    """
+
+    # The three shapes, and what each must not do. Kept as data so a route added
+    # to the trio is a one-line addition rather than a fourth near-copy.
+    MALFORMED_BODY = {'name': 'pwn'}
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_no_crud_route_turns_a_malformed_id_into_a_key(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The claim, checked at the three routes that used to break it.
+
+        `get_item`, `update_item` and `delete_item` alike: a segment the pattern
+        refuses must not reach the table at all, so the refusal cannot be confused
+        with a lookup that found nothing (`GET`) or a write that happened to be
+        harmless (`DELETE`).
+        """
+        for method, body in (
+            ('GET', None),
+            ('PUT', self.MALFORMED_BODY),
+            ('DELETE', None),
+        ):
+            for malformed in (
+                _INJECTION_PAYLOAD,
+                'a' * (feedback_form_handler.FORM_ID_MAX_LENGTH + 1),
+            ):
+                mock_table.reset_mock()
+                event = api_gateway_event(
+                    method=method,
+                    path=f'/feedback-forms/{malformed}',
+                    path_params={'form_id': malformed},
+                    body=body,
+                    resource='/feedback-forms/{form_id}',
+                )
+
+                response = feedback_form_handler.lambda_handler(
+                    event, lambda_context
+                )
+
+                assert response['statusCode'] == 404, (
+                    f'{method} /feedback-forms/<malformed> answered '
+                    f'{response["statusCode"]}, not the 404 every other route '
+                    'gives for an id that cannot be one of ours'
+                )
+                mock_table.get_item.assert_not_called()
+                mock_table.update_item.assert_not_called()
+                mock_table.delete_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_put_to_a_malformed_id_does_not_mint_a_phantom_form(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The write, which is what made this more than a docstring problem.
+
+        Before the fix this answered **200** and called `update_item` with
+        `sk='FORM#a\\');alert(document.domain);x=(\\''`. UpdateItem being an upsert,
+        that CREATED the row — and since UPDATABLE_FIELDS does not include
+        `form_id`, the row it created had none, so `item_to_form` read it back as
+        `form_id: ''`: a nameless entry in `list_forms` that no route could then
+        address or delete by id.
+
+        The response body is asserted as well as the call, because the empty
+        `form_id` coming back to the caller is the visible half of the same defect.
+        """
+        event = api_gateway_event(
+            method='PUT',
+            path=f'/feedback-forms/{_INJECTION_PAYLOAD}',
+            path_params={'form_id': _INJECTION_PAYLOAD},
+            body=self.MALFORMED_BODY,
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        mock_table.update_item.assert_not_called()
+        assert '"form_id":""' not in response['body'].replace(' ', '')
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_put_to_a_well_formed_absent_id_is_refused_by_the_table(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The other half, and the reason a format check alone was not the fix.
+
+        `deadbeef` is a perfectly well-formed id, so the validator passes it and
+        the upsert would still have created a row for a form that does not exist.
+        `attribute_exists(sk)` is what refuses it, and the route must report that
+        as the same 404 `GET` gives rather than as a 500 — a condition failing is
+        the table answering the question, not an error.
+        """
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException',
+                       'Message': 'The conditional request failed'}},
+            'UpdateItem',
+        )
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/deadbeef',
+            path_params={'form_id': 'deadbeef'},
+            body={'name': 'a rename of a form that is not there'},
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        assert 'Form not found' in response['body']
+        # The condition is on the request, not just in the docstring: without it
+        # the write above would have succeeded and this test would need the mock
+        # to fail for a different reason.
+        assert (
+            mock_table.update_item.call_args.kwargs['ConditionExpression']
+            == 'attribute_exists(sk)'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_put_to_a_form_that_exists_still_updates_it(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The contract the two guards must not have broken.
+
+        A real form still updates and still answers with the new record — so the
+        404s above are the id or the condition refusing, not the route having
+        stopped working.
+        """
+        mock_table.update_item.return_value = {
+            'Attributes': {'form_id': 'deadbeef', 'name': 'Updated', 'enabled': True}
+        }
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/deadbeef',
+            path_params={'form_id': 'deadbeef'},
+            body={'name': 'Updated'},
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['form']['name'] == 'Updated'
+        assert (
+            mock_table.update_item.call_args.kwargs['Key']['sk'] == 'FORM#deadbeef'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_delete_of_an_absent_form_stays_idempotent(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """`delete_form` deliberately gets NO existence condition, unlike `PUT`.
+
+        DeleteItem on a missing key writes nothing, so there is no phantom row to
+        prevent and the idempotent 200 is the honest answer — a caller retrying a
+        delete should not get a 404 for having succeeded the first time. Pinned so
+        the asymmetry with `update_form` reads as a decision rather than as the
+        condition having been forgotten on one of the two writes.
+        """
+        event = api_gateway_event(
+            method='DELETE',
+            path='/feedback-forms/deadbeef',
+            path_params={'form_id': 'deadbeef'},
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_table.delete_item.call_args.kwargs['Key']['sk'] == (
+            'FORM#deadbeef'
+        )
+        assert 'ConditionExpression' not in mock_table.delete_item.call_args.kwargs
+
+
+def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
+    """Every `@app.<method>` route whose path captures `<form_id>`, from source.
+
+    Returns route path -> handler function name, read off the module with `ast`
+    rather than listed here. The two classes above name their routes explicitly,
+    which is what makes their failures legible; this exists so neither of those
+    lists is what the module is measured against. A route added later appears here
+    for free, and if it does not validate its id the test below fails naming it.
+
+    Only `<form_id>` counts: `/feedback-forms` and `POST /feedback-forms` take no
+    id out of the URL and have nothing to check.
+    """
+    tree = ast.parse(source)
+    routes = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            target = decorator.func
+            # `@app.get(...)`, `@app.put(...)` and so on — the attribute is the
+            # HTTP method and the object has to be `app`, so `@tracer.capture_method`
+            # (not a Call with a string argument) and any other decorator are out.
+            if not isinstance(target, ast.Attribute):
+                continue
+            if not (isinstance(target.value, ast.Name) and target.value.id == 'app'):
+                continue
+            if not decorator.args:
+                continue
+            path = decorator.args[0]
+            if not (isinstance(path, ast.Constant) and isinstance(path.value, str)):
+                continue
+            if '<form_id>' in path.value:
+                routes[f'{target.attr.upper()} {path.value}'] = node.name
+    assert routes, (
+        'no @app route capturing <form_id> was found in the handler source — the '
+        'derivation found nothing to judge, so a green result below would be '
+        'meaningless. If the routes moved or the decorator spelling changed, fix '
+        'this helper; do not delete the assertion.'
+    )
+    return routes
+
+
+def _validates_its_form_id(source: str, function_name: str) -> bool:
+    """Does `function_name` reach `_validated_form_id` before it keys on anything?
+
+    True if the function calls it directly, or calls `_load_form_for_query` — the
+    one read `/stats` and `/submissions` make, which validates on their behalf.
+    Following the delegation rather than requiring the direct call is the point:
+    the alternative is a test that demands a particular spelling and fails on a
+    legitimate refactor.
+    """
+    tree = ast.parse(source)
+    functions = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    ]
+    assert len(functions) == 1, (
+        f'expected exactly one def {function_name}, found {len(functions)}'
+    )
+    called = {
+        node.func.id
+        for node in ast.walk(functions[0])
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    return bool(called & {'_validated_form_id', '_load_form_for_query'})
+
+
+class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
+    """`_validated_form_id`'s docstring says EVERY route; this is what checks it.
+
+    That claim was false when it was written — `/config`, `/submit`, `/iframe`,
+    `/stats` and `/submissions` were covered and the authenticated CRUD trio was
+    not, while the docstring enumerated five routes as if they were all of them.
+    A prose list is the wrong instrument for a universal claim: it goes stale
+    silently, and the reader who trusts it assumes a protection that is not there.
+
+    So the universe is derived from the module's own routing table instead.
+    """
+
+    def test_no_route_keys_on_a_form_id_without_validating_it_first(
+        self, feedback_form_handler
+    ):
+        """Every `<form_id>` route validates, or the failure names the ones that do
+        not.
+
+        This is the test that makes the docstring's "EVERY" audit itself. A route
+        added later is included automatically, so the next person to write
+        `@app.get("/feedback-forms/<form_id>/something")` finds out here rather
+        than in a review.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+        routes = _routes_keying_on_a_form_id(source)
+
+        unbounded = sorted(
+            f'{route} ({function})'
+            for route, function in routes.items()
+            if not _validates_its_form_id(source, function)
+        )
+
+        assert unbounded == [], (
+            f'{unbounded} take a form id out of the URL without reaching '
+            '_validated_form_id (directly or through _load_form_for_query), so '
+            "that function's docstring no longer describes the module. Add the "
+            'check rather than narrowing the claim: the value of a universal '
+            'bound is that a reader does not have to hold the exceptions.'
+        )
+
+    def test_the_derivation_sees_the_routes_this_module_actually_has(
+        self, feedback_form_handler
+    ):
+        """The positive control: the walk finds the whole surface, not a subset.
+
+        Without this, `_routes_keying_on_a_form_id` returning only the routes that
+        happen to pass would make the test above vacuous in the most convincing
+        way possible — a green run over an empty-ish universe. The eight are named
+        here because THIS is the assertion that is supposed to fail when the
+        surface changes, prompting a decision about the new route.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+
+        assert set(_routes_keying_on_a_form_id(source)) == {
+            'GET /feedback-forms/<form_id>',
+            'PUT /feedback-forms/<form_id>',
+            'DELETE /feedback-forms/<form_id>',
+            'GET /feedback-forms/<form_id>/config',
+            'POST /feedback-forms/<form_id>/submit',
+            'GET /feedback-forms/<form_id>/iframe',
+            'GET /feedback-forms/<form_id>/submissions',
+            'GET /feedback-forms/<form_id>/stats',
+        }
+
+    def test_the_derivation_can_fail(self):
+        """A route that keys on an id and does not check it must be REPORTED.
+
+        The control for the check itself: fed a module with one unvalidated route,
+        `_validates_its_form_id` has to say so. Otherwise the test above passes
+        because the derivation always returns True, which is indistinguishable
+        from a module that is correct.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/new-thing")
+            def get_new_thing(form_id: str):
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+
+            @app.get("/feedback-forms/<form_id>/checked")
+            def get_checked(form_id: str):
+                validated = _validated_form_id(form_id)
+                return validated
+            '''
+        )
+
+        routes = _routes_keying_on_a_form_id(source)
+        assert routes == {
+            'GET /feedback-forms/<form_id>/new-thing': 'get_new_thing',
+            'GET /feedback-forms/<form_id>/checked': 'get_checked',
+        }
+        assert not _validates_its_form_id(source, 'get_new_thing')
+        # And the delegating spelling is accepted, so the check is about reaching
+        # the validator rather than about naming it.
+        assert _validates_its_form_id(source, 'get_checked')
+
+    def test_the_derivation_accepts_the_delegating_spelling(self):
+        """`/stats` and `/submissions` validate through `_load_form_for_query`.
+
+        Pinned separately from the direct call because it is the one that would be
+        lost first: a stricter derivation that demanded `_validated_form_id` by
+        name would report those two as unbounded, and the tempting fix would be to
+        add a redundant second call to each rather than to fix the test.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/stats")
+            def get_form_stats(form_id: str):
+                form = _load_form_for_query(form_id, 'Failed')
+                return form
+            '''
+        )
+
+        assert _validates_its_form_id(source, 'get_form_stats')
+
+
+class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
+    """`_validated_form_id` returns what it was given, and that is load-bearing.
+
+    Callers use their own `form_id` for things that are not the key —
+    `source_channel` in `/submissions`, the id echoed in a response — so the
+    validated value and the parameter have to be the same string. `.strip()` was
+    removed for a related reason, but exactness is the broader property and it was
+    carried entirely by a sentence in a docstring.
+    """
+
+    def test_the_validator_returns_its_input_unchanged(self, feedback_form_handler):
+        """Identity, not merely truthiness.
+
+        A normalizing validator — lower-casing, say, for a plausible "form ids are
+        case-insensitive" change — would pass every existing test while splitting
+        the module: `/stats` would read the record its key names and then filter
+        submissions on a `source_channel` its CALLER built from the raw id, which
+        no write ever used. Zero submissions for a form that has them, which is
+        the false zero `_load_form_for_query` exists to prevent (#312).
+
+        So the invariant gets a test instead of a sentence. If ids ever should be
+        case-insensitive, the normalization belongs at the mint and at every read
+        alike, and this test is the place to come and argue with.
+        """
+        for valid in (
+            'deadbeef',
+            'DEADBEEF',
+            'website-form_2',
+            'a',
+            'a' * feedback_form_handler.FORM_ID_MAX_LENGTH,
+            feedback_form_handler._minted_form_id(),
+        ):
+            assert feedback_form_handler._validated_form_id(valid) == valid, (
+                f'{valid!r} came back as '
+                f'{feedback_form_handler._validated_form_id(valid)!r} — a '
+                'normalized return splits the key a route reads from the '
+                'source_channel it filters on'
+            )
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_key_a_query_route_reads_is_the_id_in_its_url(
+        self,
+        mock_table,
+        mock_feedback_table,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The consequence, end to end on the route where it would surface.
+
+        `_load_form_for_query` keys on the VALIDATED value while its callers build
+        `source_channel` from the parameter. Both are asserted here against the id
+        in the URL, so the two halves cannot drift apart without a failure — which
+        is the only way this defect would ever have been noticed, since it produces
+        a plausible-looking zero rather than an error.
+        """
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'DeadBeef', 'brand_name': 'acme'}
+        }
+        mock_feedback_table.query.return_value = {'Items': []}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/DeadBeef/submissions',
+            path_params={'form_id': 'DeadBeef'},
+            resource='/feedback-forms/{form_id}/submissions',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_table.get_item.call_args.kwargs['Key']['sk'] == 'FORM#DeadBeef'
+        assert (
+            mock_feedback_table.query.call_args.kwargs[
+                'ExpressionAttributeValues'
+            ][':sc']
+            == 'form_DeadBeef'
+        )
+
+
+class TestTheSubmitRouteChecksTheIdBeforeTheBody:
+    """The one input shape whose ERROR CLASS changed, pinned as a decision.
+
+    Putting the format check above `app.current_event.json_body` is deliberate —
+    `/submit` is the only public route that enqueues, so an id that cannot be one
+    of ours must reach neither the table nor the queue, whatever the body says.
+
+    The side effect is a contract change: a request carrying BOTH a malformed id
+    and an invalid body used to be told about the body (400) and is now told about
+    the id (404). That is the better answer — the id is wrong regardless of what
+    the body contains — but it is observable to an integrator whose client
+    distinguishes "fix your input" from "this form is gone", so it is recorded in
+    `docs/feedback-forms.md` as well as here, and pinned so the ordering is a
+    decision rather than an artefact of statement order.
+    """
+
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_malformed_id_with_an_invalid_body_reports_the_id(
+        self,
+        mock_table,
+        mock_sqs,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """404 for the id, not 400 for the empty text — and no read, no send."""
+        event = api_gateway_event(
+            method='POST',
+            path=f'/feedback-forms/{_INJECTION_PAYLOAD}/submit',
+            path_params={'form_id': _INJECTION_PAYLOAD},
+            body={'text': ''},
+            resource='/feedback-forms/{form_id}/submit',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        assert 'Form not found' in response['body']
+        assert 'Feedback text is required' not in response['body']
+        mock_table.get_item.assert_not_called()
+        mock_sqs.send_message.assert_not_called()
+
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_well_formed_id_with_an_invalid_body_still_reports_the_body(
+        self,
+        mock_table,
+        mock_sqs,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The other side of the precedence, which is what makes it a precedence.
+
+        With an id that could be ours, the empty `text` is still a 400 — so the
+        404 above is the id being refused first, not the route having lost its body
+        validation. Without this case, deleting the text check would leave the case
+        above green.
+        """
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/deadbeef/submit',
+            path_params={'form_id': 'deadbeef'},
+            body={'text': ''},
+            resource='/feedback-forms/{form_id}/submit',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert 'Feedback text is required' in response['body']
+        # Still before any read: the body is refused on its own terms, and the
+        # form's existence was never the question.
         mock_table.get_item.assert_not_called()
         mock_sqs.send_message.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3602,6 +3602,16 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
     makes the `all()` MORE likely to pass. That is the same vacuous pass the
     controls exist to prevent, which is why alias collection is generous while the
     REFUSAL's top-level requirement — a separate axis — stays strict.
+
+    An alias is a HANDLE, though, not a RESULT: `response = aggregates_table.
+    get_item(...)` mentions a sink and binds a dict, so counting it would make
+    every subsequent `response.get(...)` and `form.get(...)` a sink. That is not
+    merely noise — the whole point of the position comparison is which call comes
+    FIRST, so a spurious early "sink" on a line above the refusal would report a
+    correctly guarded route as unbounded. Hence an assignment whose value is itself
+    a call to a sink OPERATION binds nothing:
+    `test_the_derivation_names_only_the_real_sinks_in_the_module` pins the count on
+    the live routes, so this stays honest in both directions.
     """
     aliases: set[str] = set()
 
@@ -3612,10 +3622,20 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
             for child in ast.walk(node)
         )
 
+    def _is_operation_result(value: ast.expr) -> bool:
+        return (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Attribute)
+            and value.func.attr in _SINK_OPERATIONS
+        )
+
     def _collect_aliases(body: list[ast.stmt]) -> None:
         for statement in body:
-            if isinstance(statement, ast.Assign) and _mentions_a_sink(
-                statement.value
+            if (
+                isinstance(statement, ast.Assign)
+                and _mentions_a_sink(statement.value)
+                # A handle, not what a read returned. See the docstring.
+                and not _is_operation_result(statement.value)
             ):
                 aliases.update(
                     target.id for target in statement.targets
@@ -3923,6 +3943,64 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'GET /feedback-forms/<form_id>/submissions',
             'GET /feedback-forms/<form_id>/stats',
         }
+
+    def test_the_derivation_names_only_the_real_sinks_in_the_module(
+        self, feedback_form_handler
+    ):
+        """The other half of non-vacuity: the sink count is right, not merely
+        non-zero.
+
+        The controls in this class all check that a read is not MISSED, because a
+        missed read makes `all(...)` vacuously true. This checks the opposite
+        direction, which matching on the operation name made possible: a call that
+        is not a read must not be counted either. `form.get('name')` and
+        `response.get('Item')` are dict access, and they were being counted while
+        `aliases` tracked the RESULT of a read as though it were a table handle —
+        twelve "sinks" in `submit_form_feedback`, ten of them dict lookups.
+
+        That is not cosmetic. The whole comparison is which call comes FIRST, so a
+        spurious sink on a line above the refusal reports a correctly guarded route
+        as unbounded — and the failure would arrive as this class's own universal
+        test accusing a route that is fine, which is the least useful failure it
+        could produce.
+
+        So the count is pinned per route, against what each one actually does. The
+        numbers are small enough to read: one read each, `submit_form_feedback`
+        alone having a read AND the send that makes its cost argument different.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+        tree = ast.parse(source)
+
+        counted = {}
+        for route, function_name in _routes_keying_on_a_form_id(source).items():
+            function = next(
+                node for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef) and node.name == function_name
+            )
+            counted[route] = len(_sink_call_positions(function))
+
+        assert counted == {
+            'GET /feedback-forms/<form_id>': 1,
+            'PUT /feedback-forms/<form_id>': 1,
+            'DELETE /feedback-forms/<form_id>': 1,
+            'GET /feedback-forms/<form_id>/config': 1,
+            # The read for the enabled check, and the enqueue.
+            'POST /feedback-forms/<form_id>/submit': 2,
+            # The existence gate is inside `_load_form_for_query`, so this route
+            # touches no sink of its own — which is why "no sink" is deliberately
+            # not a pass by default in `_validates_its_form_id`.
+            'GET /feedback-forms/<form_id>/iframe': 0,
+            'GET /feedback-forms/<form_id>/submissions': 1,
+            'GET /feedback-forms/<form_id>/stats': 1,
+        }, (
+            f'{counted} — a route gained or lost a read, or the derivation started '
+            'counting something that is not one. If a count went UP without the '
+            'route changing, suspect `aliases`: binding the RESULT of a read makes '
+            'every subsequent `.get(...)` on it look like a sink, and the earliest '
+            'of those decides the verdict.'
+        )
 
     def test_the_derivation_can_fail(self):
         """A route that keys on an id and does not check it must be REPORTED.

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1167,9 +1167,10 @@ export class VocApiStack extends VocStack {
      *  decision to tighten the stage-wide default cannot silently squeeze a
      *  customer's page.
      *
-     *  Cost is the reason this can be the generous side of the pair: `config` is
-     *  one get_item, and `iframe` touches no AWS service at all — it interpolates
-     *  form_id into a static HTML shell around a module-cached widget script.
+     *  Cost is the reason this can be the generous side of the pair: both reads
+     *  are one get_item. `config` returns its projection; `iframe` reads the same
+     *  record only to confirm the form EXISTS (#379) and then renders a static
+     *  HTML shell around a module-cached widget script.
      *
      *  CACHING, not a throttle, is the right primary control for `iframe`: the
      *  response is a pure function of form_id and host. It is not adopted here
@@ -1178,15 +1179,16 @@ export class VocApiStack extends VocStack {
      *  feedback_form_handler.py change. Recorded so nobody reads the throttle as
      *  evidence that the route is uncacheable.
      *
-     *  DO NOT CACHE `iframe` BEFORE ESCAPING ITS INPUT — issue #379. That route
-     *  reflects caller-supplied input into its response unescaped, so caching
-     *  would turn a reflected flaw into a stored one served to every subsequent
-     *  visitor. The escaping is therefore a PRECONDITION of the caching follow-up,
-     *  not a parallel cleanup. Pre-existing and out of scope for a CDK-only
-     *  change; the constraint is recorded HERE because this is where the next
-     *  reader decides to implement the caching, and the mechanism and fix are in
-     *  #379 rather than restated here — one description to keep correct, and it
-     *  stops this comment asserting a live vulnerability after #379 is closed.
+     *  The PRECONDITION that used to be recorded here — do not cache `iframe`
+     *  while it reflects caller input unescaped (#379) — is MET: the handler now
+     *  refuses a form id that is not one of ours, 404s an id the table does not
+     *  hold, and emits every JavaScript value through `json.dumps`, so the
+     *  response no longer carries anything a cache could store on the caller's
+     *  behalf. Kept as a note rather than deleted because this is where the next
+     *  reader decides to implement the caching, and "was this ever checked?" is
+     *  the question they will have. Caching also freezes the existence check for
+     *  the TTL, which is a decision for that follow-up: a deleted form would keep
+     *  serving its page until the entry expires.
      *
      *  NOTHING OBSERVES THIS CEILING EITHER — see the note on `methodOptions`
      *  below, where both pairs are applied. */

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1198,6 +1198,21 @@ export class VocApiStack extends VocStack {
      *  the TTL, which is a decision for that follow-up: a deleted form would keep
      *  serving its page until the entry expires.
      *
+     *  That staleness is a FRESHNESS question and not a security one, which is the
+     *  part worth stating rather than re-deriving: A 404 IS NEVER THE CACHED
+     *  RESPONSE. The only cacheable response this route produces is the 200 for a
+     *  form that existed at render time, so the ids a cache can hold an entry for
+     *  are exactly the ids the gate already admitted. An id that was never minted
+     *  never produces a 200, so a caller cannot prime the cache with one — the
+     *  gate's guarantee weakening from "exists" to "existed within the TTL"
+     *  therefore costs a deleted form's page outliving it, and nothing more. So
+     *  the follow-up needs NO cache-invalidation-on-delete step for correctness;
+     *  it needs a TTL short enough that the stale window is acceptable, and if a
+     *  deleted form's page must disappear promptly then that is a product
+     *  requirement to decide, not a hole to close. The one constraint this does
+     *  impose: whatever form the caching takes must not become negative caching,
+     *  because a cached 404 WOULD be keyed on an id an anonymous caller chose.
+     *
      *  NOTHING OBSERVES THIS CEILING EITHER — see the note on `methodOptions`
      *  below, where both pairs are applied. */
     const publicWidgetReadThrottle: apigateway.MethodDeploymentOptions = {

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1172,6 +1172,14 @@ export class VocApiStack extends VocStack {
      *  record only to confirm the form EXISTS (#379) and then renders a static
      *  HTML shell around a module-cached widget script.
      *
+     *  And ZERO get_item for a form id that cannot be one of ours: all three
+     *  public routes format-check the path segment before they read
+     *  (`_validated_form_id`), so a probe for `/feedback-forms/admin` or a
+     *  megabyte of path segment costs a 404 and no table call on any of them.
+     *  That is what makes the cost figure above a bound on what a caller can
+     *  spend rather than a description of the happy path — which matters here,
+     *  because this ceiling is shared across every form and every caller.
+     *
      *  CACHING, not a throttle, is the right primary control for `iframe`: the
      *  response is a pure function of form_id and host. It is not adopted here
      *  because both available forms are out of a CDK-only change — an API Gateway


### PR DESCRIPTION
Closes #379.

## Summary

`GET /feedback-forms/{form_id}/iframe` interpolated the caller-supplied path segment straight into a `<script>` block and answered `200 text/html` **without reading the table at all**. Powertools' dynamic-route capture group admits `'`, `)` and `;`, so `a');alert(document.domain);x=('` matched the route and was rendered as executable script on the API's own origin — unauthenticated, with the embed delivery vector already published in `docs/feedback-forms.md`.

Verified against the installed powertools before writing the fix: the compiled rule is `^/feedback-forms/(?P<form_id>[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]+)/iframe/*$`, and it matches that payload. A test asserts this off the live resolver as a positive control, so the 404s below cannot pass by the framework refusing the string instead of the handler.

### `voc-datalake/lambda/api/feedback_form_handler.py`

- **`_validated_form_id`** — bounds character set and length (`[0-9A-Za-z_-]{1,64}`), returning `None` rather than raising. Modelled on `ballots_handler._validated_session_id` for the same reasons its docstring gives. Derived from the mint, which is now named `_minted_form_id` (`FORM_ID_LENGTH` hex chars of a uuid4) rather than the `str(uuid.uuid4())[:8]` literal it replaced. Deliberately **wider** than the mint: hand-seeded records carry ids like `website-form`, whose `/config` and `/submit` still answer, so narrowing to `[0-9a-f]{8}` would 404 a working form's embed. The width is argued in the comment and pinned by a test.
- **Existence check** — via `_load_form_for_query`, the established one-`get_item` lookup the stats/submissions routes already use. Malformed and absent both answer 404, before any HTML exists.
- **`_js_value`** — every JavaScript value is `json.dumps`, with no handwritten quote pair around it (the five interpolated fields became one serialized options object). `<`, `>` and `&` are escaped to `\uXXXX` because `</script>` ends a script element even inside a string literal — the HTML parser gets there first. `html.escape` is deliberately **not** used in script context (its `&#x27;` is an entity the script context never decodes; it would corrupt the value). `ensure_ascii` covers U+2028/9 for free. The comment records why, and where `html.escape(..., quote=True)` *would* be correct if a later change puts the id in an HTML context.
- **A CSP** on the only HTML response in the API, deliberately **without** `frame-ancestors` (and no `X-Frame-Options`) — that directive has no `default-src` fallback, so leaving it out is how "any site may embed this" is spelled. Plus `X-Content-Type-Options: nosniff` and `Referrer-Policy: no-referrer`.

The 200 response's contract is unchanged for an existing form: same page, same inlined widget, same `configEndpoint` / `submitEndpoint` / `apiEndpoint` values, and the resolver's CORS headers still present (asserted).

### Kept in scope

Throttles, CORS policy and submission-count consolidation are untouched, as the task asked. Two comment/doc corrections are included because this change makes the existing text **false**, not as cleanups:

- `lib/stacks/api-stack.ts` said "DO NOT CACHE `iframe` BEFORE ESCAPING ITS INPUT — that route reflects caller-supplied input unescaped", i.e. it asserted a live vulnerability. Its own text asked for this to be updated once #379 closed. It also said `iframe` "touches no AWS service at all", which the existence check makes untrue — a cost claim that matters, since it is the argument for that route's throttle pair.
- `docs/feedback-forms.md` repeated the same cost claim, and did not mention that the route can 404.

### Regression coverage — 12 cases, in two classes

`TestThePublicIframePageRefusesAnIdItCannotHaveMinted` and `TestEveryJavaScriptValueOnTheIframePageIsSerialized`.

The escaping is asserted **independently of the validation in front of it**, which is the point: the route now refuses the payload before rendering, so the serializer cases reach it directly. That is what keeps the render safe if the pattern is later widened.

"The input cannot create a second statement" is checked with `json.JSONDecoder().raw_decode`, which reports where the value **ends** — a payload that had closed the argument would leave a remainder carrying the attacker's code. The end-to-end case asserts the remainder after the init argument is exactly `);` followed by the closing of the script and document.

The spelling is also pinned, not just the output: an `ast` walk scoped to `get_form_iframe` reports any interpolation sitting inside a handwritten quote pair. It carries a positive control fed the exact removed spelling, so a rename or a template moved to a helper cannot make it vacuously green.

## Build and test results

| Command | Result |
|---|---|
| `pytest lambda/api/test/test_feedback_form_handler.py` | **68 passed** (56 before) |
| `pytest lambda` (full backend) | **3709 passed**, 0 failed |
| `ruff check --select F,E4,E7,E9 lambda plugins scripts` | **4 errors** — exactly `ruff.toml`'s documented baseline, unchanged |
| `ruff check` (all default rules) on the two touched files | **24**, byte-identical before and after — zero delta |
| `vitest run` (CDK, 17 files) | **318 passed** |
| `tsc --noEmit` (typecheck:cdk) | clean |

**Every one of the 12 new tests was run against the unfixed handler and shown red** (8 failures before the CSP/mint/hand-seeded cases were added, then all 12 with the fix stashed), then green after. The two that pass both ways by design are the route-pattern positive control and the `ast` derivation's own control — both exist to stop the others being vacuous.

**Not run, with reasons:**
- `mise run build` — no `mise` task is defined in this repo (`mise ERROR no tasks defined`). The equivalent, `npm run build`, is the **frontend** Vite build; it fails in this container before any of my changes because `voc-datalake/frontend/node_modules` is absent (`Cannot find module 'react'`, `'date-fns'`, `'@vitejs/plugin-react'`). This change is Python-only and touches no frontend file.
- The CDK suite needed one setup step: 63 of its cases fail on a clean checkout here because `frontend/dist` does not exist (`BucketDeployment` asset). Confirmed identical at `HEAD` before my changes. With a placeholder `frontend/dist/index.html` all 318 pass; the placeholder was removed and is not in the diff.
- `pytest` at repo root collects `plugins/` too, which needs `tenacity`, `bs4`, `app_store_web_scraper` — absent from `requirements-dev.txt`. Unrelated to this change.

## Decisions made

1. **Validator wider than the mint.** The task said to derive it from the mint's format; a validator *equal* to `[0-9a-f]{8}` would 404 the iframe for hand-seeded ids whose other two public routes work, which is a product regression rather than a refusal. So the mint drives the length constant while the bound is on character set and length. Both directions are pinned by tests, so narrowing it later is a deliberate act.
2. **Escaped `<`/`>`/`&` rather than trusting `json.dumps` alone.** `json.dumps` is correct for JavaScript but not for the HTML parser above it; a `</script>` inside a string literal still ends the element. The task's "avoid surrounding a serialized JSON string with an additional handwritten quote pair" is asserted structurally by the `ast` test rather than only by review.
3. **Added a CSP**, which the issue raised as "worth considering". It is three response headers and no behaviour change, and the reasoning about `frame-ancestors` is exactly the kind that gets lost — so it is recorded with a test. Say the word and I will drop it if it should be its own PR.
4. **`_load_form_for_query`'s return value is unused.** The page's content is a function of the id and the host, not of the record, so this is an existence gate rather than a projection. Said so in a comment, since an unused return invites a "simplification" that removes the read.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

## Agent notes

**What went well.** The issue was unusually complete — it named the mechanism, the payload, the sibling to model (`ballots_handler._validated_session_id`) and the follow-up it blocks. Confirming the route regex against the installed powertools rather than trusting the issue's quote was worth the five minutes: it turned the positive control from a guess into a derivation.

**What was difficult.** Proving "no second statement" without a JavaScript engine. Asserting the absence of `'` or `;` is the tempting shape and it is wrong twice over — the payload's apostrophe is *harmless* inside a double-quoted literal, so requiring it to be gone asserts JSON's escaping style rather than what the value can do. `raw_decode`'s end offset answers the actual question. The container also needed six pip installs before the suite would run at all (`aws-lambda-powertools`, `aws-xray-sdk`, `pydantic`, `tenacity`, …) and an `npm ci` plus a `frontend/dist` placeholder before the CDK suite would.

**Conventions discovered.** Comments here carry the *argument*, not the mechanics — they record which option was rejected and why, and which test fails if it comes back. Derivations read from source (`ast` scoped to one function, the live resolver) rather than restating a list, because a stale copy produces silence; and every derivation carries a positive control. Tests are named as outcomes. The load-bearing comments are accurate enough to trust over prose in `docs/` — `api-stack.ts` had *already* recorded this fix as a precondition of its caching follow-up and asked to be updated when it landed, which is how I found the two stale claims.

**Suggestions for future tasks.**
- `docs/deployment.md` and `docs/SYSTEM_DOCUMENTATION.md` also describe the iframe route but are not in `PINNED_DOCS` in `api-stack.test.ts`, so their claims about it are unpinned. The lockstep machinery already exists; extending it is a small, self-contained change.
- The remaining `iframe` follow-up from `api-stack.ts` — a `Cache-Control` header — is now unblocked. Note that caching freezes the existence check for the TTL, so a deleted form would keep serving its page until the entry expires; that is a decision for the follow-up and I have recorded it there rather than deciding it here.
- `requirements-dev.txt` does not install what `pytest` at the repo root needs to *collect* (`tenacity`, `bs4`, `app_store_web_scraper` come from the layer requirements). The file's header says to install the layer requirements too; a one-line note that `test:backend` needs them for `plugins/` would save the next agent a triage cycle.

```abca-verify
no-ui
```

The change is a public unauthenticated API route returning HTML that is designed to be framed on third-party sites. It renders no element in the signed-in app — the frontend links to `/feedback-forms/{id}/iframe` but never mounts its markup — and the preview's empty database has no form to address, so there is no form id whose page could be loaded. The route's own behaviour is covered by the 68 pytest cases above.