### PR TITLE
fix(plugins): make plugin-secret prefix isolation fail closed (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,9 +119,15 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `{source}` routes above would have left the boundary depending on which handler a write arrived
   through rather than on what it changed. The `GET` routes and `POST /scrapers/analyze-url` stay open
   to match the read/write split, and the Run and Delete controls on each scraper card are now disabled
-  for a non-admin. `scraper_id` is deliberately not allowlisted the way `{source}` is: it is not a
-  plugin id and reaches no secret key or function name, only a `SCRAPER_RUN#` partition and the invoke
-  payload, where the webscraper resolves it against its own configured list.
+  for a non-admin — as is **Save in the scraper editor**, which is the only UI entrance to
+  `POST /scrapers` and was the worst of the three: the editor closed as though the change had been
+  stored, because it closes unconditionally and its mutation surfaces no error, so a non-admin's edit
+  was discarded silently. `scraper_id` is deliberately not allowlisted the way `{source}` is: it is
+  not a plugin id and reaches no secret key or function name, only a `SCRAPER_RUN#` partition and the
+  invoke payload, where the webscraper resolves it against its own configured list. `/scrapers/manual/*`
+  is a **second** handler and is deliberately not covered: those routes write feedback content into
+  the ingestion pipeline and reach neither the shared secret nor any plugin resource, which is the
+  basis on which the three above were gated — see `docs/plugin-architecture.md`.
 - A plugin's `plugin.failed` audit event is no longer lost when the circuit breaker's own DynamoDB
   lookup fails. The three reporting steps for a construction failure shared one `try`, and
   `record_failure` is not exception-safe on its first line (it resolves its table in a property,
@@ -166,7 +172,9 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `POST /scrapers/{scraper_id}/run` answer 403 outside the `admins` group, while `GET /scrapers`, the
   status and run-history reads and `POST /scrapers/analyze-url` stay open. On the Settings page the
   Enabled toggle is now disabled for a non-admin, where it previously issued a request that failed
-  silently.
+  silently — and in the scraper editor so is Save, where the modal previously closed as though the
+  edit had been saved. The manual-import routes (`/scrapers/manual/*`, a different Lambda) are
+  unaffected and stay open to any authenticated caller.
 - **`POST /projects/{project_id}/document` now answers 400 for any `doc_type` other than `prd` or
   `prfaq`.** Matched exactly, with no case folding or trimming, so `PRD` and `" prd"` are refused
   too. Previously accepted values that now fail: `build_prototype`, `product_report` and the empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,21 +74,31 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   counted as a plugin failure — but a read that failed is indistinguishable from an empty secret
   (the client error is logged and discarded), so a handful of throttles inside the breaker's window
   would disable a healthy plugin's ingestion schedule, which nothing re-enables automatically. An
-  unreadable secret is now reported without being counted: the run record still moves to `error` and
-  the audit event still fires, so the failure is visible, but only a genuine misconfiguration — a
-  malformed plugin id, a namespace holding no keys, or a secret whose body is not a JSON object —
-  can trip the breaker. Because a *scheduled* run writes no run record (there is no execution id to
-  address one), an alarm on the `Refusing to load plugin secrets` log line is now the escalation
-  path for this case; see `docs/plugin-architecture.md`.
-- `PUT`/`GET /integrations/{source}/credentials` now require `source` to be a plugin that exists.
+  unreadable secret is now reported without being counted: the `plugin.failed` audit event still
+  fires, and the run record moves to `error` on a *manual* run — a scheduled run has no run record
+  to move, so an alarm on the `Refusing to load plugin secrets` log line is the escalation path for
+  that case, and the exemption depends on it existing (see `docs/plugin-architecture.md`). Only a
+  genuine misconfiguration — a malformed plugin id, a namespace holding no keys, or a secret whose
+  body is not a JSON object — can trip the breaker.
+- Every route taking a `{source}` path parameter now requires `source` to be a plugin that exists.
   Validating only its *form* left a cross-plugin credential write open, because the colliding value
   is itself well-formed: `source=app_reviews` with key `ios_app_id` stored `app_reviews_ios_app_id`,
   which `app_reviews_ios`'s next run then consumed as its own `app_id`. The synth-time guard on
   colliding plugin ids does not reach this — a colliding *stored key* needs no colliding manifest —
-  so the namespace a write may address is now restricted to the manifest-derived ids CDK already
-  hands this Lambda. Admin-only before and after; this narrows an authenticated administrator's
-  blast radius. It fails open if that variable is unavailable, so one bad environment variable
-  cannot break credential management outright.
+  so the namespace a request may address is now restricted to the manifest-derived ids CDK already
+  hands this Lambda. It fails open if that variable is unavailable, so one bad environment variable
+  cannot break credential management outright. `source` also reached an ingestor Lambda name and an
+  EventBridge rule name unvalidated on the `/sources/{source}/*` routes.
+- `POST`/`DELETE /integrations/{source}/apps`, `POST /sources/{source}/run` and
+  `PUT /sources/{source}/enable|disable` now require the caller to be in the `admins` group. Only
+  the two credentials routes were gated, so the boundary depended on which key a write happened to
+  land under: a caller whose only group was `users` could write `{source}_configs` on the same shared
+  Secrets Manager secret, invoke an ingestor (a billed third-party fetch, in a loop), and disable a
+  plugin's ingestion schedule — which nothing re-enables automatically. `GET /integrations/{source}/apps`
+  stays open deliberately: the Scrapers page lists app configs for every authenticated user, and a
+  config holds a public app-store id and a display name rather than a credential. On that page the
+  Run, Add, Save and Delete controls and the schedule toggle are now disabled for a non-admin, with
+  the reason on hover, rather than issuing a request that 403s.
 - A plugin's `plugin.failed` audit event is no longer lost when the circuit breaker's own DynamoDB
   lookup fails. The three reporting steps for a construction failure shared one `try`, and
   `record_failure` is not exception-safe on its first line (it resolves its table in a property,
@@ -115,11 +125,20 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `app_reviews_ios`). Secret keys are matched by string prefix, so the shorter id would receive the
   longer one's credentials. `cdk synth` now refuses such a pair, which is the only point at which
   the whole id set is known. No bundled pair collides.
-- **`source` on the credentials routes must now be a configured plugin id.** A request naming a
+- **`source` on every `{source}` route must now be a configured plugin id.** A request naming a
   well-formed but non-existent source (`app_reviews`, `webscraper_admin`) is answered 400 instead of
-  reading or writing that namespace. Anything addressing a real plugin id is unaffected, which is
-  every call the web app makes; a script that relied on writing to an arbitrary namespace must use
-  the owning plugin's id.
+  reading or writing that namespace, invoking `voc-ingestor-<source>` or toggling
+  `voc-ingest-<source>-schedule`. Anything addressing a real plugin id is unaffected, which is every
+  call the web app makes; a script that relied on an arbitrary namespace must use the owning plugin's
+  id. Neither this nor the synth-time id guard is retroactive: a key stored by a pre-upgrade write
+  survives in the shared secret and is still read by whichever plugin's namespace it landed in.
+  A deployment where an arbitrary `source` was used should delete the stale keys by hand.
+- **Triggering a run, toggling a schedule, and writing or deleting an app config now require the
+  `admins` group.** A caller in `users` alone receives 403 on `POST /sources/{source}/run`,
+  `PUT /sources/{source}/enable|disable` and `POST`/`DELETE /integrations/{source}/apps`. Listing app
+  configs (`GET /integrations/{source}/apps`) is unchanged and still open to any authenticated
+  caller. A non-admin who previously used the Scrapers page to run a source or edit an app config now
+  sees those controls disabled; a script doing the same needs admin credentials.
 - **`POST /projects/{project_id}/document` now answers 400 for any `doc_type` other than `prd` or
   `prfaq`.** Matched exactly, with no case folding or trimming, so `PRD` and `" prd"` are refused
   too. Previously accepted values that now fail: `build_prototype`, `product_report` and the empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,19 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   stays open deliberately: the Scrapers page lists app configs for every authenticated user, and a
   config holds a public app-store id and a display name rather than a credential. On that page the
   Run, Add, Save and Delete controls and the schedule toggle are now disabled for a non-admin, with
-  the reason on hover, rather than issuing a request that 403s.
+  the reason on hover, rather than issuing a request that 403s — and so is the Enabled toggle on the
+  Settings page's source cards, which is the other UI caller of `enable|disable`.
+- `POST /scrapers`, `DELETE /scrapers/{scraper_id}` and `POST /scrapers/{scraper_id}/run` now require
+  the `admins` group. No route in that handler had a gate, while two of them `put_secret_json` the
+  SAME shared API-credentials secret the credentials routes protect — rewriting `webscraper_configs`,
+  a key the webscraper ingestor consumes, so an unprivileged write steered which URLs got fetched —
+  and the third invoked that ingestor, a billed third-party fetch callable in a loop. Gating only the
+  `{source}` routes above would have left the boundary depending on which handler a write arrived
+  through rather than on what it changed. The `GET` routes and `POST /scrapers/analyze-url` stay open
+  to match the read/write split, and the Run and Delete controls on each scraper card are now disabled
+  for a non-admin. `scraper_id` is deliberately not allowlisted the way `{source}` is: it is not a
+  plugin id and reaches no secret key or function name, only a `SCRAPER_RUN#` partition and the invoke
+  payload, where the webscraper resolves it against its own configured list.
 - A plugin's `plugin.failed` audit event is no longer lost when the circuit breaker's own DynamoDB
   lookup fails. The three reporting steps for a construction failure shared one `try`, and
   `record_failure` is not exception-safe on its first line (it resolves its table in a property,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
 ### Security
 
+- Plugin secret isolation now fails closed. Each plugin Lambda reads one shared Secrets Manager
+  secret whose keys are namespaced `<plugin_id>_<key>`, and — because every ingestion Lambda shares
+  one IAM role — that prefix is the only boundary between one plugin's credentials and another's. A
+  prefix matching zero keys previously returned the **complete** shared secret, on the theory that
+  such a plugin predated prefixing; the effect was that a typo in a plugin id, the input most likely
+  to be wrong, produced the maximally permissive outcome. It now raises, naming the plugin and the
+  prefix it expected and nothing else. The hand-maintained plugin-id list the filter needed is gone
+  with it: forgetting to add a plugin there reclassified its keys as "shared" and leaked them into
+  every other plugin.
+- A webhook Lambda is now deployed with the environment variable its code reads for the plugin
+  identity (`SOURCE_PLATFORM`, which only the ingestor Lambda carried). Combined with the above,
+  a deployed webhook would otherwise have failed on every delivery.
 - `POST /projects/{project_id}/document` validates `doc_type` against an allowlist of `prd` and
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a
@@ -64,6 +76,19 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
 ### Upgrade notes
 
+- **A plugin must declare at least one key in its manifest's `secrets` block.** Following the
+  fail-closed change above, a plugin whose namespace holds no key in the shared secret raises a
+  `ConfigurationError` when its Lambda is constructed, rather than silently receiving every other
+  plugin's keys. Every plugin shipped in this repo declares at least one key and CDK seeds them all
+  at deploy time, so no bundled plugin is affected; a custom plugin declaring none must add a key
+  (or stop reading `self.secrets` in its constructor). A test over the manifests now fails in CI
+  rather than letting this surface in a deployed Lambda. Any onboarding notes telling a plugin
+  author to register their prefix in `_get_known_prefixes()` are obsolete — that function no longer
+  exists, and registration was never needed for a correctly prefixed key.
+- **A plugin id may no longer be a prefix of another plugin id** (`app_reviews` alongside
+  `app_reviews_ios`). Secret keys are matched by string prefix, so the shorter id would receive the
+  longer one's credentials. `cdk synth` now refuses such a pair, which is the only point at which
+  the whole id set is known. No bundled pair collides.
 - **`POST /projects/{project_id}/document` now answers 400 for any `doc_type` other than `prd` or
   `prfaq`.** Matched exactly, with no case folding or trimming, so `PRD` and `" prd"` are refused
   too. Previously accepted values that now fail: `build_prototype`, `product_report` and the empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,8 +153,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   fail-closed change above, a plugin whose namespace holds no key in the shared secret raises a
   `ConfigurationError` when its Lambda is constructed, rather than silently receiving every other
   plugin's keys. Every plugin shipped in this repo declares at least one key and CDK seeds them all
-  at deploy time, so no bundled plugin is affected; a custom plugin declaring none must add a key
-  (or stop reading `self.secrets` in its constructor). A test over the manifests now fails in CI
+  at deploy time, so no bundled plugin is affected; a custom plugin declaring none must add a key,
+  or override `_load_secrets` to return `{}` — a deliberate opt-out of the boundary. Declining to
+  *read* `self.secrets` does not avoid the raise: both base classes call `self._load_secrets()` in
+  `__init__`, before any subclass body runs. A test over the manifests now fails in CI
   rather than letting this surface in a deployed Lambda. Any onboarding notes telling a plugin
   author to register their prefix in `_get_known_prefixes()` are obsolete — that function no longer
   exists, and registration was never needed for a correctly prefixed key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   would disable a healthy plugin's ingestion schedule, which nothing re-enables automatically. An
   unreadable secret is now reported without being counted: the run record still moves to `error` and
   the audit event still fires, so the failure is visible, but only a genuine misconfiguration — a
-  malformed plugin id, or a namespace holding no keys — can trip the breaker.
+  malformed plugin id, a namespace holding no keys, or a secret whose body is not a JSON object —
+  can trip the breaker. Because a *scheduled* run writes no run record (there is no execution id to
+  address one), an alarm on the `Refusing to load plugin secrets` log line is now the escalation
+  path for this case; see `docs/plugin-architecture.md`.
 - `POST /projects/{project_id}/document` validates `doc_type` against an allowlist of `prd` and
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,14 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   Run, Add, Save and Delete controls and the schedule toggle are now disabled for a non-admin, with
   the reason on hover, rather than issuing a request that 403s — and so is the Enabled toggle on the
   Settings page's source cards, which is the other UI caller of `enable|disable`.
+- `Save to Secrets Manager` on the Settings page's source cards is now disabled for a non-admin.
+  `PUT /integrations/{source}/credentials` behind it was already admin-gated, so unlike the toggle
+  above this was not a regression — the control had always behaved this way, and it was the last
+  ungated UI entrance to an admin-gated route. It was also the least visible failure of the set:
+  that mutation has an `onSuccess` but no `onError`, so the 403 rendered no message and the button
+  merely never became `Saved!` — a non-admin typed a credential, clicked Save, and got no indication
+  it had been refused. The credential fields stay editable and `Test` stays available, because
+  `POST /integrations/{source}/test` is not gated and a non-admin can already read those fields.
 - `POST /scrapers`, `DELETE /scrapers/{scraper_id}` and `POST /scrapers/{scraper_id}/run` now require
   the `admins` group. No route in that handler had a gate, while two of them `put_secret_json` the
   SAME shared API-credentials secret the credentials routes protect — rewriting `webscraper_configs`,
@@ -172,9 +180,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `POST /scrapers/{scraper_id}/run` answer 403 outside the `admins` group, while `GET /scrapers`, the
   status and run-history reads and `POST /scrapers/analyze-url` stay open. On the Settings page the
   Enabled toggle is now disabled for a non-admin, where it previously issued a request that failed
-  silently — and in the scraper editor so is Save, where the modal previously closed as though the
-  edit had been saved. The manual-import routes (`/scrapers/manual/*`, a different Lambda) are
-  unaffected and stay open to any authenticated caller.
+  silently — as is `Save to Secrets Manager` on the same card, whose route was already admin-gated
+  but whose refusal rendered no message at all — and in the scraper editor so is Save, where the
+  modal previously closed as though the edit had been saved. The manual-import routes
+  (`/scrapers/manual/*`, a different Lambda) are unaffected and stay open to any authenticated caller.
 - **`POST /projects/{project_id}/document` now answers 400 for any `doc_type` other than `prd` or
   `prfaq`.** Matched exactly, with no case folding or trimming, so `PRD` and `" prd"` are refused
   too. Previously accepted values that now fail: `build_prototype`, `product_report` and the empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,21 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   can trip the breaker. Because a *scheduled* run writes no run record (there is no execution id to
   address one), an alarm on the `Refusing to load plugin secrets` log line is now the escalation
   path for this case; see `docs/plugin-architecture.md`.
+- `PUT`/`GET /integrations/{source}/credentials` now require `source` to be a plugin that exists.
+  Validating only its *form* left a cross-plugin credential write open, because the colliding value
+  is itself well-formed: `source=app_reviews` with key `ios_app_id` stored `app_reviews_ios_app_id`,
+  which `app_reviews_ios`'s next run then consumed as its own `app_id`. The synth-time guard on
+  colliding plugin ids does not reach this — a colliding *stored key* needs no colliding manifest —
+  so the namespace a write may address is now restricted to the manifest-derived ids CDK already
+  hands this Lambda. Admin-only before and after; this narrows an authenticated administrator's
+  blast radius. It fails open if that variable is unavailable, so one bad environment variable
+  cannot break credential management outright.
+- A plugin's `plugin.failed` audit event is no longer lost when the circuit breaker's own DynamoDB
+  lookup fails. The three reporting steps for a construction failure shared one `try`, and
+  `record_failure` is not exception-safe on its first line (it resolves its table in a property,
+  outside its own `try`), so a failure there skipped the audit event — in exactly the correlated
+  case where the same DynamoDB trouble affects both, and on a scheduled run that event is the only
+  signal the failure leaves anywhere. Each step is now guarded independently.
 - `POST /projects/{project_id}/document` validates `doc_type` against an allowlist of `prd` and
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a
@@ -100,6 +115,11 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `app_reviews_ios`). Secret keys are matched by string prefix, so the shorter id would receive the
   longer one's credentials. `cdk synth` now refuses such a pair, which is the only point at which
   the whole id set is known. No bundled pair collides.
+- **`source` on the credentials routes must now be a configured plugin id.** A request naming a
+  well-formed but non-existent source (`app_reviews`, `webscraper_admin`) is answered 400 instead of
+  reading or writing that namespace. Anything addressing a real plugin id is unaffected, which is
+  every call the web app makes; a script that relied on writing to an arbitrary namespace must use
+  the owning plugin's id.
 - **`POST /projects/{project_id}/document` now answers 400 for any `doc_type` other than `prd` or
   `prfaq`.** Matched exactly, with no case folding or trimming, so `PRD` and `" prd"` are refused
   too. Previously accepted values that now fail: `build_prototype`, `product_report` and the empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `PUT /sources/{source}/enable|disable` and `POST`/`DELETE /integrations/{source}/apps`. Listing app
   configs (`GET /integrations/{source}/apps`) is unchanged and still open to any authenticated
   caller. A non-admin who previously used the Scrapers page to run a source or edit an app config now
-  sees those controls disabled; a script doing the same needs admin credentials.
+  sees those controls disabled; a script doing the same needs admin credentials. The same applies to
+  the scraper routes: `POST /scrapers`, `DELETE /scrapers/{scraper_id}` and
+  `POST /scrapers/{scraper_id}/run` answer 403 outside the `admins` group, while `GET /scrapers`, the
+  status and run-history reads and `POST /scrapers/analyze-url` stay open. On the Settings page the
+  Enabled toggle is now disabled for a non-admin, where it previously issued a request that failed
+  silently.
 - **`POST /projects/{project_id}/document` now answers 400 for any `doc_type` other than `prd` or
   `prfaq`.** Matched exactly, with no case folding or trimming, so `PRD` and `" prd"` are refused
   too. Previously accepted values that now fail: `build_prototype`, `product_report` and the empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 - A webhook Lambda is now deployed with the environment variable its code reads for the plugin
   identity (`SOURCE_PLATFORM`, which only the ingestor Lambda carried). Combined with the above,
   a deployed webhook would otherwise have failed on every delivery.
+- A Secrets Manager read that fails no longer counts against a plugin's circuit breaker. The
+  fail-closed change above turned an unreadable secret into a refusal to start, and a refusal was
+  counted as a plugin failure — but a read that failed is indistinguishable from an empty secret
+  (the client error is logged and discarded), so a handful of throttles inside the breaker's window
+  would disable a healthy plugin's ingestion schedule, which nothing re-enables automatically. An
+  unreadable secret is now reported without being counted: the run record still moves to `error` and
+  the audit event still fires, so the failure is visible, but only a genuine misconfiguration — a
+  malformed plugin id, or a namespace holding no keys — can trip the breaker.
 - `POST /projects/{project_id}/document` validates `doc_type` against an allowlist of `prd` and
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,17 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   hands this Lambda. It fails open if that variable is unavailable, so one bad environment variable
   cannot break credential management outright. `source` also reached an ingestor Lambda name and an
   EventBridge rule name unvalidated on the `/sources/{source}/*` routes.
+- `GET /sources/status` validates the sources it takes from the query string. It is the only route
+  whose source is not a path parameter, so the guard above did not reach it, and both of its
+  branches derived a resource from an arbitrary value: `?sources=` named EventBridge rules it
+  called `describe_rule` on — reflecting each rule name back, so an arbitrary value could enumerate
+  rules and learn the naming convention — and `?run_status=` queried an arbitrary `SOURCE_RUN#`
+  partition. The `?run_status=` branch now answers 400 for a source that is not a plugin. The
+  `?sources=` branch reports such a source as `{'enabled': false, 'exists': false}` rather than
+  raising, because it answers about several sources at once and one unknown name must not fail the
+  whole response — and because its own default list contains `manual_import`, a legitimate source
+  platform that deliberately has no plugin manifest. That is the same answer as before for every
+  request the UI sends, since a schedule rule only ever exists per plugin.
 - `POST`/`DELETE /integrations/{source}/apps`, `POST /sources/{source}/run` and
   `PUT /sources/{source}/enable|disable` now require the caller to be in the `admins` group. Only
   the two credentials routes were gated, so the boundary depended on which key a write happened to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   raising, because it answers about several sources at once and one unknown name must not fail the
   whole response — and because its own default list contains `manual_import`, a legitimate source
   platform that deliberately has no plugin manifest. That is the same answer as before for every
-  request the UI sends, since a schedule rule only ever exists per plugin.
+  request the UI sends, since a schedule rule only ever exists per plugin. The `?sources=` list is
+  also de-duplicated and capped now: validation bounds *which* rules may be described but not how
+  *many* calls are made, and one valid name repeated 500 times issued 500 `describe_rule` calls while
+  overwriting the same response entry each time — the caller chose the AWS call count against a fixed
+  result, on an API throttled per account and shared with the rest of the stack. It is the only read
+  in this handler that fans out one AWS call per list element.
 - `POST`/`DELETE /integrations/{source}/apps`, `POST /sources/{source}/run` and
   `PUT /sources/{source}/enable|disable` now require the caller to be in the `admins` group. Only
   the two credentials routes were gated, so the boundary depended on which key a write happened to
@@ -172,6 +177,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   id. Neither this nor the synth-time id guard is retroactive: a key stored by a pre-upgrade write
   survives in the shared secret and is still read by whichever plugin's namespace it landed in.
   A deployment where an arbitrary `source` was used should delete the stale keys by hand.
+- **`GET /sources/status?sources=` accepts at most 50 distinct sources per request** and answers 400
+  above that. Counted after de-duplication, so repeating one name is not what trips it, and set well
+  above both the five plugin manifests and the route's own three-source default — the web app asks
+  for at most one source at a time, so no UI call approaches it. A caller passing the same source
+  more than once still receives the identical response; only the redundant `describe_rule` calls are
+  gone.
 - **Triggering a run, toggling a schedule, and writing or deleting an app config now require the
   `admins` group.** A caller in `users` alone receives 403 on `POST /sources/{source}/run`,
   `PUT /sources/{source}/enable|disable` and `POST`/`DELETE /integrations/{source}/apps`. Listing app

--- a/docs/SYSTEM_DOCUMENTATION.md
+++ b/docs/SYSTEM_DOCUMENTATION.md
@@ -322,7 +322,7 @@ All plugin Lambdas share a single tightly-scoped IAM role with permissions for: 
 
 ### Secrets Isolation
 
-Secrets are prefixed with plugin ID for isolation. At runtime, both `BaseIngestor._load_secrets()` and `BaseWebhook._load_secrets()` delegate to `plugins/_shared/secrets.py`, which strips the prefix so plugins access secrets by clean key name. A prefix matching zero keys raises a `ConfigurationError` naming the plugin and expected prefix rather than returning the whole shared secret (issue #251).
+Secrets are prefixed with plugin ID for isolation. At runtime, both `BaseIngestor._load_secrets()` and `BaseWebhook._load_secrets()` delegate to `plugins/_shared/plugin_secrets.py`, which strips the prefix so plugins access secrets by clean key name. A prefix matching zero keys raises a `ConfigurationError` naming the plugin and expected prefix rather than returning the whole shared secret (issue #251). Because that check runs in `__init__`, `BaseIngestor` reports a construction failure itself — the run record moves to `error`, the circuit breaker records it, and `plugin.failed` is emitted — and both `_load_secrets()` implementations evict the cached secret before refusing on an empty payload, so a transient Secrets Manager failure retries instead of wedging the warm container. Every plugin must therefore declare at least one key in its manifest's `secrets` block, which CI pins.
 
 ### Lambda Bundling
 

--- a/docs/SYSTEM_DOCUMENTATION.md
+++ b/docs/SYSTEM_DOCUMENTATION.md
@@ -322,7 +322,7 @@ All plugin Lambdas share a single tightly-scoped IAM role with permissions for: 
 
 ### Secrets Isolation
 
-Secrets are prefixed with plugin ID for isolation. At runtime, `BaseIngestor._load_secrets()` strips the prefix so plugins access secrets by clean key name.
+Secrets are prefixed with plugin ID for isolation. At runtime, both `BaseIngestor._load_secrets()` and `BaseWebhook._load_secrets()` delegate to `plugins/_shared/secrets.py`, which strips the prefix so plugins access secrets by clean key name. A prefix matching zero keys raises a `ConfigurationError` naming the plugin and expected prefix rather than returning the whole shared secret (issue #251).
 
 ### Lambda Bundling
 

--- a/docs/getting-started-plugins.md
+++ b/docs/getting-started-plugins.md
@@ -77,10 +77,22 @@ Edit `manifest.json` with your source details:
   },
 
   "secrets": {
-    "your_source_id_api_key": ""
+    "api_key": ""
   }
 }
 ```
+
+Declare secret keys by their **bare** name here. CDK prefixes each one with your plugin
+id when it seeds the shared secret (`api_key` is stored as `your_source_id_api_key`), so a
+key written pre-prefixed in the manifest would be stored doubly prefixed and your ingestor
+would never find it.
+
+**Declare at least one key.** Since issue #251 a plugin whose namespace holds no key
+raises a `ConfigurationError` at construction rather than silently receiving every other
+plugin's credentials, so a plugin declaring no `secrets` cannot start. If yours genuinely
+needs no configuration, declare one key anyway (or do not read `self.secrets` in your
+constructor). `plugins/_shared/test/test_plugin_secret_isolation.py` fails on a manifest
+that declares none, so this is caught in CI rather than in a deployed Lambda.
 
 ### Step 3: Implement the Ingestor
 
@@ -221,7 +233,23 @@ self.api_key = self.secrets.get("api_key", "")
 self.api_secret = self.secrets.get("api_secret", "")
 ```
 
-Secret keys in the manifest are prefixed with your plugin ID automatically.
+Secret keys in the manifest are prefixed with your plugin ID automatically, and the prefix
+is stripped again on the way in — so you read the bare name, as above.
+
+All plugins share one Secrets Manager secret, and every ingestion Lambda shares one IAM
+role, so that prefix is the **entire** boundary between your plugin's credentials and
+another's. It fails closed: if nothing in the secret carries your `<plugin_id>_` prefix,
+`self.secrets` is not empty — construction raises a `ConfigurationError` naming your
+plugin and the prefix it expected. It used to hand you the whole shared secret instead
+(issue #251).
+
+Two things follow for you as a plugin author:
+
+- Declare at least one key in `secrets` (see Step 2), or your Lambda cannot start.
+- You never need to register your plugin id anywhere for filtering to work. An earlier
+  version of this required adding it to a `_get_known_prefixes()` list in
+  `_shared/base_ingestor.py`; that function is gone, and forgetting it was itself what
+  leaked one plugin's keys into every other.
 
 ## Categories
 

--- a/docs/getting-started-plugins.md
+++ b/docs/getting-started-plugins.md
@@ -90,9 +90,13 @@ would never find it.
 **Declare at least one key.** Since issue #251 a plugin whose namespace holds no key
 raises a `ConfigurationError` at construction rather than silently receiving every other
 plugin's credentials, so a plugin declaring no `secrets` cannot start. If yours genuinely
-needs no configuration, declare one key anyway (or do not read `self.secrets` in your
-constructor). `plugins/_shared/test/test_plugin_secret_isolation.py` fails on a manifest
-that declares none, so this is caught in CI rather than in a deployed Lambda.
+needs no configuration, declare one key anyway, or override `_load_secrets` to return
+`{}` — which opts out of the boundary deliberately and visibly. Not *reading*
+`self.secrets` is not a way out: `BaseIngestor.__init__` and `BaseWebhook.__init__` both
+call `self._load_secrets()` themselves, before any subclass body runs, so the raise does
+not depend on your code touching the attribute.
+`plugins/_shared/test/test_plugin_secret_isolation.py` fails on a manifest that declares
+none, so this is caught in CI rather than in a deployed Lambda.
 
 ### Step 3: Implement the Ingestor
 

--- a/docs/mobile-app-reviews.md
+++ b/docs/mobile-app-reviews.md
@@ -346,7 +346,7 @@ cdk deploy --all
 ## Assumptions & Limitations
 
 - **Multiple apps per plugin**: each plugin supports several app configurations, managed from the **Configured Apps** list on the Scrapers page and persisted as a JSON array via the `/integrations/{source}/apps` CRUD endpoints.
-- **Implementation prerequisite**: The `KNOWN_SOURCES` set in `_shared/schemas.py` and the `_get_known_prefixes()` list in `_shared/base_ingestor.py` must include `app_reviews_ios` and `app_reviews_android` for proper secret filtering and message validation.
+- **Implementation prerequisite**: The `KNOWN_SOURCES` set in `_shared/schemas.py` must include `app_reviews_ios` and `app_reviews_android` for message validation. Secret filtering no longer needs a per-plugin list: `_shared/secrets.py` returns only the plugin's own `<plugin_id>_*` namespace and raises a configuration error when that namespace is empty, so the `_get_known_prefixes()` list this bullet used to also require is gone (issue #251).
 - **Unofficial APIs**: Both plugins use unofficial/public endpoints. These can change without notice. The circuit breaker will auto-disable the plugin if endpoints break.
 - **Rate limiting**: Apple and Google may rate-limit aggressive scraping. `app-store-web-scraper` has built-in delays with jitter. For Google, the country shuffle and configurable `max_countries_per_run` help manage request volume.
 - **iOS review depth**: Max 500 reviews per country (10 pages × 50). High-volume apps may miss reviews between runs if the schedule is too infrequent.

--- a/docs/mobile-app-reviews.md
+++ b/docs/mobile-app-reviews.md
@@ -346,7 +346,7 @@ cdk deploy --all
 ## Assumptions & Limitations
 
 - **Multiple apps per plugin**: each plugin supports several app configurations, managed from the **Configured Apps** list on the Scrapers page and persisted as a JSON array via the `/integrations/{source}/apps` CRUD endpoints.
-- **Implementation prerequisite**: The `KNOWN_SOURCES` set in `_shared/schemas.py` must include `app_reviews_ios` and `app_reviews_android` for message validation. Secret filtering no longer needs a per-plugin list: `_shared/secrets.py` returns only the plugin's own `<plugin_id>_*` namespace and raises a configuration error when that namespace is empty, so the `_get_known_prefixes()` list this bullet used to also require is gone (issue #251).
+- **Implementation prerequisite**: The `KNOWN_SOURCES` set in `_shared/schemas.py` must include `app_reviews_ios` and `app_reviews_android` for message validation. Secret filtering no longer needs a per-plugin list: `_shared/plugin_secrets.py` returns only the plugin's own `<plugin_id>_*` namespace and raises a configuration error when that namespace is empty, so the `_get_known_prefixes()` list this bullet used to also require is gone (issue #251).
 - **Unofficial APIs**: Both plugins use unofficial/public endpoints. These can change without notice. The circuit breaker will auto-disable the plugin if endpoints break.
 - **Rate limiting**: Apple and Google may rate-limit aggressive scraping. `app-store-web-scraper` has built-in delays with jitter. For Google, the country shuffle and configurable `max_countries_per_run` help manage request volume.
 - **iOS review depth**: Max 500 reviews per country (10 pages × 50). High-volume apps may miss reviews between runs if the schedule is too infrequent.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -2018,13 +2018,37 @@ close different entrances:
 
 - `loadPlugins` rejects a **manifest** id that is a prefix of another's, at synth time,
   the only place the whole id set is known.
-- `PUT /integrations/<source>/credentials` restricts `source` to those same
-  manifest-derived ids (`_validate_source_is_a_known_plugin`). The loader's guard cannot
-  see a source invented in a request: `source='app_reviews'` with key `ios_app_id` stored
-  `app_reviews_ios_app_id`, which `app_reviews_ios`'s next run consumed as its own
-  `app_id`. A colliding *stored key* needs no colliding manifest to exist. That check
-  fails open if `PLUGIN_SECRET_DEFAULTS` is unavailable, so one bad environment variable
-  cannot break credential management outright — the form check still applies.
+- Every route taking a `<source>` path parameter restricts it to those same
+  manifest-derived ids (`_validate_source_parameter`, which applies both the form check and
+  `_validate_source_is_a_known_plugin`). The loader's guard cannot see a source invented in
+  a request: `source='app_reviews'` with key `ios_app_id` stored `app_reviews_ios_app_id`,
+  which `app_reviews_ios`'s next run consumed as its own `app_id`. A colliding *stored key*
+  needs no colliding manifest to exist. That check fails open if `PLUGIN_SECRET_DEFAULTS` is
+  unavailable, so one bad environment variable cannot break credential management
+  outright — the form check still applies.
+
+Neither guard is retroactive. A key already stored by a pre-upgrade write survives, and the
+plugin whose namespace it landed in still reads it; delete such keys by hand.
+
+#### Which `<source>` routes need admin
+
+`source` reaches three kinds of resource name, and the routes that WRITE one are admin-gated:
+a Secrets Manager key (`<source>_configs`), an ingestor Lambda name
+(`voc-ingestor-<source>`), and an EventBridge rule name (`voc-ingest-<source>-schedule`).
+
+| Route | `require_admin` | Why |
+|-------|-----------------|-----|
+| `GET`/`PUT /integrations/<source>/credentials` | yes | reads and writes credentials |
+| `POST`/`DELETE /integrations/<source>/apps` | yes | writes the shared secret |
+| `POST /sources/<source>/run` | yes | billed third-party fetch, invocable in a loop |
+| `PUT /sources/<source>/enable\|disable` | yes | disabling silently stops ingestion |
+| `GET /integrations/<source>/apps` | **no** | the Scrapers page lists configs for everyone; a config holds a public app-store id and a display name, not a credential |
+
+The gate is the server's. The Scrapers page also disables the corresponding controls for a
+non-admin so the reason is visible on hover rather than arriving as a 403, but that is
+presentation only. Both properties are pinned by an `ast` pass over the route decorators in
+`test_integrations_security.py`, so a route added later is asserted rather than forgotten —
+which is how the five unguarded ones came to look like deliberate scoping.
 
 ### Cost Controls
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1981,10 +1981,23 @@ indistinguishable from the plugin's side, that branch raises `SecretUnreadableEr
 against the circuit breaker**. Counting it would let five AWS-side blips inside the
 breaker's 15-minute window call `_trip_breaker`, which disables the plugin's EventBridge
 schedule — and nothing re-enables a disabled rule, so a healthy plugin's ingestion would
-stop until an operator noticed. The run record and the audit event still fire, so the
-failure is visible; only the auto-disable is withheld. A malformed identity or a namespace
-that matches nothing is someone's mistake, stays a plain `ConfigurationError`, and still
-counts.
+stop until an operator noticed. Only the auto-disable is withheld: the run record and the
+`plugin.failed` audit event still fire. A malformed identity, a namespace that matches
+nothing, or a secret whose body is not a JSON object is someone's mistake, stays a plain
+`ConfigurationError`, and still counts — those never self-heal, and retrying them forever is
+what the breaker exists to stop.
+
+**Alarm on the refusal log line.** That is not advice, it is the escalation path this
+exemption relies on. On a *manual* run the `SOURCE_RUN#` record clears the UI's spinner and
+carries the message. On a **scheduled** run there is no such record — `_update_source_run_status`
+is a no-op without an `execution_id` — so the only signals are the
+`Refusing to load plugin secrets` log line and the `plugin.failed` audit event, and that
+event reaches EventBridge only when `AUDIT_EVENT_BUS` is set (no stack in this repo sets it;
+otherwise it is a `logger.info("AUDIT", …)`). No stack creates a metric filter or alarm
+either. So a scheduled plugin with an unreadable secret is silently not ingesting, and the
+one mechanism that used to make that state visible in the console — the breaker disabling
+the rule — is now deliberately withheld. The trade is still the right one, but it moves the
+escalation from the breaker to your alarms, which means the alarm has to exist.
 
 One limitation the prefix scan cannot see: if a plugin id were ever a **prefix** of
 another (`app_reviews` alongside `app_reviews_ios`), the shorter one would also receive the

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1962,9 +1962,12 @@ Three consequences of failing closed are worth knowing before you write a plugin
 - **A construction failure still reports.** `_load_secrets()` runs in `__init__`, so the
   raise never reaches `run()`'s `except`. `BaseIngestor` therefore reports it itself
   (`_report_construction_failure`): the `SOURCE_RUN#` record moves to `status: 'error'`,
-  the circuit breaker records the failure, and a `plugin.failed` audit event is emitted.
-  Without that, a manual "Run now" would show a permanent "Running..." spinner — the UI
-  polls until a terminal status and the API writes `'running'` before invoking.
+  a `plugin.failed` audit event is emitted, and the circuit breaker records the failure —
+  **unless the secret was merely unreadable rather than misconfigured**, which is reported
+  but deliberately *not* counted (see "A transient Secrets Manager failure" below for why,
+  and for the alarm that exemption depends on). Without any of this, a manual "Run now"
+  would show a permanent "Running..." spinner — the UI polls until a terminal status and
+  the API writes `'running'` before invoking.
 - **A webhook Lambda returns 5xx for every delivery** while its secret is missing or
   mis-prefixed, and most providers drop events after their retries expire. There is no
   manual run to recover a webhook, so watch the plugin's log group for
@@ -1981,11 +1984,19 @@ indistinguishable from the plugin's side, that branch raises `SecretUnreadableEr
 against the circuit breaker**. Counting it would let five AWS-side blips inside the
 breaker's 15-minute window call `_trip_breaker`, which disables the plugin's EventBridge
 schedule — and nothing re-enables a disabled rule, so a healthy plugin's ingestion would
-stop until an operator noticed. Only the auto-disable is withheld: the run record and the
-`plugin.failed` audit event still fire. A malformed identity, a namespace that matches
+stop until an operator noticed. Only the auto-disable is withheld: the `plugin.failed` audit
+event still fires, and the run record does too on a manual run (on a scheduled one there is
+none to move — see the next paragraph). A malformed identity, a namespace that matches
 nothing, or a secret whose body is not a JSON object is someone's mistake, stays a plain
 `ConfigurationError`, and still counts — those never self-heal, and retrying them forever is
 what the breaker exists to stop.
+
+Each of those three reporting steps is guarded **independently**, which matters more than it
+looks: `CircuitBreaker.record_failure` resolves its DynamoDB resource in the `self.table`
+property, *above* its own `try`, so a failure building that resource escapes it. Under a
+single shared `try` that failure skipped every later step, losing the `plugin.failed` event
+in exactly the correlated case where the same DynamoDB trouble breaks both — and on a
+scheduled run that event is the only signal there is.
 
 **Alarm on the refusal log line.** That is not advice, it is the escalation path this
 exemption relies on. On a *manual* run the `SOURCE_RUN#` record clears the UI's spinner and
@@ -2001,8 +2012,19 @@ escalation from the breaker to your alarms, which means the alarm has to exist.
 
 One limitation the prefix scan cannot see: if a plugin id were ever a **prefix** of
 another (`app_reviews` alongside `app_reviews_ios`), the shorter one would also receive the
-longer one's keys. `loadPlugins` refuses such a pair at synth time, which is the only place
-the whole id set is known — a plugin Lambda holds no list of its siblings by design.
+longer one's keys. A plugin Lambda holds no list of its siblings by design, so this is
+refused at the two places that do see more than one id — and both are needed, because they
+close different entrances:
+
+- `loadPlugins` rejects a **manifest** id that is a prefix of another's, at synth time,
+  the only place the whole id set is known.
+- `PUT /integrations/<source>/credentials` restricts `source` to those same
+  manifest-derived ids (`_validate_source_is_a_known_plugin`). The loader's guard cannot
+  see a source invented in a request: `source='app_reviews'` with key `ios_app_id` stored
+  `app_reviews_ios_app_id`, which `app_reviews_ios`'s next run consumed as its own
+  `app_id`. A colliding *stored key* needs no colliding manifest to exist. That check
+  fails open if `PLUGIN_SECRET_DEFAULTS` is unavailable, so one bad environment variable
+  cannot break credential management outright — the form check still applies.
 
 ### Cost Controls
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -2050,11 +2050,15 @@ as a 403, but that is presentation only. Both properties are pinned by an `ast` 
 route decorators in `test_integrations_security.py`, so a route added later is asserted rather
 than forgotten — which is how the five unguarded ones came to look like deliberate scoping.
 
-#### The same split applies to `/scrapers/*`
+#### The same split applies to `scrapers_handler`
 
 `scrapers_handler` writes the **same** shared secret, so it carries the same rule and its own
 `ast` pass (`test_scrapers_security.py`). Gating one handler and not the other would make the
 boundary depend on which handler a write arrived through rather than on what it changed.
+
+Titled for the **handler**, not for `/scrapers/*`: that URL prefix is served by two Lambdas, and
+this table covers one of them. `manual_import_handler` owns `/scrapers/manual/*` and is listed
+separately below.
 
 | Route | `require_admin` | Why |
 |-------|-----------------|-----|
@@ -2068,6 +2072,26 @@ boundary depend on which handler a write arrived through rather than on what it 
 and reaches no secret key or function name — only a `SCRAPER_RUN#` partition and the invoke
 payload, where the webscraper matches it against its own configured list, so an unknown id is a
 run that finds nothing. The admin gate is what bounds who can write those partitions.
+
+#### `/scrapers/manual/*` is a second handler, and is **not** gated
+
+| Route | `require_admin` | Why |
+|-------|-----------------|-----|
+| `POST /scrapers/manual/parse`, `.../confirm`, `.../csv-upload`, `.../json-upload` | **no** | writes feedback **content** into the pipeline (S3 + the enrichment queue); reaches neither the shared secret nor any plugin resource |
+| `GET /scrapers/manual/parse/<job_id>` | **no** | reads the caller's own parse job |
+
+Recorded rather than fixed, and the distinction is the reason. The three gated routes above were
+gated because they reach a **credential namespace** or **invoke a plugin**; these reach neither.
+Content ingestion is open to any authenticated user everywhere in this tree — `POST /feedback-forms`
+and `POST /s3-import/upload-url` answer 200 to a `users`-group caller on the same basis — so gating
+only the manual-import routes would reintroduce a boundary that depends on which page a write came
+from, which is exactly what this change removed for the secret. Whether content ingestion as a whole
+should be admin-only is a product decision spanning several handlers and their pages.
+
+Asserted, not merely written down: `test_scrapers_security.py::TestTheInventoryIsOneHandlers` pins
+both this handler's route inventory and the fact that none of its routes is gated, so adding a gate
+to one of them fails and forces this section to be re-derived. The `ast` pass cannot see across
+module boundaries, which is why the scope needs stating at all.
 
 ### Cost Controls
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -2044,11 +2044,30 @@ a Secrets Manager key (`<source>_configs`), an ingestor Lambda name
 | `PUT /sources/<source>/enable\|disable` | yes | disabling silently stops ingestion |
 | `GET /integrations/<source>/apps` | **no** | the Scrapers page lists configs for everyone; a config holds a public app-store id and a display name, not a credential |
 
-The gate is the server's. The Scrapers page also disables the corresponding controls for a
-non-admin so the reason is visible on hover rather than arriving as a 403, but that is
-presentation only. Both properties are pinned by an `ast` pass over the route decorators in
-`test_integrations_security.py`, so a route added later is asserted rather than forgotten —
-which is how the five unguarded ones came to look like deliberate scoping.
+The gate is the server's. The Scrapers page and the Settings page also disable the
+corresponding controls for a non-admin so the reason is visible on hover rather than arriving
+as a 403, but that is presentation only. Both properties are pinned by an `ast` pass over the
+route decorators in `test_integrations_security.py`, so a route added later is asserted rather
+than forgotten — which is how the five unguarded ones came to look like deliberate scoping.
+
+#### The same split applies to `/scrapers/*`
+
+`scrapers_handler` writes the **same** shared secret, so it carries the same rule and its own
+`ast` pass (`test_scrapers_security.py`). Gating one handler and not the other would make the
+boundary depend on which handler a write arrived through rather than on what it changed.
+
+| Route | `require_admin` | Why |
+|-------|-----------------|-----|
+| `POST /scrapers` | yes | writes `webscraper_configs` on the shared secret — the URLs the ingestor fetches |
+| `DELETE /scrapers/<scraper_id>` | yes | same write, and destructive |
+| `POST /scrapers/<scraper_id>/run` | yes | billed third-party fetch, invocable in a loop |
+| `GET /scrapers`, `.../status`, `.../runs`, `/scrapers/templates` | **no** | the Scrapers page renders these for everyone |
+| `POST /scrapers/analyze-url` | **no** | persists nothing; the fetch is bounded by `validate_url`'s SSRF checks |
+
+`scraper_id` is deliberately **not** allowlisted the way `<source>` is. It is not a plugin id
+and reaches no secret key or function name — only a `SCRAPER_RUN#` partition and the invoke
+payload, where the webscraper matches it against its own configured list, so an unknown id is a
+run that finds nothing. The admin gate is what bounds who can write those partitions.
 
 ### Cost Controls
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1919,25 +1919,38 @@ for (const plugin of webhookPlugins) {
 
 Plugins share a single Secrets Manager secret, but each plugin only accesses its own keys:
 
+`BaseIngestor._load_secrets()` and `BaseWebhook._load_secrets()` both delegate to one
+helper, `plugins/_shared/secrets.py`:
+
 ```python
-# In base_ingestor.py
-class BaseIngestor:
-    def _load_secrets(self) -> dict:
-        """Load only this plugin's secrets."""
-        all_secrets = get_secret(SECRETS_ARN)
-        
-        # Filter to only keys prefixed with this plugin's ID
-        prefix = f"{self.source_platform}_"
-        return {
-            k.replace(prefix, ''): v 
-            for k, v in all_secrets.items() 
-            if k.startswith(prefix)
-        }
+# In plugins/_shared/secrets.py
+def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
+    """Return plugin_id's namespaced keys, prefix stripped — or raise."""
+    prefix = f"{plugin_id}_"
+    scoped = {
+        key[len(prefix):]: value
+        for key, value in all_secrets.items()
+        if key.startswith(prefix) and len(key) > len(prefix)
+    }
+    if not scoped:
+        raise ConfigurationError(...)  # names plugin_id and prefix, nothing else
+    return scoped
 ```
 
 This means:
 - `webscraper` plugin sees: `configs`
 - Each plugin can only access its own secrets
+
+**It fails closed** (issue #251). A prefix matching zero keys — a typo'd plugin id, an
+unknown identity, an empty secret — raises a `ConfigurationError` naming the plugin and
+the expected prefix. It used to return the *complete* shared secret in that case, on the
+theory that a plugin predating prefixing had not been migrated yet; the effect was that
+the isolation boundary held only while every plugin's prefix was correct, and a typo
+produced the maximally permissive outcome. All ingestion Lambdas share one IAM role, so
+nothing else was catching it.
+
+The error and its log name the identity and the expected prefix only — never a secret
+value, and never another plugin's key names.
 
 ### Cost Controls
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1971,10 +1971,20 @@ Three consequences of failing closed are worth knowing before you write a plugin
   `Refusing to load plugin secrets` and alarm on it; the shared-secret read is
   load-bearing for a webhook in a way it is not for a scheduled ingestor.
 
-A transient Secrets Manager failure is *not* one of these cases. `get_secret` is cached
-and swallows a failed read into `{}`, so both `_load_secrets()` implementations evict the
-cache entry before refusing on an empty payload — the next invocation re-reads rather than
-the warm container staying wedged against a memoized failure.
+A transient Secrets Manager failure is *not* one of these cases, and two things keep it
+from becoming one. `get_secret` is cached and swallows a failed read into `{}`, so both
+`_load_secrets()` implementations evict the cache entry before refusing on an empty
+payload — the next invocation re-reads rather than the warm container staying wedged
+against a memoized failure. And because a failed read and a genuinely empty secret are
+indistinguishable from the plugin's side, that branch raises `SecretUnreadableError` (a
+`ConfigurationError` subclass) and `_report_construction_failure` **does not count it
+against the circuit breaker**. Counting it would let five AWS-side blips inside the
+breaker's 15-minute window call `_trip_breaker`, which disables the plugin's EventBridge
+schedule — and nothing re-enables a disabled rule, so a healthy plugin's ingestion would
+stop until an operator noticed. The run record and the audit event still fire, so the
+failure is visible; only the auto-disable is withheld. A malformed identity or a namespace
+that matches nothing is someone's mistake, stays a plain `ConfigurationError`, and still
+counts.
 
 One limitation the prefix scan cannot see: if a plugin id were ever a **prefix** of
 another (`app_reviews` alongside `app_reviews_ios`), the shorter one would also receive the

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1920,10 +1920,10 @@ for (const plugin of webhookPlugins) {
 Plugins share a single Secrets Manager secret, but each plugin only accesses its own keys:
 
 `BaseIngestor._load_secrets()` and `BaseWebhook._load_secrets()` both delegate to one
-helper, `plugins/_shared/secrets.py`:
+helper, `plugins/_shared/plugin_secrets.py`:
 
 ```python
-# In plugins/_shared/secrets.py
+# In plugins/_shared/plugin_secrets.py
 def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
     """Return plugin_id's namespaced keys, prefix stripped — or raise."""
     prefix = f"{plugin_id}_"
@@ -1951,6 +1951,35 @@ nothing else was catching it.
 
 The error and its log name the identity and the expected prefix only — never a secret
 value, and never another plugin's key names.
+
+Three consequences of failing closed are worth knowing before you write a plugin:
+
+- **Every plugin must declare at least one key** in its manifest's `secrets` block. CDK
+  seeds the declared keys at deploy time; a plugin declaring none has no `<id>_*` key to
+  find, so its Lambda raises at construction on the first invocation. Pinned in CI by
+  `test_plugin_secret_isolation.py::TestTheDeployTimeInvariantsThisBoundaryNeeds`, so a
+  zero-secret manifest fails a test run rather than a production invocation.
+- **A construction failure still reports.** `_load_secrets()` runs in `__init__`, so the
+  raise never reaches `run()`'s `except`. `BaseIngestor` therefore reports it itself
+  (`_report_construction_failure`): the `SOURCE_RUN#` record moves to `status: 'error'`,
+  the circuit breaker records the failure, and a `plugin.failed` audit event is emitted.
+  Without that, a manual "Run now" would show a permanent "Running..." spinner — the UI
+  polls until a terminal status and the API writes `'running'` before invoking.
+- **A webhook Lambda returns 5xx for every delivery** while its secret is missing or
+  mis-prefixed, and most providers drop events after their retries expire. There is no
+  manual run to recover a webhook, so watch the plugin's log group for
+  `Refusing to load plugin secrets` and alarm on it; the shared-secret read is
+  load-bearing for a webhook in a way it is not for a scheduled ingestor.
+
+A transient Secrets Manager failure is *not* one of these cases. `get_secret` is cached
+and swallows a failed read into `{}`, so both `_load_secrets()` implementations evict the
+cache entry before refusing on an empty payload — the next invocation re-reads rather than
+the warm container staying wedged against a memoized failure.
+
+One limitation the prefix scan cannot see: if a plugin id were ever a **prefix** of
+another (`app_reviews` alongside `app_reviews_ios`), the shorter one would also receive the
+longer one's keys. `loadPlugins` refuses such a pair at synth time, which is the only place
+the whole id set is known — a plugin Lambda holds no list of its siblings by design.
 
 ### Cost Controls
 

--- a/voc-datalake/frontend/src/constants/admin.ts
+++ b/voc-datalake/frontend/src/constants/admin.ts
@@ -1,0 +1,43 @@
+/**
+ * The `title` on every control the UI disables because the route behind it is
+ * admin-gated server-side.
+ *
+ * Declared once, and HERE rather than under one page, because two pages now render
+ * such a control: `pages/Scrapers` (`AppConfigComponents`' Run and Delete,
+ * `PluginConfigModal`'s Add/Save/Delete/Run and schedule toggle,
+ * `GeneratorConfigModal`'s Generate — where this wording came from) and
+ * `pages/Settings` (`SourceCard`'s Enabled toggle). It began in
+ * `pages/Scrapers/constants.ts`, which was right while Scrapers was the only page
+ * with a gated control; the Settings toggle calls the same
+ * `PUT /sources/{source}/enable|disable` pair, so a page-local home would have
+ * meant either a cross-page import or a second literal — and a per-file literal is
+ * how one surface ends up saying something different from another about the same
+ * 403.
+ *
+ * The routes: `POST`/`DELETE /integrations/{source}/apps`,
+ * `POST /sources/{source}/run`, `PUT /sources/{source}/enable|disable`, and
+ * `POST`/`DELETE /scrapers` plus `POST /scrapers/{id}/run`. None of them were
+ * gated — a `users`-group caller could write the shared API-credentials secret and
+ * invoke an ingestor — so the gate is the SERVER's and this string is only the
+ * explanation. Disabling a control is never the boundary.
+ *
+ * NOT routed through i18n, and that is a decision rather than an oversight — but a
+ * weak one, recorded so the next reader does not have to guess.
+ * `GeneratorConfigModal` carried this exact literal before it was consolidated, so
+ * the constant inherits the omission rather than introducing it, and consolidating
+ * first means translating it later is a one-line change at a single definition
+ * site. The surrounding pages ARE translated (`PluginConfigModal` alone has three
+ * `useTranslation` calls), so the inconsistency is real: a non-English user gets
+ * these tooltips in English.
+ *
+ * `frontend/scripts/i18n-check.mjs` cannot catch it either way, so nothing will
+ * prompt the fix. Its heuristic reports a DIRECTORY in which no file calls
+ * `useTranslation` at all — and both `Scrapers/` and `Settings/` are mixed, so
+ * `AppConfigComponents.tsx` and `SourceCard.tsx` (zero calls each) are invisible
+ * because their directories as a whole are exempt.
+ *
+ * Every assertion on this string imports the constant instead of restating it, so
+ * translating it is a change to this file alone and cannot fail a test whose
+ * subject is the admin gate.
+ */
+export const ADMIN_ONLY_TITLE = 'Admin access required'

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
@@ -132,10 +132,13 @@ describe('AppConfigCard', () => {
 
   describe('regardless of admin status', () => {
     /**
-     * The gate's boundary. Edit opens a form whose own Save carries the gate, so
-     * disabling it would stop a non-admin READING a config the API already serves
-     * them (`GET /integrations/{source}/apps` is deliberately open). Pinning it
-     * makes that a decision rather than an omission, and stops a future "disable
+     * The gate's boundary. Edit opens `PluginConfigModal`, whose `AppEditorForm`
+     * Save carries the gate for `POST /integrations/{source}/apps` — asserted in
+     * `PluginConfigModal.test.tsx`, not taken on trust, because the same claim
+     * about `ScraperEditor`'s Save turned out to be false. Disabling Edit would
+     * stop a non-admin READING a config the API already serves them
+     * (`GET /integrations/{source}/apps` is deliberately open). Pinning it makes
+     * that a decision rather than an omission, and stops a future "disable
      * everything for non-admins" from passing the cases above.
      */
     it.each([true, false])('opens the editor (isAdmin=%s)', async (isAdmin) => {

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * `AppConfigCard`'s admin gate on Run and Delete.
+ *
+ * The gate shipped untested: reverting Run to `disabled={isRunning}` and dropping
+ * `disabled={!isAdmin}` from Delete left all 146 tests under `src/pages/Scrapers`
+ * passing. `PluginConfigModal.test.tsx` covers the equivalent gate in the modal, but
+ * nothing rendered this card with `isAdmin={false}` — the prop threads
+ * `Scrapers` → `AppConfigList` → `AppConfigCard` and was untested at every hop.
+ *
+ * This is the MORE reachable of the two surfaces: the card is on the Scrapers page
+ * itself, always visible, while the modal is behind a click. The server refuses
+ * either way (`POST /sources/{source}/run` and
+ * `DELETE /integrations/{source}/apps/{id}` are admin-gated), so nothing was
+ * exposed; what was unprotected is the gate itself against a future refactor.
+ *
+ * Each non-admin case asserts the CALLBACK was not invoked, not merely that the
+ * button carries `disabled` — matching the convention in `PluginConfigModal.test.tsx`
+ * of asserting the request is not issued. `disabled` on a styled button is easy to
+ * render and easy to bypass; the mutation not happening is the observable.
+ *
+ * Buttons are located by their lucide `svg` class rather than by `title`, because
+ * `title` is part of what these assertions are about: Run and Delete carry the same
+ * admin-only value, so selecting on it would find the wrong button and could pass
+ * with one of the two gates removed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AppConfigCard } from './AppConfigComponents'
+// Imported, not restated — see PluginConfigModal.test.tsx.
+import { ADMIN_ONLY_TITLE } from './constants'
+import type { PluginManifest } from '../../plugins/types'
+
+const plugin = {
+  id: 'app_reviews_ios',
+  name: 'iOS App Reviews',
+  description: 'Collect reviews from the App Store',
+} as unknown as PluginManifest
+
+const app = {
+  id: 'a1',
+  app_name: 'Zara',
+  app_id: '547951480',
+  frequency_minutes: '1440',
+  max_reviews_per_run: '500',
+}
+
+const onEdit = vi.fn()
+const onDelete = vi.fn()
+const onRun = vi.fn()
+
+/** The button carrying *iconClass*, e.g. `lucide-play`. */
+function buttonWithIcon(iconClass: string): HTMLElement {
+  const found = screen.getAllByRole('button').find(
+    (el) => el.querySelector(`svg.${iconClass}`) !== null
+  )
+  if (found == null) throw new Error(`no button carrying svg.${iconClass}`)
+  return found
+}
+
+function renderCard(isAdmin: boolean) {
+  return render(
+    <AppConfigCard
+      app={app}
+      plugin={plugin}
+      isAdmin={isAdmin}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      onRun={onRun}
+      isRunning={false}
+    />
+  )
+}
+
+describe('AppConfigCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when the user is not an admin', () => {
+    it('does not trigger a run', async () => {
+      const user = userEvent.setup()
+      renderCard(false)
+
+      const run = buttonWithIcon('lucide-play')
+      expect(run).toBeDisabled()
+      expect(run).toHaveAttribute('title', ADMIN_ONLY_TITLE)
+      await user.click(run)
+      expect(onRun).not.toHaveBeenCalled()
+    })
+
+    it('does not delete the app config', async () => {
+      const user = userEvent.setup()
+      renderCard(false)
+
+      const del = buttonWithIcon('lucide-trash2')
+      expect(del).toBeDisabled()
+      expect(del).toHaveAttribute('title', ADMIN_ONLY_TITLE)
+      await user.click(del)
+      expect(onDelete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the user is an admin', () => {
+    /**
+     * Positive controls. Without these, disabling every button unconditionally
+     * would satisfy both cases above while making the card useless for the
+     * administrators it exists for.
+     */
+    it('triggers a run', async () => {
+      const user = userEvent.setup()
+      renderCard(true)
+
+      const run = buttonWithIcon('lucide-play')
+      expect(run).toBeEnabled()
+      expect(run).toHaveAttribute('title', 'Run now')
+      await user.click(run)
+      expect(onRun).toHaveBeenCalledTimes(1)
+    })
+
+    it('deletes the app config', async () => {
+      const user = userEvent.setup()
+      renderCard(true)
+
+      const del = buttonWithIcon('lucide-trash2')
+      expect(del).toBeEnabled()
+      expect(del).toHaveAttribute('title', 'Delete')
+      await user.click(del)
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('regardless of admin status', () => {
+    /**
+     * The gate's boundary. Edit opens a form whose own Save carries the gate, so
+     * disabling it would stop a non-admin READING a config the API already serves
+     * them (`GET /integrations/{source}/apps` is deliberately open). Pinning it
+     * makes that a decision rather than an omission, and stops a future "disable
+     * everything for non-admins" from passing the cases above.
+     */
+    it.each([true, false])('opens the editor (isAdmin=%s)', async (isAdmin) => {
+      const user = userEvent.setup()
+      renderCard(isAdmin)
+
+      const edit = buttonWithIcon('lucide-settings')
+      expect(edit).toBeEnabled()
+      await user.click(edit)
+      expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([true, false])('renders the app details (isAdmin=%s)', (isAdmin) => {
+      renderCard(isAdmin)
+
+      expect(screen.getByText('Zara')).toBeInTheDocument()
+      expect(screen.getByText('iOS')).toBeInTheDocument()
+      expect(screen.getByText('500')).toBeInTheDocument()
+    })
+  })
+})

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.test.tsx
@@ -28,7 +28,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AppConfigCard } from './AppConfigComponents'
 // Imported, not restated — see PluginConfigModal.test.tsx.
-import { ADMIN_ONLY_TITLE } from './constants'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import type { PluginManifest } from '../../plugins/types'
 
 const plugin = {

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import {
   Play, Settings, Trash2, Smartphone, Loader2, CheckCircle2, AlertCircle,
 } from 'lucide-react'
-import { ADMIN_ONLY_TITLE } from './constants'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import {
   getAppIdentifier, getFrequencyLabel,
 } from './scraper-helpers'

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
@@ -74,7 +74,9 @@ export function AppConfigCard({
   /** Whether the current user is an admin. `POST /sources/{source}/run` and
    *  `DELETE /integrations/{source}/apps/{id}` are admin-gated server-side, so Run
    *  and Delete are disabled rather than allowed to fire a 403. Edit stays enabled:
-   *  it opens a form whose own Save carries the gate. */
+   *  it opens `PluginConfigModal`, whose `AppEditorForm` Save button carries the
+   *  gate for `POST /integrations/{source}/apps` — verified there, not assumed,
+   *  because the equivalent claim about `ScraperEditor` turned out to be false. */
   isAdmin: boolean
   onEdit: () => void
   onDelete: () => void

--- a/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/AppConfigComponents.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx'
 import {
   Play, Settings, Trash2, Smartphone, Loader2, CheckCircle2, AlertCircle,
 } from 'lucide-react'
+import { ADMIN_ONLY_TITLE } from './constants'
 import {
   getAppIdentifier, getFrequencyLabel,
 } from './scraper-helpers'
@@ -66,10 +67,15 @@ function AppRunStatusBar({ status }: Readonly<{ status: RunStatusInfo }>) {
 }
 
 export function AppConfigCard({
-  app, plugin, onEdit, onDelete, onRun, isRunning, runStatus,
+  app, plugin, isAdmin, onEdit, onDelete, onRun, isRunning, runStatus,
 }: Readonly<{
   app: AppConfig
   plugin: PluginManifest
+  /** Whether the current user is an admin. `POST /sources/{source}/run` and
+   *  `DELETE /integrations/{source}/apps/{id}` are admin-gated server-side, so Run
+   *  and Delete are disabled rather than allowed to fire a 403. Edit stays enabled:
+   *  it opens a form whose own Save carries the gate. */
+  isAdmin: boolean
   onEdit: () => void
   onDelete: () => void
   onRun: () => void
@@ -90,11 +96,11 @@ export function AppConfigCard({
           </div>
         </div>
         <div className="flex items-center gap-1">
-          <button onClick={onRun} disabled={isRunning} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title="Run now">
+          <button onClick={onRun} disabled={isRunning || !isAdmin} className={clsx('p-2 rounded transition-colors disabled:cursor-not-allowed', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600', isAdmin ? '' : 'opacity-50')} title={isAdmin ? 'Run now' : ADMIN_ONLY_TITLE}>
             {isRunning ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
           </button>
           <button onClick={onEdit} className="p-2 hover:bg-gray-100 rounded" title="Edit"><Settings size={16} className="text-gray-500" /></button>
-          <button onClick={onDelete} className="p-2 hover:bg-gray-100 rounded text-red-500" title="Delete"><Trash2 size={16} /></button>
+          <button onClick={onDelete} disabled={!isAdmin} className="p-2 hover:bg-gray-100 rounded text-red-500 disabled:opacity-50 disabled:cursor-not-allowed" title={isAdmin ? 'Delete' : ADMIN_ONLY_TITLE}><Trash2 size={16} /></button>
         </div>
       </div>
       <div className="grid grid-cols-3 gap-4 text-sm">

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@tanstack/react-query'
 import GeneratorConfigModal from './GeneratorConfigModal'
 // Imported rather than restated — see PluginConfigModal.test.tsx for the reason.
-import { ADMIN_ONLY_TITLE } from './constants'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import type { PluginManifest } from '../../plugins/types'
 
 const mockGetIntegrationCredentials = vi.fn()

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.test.tsx
@@ -9,6 +9,8 @@ import {
   QueryClient, QueryClientProvider,
 } from '@tanstack/react-query'
 import GeneratorConfigModal from './GeneratorConfigModal'
+// Imported rather than restated — see PluginConfigModal.test.tsx for the reason.
+import { ADMIN_ONLY_TITLE } from './constants'
 import type { PluginManifest } from '../../plugins/types'
 
 const mockGetIntegrationCredentials = vi.fn()
@@ -115,7 +117,7 @@ describe('GeneratorConfigModal', () => {
     // The Generate button must be disabled for non-admins regardless of field state.
     const generateButton = screen.getByRole('button', { name: /generat/i })
     expect(generateButton).toBeDisabled()
-    expect(generateButton).toHaveAttribute('title', 'Admin access required')
+    expect(generateButton).toHaveAttribute('title', ADMIN_ONLY_TITLE)
 
     // Give queries time to fire if they were going to.
     await new Promise((resolve) => setTimeout(resolve, 50))

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
+import { ADMIN_ONLY_TITLE } from './constants'
 import {
   PluginField, SetupInstructions, ResultMessage,
 } from './PluginConfigParts'
@@ -177,7 +178,7 @@ export default function GeneratorConfigModal({
           <button
             onClick={() => generateMutation.mutate()}
             disabled={isBusy || !hasRequired || !isAdmin}
-            title={!isAdmin ? 'Admin access required' : undefined}
+            title={isAdmin ? undefined : ADMIN_ONLY_TITLE}
             className="btn btn-primary flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isBusy ? <Loader2 size={16} className="animate-spin" /> : <Sparkles size={16} />}

--- a/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/GeneratorConfigModal.tsx
@@ -19,7 +19,7 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
-import { ADMIN_ONLY_TITLE } from './constants'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import {
   PluginField, SetupInstructions, ResultMessage,
 } from './PluginConfigParts'

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
@@ -6,7 +6,7 @@ import PluginConfigModal from './PluginConfigModal'
 // Imported rather than restated: the subject of these assertions is the GATE, not
 // the wording, so a later decision to translate the tooltip must not fail a test
 // about admin access. See the constant's own docstring for why it is still English.
-import { ADMIN_ONLY_TITLE } from './constants'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import type { PluginManifest } from '../../plugins/types'
 
 const mockGetAppConfigs = vi.fn()

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import PluginConfigModal from './PluginConfigModal'
+// Imported rather than restated: the subject of these assertions is the GATE, not
+// the wording, so a later decision to translate the tooltip must not fail a test
+// about admin access. See the constant's own docstring for why it is still English.
+import { ADMIN_ONLY_TITLE } from './constants'
 import type { PluginManifest } from '../../plugins/types'
 
 const mockGetAppConfigs = vi.fn()
@@ -159,7 +163,7 @@ describe('PluginConfigModal', () => {
 
       const run = screen.getByRole('button', { name: /run now/i })
       expect(run).toBeDisabled()
-      expect(run).toHaveAttribute('title', 'Admin access required')
+      expect(run).toHaveAttribute('title', ADMIN_ONLY_TITLE)
       await user.click(run)
       expect(mockRunSource).not.toHaveBeenCalled()
     })
@@ -198,7 +202,7 @@ describe('PluginConfigModal', () => {
       // (which carries the same title) and pass with the delete gate removed. There
       // is one delete button per app; the two apps are the loaded fixture.
       const perApp = screen.getAllByRole('button')
-        .filter((el) => el.getAttribute('title') === 'Admin access required'
+        .filter((el) => el.getAttribute('title') === ADMIN_ONLY_TITLE
           && el.querySelector('svg.lucide-trash2') !== null)
       expect(perApp).toHaveLength(2)
 

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.test.tsx
@@ -59,13 +59,13 @@ describe('PluginConfigModal', () => {
   })
 
   it('renders plugin name and description', () => {
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     expect(screen.getByText('Android App Reviews')).toBeInTheDocument()
     expect(screen.getByText('Collect reviews from Google Play Store')).toBeInTheDocument()
   })
 
   it('displays configured apps after loading', async () => {
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => {
       expect(screen.getByText('Zara')).toBeInTheDocument()
       expect(screen.getByText('H&M')).toBeInTheDocument()
@@ -74,13 +74,13 @@ describe('PluginConfigModal', () => {
 
   it('shows empty state when no apps configured', async () => {
     mockGetAppConfigs.mockResolvedValue({ apps: [] })
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('No apps configured yet')).toBeInTheDocument() })
   })
 
   it('opens add form when Add App clicked', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     await user.click(screen.getByRole('button', { name: /add app/i }))
     expect(screen.getByText('Add New App')).toBeInTheDocument()
@@ -88,7 +88,7 @@ describe('PluginConfigModal', () => {
 
   it('saves new app config when form submitted', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     await user.click(screen.getByRole('button', { name: /add app/i }))
     await user.type(screen.getByPlaceholderText('my-app'), 'Nike')
@@ -101,7 +101,7 @@ describe('PluginConfigModal', () => {
 
   it('shows delete confirmation when delete clicked', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     const deleteButtons = screen.getAllByTitle('Delete')
     await user.click(deleteButtons[0])
@@ -110,32 +110,113 @@ describe('PluginConfigModal', () => {
 
   it('calls close when Close button clicked', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await user.click(screen.getByRole('button', { name: /close/i }))
     // eslint-disable-next-line vitest/prefer-called-with
     expect(onClose).toHaveBeenCalled()
   })
 
   it('shows Run Now when apps exist', async () => {
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     expect(screen.getByRole('button', { name: /run now/i })).toBeInTheDocument()
   })
 
   it('hides Run Now when no apps', async () => {
     mockGetAppConfigs.mockResolvedValue({ apps: [] })
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('No apps configured yet')).toBeInTheDocument() })
     expect(screen.queryByRole('button', { name: /run now/i })).not.toBeInTheDocument()
   })
 
   it('cancels add form without saving', async () => {
     const user = userEvent.setup()
-    render(<PluginConfigModal plugin={plugin} onClose={onClose} />, { wrapper: createWrapper() })
+    render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin />, { wrapper: createWrapper() })
     await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
     await user.click(screen.getByRole('button', { name: /add app/i }))
     await user.click(screen.getByRole('button', { name: /cancel/i }))
     expect(screen.queryByText('Add New App')).not.toBeInTheDocument()
     expect(mockSaveAppConfig).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Every mutating route this modal calls is admin-gated server-side:
+   * POST/DELETE `/integrations/{source}/apps`, `POST /sources/{source}/run` and
+   * `PUT /sources/{source}/enable|disable`. None of them was, so a caller whose
+   * only Cognito group was `users` could write the shared secret and invoke an
+   * ingestor. The server is what refuses now; these cases pin that the UI does not
+   * hand a non-admin a control that answers 403.
+   *
+   * Each asserts the API mock was NOT called, not merely that the button is
+   * disabled: `disabled` on a styled button is easy to render and easy to bypass,
+   * and the request not being issued is the observable the user actually gets.
+   */
+  describe('when the user is not an admin', () => {
+    it('does not trigger a run', async () => {
+      const user = userEvent.setup()
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+
+      const run = screen.getByRole('button', { name: /run now/i })
+      expect(run).toBeDisabled()
+      expect(run).toHaveAttribute('title', 'Admin access required')
+      await user.click(run)
+      expect(mockRunSource).not.toHaveBeenCalled()
+    })
+
+    it('does not toggle the schedule', async () => {
+      const user = userEvent.setup()
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+
+      const toggle = screen.getByRole('checkbox')
+      expect(toggle).toBeDisabled()
+      await user.click(toggle)
+      expect(mockEnableSource).not.toHaveBeenCalled()
+      expect(mockDisableSource).not.toHaveBeenCalled()
+    })
+
+    it('does not open the editor, so nothing can be saved', async () => {
+      const user = userEvent.setup()
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+
+      const add = screen.getByRole('button', { name: /add app/i })
+      expect(add).toBeDisabled()
+      await user.click(add)
+      expect(screen.queryByText('Add New App')).not.toBeInTheDocument()
+      expect(mockSaveAppConfig).not.toHaveBeenCalled()
+    })
+
+    it('does not delete an app config', async () => {
+      const user = userEvent.setup()
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+
+      // Located by its position in the per-app row rather than by title: `title` is
+      // what the assertion is ABOUT, so selecting on it would find the Run button
+      // (which carries the same title) and pass with the delete gate removed. There
+      // is one delete button per app; the two apps are the loaded fixture.
+      const perApp = screen.getAllByRole('button')
+        .filter((el) => el.getAttribute('title') === 'Admin access required'
+          && el.querySelector('svg.lucide-trash2') !== null)
+      expect(perApp).toHaveLength(2)
+
+      await user.click(perApp[0])
+      // No confirmation dialog, so the mutation is unreachable rather than merely
+      // guarded at the last step.
+      expect(screen.queryByText('Delete App')).not.toBeInTheDocument()
+      expect(mockDeleteAppConfig).not.toHaveBeenCalled()
+    })
+
+    it('still lists the app configs, which is deliberately not gated', async () => {
+      // Non-vacuity, and the property the gates must not cost: GET
+      // /integrations/{source}/apps stays open to any authenticated caller, so a
+      // non-admin sees the same list. Without this, hiding the whole modal would
+      // satisfy every case above.
+      render(<PluginConfigModal plugin={plugin} onClose={onClose} isAdmin={false} />, { wrapper: createWrapper() })
+      await waitFor(() => { expect(screen.getByText('Zara')).toBeInTheDocument() })
+      expect(screen.getByText('H&M')).toBeInTheDocument()
+    })
   })
 })

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.tsx
@@ -20,7 +20,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import ConfirmModal from '../../components/ConfirmModal'
-import { ADMIN_ONLY_TITLE } from './constants'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import {
   SetupInstructions, PluginField,
 } from './PluginConfigParts'

--- a/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/PluginConfigModal.tsx
@@ -20,6 +20,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import ConfirmModal from '../../components/ConfirmModal'
+import { ADMIN_ONLY_TITLE } from './constants'
 import {
   SetupInstructions, PluginField,
 } from './PluginConfigParts'
@@ -31,6 +32,15 @@ type AppConfig = Record<string, string>
 interface PluginConfigModalProps {
   readonly plugin: PluginManifest
   readonly onClose: () => void
+  /** Whether the current user is an admin.
+   *
+   *  Every mutating route this modal calls — POST/DELETE `/integrations/{source}/apps`,
+   *  `POST /sources/{source}/run`, `PUT /sources/{source}/enable|disable` — is
+   *  admin-gated server-side. They were not, which is why this prop is new: a
+   *  `users`-group caller could write the shared secret and invoke an ingestor.
+   *  Disabling the controls is presentation only; the gate that matters is the
+   *  server's, and this exists so a non-admin sees why rather than a silent 403. */
+  readonly isAdmin: boolean
 }
 
 function ResultMessage({
@@ -48,10 +58,11 @@ function ResultMessage({
 }
 
 function ScheduleToggle({
-  scheduleLoading, scheduleEnabled, onToggle,
+  scheduleLoading, scheduleEnabled, isAdmin, onToggle,
 }: {
   readonly scheduleLoading: boolean
   readonly scheduleEnabled: boolean
+  readonly isAdmin: boolean
   readonly onToggle: (enabled: boolean) => void
 }) {
   const { t } = useTranslation('scrapers')
@@ -62,8 +73,8 @@ function ScheduleToggle({
         <p className="text-xs text-gray-500">{t('pluginConfig.scheduleDescription')}</p>
       </div>
       {scheduleLoading ? <Loader2 size={16} className="animate-spin text-blue-600" /> : (
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input type="checkbox" checked={scheduleEnabled} onChange={(e) => onToggle(e.target.checked)} className="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+        <label className={clsx('flex items-center gap-2', isAdmin ? 'cursor-pointer' : 'cursor-not-allowed')} title={isAdmin ? undefined : ADMIN_ONLY_TITLE}>
+          <input type="checkbox" checked={scheduleEnabled} disabled={!isAdmin} onChange={(e) => onToggle(e.target.checked)} className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50" />
           <span className="text-sm text-gray-600">{scheduleEnabled ? t('pluginConfig.enabled') : t('pluginConfig.disabled')}</span>
         </label>
       )}
@@ -72,10 +83,11 @@ function ScheduleToggle({
 }
 
 function AppCard({
-  app, pluginId, onEdit, onDelete,
+  app, pluginId, isAdmin, onEdit, onDelete,
 }: {
   readonly app: AppConfig;
   readonly pluginId: string;
+  readonly isAdmin: boolean;
   readonly onEdit: () => void;
   readonly onDelete: () => void
 }) {
@@ -89,18 +101,22 @@ function AppCard({
         </div>
       </div>
       <div className="flex items-center gap-1 flex-shrink-0">
+        {/* Edit stays enabled for everyone: it only opens the form. The SAVE inside
+            it is what writes, and that is disabled below — so a non-admin can read
+            an app's settings without being handed a button that 403s. */}
         <button onClick={onEdit} className="p-1.5 hover:bg-gray-200 rounded" title="Edit"><Pencil size={14} className="text-gray-500" /></button>
-        <button onClick={onDelete} className="p-1.5 hover:bg-gray-200 rounded" title="Delete"><Trash2 size={14} className="text-red-500" /></button>
+        <button onClick={onDelete} disabled={!isAdmin} title={isAdmin ? 'Delete' : ADMIN_ONLY_TITLE} className="p-1.5 hover:bg-gray-200 rounded disabled:opacity-50 disabled:cursor-not-allowed"><Trash2 size={14} className="text-red-500" /></button>
       </div>
     </div>
   )
 }
 
 function AppEditorForm({
-  plugin, initialValues, onSave, onCancel, isPending,
+  plugin, initialValues, isAdmin, onSave, onCancel, isPending,
 }: {
   readonly plugin: PluginManifest;
   readonly initialValues: AppConfig;
+  readonly isAdmin: boolean;
   readonly onSave: (v: AppConfig) => void;
   readonly onCancel: () => void;
   readonly isPending: boolean
@@ -121,7 +137,7 @@ function AppEditorForm({
         ))}
       </div>
       <div className="flex items-center gap-2">
-        <button onClick={() => onSave({ ...values })} disabled={isPending || !hasRequired} className="btn btn-primary flex items-center gap-2 text-sm">
+        <button onClick={() => onSave({ ...values })} disabled={isPending || !hasRequired || !isAdmin} title={isAdmin ? undefined : ADMIN_ONLY_TITLE} className="btn btn-primary flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed">
           {isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
           {isEditing ? 'Save' : 'Add App'}
         </button>
@@ -132,7 +148,7 @@ function AppEditorForm({
 }
 
 function AppListSection({
-  plugin, apps, appsLoading, showEditor, editorInitialValues, savePending, onStartAdd, onStartEdit, onDelete, onSaveApp, onCancelEditor,
+  plugin, apps, appsLoading, showEditor, editorInitialValues, savePending, isAdmin, onStartAdd, onStartEdit, onDelete, onSaveApp, onCancelEditor,
 }: {
   readonly plugin: PluginManifest;
   readonly apps: AppConfig[];
@@ -140,6 +156,7 @@ function AppListSection({
   readonly showEditor: boolean
   readonly editorInitialValues: AppConfig;
   readonly savePending: boolean
+  readonly isAdmin: boolean
   readonly onStartAdd: () => void;
   readonly onStartEdit: (app: AppConfig) => void;
   readonly onDelete: (id: string) => void
@@ -150,29 +167,32 @@ function AppListSection({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h4 className="text-sm font-semibold text-gray-700">Configured Apps</h4>
-        {!showEditor && <button onClick={onStartAdd} className="btn btn-primary flex items-center gap-1.5 text-xs px-3 py-1.5"><Plus size={14} /> Add App</button>}
+        {!showEditor && <button onClick={onStartAdd} disabled={!isAdmin} title={isAdmin ? undefined : ADMIN_ONLY_TITLE} className="btn btn-primary flex items-center gap-1.5 text-xs px-3 py-1.5 disabled:opacity-50 disabled:cursor-not-allowed"><Plus size={14} /> Add App</button>}
       </div>
       {appsLoading ? <div className="flex items-center justify-center py-6"><Loader2 className="animate-spin h-6 w-6 text-blue-500" /></div> : null}
       {!appsLoading && apps.length === 0 && !showEditor && (
         <div className="text-center py-6 text-gray-400 text-sm">
           <Smartphone className="mx-auto h-8 w-8 mb-2 opacity-50" />
           <p>No apps configured yet</p>
-          <button onClick={onStartAdd} className="text-blue-600 hover:underline text-sm mt-1">Add your first app</button>
+          {/* Not rendered at all for a non-admin, rather than rendered disabled: it
+              is a prompt to do something they cannot do, and the empty state has no
+              other content to anchor a disabled control to. */}
+          {isAdmin ? <button onClick={onStartAdd} className="text-blue-600 hover:underline text-sm mt-1">Add your first app</button> : null}
         </div>
       )}
       {!appsLoading && apps.length > 0 && (
         <div className="space-y-2">
-          {apps.map((app) => <AppCard key={app.id} app={app} pluginId={plugin.id} onEdit={() => onStartEdit(app)} onDelete={() => onDelete(app.id)} />)}
+          {apps.map((app) => <AppCard key={app.id} app={app} pluginId={plugin.id} isAdmin={isAdmin} onEdit={() => onStartEdit(app)} onDelete={() => onDelete(app.id)} />)}
         </div>
       )}
-      {showEditor ? <AppEditorForm plugin={plugin} initialValues={editorInitialValues} onSave={onSaveApp} onCancel={onCancelEditor} isPending={savePending} /> : null}
+      {showEditor ? <AppEditorForm plugin={plugin} initialValues={editorInitialValues} isAdmin={isAdmin} onSave={onSaveApp} onCancel={onCancelEditor} isPending={savePending} /> : null}
     </div>
   )
 }
 
 // eslint-disable-next-line complexity
 export default function PluginConfigModal({
-  plugin, onClose,
+  plugin, onClose, isAdmin,
 }: PluginConfigModalProps) {
   const { t } = useTranslation('scrapers')
   const queryClient = useQueryClient()
@@ -251,8 +271,8 @@ export default function PluginConfigModal({
           <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl">&times;</button>
         </div>
         <div className="p-4 overflow-y-auto flex-1 space-y-5">
-          <ScheduleToggle scheduleLoading={scheduleLoading} scheduleEnabled={scheduleEnabled} onToggle={(e) => void handleToggleSchedule(e)} />
-          <AppListSection plugin={plugin} apps={apps} appsLoading={appsLoading} showEditor={showEditor} editorInitialValues={editingApp ?? {}} savePending={saveMutation.isPending}
+          <ScheduleToggle scheduleLoading={scheduleLoading} scheduleEnabled={scheduleEnabled} isAdmin={isAdmin} onToggle={(e) => void handleToggleSchedule(e)} />
+          <AppListSection plugin={plugin} apps={apps} appsLoading={appsLoading} showEditor={showEditor} editorInitialValues={editingApp ?? {}} savePending={saveMutation.isPending} isAdmin={isAdmin}
             onStartAdd={() => {
               setEditingApp(null); setIsAdding(true)
             }} onStartEdit={(app) => {
@@ -263,7 +283,7 @@ export default function PluginConfigModal({
             }} />
           {apps.length > 0 && (
             <div className="flex items-center gap-2">
-              <button onClick={() => runMutation.mutate()} disabled={runMutation.isPending} className="btn btn-secondary flex items-center gap-2 text-sm">
+              <button onClick={() => runMutation.mutate()} disabled={runMutation.isPending || !isAdmin} title={isAdmin ? undefined : ADMIN_ONLY_TITLE} className="btn btn-secondary flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed">
                 {runMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
                 {t('pluginConfig.runNow')}
               </button>

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -223,11 +223,17 @@ describe('ScraperCard admin gate on Run and Delete', () => {
 
   describe('regardless of admin status', () => {
     /**
-     * The gate's boundary. Edit opens a form whose own Save carries the gate, and a
-     * non-admin can already read this configuration through `GET /scrapers`, which
-     * stays deliberately open — so disabling Edit would hide data the API serves
-     * them. Pinning it stops a future "disable everything for non-admins" from
-     * passing the cases above.
+     * The gate's boundary. A non-admin can already read this configuration through
+     * `GET /scrapers`, which stays deliberately open, so disabling Edit would hide
+     * data the API serves them. Pinning it stops a future "disable everything for
+     * non-admins" from passing the cases above.
+     *
+     * What makes enabling Edit safe is that the editor's own Save is gated for
+     * `POST /scrapers` — asserted in `ScraperEditor.test.tsx`, not assumed here. An
+     * earlier version of this comment claimed that gate existed when it did not:
+     * `ScraperEditor` took no `isAdmin`, so a non-admin's Save issued the request
+     * and the modal closed as though it had succeeded. If that gate is ever
+     * removed, this case becomes the wrong decision rather than a boundary.
      */
     it.each([true, false])('opens the editor (isAdmin=%s)', async (isAdmin) => {
       const user = userEvent.setup()

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.test.tsx
@@ -1,17 +1,25 @@
 /**
- * @fileoverview Tests for ScraperCard — invalid base_url resilience (issue #167).
+ * @fileoverview Tests for ScraperCard.
  *
- * A render-time `new URL(...)` TypeError on a missing or malformed base_url
- * crashed the entire /scrapers route. The card must render for every value
- * runtime data has been observed to carry: undefined (mock server, older
- * configs), empty/whitespace, scheme-less, and garbage.
+ * Invalid base_url resilience (issue #167): a render-time `new URL(...)` TypeError
+ * on a missing or malformed base_url crashed the entire /scrapers route. The card
+ * must render for every value runtime data has been observed to carry: undefined
+ * (mock server, older configs), empty/whitespace, scheme-less, and garbage.
+ *
+ * The admin gate on Run and Delete: `POST /scrapers/{id}/run` and
+ * `DELETE /scrapers/{id}` are admin-gated server-side, so those controls must not
+ * issue a request a non-admin's 403 would swallow. See that describe block for the
+ * measurements.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import i18n from 'i18next'
 import ScraperCard from './ScraperCard'
 import { scraperDomainLabel } from './scraperUrl'
 import { DEFAULT_SCRAPER } from './constants'
+// Imported, not restated — see PluginConfigModal.test.tsx.
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import type { ScraperConfig } from '../../api/types'
 
 vi.mock('../../api/scrapersApi', async (importOriginal) => {
@@ -35,10 +43,30 @@ function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
   }
 }
 
-function renderCard(scraper: ScraperConfig) {
+/** Callbacks the admin-gate cases below assert on; `vi.clearAllMocks()` resets them. */
+const onEdit = vi.fn()
+const onDelete = vi.fn()
+const onRun = vi.fn()
+
+function renderCard(scraper: ScraperConfig, isAdmin = true) {
   return render(
-    <ScraperCard scraper={scraper} onEdit={vi.fn()} onDelete={vi.fn()} onRun={vi.fn()} />
+    <ScraperCard
+      scraper={scraper}
+      isAdmin={isAdmin}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      onRun={onRun}
+    />
   )
+}
+
+/** The button carrying *iconClass*, e.g. `lucide-play`. */
+function buttonWithIcon(iconClass: string): HTMLElement {
+  const found = screen.getAllByRole('button').find(
+    (el) => el.querySelector(`svg.${iconClass}`) !== null
+  )
+  if (found == null) throw new Error(`no button carrying svg.${iconClass}`)
+  return found
 }
 
 describe('scraperDomainLabel', () => {
@@ -120,5 +148,102 @@ describe('ScraperCard frequency resilience (issue #169)', () => {
     renderCard(makeScraper({ frequency_minutes: 0 }))
 
     expect(screen.getByText('Manual only')).toBeInTheDocument()
+  })
+})
+
+/**
+ * `POST /scrapers/{id}/run` and `DELETE /scrapers/{id}` became admin-gated
+ * server-side in this change: `run_scraper` invokes the webscraper (a billed
+ * third-party fetch, previously callable in a loop by anyone with an account) and
+ * `delete_scraper` rewrites `webscraper_configs` on the shared API-credentials
+ * secret. Measured before the gate as a `users`-group caller: 200 with one
+ * `lambda:Invoke` and one `SCRAPER_RUN#` row, and 200 with one `put_secret_json`.
+ *
+ * These cards are the UI entrance to both, rendered on the Scrapers page for every
+ * authenticated user, so the controls are disabled rather than left to fire a 403.
+ * The server is the boundary; this only stops the page offering an action it knows
+ * will fail.
+ *
+ * Each non-admin case asserts the CALLBACK was not invoked, not merely that the
+ * button carries `disabled` — matching `AppConfigComponents.test.tsx`. The
+ * `isAdmin` cases are its positive controls, so disabling everything cannot pass.
+ */
+describe('ScraperCard admin gate on Run and Delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const withUrl = () => makeScraper({ base_url: 'https://shop.example.com/reviews' })
+
+  describe('when the user is not an admin', () => {
+    it('does not trigger a run', async () => {
+      const user = userEvent.setup()
+      renderCard(withUrl(), false)
+
+      const run = buttonWithIcon('lucide-play')
+      expect(run).toBeDisabled()
+      expect(run).toHaveAttribute('title', ADMIN_ONLY_TITLE)
+      await user.click(run)
+      expect(onRun).not.toHaveBeenCalled()
+    })
+
+    it('does not delete the scraper', async () => {
+      const user = userEvent.setup()
+      renderCard(withUrl(), false)
+
+      const del = buttonWithIcon('lucide-trash2')
+      expect(del).toBeDisabled()
+      expect(del).toHaveAttribute('title', ADMIN_ONLY_TITLE)
+      await user.click(del)
+      expect(onDelete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the user is an admin', () => {
+    it('triggers a run', async () => {
+      const user = userEvent.setup()
+      renderCard(withUrl(), true)
+
+      const run = buttonWithIcon('lucide-play')
+      expect(run).toBeEnabled()
+      await user.click(run)
+      expect(onRun).toHaveBeenCalledTimes(1)
+    })
+
+    it('deletes the scraper', async () => {
+      const user = userEvent.setup()
+      renderCard(withUrl(), true)
+
+      const del = buttonWithIcon('lucide-trash2')
+      expect(del).toBeEnabled()
+      await user.click(del)
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('regardless of admin status', () => {
+    /**
+     * The gate's boundary. Edit opens a form whose own Save carries the gate, and a
+     * non-admin can already read this configuration through `GET /scrapers`, which
+     * stays deliberately open — so disabling Edit would hide data the API serves
+     * them. Pinning it stops a future "disable everything for non-admins" from
+     * passing the cases above.
+     */
+    it.each([true, false])('opens the editor (isAdmin=%s)', async (isAdmin) => {
+      const user = userEvent.setup()
+      renderCard(withUrl(), isAdmin)
+
+      const edit = buttonWithIcon('lucide-settings')
+      expect(edit).toBeEnabled()
+      await user.click(edit)
+      expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([true, false])('renders the scraper details (isAdmin=%s)', (isAdmin) => {
+      renderCard(withUrl(), isAdmin)
+
+      expect(screen.getByText('shop.example.com')).toBeInTheDocument()
+      expect(screen.getByText('Test scraper')).toBeInTheDocument()
+    })
   })
 })

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { scrapersApi } from '../../api/scrapersApi'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import { FREQUENCY_OPTIONS } from './constants'
 import type { ScraperConfig } from '../../api/types'
 import { normalizedBaseUrl, scraperDomainLabel } from './scraperUrl'
@@ -133,10 +134,16 @@ function LastRunSummary({ lastRunInfo }: { readonly lastRunInfo: RunStatus }) {
 }
 
 function ScraperCardHeader({
-  scraper, isRunning, onRun, onEdit, onDelete,
+  scraper, isRunning, isAdmin, onRun, onEdit, onDelete,
 }: {
   readonly scraper: ScraperConfig
   readonly isRunning: boolean
+  /** `POST /scrapers/{id}/run` and `DELETE /scrapers/{id}` are admin-gated
+   *  server-side, so those two controls are disabled for a non-admin rather than
+   *  issuing a request that 403s. Edit stays enabled: it opens a form whose own
+   *  Save carries the gate, and a non-admin can already read this config through
+   *  `GET /scrapers`. */
+  readonly isAdmin: boolean
   readonly onRun: () => void
   readonly onEdit: () => void
   readonly onDelete: () => void
@@ -156,11 +163,11 @@ function ScraperCardHeader({
         </div>
       </div>
       <div className="flex items-center gap-1">
-        <button onClick={onRun} disabled={isRunning || !hasUrl} className={clsx('p-2 rounded transition-colors', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600')} title={t('card.runNow')}>
+        <button onClick={onRun} disabled={isRunning || !hasUrl || !isAdmin} className={clsx('p-2 rounded transition-colors disabled:cursor-not-allowed', isRunning ? 'bg-blue-100 text-blue-600' : 'hover:bg-green-100 text-green-600', isAdmin ? '' : 'opacity-50')} title={isAdmin ? t('card.runNow') : ADMIN_ONLY_TITLE}>
           {isRunning ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
         </button>
         <button onClick={onEdit} className="p-2 hover:bg-gray-100 rounded" title={t('card.edit')}><Settings size={16} /></button>
-        <button onClick={onDelete} className="p-2 hover:bg-gray-100 rounded text-red-500" title={t('card.delete')}><Trash2 size={16} /></button>
+        <button onClick={onDelete} disabled={!isAdmin} className={clsx('p-2 hover:bg-gray-100 rounded text-red-500 disabled:cursor-not-allowed', isAdmin ? '' : 'opacity-50')} title={isAdmin ? t('card.delete') : ADMIN_ONLY_TITLE}><Trash2 size={16} /></button>
       </div>
     </div>
   )
@@ -243,9 +250,11 @@ function useScraperStatus(scraperId: string) {
 }
 
 export default function ScraperCard({
-  scraper, onEdit, onDelete, onRun,
+  scraper, isAdmin, onEdit, onDelete, onRun,
 }: {
   readonly scraper: ScraperConfig
+  /** See `ScraperCardHeader` — gates Run and Delete, whose routes require admin. */
+  readonly isAdmin: boolean
   readonly onEdit: () => void
   readonly onDelete: () => void
   readonly onRun: () => void
@@ -257,7 +266,7 @@ export default function ScraperCard({
 
   return (
     <div className={clsx('card border-2 transition-all', scraper.enabled ? 'border-green-200 bg-green-50/30' : 'border-gray-200 opacity-60')}>
-      <ScraperCardHeader scraper={scraper} isRunning={isRunning} onRun={() => handleRun(onRun)} onEdit={onEdit} onDelete={onDelete} />
+      <ScraperCardHeader scraper={scraper} isRunning={isRunning} isAdmin={isAdmin} onRun={() => handleRun(onRun)} onEdit={onEdit} onDelete={onDelete} />
       <ScraperCardStats scraper={scraper} lastRunInfo={lastRunInfo} />
       {showLastRunSummary ? <LastRunSummary lastRunInfo={lastRunInfo} /> : null}
       {showStatus ? <ScraperRunStatus scraperId={scraper.id} onComplete={handleComplete} /> : null}

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperCard.tsx
@@ -140,9 +140,13 @@ function ScraperCardHeader({
   readonly isRunning: boolean
   /** `POST /scrapers/{id}/run` and `DELETE /scrapers/{id}` are admin-gated
    *  server-side, so those two controls are disabled for a non-admin rather than
-   *  issuing a request that 403s. Edit stays enabled: it opens a form whose own
-   *  Save carries the gate, and a non-admin can already read this config through
-   *  `GET /scrapers`. */
+   *  issuing a request that 403s. Edit stays enabled because a non-admin can
+   *  already read this config through `GET /scrapers`, which is deliberately open —
+   *  the editor is a viewer for them, and its Save button carries the gate for
+   *  `POST /scrapers` (`ScraperEditor.tsx`, pinned by `ScraperEditor.test.tsx`). It
+   *  did NOT until this was checked: the editor had no `isAdmin` at all, so a
+   *  non-admin's Save issued the request and the modal closed as though it had
+   *  worked. Enabling Edit is only safe while that gate exists. */
   readonly isAdmin: boolean
   readonly onRun: () => void
   readonly onEdit: () => void

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.test.tsx
@@ -1,17 +1,35 @@
 /**
- * @fileoverview Tests for ScraperEditor — auto-detect visibility (issue #18).
+ * @fileoverview Tests for ScraperEditor.
  *
- * Auto-detect discovers CSS selectors; JSON-LD scrapers take their extraction
- * config from the structured data itself, so the button must not appear there
- * and suggest an extra required step. The extraction method is fixed by the
- * template chosen before the editor opens (there is no in-editor switch), so
- * the "create scraper from JSON-LD" flow from the issue is covered via the
- * template prop.
+ * Auto-detect visibility (issue #18): auto-detect discovers CSS selectors;
+ * JSON-LD scrapers take their extraction config from the structured data itself,
+ * so the button must not appear there and suggest an extra required step. The
+ * extraction method is fixed by the template chosen before the editor opens
+ * (there is no in-editor switch), so the "create scraper from JSON-LD" flow from
+ * the issue is covered via the template prop.
+ *
+ * Admin gate on Save: `POST /scrapers` is admin-gated server-side, and this
+ * editor's Save is the only UI entrance to it. The gate shipped absent — the
+ * component took no `isAdmin` at all — while three comments elsewhere justified
+ * leaving Edit and New Source enabled by claiming that "the form's own Save
+ * carries the gate". Measured before the fix, rendering with a non-admin: Save
+ * `disabled` false, `title` null, and one `onSave` call. Because
+ * `Scrapers.handleSaveScraper` closes the editor unconditionally and its
+ * `saveMutation` has no `onError`, the 403 was invisible: the modal closed as
+ * though the edit had been stored.
+ *
+ * The non-admin cases assert the CALLBACK is not invoked, not merely that the
+ * button carries `disabled` — the request not being issued is the observable, and
+ * `disabled` on a styled button is easy to render and easy to bypass.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import i18n from 'i18next'
 import ScraperEditor from './ScraperEditor'
+// Imported rather than restated: the subject of these assertions is the GATE, not
+// the wording. See the constant's own docstring.
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import { DEFAULT_SCRAPER } from './constants'
 import type { ScraperConfig, ScraperTemplate } from '../../api/types'
 
@@ -44,7 +62,7 @@ function makeScraper(overrides: Partial<ScraperConfig>): ScraperConfig {
 
 function renderEditor(scraper: ScraperConfig | null, template?: ScraperTemplate) {
   return render(
-    <ScraperEditor scraper={scraper} template={template} onSave={vi.fn()} onClose={vi.fn()} />
+    <ScraperEditor scraper={scraper} template={template} isAdmin onSave={vi.fn()} onClose={vi.fn()} />
   )
 }
 
@@ -105,5 +123,82 @@ describe('ScraperEditor auto-detect visibility', () => {
     renderEditor(makeScraper({ extraction_method: undefined }))
 
     expect(screen.getByRole('button', { name: AUTO_DETECT_LABEL })).toBeInTheDocument()
+  })
+})
+
+describe('ScraperEditor admin gate on Save', () => {
+  /** The Save button, located by its lucide icon rather than by `title`: `title`
+   *  is part of what these assertions are about, and the accessible name changes
+   *  with the locale. */
+  function saveButton(): HTMLElement {
+    const found = screen.getAllByRole('button').find(
+      (el) => el.querySelector('svg.lucide-save') !== null
+    )
+    if (found == null) throw new Error('no button carrying svg.lucide-save')
+    return found
+  }
+
+  function renderWith(isAdmin: boolean, onSave = vi.fn(), onClose = vi.fn()) {
+    render(
+      <ScraperEditor
+        scraper={makeScraper({})}
+        isAdmin={isAdmin}
+        onSave={onSave}
+        onClose={onClose}
+      />
+    )
+    return { onSave, onClose }
+  }
+
+  it('does not save for a non-admin', async () => {
+    const user = userEvent.setup()
+    const { onSave } = renderWith(false)
+
+    const save = saveButton()
+    expect(save).toBeDisabled()
+    expect(save).toHaveAttribute('title', ADMIN_ONLY_TITLE)
+    await user.click(save)
+    // The observable: the request is never issued. Asserting only `disabled`
+    // would pass against a button that fires anyway.
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('saves for an admin', async () => {
+    // Positive control. Without it, disabling Save unconditionally would satisfy
+    // the case above while making the editor useless for the administrators it
+    // exists for.
+    const user = userEvent.setup()
+    const { onSave } = renderWith(true)
+
+    const save = saveButton()
+    expect(save).toBeEnabled()
+    expect(save).not.toHaveAttribute('title', ADMIN_ONLY_TITLE)
+    await user.click(save)
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([true, false])('still closes on cancel (isAdmin=%s)', async (isAdmin) => {
+    // The gate's boundary: a non-admin who opened this editor to READ a config
+    // (`GET /scrapers` is deliberately open) must still be able to leave it. This
+    // is what stops a future "disable everything for non-admins" from passing the
+    // first case.
+    const user = userEvent.setup()
+    const { onClose } = renderWith(isAdmin)
+
+    const cancel = screen.getByRole('button', { name: i18n.t('editor.cancel', { ns: 'scrapers' }) })
+    expect(cancel).toBeEnabled()
+    await user.click(cancel)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([true, false])('leaves the form readable and editable (isAdmin=%s)', (isAdmin) => {
+    // Only Save is gated. The fields stay interactive because a non-admin can
+    // already read every one of them through `GET /scrapers`, so blanking or
+    // freezing the form would hide data the API serves them.
+    renderWith(isAdmin)
+
+    const name = screen.getByDisplayValue('Test scraper')
+    expect(name).toBeEnabled()
+    expect(screen.getByDisplayValue('https://example.com/reviews')).toBeEnabled()
   })
 })

--- a/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/ScraperEditor.tsx
@@ -10,6 +10,7 @@ import {
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { scrapersApi } from '../../api/scrapersApi'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import {
   FREQUENCY_OPTIONS, DEFAULT_SCRAPER,
 } from './constants'
@@ -20,6 +21,21 @@ import type {
 interface ScraperEditorProps {
   readonly scraper: ScraperConfig | null
   readonly template?: ScraperTemplate | null
+  /**
+   * Whether the current user is an admin. Save reaches `POST /scrapers` — through
+   * `Scrapers.handleSaveScraper` → `saveMutation` → `scrapersApi.saveScraper` — and
+   * that route is admin-gated server-side, so Save is disabled rather than allowed
+   * to fire a 403.
+   *
+   * The gate belongs HERE and not only on the controls that open this editor,
+   * because the failure was silent: `handleSaveScraper` closes the editor
+   * unconditionally and `saveMutation` carries no `onError`, so a non-admin's
+   * discarded edit presented as success. Nothing else in the form is gated — a
+   * non-admin can already read every field through `GET /scrapers`, which stays
+   * deliberately open, so for them this is a viewer and Save was the one control
+   * that lied.
+   */
+  readonly isAdmin: boolean
   readonly onSave: (scraper: ScraperConfig) => void
   readonly onClose: () => void
 }
@@ -59,7 +75,7 @@ function buildInitialConfig(scraper: ScraperConfig | null, template: ScraperTemp
 }
 
 export default function ScraperEditor({
-  scraper, template, onSave, onClose,
+  scraper, template, isAdmin, onSave, onClose,
 }: ScraperEditorProps) {
   const { t } = useTranslation('scrapers')
   const [config, setConfig] = useState<ScraperConfig>(() => buildInitialConfig(scraper, template))
@@ -159,7 +175,7 @@ export default function ScraperEditor({
 
         <div className="p-3 sm:p-4 border-t flex flex-col-reverse sm:flex-row justify-end gap-2">
           <button onClick={onClose} className="btn btn-secondary text-sm">{t('editor.cancel')}</button>
-          <button onClick={handleSave} className="btn btn-primary flex items-center justify-center gap-2 text-sm">
+          <button onClick={handleSave} disabled={!isAdmin} title={isAdmin ? undefined : ADMIN_ONLY_TITLE} className="btn btn-primary flex items-center justify-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed">
             <Save size={16} /> {t('editor.save')}
           </button>
         </div>

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -44,9 +44,14 @@ function getAppConfigPlugins(): PluginManifest[] {
 }
 
 function AppConfigList({
-  plugins, onEditPlugin, onDeleteApp, onRunApp,
+  plugins, isAdmin, onEditPlugin, onDeleteApp, onRunApp,
 }: {
   readonly plugins: PluginManifest[];
+  /** `POST /sources/{source}/run` and `DELETE /integrations/{source}/apps/{id}` are
+   *  admin-gated server-side, so the Run and Delete controls on each card are
+   *  disabled for a non-admin rather than firing a 403. Listing the configs is
+   *  deliberately NOT gated — that is why this list still renders for everyone. */
+  readonly isAdmin: boolean
   readonly onEditPlugin: (p: PluginManifest) => void
   readonly onDeleteApp: (pluginId: string, appId: string) => void;
   readonly onRunApp: (pluginId: string, appIdentifier: string) => void
@@ -172,7 +177,7 @@ function AppConfigList({
       {allApps.map(({
         app, plugin,
       }) => (
-        <AppConfigCard key={`${plugin.id}-${app.id}`} app={app} plugin={plugin}
+        <AppConfigCard key={`${plugin.id}-${app.id}`} app={app} plugin={plugin} isAdmin={isAdmin}
           onEdit={() => onEditPlugin(plugin)} onDelete={() => onDeleteApp(plugin.id, app.id)}
           onRun={() => handleRun(plugin.id, getAppIdentifier(app, plugin.id))}
           isRunning={runningApps.has(`${plugin.id}-${getAppIdentifier(app, plugin.id)}`)}
@@ -219,10 +224,11 @@ function useScraperMutations() {
 }
 
 function ScrapersContent({
-  scrapers, isLoading, appConfigPlugins, syntheticPlugins, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
+  scrapers, isLoading, appConfigPlugins, syntheticPlugins, isAdmin, onRefresh, onShowTemplates, onEdit, onDelete, onRun, onEditPlugin, onDeleteApp, onRunApp, onGenerate,
 }: {
   readonly scrapers: ScraperConfig[]
   readonly isLoading: boolean
+  readonly isAdmin: boolean
   readonly appConfigPlugins: PluginManifest[]
   readonly syntheticPlugins: PluginManifest[]
   readonly onRefresh: () => void
@@ -257,7 +263,7 @@ function ScrapersContent({
       {isLoading ? <div className="flex items-center justify-center py-12"><Loader2 className="animate-spin h-8 w-8 text-blue-500" /></div> : null}
       {!isLoading && (
         <div className="grid gap-4">
-          <AppConfigList plugins={appConfigPlugins} onEditPlugin={onEditPlugin} onDeleteApp={onDeleteApp} onRunApp={onRunApp} />
+          <AppConfigList plugins={appConfigPlugins} isAdmin={isAdmin} onEditPlugin={onEditPlugin} onDeleteApp={onDeleteApp} onRunApp={onRunApp} />
           {scrapers.map((scraper) => (
             <ScraperCard key={scraper.id} scraper={scraper} onEdit={() => onEdit(scraper)} onDelete={() => onDelete(scraper.id)} onRun={() => onRun(scraper.id)} />
           ))}
@@ -380,6 +386,7 @@ export default function Scrapers() {
         isLoading={isLoading}
         appConfigPlugins={appConfigPlugins}
         syntheticPlugins={syntheticPlugins}
+        isAdmin={isAdmin}
         onRefresh={() => void refetch()}
         onShowTemplates={() => setShowTemplates(true)}
         onEdit={setEditingScraper}
@@ -410,6 +417,7 @@ export default function Scrapers() {
 
       {selectedPlugin == null ? null : <PluginConfigModal
         plugin={selectedPlugin}
+        isAdmin={isAdmin}
         onClose={() => setSelectedPlugin(null)}
       />}
 

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -431,7 +431,7 @@ export default function Scrapers() {
         }}
       />}
 
-      {(isCreating || editingScraper != null) ? <ScraperEditor scraper={editingScraper} template={selectedTemplate} onSave={handleSaveScraper} onClose={handleCloseEditor} /> : null}
+      {(isCreating || editingScraper != null) ? <ScraperEditor scraper={editingScraper} template={selectedTemplate} isAdmin={isAdmin} onSave={handleSaveScraper} onClose={handleCloseEditor} /> : null}
 
       {deleteScraperId != null && deleteScraperId !== '' ? <ConfirmModal
         isOpen={deleteScraperId !== ''}

--- a/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
+++ b/voc-datalake/frontend/src/pages/Scrapers/Scrapers.tsx
@@ -265,7 +265,7 @@ function ScrapersContent({
         <div className="grid gap-4">
           <AppConfigList plugins={appConfigPlugins} isAdmin={isAdmin} onEditPlugin={onEditPlugin} onDeleteApp={onDeleteApp} onRunApp={onRunApp} />
           {scrapers.map((scraper) => (
-            <ScraperCard key={scraper.id} scraper={scraper} onEdit={() => onEdit(scraper)} onDelete={() => onDelete(scraper.id)} onRun={() => onRun(scraper.id)} />
+            <ScraperCard key={scraper.id} scraper={scraper} isAdmin={isAdmin} onEdit={() => onEdit(scraper)} onDelete={() => onDelete(scraper.id)} onRun={() => onRun(scraper.id)} />
           ))}
           {syntheticPlugins.length > 0 ? (
             <section aria-label={t('syntheticCard.sectionTitle')}>

--- a/voc-datalake/frontend/src/pages/Scrapers/constants.ts
+++ b/voc-datalake/frontend/src/pages/Scrapers/constants.ts
@@ -5,6 +5,24 @@
 
 import type { ScraperConfig } from '../../api/types'
 
+/**
+ * The `title` on every control this page disables because the route behind it is
+ * admin-gated server-side.
+ *
+ * Declared once, and here rather than in either component, because THREE files
+ * render such a control — `AppConfigComponents` (Run, Delete),
+ * `PluginConfigModal` (Add, Save, Delete, Run, the schedule toggle) and
+ * `GeneratorConfigModal` (Generate, which is where this wording came from). A
+ * per-file literal is how one of them ends up saying something different from the
+ * others about the same 403.
+ *
+ * The routes: `POST`/`DELETE /integrations/{source}/apps`,
+ * `POST /sources/{source}/run` and `PUT /sources/{source}/enable|disable`. These
+ * were NOT gated — a `users`-group caller could write the shared secret and invoke
+ * an ingestor — so the gate is the server's and this is only the explanation.
+ */
+export const ADMIN_ONLY_TITLE = 'Admin access required'
+
 export const FREQUENCY_OPTIONS = [
   {
     value: 0,

--- a/voc-datalake/frontend/src/pages/Scrapers/constants.ts
+++ b/voc-datalake/frontend/src/pages/Scrapers/constants.ts
@@ -5,41 +5,6 @@
 
 import type { ScraperConfig } from '../../api/types'
 
-/**
- * The `title` on every control this page disables because the route behind it is
- * admin-gated server-side.
- *
- * Declared once, and here rather than in either component, because THREE files
- * render such a control — `AppConfigComponents` (Run, Delete),
- * `PluginConfigModal` (Add, Save, Delete, Run, the schedule toggle) and
- * `GeneratorConfigModal` (Generate, which is where this wording came from). A
- * per-file literal is how one of them ends up saying something different from the
- * others about the same 403.
- *
- * The routes: `POST`/`DELETE /integrations/{source}/apps`,
- * `POST /sources/{source}/run` and `PUT /sources/{source}/enable|disable`. These
- * were NOT gated — a `users`-group caller could write the shared secret and invoke
- * an ingestor — so the gate is the server's and this is only the explanation.
- *
- * NOT routed through i18n, and that is a decision rather than an oversight — but a
- * weak one, recorded so the next reader does not have to guess. `GeneratorConfigModal`
- * carried this exact literal before it was consolidated here, so the constant
- * inherits the omission rather than introducing it, and consolidating first means
- * translating it later is a one-line change at a single definition site. The rest of
- * this page IS translated (`PluginConfigModal` has three `useTranslation` calls), so
- * the inconsistency is real: a non-English user gets this one tooltip in English.
- *
- * `frontend/scripts/i18n-check.mjs` cannot catch it either way, so nothing will
- * prompt the fix. Its heuristic reports a DIRECTORY in which no file calls
- * `useTranslation` at all — and `Scrapers/` is mixed, so `AppConfigComponents.tsx`
- * (zero calls) is invisible because the directory as a whole is exempt.
- *
- * Every assertion on this string imports the constant instead of restating it, so
- * translating it is a change to this file alone and does not fail a test whose
- * subject is the admin gate.
- */
-export const ADMIN_ONLY_TITLE = 'Admin access required'
-
 export const FREQUENCY_OPTIONS = [
   {
     value: 0,

--- a/voc-datalake/frontend/src/pages/Scrapers/constants.ts
+++ b/voc-datalake/frontend/src/pages/Scrapers/constants.ts
@@ -20,6 +20,23 @@ import type { ScraperConfig } from '../../api/types'
  * `POST /sources/{source}/run` and `PUT /sources/{source}/enable|disable`. These
  * were NOT gated — a `users`-group caller could write the shared secret and invoke
  * an ingestor — so the gate is the server's and this is only the explanation.
+ *
+ * NOT routed through i18n, and that is a decision rather than an oversight — but a
+ * weak one, recorded so the next reader does not have to guess. `GeneratorConfigModal`
+ * carried this exact literal before it was consolidated here, so the constant
+ * inherits the omission rather than introducing it, and consolidating first means
+ * translating it later is a one-line change at a single definition site. The rest of
+ * this page IS translated (`PluginConfigModal` has three `useTranslation` calls), so
+ * the inconsistency is real: a non-English user gets this one tooltip in English.
+ *
+ * `frontend/scripts/i18n-check.mjs` cannot catch it either way, so nothing will
+ * prompt the fix. Its heuristic reports a DIRECTORY in which no file calls
+ * `useTranslation` at all — and `Scrapers/` is mixed, so `AppConfigComponents.tsx`
+ * (zero calls) is invisible because the directory as a whole is exempt.
+ *
+ * Every assertion on this string imports the constant instead of restating it, so
+ * translating it is a change to this file alone and does not fail a test whose
+ * subject is the admin gate.
  */
 export const ADMIN_ONLY_TITLE = 'Admin access required'
 

--- a/voc-datalake/frontend/src/pages/Settings/SourceCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/SourceCard.test.tsx
@@ -7,6 +7,9 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import SourceCard from './SourceCard'
+// Imported rather than restated: the subject of these assertions is the admin GATE,
+// not the wording, so a later decision to translate the tooltip must not fail them.
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import type { PluginManifest } from '../../plugins/types'
 
 // Mock API
@@ -213,6 +216,61 @@ describe('SourceCard', () => {
       )
 
       expect(screen.getByRole('checkbox')).toBeDisabled()
+    })
+
+    /**
+     * The Enabled toggle calls `PUT /sources/{source}/enable|disable`, which is
+     * admin-gated server-side. It shipped enabled for a non-admin: rendered with
+     * `isAdmin={false}` the checkbox was not disabled and one click issued one
+     * `enableSource` call, whose 403 `toggleEnabled`'s empty `catch` swallows — so
+     * the checkbox silently reverted with no message.
+     *
+     * This is the only UI entrance to those two routes outside the Scrapers modal.
+     * The two cases assert the REQUEST is not issued, not merely that `disabled` is
+     * present, matching `Scrapers/AppConfigComponents.test.tsx`; the surrounding
+     * `isAdmin={true}` cases above are the positive control, so disabling the toggle
+     * for everyone cannot pass.
+     */
+    describe('when the user is not an admin', () => {
+      it('disables the toggle and issues no request when it is clicked', async () => {
+        const user = userEvent.setup()
+
+        render(
+          <SourceCard manifest={mockManifest} apiEndpoint="https://api.example.com" isAdmin={false} />,
+          { wrapper: createWrapper() }
+        )
+
+        const toggle = screen.getByRole('checkbox')
+        expect(toggle).toBeDisabled()
+
+        await user.click(toggle)
+
+        // The observable that matters: no 403 was provoked.
+        expect(mockEnableSource).not.toHaveBeenCalled()
+        expect(mockDisableSource).not.toHaveBeenCalled()
+      })
+
+      it('explains why the toggle is disabled', () => {
+        render(
+          <SourceCard manifest={mockManifest} apiEndpoint="https://api.example.com" isAdmin={false} />,
+          { wrapper: createWrapper() }
+        )
+
+        // On the label, not the input: a disabled input does not reliably surface
+        // its own title on hover.
+        expect(screen.getByTitle(ADMIN_ONLY_TITLE)).toBeInTheDocument()
+      })
+
+      it('leaves the toggle untitled for an admin', () => {
+        /** Non-vacuity for the case above: a title rendered unconditionally would
+         *  satisfy it while telling an admin their access is refused. */
+        render(
+          <SourceCard manifest={mockManifest} apiEndpoint="https://api.example.com" isAdmin={true} />,
+          { wrapper: createWrapper() }
+        )
+
+        expect(screen.queryByTitle(ADMIN_ONLY_TITLE)).not.toBeInTheDocument()
+      })
     })
   })
 

--- a/voc-datalake/frontend/src/pages/Settings/SourceCard.test.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/SourceCard.test.tsx
@@ -343,6 +343,100 @@ describe('SourceCard', () => {
         expect(mockUpdateIntegrationCredentials).toHaveBeenCalledWith('test_source', { api_key: 'secret-key' })
       })
     })
+
+    /**
+     * `Save to Secrets Manager` calls `PUT /integrations/{source}/credentials`,
+     * which `require_admin` gates server-side. Unlike the Enabled toggle above,
+     * that route was ALREADY gated before this PR, so the button has always
+     * behaved this way — measured before the fix, as a non-admin: `disabled` was
+     * false, there was no `title`, one click issued 1 `updateIntegrationCredentials`
+     * call, and because `updateCredentialsMutation` has an `onSuccess` but no
+     * `onError` the 403 rendered nothing at all. The button simply never became
+     * `Saved!`, so a non-admin typed a credential and got no indication it was
+     * refused — the same silent-discard shape `ScraperEditor`'s Save had.
+     *
+     * This was the last ungated UI entrance to an admin-gated route.
+     *
+     * The first case asserts the REQUEST is not issued rather than only that
+     * `disabled` is present, matching the toggle cases above and
+     * `Scrapers/AppConfigComponents.test.tsx`. The `isAdmin={true}` cases above
+     * ('saves credentials when save button is clicked') are its positive control,
+     * so disabling Save for everyone cannot pass.
+     */
+    describe('when the user is not an admin', () => {
+      /** Expand the card and enter a credential, so Save's only remaining
+       *  disable reason is the admin gate — `Object.keys(credentials).length === 0`
+       *  disables it on an untouched form regardless of who is looking. */
+      async function expandAndType(user: ReturnType<typeof userEvent.setup>, isAdmin: boolean) {
+        render(
+          <SourceCard manifest={mockManifest} apiEndpoint="https://api.example.com" isAdmin={isAdmin} />,
+          { wrapper: createWrapper() }
+        )
+        await user.click(screen.getByRole('button', { name: /test source/i }))
+        await user.type(screen.getByPlaceholderText('Enter api key'), 'secret-key')
+        return screen.getByRole('button', { name: /save/i })
+      }
+
+      it('disables save and issues no credential write when it is clicked', async () => {
+        const user = userEvent.setup()
+        const save = await expandAndType(user, false)
+
+        expect(save).toBeDisabled()
+
+        await user.click(save)
+
+        // The observable that matters: no 403 was provoked, so there is no
+        // silently-swallowed failure to present as success.
+        expect(mockUpdateIntegrationCredentials).not.toHaveBeenCalled()
+      })
+
+      it('explains why save is disabled', async () => {
+        const user = userEvent.setup()
+        const save = await expandAndType(user, false)
+
+        expect(save).toHaveAttribute('title', ADMIN_ONLY_TITLE)
+      })
+
+      it('leaves save untitled for an admin', async () => {
+        /** Non-vacuity for the case above: a title rendered unconditionally would
+         *  satisfy it while telling an administrator their access is refused. */
+        const user = userEvent.setup()
+        const save = await expandAndType(user, true)
+
+        expect(save).not.toHaveAttribute('title')
+      })
+
+      it('leaves the credential fields editable and gates only Save', async () => {
+        /** The gate's BOUNDARY, not the gate. A non-admin can already read these
+         *  fields — `GET /integrations/status` is what is admin-gated, not the
+         *  form — so freezing them would hide state rather than protect it. And
+         *  without this, "disable everything for a non-admin" would pass every
+         *  case above.
+         *
+         *  Save is asserted to be the ONLY control carrying the admin-only
+         *  reason, which is what pins the gate's extent. The `Test` button is
+         *  deliberately not asserted as clickable here: `POST /integrations/
+         *  {source}/test` is NOT admin-gated, but the button's `disabled` reads
+         *  `sourceStatus?.configured`, which comes from the admin-only
+         *  integration-status query — so it is already unreachable for a
+         *  non-admin for a reason that predates and is independent of this gate.
+         *  Asserting it enabled here would fail for that unrelated reason and
+         *  misattribute it to the admin gate. */
+        const user = userEvent.setup()
+        mockGetIntegrationStatus.mockResolvedValue({ test_source: { configured: true } })
+        await expandAndType(user, false)
+
+        expect(screen.getByPlaceholderText('Enter api key')).toBeEnabled()
+        expect(screen.getByPlaceholderText('Enter ID')).toBeEnabled()
+
+        // Show/Hide is a local view toggle and stays usable.
+        expect(screen.getByRole('button', { name: /show/i })).toBeEnabled()
+
+        // Save is the only control in this section carrying the admin-only
+        // reason — `Test` calls an ungated route and must not claim otherwise.
+        expect(screen.getByRole('button', { name: /^test$/i })).not.toHaveAttribute('title')
+      })
+    })
   })
 
   describe('Test Integration', () => {

--- a/voc-datalake/frontend/src/pages/Settings/SourceCard.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/SourceCard.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Save, Check, AlertCircle, Loader2, Copy, ExternalLink, Eye, EyeOff, CheckCircle2, Webhook, Key, TestTube } from 'lucide-react'
 import { api } from '../../api/client'
+import { ADMIN_ONLY_TITLE } from '../../constants/admin'
 import S3ImportExplorer from '../../components/S3ImportExplorer'
 import clsx from 'clsx'
 import type { PluginManifest, ConfigField, SetupInfo, WebhookInfo } from '../../plugins/types'
@@ -21,8 +22,11 @@ import type { PluginManifest, ConfigField, SetupInfo, WebhookInfo } from '../../
 interface SourceCardProps {
   readonly manifest: PluginManifest
   readonly apiEndpoint: string
-  /** Whether the current user is an admin. The integration-status query is
-   *  admin-gated server-side; this flag prevents a 403 for non-admin users. */
+  /** Whether the current user is an admin. Two things depend on it: the
+   *  integration-status query is admin-gated server-side, so a non-admin does not
+   *  issue it (avoiding a 403), and `PUT /sources/{source}/enable|disable` behind
+   *  the Enabled toggle is admin-gated too, so the toggle is disabled rather than
+   *  firing a request that fails. */
   readonly isAdmin: boolean
 }
 
@@ -118,6 +122,7 @@ export default function SourceCard({ manifest, apiEndpoint, isAdmin }: SourceCar
         sourceStatus={sourceStatus}
         serverStatus={serverStatus}
         apiEndpoint={apiEndpoint}
+        isAdmin={isAdmin}
         isExpanded={isExpanded}
         onToggleExpand={() => setIsExpanded(!isExpanded)}
         onToggleEnabled={toggleEnabled}
@@ -176,12 +181,17 @@ interface SourceCardHeaderProps {
   readonly sourceStatus: { configured?: boolean } | undefined
   readonly serverStatus: { enabled: boolean; loading?: boolean }
   readonly apiEndpoint: string
+  /** `PUT /sources/{source}/enable|disable` is admin-gated server-side, so the
+   *  toggle below is disabled for a non-admin rather than issuing a request whose
+   *  403 `toggleEnabled`'s empty `catch` would swallow — leaving the checkbox to
+   *  revert with no explanation. The server is the boundary; this is the reason. */
+  readonly isAdmin: boolean
   readonly isExpanded: boolean
   readonly onToggleExpand: () => void
   readonly onToggleEnabled: (enabled: boolean) => void
 }
 
-function SourceCardHeader({ manifest, sourceStatus, serverStatus, apiEndpoint, isExpanded, onToggleExpand, onToggleEnabled }: SourceCardHeaderProps) {
+function SourceCardHeader({ manifest, sourceStatus, serverStatus, apiEndpoint, isAdmin, isExpanded, onToggleExpand, onToggleEnabled }: SourceCardHeaderProps) {
   return (
     <button
       onClick={onToggleExpand}
@@ -200,7 +210,11 @@ function SourceCardHeader({ manifest, sourceStatus, serverStatus, apiEndpoint, i
             <CheckCircle2 size={14} /> <span className="hidden xs:inline">Connected</span>
           </span>
         )}
-        <label className="flex items-center gap-1.5 sm:gap-2" onClick={(e) => e.stopPropagation()}>
+        <label
+          className="flex items-center gap-1.5 sm:gap-2"
+          title={isAdmin ? undefined : ADMIN_ONLY_TITLE}
+          onClick={(e) => e.stopPropagation()}
+        >
           {serverStatus.loading ? (
             <Loader2 size={16} className="animate-spin text-blue-600" />
           ) : (
@@ -208,8 +222,8 @@ function SourceCardHeader({ manifest, sourceStatus, serverStatus, apiEndpoint, i
               type="checkbox"
               checked={serverStatus.enabled}
               onChange={(e) => onToggleEnabled(e.target.checked)}
-              disabled={!apiEndpoint}
-              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
+              disabled={!apiEndpoint || !isAdmin}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             />
           )}
           <span className="text-xs sm:text-sm text-gray-600">{serverStatus.enabled ? 'Enabled' : 'Disabled'}</span>

--- a/voc-datalake/frontend/src/pages/Settings/SourceCard.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/SourceCard.tsx
@@ -22,11 +22,21 @@ import type { PluginManifest, ConfigField, SetupInfo, WebhookInfo } from '../../
 interface SourceCardProps {
   readonly manifest: PluginManifest
   readonly apiEndpoint: string
-  /** Whether the current user is an admin. Two things depend on it: the
-   *  integration-status query is admin-gated server-side, so a non-admin does not
-   *  issue it (avoiding a 403), and `PUT /sources/{source}/enable|disable` behind
-   *  the Enabled toggle is admin-gated too, so the toggle is disabled rather than
-   *  firing a request that fails. */
+  /** Whether the current user is an admin. THREE things depend on it, all three
+   *  because the route behind them is admin-gated server-side:
+   *
+   *    1. the integration-status query (`GET /integrations/status`) is not issued
+   *       at all by a non-admin, avoiding a 403;
+   *    2. the Enabled toggle (`PUT /sources/{source}/enable|disable`) is disabled
+   *       rather than firing a request that fails;
+   *    3. `Save to Secrets Manager` in `CredentialsSection`
+   *       (`PUT /integrations/{source}/credentials`) likewise.
+   *
+   *  (3) is the worst of the three to leave ungated and was the last one found:
+   *  `updateCredentialsMutation` has an `onSuccess` but no `onError`, so its 403
+   *  rendered nothing — a non-admin typed a credential, clicked Save, and got no
+   *  indication it had been refused. A disabled control fails visibly; that one
+   *  failed silently. */
   readonly isAdmin: boolean
 }
 
@@ -50,6 +60,26 @@ function getSaveButtonIcon(isPending: boolean, saveSuccess: boolean): React.Reac
 function getSaveButtonText(saveSuccess: boolean): { full: string; short: string } {
   if (saveSuccess) return { full: 'Saved!', short: 'Saved!' }
   return { full: 'Save to Secrets Manager', short: 'Save' }
+}
+
+/**
+ * Whether `Save to Secrets Manager` is available, and if not, whether to say why.
+ *
+ * A helper rather than two expressions inline, so the admin reason and the two
+ * ordinary ones are decided in one place: a `title` that outlived its condition
+ * would tell a non-admin their access was refused while the button worked, or the
+ * reverse. (It also keeps `CredentialsSection` under the complexity limit.)
+ *
+ * `title` is set ONLY for the admin case. Pending and empty-form are transient and
+ * evident from the form itself; the 403 behind `PUT /integrations/{source}/credentials`
+ * is neither, and is the one a user cannot otherwise discover — that mutation has no
+ * `onError`, so before this gate the refusal rendered nothing at all.
+ */
+function getSaveButtonState(
+  isPending: boolean, hasCredentials: boolean, isAdmin: boolean
+): { disabled: boolean; title?: string } {
+  if (!isAdmin) return { disabled: true, title: ADMIN_ONLY_TITLE }
+  return { disabled: isPending || !hasCredentials }
 }
 
 // ============================================
@@ -147,6 +177,7 @@ export default function SourceCard({ manifest, apiEndpoint, isAdmin }: SourceCar
               showSecrets={showSecrets}
               sourceStatus={sourceStatus}
               saveSuccess={saveSuccess}
+              isAdmin={isAdmin}
               testMutation={testMutation}
               updateCredentialsMutation={updateCredentialsMutation}
               onCredentialsChange={setCredentials}
@@ -285,6 +316,11 @@ interface CredentialsSectionProps {
   readonly showSecrets: boolean
   readonly sourceStatus: { configured?: boolean } | undefined
   readonly saveSuccess: boolean
+  /** `PUT /integrations/{source}/credentials` behind Save is admin-gated
+   *  server-side, so Save is disabled for a non-admin rather than issuing a
+   *  request that 403s. Only Save: the fields stay editable (a non-admin can
+   *  already read them) and `POST /integrations/{source}/test` is not gated. */
+  readonly isAdmin: boolean
   readonly testMutation: { isPending: boolean; data?: { success: boolean; message?: string; error?: string }; mutate: () => void }
   readonly updateCredentialsMutation: { isPending: boolean; mutate: (creds: Record<string, string>) => void }
   readonly onCredentialsChange: (creds: Record<string, string>) => void
@@ -292,12 +328,15 @@ interface CredentialsSectionProps {
 }
 
 function CredentialsSection({
-  fields, credentials, showSecrets, sourceStatus, saveSuccess, testMutation, updateCredentialsMutation,
+  fields, credentials, showSecrets, sourceStatus, saveSuccess, isAdmin, testMutation, updateCredentialsMutation,
   onCredentialsChange, onToggleSecrets
 }: CredentialsSectionProps) {
   const saveIcon = getSaveButtonIcon(updateCredentialsMutation.isPending, saveSuccess)
   const saveText = getSaveButtonText(saveSuccess)
   const saveButtonClass = saveSuccess ? 'bg-green-600 text-white' : 'btn-primary'
+  const saveState = getSaveButtonState(
+    updateCredentialsMutation.isPending, Object.keys(credentials).length > 0, isAdmin
+  )
 
   return (
     <div>
@@ -324,7 +363,8 @@ function CredentialsSection({
           </button>
           <button
             onClick={() => updateCredentialsMutation.mutate(credentials)}
-            disabled={updateCredentialsMutation.isPending || Object.keys(credentials).length === 0}
+            disabled={saveState.disabled}
+            title={saveState.title}
             className={clsx('btn flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2', saveButtonClass)}
           >
             {saveIcon}

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -227,6 +227,10 @@ def _is_addressable_source(source: str) -> bool:
 
     Inherits the fail-open on an unavailable `PLUGIN_SECRET_DEFAULTS`, because
     `_validate_source_is_a_known_plugin` returns early in that state.
+
+    Applies to the `?sources=` branch ONLY. `?run_status=` raises on the same
+    `manual_import` this accepts, deliberately: see the comment at that branch for
+    why one identifier gets two answers from one route.
     """
     try:
         _validate_source_parameter(source)
@@ -804,6 +808,20 @@ def get_sources_status():
         # source, so a 400 names the actual problem instead of reporting an empty
         # status that reads as "never run". Every caller passes a real `plugin.id`
         # (GeneratorConfigModal, SyntheticSourceCard, Scrapers).
+        #
+        # So the two branches of this ONE route answer `manual_import` differently
+        # — 400 here, `{'enabled': False, 'exists': False}` there — and that
+        # disagreement is deliberate, because the two branches report different
+        # things about it. This one reports a run record, and only `run_source` and
+        # `BaseIngestor` write a `SOURCE_RUN#` partition: `manual_import` has no
+        # ingestor, so `SOURCE_RUN#manual_import` can never exist and a 400 naming
+        # the reason beats a 200 saying 'never_run' about a source that can never
+        # run. The batch branch reports SCHEDULE state, where "no rule exists" is a
+        # real answer to a real question, which is why it must not raise — see
+        # `_is_addressable_source`, whose docstring argues that half.
+        #
+        # Pinned in BOTH directions by TestTheQueryStringSourceRouteIsValidated, so
+        # neither answer can flip silently.
         _validate_source_parameter(run_status_source)
         return _get_source_run_status(run_status_source)
 

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -73,6 +73,13 @@ app = create_api_resolver()
 # parameter — see `_validate_source_is_a_known_plugin` — because form validation
 # alone left a real cross-plugin credential write open.
 #
+# That allowlist applies to EVERY route taking a `<source>` path parameter, via
+# `_validate_source_parameter`. It was first wired into the two credentials routes
+# only, which left five routes turning the same request-supplied value into a
+# Secrets Manager key, an ingestor function name or an EventBridge rule name with
+# no check at all — an asymmetry that read as deliberate scoping but was just
+# where the trail of one reported bug ended.
+#
 # The character class itself lives in `shared/plugin_identity.py`, NOT here: the
 # READ side (`plugins/_shared/plugin_secrets.py`) has to validate the same shape
 # on the plugin identity it turns into a namespace prefix, and since issue #251 a
@@ -138,8 +145,9 @@ def _validate_source_is_a_known_plugin(source: str) -> None:
     environment variable break credential management entirely. The form check
     still applies in that case, which is the state this route shipped in.
 
-    Admin-only either way (`require_admin`), so this narrows an authenticated
-    administrator's blast radius rather than an anonymous one.
+    Applied through `_validate_source_parameter` on every route that turns
+    `<source>` into a secret key, a Lambda function name or an EventBridge rule
+    name — not just the two credentials routes it was first written for.
     """
     known = _plugin_secret_defaults()
     if not known:
@@ -154,6 +162,26 @@ def _validate_source_is_a_known_plugin(source: str) -> None:
         raise ValidationError(
             f"Unknown source identifier {source[:40]!r}: it is not a configured plugin."
         )
+
+
+def _validate_source_parameter(source: str) -> None:
+    """Both source checks, for every route that takes a `<source>` path parameter.
+
+    ONE helper rather than two calls per route, because the asymmetry this closed
+    was exactly that: the two checks were wired into the credentials routes and
+    into nothing else, while five other routes turned the same request-supplied
+    `<source>` into a resource name. Every one of them addresses something derived
+    from it — a Secrets Manager key (`_get_app_configs_key`), an ingestor function
+    name (`_build_ingestor_function_name`) or an EventBridge rule name
+    (`_build_rule_name`) — so there is no route on which "is this a real plugin?"
+    is the wrong question, and a single call site per route is one thing to
+    remember rather than two.
+
+    Order matters: the form check first, so a value that is not even a plausible
+    identifier is reported as malformed rather than as unknown.
+    """
+    _validate_source(source)
+    _validate_source_is_a_known_plugin(source)
 
 
 # Stored strings that carry no configuration, whatever key they sit under.
@@ -343,12 +371,11 @@ def get_credentials(source: str):
 
     # Validate source before building the namespace prefix.  Without this
     # a caller sending source='foo_bar' + key='baz' would reach the same
-    # secret key as source='foo' + key='bar_baz' (namespace collision).
-    _validate_source(source)
-    # And the form check is not sufficient: the colliding value is well-formed.
-    # source='app_reviews' + key='ios_app_id' addresses app_reviews_ios's
-    # namespace, so the source must be a plugin that actually exists.
-    _validate_source_is_a_known_plugin(source)
+    # secret key as source='foo' + key='bar_baz' (namespace collision) — and the
+    # form check alone is not sufficient, because the colliding value is
+    # well-formed: source='app_reviews' + key='ios_app_id' addresses
+    # app_reviews_ios's namespace.
+    _validate_source_parameter(source)
 
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')
@@ -407,15 +434,11 @@ def update_credentials(source: str):
     """
     require_admin(app.current_event.raw_event)
 
-    # Validate source before building the namespace prefix.  Without this
-    # a caller sending source='foo_bar' + key='baz' would reach the same
-    # secret key as source='foo' + key='bar_baz' (namespace collision).
-    _validate_source(source)
-    # The write is the dangerous direction: without this, an admin could inject a
-    # value into another plugin's namespace (source='app_reviews' + key
-    # 'ios_app_id' → app_reviews_ios_app_id) and that plugin's next run would use
-    # it as its own credential.
-    _validate_source_is_a_known_plugin(source)
+    # The write is the dangerous direction: without the allowlist half of this,
+    # a caller could inject a value into another plugin's namespace
+    # (source='app_reviews' + key 'ios_app_id' → app_reviews_ios_app_id) and that
+    # plugin's next run would use it as its own credential.
+    _validate_source_parameter(source)
 
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')
@@ -480,7 +503,19 @@ def _get_app_configs_key(source: str) -> str:
 @app.get("/integrations/<source>/apps")
 @tracer.capture_method
 def list_app_configs(source: str):
-    """List all app configurations for a multi-instance plugin."""
+    """List all app configurations for a multi-instance plugin.
+
+    NOT admin-gated, unlike the two write routes below. The Scrapers page renders
+    this list for every authenticated user, and an app config holds a public app
+    store id and a display name — not a credential. The write routes are the ones
+    that reach the shared secret with caller-supplied content.
+    """
+    # Both source checks even though APP_CONFIG_PLUGINS is narrower and runs
+    # below: `source` reaches `_get_app_configs_key` and becomes a Secrets Manager
+    # key, so it goes through the same validation as every other route that does
+    # that. The two are not redundant in the direction that matters — a value can
+    # be a real plugin id and still not support app configs.
+    _validate_source_parameter(source)
     if source not in APP_CONFIG_PLUGINS:
         raise ValidationError(f'Source {source} does not support multiple app configs')
     if not SECRETS_ARN:
@@ -502,7 +537,16 @@ def list_app_configs(source: str):
 @app.post("/integrations/<source>/apps")
 @tracer.capture_method
 def save_app_config(source: str):
-    """Save (create or update) an app configuration for a multi-instance plugin."""
+    """Save (create or update) an app configuration for a multi-instance plugin.
+
+    Admin-gated, matching PUT /integrations/<source>/credentials: this route calls
+    `put_secret_json` on the SAME shared API-credentials secret, with content the
+    caller supplied. Gating the credentials route while leaving this one open made
+    the boundary depend on which key a write happened to land under, and a
+    `users`-group caller could write `<source>_configs` on it — measured, 200.
+    """
+    require_admin(app.current_event.raw_event)
+    _validate_source_parameter(source)
     if source not in APP_CONFIG_PLUGINS:
         raise ValidationError(f'Source {source} does not support multiple app configs')
     if not SECRETS_ARN:
@@ -545,7 +589,15 @@ def save_app_config(source: str):
 @app.delete("/integrations/<source>/apps/<app_id>")
 @tracer.capture_method
 def delete_app_config(source: str, app_id: str):
-    """Delete an app configuration from a multi-instance plugin."""
+    """Delete an app configuration from a multi-instance plugin.
+
+    Admin-gated for the same reason as the POST above — it writes the shared
+    secret — and additionally because it is destructive: it rewrites
+    `<source>_configs` with one entry removed, which stops that app being
+    ingested.
+    """
+    require_admin(app.current_event.raw_event)
+    _validate_source_parameter(source)
     if source not in APP_CONFIG_PLUGINS:
         raise ValidationError(f'Source {source} does not support multiple app configs')
     if not SECRETS_ARN:
@@ -571,13 +623,28 @@ def delete_app_config(source: str, app_id: str):
 @tracer.capture_method
 def run_source(source: str):
     """Manually trigger a data source ingestor Lambda.
-    
+
     Optionally accepts a JSON body with `app_id` to run a single app
     config instead of all configs for the source.
+
+    Admin-gated: this invokes a Lambda that fetches from a third-party API and
+    writes to the data lake, so every call costs money and consumes whatever rate
+    limit that API grants. Ungated, a `users`-group caller could invoke it in a
+    loop — measured, 200 with a real `lambda:Invoke` and a `SOURCE_RUN#` row
+    written. `enable_source`/`disable_source` are gated for the mirror reason:
+    disabling a schedule silently stops ingestion.
+
+    `source` is also validated, which it was not: it is interpolated straight into
+    `_build_ingestor_function_name`, so an arbitrary value both named a function
+    to invoke and wrote a `SOURCE_RUN#<source>` partition that nothing ever reads
+    or expires.
     """
     from datetime import datetime, timezone
 
     from shared.tables import get_aggregates_table
+
+    require_admin(app.current_event.raw_event)
+    _validate_source_parameter(source)
 
     function_name = _build_ingestor_function_name(source)
 
@@ -695,7 +762,15 @@ def get_sources_status():
 @app.put("/sources/<source>/enable")
 @tracer.capture_method
 def enable_source(source: str):
-    """Enable a data source schedule."""
+    """Enable a data source schedule.
+
+    Admin-gated and validated — see `run_source`. `source` reaches
+    `_build_rule_name`, so an arbitrary value named an EventBridge rule to
+    enable.
+    """
+    require_admin(app.current_event.raw_event)
+    _validate_source_parameter(source)
+
     rule_name = _build_rule_name(source)
     try:
         events_client.enable_rule(Name=rule_name)
@@ -708,7 +783,15 @@ def enable_source(source: str):
 @app.put("/sources/<source>/disable")
 @tracer.capture_method
 def disable_source(source: str):
-    """Disable a data source schedule."""
+    """Disable a data source schedule.
+
+    Admin-gated and validated — see `run_source`. This is the direction that
+    silently stops ingestion, so leaving it open was a denial-of-data any
+    authenticated user could cause.
+    """
+    require_admin(app.current_event.raw_event)
+    _validate_source_parameter(source)
+
     rule_name = _build_rule_name(source)
     try:
         events_client.disable_rule(Name=rule_name)

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -226,7 +226,9 @@ def _is_addressable_source(source: str) -> bool:
     value stops reaching EventBridge and stops having a rule name reflected back.
 
     Inherits the fail-open on an unavailable `PLUGIN_SECRET_DEFAULTS`, because
-    `_validate_source_is_a_known_plugin` returns early in that state.
+    `_validate_source_is_a_known_plugin` returns early in that state — so in that
+    state this accepts everything the other branch does too, and the deliberate
+    disagreement below is a property of the CONFIGURED state only.
 
     Applies to the `?sources=` branch ONLY. `?run_status=` raises on the same
     `manual_import` this accepts, deliberately: see the comment at that branch for
@@ -813,12 +815,30 @@ def get_sources_status():
         # — 400 here, `{'enabled': False, 'exists': False}` there — and that
         # disagreement is deliberate, because the two branches report different
         # things about it. This one reports a run record, and only `run_source` and
-        # `BaseIngestor` write a `SOURCE_RUN#` partition: `manual_import` has no
-        # ingestor, so `SOURCE_RUN#manual_import` can never exist and a 400 naming
-        # the reason beats a 200 saying 'never_run' about a source that can never
-        # run. The batch branch reports SCHEDULE state, where "no rule exists" is a
-        # real answer to a real question, which is why it must not raise — see
-        # `_is_addressable_source`, whose docstring argues that half.
+        # `BaseIngestor` write a `SOURCE_RUN#` partition: no CURRENT path writes
+        # `SOURCE_RUN#manual_import` while the allowlist is available, since
+        # `manual_import` has no ingestor and `run_source` validates against the
+        # same allowlist. So on a clean deployment that partition is empty, and a
+        # 400 naming the reason beats a 200 saying 'never_run' about a source with
+        # nothing to report. The batch branch reports SCHEDULE state, where "no rule
+        # exists" is a real answer to a real question, which is why it must not
+        # raise — see `_is_addressable_source`, whose docstring argues that half.
+        #
+        # Two states this stops short of, so no reader concludes such a row is
+        # IMPOSSIBLE and skips handling one (`_get_source_run_status` reports
+        # whatever it finds):
+        #
+        #   * neither guard is retroactive. `run_source` on the pre-guard base had
+        #     neither `require_admin` nor this validation — measured, a `users`
+        #     caller got 200 and wrote `SOURCE_RUN#manual_import` — so a deployment
+        #     upgraded from that build may hold a stale row today. Same limitation
+        #     the namespace guards in `plugin-loader.ts` carry for secret keys: they
+        #     close the entrances, not what is already stored.
+        #   * with PLUGIN_SECRET_DEFAULTS unavailable the documented fail-open
+        #     admits `manual_import` on BOTH branches, so the asymmetry described
+        #     above disappears and an admin can write that partition again. That is
+        #     consistent — `_is_addressable_source` inherits the same fail-open —
+        #     but it means this whole comment describes the CONFIGURED state.
         #
         # Pinned in BOTH directions by TestTheQueryStringSourceRouteIsValidated, so
         # neither answer can flip silently.

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -87,9 +87,23 @@ app = create_api_resolver()
 # copies of the rule is how a value this path accepts becomes one that path
 # refuses. `shared/` is the only directory both bundles carry.
 #
-# The one rule that stays here, because only a write has a request to bound:
+# The rules that stay here, because they bound a REQUEST rather than validate a
+# value — there is no read side to share them with:
 #   • At most MAX_CREDENTIAL_KEYS_PER_REQUEST keys per write request.
+#   • At most MAX_SOURCES_PER_STATUS_REQUEST distinct sources per status request.
 MAX_CREDENTIAL_KEYS_PER_REQUEST = 20
+
+# `GET /sources/status?sources=a,b,c` issues one `describe_rule` per element, so
+# unlike every other read in this handler its AWS call count is chosen by the
+# caller. A write is not the only thing with a request to bound: a read that fans
+# out per list element has one too, and this is the only such read here.
+#
+# Sized well above the realistic plugin count (five manifests today, and the
+# route's own default list is three) so it bounds abuse rather than use — the UI
+# asks for at most one source at a time (`api.getSourcesStatus([plugin.id])`).
+# Applied AFTER de-duplication, because the bound that matters is the number of
+# rules actually described, not the length of a string the caller typed.
+MAX_SOURCES_PER_STATUS_REQUEST = 50
 
 
 def _validate_credential_key(key: str) -> None:
@@ -775,6 +789,11 @@ def get_sources_status():
     before: `SourceCard.tsx` and `PluginConfigModal.tsx` both read it for ordinary
     users, and gating it needs the same read/write reasoning applied to
     `list_app_configs`. Validating it closes the arbitrary-rule-enumeration half.
+
+    Validation bounds WHICH rules may be described; it does not bound how MANY
+    times, so the batch branch also de-duplicates and caps its list — see
+    `MAX_SOURCES_PER_STATUS_REQUEST`. This is the only read in the handler whose
+    AWS call count is chosen by the caller.
     """
     params = app.current_event.query_string_parameters or {}
 
@@ -792,9 +811,30 @@ def get_sources_status():
 
     # Use requested sources or fall back to defaults
     if sources_param:
-        sources = [s.strip() for s in sources_param.split(',') if s.strip()]
+        # `dict.fromkeys` rather than `set`: it de-duplicates while KEEPING first
+        # appearance order, and the response is a dict the caller reads by name,
+        # so the order is part of what a JSON consumer sees.
+        #
+        # Unobservable to any caller, and that is the point — `status` is keyed by
+        # source name, so a repeat overwrote the same entry and could not change
+        # the response, while still costing one `describe_rule` each.
+        # `?sources=` with one valid name repeated 500 times measured 200 / 500
+        # calls / 1 key in the body. `DescribeRule` is throttled per account, so
+        # those 499 spare calls came out of a budget the rest of the stack shares.
+        sources = list(dict.fromkeys(
+            s.strip() for s in sources_param.split(',') if s.strip()
+        ))
     else:
         sources = ['webscraper', 'manual_import', 's3_import']
+
+    # Raises, unlike the per-source check below: this is a malformed REQUEST, not
+    # an unaddressable source, so there is no per-entry answer to report and no
+    # partial response worth returning.
+    if len(sources) > MAX_SOURCES_PER_STATUS_REQUEST:
+        raise ValidationError(
+            f"Too many sources in request: {len(sources)} exceeds the limit of "
+            f"{MAX_SOURCES_PER_STATUS_REQUEST}."
+        )
 
     status = {}
     for source in sources:

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -5,7 +5,6 @@ Manages API credentials and data source schedules.
 
 import json
 import os
-import re
 from functools import lru_cache
 from typing import Any
 
@@ -18,6 +17,7 @@ from shared.exceptions import (
     ValidationError,
 )
 from shared.logging import logger, tracer
+from shared.plugin_identity import PLUGIN_IDENTIFIER_RULES, is_valid_plugin_identifier
 
 secretsmanager = get_secrets_client()
 events_client = boto3.client("events")
@@ -71,34 +71,28 @@ app = create_api_resolver()
 # CDK synth time, not at runtime).  A manifest-derived allowlist is the
 # stronger fix and is tracked as a follow-up.
 #
-# Rules:
-#   • Only lowercase letters, digits, and underscores (no dots, slashes,
-#     hyphens, or other characters that could escape or re-enter a namespace).
-#   • Length: 1–64 characters.
-#   • May not start or end with an underscore (prevents confusion with
-#     namespace prefixes / internal keys).
-#   • At most MAX_CREDENTIAL_KEYS_PER_REQUEST keys per write request.
+# The character class itself lives in `shared/plugin_identity.py`, NOT here: the
+# READ side (`plugins/_shared/plugin_secrets.py`) has to validate the same shape
+# on the plugin identity it turns into a namespace prefix, and since issue #251 a
+# namespace miss there is a hard failure rather than a silent widening. Two
+# copies of the rule is how a value this path accepts becomes one that path
+# refuses. `shared/` is the only directory both bundles carry.
 #
-# Single alternative: optional inner body of up to 62 chars means the total
-# length is 1 (just the initial char) or 2-64 (initial + inner + final).
-# re.fullmatch is used in _validate_credential_key so anchors are not needed.
-_CREDENTIAL_KEY_RE = re.compile(r'[a-z0-9](?:[a-z0-9_]{0,62}[a-z0-9])?')
+# The one rule that stays here, because only a write has a request to bound:
+#   • At most MAX_CREDENTIAL_KEYS_PER_REQUEST keys per write request.
 MAX_CREDENTIAL_KEYS_PER_REQUEST = 20
 
 
 def _validate_credential_key(key: str) -> None:
     """Raise ValidationError if *key* does not conform to the allowed form.
 
-    Uses re.fullmatch so no explicit anchors are needed in the pattern.
     The key preview in the error message is truncated to avoid reflecting
     unbounded caller input back in the response.
     """
-    if not isinstance(key, str) or not _CREDENTIAL_KEY_RE.fullmatch(key):
+    if not is_valid_plugin_identifier(key):
         preview = repr(key[:40]) if isinstance(key, str) else repr(key)
         raise ValidationError(
-            f"Invalid credential key {preview}: keys must contain only lowercase "
-            "letters, digits, and underscores, must start and end with a "
-            "letter or digit, and must be 1–64 characters long."
+            f"Invalid credential key {preview}: keys {PLUGIN_IDENTIFIER_RULES}."
         )
 
 
@@ -110,12 +104,10 @@ def _validate_source(source: str) -> None:
     'source identifier' rather than 'credential key' so it is clear which
     input parameter is invalid when debugging a 400.
     """
-    if not isinstance(source, str) or not _CREDENTIAL_KEY_RE.fullmatch(source):
+    if not is_valid_plugin_identifier(source):
         preview = repr(source[:40]) if isinstance(source, str) else repr(source)
         raise ValidationError(
-            f"Invalid source identifier {preview}: source must contain only "
-            "lowercase letters, digits, and underscores, must start and end "
-            "with a letter or digit, and must be 1–64 characters long."
+            f"Invalid source identifier {preview}: source {PLUGIN_IDENTIFIER_RULES}."
         )
 
 

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -184,6 +184,43 @@ def _validate_source_parameter(source: str) -> None:
     _validate_source_is_a_known_plugin(source)
 
 
+def _is_addressable_source(source: str) -> bool:
+    """The same rule as `_validate_source_parameter`, as a predicate.
+
+    Calls it rather than restating the rule, because a second copy of "is this a
+    real plugin?" is how the read side comes to accept a value the write side
+    refuses — the drift that put the character class in `shared/plugin_identity.py`
+    in the first place.
+
+    Needed because ONE route cannot raise. `GET /sources/status?sources=a,b,c`
+    answers about several sources at once, so raising on the first unknown name
+    would fail the whole response rather than that one entry — and its own default
+    list is `['webscraper', 'manual_import', 's3_import']`, where `manual_import`
+    is a deliberate non-plugin: it is a legitimate `source_platform` (it appears in
+    `KNOWN_SOURCES` in `plugins/_shared/schemas.py`) with no manifest, so it is
+    absent from `PLUGIN_SECRET_DEFAULTS` and a raising guard would answer 400 to
+    the argument-less request `SourceCard.tsx` issues on every Settings render —
+    for admins too.
+
+    Skipping the EventBridge call for a source this rejects is OUTPUT-IDENTICAL
+    for every input the UI sends. A schedule rule is only ever created per plugin
+    (`scheduleRuleName` in `lib/stacks/ingestion-stack.ts` is built from
+    `plugin.id`), so for every value rejected here `describe_rule` could only have
+    raised `ResourceNotFoundException`, which the route already answers with
+    `{'enabled': False, 'exists': False}` — exactly what the default request
+    returns today for all three of its sources. What changes is that an arbitrary
+    value stops reaching EventBridge and stops having a rule name reflected back.
+
+    Inherits the fail-open on an unavailable `PLUGIN_SECRET_DEFAULTS`, because
+    `_validate_source_is_a_known_plugin` returns early in that state.
+    """
+    try:
+        _validate_source_parameter(source)
+    except ValidationError:
+        return False
+    return True
+
+
 # Stored strings that carry no configuration, whatever key they sit under.
 # '[]' and '{}' matter because save_app_config() below writes `<source>_configs`
 # at RUNTIME for the multi-instance app plugins, so no manifest declares those
@@ -723,24 +760,50 @@ def _get_source_run_status(source: str):
 @app.get("/sources/status")
 @tracer.capture_method
 def get_sources_status():
-    """Get status of all data source schedules, or run status for a specific source."""
+    """Get status of all data source schedules, or run status for a specific source.
+
+    The only route taking a source from the QUERY STRING rather than a `<source>`
+    path parameter, which is why it is outside the path-parameter guard the other
+    seven share and validates its sources here instead. Both branches derive a
+    resource from the value — `_build_rule_name` for an EventBridge rule this
+    `describe_rule`s, and a `SOURCE_RUN#` partition key for `_get_source_run_status`
+    — so "is this a real plugin?" is as much the question here as on
+    `enable`/`disable`, of which this is the read-side mirror.
+
+    The two branches answer it differently because only one of them can raise; see
+    `_is_addressable_source`. Open to any authenticated user, deliberately and as
+    before: `SourceCard.tsx` and `PluginConfigModal.tsx` both read it for ordinary
+    users, and gating it needs the same read/write reasoning applied to
+    `list_app_configs`. Validating it closes the arbitrary-rule-enumeration half.
+    """
     params = app.current_event.query_string_parameters or {}
-    
+
     # If source param provided, return run status for that source
     run_status_source = params.get('run_status')
     if run_status_source:
+        # RAISES here, unlike the batch branch below: this answers about a single
+        # source, so a 400 names the actual problem instead of reporting an empty
+        # status that reads as "never run". Every caller passes a real `plugin.id`
+        # (GeneratorConfigModal, SyntheticSourceCard, Scrapers).
+        _validate_source_parameter(run_status_source)
         return _get_source_run_status(run_status_source)
-    
+
     sources_param = params.get('sources', '')
-    
+
     # Use requested sources or fall back to defaults
     if sources_param:
         sources = [s.strip() for s in sources_param.split(',') if s.strip()]
     else:
         sources = ['webscraper', 'manual_import', 's3_import']
-    
+
     status = {}
     for source in sources:
+        if not _is_addressable_source(source):
+            # No rule can exist for a source that is not a plugin, so this is the
+            # answer `describe_rule` would have given — see `_is_addressable_source`
+            # for why that makes it output-identical, and why it must not raise.
+            status[source] = {'enabled': False, 'exists': False}
+            continue
         rule_name = _build_rule_name(source)
         try:
             response = events_client.describe_rule(Name=rule_name)

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -351,7 +351,7 @@ def get_integration_status():
         status = {}
         for source, seeded in _plugin_secret_defaults().items():
             prefix = f"{source}_"
-            # ponytail: plain prefix match, so if one plugin id were ever a
+            # CAVEAT: plain prefix match, so if one plugin id were ever a
             # prefix of another ('app_reviews' alongside 'app_reviews_ios') the
             # shorter one would also list the longer one's keys. No current id
             # pair does this, and `loadPlugins` now refuses such a manifest pair at

--- a/voc-datalake/lambda/api/integrations_handler.py
+++ b/voc-datalake/lambda/api/integrations_handler.py
@@ -67,9 +67,11 @@ app = create_api_resolver()
 # Credential key validation
 #
 # We validate the *form* of each key rather than an enumerated per-source
-# list, because this Lambda cannot see plugin manifests (they are resolved at
-# CDK synth time, not at runtime).  A manifest-derived allowlist is the
-# stronger fix and is tracked as a follow-up.
+# list, because this Lambda cannot see plugin manifests directly (they are
+# resolved at CDK synth time, not at runtime).  The manifest-derived allowlist
+# that used to be described here as a follow-up now exists for the `source`
+# parameter — see `_validate_source_is_a_known_plugin` — because form validation
+# alone left a real cross-plugin credential write open.
 #
 # The character class itself lives in `shared/plugin_identity.py`, NOT here: the
 # READ side (`plugins/_shared/plugin_secrets.py`) has to validate the same shape
@@ -108,6 +110,49 @@ def _validate_source(source: str) -> None:
         preview = repr(source[:40]) if isinstance(source, str) else repr(source)
         raise ValidationError(
             f"Invalid source identifier {preview}: source {PLUGIN_IDENTIFIER_RULES}."
+        )
+
+
+def _validate_source_is_a_known_plugin(source: str) -> None:
+    """Raise ValidationError unless *source* is a plugin CDK told us about.
+
+    The form check above cannot close the namespace-collision gap, because the
+    colliding value is WELL-FORMED. `source` becomes a key prefix, so
+    `source='app_reviews'` + key `'ios_app_id'` writes `app_reviews_ios_app_id`
+    — which `app_reviews_ios`'s Lambda then reads as its own `app_id`. Since
+    issue #251 the prefix scan in `plugins/_shared/plugin_secrets.py` is the
+    ENTIRE isolation boundary between plugins (all ingestion Lambdas share one
+    IAM role), so a write that lands inside another plugin's namespace is a
+    cross-plugin credential injection, not a display quirk. `plugin-loader.ts`
+    refuses a manifest id that is a prefix of another's, but that guard is over
+    *manifest ids* and cannot see a `source` invented in a request.
+
+    So the namespace a write may address is restricted to the plugin ids
+    themselves. `PLUGIN_SECRET_DEFAULTS` is the manifest-derived list this
+    handler is already handed for exactly this reason — no new plumbing, and it
+    cannot drift from the manifests CDK read.
+
+    Fails OPEN when that variable is absent or malformed: `_plugin_secret_defaults`
+    already degrades to `{}` rather than 500ing the Settings page, and turning
+    that degradation into "no source may be configured at all" would let one bad
+    environment variable break credential management entirely. The form check
+    still applies in that case, which is the state this route shipped in.
+
+    Admin-only either way (`require_admin`), so this narrows an authenticated
+    administrator's blast radius rather than an anonymous one.
+    """
+    known = _plugin_secret_defaults()
+    if not known:
+        logger.warning(
+            "PLUGIN_SECRET_DEFAULTS unavailable; accepting any well-formed source"
+        )
+        return
+    if source not in known:
+        # Names the rejected source but NOT the known ones: an error caused by a
+        # wrong source must not become a directory of the right ones, which is the
+        # same discipline `filter_plugin_secrets` applies on the read side.
+        raise ValidationError(
+            f"Unknown source identifier {source[:40]!r}: it is not a configured plugin."
         )
 
 
@@ -244,8 +289,12 @@ def get_integration_status():
             # ponytail: plain prefix match, so if one plugin id were ever a
             # prefix of another ('app_reviews' alongside 'app_reviews_ios') the
             # shorter one would also list the longer one's keys. No current id
-            # pair does this. Upgrade path is to iterate `seeded` by declared
-            # key instead, which costs the write-through property above.
+            # pair does this, and `loadPlugins` now refuses such a manifest pair at
+            # synth time. Iterating `seeded` by declared key instead would remove
+            # the caveat here too, at the cost of the write-through property above.
+            # This loop is over ids CDK supplied, so it cannot be reached by a
+            # request-supplied source — that entrance is closed separately, in
+            # _validate_source_is_a_known_plugin.
             configured_keys = sorted(
                 key[len(prefix):]
                 for key, value in secrets.items()
@@ -296,6 +345,10 @@ def get_credentials(source: str):
     # a caller sending source='foo_bar' + key='baz' would reach the same
     # secret key as source='foo' + key='bar_baz' (namespace collision).
     _validate_source(source)
+    # And the form check is not sufficient: the colliding value is well-formed.
+    # source='app_reviews' + key='ios_app_id' addresses app_reviews_ios's
+    # namespace, so the source must be a plugin that actually exists.
+    _validate_source_is_a_known_plugin(source)
 
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')
@@ -358,6 +411,11 @@ def update_credentials(source: str):
     # a caller sending source='foo_bar' + key='baz' would reach the same
     # secret key as source='foo' + key='bar_baz' (namespace collision).
     _validate_source(source)
+    # The write is the dangerous direction: without this, an admin could inject a
+    # value into another plugin's namespace (source='app_reviews' + key
+    # 'ios_app_id' → app_reviews_ios_app_id) and that plugin's next run would use
+    # it as its own credential.
+    _validate_source_is_a_known_plugin(source)
 
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')

--- a/voc-datalake/lambda/api/scrapers_handler.py
+++ b/voc-datalake/lambda/api/scrapers_handler.py
@@ -1,6 +1,24 @@
 """
 Scrapers API Lambda - Handles /scrapers/*
 Manages web scraper configurations and runs.
+
+Read/write split, matching `integrations_handler`: the three routes that MUTATE
+are admin-gated, the reads are not. `POST /scrapers` and
+`DELETE /scrapers/<scraper_id>` both `put_secret_json` the SAME shared
+API-credentials secret that `integrations_handler` writes — they rewrite
+`webscraper_configs`, a key the webscraper ingestor consumes, so an unprivileged
+write steers which URLs get fetched. `POST /scrapers/<scraper_id>/run` invokes
+that ingestor: a billed third-party fetch against whatever rate limit the target
+grants, callable in a loop.
+
+Gating only the `integrations_handler` half of that secret would have made the
+boundary depend on which handler a write arrived through rather than on what it
+changed, which is the same asymmetry issue #251's fix closed one file over. The
+`GET` routes and `POST /scrapers/analyze-url` stay open: they return a scraper's
+own configuration and run history to an authenticated user, which the Scrapers
+page renders for everyone. Pinned by
+`test/test_scrapers_security.py::TestEveryScraperWriteIsAdminGated`, which parses
+the decorators so a route added later cannot quietly arrive ungated.
 """
 
 import ipaddress
@@ -19,7 +37,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer
 from shared.aws import get_secrets_client, put_secret_json
-from shared.api import create_api_resolver, api_handler
+from shared.api import create_api_resolver, api_handler, require_admin
 from shared.tables import get_aggregates_table
 from shared.exceptions import ConfigurationError, ValidationError, ServiceError
 
@@ -122,7 +140,16 @@ def list_scrapers():
 @app.post("/scrapers")
 @tracer.capture_method
 def save_scraper():
-    """Save a scraper configuration."""
+    """Save a scraper configuration.
+
+    Admin-gated: `put_secret_json` on the shared API-credentials secret, with
+    content the caller supplied. `webscraper_configs` holds the URLs the
+    webscraper ingestor fetches, so an unprivileged write both mutates the same
+    secret `integrations_handler`'s credentials routes protect and steers what
+    gets scraped. Measured ungated as a `users`-group caller: 200, one
+    `put_secret_json`.
+    """
+    require_admin(app.current_event.raw_event)
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')
     
@@ -158,7 +185,14 @@ def save_scraper():
 @app.delete("/scrapers/<scraper_id>")
 @tracer.capture_method
 def delete_scraper(scraper_id: str):
-    """Delete a scraper configuration."""
+    """Delete a scraper configuration.
+
+    Admin-gated for the same reason as the POST above — it writes the shared
+    secret — and additionally because it is destructive: it rewrites
+    `webscraper_configs` with one entry removed, which stops that site being
+    scraped and cannot be undone from the run history.
+    """
+    require_admin(app.current_event.raw_event)
     if not SECRETS_ARN:
         raise ConfigurationError('Secrets not configured')
     try:
@@ -222,7 +256,21 @@ def get_templates():
 @app.post("/scrapers/<scraper_id>/run")
 @tracer.capture_method
 def run_scraper(scraper_id: str):
-    """Trigger a scraper run."""
+    """Trigger a scraper run.
+
+    Admin-gated for the reason `integrations_handler.run_source` is: this invokes
+    the webscraper Lambda, so every call is a billed fetch against a third party's
+    rate limit, and ungated it was callable in a loop by anyone with an account —
+    measured, 200 with a real `lambda:Invoke` and a `SCRAPER_RUN#` row written.
+
+    `scraper_id` is NOT validated against an allowlist, unlike `<source>` in
+    `integrations_handler`: it is not a plugin id and never becomes a secret key
+    or a function name. It reaches one `SCRAPER_RUN#` partition and the invoke
+    PAYLOAD, where the webscraper resolves it against its own configured list, so
+    an unknown id is a run that finds nothing rather than a namespace a caller
+    chose. The admin gate is what bounds who can write those partitions.
+    """
+    require_admin(app.current_event.raw_event)
     execution_id = f"run_{scraper_id}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     try:
         table = get_aggregates_table()

--- a/voc-datalake/lambda/api/scrapers_handler.py
+++ b/voc-datalake/lambda/api/scrapers_handler.py
@@ -19,6 +19,17 @@ own configuration and run history to an authenticated user, which the Scrapers
 page renders for everyone. Pinned by
 `test/test_scrapers_security.py::TestEveryScraperWriteIsAdminGated`, which parses
 the decorators so a route added later cannot quietly arrive ungated.
+
+SCOPE — the split above is THIS MODULE's, not the `/scrapers/*` URL prefix's. Five
+more routes under that prefix live in `manual_import_handler.py`
+(`/scrapers/manual/parse`, `.../parse/<job_id>`, `.../confirm`, `.../csv-upload`,
+`.../json-upload`) and none of them calls `require_admin`. That is a DIFFERENT
+question rather than the same gap: those routes write feedback CONTENT into the
+pipeline (S3 plus the enrichment queue) and touch neither the shared secret nor
+any plugin resource, which is why they were not folded into this change — see
+`test/test_scrapers_security.py`, whose inventory case asserts that boundary so a
+reader is not told the prefix is fully covered when only this handler is. The
+`ast` pass cannot see across module boundaries, so nothing else would say so.
 """
 
 import ipaddress

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -47,7 +47,8 @@ Behaviours tested:
    and a `SOURCE_RUN#` partition key with any value a caller sent. Its batch branch
    cannot raise (one unknown name must not fail the whole response, and its own
    default list contains the deliberate non-plugin `manual_import`), so the two
-   branches are guarded differently.
+   branches are guarded differently — and therefore disagree about `manual_import`
+   itself, which is asserted in BOTH directions rather than only the accepting one.
    Regression: TestTheQueryStringSourceRouteIsValidated
 
 10. That route's fan-out is bounded as well as validated
@@ -1742,7 +1743,9 @@ class TestTheQueryStringSourceRouteIsValidated:
 
     The two branches are asserted differently because they behave differently, and
     the asymmetry is the point — see `_is_addressable_source` for why the batch
-    branch must NOT raise.
+    branch must NOT raise. Its visible consequence is that `manual_import` is
+    accepted by one branch and refused by the other, so both answers are asserted:
+    a claim asserted in one direction only can regress in the other.
     """
 
     @staticmethod
@@ -1901,6 +1904,41 @@ class TestTheQueryStringSourceRouteIsValidated:
         assert response['statusCode'] == 200
         assert set(body['sources']) == {'webscraper', 'manual_import', 's3_import'}
         assert body['sources']['manual_import'] == {'enabled': False, 'exists': False}
+
+    @patch('shared.tables.get_aggregates_table')
+    def test_the_run_status_branch_refuses_the_manual_import_the_other_accepts(
+        self, mock_table, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The deliberate counterpart of the case above, and the ONE input on which
+        the two branches of this route disagree.
+
+        `manual_import` is accepted there and refused here. Both are right, because
+        the branches report different things about it: only `run_source` and
+        `BaseIngestor` write a `SOURCE_RUN#` partition, and `manual_import` has no
+        ingestor — so `SOURCE_RUN#manual_import` can never exist, and a 400 naming
+        the reason beats the pre-fix 200 `{'status': 'never_run'}` about a source
+        that can never have run. The batch branch reports schedule state, where "no
+        rule exists" is a real answer.
+
+        Asserting only the accepting half left the asymmetry unpinned in the
+        direction that could regress: a future edit swapping this branch to
+        `_is_addressable_source` would answer 200 with an empty status, which
+        `test_the_default_request_still_reports_all_three_of_its_sources` cannot
+        see. Separate from `..._an_unknown_run_status_source_queries_nothing`
+        because `not_a_plugin` is not in the route's own default list, so it does
+        not exercise the disagreement at all.
+        """
+        table = mock_table.return_value
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {'run_status': 'manual_import'})
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert table.query.call_args_list == [], (
+            'a SOURCE_RUN# partition was queried for a source that has no ingestor'
+        )
 
     @patch('shared.tables.get_aggregates_table')
     def test_an_unknown_run_status_source_queries_nothing(

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -733,23 +733,52 @@ class TestSourceParameterValidation:
 
     Both GET and PUT must reject a malformed or colliding source with 400
     before reading or writing the secret.
+
+    TWO checks, because the form check alone is not enough: the colliding value is
+    itself well-formed.  Since issue #251 the prefix scan in
+    `plugins/_shared/plugin_secrets.py` is the entire isolation boundary between
+    plugins, so a write landing in another plugin's namespace is a cross-plugin
+    credential injection.  `source` is therefore also restricted to the
+    manifest-derived plugin ids CDK hands down as PLUGIN_SECRET_DEFAULTS.
     """
 
     @patch('integrations_handler.secretsmanager')
-    def test_valid_form_source_accepted(self, mock_secrets, api_gateway_event, lambda_context):
-        """Source 'webscraper_admin' satisfies the form check and is accepted.
+    def test_a_real_plugin_id_is_accepted(
+        self, mock_secrets, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Positive control for the allowlist below: a real plugin id still works.
 
-        The form validation (lowercase, digits, underscores, no leading/trailing _)
-        correctly admits a well-formed source like 'webscraper_admin'.  Form
-        validation alone cannot close the namespace-collision gap for this value
-        (webscraper_admin + key='api_key' produces the same path as
-        webscraper + key='admin_api_key'), which is why the PR description
-        notes a manifest-derived allowlist as the stronger long-term fix.
+        Without this, rejecting EVERY source would satisfy the two rejection cases
+        that follow while breaking credential management entirely.
         """
         mock_secrets.get_secret_value.return_value = {
-            'SecretString': '{"webscraper_admin_api_key": "value"}'
+            'SecretString': '{"webscraper_api_key": "value"}'
         }
 
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/webscraper/credentials',
+            path_params={'source': 'webscraper'},
+            query_params={'keys': 'api_key'},
+        )
+        response = lambda_handler(event, lambda_context)
+        assert response['statusCode'] == 200
+
+    @patch('integrations_handler.secretsmanager')
+    def test_a_well_formed_but_unknown_source_is_rejected_on_read(
+        self, mock_secrets, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The form check cannot close the collision gap, because the colliding
+        value is WELL-FORMED.
+
+        'webscraper_admin' passes the character class, yet
+        webscraper_admin + key='api_key' addresses the same stored key as
+        webscraper + key='admin_api_key'. The source must therefore be a plugin
+        that actually exists, which `PLUGIN_SECRET_DEFAULTS` is the manifest-derived
+        list of.
+        """
         from integrations_handler import lambda_handler
 
         event = api_gateway_event(
@@ -759,7 +788,73 @@ class TestSourceParameterValidation:
             query_params={'keys': 'api_key'},
         )
         response = lambda_handler(event, lambda_context)
-        # A valid-form source is accepted; it is NOT rejected with 400.
+        assert response['statusCode'] == 400
+        mock_secrets.get_secret_value.assert_not_called()
+
+    @patch('integrations_handler.put_secret_json')
+    @patch('integrations_handler.secretsmanager')
+    def test_a_write_cannot_address_another_plugins_namespace(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        """The concrete cross-plugin credential injection, end to end.
+
+        source='app_reviews' + key='ios_app_id' stores `app_reviews_ios_app_id`,
+        which `app_reviews_ios`'s Lambda then reads as its own `app_id` — since
+        issue #251 the prefix scan is the ENTIRE isolation boundary between
+        plugins, so this is credential injection rather than a display quirk.
+        `plugin-loader.ts` refuses a colliding pair of MANIFEST ids, but cannot see
+        a source invented in a request. 'app_reviews' is well-formed and is not a
+        plugin, so it must be refused before anything is written.
+        """
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': '{"app_reviews_ios_app_name": "RealApp"}'
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/integrations/app_reviews/credentials',
+            path_params={'source': 'app_reviews'},
+            body={'ios_app_id': '99999'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert mock_put.call_args_list == [], (
+            'a value was written into app_reviews_ios namespace via source=app_reviews'
+        )
+
+    @patch('integrations_handler.secretsmanager')
+    def test_an_unavailable_allowlist_falls_back_to_the_form_check(
+        self, mock_secrets, api_gateway_event, lambda_context, monkeypatch,
+    ):
+        """Fails OPEN when PLUGIN_SECRET_DEFAULTS is absent, deliberately.
+
+        `_plugin_secret_defaults` already degrades to `{}` rather than 500ing the
+        Settings page. Turning that degradation into "no source may be configured"
+        would let one bad environment variable break credential management
+        outright, so the form check alone applies — which is the state this route
+        shipped in. Pinned so the fallback is a decision rather than an accident.
+        """
+        import integrations_handler as h
+
+        monkeypatch.delenv(h.PLUGIN_SECRET_DEFAULTS_VAR, raising=False)
+        h._plugin_secret_defaults.cache_clear()
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': '{"webscraper_admin_api_key": "value"}'
+        }
+
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/webscraper_admin/credentials',
+            path_params={'source': 'webscraper_admin'},
+            query_params={'keys': 'api_key'},
+        )
+        response = h.lambda_handler(event, lambda_context)
+        h._plugin_secret_defaults.cache_clear()
+
         assert response['statusCode'] == 200
 
     @patch('integrations_handler.secretsmanager')

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -1915,10 +1915,18 @@ class TestTheQueryStringSourceRouteIsValidated:
         `manual_import` is accepted there and refused here. Both are right, because
         the branches report different things about it: only `run_source` and
         `BaseIngestor` write a `SOURCE_RUN#` partition, and `manual_import` has no
-        ingestor — so `SOURCE_RUN#manual_import` can never exist, and a 400 naming
-        the reason beats the pre-fix 200 `{'status': 'never_run'}` about a source
-        that can never have run. The batch branch reports schedule state, where "no
-        rule exists" is a real answer.
+        ingestor — so no current path writes `SOURCE_RUN#manual_import` while the
+        allowlist is available, and a 400 naming the reason beats the pre-fix 200
+        `{'status': 'never_run'}` about a source with nothing to report. The batch
+        branch reports schedule state, where "no rule exists" is a real answer.
+
+        Scoped to the configured state, not stated as impossible, for the two
+        reasons the handler comment records: neither guard is retroactive, so a
+        deployment upgraded from the pre-guard base may hold a stale row (measured
+        on that base — a `users` caller wrote it); and the documented fail-open on
+        an unavailable PLUGIN_SECRET_DEFAULTS admits `manual_import` on both
+        branches, which is why `plugin_secret_defaults` is a fixture here rather
+        than assumed.
 
         Asserting only the accepting half left the asymmetry unpinned in the
         direction that could regress: a future edit swapping this branch to
@@ -1938,6 +1946,41 @@ class TestTheQueryStringSourceRouteIsValidated:
         assert response['statusCode'] == 400
         assert table.query.call_args_list == [], (
             'a SOURCE_RUN# partition was queried for a source that has no ingestor'
+        )
+
+    @patch('shared.tables.get_aggregates_table')
+    def test_the_asymmetry_is_a_property_of_the_configured_state_only(
+        self, mock_table, api_gateway_event, lambda_context, monkeypatch,
+    ):
+        """With the allowlist unavailable the two branches STOP disagreeing.
+
+        The case above is the configured state. The allowlist is what produces its
+        400, so under the documented fail-open — `_validate_source_is_a_known_plugin`
+        returning early, which `_is_addressable_source` inherits — this branch admits
+        `manual_import` like the batch one, and the partition is queried.
+
+        Pinned because the comment at that branch now scopes its claim to the
+        configured state instead of calling `SOURCE_RUN#manual_import` impossible,
+        and that scoping is the kind of prose this PR has already had to correct
+        twice: true when written, unverifiable afterwards. Asserting it means a
+        change making the fail-open stricter has to update the comment rather than
+        leave it describing a state that no longer exists.
+        """
+        import integrations_handler as h
+
+        table = mock_table.return_value
+        table.query.return_value = {'Items': []}
+        monkeypatch.delenv(h.PLUGIN_SECRET_DEFAULTS_VAR, raising=False)
+        h._plugin_secret_defaults.cache_clear()
+
+        event = self._status_event(api_gateway_event, {'run_status': 'manual_import'})
+        response = h.lambda_handler(event, lambda_context)
+        h._plugin_secret_defaults.cache_clear()
+
+        assert response['statusCode'] == 200
+        assert len(table.query.call_args_list) == 1, (
+            'the fail-open should admit manual_import here as it does in the batch '
+            'branch; if it no longer does, the scoping comment on that branch is stale'
         )
 
     @patch('shared.tables.get_aggregates_table')

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -49,6 +49,15 @@ Behaviours tested:
    default list contains the deliberate non-plugin `manual_import`), so the two
    branches are guarded differently.
    Regression: TestTheQueryStringSourceRouteIsValidated
+
+10. That route's fan-out is bounded as well as validated
+   Validation bounds WHICH EventBridge rules `?sources=` may describe, not how
+   MANY calls it makes: the list was neither de-duplicated nor capped, so one
+   valid name repeated 500 times measured 200 / 500 `describe_rule` calls / 1 key
+   in the response — every repeat overwriting the same entry, since the response
+   is keyed by source name. Asserted on the CALL COUNT, because a body-only
+   assertion cannot see this and every case in item 9 passes without the fix.
+   Regression: TestTheStatusRouteDoesNotFanOutPerDuplicate
 """
 import ast
 import inspect
@@ -2012,3 +2021,214 @@ class TestTheQueryStringSourceRouteIsValidated:
             if isinstance(node, ast.FunctionDef) and node.name == 'get_sources_status'
         )
         assert 'require_admin' not in _calls_in(route)
+
+
+class TestTheStatusRouteDoesNotFanOutPerDuplicate:
+    """`?sources=` describes each rule ONCE, however many times it was named.
+
+    The class above bounds WHICH rules this route may describe. It does not bound
+    how MANY calls it makes, and those are different properties: the list was
+    neither de-duplicated nor capped, so the caller chose the AWS call count. This
+    is the only read in the handler that fans out one call per list element.
+
+    Measured before the fix, as a caller whose only Cognito group is `users`:
+
+      ?sources=<one valid name × 500>  → 200, 500 describe_rule calls,
+                                         1 key in the response body
+
+    All 499 repeats overwrote the same `status[source]` entry, so they could not
+    change the response — work unbounded by the caller against a fixed observable
+    result, which is what makes it an amplifier rather than an inefficiency.
+    `DescribeRule` is throttled per account, shared with the rest of the stack.
+
+    Every assertion here is on the CALL COUNT rather than the body, deliberately:
+    the body is identical with and without the fix, which is exactly why the nine
+    cases in `TestTheQueryStringSourceRouteIsValidated` all pass on the pre-fix
+    code. A body-only assertion cannot see this defect.
+    """
+
+    @staticmethod
+    def _status_event(api_gateway_event, query):
+        return _non_admin_event(
+            api_gateway_event,
+            method='GET',
+            path='/sources/status',
+            query_params=query,
+        )
+
+    @staticmethod
+    def _stub(mock_events):
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.return_value = {
+            'State': 'ENABLED', 'ScheduleExpression': 'rate(1 day)',
+        }
+
+    @patch('integrations_handler.events_client')
+    def test_a_repeated_source_is_described_once(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The reported case: one valid name repeated many times, one AWS call."""
+        self._stub(mock_events)
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(
+            api_gateway_event, {'sources': ','.join(['webscraper'] * 500)}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert mock_events.describe_rule.call_count == 1, (
+            'a repeated source name fanned out one describe_rule call per '
+            f'occurrence ({mock_events.describe_rule.call_count} calls)'
+        )
+        # The response is unchanged by de-duplication — stated as an assertion
+        # because "the fix is observable to no caller" is the reason it is safe.
+        assert body['sources']['webscraper']['enabled'] is True
+        assert len(body['sources']) == 1
+
+    @patch('integrations_handler.events_client')
+    def test_the_control_distinct_sources_are_each_still_described(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Non-vacuity: de-duplicating too eagerly would collapse a real request.
+
+        A fix that described only the first entry, or dropped the loop, would make
+        the call count trivially 1 and satisfy the case above. This asserts one call
+        PER distinct source, and the ORDER, which `dict.fromkeys` preserves and a
+        `set` would not.
+
+        Deliberately duplicate-free input, so this control stays GREEN under the
+        very mutation it controls for — the pre-fix code describes two distinct
+        sources twice as well. A control that fails alongside its subject proves
+        nothing about vacuity.
+        """
+        self._stub(mock_events)
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(
+            api_gateway_event, {'sources': 'webscraper,s3_import'}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert mock_events.describe_rule.call_count == 2, (
+            'two distinct sources were not each described exactly once'
+        )
+        described = [c.kwargs['Name'] for c in mock_events.describe_rule.call_args_list]
+        assert described == [
+            'voc-ingest-webscraper-schedule', 'voc-ingest-s3_import-schedule',
+        ]
+        assert set(body['sources']) == {'webscraper', 's3_import'}
+
+    @patch('integrations_handler.events_client')
+    def test_a_source_list_over_the_cap_is_refused_before_any_lookup(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The cap raises rather than truncating, and describes nothing first.
+
+        A malformed REQUEST, unlike an unaddressable source: there is no per-entry
+        answer to report, so this branch behaves like the write path's key-count
+        guard. Asserting no call happened is the load-bearing half — a route that
+        answered 400 after describing 51 rules would pass a status-only assertion.
+        """
+        from integrations_handler import (
+            MAX_SOURCES_PER_STATUS_REQUEST,
+            lambda_handler,
+        )
+
+        self._stub(mock_events)
+        too_many = ','.join(
+            f'plugin_{i}' for i in range(MAX_SOURCES_PER_STATUS_REQUEST + 1)
+        )
+        event = self._status_event(api_gateway_event, {'sources': too_many})
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert mock_events.describe_rule.call_args_list == []
+
+    @patch('integrations_handler.events_client')
+    def test_the_control_a_list_at_the_cap_is_still_answered(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Non-vacuity for the cap: an off-by-one that refused the limit itself
+        would satisfy the case above, and the cap is meant to bound abuse rather
+        than any request a caller could legitimately make."""
+        from integrations_handler import (
+            MAX_SOURCES_PER_STATUS_REQUEST,
+            lambda_handler,
+        )
+
+        self._stub(mock_events)
+        at_cap = ','.join(
+            f'plugin_{i}' for i in range(MAX_SOURCES_PER_STATUS_REQUEST)
+        )
+        event = self._status_event(api_gateway_event, {'sources': at_cap})
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        # None is a configured plugin, so the allowlist answers all of them and
+        # EventBridge is never reached — the cap is what is under test, and it
+        # must not fire at exactly the limit.
+        assert len(json.loads(response['body'])['sources']) == (
+            MAX_SOURCES_PER_STATUS_REQUEST
+        )
+
+    @patch('integrations_handler.events_client')
+    def test_the_cap_counts_distinct_sources_not_typed_ones(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """De-duplication runs BEFORE the cap, which is the useful order.
+
+        The bound that matters is the number of rules actually described, so a
+        caller who repeats one legitimate name past the cap is answered rather than
+        refused. Capping the typed list first would reject a request that costs one
+        AWS call.
+        """
+        from integrations_handler import (
+            MAX_SOURCES_PER_STATUS_REQUEST,
+            lambda_handler,
+        )
+
+        self._stub(mock_events)
+        event = self._status_event(api_gateway_event, {
+            'sources': ','.join(
+                ['webscraper'] * (MAX_SOURCES_PER_STATUS_REQUEST + 10)
+            ),
+        })
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_events.describe_rule.call_count == 1
+
+    @patch('integrations_handler.events_client')
+    def test_the_default_request_is_unaffected_by_either_guard(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The regression control, on the path every Settings render takes.
+
+        `SourceCard.tsx` calls `getSourcesStatus()` with no argument, so the
+        fallback list must reach the loop untouched by de-duplication or the cap —
+        it holds no duplicates and three entries, and `manual_import` among them is
+        a deliberate non-plugin.
+        """
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.side_effect = (
+            mock_events.exceptions.ResourceNotFoundException
+        )
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {})
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert set(body['sources']) == {'webscraper', 'manual_import', 's3_import'}

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -31,7 +31,17 @@ Behaviours tested:
 
 7. Manifest key acceptance
    Every config key declared in plugin manifests passes _validate_credential_key.
+
+8. Every `<source>` route validates and gates
+   `_validate_source_parameter` reaches all seven routes taking a `<source>` path
+   parameter, and the five that write reach `require_admin`. The allowlist and the
+   admin gate were first wired into the two credentials routes only, which left a
+   `users`-group caller able to write the shared secret and invoke an ingestor.
+   Regressions: TestEverySourceRouteIsValidated, TestEverySourceWriteIsAdminGated,
+                TestSourceRouteCoverageIsComplete
 """
+import ast
+import inspect
 import json
 from unittest.mock import patch
 
@@ -1156,3 +1166,526 @@ class TestManifestKeysAccepted:
         from integrations_handler import _validate_source
         # Must not raise.
         _validate_source(plugin_id)
+
+
+# ---------------------------------------------------------------------------
+# Every `<source>` route validates its source and gates its writes.
+#
+# The allowlist and the admin gate were both wired into the two credentials
+# routes and into nothing else, while five other routes turned the same
+# request-supplied `<source>` into a Secrets Manager key, an ingestor Lambda
+# name or an EventBridge rule name. Measured before the fix, as a caller whose
+# only Cognito group is `users`:
+#
+#   POST /integrations/app_reviews_ios/apps  → 200, one put_secret_json
+#   POST /sources/not_a_plugin/run           → 200, real lambda:Invoke of
+#                                              voc-ingestor-not_a_plugin, plus a
+#                                              SOURCE_RUN#not_a_plugin row
+#   PUT  /sources/not_a_plugin/enable        → 200, events:EnableRule
+#
+# The route-by-route cases below are the behavioural half. The `ast` pass after
+# them is the half that covers a route added LATER: a behavioural test can only
+# assert about a route somebody remembered to write it for, and forgetting is the
+# failure this whole section exists to catch.
+# ---------------------------------------------------------------------------
+
+def _handler_module():
+    import integrations_handler
+    return integrations_handler
+
+
+def _route_functions() -> dict[str, ast.FunctionDef]:
+    """Every module-level function carrying an `@app.<method>("<path>")` decorator.
+
+    Parsed rather than read off the resolver, because the resolver records the
+    route's PATH and handler but not the guards inside the handler's body, which
+    is the thing under test. Keyed by function name; the paths are recovered
+    separately in `_route_paths` below.
+    """
+    tree = ast.parse(inspect.getsource(_handler_module()))
+    routes = {}
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if any(_route_path_of(decorator) for decorator in node.decorator_list):
+            routes[node.name] = node
+    return routes
+
+
+def _route_path_of(decorator: ast.expr) -> str | None:
+    """The literal path of an `@app.get("/x")`-style decorator, else None.
+
+    Matches on the `app` receiver and a string first argument, so
+    `@tracer.capture_method` (no arguments) and any future non-routing decorator
+    are ignored without needing a list of method names to exclude.
+    """
+    if not isinstance(decorator, ast.Call):
+        return None
+    func = decorator.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if not isinstance(func.value, ast.Name) or func.value.id != 'app':
+        return None
+    if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+        return None
+    path = decorator.args[0].value
+    return path if isinstance(path, str) else None
+
+
+def _route_paths(node: ast.FunctionDef) -> list[str]:
+    return [
+        path for path in (_route_path_of(d) for d in node.decorator_list)
+        if path is not None
+    ]
+
+
+def _calls_in(node: ast.FunctionDef) -> set[str]:
+    """Names of the plain-function calls anywhere in *node*'s body."""
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+def _source_routes() -> dict[str, ast.FunctionDef]:
+    """Route functions that take a `<source>` path parameter.
+
+    Selected by the DECORATOR's path containing `<source>`, not by the presence of
+    a `source` argument: `get_sources_status` takes its source from a query string
+    (`?run_status=`) and addresses no namespace with it, so including it by
+    parameter name would demand a guard the route does not need.
+    """
+    return {
+        name: node for name, node in _route_functions().items()
+        if any('<source>' in path for path in _route_paths(node))
+    }
+
+
+# The routes that WRITE — a Secrets Manager value, an ingestor invocation, or an
+# EventBridge rule state. Listed explicitly because "does this route write?" is a
+# judgement no parse can make, and because the read/write split is the whole
+# argument for gating five of the seven: `list_app_configs` returns a public app
+# store id and a display name to any authenticated user, which the Scrapers page
+# renders for everyone.
+SOURCE_WRITE_ROUTES = {
+    'update_credentials',
+    'save_app_config',
+    'delete_app_config',
+    'run_source',
+    'enable_source',
+    'disable_source',
+}
+
+# `get_credentials` is admin-gated too, but as a READ: it returns stored
+# configuration values. Kept out of the set above so that set means "mutates
+# something", which is what its assertions claim.
+SOURCE_ADMIN_ROUTES = SOURCE_WRITE_ROUTES | {'get_credentials'}
+
+
+class TestSourceRouteCoverageIsComplete:
+    """Non-vacuity for the two `ast` classes below.
+
+    Every assertion there is "for each route found", so a parse that finds NOTHING
+    — a rename of `app`, a move to a router object, a decorator style change —
+    passes all of them over an empty set. These cases make that loud, and pin the
+    route inventory the two lists above are asserted against.
+    """
+
+    def test_the_parser_finds_every_source_route(self):
+        found = set(_source_routes())
+        assert found == {
+            'get_credentials',
+            'update_credentials',
+            'list_app_configs',
+            'save_app_config',
+            'delete_app_config',
+            'run_source',
+            'enable_source',
+            'disable_source',
+        }, (
+            'the route inventory changed; a NEW <source> route must be added to '
+            'SOURCE_WRITE_ROUTES (if it mutates) and will otherwise be asserted '
+            'as a read'
+        )
+
+    def test_every_named_write_route_is_a_route_the_parser_found(self):
+        """The lists above cannot name a function that no longer exists.
+
+        Otherwise deleting or renaming a route would silently drop its guard
+        assertions rather than failing.
+        """
+        assert SOURCE_ADMIN_ROUTES <= set(_source_routes())
+
+    def test_the_only_ungated_source_route_is_the_app_config_read(self):
+        """States the read/write split as an assertion, so widening it is a choice.
+
+        If a future route is added and left out of SOURCE_WRITE_ROUTES, this fails
+        rather than quietly accepting it as a read that needs no admin.
+        """
+        assert set(_source_routes()) - SOURCE_ADMIN_ROUTES == {'list_app_configs'}
+
+
+class TestEverySourceRouteIsValidated:
+    """Each `<source>` route validates the parameter before using it.
+
+    `<source>` becomes a Secrets Manager key prefix (`_get_app_configs_key`), an
+    ingestor function name (`_build_ingestor_function_name`) or an EventBridge rule
+    name (`_build_rule_name`) on every one of these routes, so there is no route on
+    which "is this a real plugin?" is the wrong question.
+    """
+
+    @pytest.mark.parametrize('route', sorted(_source_routes()))
+    def test_the_route_validates_its_source(self, route):
+        calls = _calls_in(_source_routes()[route])
+        assert '_validate_source_parameter' in calls, (
+            f'{route} uses <source> without validating it; a well-formed but '
+            'unknown value reaches a secret key, a Lambda name or a rule name'
+        )
+
+    def test_the_validator_applies_both_checks(self):
+        """The form check alone is what left the collision open, so both must run.
+
+        Asserted on the helper rather than at each of the seven call sites: a route
+        calling `_validate_source_parameter` gets both, and this is what makes that
+        true.
+        """
+        validator = next(
+            node for node in ast.parse(inspect.getsource(_handler_module())).body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == '_validate_source_parameter'
+        )
+        assert _calls_in(validator) == {
+            '_validate_source',
+            '_validate_source_is_a_known_plugin',
+        }
+
+
+class TestEverySourceWriteIsAdminGated:
+    """Each mutating `<source>` route calls require_admin.
+
+    The three `apps` routes and the three `sources` routes carried no gate while
+    the credentials routes beside them did, so the boundary depended on which key
+    a write happened to land under.
+    """
+
+    @pytest.mark.parametrize('route', sorted(SOURCE_ADMIN_ROUTES))
+    def test_the_route_requires_admin(self, route):
+        assert 'require_admin' in _calls_in(_source_routes()[route]), (
+            f'{route} mutates or reads configuration with no admin gate'
+        )
+
+    def test_the_control_the_app_config_read_is_deliberately_open(self):
+        """Non-vacuity: without this, gating EVERY route would satisfy the above.
+
+        `list_app_configs` is rendered for every authenticated user on the Scrapers
+        page and returns a public app store id and a display name. Gating it would
+        empty that list for non-admins, so its openness is a decision and is pinned
+        as one.
+        """
+        assert 'require_admin' not in _calls_in(_source_routes()['list_app_configs'])
+
+
+class TestAnUnknownSourceReachesNoResource:
+    """The allowlist, driven through lambda_handler on the newly-guarded routes.
+
+    Admin events throughout: the subject is the allowlist, so a 403 from the admin
+    gate would mask whether the source was checked at all.
+    """
+
+    @patch('integrations_handler.put_secret_json')
+    @patch('integrations_handler.secretsmanager')
+    def test_an_unknown_source_cannot_write_an_app_config(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        """POST /integrations/<source>/apps writes `<source>_configs` on the SAME
+        shared secret the credentials route writes, so it needs the same check.
+
+        The 400 here is OVERDETERMINED, and the assertion says so deliberately:
+        `APP_CONFIG_PLUGINS` is a two-element set, so an unknown source is refused
+        by that narrower check even with the allowlist removed. What this case pins
+        is which of the two answers, i.e. that the allowlist runs FIRST — because
+        "does not support multiple app configs" is a misleading thing to tell
+        someone who named a source that does not exist at all, and reading it sends
+        them looking for a manifest capability rather than a typo.
+
+        The load-bearing guard for these three routes is the `ast` pass in
+        TestEverySourceRouteIsValidated: a behavioural assertion cannot distinguish
+        a defence-in-depth check from an absent one when a narrower check already
+        refuses the same input.
+        """
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST',
+            path='/integrations/not_a_plugin/apps',
+            path_params={'source': 'not_a_plugin'},
+            body={'app': {'app_name': 'Injected'}},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert mock_put.call_args_list == [], 'a value was written under not_a_plugin_configs'
+        error = json.loads(response['body']).get('error', '')
+        assert 'not a configured plugin' in error, (
+            f'expected the allowlist to answer first, got: {error!r}'
+        )
+
+    @patch('shared.tables.get_aggregates_table')
+    @patch('boto3.client')
+    def test_an_unknown_source_invokes_no_lambda_and_writes_no_run_record(
+        self, mock_boto_client, mock_table, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        """POST /sources/<source>/run interpolated <source> straight into a Lambda
+        function name and a `SOURCE_RUN#<source>` partition key."""
+        lambda_client = mock_boto_client.return_value
+        lambda_client.invoke.return_value = {'StatusCode': 202}
+        table = mock_table.return_value
+
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST',
+            path='/sources/not_a_plugin/run',
+            path_params={'source': 'not_a_plugin'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert lambda_client.invoke.call_args_list == []
+        assert table.put_item.call_args_list == [], (
+            'a SOURCE_RUN# partition was written for a source that is not a plugin'
+        )
+
+    @pytest.mark.parametrize('action', ['enable', 'disable'])
+    @patch('integrations_handler.events_client')
+    def test_an_unknown_source_touches_no_eventbridge_rule(
+        self, mock_events, action, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='PUT',
+            path=f'/sources/not_a_plugin/{action}',
+            path_params={'source': 'not_a_plugin'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert mock_events.enable_rule.call_args_list == []
+        assert mock_events.disable_rule.call_args_list == []
+
+    @patch('integrations_handler.secretsmanager')
+    def test_the_control_a_real_plugin_id_still_reads_its_app_configs(
+        self, mock_secrets, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Non-vacuity for the four cases above: rejecting every source would
+        satisfy them all while breaking the Scrapers page outright."""
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({
+                'app_reviews_ios_configs': json.dumps([{'id': 'a1', 'app_name': 'Real'}]),
+            })
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='GET',
+            path='/integrations/app_reviews_ios/apps',
+            path_params={'source': 'app_reviews_ios'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['apps'][0]['app_name'] == 'Real'
+
+    @patch('shared.tables.get_aggregates_table')
+    @patch('boto3.client')
+    def test_the_control_a_real_plugin_id_still_runs(
+        self, mock_boto_client, mock_table, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        lambda_client = mock_boto_client.return_value
+        lambda_client.invoke.return_value = {'StatusCode': 202}
+        mock_table.return_value = None
+
+        from integrations_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST',
+            path='/sources/webscraper/run',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert lambda_client.invoke.call_args_list, 'the real ingestor was not invoked'
+
+    @patch('shared.tables.get_aggregates_table')
+    @patch('boto3.client')
+    def test_an_unavailable_allowlist_still_admits_a_run(
+        self, mock_boto_client, mock_table, api_gateway_event, lambda_context, monkeypatch,
+    ):
+        """Fails OPEN when PLUGIN_SECRET_DEFAULTS is absent, on these routes too.
+
+        Same reasoning as on the credentials routes: `_plugin_secret_defaults`
+        degrades to `{}` rather than 500ing, and turning that into "no source may
+        be run or toggled" would let one bad environment variable take ingestion
+        management out entirely. The ADMIN gate is unconditional and covers this
+        state — see TestNoNonAdminReachesASourceWrite.
+        """
+        import integrations_handler as h
+
+        monkeypatch.delenv(h.PLUGIN_SECRET_DEFAULTS_VAR, raising=False)
+        h._plugin_secret_defaults.cache_clear()
+        lambda_client = mock_boto_client.return_value
+        lambda_client.invoke.return_value = {'StatusCode': 202}
+        mock_table.return_value = None
+
+        event = api_gateway_event(
+            method='POST',
+            path='/sources/webscraper/run',
+            path_params={'source': 'webscraper'},
+        )
+        response = h.lambda_handler(event, lambda_context)
+        h._plugin_secret_defaults.cache_clear()
+
+        assert response['statusCode'] == 200
+
+
+class TestNoNonAdminReachesASourceWrite:
+    """A `users`-group caller is refused on every mutating `<source>` route.
+
+    Real plugin ids throughout, so the refusal cannot be coming from the allowlist
+    — the admin gate is the subject. Each case also asserts the ABSENCE of the side
+    effect, not just the status: a route that answered 403 while still writing
+    would satisfy a status-only assertion.
+    """
+
+    @patch('integrations_handler.put_secret_json')
+    @patch('integrations_handler.secretsmanager')
+    def test_a_non_admin_cannot_save_an_app_config(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        mock_secrets.get_secret_value.return_value = {'SecretString': '{}'}
+
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='POST',
+            path='/integrations/app_reviews_ios/apps',
+            path_params={'source': 'app_reviews_ios'},
+            body={'app': {'app_name': 'Injected'}},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
+        assert mock_put.call_args_list == [], (
+            'a users-group caller wrote app_reviews_ios_configs on the shared secret'
+        )
+
+    @patch('integrations_handler.put_secret_json')
+    @patch('integrations_handler.secretsmanager')
+    def test_a_non_admin_cannot_delete_an_app_config(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({
+                'app_reviews_ios_configs': json.dumps([{'id': 'a1', 'app_name': 'Real'}]),
+            })
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='DELETE',
+            path='/integrations/app_reviews_ios/apps/a1',
+            path_params={'source': 'app_reviews_ios', 'app_id': 'a1'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
+        assert mock_put.call_args_list == [], 'a users-group caller deleted an app config'
+
+    @patch('shared.tables.get_aggregates_table')
+    @patch('boto3.client')
+    def test_a_non_admin_cannot_trigger_a_run(
+        self, mock_boto_client, mock_table, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        """Every run fetches from a third-party API and writes the data lake, so
+        this is a billed operation and a rate limit any authenticated user could
+        exhaust."""
+        lambda_client = mock_boto_client.return_value
+        lambda_client.invoke.return_value = {'StatusCode': 202}
+        table = mock_table.return_value
+
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='POST',
+            path='/sources/webscraper/run',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
+        assert lambda_client.invoke.call_args_list == [], (
+            'a users-group caller invoked the webscraper ingestor'
+        )
+        assert table.put_item.call_args_list == []
+
+    @pytest.mark.parametrize('action', ['enable', 'disable'])
+    @patch('integrations_handler.events_client')
+    def test_a_non_admin_cannot_toggle_a_schedule(
+        self, mock_events, action, api_gateway_event, lambda_context,
+        plugin_secret_defaults,
+    ):
+        """`disable` is the direction that matters most: it silently stops
+        ingestion, and nothing in this repo re-enables a rule automatically."""
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='PUT',
+            path=f'/sources/webscraper/{action}',
+            path_params={'source': 'webscraper'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 403
+        assert mock_events.enable_rule.call_args_list == []
+        assert mock_events.disable_rule.call_args_list == []
+
+    @patch('integrations_handler.secretsmanager')
+    def test_the_control_a_non_admin_can_still_list_app_configs(
+        self, mock_secrets, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Non-vacuity, and the property the gates must not cost: the Scrapers page
+        renders this list for every authenticated user."""
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({
+                'app_reviews_ios_configs': json.dumps([{'id': 'a1', 'app_name': 'Real'}]),
+            })
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = _non_admin_event(
+            api_gateway_event,
+            method='GET',
+            path='/integrations/app_reviews_ios/apps',
+            path_params={'source': 'app_reviews_ios'},
+        )
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['apps'][0]['app_name'] == 'Real'

--- a/voc-datalake/lambda/api/test/test_integrations_security.py
+++ b/voc-datalake/lambda/api/test/test_integrations_security.py
@@ -39,6 +39,16 @@ Behaviours tested:
    `users`-group caller able to write the shared secret and invoke an ingestor.
    Regressions: TestEverySourceRouteIsValidated, TestEverySourceWriteIsAdminGated,
                 TestSourceRouteCoverageIsComplete
+
+9. The query-string source route validates too
+   `GET /sources/status` is the ONE route taking a source from the query string
+   rather than a `<source>` path parameter, so the inventory above cannot see it —
+   and it was the last unvalidated one, reaching `_build_rule_name`/`describe_rule`
+   and a `SOURCE_RUN#` partition key with any value a caller sent. Its batch branch
+   cannot raise (one unknown name must not fail the whole response, and its own
+   default list contains the deliberate non-plugin `manual_import`), so the two
+   branches are guarded differently.
+   Regression: TestTheQueryStringSourceRouteIsValidated
 """
 import ast
 import inspect
@@ -1252,9 +1262,17 @@ def _source_routes() -> dict[str, ast.FunctionDef]:
     """Route functions that take a `<source>` path parameter.
 
     Selected by the DECORATOR's path containing `<source>`, not by the presence of
-    a `source` argument: `get_sources_status` takes its source from a query string
-    (`?run_status=`) and addresses no namespace with it, so including it by
-    parameter name would demand a guard the route does not need.
+    a `source` argument. That is the whole of the criterion, and the exclusion it
+    produces rests on nothing else: `get_sources_status` takes its sources from the
+    QUERY STRING (`?sources=a,b,c` and `?run_status=`), so it is out of scope for a
+    path-parameter inventory.
+
+    It is NOT out of scope for validation, and an earlier version of this docstring
+    wrongly said it addressed no namespace — it derives an EventBridge rule name
+    (`_build_rule_name`, then `describe_rule`) and a `SOURCE_RUN#` partition key.
+    That route validates its sources INLINE, in the handler, because one branch
+    answers about several sources at once and so cannot raise; see
+    `_is_addressable_source` and TestTheQueryStringSourceRouteIsValidated below.
     """
     return {
         name: node for name, node in _route_functions().items()
@@ -1689,3 +1707,308 @@ class TestNoNonAdminReachesASourceWrite:
 
         assert response['statusCode'] == 200
         assert json.loads(response['body'])['apps'][0]['app_name'] == 'Real'
+
+
+class TestTheQueryStringSourceRouteIsValidated:
+    """`GET /sources/status` validates the sources it takes from the query string.
+
+    The one route outside `_source_routes()`' inventory, because its sources arrive
+    as `?sources=a,b,c` and `?run_status=` rather than as a `<source>` path
+    parameter — so the guard the other seven share by construction had to be wired
+    in by hand here, and was not. Measured before the fix, as a caller whose only
+    Cognito group is `users`:
+
+      ?sources=not_a_plugin,../../etc  → 200, with describe_rule called for
+                                        voc-ingest-not_a_plugin-schedule and
+                                        voc-ingest-../../etc-schedule, and each
+                                        rule's State, ScheduleExpression and
+                                        rule_name returned
+      ?run_status=not_a_plugin         → 200, an unbounded SOURCE_RUN# query with
+                                        the run's `errors` array verbatim
+
+    Admin events are NOT used here, unlike the classes above: this route is open to
+    any authenticated user by design (`SourceCard.tsx` reads it on every Settings
+    render), so a non-admin event is the real caller and proves the validation is
+    not coming from an admin gate that does not exist.
+
+    The two branches are asserted differently because they behave differently, and
+    the asymmetry is the point — see `_is_addressable_source` for why the batch
+    branch must NOT raise.
+    """
+
+    @staticmethod
+    def _status_event(api_gateway_event, query):
+        return _non_admin_event(
+            api_gateway_event,
+            method='GET',
+            path='/sources/status',
+            query_params=query,
+        )
+
+    @patch('integrations_handler.events_client')
+    def test_an_unknown_source_reaches_no_eventbridge_rule(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The batch branch reports the source as absent instead of describing it.
+
+        Asserts the ABSENCE of the call, not just the response shape: a route that
+        answered `exists: False` while still calling `describe_rule` would satisfy a
+        response-only assertion and still enumerate rules.
+        """
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.return_value = {
+            'State': 'ENABLED', 'ScheduleExpression': 'rate(1 day)',
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {'sources': 'not_a_plugin'})
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert mock_events.describe_rule.call_args_list == [], (
+            'an arbitrary query-string value reached EventBridge'
+        )
+        assert body['sources']['not_a_plugin'] == {'enabled': False, 'exists': False}
+        # No rule name reflected back: the pre-fix response carried
+        # 'voc-ingest-not_a_plugin-schedule', which tells a caller the naming
+        # convention for rules it may not address.
+        assert 'rule_name' not in body['sources']['not_a_plugin']
+
+    @patch('integrations_handler.events_client')
+    def test_a_malformed_source_reaches_no_eventbridge_rule(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The traversal-shaped value from the report, which the form check catches.
+
+        Separate from the case above because it fails a DIFFERENT check — the
+        character class rather than the allowlist — and `_is_addressable_source`
+        converts both to the same answer. A guard wired to only one of the two would
+        pass one of these cases.
+        """
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {'sources': '../../etc'})
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_events.describe_rule.call_args_list == []
+        assert json.loads(response['body'])['sources']['../../etc'] == {
+            'enabled': False, 'exists': False,
+        }
+
+    @patch('integrations_handler.events_client')
+    def test_the_control_a_real_plugin_id_is_still_described(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Non-vacuity: rejecting every source would satisfy both cases above while
+        making every schedule on the Settings page read as disabled."""
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.return_value = {
+            'State': 'ENABLED', 'ScheduleExpression': 'rate(1 day)',
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {'sources': 'webscraper'})
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert mock_events.describe_rule.call_args_list, (
+            'a configured plugin was not described'
+        )
+        assert body['sources']['webscraper']['enabled'] is True
+
+    @patch('integrations_handler.events_client')
+    def test_a_mixed_request_reports_the_unknown_and_still_describes_the_known(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The reason the batch branch skips rather than raises.
+
+        One unknown name among several must not fail the whole response. A raising
+        guard here would answer 400 and the caller would learn nothing about the
+        sources it asked about that DO exist.
+        """
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.return_value = {
+            'State': 'ENABLED', 'ScheduleExpression': 'rate(1 day)',
+        }
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(
+            api_gateway_event, {'sources': 'not_a_plugin,webscraper'}
+        )
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert body['sources']['not_a_plugin'] == {'enabled': False, 'exists': False}
+        assert body['sources']['webscraper']['enabled'] is True
+
+    @patch('integrations_handler.events_client')
+    def test_the_default_request_still_reports_all_three_of_its_sources(
+        self, mock_events, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """The regression this route's guard must not cause, and why it cannot raise.
+
+        `SourceCard.tsx` calls `getSourcesStatus()` with NO argument on every
+        Settings render, taking the fallback list below. `manual_import` is in that
+        list, is a legitimate `source_platform` (it is in `KNOWN_SOURCES` in
+        `plugins/_shared/schemas.py`) and has no manifest — so it is absent from
+        `PLUGIN_SECRET_DEFAULTS` and a raising guard would answer 400 to that
+        request for every user, admin included.
+
+        Asserted as an equality over the keys, not a membership: dropping
+        `manual_import` from the response entirely is the other way this regresses,
+        and `'manual_import' in body` would not notice a route that reported it as
+        an error instead of a status.
+        """
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.side_effect = (
+            mock_events.exceptions.ResourceNotFoundException
+        )
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {})
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert set(body['sources']) == {'webscraper', 'manual_import', 's3_import'}
+        assert body['sources']['manual_import'] == {'enabled': False, 'exists': False}
+
+    @patch('shared.tables.get_aggregates_table')
+    def test_an_unknown_run_status_source_queries_nothing(
+        self, mock_table, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """This branch DOES raise: it answers about one source, so a 400 is honest.
+
+        The `errors` array this returns is the one field in the response that can
+        carry a `ConfigurationError` message naming a namespace, which is why an
+        unbounded query on an attacker-chosen partition mattered here.
+        """
+        table = mock_table.return_value
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {'run_status': 'not_a_plugin'})
+        response = lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert table.query.call_args_list == [], (
+            'a SOURCE_RUN# partition was queried for a source that is not a plugin'
+        )
+
+    @patch('shared.tables.get_aggregates_table')
+    def test_the_control_a_real_plugin_id_still_returns_its_run_status(
+        self, mock_table, api_gateway_event, lambda_context, plugin_secret_defaults,
+    ):
+        """Non-vacuity for the case above: the Scrapers page polls this every two
+        seconds while a run is in flight, so refusing every source would leave a
+        completed run showing as running forever."""
+        table = mock_table.return_value
+        table.query.return_value = {'Items': [{
+            'sk': 'run_webscraper_1', 'status': 'completed', 'items_found': 7,
+        }]}
+
+        from integrations_handler import lambda_handler
+
+        event = self._status_event(api_gateway_event, {'run_status': 'webscraper'})
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        assert response['statusCode'] == 200
+        assert table.query.call_args_list, 'a configured plugin was not queried'
+        assert body['status'] == 'completed'
+        assert body['items_found'] == 7
+
+    @patch('integrations_handler.events_client')
+    def test_an_unavailable_allowlist_still_reports_every_source(
+        self, mock_events, api_gateway_event, lambda_context, monkeypatch,
+    ):
+        """Fails OPEN when PLUGIN_SECRET_DEFAULTS is absent, here as elsewhere.
+
+        `_is_addressable_source` delegates to `_validate_source_is_a_known_plugin`,
+        which returns early in that state, so this route inherits the degradation
+        rather than restating it. On a READ-only route the trade is easier than on
+        the write routes: the worst case is the pre-allowlist behaviour, and this
+        route never had an admin gate to fall back on.
+        """
+        import integrations_handler as h
+
+        monkeypatch.delenv(h.PLUGIN_SECRET_DEFAULTS_VAR, raising=False)
+        h._plugin_secret_defaults.cache_clear()
+        mock_events.exceptions.ResourceNotFoundException = type(
+            'ResourceNotFoundException', (Exception,), {}
+        )
+        mock_events.describe_rule.return_value = {
+            'State': 'ENABLED', 'ScheduleExpression': 'rate(1 day)',
+        }
+
+        event = self._status_event(api_gateway_event, {'sources': 'custom_source'})
+        response = h.lambda_handler(event, lambda_context)
+        h._plugin_secret_defaults.cache_clear()
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['sources']['custom_source']['enabled'] is True
+
+    def test_the_predicate_shares_the_rule_it_enforces(self):
+        """`_is_addressable_source` must DELEGATE, not restate.
+
+        A second copy of "is this a real plugin?" is how the batch branch comes to
+        accept a value the path routes refuse. Parsed rather than behavioural
+        because the equivalence is the property: a behavioural test would pass just
+        as well against a duplicated rule that happens to agree today.
+        """
+        predicate = next(
+            node for node in ast.parse(inspect.getsource(_handler_module())).body
+            if isinstance(node, ast.FunctionDef) and node.name == '_is_addressable_source'
+        )
+        assert _calls_in(predicate) == {'_validate_source_parameter'}
+
+    def test_the_route_uses_the_predicate_and_the_validator(self):
+        """Both branches are guarded, and by the intended one of the two.
+
+        The findability half matters as much as the assertion: if the route were
+        renamed or its guards moved into a helper, `next` raises StopIteration here
+        rather than this passing over a route that no longer exists.
+        """
+        route = next(
+            node for node in ast.parse(inspect.getsource(_handler_module())).body
+            if isinstance(node, ast.FunctionDef) and node.name == 'get_sources_status'
+        )
+        calls = _calls_in(route)
+        assert '_is_addressable_source' in calls, 'the ?sources= branch is unguarded'
+        assert '_validate_source_parameter' in calls, (
+            'the ?run_status= branch is unguarded'
+        )
+
+    def test_the_route_is_deliberately_not_admin_gated(self):
+        """Pins the one judgement here that is not "add the guard".
+
+        `SourceCard.tsx` and `PluginConfigModal.tsx` both read this route for
+        ordinary users, so gating it would blank the schedule state on the Settings
+        page for non-admins. Recorded as a decision so a future reader does not
+        read the absence as the same oversight the validation was.
+        """
+        route = next(
+            node for node in ast.parse(inspect.getsource(_handler_module())).body
+            if isinstance(node, ast.FunctionDef) and node.name == 'get_sources_status'
+        )
+        assert 'require_admin' not in _calls_in(route)

--- a/voc-datalake/lambda/api/test/test_scrapers_security.py
+++ b/voc-datalake/lambda/api/test/test_scrapers_security.py
@@ -1,4 +1,33 @@
-"""Every mutating /scrapers route is admin-gated.
+"""Every mutating route in `scrapers_handler` is admin-gated.
+
+SCOPE, first, because the module name and the URL prefix do not line up: this file
+covers `scrapers_handler` ONLY. `/scrapers/*` is served by TWO Lambdas — five more
+routes under the same prefix live in `manual_import_handler`
+(`/scrapers/manual/parse`, `.../parse/<job_id>`, `.../confirm`, `.../csv-upload`,
+`.../json-upload`), and none of them calls `require_admin`. Measured as a caller
+whose only `cognito:groups` claim is `users`:
+
+    POST /scrapers/manual/csv-upload → 200, one s3.put_object + one SQS batch
+    POST /scrapers/manual/confirm    → 200, one s3.put_object
+    POST /scrapers/manual/parse      → 200, one job row + one async invoke
+
+So the eight-route inventory below is NOT an all-clear for the URL prefix, and the
+`ast` pass cannot say so on its own: it parses one module, and no parse of one
+module can notice a sibling serving the same prefix. `TestTheInventoryIsOneHandlers`
+asserts the boundary explicitly so a reader inherits a known scope rather than a
+false one.
+
+Those five are left ungated deliberately, as a different question rather than the
+same gap: they write feedback CONTENT into the ingestion pipeline (S3 plus the
+enrichment queue that Bedrock drains) and reach neither the shared API-credentials
+secret nor any plugin resource — which is the whole basis on which the three routes
+here were gated. Every content-ingestion route in this tree is open to an
+authenticated user on that basis (`POST /feedback-forms`,
+`POST /s3-import/upload-url`, both verified 200 as `users`), so gating only the
+manual-import three would create exactly the arbitrary boundary this change closed
+for the secret — one that depends on which page a write arrived from. Whether
+content ingestion as a whole should be admin-only is a product decision across
+several handlers and their pages, not a rider on a secret-isolation fix.
 
 `scrapers_handler` writes the SAME shared API-credentials secret that
 `integrations_handler` does — `POST /scrapers` and `DELETE /scrapers/<id>` both
@@ -39,6 +68,13 @@ REVERT MAP — each assertion below names the mutation it catches:
   TestTheReadRoutesStayOpen
     — gates a read. Without it, `require_admin` on all eight routes would satisfy
       every assertion above while blanking the Scrapers page for non-admins.
+
+  TestTheInventoryIsOneHandlers
+    — lets a reader take the eight-route inventory for the whole `/scrapers/*`
+      prefix. It is not: `manual_import_handler` serves five more, ungated. Pins
+      that module's own inventory too, so if one of ITS routes later grows a
+      `require_admin` — making the recorded scope stale — this fails and the
+      docstring above has to be re-derived rather than left contradicting the code.
 """
 import ast
 import inspect
@@ -243,14 +279,20 @@ def _route_path_of(decorator: ast.expr) -> str | None:
     return path if isinstance(path, str) else None
 
 
-def _route_functions() -> dict[str, ast.FunctionDef]:
+def _route_functions(module=None) -> dict[str, ast.FunctionDef]:
     """Every module-level function carrying an `@app.<method>("<path>")` decorator.
 
     Parsed rather than read off the resolver, because the resolver records a
     route's path and handler but not the guards inside the handler's body, which
     is the thing under test.
+
+    Takes a module so `TestTheInventoryIsOneHandlers` can point it at
+    `manual_import_handler` — the sibling serving the other half of the
+    `/scrapers/*` prefix — with the same parser rather than a second one that could
+    disagree with this one about what a route is. Defaults to `scrapers_handler`,
+    which every other caller means.
     """
-    tree = ast.parse(inspect.getsource(_handler_module()))
+    tree = ast.parse(inspect.getsource(module or _handler_module()))
     return {
         node.name: node
         for node in tree.body
@@ -276,6 +318,21 @@ SCRAPER_WRITE_ROUTES = {
     'save_scraper',
     'delete_scraper',
     'run_scraper',
+}
+
+# `manual_import_handler`'s routes, all under `/scrapers/manual/`, and — as of this
+# change — the complete set of `/scrapers/*` routes NOT covered by anything else in
+# this file. Recorded as data rather than prose so that a change to either the
+# inventory or its gate state fails an assertion instead of quietly making the
+# scope paragraph in the module docstring wrong. Module level, beside
+# SCRAPER_WRITE_ROUTES, because the two are the same kind of thing: a judgement no
+# parse can make.
+MANUAL_IMPORT_ROUTES = {
+    'start_parse',
+    'get_parse_status',
+    'confirm_import',
+    'csv_upload',
+    'json_upload',
 }
 
 
@@ -339,3 +396,72 @@ class TestEveryScraperWriteIsAdminGated:
             f'{route} is a read; gating it would blank the Scrapers page for a '
             'non-admin. Move it to SCRAPER_WRITE_ROUTES if that is intended.'
         )
+
+
+class TestTheInventoryIsOneHandlers:
+    """The eight routes above are `scrapers_handler`'s, not `/scrapers/*`'s.
+
+    Every other assertion in this file is scoped to one module, and nothing in a
+    one-module parse can reveal that a SECOND Lambda serves the same URL prefix. A
+    reader arriving at `TestScraperRouteCoverageIsComplete` would reasonably read
+    its eight-route equality as covering `/scrapers/*`; it does not. These cases
+    make the real boundary an assertion rather than a paragraph.
+    """
+
+    @staticmethod
+    def _manual_import_module():
+        import manual_import_handler
+        return manual_import_handler
+
+    def test_a_second_handler_serves_the_same_url_prefix(self):
+        """The scope claim itself, as data.
+
+        If `manual_import_handler`'s inventory changes, the docstring at the top of
+        this file is describing routes that no longer exist and has to be
+        re-derived.
+        """
+        found = set(_route_functions(self._manual_import_module()))
+        assert found == MANUAL_IMPORT_ROUTES
+
+        paths = [
+            path
+            for node in _route_functions(self._manual_import_module()).values()
+            for path in (_route_path_of(d) for d in node.decorator_list)
+            if path is not None
+        ]
+        assert all(path.startswith('/scrapers/') for path in paths), (
+            'this class exists because those routes share the /scrapers/ prefix; '
+            f'they no longer all do: {paths}'
+        )
+
+    def test_none_of_them_is_admin_gated_and_that_is_recorded_not_assumed(self):
+        """The state the docstring above describes, pinned.
+
+        Deliberately asserts the ABSENCE. Gating those routes may well be right —
+        they write feedback content into the pipeline — but it is a decision about
+        content ingestion across several handlers and their pages, not a rider on a
+        secret-isolation fix. This is what stops that decision being made silently:
+        adding a gate to one of them fails here, and whoever adds it has to update
+        the scope paragraph rather than leave this file asserting a stale claim.
+        """
+        gated = {
+            name
+            for name, node in _route_functions(self._manual_import_module()).items()
+            if 'require_admin' in _calls_in(node)
+        }
+        assert gated == set(), (
+            f'{sorted(gated)} is now admin-gated. That may be correct — but the '
+            'scope paragraph in this module docstring says the manual-import '
+            'routes are ungated, and it is now wrong. Update it, and consider '
+            'whether the rest of that set should follow.'
+        )
+
+    def test_the_control_the_parser_reaches_that_module_at_all(self):
+        """Non-vacuity for the assertion above.
+
+        `gated == set()` passes just as well over an EMPTY parse — a renamed `app`,
+        a decorator style change, an import that silently fails. The inventory
+        equality in the first case is the real guard; this states the minimum
+        directly so the failure names the cause.
+        """
+        assert len(_route_functions(self._manual_import_module())) == len(MANUAL_IMPORT_ROUTES)

--- a/voc-datalake/lambda/api/test/test_scrapers_security.py
+++ b/voc-datalake/lambda/api/test/test_scrapers_security.py
@@ -1,0 +1,341 @@
+"""Every mutating /scrapers route is admin-gated.
+
+`scrapers_handler` writes the SAME shared API-credentials secret that
+`integrations_handler` does — `POST /scrapers` and `DELETE /scrapers/<id>` both
+`put_secret_json` it, rewriting `webscraper_configs`, a key the webscraper
+ingestor consumes — and `POST /scrapers/<id>/run` invokes that ingestor. None of
+its eight routes called `require_admin`. Measured before the fix, as a caller
+whose only `cognito:groups` claim is `users`:
+
+    POST   /scrapers          → 200, one put_secret_json
+    DELETE /scrapers/x        → 200, one put_secret_json
+    POST   /scrapers/x/run    → 200, one lambda:Invoke + one SCRAPER_RUN# row
+
+That state predated the `<source>`-route gating in `integrations_handler`, but
+gating only that half left the boundary depending on which HANDLER a write
+arrived through rather than on what it changed — the same asymmetry the
+`<source>` work closed inside one file, now sitting between two files that write
+one secret.
+
+REVERT MAP — each assertion below names the mutation it catches:
+
+  TestANonAdminCannotWriteTheSharedSecret
+    — drops `require_admin` from `save_scraper` or `delete_scraper`. Asserts the
+      403 AND that `put_secret_json` was never called: a 403 with the write
+      already done would satisfy a status-code-only check.
+
+  TestANonAdminCannotTriggerAScraperRun
+    — drops `require_admin` from `run_scraper`. Asserts no `lambda:Invoke` and no
+      `SCRAPER_RUN#` row, because the invoke is the billed effect and the row is
+      what the UI then polls.
+
+  TestEveryScraperWriteIsAdminGated
+    — the half that covers a route added LATER. A behavioural case can only speak
+      about a route somebody remembered to write it for, and forgetting is the
+      whole failure here, so this parses the `@app.<method>` decorators and
+      asserts over every route found. Its inventory case is what stops the parse
+      silently finding nothing and passing vacuously.
+
+  TestTheReadRoutesStayOpen
+    — gates a read. Without it, `require_admin` on all eight routes would satisfy
+      every assertion above while blanking the Scrapers page for non-admins.
+"""
+import ast
+import inspect
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _handler_module():
+    import scrapers_handler
+    return scrapers_handler
+
+
+def _non_admin_event(api_gateway_event, **kwargs):
+    """An API Gateway event whose only Cognito group is `users`."""
+    event = api_gateway_event(**kwargs)
+    event['requestContext']['authorizer']['claims']['cognito:groups'] = 'users'
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Behavioural half
+# ---------------------------------------------------------------------------
+
+class TestANonAdminCannotWriteTheSharedSecret:
+    """`POST /scrapers` and `DELETE /scrapers/<id>` write the shared secret."""
+
+    @patch('scrapers_handler.put_secret_json')
+    @patch('scrapers_handler.secretsmanager')
+    def test_a_non_admin_save_is_refused_and_writes_nothing(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context
+    ):
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({'webscraper_configs': '[]'})
+        }
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(_non_admin_event(
+            api_gateway_event,
+            method='POST',
+            path='/scrapers',
+            body={'scraper': {'id': 'injected', 'name': 'Injected', 'base_url': 'https://attacker.example'}},
+        ), lambda_context)
+
+        assert response['statusCode'] == 403
+        # The status code alone would pass if the write happened first.
+        assert mock_put.call_args_list == []
+
+    @patch('scrapers_handler.put_secret_json')
+    @patch('scrapers_handler.secretsmanager')
+    def test_a_non_admin_delete_is_refused_and_writes_nothing(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context
+    ):
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({'webscraper_configs': '[{"id": "keep-me"}]'})
+        }
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(_non_admin_event(
+            api_gateway_event,
+            method='DELETE',
+            path='/scrapers/keep-me',
+            path_params={'scraper_id': 'keep-me'},
+        ), lambda_context)
+
+        assert response['statusCode'] == 403
+        assert mock_put.call_args_list == []
+
+    @patch('scrapers_handler.put_secret_json')
+    @patch('scrapers_handler.secretsmanager')
+    def test_the_control_an_admin_save_still_writes(
+        self, mock_secrets, mock_put, api_gateway_event, lambda_context
+    ):
+        """Non-vacuity: without this, refusing EVERY caller would pass the above."""
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({'webscraper_configs': '[]'})
+        }
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(api_gateway_event(
+            method='POST',
+            path='/scrapers',
+            body={'scraper': {'id': 'legit', 'name': 'Legit', 'base_url': 'https://example.com'}},
+        ), lambda_context)
+
+        assert response['statusCode'] == 200
+        assert len(mock_put.call_args_list) == 1
+
+
+class TestANonAdminCannotTriggerAScraperRun:
+    """`POST /scrapers/<id>/run` invokes the webscraper — a billed fetch."""
+
+    @patch('scrapers_handler.require_webscraper_function')
+    @patch('scrapers_handler.lambda_client')
+    @patch('scrapers_handler.get_aggregates_table')
+    def test_a_non_admin_run_is_refused_and_invokes_nothing(
+        self, mock_get_table, mock_lambda, mock_require_fn, api_gateway_event, lambda_context
+    ):
+        table = MagicMock()
+        mock_get_table.return_value = table
+        mock_require_fn.return_value = 'test-webscraper-function'
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(_non_admin_event(
+            api_gateway_event,
+            method='POST',
+            path='/scrapers/some-scraper/run',
+            path_params={'scraper_id': 'some-scraper'},
+        ), lambda_context)
+
+        assert response['statusCode'] == 403
+        assert mock_lambda.invoke.call_args_list == [], 'a billed third-party fetch was issued'
+        assert table.put_item.call_args_list == [], 'a SCRAPER_RUN# row was written'
+
+    @patch('scrapers_handler.require_webscraper_function')
+    @patch('scrapers_handler.lambda_client')
+    @patch('scrapers_handler.get_aggregates_table')
+    def test_the_control_an_admin_run_still_invokes(
+        self, mock_get_table, mock_lambda, mock_require_fn, api_gateway_event, lambda_context
+    ):
+        table = MagicMock()
+        mock_get_table.return_value = table
+        mock_require_fn.return_value = 'test-webscraper-function'
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(api_gateway_event(
+            method='POST',
+            path='/scrapers/some-scraper/run',
+            path_params={'scraper_id': 'some-scraper'},
+        ), lambda_context)
+
+        assert response['statusCode'] == 200
+        assert len(mock_lambda.invoke.call_args_list) == 1
+
+
+class TestTheReadRoutesStayOpen:
+    """The reads are deliberately ungated, and that is asserted, not assumed.
+
+    Non-vacuity for every case above: `require_admin` on all eight routes would
+    satisfy all of them. It would also empty the Scrapers page for a non-admin,
+    which is why the split is read/write rather than route-by-route.
+    """
+
+    @patch('scrapers_handler.secretsmanager')
+    def test_a_non_admin_can_list_scrapers(
+        self, mock_secrets, api_gateway_event, lambda_context
+    ):
+        mock_secrets.get_secret_value.return_value = {
+            'SecretString': json.dumps({'webscraper_configs': '[{"id": "one"}]'})
+        }
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(_non_admin_event(
+            api_gateway_event, method='GET', path='/scrapers',
+        ), lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['scrapers'] == [{'id': 'one'}]
+
+    @patch('scrapers_handler.get_aggregates_table')
+    def test_a_non_admin_can_read_a_run_status(
+        self, mock_get_table, api_gateway_event, lambda_context
+    ):
+        table = MagicMock()
+        table.query.return_value = {'Items': []}
+        mock_get_table.return_value = table
+        from scrapers_handler import lambda_handler
+
+        response = lambda_handler(_non_admin_event(
+            api_gateway_event,
+            method='GET',
+            path='/scrapers/one/status',
+            path_params={'scraper_id': 'one'},
+        ), lambda_context)
+
+        assert response['statusCode'] == 200
+
+
+# ---------------------------------------------------------------------------
+# `ast` half — covers a route added later
+# ---------------------------------------------------------------------------
+
+def _route_path_of(decorator: ast.expr) -> str | None:
+    """The literal path of an `@app.get("/x")`-style decorator, else None.
+
+    Matches on the `app` receiver and a string first argument, so
+    `@tracer.capture_method` (no arguments) is ignored without needing a list of
+    method names to exclude. Same shape as `test_integrations_security.py`'s
+    parser, deliberately: the two handlers are asserted about the same way.
+    """
+    if not isinstance(decorator, ast.Call):
+        return None
+    func = decorator.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if not isinstance(func.value, ast.Name) or func.value.id != 'app':
+        return None
+    if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+        return None
+    path = decorator.args[0].value
+    return path if isinstance(path, str) else None
+
+
+def _route_functions() -> dict[str, ast.FunctionDef]:
+    """Every module-level function carrying an `@app.<method>("<path>")` decorator.
+
+    Parsed rather than read off the resolver, because the resolver records a
+    route's path and handler but not the guards inside the handler's body, which
+    is the thing under test.
+    """
+    tree = ast.parse(inspect.getsource(_handler_module()))
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and any(_route_path_of(d) for d in node.decorator_list)
+    }
+
+
+def _calls_in(node: ast.FunctionDef) -> set[str]:
+    """Names of the plain-function calls anywhere in *node*'s body."""
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+# The routes that MUTATE — a Secrets Manager value or a webscraper invocation.
+# Listed explicitly because "does this route write?" is a judgement no parse can
+# make, and because the read/write split is the whole argument for gating three
+# of the eight rather than all of them.
+SCRAPER_WRITE_ROUTES = {
+    'save_scraper',
+    'delete_scraper',
+    'run_scraper',
+}
+
+
+class TestScraperRouteCoverageIsComplete:
+    """Non-vacuity for the class below.
+
+    Its assertion is "for each route found", so a parse that finds NOTHING — a
+    rename of `app`, a move to a router object, a decorator style change — would
+    pass over an empty set. These cases make that loud, and pin the inventory the
+    list above is asserted against.
+    """
+
+    def test_the_parser_finds_every_scraper_route(self):
+        assert set(_route_functions()) == {
+            'list_scrapers',
+            'save_scraper',
+            'delete_scraper',
+            'get_templates',
+            'run_scraper',
+            'get_scraper_status',
+            'get_scraper_runs',
+            'analyze_url',
+        }, (
+            'the route inventory changed; a NEW route must be added to '
+            'SCRAPER_WRITE_ROUTES if it mutates, and will otherwise be asserted '
+            'as a read that is deliberately open'
+        )
+
+    def test_every_named_write_route_is_a_route_the_parser_found(self):
+        """The list above cannot name a function that no longer exists.
+
+        Otherwise renaming a route would silently drop its guard assertion rather
+        than failing.
+        """
+        assert SCRAPER_WRITE_ROUTES <= set(_route_functions())
+
+
+class TestEveryScraperWriteIsAdminGated:
+    """Each mutating route calls require_admin; each read deliberately does not."""
+
+    @pytest.mark.parametrize('route', sorted(SCRAPER_WRITE_ROUTES))
+    def test_the_route_requires_admin(self, route):
+        assert 'require_admin' in _calls_in(_route_functions()[route]), (
+            f'{route} mutates the shared secret or invokes the webscraper with no '
+            'admin gate'
+        )
+
+    @pytest.mark.parametrize(
+        'route',
+        sorted(set(_route_functions()) - SCRAPER_WRITE_ROUTES),
+    )
+    def test_the_read_routes_are_deliberately_not_gated(self, route):
+        """States the split as an assertion, so widening it is a choice.
+
+        `analyze_url` is here rather than in the write set on purpose: it fetches
+        a URL the caller supplies and asks Bedrock about it, but persists nothing
+        — and `validate_url` already bounds the fetch (SSRF). If a future change
+        makes it store something, this fails and forces the classification.
+        """
+        assert 'require_admin' not in _calls_in(_route_functions()[route]), (
+            f'{route} is a read; gating it would blank the Scrapers page for a '
+            'non-admin. Move it to SCRAPER_WRITE_ROUTES if that is intended.'
+        )

--- a/voc-datalake/lambda/shared/api.py
+++ b/voc-datalake/lambda/shared/api.py
@@ -17,6 +17,7 @@ from shared.exceptions import (
     ValidationError,
     NotFoundError,
     ConfigurationError,
+    SecretUnreadableError,
     ServiceError,
     AuthorizationError,
     ConflictError,
@@ -328,6 +329,11 @@ def _register_exception_handlers(app: APIGatewayRestResolver) -> None:
             body=json.dumps({'success': False, 'error': ex.message})
         )
     
+    # Intentionally covers the SecretUnreadableError SUBCLASS too, with no handler
+    # of its own: Powertools resolves a handler by walking `exp_type.__mro__`, and
+    # the HTTP answer is the same 500 — only callers that must decide whether to
+    # COUNT the failure (see BaseIngestor._report_construction_failure) care which
+    # of the two it is.
     @app.exception_handler(ConfigurationError)
     def handle_configuration_error(ex: ConfigurationError):
         logger.error(f"Configuration error: {ex.message}")
@@ -423,6 +429,7 @@ __all__ = [
     'ValidationError',
     'NotFoundError',
     'ConfigurationError',
+    'SecretUnreadableError',
     'ServiceError',
     'AuthorizationError',
     'ConflictError',

--- a/voc-datalake/lambda/shared/exceptions.py
+++ b/voc-datalake/lambda/shared/exceptions.py
@@ -66,6 +66,22 @@ class ConfigurationError(ApiError):
     status_code = 500
 
 
+class SecretUnreadableError(ConfigurationError):
+    """Raised when a secret could not be READ, as distinct from being misconfigured.
+
+    A subclass so every existing ``except ConfigurationError`` keeps catching it —
+    the HTTP answer is the same 500 — while a caller that needs to tell the two
+    apart can. The distinction matters where a failure is *counted* against the
+    thing that failed: ``shared.aws.get_secret`` logs and swallows every client
+    error into ``{}``, so an empty payload means either "genuinely empty" or "the
+    read failed", and a plugin whose ingestion schedule is auto-disabled after N
+    failures must not be disabled by an AWS-side throttle it did nothing to cause
+    (see ``BaseIngestor._report_construction_failure``).
+
+    HTTP Status: 500 Internal Server Error
+    """
+
+
 class ServiceError(ApiError):
     """Raised when an external service call fails.
     

--- a/voc-datalake/lambda/shared/mcp_tokens.py
+++ b/voc-datalake/lambda/shared/mcp_tokens.py
@@ -71,7 +71,7 @@ _TOKEN_PART_COUNT: Final = 4
 # what keeps them out of `projects.list_projects` (it queries the
 # `TYPE#PROJECT` GSI, so an unindexed row is invisible to it).
 #
-# ponytail: single hot partition for all tokens. Ceiling is per-partition
+# SCALING: single hot partition for all tokens. Ceiling is per-partition
 # throughput (~3 000 RCU), which the endpoint's own 20 rps stage throttle sits
 # three orders of magnitude below. Upgrade path if tokens ever number in the
 # thousands: shard the pk by a prefix of the token id, which changes only the

--- a/voc-datalake/lambda/shared/plugin_identity.py
+++ b/voc-datalake/lambda/shared/plugin_identity.py
@@ -1,0 +1,64 @@
+"""The character class a plugin id / credential key must satisfy, declared ONCE.
+
+A plugin id and a credential key are both used as, or inside, a Secrets Manager
+key namespace (`<plugin_id>_<key>`), so the same character class has to hold on
+both sides of that namespace:
+
+  * the WRITE path (`lambda/api/integrations_handler.py`) validates the `source`
+    path parameter and every submitted credential key before it prefixes and
+    stores them;
+  * the READ path (`plugins/_shared/plugin_secrets.py`) validates the plugin
+    identity it is about to turn into a prefix, because since issue #251 a
+    namespace miss is a hard failure rather than a silent widening to the whole
+    shared secret.
+
+Those two used to carry their own copies of the pattern. Read-path and
+write-path validation drifting apart is the same class of defect issue #251 was
+about one level down — a write that stores `Foo_key` under a rule the reader does
+not share, or a reader that refuses an identity the writer accepted — so the
+pattern lives here instead.
+
+`lambda/shared/` is the only directory both bundles contain: the API Lambdas get
+`lambda/api/<handler>.py` + `lambda/shared/`, and a plugin Lambda gets
+`plugins/<id>/...` + `plugins/_shared/` + `lambda/shared/` (see
+`createApiLambdaCode` in `lib/stacks/api-stack.ts` and `createIngestorLambda` in
+`lib/stacks/ingestion-stack.ts`). `lambda/api` is NOT on a plugin Lambda's path,
+which is why the plugin side cannot simply import the handler's constant.
+
+Rules, unchanged from the write path's original statement of them:
+
+  * Only lowercase letters, digits, and underscores — no dots, slashes, hyphens
+    or other characters that could escape or re-enter a namespace.
+  * Length 1-64 characters.
+  * May not start or end with an underscore, which would blur the boundary
+    between a name and the `_` namespace separator.
+
+Single alternative: the optional inner body of up to 62 chars means the total
+length is 1 (just the initial char) or 2-64 (initial + inner + final). Callers
+use `re.fullmatch`, so no anchors are needed in the pattern.
+"""
+
+import re
+
+__all__ = ["PLUGIN_IDENTIFIER_RE", "PLUGIN_IDENTIFIER_RULES", "is_valid_plugin_identifier"]
+
+PLUGIN_IDENTIFIER_RE = re.compile(r'[a-z0-9](?:[a-z0-9_]{0,62}[a-z0-9])?')
+
+# The rules above in the words both paths' error messages use, so a 400 from the
+# write path and a ConfigurationError from the read path describe the same
+# constraint identically.
+PLUGIN_IDENTIFIER_RULES = (
+    "must contain only lowercase letters, digits, and underscores, must start "
+    "and end with a letter or digit, and must be 1–64 characters long"
+)
+
+
+def is_valid_plugin_identifier(value: object) -> bool:
+    """True if *value* is a string conforming to the rules above.
+
+    The isinstance check is part of the contract rather than the caller's job:
+    both paths receive this value from outside (a path parameter, an environment
+    variable) and `re.fullmatch` raises on a non-string instead of returning
+    False.
+    """
+    return isinstance(value, str) and PLUGIN_IDENTIFIER_RE.fullmatch(value) is not None

--- a/voc-datalake/lambda/shared/test/test_exceptions.py
+++ b/voc-datalake/lambda/shared/test/test_exceptions.py
@@ -6,6 +6,7 @@ from shared.exceptions import (
     ValidationError,
     NotFoundError,
     ConfigurationError,
+    SecretUnreadableError,
     ServiceError,
     AuthorizationError,
     ConflictError,
@@ -65,9 +66,31 @@ class TestConfigurationError:
         assert isinstance(error, ApiError)
 
 
+class TestSecretUnreadableError:
+    """Tests for SecretUnreadableError."""
+
+    def test_status_code_is_500(self):
+        error = SecretUnreadableError('Secret could not be read')
+        assert error.status_code == 500
+
+    def test_inherits_from_configuration_error(self):
+        """The subclassing is the compatibility promise, not an implementation
+        detail: `BaseIngestor.__init__` and every plugin handler catch
+        `ConfigurationError`, so a sibling type would escape all of them and turn a
+        handled misconfiguration into an unhandled crash. It is also why no separate
+        `@app.exception_handler` is registered — Powertools resolves one by walking
+        the MRO, so the ConfigurationError handler already returns this 500."""
+        error = SecretUnreadableError('Throttled')
+        assert isinstance(error, ConfigurationError)
+
+    def test_inherits_from_api_error(self):
+        error = SecretUnreadableError('Throttled')
+        assert isinstance(error, ApiError)
+
+
 class TestServiceError:
     """Tests for ServiceError."""
-    
+
     def test_status_code_is_500(self):
         error = ServiceError('DynamoDB operation failed')
         assert error.status_code == 500

--- a/voc-datalake/lib/plugin-loader.test.ts
+++ b/voc-datalake/lib/plugin-loader.test.ts
@@ -152,6 +152,76 @@ describe('Plugin Loader', () => {
     });
   });
 
+  /**
+   * A plugin id becomes a Secrets Manager key namespace (`<plugin_id>_<key>`), and
+   * both readers of that secret match the namespace by plain string prefix — the
+   * runtime one in `plugins/_shared/plugin_secrets.py`, which is the ENTIRE
+   * isolation boundary between plugins because all ingestion Lambdas share one IAM
+   * role, and the status one in `integrations_handler.get_credentials`.
+   *
+   * Neither can see the other ids, by design: since issue #251 a plugin Lambda
+   * holds no list of its siblings' prefixes (keeping one is what let a plugin's
+   * keys be reclassified as "shared" and leak into every other plugin). So synth
+   * is the only vantage point from which a colliding pair can be refused, and this
+   * is the guard that does it.
+   */
+  describe('plugin id namespace collisions', () => {
+    /** Mock two manifests, returning each by the path being read. */
+    function mockTwoPlugins(first: string, second: string) {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(mockDirents(first, second));
+      mockFs.readFileSync.mockImplementation((p) => JSON.stringify({
+        id: String(p).includes(`/${second}/`) ? second : first,
+        name: 'Plugin',
+        icon: '📦',
+        infrastructure: { ingestor: { enabled: true } },
+        secrets: { api_key: '' },
+      }));
+    }
+
+    it('rejects an id that is a namespace prefix of another id', async () => {
+      // The concrete hazard, not an abstract one: `app_reviews_ios` ships today,
+      // and `app_reviews` is a plausible future id for a combined plugin. It would
+      // silently receive every `app_reviews_ios_*` key under a mangled name
+      // (`app_reviews_ios_app_id` arriving as `ios_app_id`).
+      mockTwoPlugins('app_reviews', 'app_reviews_ios');
+
+      const { loadPlugins } = await import('./plugin-loader');
+
+      expect(() => loadPlugins('/test/plugins')).toThrow();
+    });
+
+    it('accepts ids that merely share a leading substring', async () => {
+      // Non-vacuity, and the property the guard must not overreach on: the
+      // boundary is the `_` separator, so `app_reviewsx` is NOT inside
+      // `app_reviews`'s namespace and must still load. A guard written as a bare
+      // `startsWith(id)` would reject this pair and block a legitimate plugin.
+      mockTwoPlugins('app_reviews', 'app_reviewsx');
+
+      const { loadPlugins } = await import('./plugin-loader');
+
+      expect(loadPlugins('/test/plugins').map((p) => p.id).sort())
+        .toEqual(['app_reviews', 'app_reviewsx']);
+    });
+
+    it('names both ids in the error, so the fix is not a guessing game', async () => {
+      mockTwoPlugins('app_reviews', 'app_reviews_ios');
+
+      const { loadPlugins } = await import('./plugin-loader');
+      const errors: string[] = [];
+      const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+        errors.push(args.map(String).join(' '));
+      });
+
+      expect(() => loadPlugins('/test/plugins')).toThrow();
+      spy.mockRestore();
+
+      const combined = errors.join('\n');
+      expect(combined).toContain('app_reviews');
+      expect(combined).toContain('app_reviews_ios');
+    });
+  });
+
   describe('Manifest Schema Validation', () => {
     it('rejects invalid plugin ID format', async () => {
       mockFs.existsSync.mockReturnValue(true);

--- a/voc-datalake/lib/plugin-loader.ts
+++ b/voc-datalake/lib/plugin-loader.ts
@@ -240,8 +240,12 @@ export function loadPlugins(pluginsDir: string, options: LoadPluginsOptions = {}
  * `PUT /integrations/app_reviews/credentials` with key `ios_app_id` writes
  * `app_reviews_ios_app_id`, which `app_reviews_ios` then reads as its own `app_id`.
  * That entrance is a request parameter this function never sees, and is closed in
- * `integrations_handler._validate_source_is_a_known_plugin` by restricting the
- * namespace a write may address to the ids below. Both guards are needed.
+ * `integrations_handler._validate_source_parameter` — applied on EVERY route taking a
+ * `<source>`, not only the credentials ones — by restricting the namespace a request
+ * may address to the ids below. Both guards are needed.
+ *
+ * Neither is retroactive: a key stored before either existed survives, and the plugin
+ * whose namespace it landed in still reads it.
  */
 function namespaceCollisionErrors(plugins: PluginManifest[]): string[] {
   const ids = plugins.map(p => p.id);

--- a/voc-datalake/lib/plugin-loader.ts
+++ b/voc-datalake/lib/plugin-loader.ts
@@ -204,6 +204,10 @@ export function loadPlugins(pluginsDir: string, options: LoadPluginsOptions = {}
     }
   }
 
+  // Cross-plugin checks, after the per-manifest ones: this is the only place that
+  // sees the whole id set at once.
+  errors.push(...namespaceCollisionErrors(plugins));
+
   if (errors.length > 0) {
     console.error('Plugin loading errors:');
     errors.forEach(e => console.error(`  - ${e}`));
@@ -212,6 +216,42 @@ export function loadPlugins(pluginsDir: string, options: LoadPluginsOptions = {}
 
   console.log(`Loaded ${plugins.length} plugins: ${plugins.map(p => p.id).join(', ')}`);
   return plugins;
+}
+
+/**
+ * Reject an id that is a PREFIX of another id.
+ *
+ * The shared API-credentials secret namespaces every key `<plugin_id>_<key>`, and
+ * both readers of it match that namespace by plain string prefix — the runtime one
+ * in `plugins/_shared/plugin_secrets.py`, which is the entire isolation boundary
+ * between plugins (all ingestion Lambdas share one IAM role), and the status one in
+ * `integrations_handler.get_credentials`. So `app_reviews` alongside the existing
+ * `app_reviews_ios` would hand the shorter plugin every key of the longer one, under
+ * mangled names (`app_reviews_ios_app_id` arriving as `ios_app_id`).
+ *
+ * Enforced HERE and not at runtime because this is the only vantage point with the
+ * whole id set: a plugin Lambda knows its own id and, by design since issue #251,
+ * nothing about the others — a hand-maintained list of sibling prefixes is exactly
+ * the hole that change closed. Ids are a synth-time input, so synth is also the last
+ * moment at which refusing one is free.
+ */
+function namespaceCollisionErrors(plugins: PluginManifest[]): string[] {
+  const ids = plugins.map(p => p.id);
+  const errors: string[] = [];
+
+  for (const id of ids) {
+    for (const other of ids) {
+      if (other !== id && other.startsWith(`${id}_`)) {
+        errors.push(
+          `Plugin id '${id}' is a namespace prefix of '${other}': the shared secret ` +
+          `keys both plugins' credentials as <plugin_id>_<key>, so '${id}' would also ` +
+          `receive every '${other}' key. Rename one of them.`
+        );
+      }
+    }
+  }
+
+  return errors;
 }
 
 function validateManifestLimits(manifest: PluginManifest): void {

--- a/voc-datalake/lib/plugin-loader.ts
+++ b/voc-datalake/lib/plugin-loader.ts
@@ -234,6 +234,14 @@ export function loadPlugins(pluginsDir: string, options: LoadPluginsOptions = {}
  * nothing about the others — a hand-maintained list of sibling prefixes is exactly
  * the hole that change closed. Ids are a synth-time input, so synth is also the last
  * moment at which refusing one is free.
+ *
+ * SCOPE: this constrains MANIFEST IDS, which is not the whole collision class. A
+ * colliding key can also be STORED without any colliding manifest existing:
+ * `PUT /integrations/app_reviews/credentials` with key `ios_app_id` writes
+ * `app_reviews_ios_app_id`, which `app_reviews_ios` then reads as its own `app_id`.
+ * That entrance is a request parameter this function never sees, and is closed in
+ * `integrations_handler._validate_source_is_a_known_plugin` by restricting the
+ * namespace a write may address to the ids below. Both guards are needed.
  */
 function namespaceCollisionErrors(plugins: PluginManifest[]): string[] {
   const ids = plugins.map(p => p.id);

--- a/voc-datalake/lib/stacks/api-stack-webhook-env.test.ts
+++ b/voc-datalake/lib/stacks/api-stack-webhook-env.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The environment a webhook Lambda is deployed with, against what
+ * `plugins/_shared/base_webhook.py` actually reads.
+ *
+ * `createWebhookLambda` set `PLUGIN_ID` while `base_webhook.py` read
+ * `SOURCE_PLATFORM`, so on a deployed webhook the plugin identity was `''`. Under
+ * the old fail-open secret filter that empty identity matched nothing and the
+ * whole shared secret came back; since issue #251 it is a hard
+ * `ConfigurationError` at construction, so EVERY delivery would have died — on a
+ * message blaming the identity rather than the missing variable, which is the
+ * wrong thing to hand a deployer at 3am.
+ *
+ * IN ITS OWN FILE, and this is the point of the whole file: no manifest declares
+ * `infrastructure.webhook` and no plugin has a `webhook/` directory, so
+ * `api-stack.test.ts`'s fixtures — which read the real manifests — synthesize no
+ * webhook Lambda at all and CANNOT see this. Rather than wait for the first
+ * webhook plugin to discover it in production, the loader is mocked here to
+ * declare one. Mocking `loadPlugins` is why this cannot live in
+ * `api-stack.test.ts`: `vi.mock` is module-scoped and hoisted, and every other
+ * case in that file depends on the real manifests.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect, vi } from 'vitest';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import { z } from 'zod';
+
+const WEBHOOK_PLUGIN_ID = 'webhook_fixture';
+
+/** A manifest declaring a webhook, which nothing on disk does. Otherwise shaped
+ *  exactly like a real one, so it travels the same `createWebhookLambda` path. */
+const webhookPlugin = {
+  id: WEBHOOK_PLUGIN_ID,
+  name: 'Webhook Fixture',
+  icon: '🔔',
+  infrastructure: {
+    webhook: { enabled: true, path: '/webhooks/fixture', methods: ['POST'] as const },
+  },
+  config: [],
+  secrets: { api_key: '' },
+};
+
+// Only `loadPlugins` is replaced; every other export (aggregateSecretsByPlugin,
+// getEnabledPlugins, getPluginsWithWebhook, capitalize, ManifestSchema) stays
+// real, so the stack still exercises the genuine filtering and naming logic.
+vi.mock('../plugin-loader', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../plugin-loader')>();
+  return { ...actual, loadPlugins: () => [webhookPlugin] };
+});
+
+// Imported AFTER the mock declaration for readability only — `vi.mock` is
+// hoisted above both.
+import { VocApiStack } from './api-stack';
+
+function synthWithWebhookPlugin(): Template {
+  const app = new cdk.App({
+    context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true },
+  });
+  const env = { account: '111111111111', region: 'us-east-1' };
+  const deps = new cdk.Stack(app, 'TestDeps', { env });
+
+  const table = (id: string) => new dynamodb.Table(deps, id, {
+    partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+    sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+  });
+  const userPool = new cognito.UserPool(deps, 'UserPool');
+  const websiteBucket = new s3.Bucket(deps, 'Website');
+
+  const stack = new VocApiStack(app, 'TestApiStack', {
+    env,
+    feedbackTable: table('Feedback'),
+    aggregatesTable: table('Aggregates'),
+    projectsTable: table('Projects'),
+    jobsTable: table('Jobs'),
+    conversationsTable: table('Conversations'),
+    kmsKey: new kms.Key(deps, 'Key'),
+    rawDataBucket: new s3.Bucket(deps, 'RawData'),
+    avatarsCdnUrl: 'https://cdn.example.invalid/avatars',
+    prototypesCdnUrl: 'https://cdn.example.invalid/prototypes',
+    cdnSigningSecretArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:cdn-signing`,
+    cdnSigningKeyPairId: 'KEXAMPLE0000',
+    websiteBucket,
+    frontendDistribution: new cloudfront.Distribution(deps, 'Dist', {
+      defaultBehavior: { origin: origins.S3BucketOrigin.withOriginAccessControl(websiteBucket) },
+    }),
+    frontendDomainName: 'app.example.invalid',
+    userPool,
+    userPoolClient: userPool.addClient('Client'),
+    identityPool: new cognito.CfnIdentityPool(deps, 'IdentityPool', { allowUnauthenticatedIdentities: false }),
+    authenticatedRole: new iam.Role(deps, 'AuthRole', { assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com') }),
+    processingQueueUrl: `https://sqs.${env.region}.amazonaws.com/${env.account}/processing`,
+    processingQueueArn: `arn:aws:sqs:${env.region}:${env.account}:processing`,
+    secretsArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:voc`,
+    s3ImportBucket: new s3.Bucket(deps, 'S3Import'),
+    researchStateMachine: new sfn.StateMachine(deps, 'Research', {
+      definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(deps, 'Noop')),
+    }),
+    brandName: 'TestBrand',
+    // The fixture plugin has to be ENABLED for a webhook Lambda to be created:
+    // api-stack.ts filters `getEnabledPlugins` before `getPluginsWithWebhook`.
+    enabledSources: [WEBHOOK_PLUGIN_ID],
+  });
+
+  return Template.fromStack(stack);
+}
+
+let cached: Template | undefined;
+const template = () => (cached ??= synthWithWebhookPlugin());
+
+const EnvSchema = z.object({
+  Properties: z.object({ Environment: z.object({ Variables: z.record(z.string(), z.unknown()) }) }),
+});
+
+/** The fixture plugin's webhook function, found by its Powertools service name
+ *  (the same way api-stack.test.ts locates the integrations function). */
+function webhookEnv(): Record<string, unknown> {
+  const functions = Object.values(template().findResources('AWS::Lambda::Function'));
+  const fn = functions.find(
+    (f) => EnvSchema.safeParse(f).success
+      && EnvSchema.parse(f).Properties.Environment.Variables.POWERTOOLS_SERVICE_NAME
+        === `voc-webhook-${WEBHOOK_PLUGIN_ID}`,
+  );
+  expect(fn, `no webhook Lambda synthesized for ${WEBHOOK_PLUGIN_ID}`).toBeDefined();
+  return EnvSchema.parse(fn).Properties.Environment.Variables;
+}
+
+describe('webhook Lambda environment', () => {
+  it('synthesizes a webhook Lambda at all, so the assertions below are not vacuous', () => {
+    // The mock is the only reason a webhook function exists in this template. If
+    // it stopped taking effect — an import path change, a rename of `loadPlugins`
+    // — every case here would pass over nothing. `webhookEnv()` throwing is what
+    // makes that loud.
+    expect(webhookEnv().POWERTOOLS_SERVICE_NAME).toBe(`voc-webhook-${WEBHOOK_PLUGIN_ID}`);
+  });
+
+  it('carries SOURCE_PLATFORM, which is the name base_webhook.py reads', () => {
+    // `plugins/_shared/base_webhook.py` resolves the plugin identity from
+    // SOURCE_PLATFORM and hands it to `filter_plugin_secrets`, which since issue
+    // #251 raises on an empty one. `createIngestorLambda` sets both names; this
+    // one used to set only PLUGIN_ID.
+    expect(webhookEnv().SOURCE_PLATFORM).toBe(WEBHOOK_PLUGIN_ID);
+  });
+
+  it('keeps PLUGIN_ID too, so nothing reading the older name breaks', () => {
+    expect(webhookEnv().PLUGIN_ID).toBe(WEBHOOK_PLUGIN_ID);
+  });
+
+  it('agrees with the variable base_webhook.py actually reads', () => {
+    // The independent oracle, and the half that keeps this honest in the other
+    // direction: the two assertions above would still pass if the Python side were
+    // changed to read a third name. Read out of the Python source rather than
+    // re-stated, which is this repo's convention for a contract two languages
+    // share (see the MCP_TOKEN_PK and TRANSPORT_HEADERS tests in
+    // api-stack.test.ts).
+    const source = readFileSync(
+      join(__dirname, '..', '..', 'plugins', '_shared', 'base_webhook.py'),
+      'utf-8',
+    );
+    const name = source.match(/^SOURCE_PLATFORM = os\.environ\.get\("([A-Z_]+)"/m)?.[1];
+
+    expect(name, 'could not read the identity env var from base_webhook.py').toBeDefined();
+    expect(Object.keys(webhookEnv())).toContain(name);
+  });
+
+  it('grants the webhook role read access to the shared secret it now depends on', () => {
+    // Failing closed makes the secret read load-bearing: without the grant, every
+    // delivery raises at construction rather than degrading. Asserted here because
+    // this is the only fixture in the suite that synthesizes the role at all.
+    const policies = Object.values(template().findResources('AWS::IAM::Policy'));
+    const grantsSecretRead = policies.some((p) => JSON.stringify(p).includes('secretsmanager:GetSecretValue'));
+
+    expect(grantsSecretRead).toBe(true);
+  });
+});

--- a/voc-datalake/lib/stacks/api-stack-webhook-env.test.ts
+++ b/voc-datalake/lib/stacks/api-stack-webhook-env.test.ts
@@ -187,6 +187,14 @@ const actionsOf = (statement: { Action?: string | string[] }): string[] => {
   return action ?? [];
 };
 
+/** A statement's resources, normalized to an array. CloudFormation renders a
+ *  single-resource grant as a bare string and a multi-resource one as an array, and
+ *  the case below asks about the PERMISSION rather than the rendering — see the
+ *  comment there for why containment, not equality. */
+const resourcesOf = (statement: { Resource?: unknown }): unknown[] => (
+  Array.isArray(statement.Resource) ? statement.Resource : [statement.Resource]
+);
+
 describe('webhook Lambda environment', () => {
   it('synthesizes a webhook Lambda at all, so the assertions below are not vacuous', () => {
     // The mock is the only reason a webhook function exists in this template. If
@@ -236,12 +244,20 @@ describe('webhook Lambda environment', () => {
     // same stack all grant that action, so deleting the webhook role's grant left
     // the assertion green. The CDN signing secret is excluded for the same reason —
     // a grant on THAT ARN does not let base_webhook.py read its credentials.
+    //
+    // CONTAINMENT, not equality, and deliberately so: equality on the rendered
+    // `Resource` pins the CloudFormation output rather than the permission, so a
+    // grant that is equally correct but rendered as a one-element array — an added
+    // resource, or a move to `secret.grantRead()` — would report a MISSING grant
+    // that is in fact present, which is the costliest failure direction here.
+    // Containment keeps the CDN discrimination: a statement scoped only to
+    // CDN_SIGNING_SECRET_ARN still does not match. Do not tighten this back.
     const roleLogicalId = RoleRefSchema.parse(webhookFunction())
       .Properties.Role['Fn::GetAtt'][0];
 
     const grants = statementsFor(roleLogicalId).filter(
       (s) => actionsOf(s).includes('secretsmanager:GetSecretValue')
-        && JSON.stringify(s.Resource) === JSON.stringify(SHARED_SECRET_ARN),
+        && resourcesOf(s).includes(SHARED_SECRET_ARN),
     );
 
     expect(

--- a/voc-datalake/lib/stacks/api-stack-webhook-env.test.ts
+++ b/voc-datalake/lib/stacks/api-stack-webhook-env.test.ts
@@ -37,6 +37,14 @@ import { z } from 'zod';
 
 const WEBHOOK_PLUGIN_ID = 'webhook_fixture';
 
+const ACCOUNT = '111111111111';
+const REGION = 'us-east-1';
+/** The SHARED API-credentials secret — the one `base_webhook.py` reads. Named here
+ *  because the IAM case below has to tell it apart from the CDN signing secret,
+ *  which the same stack also grants reads of. */
+const SHARED_SECRET_ARN = `arn:aws:secretsmanager:${REGION}:${ACCOUNT}:secret:voc`;
+const CDN_SIGNING_SECRET_ARN = `arn:aws:secretsmanager:${REGION}:${ACCOUNT}:secret:cdn-signing`;
+
 /** A manifest declaring a webhook, which nothing on disk does. Otherwise shaped
  *  exactly like a real one, so it travels the same `createWebhookLambda` path. */
 const webhookPlugin = {
@@ -66,7 +74,7 @@ function synthWithWebhookPlugin(): Template {
   const app = new cdk.App({
     context: { 'aws:cdk:bundling-stacks': [], skipFrontendBuildCheck: true },
   });
-  const env = { account: '111111111111', region: 'us-east-1' };
+  const env = { account: ACCOUNT, region: REGION };
   const deps = new cdk.Stack(app, 'TestDeps', { env });
 
   const table = (id: string) => new dynamodb.Table(deps, id, {
@@ -87,7 +95,7 @@ function synthWithWebhookPlugin(): Template {
     rawDataBucket: new s3.Bucket(deps, 'RawData'),
     avatarsCdnUrl: 'https://cdn.example.invalid/avatars',
     prototypesCdnUrl: 'https://cdn.example.invalid/prototypes',
-    cdnSigningSecretArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:cdn-signing`,
+    cdnSigningSecretArn: CDN_SIGNING_SECRET_ARN,
     cdnSigningKeyPairId: 'KEXAMPLE0000',
     websiteBucket,
     frontendDistribution: new cloudfront.Distribution(deps, 'Dist', {
@@ -100,7 +108,7 @@ function synthWithWebhookPlugin(): Template {
     authenticatedRole: new iam.Role(deps, 'AuthRole', { assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com') }),
     processingQueueUrl: `https://sqs.${env.region}.amazonaws.com/${env.account}/processing`,
     processingQueueArn: `arn:aws:sqs:${env.region}:${env.account}:processing`,
-    secretsArn: `arn:aws:secretsmanager:${env.region}:${env.account}:secret:voc`,
+    secretsArn: SHARED_SECRET_ARN,
     s3ImportBucket: new s3.Bucket(deps, 'S3Import'),
     researchStateMachine: new sfn.StateMachine(deps, 'Research', {
       definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(deps, 'Noop')),
@@ -123,7 +131,7 @@ const EnvSchema = z.object({
 
 /** The fixture plugin's webhook function, found by its Powertools service name
  *  (the same way api-stack.test.ts locates the integrations function). */
-function webhookEnv(): Record<string, unknown> {
+function webhookFunction(): unknown {
   const functions = Object.values(template().findResources('AWS::Lambda::Function'));
   const fn = functions.find(
     (f) => EnvSchema.safeParse(f).success
@@ -131,8 +139,53 @@ function webhookEnv(): Record<string, unknown> {
         === `voc-webhook-${WEBHOOK_PLUGIN_ID}`,
   );
   expect(fn, `no webhook Lambda synthesized for ${WEBHOOK_PLUGIN_ID}`).toBeDefined();
-  return EnvSchema.parse(fn).Properties.Environment.Variables;
+  return fn;
 }
+
+function webhookEnv(): Record<string, unknown> {
+  return EnvSchema.parse(webhookFunction()).Properties.Environment.Variables;
+}
+
+/** A function's `Role` is a `Fn::GetAtt` on the role's logical id — element 0. */
+const RoleRefSchema = z.object({
+  Properties: z.object({
+    Role: z.object({ 'Fn::GetAtt': z.tuple([z.string(), z.literal('Arn')]) }),
+  }),
+});
+
+/** Statements of the inline policies attached to *roleLogicalId*, and nothing
+ *  else's. Scoping to the role is the whole point: five other roles in this stack
+ *  grant `secretsmanager:GetSecretValue`, so a template-wide scan for that action
+ *  passes with the webhook's own grant deleted. */
+const PolicySchema = z.object({
+  Properties: z.object({
+    Roles: z.array(z.object({ Ref: z.string() }).or(z.unknown())),
+    PolicyDocument: z.object({
+      Statement: z.array(z.object({
+        Action: z.union([z.string(), z.array(z.string())]).optional(),
+        Resource: z.unknown().optional(),
+      }).passthrough()),
+    }),
+  }),
+});
+
+function statementsFor(roleLogicalId: string): { Action?: string | string[]; Resource?: unknown }[] {
+  return Object.values(template().findResources('AWS::IAM::Policy'))
+    .filter((p) => {
+      const parsed = PolicySchema.safeParse(p);
+      if (!parsed.success) return false;
+      return parsed.data.Properties.Roles.some(
+        (r) => typeof r === 'object' && r !== null && (r as { Ref?: string }).Ref === roleLogicalId,
+      );
+    })
+    .flatMap((p) => PolicySchema.parse(p).Properties.PolicyDocument.Statement);
+}
+
+const actionsOf = (statement: { Action?: string | string[] }): string[] => {
+  const action = statement.Action;
+  if (typeof action === 'string') return [action];
+  return action ?? [];
+};
 
 describe('webhook Lambda environment', () => {
   it('synthesizes a webhook Lambda at all, so the assertions below are not vacuous', () => {
@@ -172,13 +225,50 @@ describe('webhook Lambda environment', () => {
     expect(Object.keys(webhookEnv())).toContain(name);
   });
 
-  it('grants the webhook role read access to the shared secret it now depends on', () => {
+  it("grants the webhook's OWN role read access to the shared secret", () => {
     // Failing closed makes the secret read load-bearing: without the grant, every
     // delivery raises at construction rather than degrading. Asserted here because
     // this is the only fixture in the suite that synthesizes the role at all.
-    const policies = Object.values(template().findResources('AWS::IAM::Policy'));
-    const grantsSecretRead = policies.some((p) => JSON.stringify(p).includes('secretsmanager:GetSecretValue'));
+    //
+    // Scoped to the webhook function's own role, and to the shared secret's ARN
+    // specifically. A template-wide `some(... includes('GetSecretValue'))` was
+    // vacuous: the integrations, scrapers, projects and chat-stream roles in this
+    // same stack all grant that action, so deleting the webhook role's grant left
+    // the assertion green. The CDN signing secret is excluded for the same reason —
+    // a grant on THAT ARN does not let base_webhook.py read its credentials.
+    const roleLogicalId = RoleRefSchema.parse(webhookFunction())
+      .Properties.Role['Fn::GetAtt'][0];
 
-    expect(grantsSecretRead).toBe(true);
+    const grants = statementsFor(roleLogicalId).filter(
+      (s) => actionsOf(s).includes('secretsmanager:GetSecretValue')
+        && JSON.stringify(s.Resource) === JSON.stringify(SHARED_SECRET_ARN),
+    );
+
+    expect(
+      grants.length,
+      `the webhook role ${roleLogicalId} may not read ${SHARED_SECRET_ARN}, so every `
+      + 'delivery would raise ConfigurationError at construction',
+    ).toBeGreaterThan(0);
+  });
+
+  it('the control: the webhook role is found and does carry other statements', () => {
+    // Non-vacuity for the case above, in the direction that actually threatens it:
+    // if `statementsFor` matched nothing — a logical-id shape change, a move from
+    // AWS::IAM::Policy to an inline role policy — the filter would return empty and
+    // the case above would fail with a message blaming the grant. This says which
+    // of the two broke.
+    //
+    // Written to NOT fail under the mutation it controls for: it asserts the role
+    // has statements and does not mention GetSecretValue, so deleting the secret
+    // grant leaves this green.
+    const roleLogicalId = RoleRefSchema.parse(webhookFunction())
+      .Properties.Role['Fn::GetAtt'][0];
+    const statements = statementsFor(roleLogicalId);
+
+    expect(statements.length, `no IAM policy resolves to role ${roleLogicalId}`)
+      .toBeGreaterThan(0);
+    // sqs:SendMessage is granted to the same role on the line above the secret one,
+    // so its presence proves the lookup reaches the right policy document.
+    expect(statements.flatMap(actionsOf)).toContain('sqs:SendMessage');
   });
 });

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -2079,6 +2079,16 @@ exports.handler = async (event) => {
         FEEDBACK_TABLE: feedbackTableName,
         SECRETS_ARN: secretsArn,
         BRAND_NAME: brandName,
+        // BOTH names, matching createIngestorLambda in ingestion-stack.ts.
+        // `base_webhook.py` reads SOURCE_PLATFORM for the plugin identity it
+        // scopes the shared secret by, and since issue #251 an empty identity is
+        // a hard ConfigurationError at construction — so with only PLUGIN_ID set
+        // every delivery to a deployed webhook would have failed, on a message
+        // blaming the identity rather than the missing variable. Latent until a
+        // manifest declares `infrastructure.webhook` (none does yet), which is
+        // exactly why it would have surfaced as a deploy-time mystery. Pinned by
+        // 'SOURCE_PLATFORM' in api-stack.test.ts.
+        SOURCE_PLATFORM: plugin.id,
         PLUGIN_ID: plugin.id,
         POWERTOOLS_SERVICE_NAME: `voc-webhook-${plugin.id}`,
         LOG_LEVEL: 'INFO',

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -2087,7 +2087,9 @@ exports.handler = async (event) => {
         // blaming the identity rather than the missing variable. Latent until a
         // manifest declares `infrastructure.webhook` (none does yet), which is
         // exactly why it would have surfaced as a deploy-time mystery. Pinned by
-        // 'SOURCE_PLATFORM' in api-stack.test.ts.
+        // 'SOURCE_PLATFORM' in api-stack-webhook-env.test.ts — that latency is
+        // also why it needs its own file: api-stack.test.ts's fixtures read the
+        // real manifests and so synthesize no webhook Lambda to assert against.
         SOURCE_PLATFORM: plugin.id,
         PLUGIN_ID: plugin.id,
         POWERTOOLS_SERVICE_NAME: `voc-webhook-${plugin.id}`,

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -17,6 +17,7 @@ import hashlib
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer, metrics
+from shared.exceptions import ConfigurationError
 from shared.http_utils import fetch_with_retry
 from shared.aws import (
     clear_secret_cache,
@@ -27,7 +28,7 @@ from shared.aws import (
 )
 from .circuit_breaker import CircuitBreaker
 from .audit import emit_audit_event
-from .secrets import filter_plugin_secrets
+from .plugin_secrets import filter_plugin_secrets
 from .sqs_utils import send_messages_to_queue
 
 # Re-export for backwards compatibility with existing handlers
@@ -63,12 +64,70 @@ class BaseIngestor(ABC):
         self.source_platform = SOURCE_PLATFORM
         self.brand_name = BRAND_NAME
         self.brand_handles = BRAND_HANDLES
-        self.secrets = self._load_secrets()
+        # Everything the failure path needs is wired BEFORE the secret is read.
+        # Since issue #251 a namespace miss raises here rather than silently
+        # widening to the whole shared secret, so construction failing is a
+        # routine outcome — and a raise out of __init__ never reaches run()'s
+        # except block, which is what tells the operator anything (see
+        # _report_construction_failure). Ordering this after the read is what left
+        # a manual run's status record stranded at 'running' with a permanent
+        # spinner in the UI.
         self.watermarks_table = get_dynamodb_resource().Table(WATERMARKS_TABLE)
+        self.aggregates_table = get_dynamodb_resource().Table(AGGREGATES_TABLE) if AGGREGATES_TABLE else None
+        self.circuit_breaker = CircuitBreaker(self.source_platform)
         self._s3 = get_s3_client()
         self._sqs = get_sqs_client()
-        self.circuit_breaker = CircuitBreaker(self.source_platform)
-        self.aggregates_table = get_dynamodb_resource().Table(AGGREGATES_TABLE) if AGGREGATES_TABLE else None
+        try:
+            self.secrets = self._load_secrets()
+        except ConfigurationError as error:
+            self._report_construction_failure(error)
+            raise
+
+    def _report_construction_failure(self, error: Exception) -> None:
+        """Give a construction-time failure the same reporting run() gives its own.
+
+        ``_load_secrets`` runs in ``__init__``, and every ``lambda_handler``
+        constructs the ingestor before calling ``run()`` — so a raise from here
+        bypasses run()'s ``except`` entirely. Three things that block go on to do
+        are what the operator actually sees, and all three were missing:
+
+          * the ``SOURCE_RUN#`` record stays at 'running', which
+            ``integrations_handler.run_source`` wrote before invoking us and which
+            the Scrapers UI polls with no timeout — so a manual "Run now" spins
+            forever and the diagnosis exists only in CloudWatch;
+          * the circuit breaker never counts the failure, so a plugin broken this
+            way does not auto-disable its schedule;
+          * no ``plugin.failed`` audit event is emitted.
+
+        Reported HERE rather than in each plugin's ``lambda_handler`` for the same
+        reason the manual-run cache clear is centralized (#141/#215): a per-handler
+        wrapper is one a new plugin can forget, and forgetting it is silent.
+
+        Never raises. It runs while a ConfigurationError is propagating, and
+        replacing that error with a DynamoDB one would hide the thing worth
+        reporting; each step already swallows its own failures, and the belt-and-
+        braces catch covers a client that is missing altogether.
+        """
+        try:
+            self._update_source_run_status({
+                'status': 'error',
+                'items_found': 0,
+                'completed_at': datetime.now(timezone.utc).isoformat(),
+                'errors': [str(error)],
+            })
+            self.circuit_breaker.record_failure(str(error))
+            emit_audit_event("plugin.failed", self.source_platform, False, {
+                "error": str(error),
+                "error_type": type(error).__name__,
+                "phase": "construction",
+            })
+        # Deliberately blind: narrowing it means enumerating what three AWS clients
+        # can raise, and anything missed REPLACES the ConfigurationError being
+        # propagated with an unrelated one — hiding the only message that names the
+        # prefix the plugin expected. Pinned by
+        # test_the_report_does_not_replace_the_error_the_operator_needs.
+        except Exception as reporting_error:  # noqa: BLE001
+            logger.warning(f"Failed to report construction failure: {reporting_error}")
 
     def _load_secrets(self) -> dict:
         """
@@ -78,9 +137,9 @@ class BaseIngestor(ABC):
         returns only this plugin's namespace with the prefix stripped, and RAISES
         rather than widening when the namespace matches nothing (issue #251 — the
         old ``filtered if filtered else all_secrets`` turned a typo'd plugin id
-        into cross-plugin credential access). See ``_shared/secrets.py`` for why
-        the "keys with no known prefix are shared/legacy" branch, and the plugin-id
-        list it needed, are gone.
+        into cross-plugin credential access). See ``_shared/plugin_secrets.py`` for
+        why the "keys with no known prefix are shared/legacy" branch, and the
+        plugin-id list it needed, are gone.
 
         An absent SECRETS_ARN stays a warning rather than a raise: that is the
         env-var-not-wired case, not a namespace mismatch, and no secret is read at
@@ -91,7 +150,20 @@ class BaseIngestor(ABC):
             logger.warning("SECRETS_ARN not configured")
             return {}
 
-        return filter_plugin_secrets(self.source_platform, get_secret(SECRETS_ARN))
+        all_secrets = get_secret(SECRETS_ARN)
+        if not all_secrets:
+            # `get_secret` is lru_cached and swallows EVERY exception into `{}`,
+            # so a throttle or timeout memoizes an empty payload under the ARN.
+            # filter_plugin_secrets refuses to run on it (correctly), but without
+            # this eviction the refusal is permanent: every later invocation in
+            # the warm container re-reads the cached `{}` and raises again with no
+            # further API call. Only a manual "Run now" clears the cache, so a
+            # SCHEDULED plugin would stay wedged for the container's lifetime
+            # after a single transient blip. Evicting here costs one extra read on
+            # the next invocation and makes the failure retry-safe.
+            clear_secret_cache()
+
+        return filter_plugin_secrets(self.source_platform, all_secrets)
 
     def get_watermark(self, key: str, default: str = None) -> str:
         """Get watermark for a specific source/key from DynamoDB."""

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -17,7 +17,7 @@ import hashlib
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer, metrics
-from shared.exceptions import ConfigurationError
+from shared.exceptions import ConfigurationError, SecretUnreadableError
 from shared.http_utils import fetch_with_retry
 from shared.aws import (
     clear_secret_cache,
@@ -99,6 +99,19 @@ class BaseIngestor(ABC):
             way does not auto-disable its schedule;
           * no ``plugin.failed`` audit event is emitted.
 
+        The breaker is the exception, and deliberately so: a
+        ``SecretUnreadableError`` is NOT counted. ``get_secret`` swallows every
+        client error into ``{}``, so an unreadable secret may be an AWS-side
+        throttle the plugin did nothing to cause — and at the default threshold
+        (5 failures in 15 minutes) counting it lets a handful of blips call
+        ``_trip_breaker``, which disables the plugin's EventBridge schedule.
+        Nothing in this tree re-enables a disabled rule, so ingestion would stop
+        until an operator noticed. The run record and the audit event still fire,
+        because those are how the failure becomes visible; only the auto-disable
+        is withheld. A misconfiguration — a malformed identity or a namespace that
+        matches nothing — is a plain ``ConfigurationError`` and still counts, since
+        retrying it forever is exactly what the breaker exists to stop.
+
         Reported HERE rather than in each plugin's ``lambda_handler`` for the same
         reason the manual-run cache clear is centralized (#141/#215): a per-handler
         wrapper is one a new plugin can forget, and forgetting it is silent.
@@ -108,6 +121,7 @@ class BaseIngestor(ABC):
         reporting; each step already swallows its own failures, and the belt-and-
         braces catch covers a client that is missing altogether.
         """
+        unreadable = isinstance(error, SecretUnreadableError)
         try:
             self._update_source_run_status({
                 'status': 'error',
@@ -115,11 +129,16 @@ class BaseIngestor(ABC):
                 'completed_at': datetime.now(timezone.utc).isoformat(),
                 'errors': [str(error)],
             })
-            self.circuit_breaker.record_failure(str(error))
+            if not unreadable:
+                self.circuit_breaker.record_failure(str(error))
             emit_audit_event("plugin.failed", self.source_platform, False, {
                 "error": str(error),
                 "error_type": type(error).__name__,
                 "phase": "construction",
+                # Names WHY the breaker did not count this one, so an operator
+                # reading the audit trail after a burst of these does not conclude
+                # the breaker is broken.
+                "counted_against_circuit_breaker": not unreadable,
             })
         # Deliberately blind: narrowing it means enumerating what three AWS clients
         # can raise, and anything missed REPLACES the ConfigurationError being

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -27,6 +27,7 @@ from shared.aws import (
 )
 from .circuit_breaker import CircuitBreaker
 from .audit import emit_audit_event
+from .secrets import filter_plugin_secrets
 from .sqs_utils import send_messages_to_queue
 
 # Re-export for backwards compatibility with existing handlers
@@ -71,39 +72,26 @@ class BaseIngestor(ABC):
 
     def _load_secrets(self) -> dict:
         """
-        Load API credentials from Secrets Manager.
-        
-        With per-plugin secrets isolation, each plugin has its own secret.
-        The secret keys are prefixed with the plugin ID, which we strip here.
+        Load this plugin's API credentials from the shared Secrets Manager secret.
+
+        Keys are stored namespaced as ``<plugin_id>_<key>``; ``filter_plugin_secrets``
+        returns only this plugin's namespace with the prefix stripped, and RAISES
+        rather than widening when the namespace matches nothing (issue #251 — the
+        old ``filtered if filtered else all_secrets`` turned a typo'd plugin id
+        into cross-plugin credential access). See ``_shared/secrets.py`` for why
+        the "keys with no known prefix are shared/legacy" branch, and the plugin-id
+        list it needed, are gone.
+
+        An absent SECRETS_ARN stays a warning rather than a raise: that is the
+        env-var-not-wired case, not a namespace mismatch, and no secret is read at
+        all — so there is nothing to over-share. It is also what a plugin invoked
+        outside the CDK-built environment (a local smoke run) hits.
         """
         if not SECRETS_ARN:
             logger.warning("SECRETS_ARN not configured")
             return {}
-        
-        all_secrets = get_secret(SECRETS_ARN)
-        
-        # Filter to only keys prefixed with this plugin's ID
-        prefix = f"{self.source_platform}_"
-        filtered = {}
-        for key, value in all_secrets.items():
-            if key.startswith(prefix):
-                # Strip the prefix for cleaner access
-                clean_key = key[len(prefix):]
-                filtered[clean_key] = value
-            elif not any(key.startswith(f"{p}_") for p in self._get_known_prefixes()):
-                # Include keys without any known prefix (legacy/shared keys)
-                filtered[key] = value
-        
-        return filtered if filtered else all_secrets
 
-    def _get_known_prefixes(self) -> list[str]:
-        """Get list of known plugin prefixes for secret filtering."""
-        # This could be loaded from environment or manifest
-        return [
-            "webscraper", "s3_import", "manual_import",
-            "app_reviews_ios", "app_reviews_android",
-            "synthetic_reviews",
-        ]
+        return filter_plugin_secrets(self.source_platform, get_secret(SECRETS_ARN))
 
     def get_watermark(self, key: str, default: str = None) -> str:
         """Get watermark for a specific source/key from DynamoDB."""

--- a/voc-datalake/plugins/_shared/base_ingestor.py
+++ b/voc-datalake/plugins/_shared/base_ingestor.py
@@ -106,9 +106,12 @@ class BaseIngestor(ABC):
         (5 failures in 15 minutes) counting it lets a handful of blips call
         ``_trip_breaker``, which disables the plugin's EventBridge schedule.
         Nothing in this tree re-enables a disabled rule, so ingestion would stop
-        until an operator noticed. The run record and the audit event still fire,
-        because those are how the failure becomes visible; only the auto-disable
-        is withheld. A misconfiguration — a malformed identity or a namespace that
+        until an operator noticed. Only the auto-disable is withheld; the audit
+        event still fires, and the run record does too on a MANUAL run — on a
+        scheduled one there is no ``SOURCE_RUN#`` record to move, which is why the
+        audit event is the only remaining signal and why losing it mattered. See
+        ``docs/plugin-architecture.md`` on the alarm this exemption relies on. A
+        misconfiguration — a malformed identity or a namespace that
         matches nothing — is a plain ``ConfigurationError`` and still counts, since
         retrying it forever is exactly what the breaker exists to stop.
 
@@ -116,21 +119,37 @@ class BaseIngestor(ABC):
         reason the manual-run cache clear is centralized (#141/#215): a per-handler
         wrapper is one a new plugin can forget, and forgetting it is silent.
 
+        Each step is INDEPENDENTLY guarded, and one step is not merely tidier than
+        one shared ``try`` — it is the difference between reporting and not.
+        ``CircuitBreaker.record_failure`` looks exception-safe but is not on its
+        first line: ``self.table`` is a property that calls
+        ``get_dynamodb_resource()`` OUTSIDE record_failure's own ``try``, so a
+        failure constructing that resource escapes it. Under one shared ``try``
+        that landed in the catch below and the audit event two lines later never
+        ran — losing the ONLY signal a scheduled run leaves behind, since
+        ``_update_source_run_status`` is a no-op without an ``execution_id``. That
+        is also the correlated case: the same DynamoDB trouble affects both.
+
+        Ordered audit-event first as well, but the per-step guards are what carry
+        the guarantee — the order alone is defence in depth and should not be
+        mistaken for the fix (with the guards in place, reordering these three
+        changes nothing, which is the point). ``emit_audit_event`` swallows its own
+        EventBridge errors and always logs, so it is the cheapest and most reliable
+        of the three; running it first means it survives even a future edit that
+        reintroduces a shared ``try``.
+
         Never raises. It runs while a ConfigurationError is propagating, and
         replacing that error with a DynamoDB one would hide the thing worth
-        reporting; each step already swallows its own failures, and the belt-and-
-        braces catch covers a client that is missing altogether.
+        reporting.
         """
         unreadable = isinstance(error, SecretUnreadableError)
+
+        # Deliberately blind catches: narrowing them means enumerating what three
+        # AWS clients can raise, and anything missed REPLACES the
+        # ConfigurationError being propagated with an unrelated one — hiding the
+        # only message that names the prefix the plugin expected. Pinned by
+        # test_the_report_does_not_replace_the_error_the_operator_needs.
         try:
-            self._update_source_run_status({
-                'status': 'error',
-                'items_found': 0,
-                'completed_at': datetime.now(timezone.utc).isoformat(),
-                'errors': [str(error)],
-            })
-            if not unreadable:
-                self.circuit_breaker.record_failure(str(error))
             emit_audit_event("plugin.failed", self.source_platform, False, {
                 "error": str(error),
                 "error_type": type(error).__name__,
@@ -140,13 +159,24 @@ class BaseIngestor(ABC):
                 # the breaker is broken.
                 "counted_against_circuit_breaker": not unreadable,
             })
-        # Deliberately blind: narrowing it means enumerating what three AWS clients
-        # can raise, and anything missed REPLACES the ConfigurationError being
-        # propagated with an unrelated one — hiding the only message that names the
-        # prefix the plugin expected. Pinned by
-        # test_the_report_does_not_replace_the_error_the_operator_needs.
         except Exception as reporting_error:  # noqa: BLE001
-            logger.warning(f"Failed to report construction failure: {reporting_error}")
+            logger.warning(f"Failed to emit construction failure audit event: {reporting_error}")
+
+        try:
+            self._update_source_run_status({
+                'status': 'error',
+                'items_found': 0,
+                'completed_at': datetime.now(timezone.utc).isoformat(),
+                'errors': [str(error)],
+            })
+        except Exception as reporting_error:  # noqa: BLE001
+            logger.warning(f"Failed to record construction failure run status: {reporting_error}")
+
+        if not unreadable:
+            try:
+                self.circuit_breaker.record_failure(str(error))
+            except Exception as reporting_error:  # noqa: BLE001
+                logger.warning(f"Failed to record construction failure with the circuit breaker: {reporting_error}")
 
     def _load_secrets(self) -> dict:
         """

--- a/voc-datalake/plugins/_shared/base_webhook.py
+++ b/voc-datalake/plugins/_shared/base_webhook.py
@@ -13,10 +13,10 @@ from typing import Any
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer, metrics
-from shared.aws import get_sqs_client, get_secret
+from shared.aws import clear_secret_cache, get_sqs_client, get_secret
 
 from .audit import emit_audit_event
-from .secrets import filter_plugin_secrets
+from .plugin_secrets import filter_plugin_secrets
 from .sqs_utils import send_messages_to_queue
 
 __all__ = ["BaseWebhook", "logger", "tracer", "metrics"]
@@ -41,16 +41,32 @@ class BaseWebhook(ABC):
         """Load this plugin's secrets from the shared secret, prefix stripped.
 
         Same choke point as ``BaseIngestor._load_secrets`` — one implementation in
-        ``_shared/secrets.py`` — so the webhook path cannot keep failing open after
-        the ingestor path was fixed (issue #251). A webhook is the more exposed of
-        the two: its Lambda is reachable from the internet, and its shared secret
-        holds the signing secret every OTHER plugin's webhook verifies against.
+        ``_shared/plugin_secrets.py`` — so the webhook path cannot keep failing
+        open after the ingestor path was fixed (issue #251). A webhook is the more
+        exposed of the two: its Lambda is reachable from the internet with no
+        Cognito authorizer in front of it.
+
+        The identity comes from ``SOURCE_PLATFORM``, which ``createWebhookLambda``
+        sets alongside ``PLUGIN_ID`` — it previously set only the latter, so this
+        read saw ``''`` and every delivery would have died on a message about a
+        malformed identity rather than the missing variable. Pinned by
+        'SOURCE_PLATFORM' in ``lib/stacks/api-stack.test.ts``.
         """
         if not SECRETS_ARN:
             logger.warning("SECRETS_ARN not configured")
             return {}
 
-        return filter_plugin_secrets(self.source_platform, get_secret(SECRETS_ARN))
+        all_secrets = get_secret(SECRETS_ARN)
+        if not all_secrets:
+            # Evict the memoized empty payload before refusing on it — see the
+            # same branch in `BaseIngestor._load_secrets` for why `get_secret`
+            # caching a failed read would otherwise wedge the warm container. A
+            # webhook has no manual "Run now" to clear the cache at all, so
+            # without this the only recovery is a container recycle while the
+            # provider's retries expire.
+            clear_secret_cache()
+
+        return filter_plugin_secrets(self.source_platform, all_secrets)
 
     @abstractmethod
     def parse_webhook_payload(self, body: dict, headers: dict) -> list[dict]:

--- a/voc-datalake/plugins/_shared/base_webhook.py
+++ b/voc-datalake/plugins/_shared/base_webhook.py
@@ -16,6 +16,7 @@ from shared.logging import logger, tracer, metrics
 from shared.aws import get_sqs_client, get_secret
 
 from .audit import emit_audit_event
+from .secrets import filter_plugin_secrets
 from .sqs_utils import send_messages_to_queue
 
 __all__ = ["BaseWebhook", "logger", "tracer", "metrics"]
@@ -37,22 +38,19 @@ class BaseWebhook(ABC):
         self._sqs = get_sqs_client()
 
     def _load_secrets(self) -> dict:
-        """Load secrets from Secrets Manager with plugin prefix filtering."""
+        """Load this plugin's secrets from the shared secret, prefix stripped.
+
+        Same choke point as ``BaseIngestor._load_secrets`` — one implementation in
+        ``_shared/secrets.py`` — so the webhook path cannot keep failing open after
+        the ingestor path was fixed (issue #251). A webhook is the more exposed of
+        the two: its Lambda is reachable from the internet, and its shared secret
+        holds the signing secret every OTHER plugin's webhook verifies against.
+        """
         if not SECRETS_ARN:
             logger.warning("SECRETS_ARN not configured")
             return {}
-        
-        all_secrets = get_secret(SECRETS_ARN)
-        
-        # Filter to only keys prefixed with this plugin's ID
-        prefix = f"{self.source_platform}_"
-        filtered = {}
-        for key, value in all_secrets.items():
-            if key.startswith(prefix):
-                clean_key = key[len(prefix):]
-                filtered[clean_key] = value
-        
-        return filtered if filtered else all_secrets
+
+        return filter_plugin_secrets(self.source_platform, get_secret(SECRETS_ARN))
 
     @abstractmethod
     def parse_webhook_payload(self, body: dict, headers: dict) -> list[dict]:

--- a/voc-datalake/plugins/_shared/base_webhook.py
+++ b/voc-datalake/plugins/_shared/base_webhook.py
@@ -50,7 +50,7 @@ class BaseWebhook(ABC):
         sets alongside ``PLUGIN_ID`` — it previously set only the latter, so this
         read saw ``''`` and every delivery would have died on a message about a
         malformed identity rather than the missing variable. Pinned by
-        'SOURCE_PLATFORM' in ``lib/stacks/api-stack.test.ts``.
+        'SOURCE_PLATFORM' in ``lib/stacks/api-stack-webhook-env.test.ts``.
         """
         if not SECRETS_ARN:
             logger.warning("SECRETS_ARN not configured")

--- a/voc-datalake/plugins/_shared/plugin_secrets.py
+++ b/voc-datalake/plugins/_shared/plugin_secrets.py
@@ -58,7 +58,7 @@ from collections.abc import Mapping
 # test without importing a base class first.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from shared.exceptions import ConfigurationError
+from shared.exceptions import ConfigurationError, SecretUnreadableError
 from shared.logging import logger
 from shared.plugin_identity import PLUGIN_IDENTIFIER_RULES, is_valid_plugin_identifier
 
@@ -78,9 +78,15 @@ def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
     callers are unchanged.
 
     Raises:
-        ConfigurationError: If *plugin_id* is missing or malformed, if
-            *all_secrets* is empty, or if no key carries this plugin's prefix.
-            Every one of those states used to yield the complete shared secret.
+        ConfigurationError: If *plugin_id* is missing or malformed, or if no key
+            carries this plugin's prefix. Either state used to yield the complete
+            shared secret. Both mean a human wrote something wrong.
+        SecretUnreadableError: If *all_secrets* is empty. A ConfigurationError
+            SUBCLASS, so `except ConfigurationError` still catches it, but
+            distinguishable — this is the one branch that may be an AWS-side blip
+            rather than a misconfiguration, because `get_secret` swallows a failed
+            read into `{}`. `BaseIngestor` uses the distinction to keep a throttle
+            from counting against the circuit breaker.
 
     The empty-payload branch is RETRY-SAFE, but only because the caller makes it
     so: `shared.aws.get_secret` is `lru_cache`d and swallows a failed read into
@@ -117,17 +123,22 @@ def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
     prefix = plugin_secret_prefix(plugin_id)
 
     if not isinstance(all_secrets, Mapping) or not all_secrets:
-        # An empty secret is a configuration failure, not an empty namespace:
-        # `get_secret` returns {} both for a genuinely empty secret and for a
-        # read that FAILED (it logs and swallows), and neither is a state in
-        # which a plugin should quietly run with no credentials. The caller has
-        # already evicted the cache entry, so a transient failure retries on the
-        # next invocation rather than wedging the container.
+        # An empty secret is still a refusal — neither a genuinely empty secret
+        # nor a failed read is a state in which a plugin should quietly run with
+        # no credentials — but it is the ONLY branch here that may not be anyone's
+        # mistake: `get_secret` logs and swallows every client error into `{}`, so
+        # a throttle and an empty secret are indistinguishable from here.
+        #
+        # Hence the narrower type. The caller has already evicted the cache entry
+        # so the next invocation retries, and `BaseIngestor` reports this without
+        # recording a circuit-breaker failure: counting it would let five transient
+        # Secrets Manager errors in one window disable a healthy plugin's
+        # EventBridge schedule, which nothing in this tree re-enables.
         logger.error(
             "Refusing to load plugin secrets: secret payload is empty",
             extra={"plugin_id": plugin_id, "expected_prefix": prefix},
         )
-        raise ConfigurationError(
+        raise SecretUnreadableError(
             f"Cannot load plugin secrets for '{plugin_id}': the shared secret is "
             f"empty or unreadable, so no '{prefix}*' keys could be read."
         )

--- a/voc-datalake/plugins/_shared/plugin_secrets.py
+++ b/voc-datalake/plugins/_shared/plugin_secrets.py
@@ -1,5 +1,10 @@
 """Plugin-scoped reads of the shared API-credentials secret.
 
+Named `plugin_secrets`, not `secrets`: `plugins/_shared` is on `sys.path` in the
+deployed bundle (the ingestor handler sits at the bundle root beside `_shared/`),
+and a module called `secrets.py` there shadows the stdlib `secrets` for anything
+that imports it — six modules in this tree do.
+
 Every plugin Lambda reads ONE Secrets Manager secret whose keys are namespaced
 `<plugin_id>_<key>` (CDK seeds them that way in `aggregateSecrets()`, and the
 only writers — `integrations_handler` and `scrapers_handler` — always prefix).
@@ -25,28 +30,39 @@ so neither base class can drift from the other:
      — the one input most likely to be wrong — produced the maximally permissive
      outcome, handing that plugin every other plugin's credentials. A raise is
      loud, names what to fix, and cannot be mistaken for success.
+
+What this boundary does NOT guarantee:
+
+  ponytail: the scan is a plain prefix match, so if one plugin id were ever a
+  PREFIX of another (`app_reviews` alongside the existing `app_reviews_ios`) the
+  shorter one would also receive the longer one's keys, under mangled names
+  (`app_reviews_ios_app_id` arriving as `ios_app_id`). No current id pair does
+  this, and the write path carries the same caveat for the same reason
+  (`integrations_handler.get_credentials`) — the two mirrors are kept in step so
+  a reader comparing them finds the same limitation stated in both. The fix
+  belongs at synth time, where the whole id set is known: `plugin-loader.ts` can
+  reject a manifest whose id is a prefix of another's, and does so as of this
+  change (`test_plugin_secret_isolation.py` pins that the two agree). It cannot
+  be enforced here, which sees one id at a time and has no list of the others by
+  design — keeping such a list is precisely the hole rule 1 closed.
 """
 
 import os
-import re
 import sys
 from collections.abc import Mapping
 
-# Add lambda/shared to path (mirrors the other _shared modules, so this one can
-# be imported directly by a test without importing a base class first).
+# Add the `plugins/` directory (this file's grandparent) to sys.path. `shared.*`
+# below resolves through it: `lambda/shared/` is copied in beside `_shared/` when
+# the bundle is built, and `plugins/`'s parent carries it in a source checkout.
+# Mirrors the other `_shared` modules, so this one can be imported directly by a
+# test without importing a base class first.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.exceptions import ConfigurationError
 from shared.logging import logger
+from shared.plugin_identity import PLUGIN_IDENTIFIER_RULES, is_valid_plugin_identifier
 
 __all__ = ["filter_plugin_secrets", "plugin_secret_prefix"]
-
-# Same character class the write path enforces on `source`
-# (`integrations_handler._validate_source`): a plugin id becomes a key prefix,
-# so anything outside `[a-z0-9_]` could escape or re-enter another namespace.
-# Duplicated rather than imported because `lambda/api` is not on a plugin
-# Lambda's path — only `lambda/shared` and `plugins/` are bundled.
-_PLUGIN_ID_RE = re.compile(r'[a-z0-9](?:[a-z0-9_]{0,62}[a-z0-9])?')
 
 
 def plugin_secret_prefix(plugin_id: str) -> str:
@@ -66,24 +82,36 @@ def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
             *all_secrets* is empty, or if no key carries this plugin's prefix.
             Every one of those states used to yield the complete shared secret.
 
+    The empty-payload branch is RETRY-SAFE, but only because the caller makes it
+    so: `shared.aws.get_secret` is `lru_cache`d and swallows a failed read into
+    `{}`, so both `_load_secrets` callers evict that entry before delegating here
+    (see `BaseIngestor._load_secrets`). Without the eviction, one transient
+    Secrets Manager blip would wedge every later invocation in the warm container
+    against a cached `{}`, with no further API call.
+
     Log/message discipline: the identity and the expected prefix are the only
     things named. No secret VALUE and no OTHER plugin's key name is emitted —
     an error raised because a prefix was wrong must not become a directory of
     what the correct prefixes are.
     """
-    if not isinstance(plugin_id, str) or not _PLUGIN_ID_RE.fullmatch(plugin_id):
+    # The identity becomes a key prefix, so it is validated against the same
+    # character class the WRITE path enforces on `source`. Both import it from
+    # `shared/plugin_identity.py`: the read path refusing an identity the write
+    # path accepted (or the reverse) is the same drift, one level up, that having
+    # two copies of the prefix scan produced.
+    if not is_valid_plugin_identifier(plugin_id):
         # Truncated repr, not the raw value: the identity comes from
         # SOURCE_PLATFORM and is expected to be short, but an error message is
-        # not the place to echo an unbounded string back.
-        preview = repr(plugin_id[:40]) if isinstance(plugin_id, str) else repr(type(plugin_id).__name__)
+        # not the place to echo an unbounded string back. A non-string is named
+        # by its bare type name — `repr` of it would double the quoting.
+        preview = repr(plugin_id[:40]) if isinstance(plugin_id, str) else type(plugin_id).__name__
         logger.error(
             "Refusing to load plugin secrets: plugin identity is missing or malformed",
             extra={"plugin_id": preview},
         )
         raise ConfigurationError(
             f"Cannot load plugin secrets: plugin identity {preview} is missing or "
-            "malformed (expected lowercase letters, digits and underscores, "
-            "starting and ending with a letter or digit)."
+            f"malformed (it {PLUGIN_IDENTIFIER_RULES})."
         )
 
     prefix = plugin_secret_prefix(plugin_id)
@@ -92,7 +120,9 @@ def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
         # An empty secret is a configuration failure, not an empty namespace:
         # `get_secret` returns {} both for a genuinely empty secret and for a
         # read that FAILED (it logs and swallows), and neither is a state in
-        # which a plugin should quietly run with no credentials.
+        # which a plugin should quietly run with no credentials. The caller has
+        # already evicted the cache entry, so a transient failure retries on the
+        # next invocation rather than wedging the container.
         logger.error(
             "Refusing to load plugin secrets: secret payload is empty",
             extra={"plugin_id": plugin_id, "expected_prefix": prefix},

--- a/voc-datalake/plugins/_shared/plugin_secrets.py
+++ b/voc-datalake/plugins/_shared/plugin_secrets.py
@@ -78,9 +78,10 @@ def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
     callers are unchanged.
 
     Raises:
-        ConfigurationError: If *plugin_id* is missing or malformed, or if no key
-            carries this plugin's prefix. Either state used to yield the complete
-            shared secret. Both mean a human wrote something wrong.
+        ConfigurationError: If *plugin_id* is missing or malformed, if
+            *all_secrets* is not a JSON object, or if no key carries this plugin's
+            prefix. The first and last used to yield the complete shared secret.
+            All three mean a human wrote something wrong.
         SecretUnreadableError: If *all_secrets* is empty. A ConfigurationError
             SUBCLASS, so `except ConfigurationError` still catches it, but
             distinguishable — this is the one branch that may be an AWS-side blip
@@ -122,7 +123,26 @@ def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
 
     prefix = plugin_secret_prefix(plugin_id)
 
-    if not isinstance(all_secrets, Mapping) or not all_secrets:
+    # Tested BEFORE the empty check, because `not all_secrets` is also true of `[]`
+    # and `''`. `get_secret` does `json.loads` on the SecretString, which succeeds
+    # for any valid JSON — so a secret whose body is an array, a string or a number
+    # arrives here as a non-Mapping. That is nobody's throttle: it is a human having
+    # written the wrong thing, it will never self-heal, and it therefore belongs to
+    # the COUNTED class alongside a malformed identity and a namespace miss. Folding
+    # it into the branch below would both exempt it from the circuit breaker and log
+    # "payload is empty" about a populated JSON array.
+    if not isinstance(all_secrets, Mapping):
+        logger.error(
+            "Refusing to load plugin secrets: secret payload is not a JSON object",
+            extra={"plugin_id": plugin_id, "expected_prefix": prefix,
+                   "payload_type": type(all_secrets).__name__},
+        )
+        raise ConfigurationError(
+            f"Cannot load plugin secrets for '{plugin_id}': the shared secret is not "
+            f"a JSON object, so it cannot carry '{prefix}*' keys."
+        )
+
+    if not all_secrets:
         # An empty secret is still a refusal — neither a genuinely empty secret
         # nor a failed read is a state in which a plugin should quietly run with
         # no credentials — but it is the ONLY branch here that may not be anyone's

--- a/voc-datalake/plugins/_shared/plugin_secrets.py
+++ b/voc-datalake/plugins/_shared/plugin_secrets.py
@@ -39,12 +39,22 @@ What this boundary does NOT guarantee:
   (`app_reviews_ios_app_id` arriving as `ios_app_id`). No current id pair does
   this, and the write path carries the same caveat for the same reason
   (`integrations_handler.get_credentials`) — the two mirrors are kept in step so
-  a reader comparing them finds the same limitation stated in both. The fix
-  belongs at synth time, where the whole id set is known: `plugin-loader.ts` can
-  reject a manifest whose id is a prefix of another's, and does so as of this
-  change (`test_plugin_secret_isolation.py` pins that the two agree). It cannot
-  be enforced here, which sees one id at a time and has no list of the others by
-  design — keeping such a list is precisely the hole rule 1 closed.
+  a reader comparing them finds the same limitation stated in both. It cannot be
+  enforced HERE, which sees one id at a time and holds no list of the others by
+  design — keeping such a list is precisely the hole rule 1 closed. It is instead
+  refused at the two places that DO see more than one id, and both are needed
+  because they close different entrances:
+
+    * `plugin-loader.ts` rejects a manifest whose id is a prefix of another's, at
+      synth time, where the whole id set is known
+      (`test_plugin_secret_isolation.py` pins that the tree agrees).
+    * `integrations_handler._validate_source_is_a_known_plugin` restricts the
+      namespace a WRITE may address to the manifest-derived plugin ids. The
+      loader's guard is over manifest ids and cannot see a `source` invented in a
+      request: `PUT /integrations/app_reviews/credentials` with key `ios_app_id`
+      stored `app_reviews_ios_app_id`, which this scan then handed to
+      `app_reviews_ios` as its own `app_id` — a stored key needs no colliding
+      manifest to exist.
 """
 
 import os

--- a/voc-datalake/plugins/_shared/plugin_secrets.py
+++ b/voc-datalake/plugins/_shared/plugin_secrets.py
@@ -33,7 +33,7 @@ so neither base class can drift from the other:
 
 What this boundary does NOT guarantee:
 
-  ponytail: the scan is a plain prefix match, so if one plugin id were ever a
+  CAVEAT: the scan is a plain prefix match, so if one plugin id were ever a
   PREFIX of another (`app_reviews` alongside the existing `app_reviews_ios`) the
   shorter one would also receive the longer one's keys, under mangled names
   (`app_reviews_ios_app_id` arriving as `ios_app_id`). No current id pair does

--- a/voc-datalake/plugins/_shared/plugin_secrets.py
+++ b/voc-datalake/plugins/_shared/plugin_secrets.py
@@ -48,13 +48,16 @@ What this boundary does NOT guarantee:
     * `plugin-loader.ts` rejects a manifest whose id is a prefix of another's, at
       synth time, where the whole id set is known
       (`test_plugin_secret_isolation.py` pins that the tree agrees).
-    * `integrations_handler._validate_source_is_a_known_plugin` restricts the
-      namespace a WRITE may address to the manifest-derived plugin ids. The
-      loader's guard is over manifest ids and cannot see a `source` invented in a
-      request: `PUT /integrations/app_reviews/credentials` with key `ios_app_id`
-      stored `app_reviews_ios_app_id`, which this scan then handed to
-      `app_reviews_ios` as its own `app_id` — a stored key needs no colliding
-      manifest to exist.
+    * `integrations_handler._validate_source_parameter` restricts the namespace a
+      REQUEST may address to the manifest-derived plugin ids, on every route taking
+      a `<source>` path parameter. The loader's guard is over manifest ids and
+      cannot see a `source` invented in a request: `PUT
+      /integrations/app_reviews/credentials` with key `ios_app_id` stored
+      `app_reviews_ios_app_id`, which this scan then handed to `app_reviews_ios` as
+      its own `app_id` — a stored key needs no colliding manifest to exist.
+
+  Neither guard is retroactive: a key stored before they existed survives, and
+  this scan still hands it over. Only deleting it from the secret removes it.
 """
 
 import os

--- a/voc-datalake/plugins/_shared/secrets.py
+++ b/voc-datalake/plugins/_shared/secrets.py
@@ -1,0 +1,124 @@
+"""Plugin-scoped reads of the shared API-credentials secret.
+
+Every plugin Lambda reads ONE Secrets Manager secret whose keys are namespaced
+`<plugin_id>_<key>` (CDK seeds them that way in `aggregateSecrets()`, and the
+only writers — `integrations_handler` and `scrapers_handler` — always prefix).
+The namespace prefix is therefore the entire isolation boundary: all ingestion
+Lambdas share one IAM role, so IAM cannot provide a second layer (issue #251).
+
+Two rules follow from that, and this module is the single choke point for both,
+so neither base class can drift from the other:
+
+  1. **Only the plugin's own namespace is returned.** Previously a key carrying
+     no *known* plugin prefix was passed through as a "legacy/shared" value,
+     which required `BaseIngestor` to keep a hand-maintained list of plugin ids:
+     forget to add one and its `<plugin>_*` keys read as unprefixed and leaked
+     into every other plugin. Nothing in production writes an unprefixed key
+     (the only one that exists is Secrets Manager's own generated
+     `placeholder`, which no plugin consumes), so the list bought nothing and
+     cost an isolation hole. See
+     `test_plugin_secret_isolation.py::TestOnlyThisPluginsNamespaceIsLoaded`.
+
+  2. **A prefix that matches nothing FAILS, it does not widen.** The previous
+     `return filtered if filtered else all_secrets` was a migration convenience
+     for plugins predating prefixing; the effect was that a typo in a plugin id
+     — the one input most likely to be wrong — produced the maximally permissive
+     outcome, handing that plugin every other plugin's credentials. A raise is
+     loud, names what to fix, and cannot be mistaken for success.
+"""
+
+import os
+import re
+import sys
+from collections.abc import Mapping
+
+# Add lambda/shared to path (mirrors the other _shared modules, so this one can
+# be imported directly by a test without importing a base class first).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.exceptions import ConfigurationError
+from shared.logging import logger
+
+__all__ = ["filter_plugin_secrets", "plugin_secret_prefix"]
+
+# Same character class the write path enforces on `source`
+# (`integrations_handler._validate_source`): a plugin id becomes a key prefix,
+# so anything outside `[a-z0-9_]` could escape or re-enter another namespace.
+# Duplicated rather than imported because `lambda/api` is not on a plugin
+# Lambda's path — only `lambda/shared` and `plugins/` are bundled.
+_PLUGIN_ID_RE = re.compile(r'[a-z0-9](?:[a-z0-9_]{0,62}[a-z0-9])?')
+
+
+def plugin_secret_prefix(plugin_id: str) -> str:
+    """The namespace every one of *plugin_id*'s keys carries in the secret."""
+    return f"{plugin_id}_"
+
+
+def filter_plugin_secrets(plugin_id: str, all_secrets: Mapping) -> dict:
+    """Return *plugin_id*'s namespaced keys from *all_secrets*, prefix stripped.
+
+    The returned shape is what plugin handlers already consume — bare field
+    names (`api_key`, `configs`, `app_id`), not the stored prefixed ones — so
+    callers are unchanged.
+
+    Raises:
+        ConfigurationError: If *plugin_id* is missing or malformed, if
+            *all_secrets* is empty, or if no key carries this plugin's prefix.
+            Every one of those states used to yield the complete shared secret.
+
+    Log/message discipline: the identity and the expected prefix are the only
+    things named. No secret VALUE and no OTHER plugin's key name is emitted —
+    an error raised because a prefix was wrong must not become a directory of
+    what the correct prefixes are.
+    """
+    if not isinstance(plugin_id, str) or not _PLUGIN_ID_RE.fullmatch(plugin_id):
+        # Truncated repr, not the raw value: the identity comes from
+        # SOURCE_PLATFORM and is expected to be short, but an error message is
+        # not the place to echo an unbounded string back.
+        preview = repr(plugin_id[:40]) if isinstance(plugin_id, str) else repr(type(plugin_id).__name__)
+        logger.error(
+            "Refusing to load plugin secrets: plugin identity is missing or malformed",
+            extra={"plugin_id": preview},
+        )
+        raise ConfigurationError(
+            f"Cannot load plugin secrets: plugin identity {preview} is missing or "
+            "malformed (expected lowercase letters, digits and underscores, "
+            "starting and ending with a letter or digit)."
+        )
+
+    prefix = plugin_secret_prefix(plugin_id)
+
+    if not isinstance(all_secrets, Mapping) or not all_secrets:
+        # An empty secret is a configuration failure, not an empty namespace:
+        # `get_secret` returns {} both for a genuinely empty secret and for a
+        # read that FAILED (it logs and swallows), and neither is a state in
+        # which a plugin should quietly run with no credentials.
+        logger.error(
+            "Refusing to load plugin secrets: secret payload is empty",
+            extra={"plugin_id": plugin_id, "expected_prefix": prefix},
+        )
+        raise ConfigurationError(
+            f"Cannot load plugin secrets for '{plugin_id}': the shared secret is "
+            f"empty or unreadable, so no '{prefix}*' keys could be read."
+        )
+
+    # `len(key) > len(prefix)` drops a key that IS the bare prefix, which would
+    # otherwise be handed to the plugin under the empty name ''.
+    scoped = {
+        key[len(prefix):]: value
+        for key, value in all_secrets.items()
+        if isinstance(key, str) and key.startswith(prefix) and len(key) > len(prefix)
+    }
+
+    if not scoped:
+        logger.error(
+            "Refusing to load plugin secrets: no key carries this plugin's prefix",
+            extra={"plugin_id": plugin_id, "expected_prefix": prefix},
+        )
+        raise ConfigurationError(
+            f"Cannot load plugin secrets for '{plugin_id}': the shared secret "
+            f"contains no '{prefix}*' keys. Check the plugin id and that its "
+            "credentials were saved under that prefix."
+        )
+
+    return scoped

--- a/voc-datalake/plugins/_shared/test/scoped_secret.py
+++ b/voc-datalake/plugins/_shared/test/scoped_secret.py
@@ -12,12 +12,22 @@ production prefix construction changed under it, which is exactly the silence
 this module exists to avoid. Imported by tests of individual plugins too (they
 all run with the same SOURCE_PLATFORM from `plugins/conftest.py`), so the
 knowledge lives in one place rather than in six test files.
+
+The zero-argument filler key is deliberately one NO plugin manifest declares. It
+is the property the ~50 bare `scoped_secret()` call sites rely on: the filler has
+to be inert at every one of them, and a real key name (`api_key`, which
+`_template` declares) would mean a future test whose subject IS that key could
+pass or fail for a reason written down nowhere near its call site.
 """
 
 from _shared import base_ingestor
-from _shared.secrets import plugin_secret_prefix
+from _shared.plugin_secrets import plugin_secret_prefix
 
-__all__ = ["scoped_secret"]
+__all__ = ["FILLER_KEY", "scoped_secret"]
+
+# Not a key any manifest declares — see the module docstring. Named so a reader
+# who greps a failing payload for it lands on the reason it exists.
+FILLER_KEY = "unused_by_this_test"
 
 
 def scoped_secret(**values: str) -> dict:
@@ -28,5 +38,5 @@ def scoped_secret(**values: str) -> dict:
     """
     prefix = plugin_secret_prefix(base_ingestor.SOURCE_PLATFORM)
     if not values:
-        values = {"api_key": "unused-by-this-test"}
+        values = {FILLER_KEY: "filler"}
     return {f"{prefix}{key}": value for key, value in values.items()}

--- a/voc-datalake/plugins/_shared/test/scoped_secret.py
+++ b/voc-datalake/plugins/_shared/test/scoped_secret.py
@@ -1,0 +1,32 @@
+"""Test helper: build a secret payload inside the plugin's own namespace.
+
+Since issue #251 both base classes REFUSE a secret that carries no key under
+`<SOURCE_PLATFORM>_`, so `{}` — which most of these tests used to pass as "no
+secrets configured" — is now a ConfigurationError. Tests that are not about
+secret filtering need a payload that satisfies the boundary without restating
+it, hence this helper.
+
+The prefix is DERIVED from the live `SOURCE_PLATFORM` the base classes read, not
+spelled out: a test that hardcoded `'test_source_'` would keep passing if the
+production prefix construction changed under it, which is exactly the silence
+this module exists to avoid. Imported by tests of individual plugins too (they
+all run with the same SOURCE_PLATFORM from `plugins/conftest.py`), so the
+knowledge lives in one place rather than in six test files.
+"""
+
+from _shared import base_ingestor
+from _shared.secrets import plugin_secret_prefix
+
+__all__ = ["scoped_secret"]
+
+
+def scoped_secret(**values: str) -> dict:
+    """Return *values* re-keyed into the namespace the base classes accept.
+
+    With no arguments, returns a single filler key — enough to pass the
+    fail-closed check for tests whose subject is not secret loading at all.
+    """
+    prefix = plugin_secret_prefix(base_ingestor.SOURCE_PLATFORM)
+    if not values:
+        values = {"api_key": "unused-by-this-test"}
+    return {f"{prefix}{key}": value for key, value in values.items()}

--- a/voc-datalake/plugins/_shared/test/test_base_ingestor.py
+++ b/voc-datalake/plugins/_shared/test/test_base_ingestor.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from _shared.test.scoped_secret import scoped_secret
+
 
 class TestBaseIngestorInit:
     """Tests for BaseIngestor initialization."""
@@ -37,23 +39,30 @@ class TestBaseIngestorInit:
     @patch('_shared.base_ingestor.get_s3_client')
     @patch('_shared.base_ingestor.get_sqs_client')
     @patch('_shared.base_ingestor.get_secret')
-    def test_does_not_leak_other_known_plugin_secrets(
+    def test_does_not_leak_another_plugins_or_an_unprefixed_secret(
         self, mock_get_secret, mock_sqs, mock_s3, mock_dynamo
     ):
-        """Keys prefixed for another KNOWN plugin must not leak into this plugin's secrets.
+        """Only this plugin's namespace is loaded — nothing else, however it is keyed.
 
-        Regression guard for per-plugin secret isolation: every plugin id must be
-        listed in BaseIngestor._get_known_prefixes(). If a plugin (e.g. synthetic_reviews)
-        is missing from that list, its `<plugin>_*` keys in the shared secret are treated
-        as unprefixed shared/legacy keys and leak into every other plugin's loaded config.
-        This test fails if a known plugin is dropped from the prefix list.
+        This used to depend on a hand-maintained plugin-id list inside
+        BaseIngestor: a key carrying no *known* prefix was passed through as a
+        shared/legacy value, so forgetting to add a plugin to that list made its
+        `<plugin>_*` keys read as unprefixed and leak into every other plugin.
+        The list is gone (issue #251); the prefix scan is now the whole rule, so
+        an unknown plugin's keys are excluded because they are not ours — not
+        because someone remembered to enumerate them.
+
+        Reverts-to-catch: restoring the "no known prefix -> shared/legacy"
+        branch makes `shared_legacy_key` appear, and makes
+        `synthetic_reviews_api_key` appear too as soon as that id falls off the
+        list.
         """
         from _shared.base_ingestor import BaseIngestor
 
         mock_get_secret.return_value = {
             'test_source_api_key': 'mine',            # this plugin's own key
-            'synthetic_reviews_api_key': 'not-mine',  # another known plugin's key
-            'shared_legacy_key': 'shared',            # no known prefix -> shared/legacy
+            'synthetic_reviews_api_key': 'not-mine',  # another plugin's key
+            'shared_legacy_key': 'shared',            # carries no plugin prefix
         }
         mock_dynamo.return_value.Table.return_value = MagicMock()
 
@@ -63,13 +72,11 @@ class TestBaseIngestorInit:
 
         ingestor = TestIngestor()  # source_platform = 'test_source' (conftest env)
 
-        # own key: present and prefix-stripped
-        assert ingestor.secrets.get('api_key') == 'mine'
-        # unprefixed key: kept as a shared/legacy value
-        assert ingestor.secrets.get('shared_legacy_key') == 'shared'
-        # another known plugin's key: excluded entirely, and never surfaced under any name
-        assert 'synthetic_reviews_api_key' not in ingestor.secrets
+        # own key: present and prefix-stripped — and it is the ONLY thing loaded
+        assert ingestor.secrets == {'api_key': 'mine'}
+        # neither foreign value is reachable under any name
         assert 'not-mine' not in ingestor.secrets.values()
+        assert 'shared' not in ingestor.secrets.values()
 
     @patch('_shared.base_ingestor.get_dynamodb_resource')
     @patch('_shared.base_ingestor.get_s3_client')
@@ -81,7 +88,7 @@ class TestBaseIngestorInit:
         """Creates CircuitBreaker for the plugin."""
         from _shared.base_ingestor import BaseIngestor
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_dynamo.return_value.Table.return_value = MagicMock()
         
         class TestIngestor(BaseIngestor):
@@ -112,7 +119,7 @@ class TestBaseIngestorWatermarks:
             'Item': {'value': '2025-01-01T00:00:00Z'}
         }
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -139,7 +146,7 @@ class TestBaseIngestorWatermarks:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}  # No Item
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -162,7 +169,7 @@ class TestBaseIngestorWatermarks:
         
         mock_table = MagicMock()
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -194,7 +201,7 @@ class TestBaseIngestorNormalizeItem:
         from _shared.base_ingestor import BaseIngestor
         
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -235,7 +242,7 @@ class TestBaseIngestorNormalizeItem:
         mock_s3_client = MagicMock()
         mock_s3.return_value = mock_s3_client
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -283,7 +290,7 @@ class TestBaseIngestorSendToQueue:
         mock_sqs_client.send_message_batch.side_effect = _batch_success
         mock_sqs.return_value = mock_sqs_client
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -316,7 +323,7 @@ class TestBaseIngestorSendToQueue:
         mock_sqs_client = MagicMock()
         mock_sqs.return_value = mock_sqs_client
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -357,7 +364,7 @@ class TestBaseIngestorSendToQueue:
         }
         mock_sqs.return_value = mock_sqs_client
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -399,7 +406,7 @@ class TestBaseIngestorSendToQueue:
         }
         mock_sqs.return_value = mock_sqs_client
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -447,7 +454,7 @@ class TestBaseIngestorSendToQueue:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -486,7 +493,7 @@ class TestBaseIngestorRun:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -519,7 +526,7 @@ class TestBaseIngestorRun:
         from _shared.base_ingestor import BaseIngestor
         
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -562,7 +569,7 @@ class TestBaseIngestorRun:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -618,7 +625,7 @@ class TestBaseIngestorRun:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -668,7 +675,7 @@ class TestBaseIngestorRun:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -726,7 +733,7 @@ class TestBaseIngestorRun:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -780,7 +787,7 @@ class TestBaseIngestorRun:
         mock_table = MagicMock()
         mock_table.get_item.return_value = {}
         mock_dynamo.return_value.Table.return_value = mock_table
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
 
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -829,7 +836,7 @@ class TestBaseIngestorRun:
         from _shared.base_ingestor import BaseIngestor
         
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -859,7 +866,7 @@ class TestBaseIngestorGenerateDeterministicId:
         from _shared.base_ingestor import BaseIngestor
         
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -884,7 +891,7 @@ class TestBaseIngestorGenerateDeterministicId:
         from _shared.base_ingestor import BaseIngestor
         
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -913,7 +920,7 @@ class TestBaseIngestorGenerateDeterministicId:
         from _shared.base_ingestor import BaseIngestor
         
         mock_dynamo.return_value.Table.return_value = MagicMock()
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestIngestor(BaseIngestor):
             def fetch_new_items(self):
@@ -968,7 +975,7 @@ class TestManualRunSecretCacheClear:
 
         def record_get_secret(_arn):
             call_order.append('get_secret')
-            return {}
+            return scoped_secret()
 
         mock_get_secret.side_effect = record_get_secret
         mock_dynamo.return_value.Table.return_value = MagicMock()
@@ -986,7 +993,7 @@ class TestManualRunSecretCacheClear:
     def test_scheduled_run_keeps_the_warm_cache(
         self, mock_clear, mock_get_secret, mock_sqs, mock_s3, mock_dynamo
     ):
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_dynamo.return_value.Table.return_value = MagicMock()
 
         ingestor = self._make_ingestor()

--- a/voc-datalake/plugins/_shared/test/test_base_webhook.py
+++ b/voc-datalake/plugins/_shared/test/test_base_webhook.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from _shared.test.scoped_secret import scoped_secret
+
 
 class TestBaseWebhookInit:
     """Tests for BaseWebhook initialization."""
@@ -30,6 +32,10 @@ class TestBaseWebhookInit:
         
         assert webhook.secrets.get('webhook_secret') == 'secret-123'
         assert webhook.secrets.get('api_key') == 'key-456'
+        # Equality, not two .get()s: an assertion pair cannot notice a THIRD
+        # key arriving, which is how the foreign 'other_plugin_key' used to
+        # slip through (issue #251).
+        assert webhook.secrets == {'webhook_secret': 'secret-123', 'api_key': 'key-456'}
 
     @patch('_shared.base_webhook.get_sqs_client')
     @patch('_shared.base_webhook.get_secret')
@@ -37,7 +43,7 @@ class TestBaseWebhookInit:
         """Creates SQS client for queue operations."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs.return_value = mock_sqs_client
         
@@ -59,7 +65,7 @@ class TestBaseWebhookNormalizeItem:
         """Converts webhook item to normalized schema."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):
@@ -92,7 +98,7 @@ class TestBaseWebhookNormalizeItem:
         """Uses 'webhook' as default channel."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):
@@ -115,7 +121,7 @@ class TestBaseWebhookSendToQueue:
         """Sends items to SQS in batches of 10."""
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         # Use a callable side_effect that derives Successful from the actual
         # Entries passed.  This is correct for any batch size and any number of
@@ -153,7 +159,7 @@ class TestBaseWebhookSendToQueue:
         """Does not call SQS when items list is empty."""
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs.return_value = mock_sqs_client
 
@@ -178,7 +184,7 @@ class TestBaseWebhookSendToQueue:
         """
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs_client.send_message_batch.return_value = {
             'Successful': [],
@@ -214,7 +220,7 @@ class TestBaseWebhookSendToQueue:
         """
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs_client.send_message_batch.return_value = {
             'Successful': [{'Id': '0'}],
@@ -256,7 +262,7 @@ class TestBaseWebhookHandle:
         """Parses payload, normalizes items, and queues them."""
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs_client.send_message_batch.return_value = {
             'Successful': [{'Id': '0'}, {'Id': '1'}],
@@ -305,7 +311,7 @@ class TestBaseWebhookHandle:
         """
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs.return_value = MagicMock()
 
         class TestWebhook(BaseWebhook):
@@ -351,7 +357,7 @@ class TestBaseWebhookHandle:
         """Returns success with 0 items when payload has no items."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):
@@ -381,7 +387,7 @@ class TestBaseWebhookHandle:
         """Returns 400 when body is not valid JSON."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):
@@ -410,7 +416,7 @@ class TestBaseWebhookHandle:
         """Returns 500 when processing fails."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):
@@ -440,7 +446,7 @@ class TestBaseWebhookHandle:
         import base64
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs_client.send_message_batch.return_value = {
             'Successful': [{'Id': '0'}],
@@ -482,7 +488,7 @@ class TestBaseWebhookHandle:
         """Emits webhook.received audit event."""
         from _shared.base_webhook import BaseWebhook
 
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         mock_sqs_client = MagicMock()
         mock_sqs_client.send_message_batch.return_value = {
             'Successful': [{'Id': '0'}],
@@ -519,7 +525,7 @@ class TestBaseWebhookExtractClientIp:
         """Extracts source IP from API Gateway event."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):
@@ -543,7 +549,7 @@ class TestBaseWebhookExtractClientIp:
         """Returns 'unknown' when IP not in event."""
         from _shared.base_webhook import BaseWebhook
         
-        mock_get_secret.return_value = {}
+        mock_get_secret.return_value = scoped_secret()
         
         class TestWebhook(BaseWebhook):
             def parse_webhook_payload(self, body, headers):

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -63,15 +63,23 @@ REVERT MAP — each assertion below names the mutation it catches:
 
   test_a_broken_circuit_breaker_does_not_swallow_the_audit_event /
   test_a_broken_circuit_breaker_does_not_swallow_the_run_record
-    — re-merges the three reporting steps into ONE `try`, or moves the audit event
-      back after the breaker call. `CircuitBreaker.record_failure` is not
-      exception-safe on its first line: `self.table` resolves
-      `get_dynamodb_resource()` above its own `try`, so a failure building that
-      resource escapes into `_report_construction_failure`'s blind catch and every
-      later step is skipped. Under the old order that lost `plugin.failed` — the
-      ONLY signal a scheduled run leaves, since `_update_source_run_status` is a
-      no-op without an `execution_id` — in exactly the correlated case where the
-      same DynamoDB trouble breaks both.
+    — re-merges the three reporting steps in `_report_construction_failure` into
+      ONE `try`. Either order fails: with the audit event last (the pre-fix shape)
+      the audit case fails; with the breaker first, both do.
+      `CircuitBreaker.record_failure` is not exception-safe on its first line:
+      `self.table` resolves `get_dynamodb_resource()` above its own `try`, so a
+      failure building that resource escapes into `_report_construction_failure`'s
+      catch and every LATER step in the same `try` is skipped. Under the old shape
+      that lost `plugin.failed` — the ONLY signal a scheduled run leaves, since
+      `_update_source_run_status` is a no-op without an `execution_id` — in exactly
+      the correlated case where the same DynamoDB trouble breaks both.
+
+      Reordering ALONE is not caught, and must not be: with the per-step guards in
+      place, moving `emit_audit_event` back after the breaker call changes nothing
+      and all cases here pass (measured). The guards carry the guarantee; the order
+      is defence in depth against a future edit that reintroduces a shared `try`.
+      `_report_construction_failure`'s own docstring says the same, so a reader
+      asking "is the ordering load-bearing?" gets one answer from both.
 
   test_an_unreadable_secret_is_not_counted_against_the_circuit_breaker
     — raises plain `ConfigurationError` from the empty-payload branch instead of

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -61,6 +61,28 @@ REVERT MAP — each assertion below names the mutation it catches:
       invoking, and the UI polls it with no timeout — a permanent spinner with the
       diagnosis only in CloudWatch.
 
+  test_an_unreadable_secret_is_not_counted_against_the_circuit_breaker
+    — raises plain `ConfigurationError` from the empty-payload branch instead of
+      `SecretUnreadableError`, or drops the `if not unreadable` guard around
+      `record_failure`. `get_secret` swallows every client error into `{}`, so an
+      empty payload can be an AWS-side throttle. At the default threshold (5 in 15
+      minutes) counting those calls `_trip_breaker`, which disables the plugin's
+      EventBridge schedule — and nothing in this tree re-enables one, so a healthy
+      plugin's ingestion stops until an operator notices. The sibling assertion
+      that a NAMESPACE MISS still counts is what stops this becoming "the breaker
+      no longer fires".
+
+  test_a_real_aws_call_is_refused /
+  test_the_attempt_is_recorded_even_when_the_code_swallows_it
+    — removes `no_real_aws_calls` from `plugins/conftest.py`, or reduces it to
+      refusing without recording. Because `_report_construction_failure` now runs
+      the circuit breaker on the construction path, and `_shared.circuit_breaker`
+      resolves DynamoDB through its OWN import, three tests here issued a genuine
+      `dynamodb.Query` against whatever account the runner held credentials for —
+      invisibly, since `record_failure` swallowed the result. Refusing alone would
+      be swallowed the same way, so the attempt is recorded and asserted at
+      teardown.
+
   test_the_identity_rule_is_the_one_the_write_path_enforces
     — re-inlines the character class into either path. A read that refuses an
       identity the write path accepted is the same drift, one level up, that two
@@ -95,7 +117,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import shared.aws as shared_aws
-from shared.exceptions import ConfigurationError
+from shared.exceptions import ConfigurationError, SecretUnreadableError
 from shared.plugin_identity import is_valid_plugin_identifier
 
 from _shared import base_ingestor, base_webhook
@@ -294,7 +316,13 @@ class TestBothBaseClassesFailClosed:
     @patch('_shared.base_ingestor.get_s3_client')
     @patch('_shared.base_ingestor.get_sqs_client')
     @patch('_shared.base_ingestor.get_secret')
-    def _ingestor_with(payload, mock_get_secret, mock_sqs, mock_s3, mock_dynamo):
+    # `_report_construction_failure` runs on the refusal cases below, and
+    # `CircuitBreaker` resolves DynamoDB through `_shared.circuit_breaker`'s OWN
+    # `get_dynamodb_resource` import — patching `base_ingestor`'s does not reach it,
+    # so an unpatched breaker issues a genuine `dynamodb.Query` and `record_failure`
+    # swallows the result. Pinned by plugins/conftest.py::no_real_aws_calls.
+    @patch.object(base_ingestor.CircuitBreaker, 'record_failure')
+    def _ingestor_with(payload, mock_record_failure, mock_get_secret, mock_sqs, mock_s3, mock_dynamo):
         mock_get_secret.return_value = payload
         mock_dynamo.return_value.Table.return_value = MagicMock()
         return _make_ingestor()
@@ -440,7 +468,12 @@ class TestATransientReadFailureIsRetryable:
                 patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
                 patch('_shared.base_ingestor.get_s3_client'), \
                 patch('_shared.base_ingestor.get_sqs_client'), \
-                patch('_shared.base_webhook.get_sqs_client'):
+                patch('_shared.base_webhook.get_sqs_client'), \
+                patch.object(base_ingestor.CircuitBreaker, 'record_failure'):
+            # The breaker is patched even though a SecretUnreadableError does not
+            # reach it today: a test about the secret CACHE should not depend on how
+            # the breaker classifies the error, and an unpatched breaker reaches real
+            # DynamoDB (see plugins/conftest.py::no_real_aws_calls).
             mock_dynamo.return_value.Table.return_value = MagicMock()
             construct = _make_ingestor if kind == 'ingestor' else _make_webhook
 
@@ -590,6 +623,158 @@ class TestAConstructionFailureIsReported:
         assert self._status_written(table) is None
         assert record_failure.call_args_list == []
         assert [call.args[0] for call in emit.call_args_list if call.args] == []
+
+
+class TestAnUnreadableSecretIsNotAPluginFailure:
+    """A throttle must not auto-disable a healthy plugin's schedule.
+
+    `shared.aws.get_secret` logs and swallows EVERY client error into `{}`, so an
+    empty payload means either "genuinely empty" or "the read failed" — the same
+    ambiguity the cache eviction acknowledges. Reporting it is right; COUNTING it is
+    not: `CircuitBreaker.record_failure` trips at 5 failures in 15 minutes by
+    default, and `_trip_breaker` calls `events.disable_rule` on the plugin's
+    EventBridge schedule. Nothing in this tree re-enables a disabled rule and
+    `record_success` only resets on a run that completes, so five Secrets Manager
+    blips inside one window stop a healthy plugin's ingestion until an operator
+    notices and re-enables it by hand.
+
+    The fail-OPEN code could not do this — a transient `{}` never raised — so this
+    is availability coupling the fail-closed direction introduced, not something
+    pre-existing.
+
+    The empty-payload branch therefore raises `SecretUnreadableError`, a
+    `ConfigurationError` subclass so nothing that catches the parent stops working,
+    and `_report_construction_failure` skips only the breaker for it.
+    """
+
+    # Reuses the construction harness above rather than restating it: the subject is
+    # which of the three reporting effects fire, and those are exactly what it
+    # returns.
+    _construct = staticmethod(TestAConstructionFailureIsReported._construct)
+    _status_written = staticmethod(TestAConstructionFailureIsReported._status_written)
+    EXECUTION_ID = TestAConstructionFailureIsReported.EXECUTION_ID
+
+    def test_an_empty_secret_raises_the_narrower_unreadable_type(self):
+        """The classification itself, at the raise site. Asserted separately from
+        the breaker behaviour below so a failure says WHICH of the two halves broke
+        — the type or the branch that reads it."""
+        with pytest.raises(SecretUnreadableError):
+            filter_plugin_secrets(PLUGIN_ID, {})
+
+    def test_a_namespace_miss_is_not_the_unreadable_type(self):
+        """The other side of the classification: a populated secret that simply has
+        no key for this plugin IS someone's mistake, and must stay a plain
+        `ConfigurationError`. Without this, raising `SecretUnreadableError` from
+        every branch would satisfy the assertion above and silently stop the breaker
+        from ever firing."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            filter_plugin_secrets(PLUGIN_ID, FOREIGN_ONLY_SECRET)
+
+        assert not isinstance(excinfo.value, SecretUnreadableError)
+
+    def test_the_unreadable_type_is_still_caught_as_a_configuration_error(self):
+        """Subclassing is the compatibility promise: `BaseIngestor.__init__` and
+        every plugin handler catch `ConfigurationError`, and a sibling type would
+        escape all of them — turning a handled misconfiguration into an unhandled
+        crash. Cheap to assert, and the reason this is not a new top-level
+        exception."""
+        assert issubclass(SecretUnreadableError, ConfigurationError)
+
+    def test_an_unreadable_secret_is_not_counted_against_the_circuit_breaker(self):
+        error, _, record_failure, _ = self._construct({}, self.EXECUTION_ID)
+
+        assert isinstance(error, SecretUnreadableError), (
+            'expected construction to refuse an empty payload'
+        )
+        assert record_failure.call_args_list == [], (
+            'a transient Secrets Manager failure was counted as a plugin failure; '
+            'five in one window disable the schedule of a plugin that is fine'
+        )
+
+    def test_the_control_a_namespace_miss_still_is_counted(self):
+        """Non-vacuity, and the property the exemption must not cost: the breaker
+        still fires for a genuine misconfiguration. Without this, dropping
+        `record_failure` altogether — or widening the exemption to every
+        `ConfigurationError` — passes the assertion above while removing the
+        auto-disable entirely, which is a defect in the opposite direction."""
+        _, _, record_failure, _ = self._construct(FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        assert record_failure.call_args_list, (
+            'a namespace miss is a misconfiguration and retrying it forever is what '
+            'the breaker exists to stop'
+        )
+
+    def test_an_unreadable_secret_still_moves_the_run_record_to_error(self):
+        """The exemption is scoped to the breaker alone. The run record is what
+        clears the UI's spinner, so withholding it would trade one availability
+        problem for a worse observability one."""
+        _, table, _, _ = self._construct({}, self.EXECUTION_ID)
+
+        assert self._status_written(table) == 'error'
+
+    def test_an_unreadable_secret_still_emits_the_audit_event(self):
+        """Likewise. The event also records that the breaker did NOT count this
+        one, so an operator reading a burst of them does not conclude the breaker
+        is broken."""
+        _, _, _, emit = self._construct({}, self.EXECUTION_ID)
+
+        failed = [call for call in emit.call_args_list
+                  if call.args and call.args[0] == 'plugin.failed']
+        assert failed, 'the failure was silent in the audit trail'
+        assert failed[-1].args[3]['counted_against_circuit_breaker'] is False
+
+
+class TestNoPluginTestReachesRealAws:
+    """The guard in `plugins/conftest.py`, controlled for.
+
+    Three tests in this file once issued a genuine `dynamodb.Query` against whatever
+    account the runner held credentials for, and it was INVISIBLE: `record_failure`
+    swallows its own exceptions, so the call went out, failed, and the assertion
+    still passed. `AccessDeniedException` is the benign outcome — a laptop or a CI
+    deploy role that does grant DynamoDB gets a real query and `put_item` against a
+    live `test-watermarks`, and at threshold a real `events:DisableRule`.
+
+    `no_real_aws_calls` is autouse, so every test in `plugins/` is already covered.
+    What is asserted here is that the guard is ARMED — an autouse fixture that
+    silently stopped applying (a conftest move, a rename, a `patch.object` target
+    change in botocore) would leave the whole suite unprotected with nothing failing.
+    """
+
+    def test_a_real_aws_call_is_refused(self, no_real_aws_calls):
+        """The guard's own subject, exercised directly rather than trusted: a client
+        built the ordinary way must not reach the network. `no_real_aws_calls` is
+        requested by name so the deliberate attempt can be cleared from its record —
+        otherwise this test would fail at its own teardown for doing its job."""
+        import boto3
+
+        client = boto3.client('dynamodb', region_name='us-east-1')
+
+        with pytest.raises(AssertionError, match='refused real AWS call'):
+            client.describe_table(TableName='test-watermarks')
+
+        assert no_real_aws_calls == ['dynamodb.DescribeTable']
+        no_real_aws_calls.clear()
+
+    def test_the_attempt_is_recorded_even_when_the_code_swallows_it(self, no_real_aws_calls):
+        """Why refusing alone is not enough, and the actual defect being guarded
+        against: `record_failure`'s `except Exception` hides this AssertionError
+        exactly as it hid the original `AccessDeniedException`. The record survives
+        the swallow, which is what lets the fixture report at teardown — somewhere no
+        `except` in the code under test can reach."""
+        import boto3
+
+        client = boto3.client('dynamodb', region_name='us-east-1')
+        swallowed = None
+        try:
+            client.describe_table(TableName='test-watermarks')
+        except Exception as error:  # noqa: BLE001 — mimicking record_failure's own catch
+            swallowed = error
+
+        assert swallowed is not None, 'the refusal did not even reach the caller'
+        assert no_real_aws_calls == ['dynamodb.DescribeTable'], (
+            'the guard cannot report an attempt the code under test swallowed'
+        )
+        no_real_aws_calls.clear()
 
 
 class TestTheIdentityRuleIsSharedWithTheWritePath:

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -131,12 +131,21 @@ REVERT MAP — each assertion below names the mutation it catches:
       seeded, so its Lambda dies at construction. That fails in CI here rather
       than in a production Lambda.
 
+  test_both_base_classes_read_secrets_unconditionally_in_init
+    — the mechanism four docs describe, and previously described WRONGLY: three of
+      them offered "do not read `self.secrets` in your constructor" as a way out.
+      There is no such way out — `__init__` calls `self._load_secrets()` itself,
+      before any subclass body runs — so a plugin following that advice passed the
+      manifest test and then died on its first invocation. Pinned so the escape
+      hatch the docs now name is the one that actually exists.
+
 Known consequence, deliberate: a plugin that declares NO secret keys in its
 manifest now fails at construction rather than silently receiving every other
 plugin's keys. Every current plugin declares at least one key and CDK seeds them
-all at deploy time (both pinned below), so no shipped plugin is affected; a future
-one that needs no configuration should declare a key or not call the base
-constructor's secret read, and the error tells it which prefix was expected.
+all at deploy time (both pinned below), so no shipped plugin is affected. A future
+one that needs no configuration should declare a key, or override `_load_secrets`
+to return `{}` — the only actual opt-out, since the base constructor's read is
+unconditional — and the error tells it which prefix was expected.
 """
 
 import ast
@@ -462,6 +471,96 @@ class TestOneImplementationOfTheBoundary:
             assert len(tree.body) > 1, 'expected a real body, not a stub'
         assert (base_ingestor.BaseIngestor._load_secrets
                 is not base_webhook.BaseWebhook._load_secrets)
+
+
+class TestTheOnlyOptOutIsOverridingLoadSecrets:
+    """The requirement is escapable exactly one way, and the docs must say which.
+
+    Three sites (`docs/getting-started-plugins.md`, `CHANGELOG.md`'s upgrade note
+    and `test_every_plugin_declares_at_least_one_secret_key`'s docstring) offered
+    "do not read `self.secrets` in your constructor" as the way for a plugin
+    needing no configuration to avoid the raise. That is not a thing: the read is
+    in `__init__`, not in the attribute access, so a plugin following it declared
+    no `secrets`, passed the manifest test — which only fails once such a manifest
+    exists — and then died on its first invocation in a deployed Lambda. Exactly
+    the outcome the surrounding paragraph claimed CI now prevents.
+
+    Prose could not have caught that, which is the argument for these two cases:
+    the docs are now checkable rather than merely written.
+    """
+
+    @pytest.mark.parametrize(
+        'cls',
+        [base_ingestor.BaseIngestor, base_webhook.BaseWebhook],
+        ids=['ingestor', 'webhook'],
+    )
+    def test_both_base_classes_read_secrets_unconditionally_in_init(self, cls):
+        """`__init__` calls `self._load_secrets()`, so not reading the attribute
+        cannot help. Parsed rather than behavioural: the claim is about WHERE the
+        call sits, and a subclass that never touches `self.secrets` still raising
+        (asserted below) is the consequence, not the mechanism."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(cls.__init__)))
+        loads = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == '_load_secrets'
+        ]
+        assert loads, (
+            f'{cls.__name__}.__init__ no longer reads secrets itself. If the read '
+            'moved to first use, the documented requirement is now escapable by '
+            'not reading `self.secrets` — update the three docs that say it is not.'
+        )
+
+    @patch('_shared.base_ingestor.get_dynamodb_resource')
+    @patch('_shared.base_ingestor.get_s3_client')
+    @patch('_shared.base_ingestor.get_sqs_client')
+    @patch('_shared.base_ingestor.get_secret')
+    @patch.object(base_ingestor.CircuitBreaker, 'record_failure')
+    def test_a_plugin_that_never_reads_the_attribute_still_fails_closed(
+        self, mock_record_failure, mock_get_secret, mock_sqs, mock_s3, mock_dynamo
+    ):
+        """The consequence, end to end: a subclass declaring nothing and never
+        referencing `self.secrets` is refused against a secret populated for OTHER
+        plugins. This is the case the wrong advice produced."""
+        mock_get_secret.return_value = FOREIGN_ONLY_SECRET
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+
+        class _NeverReadsSecrets(base_ingestor.BaseIngestor):
+            def fetch_new_items(self):
+                yield from []
+
+        with pytest.raises(ConfigurationError) as raised:
+            _NeverReadsSecrets()
+
+        assert PREFIX in str(raised.value)
+        # And it did not quietly receive the other plugin's credentials instead.
+        assert OTHER_PLUGIN_VALUE not in str(raised.value)
+
+    @patch('_shared.base_ingestor.get_dynamodb_resource')
+    @patch('_shared.base_ingestor.get_s3_client')
+    @patch('_shared.base_ingestor.get_sqs_client')
+    @patch('_shared.base_ingestor.get_secret')
+    def test_the_control_overriding_load_secrets_does_opt_out(
+        self, mock_get_secret, mock_sqs, mock_s3, mock_dynamo
+    ):
+        """Non-vacuity for the case above, and the escape hatch the docs now name.
+
+        Without this, "construction always raises against a foreign secret" would
+        satisfy the case above — and the docs would be pointing at an opt-out that
+        does not work, which is the defect being fixed rather than a fix for it.
+        """
+        mock_get_secret.return_value = FOREIGN_ONLY_SECRET
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+
+        class _OptsOut(base_ingestor.BaseIngestor):
+            def _load_secrets(self):
+                return {}
+
+            def fetch_new_items(self):
+                yield from []
+
+        assert _OptsOut().secrets == {}
 
 
 class TestATransientReadFailureIsRetryable:
@@ -1033,8 +1132,13 @@ class TestTheDeployTimeInvariantsThisBoundaryNeeds:
         is why this is pinned rather than asserted in the PR description.
 
         A future plugin that genuinely needs no configuration is not blocked: it
-        can declare one key, or not read secrets in its constructor. What it may
-        not do is discover the requirement from a CloudWatch log."""
+        can declare one key, or override `_load_secrets` to return `{}`. NOT
+        reading `self.secrets` is not an escape hatch — both base classes call
+        `self._load_secrets()` from `__init__` before any subclass body runs, so
+        the raise does not depend on the attribute being read. Stated precisely
+        because this docstring is what an author reads when this test fails, which
+        is the moment they are looking for a way around it. What they may not do is
+        discover the requirement from a CloudWatch log."""
         empty = [
             name for name, manifest in self._manifests().items()
             if not manifest.get('secrets')

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -1,9 +1,9 @@
 """Plugin secret prefix isolation fails CLOSED (issue #251).
 
-`plugins/_shared/secrets.py` is the only place a plugin Lambda turns the shared
-API-credentials secret into its own config. All ingestion Lambdas share one IAM
-role, so that prefix scan is the entire isolation boundary — there is no second
-layer to catch a mistake.
+`plugins/_shared/plugin_secrets.py` is the only place a plugin Lambda turns the
+shared API-credentials secret into its own config. All ingestion Lambdas share one
+IAM role, so that prefix scan is the entire isolation boundary — there is no
+second layer to catch a mistake.
 
 REVERT MAP — each assertion below names the mutation it catches:
 
@@ -42,24 +42,64 @@ REVERT MAP — each assertion below names the mutation it catches:
       two drifted in the first place: it never had even the (broken) known-prefix
       list that the ingestor copy carried.
 
+  test_a_transient_read_failure_is_retried_on_the_next_invocation
+    — drops the `clear_secret_cache()` in either `_load_secrets` empty-payload
+      branch. `get_secret` is lru_cached and swallows every exception into `{}`,
+      so without the eviction ONE transient Secrets Manager blip caches that `{}`
+      and every later invocation in the warm container raises off the cache with
+      no further API call. Only a manual "Run now" clears it, so a SCHEDULED
+      plugin — and a webhook, which has no manual run at all — stays wedged for
+      the container's lifetime.
+
+  test_a_namespace_miss_moves_the_run_record_to_error /
+  test_a_namespace_miss_records_a_circuit_breaker_failure /
+  test_a_namespace_miss_emits_a_plugin_failed_audit_event
+    — removes `_report_construction_failure` from `BaseIngestor.__init__`, or
+      moves the secret read back above the tables it needs. `_load_secrets` runs
+      in `__init__`, so the raise never reaches `run()`'s except block: the
+      `SOURCE_RUN#` record stays at the 'running' that `run_source` wrote before
+      invoking, and the UI polls it with no timeout — a permanent spinner with the
+      diagnosis only in CloudWatch.
+
+  test_the_identity_rule_is_the_one_the_write_path_enforces
+    — re-inlines the character class into either path. A read that refuses an
+      identity the write path accepted is the same drift, one level up, that two
+      copies of the prefix scan produced.
+
+  test_no_plugin_id_is_a_namespace_prefix_of_another
+    — the collision the scan cannot see: `app_reviews` alongside
+      `app_reviews_ios` would receive the latter's keys under mangled names. Not
+      preventable here (a plugin knows only its own id, by design), so this
+      asserts the synth-time guard in `plugin-loader.ts` and the tree agree.
+
+  test_every_plugin_declares_at_least_one_secret_key
+    — the deploy-time invariant this change introduces, otherwise unpinned: a
+      plugin whose manifest declares no `secrets` block gets no `<id>_*` key
+      seeded, so its Lambda dies at construction. That fails in CI here rather
+      than in a production Lambda.
+
 Known consequence, deliberate: a plugin that declares NO secret keys in its
 manifest now fails at construction rather than silently receiving every other
 plugin's keys. Every current plugin declares at least one key and CDK seeds them
-all at deploy time, so no shipped plugin is affected; a future one that needs no
-configuration should declare a key or not call the base constructor's secret
-read, and the error tells it which prefix was expected.
+all at deploy time (both pinned below), so no shipped plugin is affected; a future
+one that needs no configuration should declare a key or not call the base
+constructor's secret read, and the error tells it which prefix was expected.
 """
 
 import ast
 import inspect
+import json
 import textwrap
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import shared.aws as shared_aws
 from shared.exceptions import ConfigurationError
+from shared.plugin_identity import is_valid_plugin_identifier
 
 from _shared import base_ingestor, base_webhook
-from _shared.secrets import filter_plugin_secrets, plugin_secret_prefix
+from _shared.plugin_secrets import filter_plugin_secrets, plugin_secret_prefix
 
 # The identity these tests run as — read from the same module attribute the base
 # classes read, so a rename of the env plumbing cannot leave this file asserting
@@ -90,12 +130,12 @@ FOREIGN_ONLY_SECRET = {
 }
 
 
-def _make_ingestor():
+def _make_ingestor(execution_id=None):
     class _Ingestor(base_ingestor.BaseIngestor):
         def fetch_new_items(self):
             yield from []
 
-    return _Ingestor()
+    return _Ingestor(execution_id=execution_id)
 
 
 def _make_webhook():
@@ -216,7 +256,7 @@ class TestErrorsRevealTheMisconfigurationAndNothingElse:
         # The module logger is the Powertools `Logger`, which is service-named and
         # does not propagate, so `caplog` never sees it. Patching the logger
         # object is what the neighbouring plugin suites do (test_sqs_utils.py).
-        with patch('_shared.secrets.logger') as mock_logger, \
+        with patch('_shared.plugin_secrets.logger') as mock_logger, \
                 pytest.raises(ConfigurationError):
             filter_plugin_secrets(PLUGIN_ID, FOREIGN_ONLY_SECRET)
 
@@ -239,7 +279,7 @@ class TestErrorsRevealTheMisconfigurationAndNothingElse:
     def test_the_log_control_a_successful_load_logs_nothing(self):
         """Non-vacuity for the assertion above: without this, a refusal logged
         unconditionally on every load would satisfy it."""
-        with patch('_shared.secrets.logger') as mock_logger:
+        with patch('_shared.plugin_secrets.logger') as mock_logger:
             filter_plugin_secrets(PLUGIN_ID, MIXED_SECRET)
 
         assert mock_logger.error.call_args_list == []
@@ -348,7 +388,7 @@ class TestOneImplementationOfTheBoundary:
         }
         assert 'startswith' not in attribute_calls, (
             f'{module.__name__}._load_secrets appears to filter by prefix itself; '
-            'the scan belongs in _shared/secrets.py alone'
+            'the scan belongs in _shared/plugin_secrets.py alone'
         )
 
     def test_the_findability_control_the_parser_reads_a_real_body(self):
@@ -363,3 +403,297 @@ class TestOneImplementationOfTheBoundary:
             assert len(tree.body) > 1, 'expected a real body, not a stub'
         assert (base_ingestor.BaseIngestor._load_secrets
                 is not base_webhook.BaseWebhook._load_secrets)
+
+
+class TestATransientReadFailureIsRetryable:
+    """A blip must not wedge the warm container.
+
+    `shared.aws.get_secret` is `lru_cache`d and swallows EVERY exception into
+    `{}`. Under the old fail-open filter that cached `{}` produced a wrong but
+    non-fatal run; now it correctly raises — which makes the caching itself the
+    problem, because the raise would then repeat on every later invocation in the
+    container with NO further API call. Only a manual "Run now" clears the cache
+    (`clear_secret_cache()` via `execution_id`), so a scheduled plugin, and a
+    webhook which has no manual run at all, would stay broken until recycled.
+
+    Driven through the real `get_secret` and a stubbed Secrets Manager client
+    rather than a patched `get_secret`, deliberately: the cache is the subject, and
+    patching the function that holds it removes the thing under test.
+    """
+
+    @staticmethod
+    def _client_failing_once():
+        """A Secrets Manager client that fails the first read, then succeeds."""
+        client = MagicMock()
+        client.get_secret_value.side_effect = [
+            Exception('Throttled'),
+            {'SecretString': json.dumps(MIXED_SECRET)},
+        ]
+        return client
+
+    @pytest.mark.parametrize('kind', ['ingestor', 'webhook'], ids=['ingestor', 'webhook'])
+    def test_a_transient_read_failure_is_retried_on_the_next_invocation(self, kind):
+        client = self._client_failing_once()
+        shared_aws.clear_secret_cache()
+
+        with patch('shared.aws.get_secrets_client', return_value=client), \
+                patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
+                patch('_shared.base_ingestor.get_s3_client'), \
+                patch('_shared.base_ingestor.get_sqs_client'), \
+                patch('_shared.base_webhook.get_sqs_client'):
+            mock_dynamo.return_value.Table.return_value = MagicMock()
+            construct = _make_ingestor if kind == 'ingestor' else _make_webhook
+
+            # First invocation: the read fails, `get_secret` returns {} and caches
+            # it, and construction refuses to proceed on an empty secret.
+            with pytest.raises(ConfigurationError):
+                construct()
+
+            # Second invocation in the SAME process — a warm container. It must
+            # reach the client again and succeed.
+            loaded = construct()
+
+        assert loaded.secrets == {'api_key': 'mine-key', 'configs': '[]'}
+        assert client.get_secret_value.call_count == 2, (
+            'the failed read stayed memoized: the second construction never '
+            'consulted Secrets Manager again'
+        )
+
+    def test_the_control_a_successful_read_is_still_cached(self):
+        """Non-vacuity, and the property the eviction must not cost: the cache
+        still serves a SUCCESSFUL read, so the fix did not turn every invocation
+        into a Secrets Manager call. Without this, `clear_secret_cache()` on every
+        load would satisfy the assertion above."""
+        client = MagicMock()
+        client.get_secret_value.return_value = {'SecretString': json.dumps(MIXED_SECRET)}
+        shared_aws.clear_secret_cache()
+
+        with patch('shared.aws.get_secrets_client', return_value=client), \
+                patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
+                patch('_shared.base_ingestor.get_s3_client'), \
+                patch('_shared.base_ingestor.get_sqs_client'):
+            mock_dynamo.return_value.Table.return_value = MagicMock()
+            _make_ingestor()
+            _make_ingestor()
+
+        assert client.get_secret_value.call_count == 1
+
+
+class TestAConstructionFailureIsReported:
+    """The raise happens in `__init__`, so it must report for itself.
+
+    Every `lambda_handler` constructs the ingestor before calling `run()`, so a
+    `ConfigurationError` from `_load_secrets` never reaches run()'s `except` — the
+    block that writes the `SOURCE_RUN#` record, records the circuit-breaker
+    failure and emits `plugin.failed`. `integrations_handler.run_source` writes
+    `status: 'running'` BEFORE invoking, and the UI polls until a terminal status
+    with no timeout, so an unreported construction failure is a permanent
+    "Running..." spinner.
+    """
+
+    EXECUTION_ID = 'exec-abc123'
+
+    @staticmethod
+    def _construct(payload, execution_id):
+        """Construct with a manual-run execution_id, returning the mocked table.
+
+        `AGGREGATES_TABLE` is patched to a non-empty name because
+        `_update_source_run_status` is a no-op without one, and `plugins/conftest.py`
+        does not set it.
+        """
+        table = MagicMock()
+        with patch('_shared.base_ingestor.AGGREGATES_TABLE', 'test-aggregates'), \
+                patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
+                patch('_shared.base_ingestor.get_s3_client'), \
+                patch('_shared.base_ingestor.get_sqs_client'), \
+                patch('_shared.base_ingestor.get_secret', return_value=payload), \
+                patch('_shared.base_ingestor.clear_secret_cache'), \
+                patch.object(base_ingestor.CircuitBreaker, 'record_failure') as record_failure, \
+                patch('_shared.base_ingestor.emit_audit_event') as emit:
+            mock_dynamo.return_value.Table.return_value = table
+            error = None
+            try:
+                _make_ingestor(execution_id=execution_id)
+            except ConfigurationError as raised:
+                error = raised
+        return error, table, record_failure, emit
+
+    @staticmethod
+    def _status_written(table):
+        """The `status` value the run record was last updated to, or None."""
+        for call in table.update_item.call_args_list:
+            values = call.kwargs.get('ExpressionAttributeValues', {})
+            if ':status' in values:
+                return values[':status']
+        return None
+
+    def test_a_namespace_miss_moves_the_run_record_to_error(self):
+        error, table, _, _ = self._construct(FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        assert error is not None, 'expected construction to refuse the payload'
+        assert self._status_written(table) == 'error', (
+            "the run record was left at the 'running' that run_source wrote, so "
+            'the UI would poll it forever'
+        )
+
+    def test_the_run_record_is_addressed_by_this_execution(self):
+        """The record the UI polls, not just any record: `run_source` keys it
+        `SOURCE_RUN#<source>` / `<execution_id>`, and a write to a different sort
+        key would leave the polled one at 'running' while this test passed."""
+        _, table, _, _ = self._construct(FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        keys = [call.kwargs.get('Key') for call in table.update_item.call_args_list]
+        assert {'pk': f'SOURCE_RUN#{PLUGIN_ID}', 'sk': self.EXECUTION_ID} in keys
+
+    def test_a_namespace_miss_records_a_circuit_breaker_failure(self):
+        """Otherwise a plugin broken this way never auto-disables its schedule —
+        it just fails every fifteen minutes forever."""
+        _, _, record_failure, _ = self._construct(FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        assert record_failure.call_args_list, 'the circuit breaker saw nothing'
+
+    def test_a_namespace_miss_emits_a_plugin_failed_audit_event(self):
+        _, _, _, emit = self._construct(FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        actions = [call.args[0] for call in emit.call_args_list if call.args]
+        assert 'plugin.failed' in actions
+
+    def test_the_report_does_not_replace_the_error_the_operator_needs(self):
+        """The reporting runs while a ConfigurationError is propagating. If a
+        DynamoDB failure there escaped, it would mask the only message that says
+        which prefix was expected — so the original must still arrive even when
+        every reporting step throws."""
+        table = MagicMock()
+        table.update_item.side_effect = Exception('DynamoDB unavailable')
+
+        with patch('_shared.base_ingestor.AGGREGATES_TABLE', 'test-aggregates'), \
+                patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
+                patch('_shared.base_ingestor.get_s3_client'), \
+                patch('_shared.base_ingestor.get_sqs_client'), \
+                patch('_shared.base_ingestor.get_secret', return_value=FOREIGN_ONLY_SECRET), \
+                patch.object(base_ingestor.CircuitBreaker, 'record_failure',
+                             side_effect=Exception('table gone')), \
+                patch('_shared.base_ingestor.emit_audit_event',
+                      side_effect=Exception('bus gone')):
+            mock_dynamo.return_value.Table.return_value = table
+            with pytest.raises(ConfigurationError) as excinfo:
+                _make_ingestor()
+
+        assert PREFIX in str(excinfo.value)
+
+    def test_the_control_a_successful_construction_reports_nothing(self):
+        """Non-vacuity: an unconditional error write would satisfy every
+        assertion above."""
+        error, table, record_failure, emit = self._construct(MIXED_SECRET, self.EXECUTION_ID)
+
+        assert error is None
+        assert self._status_written(table) is None
+        assert record_failure.call_args_list == []
+        assert [call.args[0] for call in emit.call_args_list if call.args] == []
+
+
+class TestTheIdentityRuleIsSharedWithTheWritePath:
+    """One character class, imported by both sides of the namespace.
+
+    The write path (`integrations_handler._validate_source`) decides what may be
+    STORED under a prefix; this module decides what may be READ from one. A value
+    one accepts and the other refuses is the same drift, one level up, that two
+    copies of the prefix scan produced — so both import
+    `shared.plugin_identity.is_valid_plugin_identifier`.
+    """
+
+    def test_the_identity_rule_is_the_one_the_write_path_enforces(self):
+        """Asserted by IDENTITY of the callable, not by comparing behaviour on a
+        sample: two independently-written regexes agreeing on the cases a test
+        thinks to try is exactly the drift that goes unnoticed."""
+        import importlib
+        import sys as _sys
+
+        lambda_api = str(Path(__file__).resolve().parents[3] / 'lambda' / 'api')
+        if lambda_api not in _sys.path:
+            _sys.path.insert(0, lambda_api)
+        handler = importlib.import_module('integrations_handler')
+
+        assert handler.is_valid_plugin_identifier is is_valid_plugin_identifier
+
+    @pytest.mark.parametrize('plugin_id', ['webscraper', 'app_reviews_ios', 's3_import'])
+    def test_every_real_plugin_id_satisfies_the_shared_rule(self, plugin_id):
+        """The rule has to admit the ids actually deployed. A tightening that
+        rejected one of these would fail every one of that plugin's invocations at
+        construction, which is not a failure a unit test of the regex alone would
+        report as an outage."""
+        assert is_valid_plugin_identifier(plugin_id)
+
+
+class TestTheDeployTimeInvariantsThisBoundaryNeeds:
+    """Two facts outside this file that the fail-closed rule depends on.
+
+    Neither is enforceable at runtime — a plugin Lambda sees its own id and its
+    own namespace by design — so they are asserted against the manifests on disk,
+    which is what CDK reads at synth time.
+    """
+
+    @staticmethod
+    def _manifests():
+        plugins_dir = Path(__file__).resolve().parents[2]
+        found = {}
+        for path in sorted(plugins_dir.glob('*/manifest.json')):
+            if path.parent.name.startswith('_'):
+                continue
+            found[path.parent.name] = json.loads(path.read_text(encoding='utf-8'))
+        return found
+
+    def test_the_manifest_scan_finds_the_real_plugins(self):
+        """Non-vacuity for both assertions below: an empty or mis-rooted glob
+        would make each of them pass over nothing."""
+        manifests = self._manifests()
+
+        assert len(manifests) >= 5, f'expected >=5 plugins, found {sorted(manifests)}'
+        assert 'webscraper' in manifests
+        # `_template` is scaffolding, not a deployable plugin — CDK's loadPlugins
+        # skips `_`-prefixed directories and so must this.
+        assert not any(name.startswith('_') for name in manifests)
+
+    def test_every_plugin_declares_at_least_one_secret_key(self):
+        """A plugin declaring NO secrets gets no `<id>_*` key seeded into the
+        shared secret, so `filter_plugin_secrets` finds an empty namespace and its
+        Lambda dies at construction — in production, on the first invocation.
+        `manual_import` and `s3_import` are the plausible zero-secret shapes, which
+        is why this is pinned rather than asserted in the PR description.
+
+        A future plugin that genuinely needs no configuration is not blocked: it
+        can declare one key, or not read secrets in its constructor. What it may
+        not do is discover the requirement from a CloudWatch log."""
+        empty = [
+            name for name, manifest in self._manifests().items()
+            if not manifest.get('secrets')
+        ]
+
+        assert empty == [], (
+            f'Plugins declare no secret keys: {empty}. Since issue #251 an empty '
+            'namespace is a ConfigurationError at construction, so such a plugin '
+            'cannot start. Declare at least one key in the manifest.'
+        )
+
+    def test_no_plugin_id_is_a_namespace_prefix_of_another(self):
+        """The one collision the prefix scan cannot see. `app_reviews` alongside
+        the existing `app_reviews_ios` would receive that plugin's keys under
+        mangled names (`app_reviews_ios_app_id` arriving as `ios_app_id`) — a
+        cross-plugin leak, not a display quirk, since this scan IS the boundary.
+
+        `plugin-loader.ts` refuses such a pair at synth time, which is the only
+        vantage point holding the whole id set; this asserts the tree agrees, so a
+        Python-side reader of the caveat sees it enforced rather than only
+        described."""
+        ids = sorted(self._manifests())
+        collisions = [
+            (shorter, longer)
+            for shorter in ids
+            for longer in ids
+            if shorter != longer and longer.startswith(plugin_secret_prefix(shorter))
+        ]
+
+        assert collisions == [], (
+            f'Plugin ids collide as secret namespaces: {collisions}. The shorter id '
+            "would also receive the longer one's keys. Rename one."
+        )

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -72,6 +72,15 @@ REVERT MAP — each assertion below names the mutation it catches:
       that a NAMESPACE MISS still counts is what stops this becoming "the breaker
       no longer fires".
 
+  test_a_non_object_payload_is_not_the_unreadable_type /
+  test_a_non_object_payload_is_counted_against_the_circuit_breaker
+    — folds `not isinstance(all_secrets, Mapping)` back into the empty-payload
+      branch. `get_secret` does `json.loads`, so a secret whose body is a JSON
+      array, string or number arrives as a non-Mapping — a permanent mistake, not a
+      throttle. Classified as "unreadable" it would escape the breaker and retry on
+      every schedule tick forever, and be logged as "payload is empty" while
+      populated.
+
   test_a_real_aws_call_is_refused /
   test_the_attempt_is_recorded_even_when_the_code_swallows_it
     — removes `no_real_aws_calls` from `plugins/conftest.py`, or reduces it to
@@ -86,7 +95,9 @@ REVERT MAP — each assertion below names the mutation it catches:
   test_the_identity_rule_is_the_one_the_write_path_enforces
     — re-inlines the character class into either path. A read that refuses an
       identity the write path accepted is the same drift, one level up, that two
-      copies of the prefix scan produced.
+      copies of the prefix scan produced. Its control catches the load being done
+      by `sys.path.insert` + `import_module` again, which left `lambda/api` on the
+      path and the handler in `sys.modules` for the whole session.
 
   test_no_plugin_id_is_a_namespace_prefix_of_another
     — the collision the scan cannot see: `app_reviews` alongside
@@ -704,6 +715,30 @@ class TestAnUnreadableSecretIsNotAPluginFailure:
             'the breaker exists to stop'
         )
 
+    def test_a_non_object_payload_is_not_the_unreadable_type(self):
+        """`get_secret` does `json.loads`, which succeeds for any valid JSON — so a
+        secret whose body is `["a", "b"]`, `"oops"` or `123` arrives as a
+        non-Mapping. That is not a throttle: it is a human having written the wrong
+        thing, it will never self-heal, and so it belongs to the COUNTED class. The
+        log line matters too — "payload is empty" is simply false about a populated
+        JSON array."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            filter_plugin_secrets(PLUGIN_ID, ['a', 'b'])
+
+        assert not isinstance(excinfo.value, SecretUnreadableError)
+
+    def test_a_non_object_payload_is_counted_against_the_circuit_breaker(self):
+        """The classification reaching the effect that depends on it. Asserted
+        through real construction rather than on the type alone, because the type is
+        only interesting if `_report_construction_failure` acts on it."""
+        error, _, record_failure, _ = self._construct(['a', 'b'], self.EXECUTION_ID)
+
+        assert error is not None, 'expected construction to refuse a non-object payload'
+        assert record_failure.call_args_list, (
+            'a secret body that is not a JSON object is a permanent misconfiguration; '
+            'exempting it from the breaker means retrying it every tick forever'
+        )
+
     def test_an_unreadable_secret_still_moves_the_run_record_to_error(self):
         """The exemption is scoped to the breaker alone. The run record is what
         clears the UI's spinner, so withholding it would trade one availability
@@ -787,19 +822,65 @@ class TestTheIdentityRuleIsSharedWithTheWritePath:
     `shared.plugin_identity.is_valid_plugin_identifier`.
     """
 
+    @staticmethod
+    def _load_write_path_module():
+        """`integrations_handler`, loaded WITHOUT lasting effects on this process.
+
+        Not `importlib.import_module` after an `sys.path.insert`: that leaves
+        `lambda/api` on the path and the module in `sys.modules` for every later
+        test in the session, which both makes the plugin suite order-dependent and
+        risks a `lambda/api` module shadowing a plugin-side name of the same stem.
+        `spec_from_file_location` addresses the file directly and registers nothing.
+
+        The module's own imports are all `shared.*` and stdlib, and `plugins/
+        conftest.py` already has `lambda/` on the path, so no path entry is needed
+        at all — which is the point.
+        """
+        import importlib.util
+
+        path = Path(__file__).resolve().parents[3] / 'lambda' / 'api' / 'integrations_handler.py'
+        spec = importlib.util.spec_from_file_location('_write_path_under_test', path)
+        assert spec and spec.loader, f'could not load {path}'
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
     def test_the_identity_rule_is_the_one_the_write_path_enforces(self):
         """Asserted by IDENTITY of the callable, not by comparing behaviour on a
         sample: two independently-written regexes agreeing on the cases a test
         thinks to try is exactly the drift that goes unnoticed."""
-        import importlib
-        import sys as _sys
-
-        lambda_api = str(Path(__file__).resolve().parents[3] / 'lambda' / 'api')
-        if lambda_api not in _sys.path:
-            _sys.path.insert(0, lambda_api)
-        handler = importlib.import_module('integrations_handler')
+        handler = self._load_write_path_module()
 
         assert handler.is_valid_plugin_identifier is is_valid_plugin_identifier
+
+    def test_the_control_the_write_path_module_loaded_without_polluting_the_session(self):
+        """Non-vacuity in the direction that bit this test before: the assertion
+        above passes whether or not the load leaked, so this pins the isolation
+        itself.
+
+        Asserted on the LOAD's own contract, not on process-global state, and that
+        is the load-bearing choice. A before/after diff of `sys.path` looks like the
+        obvious control and is worthless here: under the leaky implementation the
+        insert is guarded by `if not in sys.path`, so whichever of these two tests
+        runs second sees no delta and passes — the control would then hold only in
+        one ordering, which is the very flakiness it exists to prevent. Two
+        ordering-independent facts stand in for it instead.
+        """
+        import sys as _sys
+
+        first = self._load_write_path_module()
+        second = self._load_write_path_module()
+
+        assert first.is_valid_plugin_identifier is is_valid_plugin_identifier
+        # Registered nowhere: `sys.modules` does not map this module's own name to
+        # it, so nothing later in the session can import it — or be shadowed by it.
+        assert _sys.modules.get(first.__name__) is not first, (
+            f'the load registered {first.__name__!r} in sys.modules for the rest of '
+            'the session'
+        )
+        # And each load is genuinely fresh rather than served from that registry,
+        # which is what `import_module` would do.
+        assert second is not first
 
     @pytest.mark.parametrize('plugin_id', ['webscraper', 'app_reviews_ios', 's3_import'])
     def test_every_real_plugin_id_satisfies_the_shared_rule(self, plugin_id):

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -1,0 +1,365 @@
+"""Plugin secret prefix isolation fails CLOSED (issue #251).
+
+`plugins/_shared/secrets.py` is the only place a plugin Lambda turns the shared
+API-credentials secret into its own config. All ingestion Lambdas share one IAM
+role, so that prefix scan is the entire isolation boundary — there is no second
+layer to catch a mistake.
+
+REVERT MAP — each assertion below names the mutation it catches:
+
+  test_a_namespace_miss_raises_instead_of_returning_the_whole_secret
+    — restores `return filtered if filtered else all_secrets`. That line is the
+      defect: a plugin id with a typo matched nothing, and "nothing" was read as
+      "not migrated yet", so the plugin received EVERY plugin's credentials. The
+      positive control in the same class proves the raise is conditional and not
+      a helper that now refuses everything.
+
+  test_an_empty_secret_raises
+    — treats `{}` as an empty namespace and returns it. `get_secret` returns `{}`
+      for a genuinely empty secret AND for a read that failed (it logs and
+      swallows), so a plugin would run credential-less believing it was
+      configured.
+
+  test_a_key_outside_every_plugin_namespace_is_not_returned
+    — restores BaseIngestor's "no KNOWN prefix means shared/legacy" branch and
+      the hand-maintained plugin-id list it needed. Under that branch a plugin id
+      missing from the list had its keys reclassified as shared and leaked into
+      every other plugin.
+
+  test_a_bare_prefix_key_does_not_count_as_a_match
+    — drops the `len(key) > len(prefix)` guard, which both hands the plugin a
+      value under the empty key name and lets a single junk key `test_source_`
+      satisfy the fail-closed check for a namespace that is otherwise absent.
+
+  test_the_error_names_the_identity_and_prefix_and_nothing_else /
+  test_the_log_carries_the_identity_and_prefix_and_no_secret_material
+    — widens the message to dump the secret's keys or values "to help debug".
+      The failure here is a mis-prefixed plugin; answering it with a list of the
+      other plugins' key names turns a misconfiguration into reconnaissance.
+
+  test_both_base_classes_delegate_to_the_one_helper
+    — re-inlines the filter into either base class. The webhook copy is how the
+      two drifted in the first place: it never had even the (broken) known-prefix
+      list that the ingestor copy carried.
+
+Known consequence, deliberate: a plugin that declares NO secret keys in its
+manifest now fails at construction rather than silently receiving every other
+plugin's keys. Every current plugin declares at least one key and CDK seeds them
+all at deploy time, so no shipped plugin is affected; a future one that needs no
+configuration should declare a key or not call the base constructor's secret
+read, and the error tells it which prefix was expected.
+"""
+
+import ast
+import inspect
+import textwrap
+from unittest.mock import MagicMock, patch
+
+import pytest
+from shared.exceptions import ConfigurationError
+
+from _shared import base_ingestor, base_webhook
+from _shared.secrets import filter_plugin_secrets, plugin_secret_prefix
+
+# The identity these tests run as — read from the same module attribute the base
+# classes read, so a rename of the env plumbing cannot leave this file asserting
+# against a plugin id that is no longer in play.
+PLUGIN_ID = base_ingestor.SOURCE_PLATFORM
+PREFIX = plugin_secret_prefix(PLUGIN_ID)
+
+# A shared secret shaped like the deployed one: several plugins' namespaces plus
+# the `placeholder` key Secrets Manager generates. Values are recognisable so an
+# assertion can prove a leak by content, not only by key name.
+OTHER_PLUGIN_KEY = 'synthetic_reviews_company_name'
+OTHER_PLUGIN_VALUE = 'other-plugins-value'
+UNPREFIXED_KEY = 'placeholder'
+UNPREFIXED_VALUE = 'generated-by-secrets-manager'
+
+MIXED_SECRET = {
+    f'{PREFIX}api_key': 'mine-key',
+    f'{PREFIX}configs': '[]',
+    OTHER_PLUGIN_KEY: OTHER_PLUGIN_VALUE,
+    UNPREFIXED_KEY: UNPREFIXED_VALUE,
+}
+
+# The same payload with THIS plugin's namespace removed: what a mis-prefixed
+# identity really sees in production.
+FOREIGN_ONLY_SECRET = {
+    OTHER_PLUGIN_KEY: OTHER_PLUGIN_VALUE,
+    UNPREFIXED_KEY: UNPREFIXED_VALUE,
+}
+
+
+def _make_ingestor():
+    class _Ingestor(base_ingestor.BaseIngestor):
+        def fetch_new_items(self):
+            yield from []
+
+    return _Ingestor()
+
+
+def _make_webhook():
+    class _Webhook(base_webhook.BaseWebhook):
+        def parse_webhook_payload(self, body, headers):
+            return []
+
+    return _Webhook()
+
+
+class TestOnlyThisPluginsNamespaceIsLoaded:
+    """A valid identity gets its own namespace, in the shape handlers consume."""
+
+    def test_returns_only_this_plugins_keys_with_the_prefix_stripped(self):
+        assert filter_plugin_secrets(PLUGIN_ID, MIXED_SECRET) == {
+            'api_key': 'mine-key',
+            'configs': '[]',
+        }
+
+    def test_a_key_outside_every_plugin_namespace_is_not_returned(self):
+        loaded = filter_plugin_secrets(PLUGIN_ID, MIXED_SECRET)
+        assert UNPREFIXED_KEY not in loaded
+        assert UNPREFIXED_VALUE not in loaded.values()
+
+    def test_another_plugins_namespace_is_not_returned(self):
+        loaded = filter_plugin_secrets(PLUGIN_ID, MIXED_SECRET)
+        assert OTHER_PLUGIN_VALUE not in loaded.values()
+        # Not under its stored name and not under a stripped one either.
+        assert not any('company_name' in key for key in loaded)
+
+    def test_the_consumer_facing_key_shape_is_the_bare_field_name(self):
+        """Handlers call `self.secrets.get('configs')`, never the stored
+        `<plugin>_configs`. The stripped shape is the contract, so it is asserted
+        rather than left implied by the equality above."""
+        loaded = filter_plugin_secrets(PLUGIN_ID, MIXED_SECRET)
+        assert 'configs' in loaded
+        assert f'{PREFIX}configs' not in loaded
+
+
+class TestANamespaceMissFailsClosed:
+    """Zero matching keys is a configuration error, never the whole secret."""
+
+    def test_a_namespace_miss_raises_instead_of_returning_the_whole_secret(self):
+        with pytest.raises(ConfigurationError):
+            filter_plugin_secrets(PLUGIN_ID, FOREIGN_ONLY_SECRET)
+
+    def test_the_positive_control_same_payload_plus_our_namespace_succeeds(self):
+        """Non-vacuity: every assertion in this class would pass just as well
+        against a helper that refuses every input. One key inside our namespace
+        must be enough to make the identical call succeed.
+
+        Deliberately asserts only that the call RETURNS and carries our key, not
+        the exact mapping — exclusion of everything else is the subject of
+        TestOnlyThisPluginsNamespaceIsLoaded. Asserting equality here would make
+        this control fail under the fail-open mutation too, and a control that
+        fails alongside the thing it controls proves nothing.
+        """
+        payload = {**FOREIGN_ONLY_SECRET, f'{PREFIX}api_key': 'mine-key'}
+        assert filter_plugin_secrets(PLUGIN_ID, payload)['api_key'] == 'mine-key'
+
+    def test_a_mis_prefixed_identity_raises_though_a_close_prefix_exists(self):
+        """The typo case from the issue: `test_sourc` for `test_source`. The
+        secret is fully populated for the CORRECT id, which is what made the old
+        fallback so damaging — the miss looked like a not-yet-migrated plugin."""
+        typo = PLUGIN_ID[:-1]
+        assert typo and typo != PLUGIN_ID
+        with pytest.raises(ConfigurationError):
+            filter_plugin_secrets(typo, MIXED_SECRET)
+
+    def test_an_empty_secret_raises(self):
+        with pytest.raises(ConfigurationError):
+            filter_plugin_secrets(PLUGIN_ID, {})
+
+    def test_a_bare_prefix_key_does_not_count_as_a_match(self):
+        with pytest.raises(ConfigurationError):
+            filter_plugin_secrets(PLUGIN_ID, {PREFIX: 'junk', **FOREIGN_ONLY_SECRET})
+
+    @pytest.mark.parametrize(
+        'identity',
+        ['', None, 'Test_Source', 'test-source', '_test_source', 'test_source_', 'a' * 65],
+        ids=['empty', 'none', 'uppercase', 'hyphen', 'leading_underscore',
+             'trailing_underscore', 'too_long'],
+    )
+    def test_a_missing_or_malformed_identity_raises(self, identity):
+        """A plugin id becomes a key prefix, so it is validated on the same
+        character class the write path enforces on `source`. An empty identity is
+        the one that matters most: `prefix = '_'` would otherwise match nothing
+        and, under the old fallback, return everything."""
+        with pytest.raises(ConfigurationError):
+            filter_plugin_secrets(identity, MIXED_SECRET)
+
+
+class TestErrorsRevealTheMisconfigurationAndNothingElse:
+    """Identity and expected prefix only — no credential material."""
+
+    @staticmethod
+    def _message_for(identity, payload):
+        with pytest.raises(ConfigurationError) as excinfo:
+            filter_plugin_secrets(identity, payload)
+        return str(excinfo.value)
+
+    def test_the_error_names_the_identity_and_prefix_and_nothing_else(self):
+        message = self._message_for(PLUGIN_ID, FOREIGN_ONLY_SECRET)
+        assert PLUGIN_ID in message
+        assert PREFIX in message
+        # Nothing about the keys or values that DO exist in the secret.
+        assert OTHER_PLUGIN_KEY not in message
+        assert OTHER_PLUGIN_VALUE not in message
+        assert UNPREFIXED_KEY not in message
+        assert UNPREFIXED_VALUE not in message
+
+    def test_the_empty_secret_error_also_names_the_prefix(self):
+        message = self._message_for(PLUGIN_ID, {})
+        assert PLUGIN_ID in message
+        assert PREFIX in message
+
+    def test_the_log_carries_the_identity_and_prefix_and_no_secret_material(self):
+        # The module logger is the Powertools `Logger`, which is service-named and
+        # does not propagate, so `caplog` never sees it. Patching the logger
+        # object is what the neighbouring plugin suites do (test_sqs_utils.py).
+        with patch('_shared.secrets.logger') as mock_logger, \
+                pytest.raises(ConfigurationError):
+            filter_plugin_secrets(PLUGIN_ID, FOREIGN_ONLY_SECRET)
+
+        assert mock_logger.error.call_args_list, (
+            'a namespace miss must be logged, not only raised'
+        )
+        call = mock_logger.error.call_args
+        assert call.kwargs['extra'] == {
+            'plugin_id': PLUGIN_ID,
+            'expected_prefix': PREFIX,
+        }
+        # The whole call — message AND extra — must be free of secret material.
+        # Asserting on the message alone would miss an `extra` that attached the
+        # payload, which is the more likely way this regresses.
+        rendered = repr(call)
+        assert OTHER_PLUGIN_KEY not in rendered
+        assert OTHER_PLUGIN_VALUE not in rendered
+        assert UNPREFIXED_VALUE not in rendered
+
+    def test_the_log_control_a_successful_load_logs_nothing(self):
+        """Non-vacuity for the assertion above: without this, a refusal logged
+        unconditionally on every load would satisfy it."""
+        with patch('_shared.secrets.logger') as mock_logger:
+            filter_plugin_secrets(PLUGIN_ID, MIXED_SECRET)
+
+        assert mock_logger.error.call_args_list == []
+        assert mock_logger.warning.call_args_list == []
+
+
+class TestBothBaseClassesFailClosed:
+    """Thin integration checks: the behaviour reaches real construction."""
+
+    @staticmethod
+    @patch('_shared.base_ingestor.get_dynamodb_resource')
+    @patch('_shared.base_ingestor.get_s3_client')
+    @patch('_shared.base_ingestor.get_sqs_client')
+    @patch('_shared.base_ingestor.get_secret')
+    def _ingestor_with(payload, mock_get_secret, mock_sqs, mock_s3, mock_dynamo):
+        mock_get_secret.return_value = payload
+        mock_dynamo.return_value.Table.return_value = MagicMock()
+        return _make_ingestor()
+
+    @staticmethod
+    @patch('_shared.base_webhook.get_sqs_client')
+    @patch('_shared.base_webhook.get_secret')
+    def _webhook_with(payload, mock_get_secret, mock_sqs):
+        mock_get_secret.return_value = payload
+        return _make_webhook()
+
+    def test_the_ingestor_loads_only_its_own_namespace(self):
+        assert self._ingestor_with(MIXED_SECRET).secrets == {
+            'api_key': 'mine-key',
+            'configs': '[]',
+        }
+
+    def test_the_webhook_loads_only_its_own_namespace(self):
+        assert self._webhook_with(MIXED_SECRET).secrets == {
+            'api_key': 'mine-key',
+            'configs': '[]',
+        }
+
+    @pytest.mark.parametrize(
+        'payload',
+        [FOREIGN_ONLY_SECRET, {}],
+        ids=['unknown_prefix', 'empty_secret'],
+    )
+    def test_the_ingestor_refuses_to_construct(self, payload):
+        with pytest.raises(ConfigurationError):
+            self._ingestor_with(payload)
+
+    @pytest.mark.parametrize(
+        'payload',
+        [FOREIGN_ONLY_SECRET, {}],
+        ids=['unknown_prefix', 'empty_secret'],
+    )
+    def test_the_webhook_refuses_to_construct(self, payload):
+        with pytest.raises(ConfigurationError):
+            self._webhook_with(payload)
+
+    def test_an_unconfigured_secrets_arn_still_yields_an_empty_config(self):
+        """The one case that is NOT a namespace miss: no ARN means no secret was
+        read at all, so there is nothing to over-share. Kept a warning so a local
+        or partially-wired invocation is not turned into a hard failure by this
+        change."""
+        with patch('_shared.base_ingestor.SECRETS_ARN', ''):
+            assert self._ingestor_with({'unused': 'never-read'}).secrets == {}
+        with patch('_shared.base_webhook.SECRETS_ARN', ''):
+            assert self._webhook_with({'unused': 'never-read'}).secrets == {}
+
+
+class TestOneImplementationOfTheBoundary:
+    """Neither base class may carry its own copy of the filter.
+
+    The ingestor and webhook copies had already drifted — only one of them ever
+    had the (broken) known-prefix list — so "both call the same function" is the
+    property worth pinning, not the behaviour of each copy.
+    """
+
+    @staticmethod
+    def _load_secrets_body(module):
+        """The `_load_secrets` function body, parsed. Scoped to one function
+        deliberately: a regex over the module would match the prefix arithmetic
+        that legitimately lives in `secrets.py`-style helpers elsewhere."""
+        cls = base_ingestor.BaseIngestor if module is base_ingestor else base_webhook.BaseWebhook
+        source = textwrap.dedent(inspect.getsource(cls._load_secrets))
+        return ast.parse(source).body[0]
+
+    @pytest.mark.parametrize('module', [base_ingestor, base_webhook],
+                             ids=['ingestor', 'webhook'])
+    def test_both_base_classes_delegate_to_the_one_helper(self, module):
+        tree = self._load_secrets_body(module)
+        called = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert 'filter_plugin_secrets' in called, (
+            f'{module.__name__}._load_secrets must delegate to the shared helper'
+        )
+
+    @pytest.mark.parametrize('module', [base_ingestor, base_webhook],
+                             ids=['ingestor', 'webhook'])
+    def test_neither_base_class_re_implements_the_prefix_scan(self, module):
+        tree = self._load_secrets_body(module)
+        attribute_calls = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert 'startswith' not in attribute_calls, (
+            f'{module.__name__}._load_secrets appears to filter by prefix itself; '
+            'the scan belongs in _shared/secrets.py alone'
+        )
+
+    def test_the_findability_control_the_parser_reads_a_real_body(self):
+        """Non-vacuity: if `_load_secrets` were renamed or the parse returned an
+        empty tree, both assertions above would fail rather than pass silently —
+        but this makes the failure say so. It also pins that the two bodies are
+        actually distinct functions, not one inherited from the other."""
+        for module in (base_ingestor, base_webhook):
+            tree = self._load_secrets_body(module)
+            assert isinstance(tree, ast.FunctionDef)
+            assert tree.name == '_load_secrets'
+            assert len(tree.body) > 1, 'expected a real body, not a stub'
+        assert (base_ingestor.BaseIngestor._load_secrets
+                is not base_webhook.BaseWebhook._load_secrets)

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -61,6 +61,18 @@ REVERT MAP — each assertion below names the mutation it catches:
       invoking, and the UI polls it with no timeout — a permanent spinner with the
       diagnosis only in CloudWatch.
 
+  test_a_broken_circuit_breaker_does_not_swallow_the_audit_event /
+  test_a_broken_circuit_breaker_does_not_swallow_the_run_record
+    — re-merges the three reporting steps into ONE `try`, or moves the audit event
+      back after the breaker call. `CircuitBreaker.record_failure` is not
+      exception-safe on its first line: `self.table` resolves
+      `get_dynamodb_resource()` above its own `try`, so a failure building that
+      resource escapes into `_report_construction_failure`'s blind catch and every
+      later step is skipped. Under the old order that lost `plugin.failed` — the
+      ONLY signal a scheduled run leaves, since `_update_source_run_status` is a
+      no-op without an `execution_id` — in exactly the correlated case where the
+      same DynamoDB trouble breaks both.
+
   test_an_unreadable_secret_is_not_counted_against_the_circuit_breaker
     — raises plain `ConfigurationError` from the empty-payload branch instead of
       `SecretUnreadableError`, or drops the `if not unreadable` guard around
@@ -601,6 +613,91 @@ class TestAConstructionFailureIsReported:
 
         actions = [call.args[0] for call in emit.call_args_list if call.args]
         assert 'plugin.failed' in actions
+
+    @staticmethod
+    def _construct_with_a_broken_breaker(payload, execution_id):
+        """Construct with the breaker's OWN DynamoDB resource failing to build.
+
+        Deliberately does NOT patch `CircuitBreaker.record_failure`, unlike
+        `_construct`: the subject is that the real `record_failure` is not
+        exception-safe on its first line — `self.table` resolves
+        `get_dynamodb_resource()` OUTSIDE its `try` — so a failure there escapes it
+        into `_report_construction_failure`. Patching the method away would remove
+        the thing under test.
+
+        `_shared.circuit_breaker.get_dynamodb_resource` is the target, not
+        `_shared.base_ingestor`'s: the breaker resolves DynamoDB through its own
+        module-level import, which is precisely why patching only the ingestor's
+        left three tests issuing real queries.
+        """
+        table = MagicMock()
+        with patch('_shared.base_ingestor.AGGREGATES_TABLE', 'test-aggregates'), \
+                patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
+                patch('_shared.base_ingestor.get_s3_client'), \
+                patch('_shared.base_ingestor.get_sqs_client'), \
+                patch('_shared.base_ingestor.get_secret', return_value=payload), \
+                patch('_shared.base_ingestor.clear_secret_cache'), \
+                patch('_shared.circuit_breaker.get_dynamodb_resource',
+                      side_effect=Exception('resource construction failed')), \
+                patch('_shared.base_ingestor.emit_audit_event') as emit:
+            mock_dynamo.return_value.Table.return_value = table
+            error = None
+            try:
+                _make_ingestor(execution_id=execution_id)
+            except ConfigurationError as raised:
+                error = raised
+        return error, table, emit
+
+    def test_a_broken_circuit_breaker_does_not_swallow_the_audit_event(self):
+        """The audit event must not be gated on the most failure-prone step.
+
+        `CircuitBreaker.record_failure` resolves `get_dynamodb_resource()` in the
+        `self.table` property, ABOVE its own `try` — so a failure building that
+        resource escapes it. Under one shared `try` for all three reporting steps
+        that landed in the blind catch and `emit_audit_event` never ran. On a
+        SCHEDULED run the audit event is the only signal there is
+        (`_update_source_run_status` is a no-op without an `execution_id`), and this
+        is the correlated case: the same DynamoDB trouble breaks both.
+        """
+        error, _, emit = self._construct_with_a_broken_breaker(
+            FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        assert error is not None, 'expected construction to refuse the payload'
+        actions = [call.args[0] for call in emit.call_args_list if call.args]
+        assert 'plugin.failed' in actions, (
+            'the breaker failing took the audit event with it; on a scheduled run '
+            'that is the only signal the failure leaves anywhere'
+        )
+
+    def test_a_broken_circuit_breaker_does_not_swallow_the_run_record(self):
+        """The other step ordered after the breaker under the old shared `try`. The
+        run record is what clears the UI's spinner on a manual run, so it must
+        survive a breaker that cannot build its table."""
+        _, table, _ = self._construct_with_a_broken_breaker(
+            FOREIGN_ONLY_SECRET, self.EXECUTION_ID)
+
+        assert self._status_written(table) == 'error'
+
+    def test_the_control_record_failure_really_does_escape_its_own_try(self):
+        """Non-vacuity for the two cases above: they would pass just as well if the
+        patch never took effect and the breaker were healthy, proving nothing.
+
+        Asserted against `record_failure` DIRECTLY rather than through the reporting
+        path, and deliberately so — this control must not fail under the mutation it
+        controls for. It names nothing about `_report_construction_failure`, so
+        re-merging the three steps into one `try` leaves it green while the two above
+        go red.
+
+        It also pins the upstream fact the whole fix rests on: `self.table` resolves
+        `get_dynamodb_resource()` in a property evaluated ABOVE `record_failure`'s
+        own `try`, so a failure building the resource is NOT swallowed by it. Should
+        `circuit_breaker.py` ever move that resolution inside the `try`, this fails
+        and says the hazard is gone.
+        """
+        with patch('_shared.circuit_breaker.get_dynamodb_resource',
+                   side_effect=Exception('resource construction failed')), \
+                pytest.raises(Exception, match='resource construction failed'):
+            base_ingestor.CircuitBreaker(PLUGIN_ID).record_failure('boom')
 
     def test_the_report_does_not_replace_the_error_the_operator_needs(self):
         """The reporting runs while a ConfigurationError is propagating. If a

--- a/voc-datalake/plugins/_template/ingestor/handler.py
+++ b/voc-datalake/plugins/_template/ingestor/handler.py
@@ -23,7 +23,11 @@ class MySourceIngestor(BaseIngestor):
         # Never assign ingestor.execution_id after construction; that would
         # skip the guard (enforced by plugins/test_manual_run_guard.py).
         super().__init__(execution_id=execution_id)
-        # Access your secrets (prefixed keys are stripped automatically)
+        # Access your secrets by their BARE name — the `<plugin_id>_` prefix they
+        # are stored under is stripped for you. Declare every key in
+        # manifest.json's "secrets" block: construction FAILS if the shared secret
+        # holds no key under this plugin's prefix, rather than quietly handing you
+        # every other plugin's credentials (issue #251).
         self.api_key = self.secrets.get("api_key", "")
 
     def fetch_new_items(self) -> Generator[dict, None, None]:

--- a/voc-datalake/plugins/conftest.py
+++ b/voc-datalake/plugins/conftest.py
@@ -4,6 +4,9 @@ Sets up paths before any imports happen.
 """
 import os
 import sys
+from unittest.mock import patch
+
+import pytest
 
 # Add lambda directory to path for shared module imports FIRST
 # This must happen before any plugin modules are imported
@@ -32,3 +35,74 @@ os.environ.setdefault('CIRCUIT_BREAKER_THRESHOLD', '3')
 os.environ.setdefault('CIRCUIT_BREAKER_WINDOW', '5')
 os.environ.setdefault('AUDIT_EVENT_BUS', '')
 os.environ.setdefault('WEBHOOK_SECRET', 'test-webhook-secret')
+
+# Credentials that cannot resolve to a real account. Belt to the braces of the
+# fixture below: if a call somehow escapes it, this is what stops the request from
+# being signed with a developer's or CI runner's live credentials.
+os.environ.setdefault('AWS_ACCESS_KEY_ID', 'testing')
+os.environ.setdefault('AWS_SECRET_ACCESS_KEY', 'testing')
+os.environ.setdefault('AWS_SESSION_TOKEN', 'testing')
+os.environ.setdefault('AWS_SECURITY_TOKEN', 'testing')
+# Stops botocore reading ~/.aws/{config,credentials} and an EC2/ECS metadata
+# endpoint, either of which can supply real credentials the four above do not
+# cover.
+os.environ.setdefault('AWS_EC2_METADATA_DISABLED', 'true')
+os.environ.setdefault('AWS_CONFIG_FILE', os.devnull)
+os.environ.setdefault('AWS_SHARED_CREDENTIALS_FILE', os.devnull)
+
+
+@pytest.fixture(autouse=True)
+def no_real_aws_calls():
+    """Fail a plugin test that reaches AWS, rather than letting it succeed quietly.
+
+    Every AWS-touching path in this tree swallows its own errors — `record_failure`
+    and `_trip_breaker` in `circuit_breaker.py`, `get_secret` in `shared/aws.py`,
+    `emit_audit_event` — so a test that misses a patch does not fail: the call goes
+    out, the error is logged and discarded, and the assertion still passes. That is
+    how three tests came to issue a real `dynamodb.Query` against whatever account
+    the runner was credentialed for, invisibly. `AccessDeniedException` is the
+    BENIGN outcome; a laptop or a CI role that does grant DynamoDB gets a genuine
+    query and `put_item` against a live `test-watermarks`, and at the breaker's
+    threshold a genuine `events:DisableRule`.
+
+    Enforced at `botocore`'s single choke point rather than by patching each
+    `get_*_client` accessor, because the accessors are what a test forgets to patch
+    — a guard that shares the omission it is meant to catch is no guard. Raising
+    (not returning a mock) is deliberate too: a silent mock would let the test pass
+    on a code path nobody meant to exercise, which is the defect, one level up.
+
+    The attempt is BOTH refused and recorded, and the recording is what the failure
+    is reported from. Refusing alone is not enough to be loud: the very `except
+    Exception` blocks that hid the real call would equally hide this AssertionError,
+    leaving a green test that reached for AWS and was quietly stopped. Asserting
+    after the test body has finished puts the report somewhere no `except` can
+    reach.
+
+    Yields the record of attempts, so a test whose SUBJECT is this guard can make a
+    deliberate call, assert on it, and `.clear()` the list to say the attempt was
+    intentional. That is the whole escape hatch — deliberately not a marker that
+    disarms the patch, because a disarmed test is one that can still reach a real
+    account, which is the thing being prevented. See
+    `test_plugin_secret_isolation.py::TestNoPluginTestReachesRealAws`.
+    """
+    import botocore.client
+
+    attempted = []
+
+    def _refuse(self, operation_name, api_params):
+        call = f"{self.meta.service_model.service_name}.{operation_name}"
+        attempted.append(call)
+        raise AssertionError(f"refused real AWS call: {call}")
+
+    with patch.object(botocore.client.BaseClient, '_make_api_call', _refuse):
+        yield attempted
+
+    assert not attempted, (
+        f"This test attempted real AWS calls: {sorted(set(attempted))}. They were "
+        'refused, so nothing reached an account — but patch the boundary the code '
+        'under test resolves through. Note that `_shared.circuit_breaker` imports '
+        '`get_dynamodb_resource` itself, so patching '
+        '`_shared.base_ingestor.get_dynamodb_resource` does NOT cover it; patch '
+        '`base_ingestor.CircuitBreaker.record_failure` or '
+        '`_shared.circuit_breaker.get_dynamodb_resource` as well.'
+    )

--- a/voc-datalake/plugins/conftest.py
+++ b/voc-datalake/plugins/conftest.py
@@ -47,6 +47,14 @@ os.environ.setdefault('AWS_SECURITY_TOKEN', 'testing')
 # endpoint, either of which can supply real credentials the four above do not
 # cover.
 os.environ.setdefault('AWS_EC2_METADATA_DISABLED', 'true')
+# `pop`, not `setdefault`: the point is to DISCARD a value inherited from the
+# developer's shell. Emptying the config file while leaving AWS_PROFILE pointing
+# into it makes the profile unresolvable, so botocore raises ProfileNotFound the
+# first time anything builds a client — and `_shared/audit.py` builds one at
+# IMPORT time via Powertools' Tracer, which turns that into collection errors and
+# zero tests run. CI never sets a profile, so this lands only on developers.
+os.environ.pop('AWS_PROFILE', None)
+os.environ.pop('AWS_DEFAULT_PROFILE', None)
 os.environ.setdefault('AWS_CONFIG_FILE', os.devnull)
 os.environ.setdefault('AWS_SHARED_CREDENTIALS_FILE', os.devnull)
 
@@ -78,6 +86,16 @@ def no_real_aws_calls():
     after the test body has finished puts the report somewhere no `except` can
     reach.
 
+    NOT compatible with `moto`'s `mock_aws` or `botocore.stub.Stubber`: both
+    intercept this same `_make_api_call` seam, so a call they would have faked is
+    refused here with a message that says "real", which is the wrong diagnosis to
+    hand someone holding a `mock_aws` context. `moto` is already in
+    `requirements-dev.txt` and used under `lambda/`, so this is a likely next step
+    rather than a hypothetical. The compatible styles — and what every test in
+    `plugins/` uses today — are patching the `get_*_client` / `get_dynamodb_resource`
+    accessors, or `patch.object` on a specific method such as
+    `CircuitBreaker.record_failure`.
+
     Yields the record of attempts, so a test whose SUBJECT is this guard can make a
     deliberate call, assert on it, and `.clear()` the list to say the attempt was
     intentional. That is the whole escape hatch — deliberately not a marker that
@@ -92,7 +110,13 @@ def no_real_aws_calls():
     def _refuse(self, operation_name, api_params):
         call = f"{self.meta.service_model.service_name}.{operation_name}"
         attempted.append(call)
-        raise AssertionError(f"refused real AWS call: {call}")
+        raise AssertionError(
+            f"refused real AWS call: {call}. Patch the client accessor the code "
+            "under test resolves through (`get_*_client` / `get_dynamodb_resource`) "
+            "or the specific method. Note that `moto`'s mock_aws and "
+            "botocore.stub.Stubber also route through this same seam, so neither "
+            "can be used to fake a call here."
+        )
 
     with patch.object(botocore.client.BaseClient, '_make_api_call', _refuse):
         yield attempted

--- a/voc-datalake/plugins/s3_import/ingestor/test_s3_import_handler.py
+++ b/voc-datalake/plugins/s3_import/ingestor/test_s3_import_handler.py
@@ -10,6 +10,8 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 
+from _shared.test.scoped_secret import scoped_secret
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -265,7 +267,7 @@ def ingestor():
         patch("_shared.base_ingestor.get_dynamodb_resource") as mock_dynamo,
         patch("_shared.base_ingestor.get_s3_client"),
         patch("_shared.base_ingestor.get_sqs_client"),
-        patch("_shared.base_ingestor.get_secret", return_value={}),
+        patch("_shared.base_ingestor.get_secret", return_value=scoped_secret()),
     ):
         mock_dynamo.return_value.Table.return_value = MagicMock()
         from s3_import.ingestor.handler import S3ImportIngestor

--- a/voc-datalake/plugins/test_app_reviews_enabled_filter.py
+++ b/voc-datalake/plugins/test_app_reviews_enabled_filter.py
@@ -20,6 +20,8 @@ import sys
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+from _shared.test.scoped_secret import scoped_secret
+
 _PLUGINS_DIR = os.path.dirname(os.path.abspath(__file__))
 ANDROID_DIR = os.path.join(_PLUGINS_DIR, "app_reviews_android", "ingestor")
 IOS_DIR = os.path.join(_PLUGINS_DIR, "app_reviews_ios", "ingestor")
@@ -33,7 +35,7 @@ def _patched_aws():
     with patch("_shared.base_ingestor.get_dynamodb_resource") as mock_dynamo, \
             patch("_shared.base_ingestor.get_s3_client"), \
             patch("_shared.base_ingestor.get_sqs_client"), \
-            patch("_shared.base_ingestor.get_secret", return_value={}):
+            patch("_shared.base_ingestor.get_secret", return_value=scoped_secret()):
         mock_dynamo.return_value.Table.return_value = MagicMock()
         yield
 

--- a/voc-datalake/plugins/test_synthetic_reviews.py
+++ b/voc-datalake/plugins/test_synthetic_reviews.py
@@ -8,15 +8,23 @@ import json
 from contextlib import contextmanager
 from unittest.mock import patch, MagicMock
 
+from _shared.test.scoped_secret import scoped_secret
 
 
 @contextmanager
 def _make_ingestor(secrets: dict):
-    """Instantiate SyntheticReviewsIngestor with AWS deps + secrets mocked."""
+    """Instantiate SyntheticReviewsIngestor with AWS deps + secrets mocked.
+
+    The stored secret is keyed `<plugin_id>_<field>`; the handler consumes the
+    STRIPPED names, so these tests declare the stripped ones and `scoped_secret`
+    re-keys them into the namespace the base class will accept. They used to be
+    passed through unprefixed and arrived intact only because a namespace miss
+    returned the whole secret — the fail-open path issue #251 removed.
+    """
     with patch('_shared.base_ingestor.get_dynamodb_resource') as mock_dynamo, \
             patch('_shared.base_ingestor.get_s3_client'), \
             patch('_shared.base_ingestor.get_sqs_client'), \
-            patch('_shared.base_ingestor.get_secret', return_value=secrets):
+            patch('_shared.base_ingestor.get_secret', return_value=scoped_secret(**secrets)):
         mock_dynamo.return_value.Table.return_value = MagicMock()
         from synthetic_reviews.ingestor.handler import SyntheticReviewsIngestor
         yield SyntheticReviewsIngestor()

--- a/voc-datalake/plugins/webscraper/ingestor/test_webscraper_handler.py
+++ b/voc-datalake/plugins/webscraper/ingestor/test_webscraper_handler.py
@@ -12,6 +12,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 from bs4 import BeautifulSoup
 
+from _shared.test.scoped_secret import scoped_secret
+
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -29,7 +31,7 @@ def ingestor():
         patch("_shared.base_ingestor.get_dynamodb_resource") as mock_dynamo,
         patch("_shared.base_ingestor.get_s3_client"),
         patch("_shared.base_ingestor.get_sqs_client"),
-        patch("_shared.base_ingestor.get_secret", return_value={}),
+        patch("_shared.base_ingestor.get_secret", return_value=scoped_secret()),
     ):
         mock_dynamo.return_value.Table.return_value = MagicMock()
         from webscraper.ingestor.handler import WebScraperIngestor
@@ -167,7 +169,7 @@ class TestLambdaHandlerSecretCache:
 
         def record_get_secret(_arn):
             call_order.append("get_secret")
-            return {"configs": "[]"}
+            return scoped_secret(configs="[]")
 
         mock_get_secret.side_effect = record_get_secret
         mock_dynamo.return_value.Table.return_value = MagicMock()


### PR DESCRIPTION
## Summary

Closes #251.

`plugins/_shared/base_ingestor.py:96` and `base_webhook.py:54` both ended their prefix filter with:

```python
return filtered if filtered else all_secrets
```

A plugin whose prefix matched zero keys therefore received the **complete** shared secret. The intent was a migration convenience for plugins predating prefixing; the effect was that the isolation boundary held only while every plugin's prefix was correct, and a typo — the input most likely to be wrong — produced the maximally permissive outcome. All ingestion Lambdas share one IAM role, so nothing else was catching it.

### What changed

**New `plugins/_shared/secrets.py`** — the one implementation of the boundary. There was no existing shared secret-filter helper (I looked: the two base classes each carried their own copy, and they had already drifted — only the ingestor had the known-prefix list). Both `_load_secrets` methods now delegate to `filter_plugin_secrets(plugin_id, all_secrets)`:

- A valid identity gets **only** its own `<plugin_id>_*` namespace, prefix stripped — the same bare-key shape handlers already consume (`self.secrets.get('configs')`), so no plugin handler changed.
- Missing, malformed, unknown, or mis-prefixed identity → `ConfigurationError`. Identity is validated against the same character class the write path enforces on `source` in `integrations_handler._validate_source`.
- Empty secret object → `ConfigurationError`. Deliberate: `get_secret` returns `{}` both for a genuinely empty secret and for a read that *failed* (it logs and swallows), and neither is a state in which a plugin should quietly run credential-less.
- Errors and logs name the plugin id and expected prefix **only** — no secret values, no other plugins' key names. An error caused by a wrong prefix must not become a directory of the correct ones.

**Retired `BaseIngestor._get_known_prefixes()`.** Its "a key with no *known* prefix is a shared/legacy value" branch required a hand-maintained plugin-id list; forget to add a plugin and its `<plugin>_*` keys were reclassified as shared and leaked into *every* other plugin. Nothing in production writes an unprefixed key (the only one is Secrets Manager's generated `placeholder`, which no plugin consumes), so the list bought nothing and cost an isolation hole.

Kept deliberately out of scope per the issue and task boundary: IAM architecture, secret storage layout, and per-plugin Secrets Manager resources. An absent `SECRETS_ARN` also stays a warning rather than a raise — no secret is read at all in that case, so there is nothing to over-share.

### Decisions worth flagging

- **`ConfigurationError`** from `shared/exceptions.py` rather than a new exception type — it is the repo's existing "required configuration is missing" type and is already what `integrations_handler` raises for the same secret.
- **Behaviour change:** a plugin declaring **no** secret keys would now fail at construction. Every current plugin declares at least one key and CDK seeds them all at deploy time, so no shipped plugin is affected. Noted in the test module docstring with the upgrade path.
- **`caplog` does not work here.** The plugin logger is the Powertools `Logger` — service-named and non-propagating — so the log assertions patch the logger object, which is what the neighbouring `test_sqs_utils.py` does.
- Three docs stated the old behaviour (`plugin-architecture.md` still showed the pre-prefix-strip snippet; `mobile-app-reviews.md` named `_get_known_prefixes()` as an implementation prerequisite) and are corrected. The `_template` handler comment now says construction fails rather than silently widening.

### Regression coverage

`plugins/_shared/test/test_plugin_secret_isolation.py` (32 cases) carries a REVERT MAP naming which mutation each assertion catches, and I ran each mutation to confirm red-then-green rather than asserting it:

| Mutation applied to the fixed code | Result |
|---|---|
| Restore `return filtered if filtered else all_secrets` **and** the known-prefix branch | **16 failed** / 16 passed |
| Restore only `return ... else all_secrets` (the exact issue line) | **11 failed** / 21 passed |
| Re-inline the filter into `BaseWebhook` | **4 failed** / 28 passed |
| Widen the error/log to list the secret's keys | **2 failed** / 30 passed |

Covers correct prefix, unknown prefix, mis-prefixed identity (`test_sourc` for `test_source`, with the secret fully populated for the correct id), empty secret, bare-prefix-only key, and seven malformed identities. Both paths are exercised end-to-end through real `BaseIngestor` and `BaseWebhook` construction, plus an `ast`-based lockstep guard (scoped to the one function, not a regex over the file) proving neither base class re-implements the scan.

Every non-vacuity concern has its own positive control: the fail-closed class has one proving the raise is conditional (asserting membership, not equality, so it does *not* fail under the fail-open mutation — a control that fails alongside its subject proves nothing), the log assertions have a silent-on-success control, and the lockstep guard has a findability control.

`plugins/_shared/test/scoped_secret.py` re-keys payloads into the live namespace, **derived** from the `SOURCE_PLATFORM` the base classes read rather than hardcoding `'test_source_'`, so a stale copy cannot go quiet.

## Build and test results

`mise run build` does not exist in this repo (`mise ERROR no tasks defined`), as the setup notes flagged. Ran the documented root gates instead.

| Command | Result |
|---|---|
| `npm run build` | **pass** (`✓ built in 8.69s`) |
| `npm run lint:python` (`ruff check lambda plugins scripts`) | **pass** — 518 findings, **zero delta** vs `development` (518 before, 519 after my first draft, fixed the one new `I001`). Restricted to the documented set `--select F,E4,E7,E9`: **4**, the same 4 pre-existing `E402`s |
| `npm run lint:frontend` / `lint:stream` | **pass** (0 errors) |
| `npm run typecheck` / `typecheck:cdk` | **pass** |
| `npm run test:backend` (pytest) | **pass** — 4022 passed |
| plugin suites only | **pass** — 325 passed |
| focused isolation suite | **pass** — 32 passed |
| `npm run test` (frontend vitest) | **pass** — 3191 passed / 189 files |
| `npm run test:cdk` | **pass** — 318 passed / 17 files |
| `npm run test:stream` | **pass** — 399 passed / 24 files |

Two environmental snags, both resolved and neither caused by this diff — worth recording since a future run will hit them: the container had no `.venv` and several dev deps missing (built one from `requirements-dev.txt`), and `test:cdk` initially reported 63 failures that were all `CannotFindAsset: frontend/dist` — they pass once the frontend artifact exists. The container FD limit is 1024 and unraisable, which made the first `npm run build` die with `EMFILE`; it succeeded after dependencies were fully installed.

## Agent notes

**What went well.** The issue named the two exact lines, and the repo's own conventions pointed at the fix: `integrations_handler.get_credentials` already documents *why* it has no unprefixed fallback ("would allow any caller to read keys belonging to other features"), so the read path just had to be brought in line with the write path it mirrors. Extracting the helper was clearly right rather than a judgement call — the two copies had already drifted, which is itself the argument for one choke point.

**What was difficult.** Three things:

1. The fail-closed change broke **56 existing tests**, because `mock_get_secret.return_value = {}` was the idiom for "no secrets needed here" in six files — and it only ever worked *because* of the fail-open path. That is the fallback's blast radius made visible. Rather than sprinkle literal prefixed dicts, I added `scoped_secret()` deriving the prefix from the live `SOURCE_PLATFORM`.
2. `test_synthetic_reviews.py` passed **unprefixed** config keys and they arrived intact purely via the fallback — a test suite that was, unintentionally, exercising the defect as though it were the contract.
3. Powertools `Logger` is non-propagating, so my first `caplog`-based log assertions passed vacuously. Patching the logger object (the `test_sqs_utils.py` pattern) was the fix.

**Conventions discovered.** Comments here carry the *argument*, not the mechanics — they record why the alternative was rejected and which defect the line prevents; I matched that. Test classes and methods are named as outcomes; module docstrings carry a REVERT MAP; lockstep tests parse with `ast` scoped to one function rather than regex over a file; every non-vacuity concern earns its own positive control. `ruff.toml`'s header states the real invariant is "no NEW findings against the same ruff version", not an absolute count — so I measured the delta both ways rather than trusting the raw 518.

**Suggestions for future tasks.**

- `plugins/conftest.py` sets `SECRETS_ARN` but no secret content; a fixture supplying a realistically namespaced payload would stop new tests reaching for `{}`.
- The `_PLUGIN_ID_RE` in `secrets.py` duplicates `_CREDENTIAL_KEY_RE` in `integrations_handler.py` by necessity — `lambda/api` is not on a plugin Lambda's path, only `lambda/shared` and `plugins/` are bundled. If the two ever need to stay in lockstep, `lambda/shared/` is the only place both can import from.
- `test:stream` and `test:cdk` fail confusingly when deps or `frontend/dist` are absent (missing-package and `CannotFindAsset` errors that look like real failures). A note in `docs/deployment.md`, or a preflight check, would save the next agent the triage.
- Per the issue's own longer-term item: per-plugin secrets rather than prefixes in one shared secret would remove this failure mode entirely. This PR makes the current design fail loudly; it does not remove the shared blob.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

```abca-verify
no-ui
```