### PR TITLE
fix(projects): validate merge body before job creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a
   model call.
+- `POST /projects/{project_id}/documents/merge` now requires a JSON object before creating its job.
+  Arrays, strings, numbers and booleans previously became `merge_config` and failed only inside the
+  asynchronously invoked merger, after the job row existed and the invocation had been billed.
 
 ### Upgrade notes
 
@@ -75,6 +78,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   previously started a default `prd` generation. Unparseable JSON is a 400 too, where it was
   previously a 500. A body that is absent altogether, a literal JSON `null`, or zero-length
   (`Content-Length: 0`), still means "generate a PRD with the defaults" and is unchanged.
+- **`POST /projects/{project_id}/documents/merge` now applies the same body-shape contract before
+  creating a job.** A present array, string, number or boolean, and unparseable JSON, answer 400.
+  An absent body, JSON `null` or zero-length body still means an empty merge configuration and is
+  unchanged.
 
 ## [0.2.0] - 2026-08-19
 

--- a/voc-datalake/lambda/api/projects_handler.py
+++ b/voc-datalake/lambda/api/projects_handler.py
@@ -438,7 +438,7 @@ def api_create_document(project_id: str):
 @tracer.capture_method
 def api_merge_documents(project_id: str):
     """Merge multiple documents."""
-    body = app.current_event.json_body or {}
+    body = _json_object_body()
     job_id, _ = create_job(project_id, 'merge_documents', 'merge_config', body, status='pending')
     invoke_lambda_async(DOCUMENT_MERGER_FUNCTION, {
         'project_id': project_id,
@@ -839,18 +839,10 @@ def _json_object_body() -> dict:
     Not extracted into `shared/` while it has two copies; the third one should do
     that rather than a second refactor of the first two.
 
-    SCOPE: the prioritization routes and `api_generate_document`. The other bodies
-    in this module have the same latent shape and predate this change, and
-    sweeping ~20 pre-existing routes is its own reviewable diff rather than a
-    rider on a change to one route.
-
-    One of those routes is not merely unswept but actively defective, and it is the
-    one a reader here would most likely assume is covered: `api_merge_documents`
-    still reads `json_body or {}` and calls `create_job` BEFORE anything inspects
-    the body, so a JSON array or a bare string produces a billed job row whose
-    `merge_config` is not an object. Tracked with the measurements in issue #380;
-    the fix is to call this helper. Adopting it here rather than there was the
-    scope line, not a judgement that the other route is fine.
+    SCOPE: the prioritization routes, `api_generate_document`, and
+    `api_merge_documents`. The other bodies in this module have the same latent
+    shape and predate this change; sweeping ~20 pre-existing routes is its own
+    reviewable diff rather than a rider on a change to one route.
     """
     try:
         body = app.current_event.json_body

--- a/voc-datalake/lambda/api/test/test_projects_handler.py
+++ b/voc-datalake/lambda/api/test/test_projects_handler.py
@@ -866,6 +866,105 @@ class TestGenerateDocumentDocType:
         )
 
 
+
+
+class TestMergeDocumentsBody:
+    """POST /projects/<id>/documents/merge validates the body before billing."""
+
+    @staticmethod
+    def _post(api_gateway_event, lambda_context, raw_body=None):
+        from projects_handler import lambda_handler
+
+        event = api_gateway_event(
+            method='POST',
+            path='/projects/proj-123/documents/merge',
+            path_params={'project_id': 'proj-123'},
+        )
+        if raw_body is not None:
+            event['body'] = raw_body
+
+        with patch(
+            'projects_handler.create_job', return_value=('job-1', {})
+        ) as mock_create_job, patch(
+            'projects_handler.invoke_lambda_async'
+        ) as mock_invoke:
+            response = lambda_handler(event, lambda_context)
+        return response, mock_create_job, mock_invoke
+
+    def test_an_object_body_still_starts_a_merge_job(
+        self, api_gateway_event, lambda_context
+    ):
+        response, mock_create_job, mock_invoke = self._post(
+            api_gateway_event,
+            lambda_context,
+            '{"output_type": "prd"}',
+        )
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['job_id'] == 'job-1'
+        assert mock_create_job.call_args.args[3] == {'output_type': 'prd'}
+        assert mock_invoke.call_args.args[1]['merge_config'] == {
+            'output_type': 'prd'
+        }
+
+    @pytest.mark.parametrize(
+        'raw_body',
+        [None, 'null'],
+        ids=['absent', 'json_null'],
+    )
+    def test_an_absent_or_null_body_keeps_the_empty_config_default(
+        self, api_gateway_event, lambda_context, raw_body
+    ):
+        response, mock_create_job, mock_invoke = self._post(
+            api_gateway_event, lambda_context, raw_body
+        )
+
+        assert response['statusCode'] == 200
+        assert mock_create_job.call_args.args[3] == {}
+        assert mock_invoke.call_args.args[1]['merge_config'] == {}
+
+    @pytest.mark.parametrize(
+        'raw_body',
+        ['[1, 2]', '"hi"', '7', 'true', '[]', 'false', '0', '""'],
+        ids=[
+            'array',
+            'string',
+            'number',
+            'boolean',
+            'empty_array',
+            'false',
+            'zero',
+            'empty_string',
+        ],
+    )
+    def test_a_non_object_body_is_refused_before_job_creation(
+        self, api_gateway_event, lambda_context, raw_body
+    ):
+        response, mock_create_job, mock_invoke = self._post(
+            api_gateway_event, lambda_context, raw_body
+        )
+
+        assert response['statusCode'] == 400
+        assert 'JSON object' in json.loads(response['body'])['error']
+        mock_create_job.assert_not_called()
+        mock_invoke.assert_not_called()
+
+    @pytest.mark.parametrize(
+        'raw_body',
+        ['{not json', '   '],
+        ids=['malformed', 'whitespace'],
+    )
+    def test_unparseable_json_is_refused_before_job_creation(
+        self, api_gateway_event, lambda_context, raw_body
+    ):
+        response, mock_create_job, mock_invoke = self._post(
+            api_gateway_event, lambda_context, raw_body
+        )
+
+        assert response['statusCode'] == 400
+        assert 'must be JSON' in json.loads(response['body'])['error']
+        mock_create_job.assert_not_called()
+        mock_invoke.assert_not_called()
 class TestDocumentCRUDEndpoints:
     """Tests for document CRUD endpoints."""
 

--- a/voc-datalake/lambda/api/test/test_projects_handler.py
+++ b/voc-datalake/lambda/api/test/test_projects_handler.py
@@ -866,8 +866,6 @@ class TestGenerateDocumentDocType:
         )
 
 
-
-
 class TestMergeDocumentsBody:
     """POST /projects/<id>/documents/merge validates the body before billing."""
 
@@ -880,8 +878,7 @@ class TestMergeDocumentsBody:
             path='/projects/proj-123/documents/merge',
             path_params={'project_id': 'proj-123'},
         )
-        if raw_body is not None:
-            event['body'] = raw_body
+        event['body'] = raw_body
 
         with patch(
             'projects_handler.create_job', return_value=('job-1', {})
@@ -965,6 +962,8 @@ class TestMergeDocumentsBody:
         assert 'must be JSON' in json.loads(response['body'])['error']
         mock_create_job.assert_not_called()
         mock_invoke.assert_not_called()
+
+
 class TestDocumentCRUDEndpoints:
     """Tests for document CRUD endpoints."""
 


### PR DESCRIPTION
## Summary

`POST /projects/{project_id}/documents/merge` now validates that a present request body is a JSON object **before** creating the job and invoking the asynchronous merger.

Fixes #380.

## The defect

The route currently does this:

```python
body = app.current_event.json_body or {}
job_id, _ = create_job(project_id, 'merge_documents', 'merge_config', body, status='pending')
```

That produces two failure modes:

1. Truthy non-objects such as `[1, 2]`, `"hi"`, `7` and `true` become `merge_config`, create a job, invoke the merger, and fail only later when the merger calls `.get(...)` on the value.
2. Falsy non-objects such as `[]`, `false`, `0` and `""` are collapsed by `or {}` and silently accepted as an empty configuration.

The first path leaves a failed job row and bills an asynchronous invocation for a request shape the route never supports.

## Change

Use the existing `_json_object_body()` helper in the same module:

```diff
-    body = app.current_event.json_body or {}
+    body = _json_object_body()
```

The helper is already used by adjacent prioritization and document-generation routes and already owns the distinction this route needs:

- absent body, zero-length body, and literal JSON `null` → `{}` (existing behavior preserved)
- JSON object → accepted unchanged
- JSON non-object → 400 `the request body must be a JSON object`
- unparseable JSON → 400 `the request body must be JSON`

Its scope docstring is updated to name `api_merge_documents` now that the route actually uses it.

## Automated-triage clarifications

- **Deployed API stage:** I reproduced through the real `lambda_handler`, not a deployed stage. There is no route-specific API Gateway request model or validator in this repository for `documents/merge`; the Lambda proxy handler is the request-shape boundary, so nothing upstream changes the body contract in deployment.
- **Legitimate empty callers:** absent, zero-length and JSON `null` bodies remain accepted as `{}`. Only a *present non-object* changes from accepted/500 to 400.
- **The wider sweep:** deliberately out of scope. The helper docstring records the remaining `json_body or {}` routes as a separate reviewable diff; this PR fixes the one route that creates a billed artifact before inspecting the shape.

## Tests

A new `TestMergeDocumentsBody` class covers 13 cases:

- valid object still creates and invokes a merge job;
- absent and JSON-null bodies still create a job with `{}`;
- eight non-object JSON values return 400 before `create_job`;
- two unparseable bodies return 400 before `create_job`.

Results:

```
$ pytest lambda/api/test/test_projects_handler.py -q --no-cov
118 passed
```

### Revert check

With the tests kept and only the handler restored to the old implementation:

```
10 failed, 3 passed
```

Restoring the one-line fix returns all 13 new tests to green. This proves the tests fail on the behavior being corrected rather than merely exercising the route.

### Ruff

`ruff check` on the two changed Python files reports the same three pre-existing findings in `projects_handler.py` (the long-standing import block and two broad exception catches at lines 1633 and 4257). No finding is in the new test class or changed route.

## Changelog

Adds a Security entry and an Upgrade note stating the new 400 behavior and the unchanged absent/null default.

## Scope

Exactly three files:

- `CHANGELOG.md`
- `voc-datalake/lambda/api/projects_handler.py`
- `voc-datalake/lambda/api/test/test_projects_handler.py`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).
